### PR TITLE
Allow hotplates in blunderbuss shot/slug/flechette crafting

### DIFF
--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -824,13 +824,7 @@
   "qualities":[
     {"id":"SAW_M","level":1}
   ],
-  "tools": [
-    [
-      [ "fire", -1 ],
-      [ "hotplate", 2 ],
-      [ "toolset", 2 ]
-    ]
-  ],
+  "using": [ [ "surface_heat", 2 ] ],
   "components": [
     [
       [ "gunpowder", 16 ],
@@ -862,13 +856,7 @@
   "qualities":[
     {"id":"SAW_M","level":1}
   ],
-  "tools": [
-    [
-      [ "fire", -1 ],
-      [ "hotplate", 2 ],
-      [ "toolset", 2 ]
-    ]
-  ],
+  "using": [ [ "surface_heat", 2 ] ],
   "components": [
     [
       [ "gunpowder", 16 ],
@@ -894,15 +882,9 @@
   "autolearn": true,
   "book_learn": [["recipe_bullets" , 2 ] , [ "manual_shotgun", 2 ]],
   "qualities":[
-  {"id":"SAW_M","level":1}
+    {"id":"SAW_M","level":1}
   ],
-  "tools": [
-    [
-      [ "fire", -1 ],
-      [ "hotplate", 2 ],
-      [ "toolset", 2 ]
-    ]
-  ],
+  "using": [ [ "surface_heat", 2 ] ],
   "components":  [
     [
       [ "gunpowder", 16 ],

--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -827,6 +827,7 @@
   "tools": [
     [
       [ "fire", -1 ],
+      [ "hotplate", 2 ],
       [ "toolset", 2 ]
     ]
   ],
@@ -859,14 +860,16 @@
   "autolearn": true,
   "book_learn": [["recipe_bullets" , 2 ] , [ "manual_shotgun", 2 ]],
   "qualities":[
-  {"id":"SAW_M","level":1}
+    {"id":"SAW_M","level":1}
   ],
   "tools": [
     [
       [ "fire", -1 ],
+      [ "hotplate", 2 ],
       [ "toolset", 2 ]
     ]
-  ],"components": [
+  ],
+  "components": [
     [
       [ "gunpowder", 16 ],
       [ "chem_black_powder", 16 ]
@@ -896,9 +899,11 @@
   "tools": [
     [
       [ "fire", -1 ],
+      [ "hotplate", 2 ],
       [ "toolset", 2 ]
     ]
-  ], "components":  [
+  ],
+  "components":  [
     [
       [ "gunpowder", 16 ],
       [ "chem_black_powder", 16 ]


### PR DESCRIPTION
I presume that the fire source is intended as a means of shaping the various metal parts into ball form, as Wikipedia claims that not doing this would damage the bore. This is consistent with what I understand is the intention behind shaping the bullet in virtually all other types of ammunition.

What is not consistent however is that, unlike cartridge ammo, the recipes don't let you use a hotplate for this purpose.