### PR TITLE
update relic on item convert

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -489,6 +489,7 @@ item item::make_corpse( const mtype_id &mt, time_point turn, const std::string &
 item &item::convert( const itype_id &new_type )
 {
     type = find_type( new_type );
+	relic_data = type->relic_data;
     return *this;
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -489,7 +489,7 @@ item item::make_corpse( const mtype_id &mt, time_point turn, const std::string &
 item &item::convert( const itype_id &new_type )
 {
     type = find_type( new_type );
-	relic_data = type->relic_data;
+    relic_data = type->relic_data;
     return *this;
 }
 


### PR DESCRIPTION
Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/38409

Example rings stat effect double, looks like separate bug. Rings effects change when transformed.