### PR TITLE
Optional worldmod to disable lifting requirements (strength and lifting quality)

### DIFF
--- a/data/mods/No_Lift_Requirements/modinfo.json
+++ b/data/mods/No_Lift_Requirements/modinfo.json
@@ -1,0 +1,15 @@
+[
+  {
+    "type": "MOD_INFO",
+    "ident": "disable_lifting",
+    "name": "No Lifting Reqs",
+    "authors": "Wad67",
+    "description": "Strength checks and lifting qualities are no longer required for installing or removing vehicle parts.",
+    "category": "rebalance",
+    "dependencies": [ "dda" ]
+  },
+  {
+    "type": "WORLD_OPTION",
+    "options": [ "DISABLE_LIFTING" ]
+  }
+]

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2168,6 +2168,11 @@ void options_manager::add_options_world_default()
     { { "any", translate_marker( "Any" ) }, { "multi_pool", translate_marker( "Multi-pool only" ) }, { "no_freeform", translate_marker( "No freeform" ) } },
     "any"
        );
+	   
+    add( "DISABLE_LIFTING", "world_default", translate_marker( "Disables lifting requirements for vehicle parts." ),
+        translate_marker( "If true, strength checks and/or lifting qualities no longer need to be met in order to change parts." ),
+        false, COPT_ALWAYS_HIDE
+        );
 }
 
 void options_manager::add_options_android()

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -40,6 +40,7 @@
 #include "monster.h"
 #include "npc.h"
 #include "optional.h"
+#include "options.h"
 #include "output.h"
 #include "overmapbuffer.h"
 #include "pimpl.h"
@@ -767,7 +768,14 @@ bool veh_interact::can_install_part()
         str = veh->lift_strength();
         use_aid = ( max_jack >= lvl ) || can_self_jack();
         use_str = g->u.can_lift( *veh );
-    } else {
+    } else if( get_option<bool>( "DISABLE_LIFTING") ) {
+		qual = qual_LIFT;
+		lvl = std::ceil( units::quantity<double, units::mass::unit_type>( base.weight() ) /
+                         TOOL_LIFT_FACTOR );
+		str = base.lift_strength();
+		use_aid = max_lift >= lvl;
+		use_str = g->u.can_lift( base );
+		} else {
         qual = qual_LIFT;
         lvl = std::ceil( units::quantity<double, units::mass::unit_type>( base.weight() ) /
                          TOOL_LIFT_FACTOR );
@@ -1740,7 +1748,14 @@ bool veh_interact::can_remove_part( int idx, const player &p )
         str = veh->lift_strength();
         use_aid = ( max_jack >= lvl ) || can_self_jack();
         use_str = g->u.can_lift( *veh );
-    } else {
+    } else if( get_option<bool>( "DISABLE_LIFTING") ) {
+		qual = qual_LIFT;
+		lvl = std::ceil( units::quantity<double, units::mass::unit_type>( base.weight() ) /
+                         TOOL_LIFT_FACTOR );
+		str = base.lift_strength();
+		use_aid = true;
+		use_str = true;
+		} else  {
         qual = qual_LIFT;
         lvl = std::ceil( units::quantity<double, units::mass::unit_type>( base.weight() ) /
                          TOOL_LIFT_FACTOR );


### PR DESCRIPTION
#### Summary
SUMMARY: [Mods] "Based on previous attempt: https://github.com/CleverRaven/Cataclysm-DDA/pull/24053"

#### Purpose of change

This is a small, optional 're-balance' mod that simply bypasses the checks for lifting quality and strength when adding or removing vehicle parts.

#### Describe the solution

Adds (hidden) DISABLE_LIFTING world option, mod and relevant 'overrides' to can_install_part() and can_remove_part( ).
Had to include options.h in veh_interact.cpp

#### Describe alternatives you've considered

Succumb to tedium

#### Testing

Random character, enabled worldmod
Spawned vehicle, toolbox
Removed and added parts without being hindered by lifting or strength requirements 

