### PR TITLE
Make localization part of doc COMPILING.md clealier

### DIFF
--- a/doc/COMPILING/COMPILING-CMAKE.md
+++ b/doc/COMPILING/COMPILING-CMAKE.md
@@ -1,4 +1,4 @@
-#Disclaimer
+# Disclaimer
 
 **WARNING**: CMake build is **NOT** official and should be used for *dev purposes ONLY*.
 
@@ -6,19 +6,20 @@ For official way to build CataclysmDDA See:
   * [COMPILING.md](COMPILING.md)
 
 
-#Contents
+# Contents
 
-  1. Prerequisites
-  2. Build Environment
-    * UNIX Environment
-    * Windows Environment
-  3. CMake Build
-    * MinGW,MSYS,MSYS2
-  5. Build Options
-    * CMake specific options
-    * CataclysmDDA specific options
+  * [Prerequisites](#prerequisites)
+  * [Build Environment](#build-environment)
+    * [UNIX Environment](#unix-environment)
+    * [Windows Environment](#windows-environment-msys2)
+  * [CMake Build](#cmake-build)
+    * [MinGW,MSYS,MSYS2](#cmake-build-for-msys2-mingw)
+    * [MSBuild, VisualStudio](#cmake-build-for-visual-studio--msbuild)
+  * [Build Options](#build-options)
+    * [CMake specific options](#cmake-specific-options)
+    * [CataclysmDDA specific options])(#cataclysmdda-specific-options)
 
-#1. Prerequisites
+# Prerequisites
 
 You'll need to have these libraries and their development headers installed in
 order to build CataclysmDDA:
@@ -47,7 +48,7 @@ order to build CataclysmDDA:
    * `iconv`
 
 
-#2. Build Environment
+# Build Environment
 
 You can obtain the source code tarball for the latest version from [git](https://github.com/CleverRaven/Cataclysm-DDA).
 
@@ -348,3 +349,4 @@ Run the game. Should work.
 ```
 cmake ../ -DCMAKE_BUILD_TYPE=Release -DTILES=ON -DSOUND=ON
 ```
+

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -88,6 +88,7 @@ Given you're building from source you have a number of choices to make:
   * `TILES=1` - with this you'll get the tiles version, without it the curses version
   * `SOUND=1` - if you want sound; this requires `TILES=1`
   * `LOCALIZE=0` - this disables localizations so `gettext` is not needed
+  * `LANGUAGES=` - specifies localizations. See details [here](#compiling-localization-files)
   * `CLANG=1` - use Clang instead of GCC
   * `CCACHE=1` - use ccache
   * `USE_LIBCXX=1` - use libc++ instead of libstdc++ with Clang (default on OS X)
@@ -109,11 +110,11 @@ You should probably always build with `RELEASE=1` unless you experience segfault
 
 ## Compiling localization files
 
-If you want to compile localization files for specific languages, you can add `LANGUAGES="<lang_id_1> [lang_id_2] [...]"` option to make command:
+Setting `LOCALIZE=1` only may not tell `make` to compile those localization files for you. So if you want to compile localization files for specific languages, you should add `LANGUAGES="<lang_id_1> [lang_id_2] [...]"` option to make command:
 
     make LANGUAGES="zh_CN zh_TW"
 
-You can get the language ID from the filenames of `*.po` in `lang/po` directory. Setting `LOCALIZE=1` only may not tell `make` to compile those localization files for you.
+You can get the language ID from the filenames of `*.po` in `lang/po` directory or use `LANGUAGES="all"` to complile all available localizations. 
 
 Special note for MinGW: due to a [libintl bug](https://savannah.gnu.org/bugs/index.php?58006), using English without a `.mo` file would cause significant slow down on MinGW targets. In such case you can compile a `.mo` file for English using `make LANGUAGES="en"`. `make LANGUAGE="all"` also compiles a `.mo` file for English in addition to other languages.
 

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -110,7 +110,7 @@ You should probably always build with `RELEASE=1` unless you experience segfault
 
 ## Compiling localization files
 
-Despite `LOCALIZE=1` is enabled by default, it may not tell `make` to compile localization files for you. So if you want to compile files for specific languages, you should add `LANGUAGES="<lang_id_1> [lang_id_2] [...]"` option to make command:
+`LOCALIZE` (enabled by default) only enables localization itself, but doesn't include any languages. If you want to compile files for specific languages, you should add `LANGUAGES="<lang_id_1> [lang_id_2] [...]"` option to make command:
 
     make LANGUAGES="zh_CN zh_TW"
 

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -110,7 +110,7 @@ You should probably always build with `RELEASE=1` unless you experience segfault
 
 ## Compiling localization files
 
-Setting `LOCALIZE=1` only may not tell `make` to compile those localization files for you. So if you want to compile localization files for specific languages, you should add `LANGUAGES="<lang_id_1> [lang_id_2] [...]"` option to make command:
+Despite `LOCALIZE=1` is enabled by default, it may not tell `make` to compile localization files for you. So if you want to compile files for specific languages, you should add `LANGUAGES="<lang_id_1> [lang_id_2] [...]"` option to make command:
 
     make LANGUAGES="zh_CN zh_TW"
 


### PR DESCRIPTION
I've misunderstood part of `COMPLINIG.md` related to languages, .mo's and localization.

So I've edited this doc a bit to help other people understand localization flags.

Also I've changed `OMPILING-CMAKE.md ` just to make it more fancy.