### PR TITLE
Reduce ammo for turrets

### DIFF
--- a/data/json/monsters/turrets.json
+++ b/data/json/monsters/turrets.json
@@ -131,7 +131,7 @@
     "vision_day": 50,
     "vision_night": 3,
     "revert_to_itype": "bot_antimateriel",
-    "starting_ammo": { "50bmg": 100 },
+    "starting_ammo": { "50bmg": 75 },
     "special_attacks": [
       {
         "type": "gun",
@@ -189,7 +189,7 @@
     "vision_day": 50,
     "vision_night": 3,
     "revert_to_itype": "bot_rifleturret",
-    "starting_ammo": { "556": 160 },
+    "starting_ammo": { "556": 100 },
     "special_attacks": [
       {
         "type": "gun",

--- a/data/json/monsters/turrets.json
+++ b/data/json/monsters/turrets.json
@@ -131,7 +131,7 @@
     "vision_day": 50,
     "vision_night": 3,
     "revert_to_itype": "bot_antimateriel",
-    "starting_ammo": { "50bmg": 75 },
+    "starting_ammo": { "50bmg": 90 },
     "special_attacks": [
       {
         "type": "gun",
@@ -189,7 +189,7 @@
     "vision_day": 50,
     "vision_night": 3,
     "revert_to_itype": "bot_rifleturret",
-    "starting_ammo": { "556": 100 },
+    "starting_ammo": { "556": 120 },
     "special_attacks": [
       {
         "type": "gun",
@@ -247,7 +247,7 @@
     "vision_day": 50,
     "vision_night": 3,
     "revert_to_itype": "bot_crows_m240",
-    "starting_ammo": { "762_51": 100 },
+    "starting_ammo": { "762_51": 120 },
     "special_attacks": [
       {
         "type": "gun",

--- a/data/json/monsters/turrets.json
+++ b/data/json/monsters/turrets.json
@@ -131,7 +131,7 @@
     "vision_day": 50,
     "vision_night": 3,
     "revert_to_itype": "bot_antimateriel",
-    "starting_ammo": { "50bmg": 400 },
+    "starting_ammo": { "50bmg": 100 },
     "special_attacks": [
       {
         "type": "gun",
@@ -189,7 +189,7 @@
     "vision_day": 50,
     "vision_night": 3,
     "revert_to_itype": "bot_rifleturret",
-    "starting_ammo": { "556": 1600 },
+    "starting_ammo": { "556": 160 },
     "special_attacks": [
       {
         "type": "gun",
@@ -247,7 +247,7 @@
     "vision_day": 50,
     "vision_night": 3,
     "revert_to_itype": "bot_crows_m240",
-    "starting_ammo": { "762_51": 1000 },
+    "starting_ammo": { "762_51": 100 },
     "special_attacks": [
       {
         "type": "gun",


### PR DESCRIPTION
Reducing ammo for turrets.
Basically it is fixing that:
https://github.com/CleverRaven/Cataclysm-DDA/issues/38638
https://github.com/CleverRaven/Cataclysm-DDA/pull/33436#issuecomment-527393955


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

Reduce aturrets ammo to sane ammounts.

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->
Previous version of turrets has around 100 ammo. But for realistic reason ammo count was changed to insane numbers. This PR going to fix that. 

Turrets still going to have around 100 ammo as it was before change. It should be enough to mantain fire and at the same time prevents turret to drop lifetime ammo pile for player.
#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

M2HB autonomous CROWS II .50 BMG ammo: 400 ->90
M240 autonomous CROWS II  7.62 ammo: 1000 -> 120
M249 autonomous CROWS II  5.56 ammo: 1600 ->120

It is exaclly 30 bursts before running out of ammo. I have to compensate turret fire rate with ammo count.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Implementing system that burn most ammo in turret destruction.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
