### PR TITLE
Fix for Unloaded ammo belt doesn't disappear

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -899,7 +899,8 @@ void avatar_action::aim_do_turn( avatar &you, map &m )
         bool not_aiming = you.activity.id() != ACT_AIM;
         if( not_aiming && gun->has_flag( flag_RELOAD_AND_SHOOT ) ) {
             const auto previous_moves = you.moves;
-            g->unload( *gun );
+            item_location loc = item_location( you, gun.target );
+            g->unload( loc );
             // Give back time for unloading as essentially nothing has been done.
             // Note that reload_time has not been applied either.
             you.moves = previous_moves;
@@ -1284,9 +1285,11 @@ void avatar_action::unload( avatar &you )
         return;
     }
 
-    if( you.unload( *loc ) ) {
-        if( loc->has_flag( "MAG_DESTROY" ) && loc->ammo_remaining() == 0 ) {
-            loc.remove_item();
-        }
-    }
+    //if( you.unload( *loc ) ) {
+    //    if( loc->has_flag( "MAG_DESTROY" ) && loc->ammo_remaining() == 0 ) {
+    //        loc.remove_item();
+    //    }
+    //}
+
+    you.unload(loc);
 }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1285,11 +1285,5 @@ void avatar_action::unload( avatar &you )
         return;
     }
 
-    //if( you.unload( *loc ) ) {
-    //    if( loc->has_flag( "MAG_DESTROY" ) && loc->ammo_remaining() == 0 ) {
-    //        loc.remove_item();
-    //    }
-    //}
-
-    you.unload(loc);
+    you.unload( loc );
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8652,7 +8652,7 @@ void game::reload_weapon( bool try_everything )
     reload_item();
 }
 
-bool game::unload( item_location &loc )
+bool game::unload( item_location loc )
 {
     return u.unload( loc );
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2193,7 +2193,7 @@ int game::inventory_item_menu( item_location locThisItem, int iStartX, int iWidt
                     u.drop( locThisItem, u.pos() );
                     break;
                 case 'U':
-                    unload( oThisItem );
+                    unload( locThisItem );
                     break;
                 case 'r':
                     reload( locThisItem );
@@ -8652,9 +8652,9 @@ void game::reload_weapon( bool try_everything )
     reload_item();
 }
 
-bool game::unload( item &it )
+bool game::unload( item_location &loc )
 {
-    return u.unload( it );
+    return u.unload( loc );
 }
 
 void game::wield( item_location &loc )

--- a/src/game.h
+++ b/src/game.h
@@ -793,7 +793,7 @@ class game
         point place_player( const tripoint &dest );
         void place_player_overmap( const tripoint &om_dest );
 
-        bool unload( item &it ); // Unload a gun/tool  'U'
+        bool unload( item_location &loc ); // Unload a gun/tool  'U'
 
         unsigned int get_seed() const;
 

--- a/src/game.h
+++ b/src/game.h
@@ -793,7 +793,7 @@ class game
         point place_player( const tripoint &dest );
         void place_player_overmap( const tripoint &om_dest );
 
-        bool unload( item_location &loc ); // Unload a gun/tool  'U'
+        bool unload( item_location loc ); // Unload a gun/tool  'U'
 
         unsigned int get_seed() const;
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1703,7 +1703,7 @@ int iuse::remove_all_mods( player *p, item *, bool, const tripoint & )
         return 0;
     }
 
-    if ( !loc->ammo_remaining() || g->unload (loc ) ) {
+    if( !loc->ammo_remaining() || g->unload( loc ) ) {
         item *mod = loc->contents.get_item_with(
         []( const item & e ) {
             return e.is_toolmod() && !e.is_irremovable();
@@ -5917,7 +5917,7 @@ int iuse::toolmod_attach( player *p, item *it, bool, const tripoint & )
     }
 
     if( loc->ammo_remaining() ) {
-        if ( !g->unload( loc ) ) {
+        if( !g->unload( loc ) ) {
             p->add_msg_if_player( m_info, _( "You cancel unloading the tool." ) );
             return 0;
         }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1703,7 +1703,7 @@ int iuse::remove_all_mods( player *p, item *, bool, const tripoint & )
         return 0;
     }
 
-    if( !loc->ammo_remaining() || g->unload( *loc ) ) {
+    if ( !loc->ammo_remaining() || g->unload (loc ) ) {
         item *mod = loc->contents.get_item_with(
         []( const item & e ) {
             return e.is_toolmod() && !e.is_irremovable();
@@ -5917,7 +5917,7 @@ int iuse::toolmod_attach( player *p, item *it, bool, const tripoint & )
     }
 
     if( loc->ammo_remaining() ) {
-        if( !g->unload( *loc ) ) {
+        if ( !g->unload( loc ) ) {
             p->add_msg_if_player( m_info, _( "You cancel unloading the tool." ) );
             return 0;
         }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3097,10 +3097,12 @@ bool player::add_or_drop_with_msg( item &it, const bool unloading )
 
 bool player::unload( item_location loc )
 {
-    unload_internal( loc );
+    bool result = unload_internal( loc );
+
     if( loc->has_flag( "MAG_DESTROY" ) && loc->ammo_remaining() == 0 ) {
         loc.remove_item();
     }
+    return result;
 }
 
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3106,7 +3106,7 @@ bool player::unload( item_location loc )
 }
 
 
-bool player::unload_internal( item_location loc )
+inline bool unload_internal( item_location loc )
 {
     item &it = *loc.get_item();
     // Unload a container consuming moves per item successfully removed

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3095,7 +3095,7 @@ bool player::add_or_drop_with_msg( item &it, const bool unloading )
     return true;
 }
 
-bool player::unload( item_location &loc )
+bool player::unload( item_location loc )
 {
     unload_internal( loc );
     if( loc->has_flag( "MAG_DESTROY" ) && loc->ammo_remaining() == 0 ) {
@@ -3104,7 +3104,7 @@ bool player::unload( item_location &loc )
 }
 
 
-bool player::unload_internal( item_location &loc )
+bool player::unload_internal( item_location loc )
 {
     item &it = *loc.get_item();
     // Unload a container consuming moves per item successfully removed
@@ -3495,7 +3495,7 @@ bool player::gunmod_remove( item &gun, item &mod )
     }
 
     item_location loc = item_location( *this, &mod );
-    if ( mod.ammo_remaining() && !g->unload( loc ) ) {
+    if( mod.ammo_remaining() && !g->unload( loc ) ) {
         return false;
     }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3097,187 +3097,183 @@ bool player::add_or_drop_with_msg( item &it, const bool unloading )
 
 bool player::unload( item_location loc )
 {
-    auto unload_internal = [&]( item_location loc ) {
-        item &it = *loc.get_item();
-        // Unload a container consuming moves per item successfully removed
-        if( it.is_container() || it.is_bandolier() ) {
-            if( it.contents.empty() ) {
-                add_msg( m_info, _( "The %s is already empty!" ), it.tname() );
-                return false;
-            }
-            if( !it.can_unload_liquid() ) {
-                add_msg( m_info, _( "The liquid can't be unloaded in its current state!" ) );
-                return false;
-            }
-
-            bool changed = false;
-            for( item *contained : it.contents.all_items_top() ) {
-                int old_charges = contained->charges;
-                const bool consumed = this->add_or_drop_with_msg( *contained, true );
-                changed = changed || consumed || contained->charges != old_charges;
-                if( consumed ) {
-                    this->mod_moves( -this->item_handling_cost( *contained ) );
-                    it.remove_item( *contained );
-                }
-            }
-
-            if( changed ) {
-                it.on_contents_changed();
-            }
-            return true;
+    item &it = *loc.get_item();
+    // Unload a container consuming moves per item successfully removed
+    if( it.is_container() || it.is_bandolier() ) {
+        if( it.contents.empty() ) {
+            add_msg( m_info, _( "The %s is already empty!" ), it.tname() );
+            return false;
+        }
+        if( !it.can_unload_liquid() ) {
+            add_msg( m_info, _( "The liquid can't be unloaded in its current state!" ) );
+            return false;
         }
 
-        // If item can be unloaded more than once (currently only guns) prompt user to choose
-        std::vector<std::string> msgs( 1, it.tname() );
-        std::vector<item *> opts( 1, &it );
-
-        for( auto e : it.gunmods() ) {
-            if( e->is_gun() && !e->has_flag( "NO_UNLOAD" ) &&
-                ( e->magazine_current() || e->ammo_remaining() > 0 || e->casings_count() > 0 ) ) {
-                msgs.emplace_back( e->tname() );
-                opts.emplace_back( e );
+        bool changed = false;
+        for( item *contained : it.contents.all_items_top() ) {
+            int old_charges = contained->charges;
+            const bool consumed = this->add_or_drop_with_msg( *contained, true );
+            changed = changed || consumed || contained->charges != old_charges;
+            if( consumed ) {
+                this->mod_moves( -this->item_handling_cost( *contained ) );
+                it.remove_item( *contained );
             }
         }
 
-        item *target = nullptr;
-        if( opts.size() > 1 ) {
-            const int ret = uilist( _( "Unload what?" ), msgs );
-            if( ret >= 0 ) {
-                target = opts[ret];
-            }
+        if( changed ) {
+            it.on_contents_changed();
+        }
+        return true;
+    }
+
+    // If item can be unloaded more than once (currently only guns) prompt user to choose
+    std::vector<std::string> msgs( 1, it.tname() );
+    std::vector<item *> opts( 1, &it );
+
+    for( auto e : it.gunmods() ) {
+        if( e->is_gun() && !e->has_flag( "NO_UNLOAD" ) &&
+            ( e->magazine_current() || e->ammo_remaining() > 0 || e->casings_count() > 0 ) ) {
+            msgs.emplace_back( e->tname() );
+            opts.emplace_back( e );
+        }
+    }
+
+    item *target = nullptr;
+    if( opts.size() > 1 ) {
+        const int ret = uilist( _( "Unload what?" ), msgs );
+        if( ret >= 0 ) {
+            target = opts[ret];
+        }
+    } else {
+        target = &it;
+    }
+
+    if( target == nullptr ) {
+        return false;
+    }
+
+    // Next check for any reasons why the item cannot be unloaded
+    if( target->ammo_types().empty() || target->ammo_capacity() <= 0 ) {
+        add_msg( m_info, _( "You can't unload a %s!" ), target->tname() );
+        return false;
+    }
+
+    if( target->has_flag( "NO_UNLOAD" ) ) {
+        if( target->has_flag( "RECHARGE" ) || target->has_flag( "USE_UPS" ) ) {
+            add_msg( m_info, _( "You can't unload a rechargeable %s!" ), target->tname() );
         } else {
-            target = &it;
-        }
-
-        if( target == nullptr ) {
-            return false;
-        }
-
-        // Next check for any reasons why the item cannot be unloaded
-        if( target->ammo_types().empty() || target->ammo_capacity() <= 0 ) {
             add_msg( m_info, _( "You can't unload a %s!" ), target->tname() );
-            return false;
         }
+        return false;
+    }
 
-        if( target->has_flag( "NO_UNLOAD" ) ) {
-            if( target->has_flag( "RECHARGE" ) || target->has_flag( "USE_UPS" ) ) {
-                add_msg( m_info, _( "You can't unload a rechargeable %s!" ), target->tname() );
-            } else {
-                add_msg( m_info, _( "You can't unload a %s!" ), target->tname() );
+    if( !target->magazine_current() && target->ammo_remaining() <= 0 && target->casings_count() <= 0 ) {
+        if( target->is_tool() ) {
+            add_msg( m_info, _( "Your %s isn't charged." ), target->tname() );
+        } else {
+            add_msg( m_info, _( "Your %s isn't loaded." ), target->tname() );
+        }
+        return false;
+    }
+
+    target->casings_handle( [&]( item & e ) {
+        return this->i_add_or_drop( e );
+    } );
+
+    if( target->is_magazine() ) {
+        // Calculate the time to remove the contained ammo (consuming half as much time as required to load the magazine)
+        int mv = 0;
+        int qty = 0;
+        std::vector<item *> remove_contained;
+        for( item *contained : it.contents.all_items_top() ) {
+            mv += this->item_reload_cost( it, *contained, contained->charges ) / 2;
+            if( add_or_drop_with_msg( *contained, true ) ) {
+                qty += contained->charges;
+                remove_contained.push_back( contained );
             }
-            return false;
+        }
+        // remove the ammo leads in the belt
+        for( item *remove : remove_contained ) {
+            it.remove_item( *remove );
         }
 
-        if( !target->magazine_current() && target->ammo_remaining() <= 0 && target->casings_count() <= 0 ) {
-            if( target->is_tool() ) {
-                add_msg( m_info, _( "Your %s isn't charged." ), target->tname() );
-            } else {
-                add_msg( m_info, _( "Your %s isn't loaded." ), target->tname() );
+        // remove the belt linkage
+        if( it.is_ammo_belt() ) {
+            if( it.type->magazine->linkage ) {
+                item link( *it.type->magazine->linkage, calendar::turn, qty );
+                add_or_drop_with_msg( link, true );
             }
-            return false;
+            add_msg( _( "You disassemble your %s." ), it.tname() );
+        } else {
+            add_msg( _( "You unload your %s." ), it.tname() );
         }
 
-        target->casings_handle( [&]( item & e ) {
-            return this->i_add_or_drop( e );
+        mod_moves( -std::min( 200, mv ) );
+        if( loc->has_flag( "MAG_DESTROY" ) && loc->ammo_remaining() == 0 ) {
+            loc.remove_item();
+        }
+        return true;
+
+    } else if( target->magazine_current() ) {
+        if( !this->add_or_drop_with_msg( *target->magazine_current(), true ) ) {
+            return false;
+        }
+        // Eject magazine consuming half as much time as required to insert it
+        this->moves -= this->item_reload_cost( *target, *target->magazine_current(), -1 ) / 2;
+
+        target->remove_items_with( [&target]( const item & e ) {
+            return target->magazine_current() == &e;
         } );
 
-        if( target->is_magazine() ) {
-            // Calculate the time to remove the contained ammo (consuming half as much time as required to load the magazine)
-            int mv = 0;
-            int qty = 0;
-            std::vector<item *> remove_contained;
-            for( item *contained : it.contents.all_items_top() ) {
-                mv += this->item_reload_cost( it, *contained, contained->charges ) / 2;
-                if( add_or_drop_with_msg( *contained, true ) ) {
-                    qty += contained->charges;
-                    remove_contained.push_back( contained );
-                }
-            }
-            // remove the ammo leads in the belt
-            for( item *remove : remove_contained ) {
-                it.remove_item( *remove );
-            }
+    } else if( target->ammo_remaining() ) {
+        int qty = target->ammo_remaining();
 
-            // remove the belt linkage
-            if( it.is_ammo_belt() ) {
-                if( it.type->magazine->linkage ) {
-                    item link( *it.type->magazine->linkage, calendar::turn, qty );
-                    add_or_drop_with_msg( link, true );
-                }
-                add_msg( _( "You disassemble your %s." ), it.tname() );
+        if( target->ammo_current() == "plut_cell" ) {
+            qty = target->ammo_remaining() / PLUTONIUM_CHARGES;
+            if( qty > 0 ) {
+                add_msg( _( "You recover %i unused plutonium." ), qty );
             } else {
-                add_msg( _( "You unload your %s." ), it.tname() );
-            }
-
-            mod_moves( -std::min( 200, mv ) );
-
-            return true;
-
-        } else if( target->magazine_current() ) {
-            if( !this->add_or_drop_with_msg( *target->magazine_current(), true ) ) {
+                add_msg( m_info, _( "You can't remove partially depleted plutonium!" ) );
                 return false;
             }
-            // Eject magazine consuming half as much time as required to insert it
-            this->moves -= this->item_reload_cost( *target, *target->magazine_current(), -1 ) / 2;
-
-            target->remove_items_with( [&target]( const item & e ) {
-                return target->magazine_current() == &e;
-            } );
-
-        } else if( target->ammo_remaining() ) {
-            int qty = target->ammo_remaining();
-
-            if( target->ammo_current() == "plut_cell" ) {
-                qty = target->ammo_remaining() / PLUTONIUM_CHARGES;
-                if( qty > 0 ) {
-                    add_msg( _( "You recover %i unused plutonium." ), qty );
-                } else {
-                    add_msg( m_info, _( "You can't remove partially depleted plutonium!" ) );
-                    return false;
-                }
-            }
-
-            // Construct a new ammo item and try to drop it
-            item ammo( target->ammo_current(), calendar::turn, qty );
-            if( target->is_filthy() ) {
-                ammo.set_flag( "FILTHY" );
-            }
-
-            if( ammo.made_of( LIQUID ) ) {
-                if( !this->add_or_drop_with_msg( ammo ) ) {
-                    qty -= ammo.charges; // only handled part (or none) of the liquid
-                }
-                if( qty <= 0 ) {
-                    return false; // no liquid was moved
-                }
-
-            } else if( !this->add_or_drop_with_msg( ammo, qty > 1 ) ) {
-                return false;
-            }
-
-            // If successful remove appropriate qty of ammo consuming half as much time as required to load it
-            this->moves -= this->item_reload_cost( *target, ammo, qty ) / 2;
-
-            if( target->ammo_current() == "plut_cell" ) {
-                qty *= PLUTONIUM_CHARGES;
-            }
-
-            target->ammo_set( target->ammo_current(), target->ammo_remaining() - qty );
         }
 
-        // Turn off any active tools
-        if( target->is_tool() && target->active && target->ammo_remaining() == 0 ) {
-            target->type->invoke( *this, *target, this->pos() );
+        // Construct a new ammo item and try to drop it
+        item ammo( target->ammo_current(), calendar::turn, qty );
+        if( target->is_filthy() ) {
+            ammo.set_flag( "FILTHY" );
         }
 
-        add_msg( _( "You unload your %s." ), target->tname() );
-        return true;
-    };
-    bool result = unload_internal( loc );
-    if( loc->has_flag( "MAG_DESTROY" ) && loc->ammo_remaining() == 0 ) {
-        loc.remove_item();
+        if( ammo.made_of( LIQUID ) ) {
+            if( !this->add_or_drop_with_msg( ammo ) ) {
+                qty -= ammo.charges; // only handled part (or none) of the liquid
+            }
+            if( qty <= 0 ) {
+                return false; // no liquid was moved
+            }
+
+        } else if( !this->add_or_drop_with_msg( ammo, qty > 1 ) ) {
+            return false;
+        }
+
+        // If successful remove appropriate qty of ammo consuming half as much time as required to load it
+        this->moves -= this->item_reload_cost( *target, ammo, qty ) / 2;
+
+        if( target->ammo_current() == "plut_cell" ) {
+            qty *= PLUTONIUM_CHARGES;
+        }
+
+        target->ammo_set( target->ammo_current(), target->ammo_remaining() - qty );
     }
-    return result;
+
+    // Turn off any active tools
+    if( target->is_tool() && target->active && target->ammo_remaining() == 0 ) {
+        target->type->invoke( *this, *target, this->pos() );
+    }
+
+    add_msg( _( "You unload your %s." ), target->tname() );
+    return true;
+
 }
 
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3095,8 +3095,18 @@ bool player::add_or_drop_with_msg( item &it, const bool unloading )
     return true;
 }
 
-bool player::unload( item &it )
+bool player::unload( item_location &loc )
 {
+    unload_internal( loc );
+    if( loc->has_flag( "MAG_DESTROY" ) && loc->ammo_remaining() == 0 ) {
+        loc.remove_item();
+    }
+}
+
+
+bool player::unload_internal( item_location &loc )
+{
+    item &it = *loc.get_item();
     // Unload a container consuming moves per item successfully removed
     if( it.is_container() || it.is_bandolier() ) {
         if( it.contents.empty() ) {
@@ -3483,7 +3493,9 @@ bool player::gunmod_remove( item &gun, item &mod )
         debugmsg( "Cannot remove non-existent gunmod" );
         return false;
     }
-    if( mod.ammo_remaining() && !g->unload( mod ) ) {
+
+    item_location loc = item_location( *this, &mod );
+    if ( mod.ammo_remaining() && !g->unload( loc ) ) {
         return false;
     }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3097,192 +3097,189 @@ bool player::add_or_drop_with_msg( item &it, const bool unloading )
 
 bool player::unload( item_location loc )
 {
-    bool result = unload_internal( loc );
+    auto unload_internal = [&]( item_location loc ) {
+        item &it = *loc.get_item();
+        // Unload a container consuming moves per item successfully removed
+        if( it.is_container() || it.is_bandolier() ) {
+            if( it.contents.empty() ) {
+                add_msg( m_info, _( "The %s is already empty!" ), it.tname() );
+                return false;
+            }
+            if( !it.can_unload_liquid() ) {
+                add_msg( m_info, _( "The liquid can't be unloaded in its current state!" ) );
+                return false;
+            }
 
+            bool changed = false;
+            for( item *contained : it.contents.all_items_top() ) {
+                int old_charges = contained->charges;
+                const bool consumed = this->add_or_drop_with_msg( *contained, true );
+                changed = changed || consumed || contained->charges != old_charges;
+                if( consumed ) {
+                    this->mod_moves( -this->item_handling_cost( *contained ) );
+                    it.remove_item( *contained );
+                }
+            }
+
+            if( changed ) {
+                it.on_contents_changed();
+            }
+            return true;
+        }
+
+        // If item can be unloaded more than once (currently only guns) prompt user to choose
+        std::vector<std::string> msgs( 1, it.tname() );
+        std::vector<item *> opts( 1, &it );
+
+        for( auto e : it.gunmods() ) {
+            if( e->is_gun() && !e->has_flag( "NO_UNLOAD" ) &&
+                ( e->magazine_current() || e->ammo_remaining() > 0 || e->casings_count() > 0 ) ) {
+                msgs.emplace_back( e->tname() );
+                opts.emplace_back( e );
+            }
+        }
+
+        item *target = nullptr;
+        if( opts.size() > 1 ) {
+            const int ret = uilist( _( "Unload what?" ), msgs );
+            if( ret >= 0 ) {
+                target = opts[ret];
+            }
+        } else {
+            target = &it;
+        }
+
+        if( target == nullptr ) {
+            return false;
+        }
+
+        // Next check for any reasons why the item cannot be unloaded
+        if( target->ammo_types().empty() || target->ammo_capacity() <= 0 ) {
+            add_msg( m_info, _( "You can't unload a %s!" ), target->tname() );
+            return false;
+        }
+
+        if( target->has_flag( "NO_UNLOAD" ) ) {
+            if( target->has_flag( "RECHARGE" ) || target->has_flag( "USE_UPS" ) ) {
+                add_msg( m_info, _( "You can't unload a rechargeable %s!" ), target->tname() );
+            } else {
+                add_msg( m_info, _( "You can't unload a %s!" ), target->tname() );
+            }
+            return false;
+        }
+
+        if( !target->magazine_current() && target->ammo_remaining() <= 0 && target->casings_count() <= 0 ) {
+            if( target->is_tool() ) {
+                add_msg( m_info, _( "Your %s isn't charged." ), target->tname() );
+            } else {
+                add_msg( m_info, _( "Your %s isn't loaded." ), target->tname() );
+            }
+            return false;
+        }
+
+        target->casings_handle( [&]( item & e ) {
+            return this->i_add_or_drop( e );
+        } );
+
+        if( target->is_magazine() ) {
+            // Calculate the time to remove the contained ammo (consuming half as much time as required to load the magazine)
+            int mv = 0;
+            int qty = 0;
+            std::vector<item *> remove_contained;
+            for( item *contained : it.contents.all_items_top() ) {
+                mv += this->item_reload_cost( it, *contained, contained->charges ) / 2;
+                if( add_or_drop_with_msg( *contained, true ) ) {
+                    qty += contained->charges;
+                    remove_contained.push_back( contained );
+                }
+            }
+            // remove the ammo leads in the belt
+            for( item *remove : remove_contained ) {
+                it.remove_item( *remove );
+            }
+
+            // remove the belt linkage
+            if( it.is_ammo_belt() ) {
+                if( it.type->magazine->linkage ) {
+                    item link( *it.type->magazine->linkage, calendar::turn, qty );
+                    add_or_drop_with_msg( link, true );
+                }
+                add_msg( _( "You disassemble your %s." ), it.tname() );
+            } else {
+                add_msg( _( "You unload your %s." ), it.tname() );
+            }
+
+            mod_moves( -std::min( 200, mv ) );
+
+            return true;
+
+        } else if( target->magazine_current() ) {
+            if( !this->add_or_drop_with_msg( *target->magazine_current(), true ) ) {
+                return false;
+            }
+            // Eject magazine consuming half as much time as required to insert it
+            this->moves -= this->item_reload_cost( *target, *target->magazine_current(), -1 ) / 2;
+
+            target->remove_items_with( [&target]( const item & e ) {
+                return target->magazine_current() == &e;
+            } );
+
+        } else if( target->ammo_remaining() ) {
+            int qty = target->ammo_remaining();
+
+            if( target->ammo_current() == "plut_cell" ) {
+                qty = target->ammo_remaining() / PLUTONIUM_CHARGES;
+                if( qty > 0 ) {
+                    add_msg( _( "You recover %i unused plutonium." ), qty );
+                } else {
+                    add_msg( m_info, _( "You can't remove partially depleted plutonium!" ) );
+                    return false;
+                }
+            }
+
+            // Construct a new ammo item and try to drop it
+            item ammo( target->ammo_current(), calendar::turn, qty );
+            if( target->is_filthy() ) {
+                ammo.set_flag( "FILTHY" );
+            }
+
+            if( ammo.made_of( LIQUID ) ) {
+                if( !this->add_or_drop_with_msg( ammo ) ) {
+                    qty -= ammo.charges; // only handled part (or none) of the liquid
+                }
+                if( qty <= 0 ) {
+                    return false; // no liquid was moved
+                }
+
+            } else if( !this->add_or_drop_with_msg( ammo, qty > 1 ) ) {
+                return false;
+            }
+
+            // If successful remove appropriate qty of ammo consuming half as much time as required to load it
+            this->moves -= this->item_reload_cost( *target, ammo, qty ) / 2;
+
+            if( target->ammo_current() == "plut_cell" ) {
+                qty *= PLUTONIUM_CHARGES;
+            }
+
+            target->ammo_set( target->ammo_current(), target->ammo_remaining() - qty );
+        }
+
+        // Turn off any active tools
+        if( target->is_tool() && target->active && target->ammo_remaining() == 0 ) {
+            target->type->invoke( *this, *target, this->pos() );
+        }
+
+        add_msg( _( "You unload your %s." ), target->tname() );
+        return true;
+    };
+    bool result = unload_internal( loc );
     if( loc->has_flag( "MAG_DESTROY" ) && loc->ammo_remaining() == 0 ) {
         loc.remove_item();
     }
     return result;
 }
 
-
-bool player::unload_internal( item_location loc )
-{
-    item &it = *loc.get_item();
-    // Unload a container consuming moves per item successfully removed
-    if( it.is_container() || it.is_bandolier() ) {
-        if( it.contents.empty() ) {
-            add_msg( m_info, _( "The %s is already empty!" ), it.tname() );
-            return false;
-        }
-        if( !it.can_unload_liquid() ) {
-            add_msg( m_info, _( "The liquid can't be unloaded in its current state!" ) );
-            return false;
-        }
-
-        bool changed = false;
-        for( item *contained : it.contents.all_items_top() ) {
-            int old_charges = contained->charges;
-            const bool consumed = this->add_or_drop_with_msg( *contained, true );
-            changed = changed || consumed || contained->charges != old_charges;
-            if( consumed ) {
-                this->mod_moves( -this->item_handling_cost( *contained ) );
-                it.remove_item( *contained );
-            }
-        }
-
-        if( changed ) {
-            it.on_contents_changed();
-        }
-        return true;
-    }
-
-    // If item can be unloaded more than once (currently only guns) prompt user to choose
-    std::vector<std::string> msgs( 1, it.tname() );
-    std::vector<item *> opts( 1, &it );
-
-    for( auto e : it.gunmods() ) {
-        if( e->is_gun() && !e->has_flag( "NO_UNLOAD" ) &&
-            ( e->magazine_current() || e->ammo_remaining() > 0 || e->casings_count() > 0 ) ) {
-            msgs.emplace_back( e->tname() );
-            opts.emplace_back( e );
-        }
-    }
-
-    item *target = nullptr;
-    if( opts.size() > 1 ) {
-        const int ret = uilist( _( "Unload what?" ), msgs );
-        if( ret >= 0 ) {
-            target = opts[ret];
-        }
-    } else {
-        target = &it;
-    }
-
-    if( target == nullptr ) {
-        return false;
-    }
-
-    // Next check for any reasons why the item cannot be unloaded
-    if( target->ammo_types().empty() || target->ammo_capacity() <= 0 ) {
-        add_msg( m_info, _( "You can't unload a %s!" ), target->tname() );
-        return false;
-    }
-
-    if( target->has_flag( "NO_UNLOAD" ) ) {
-        if( target->has_flag( "RECHARGE" ) || target->has_flag( "USE_UPS" ) ) {
-            add_msg( m_info, _( "You can't unload a rechargeable %s!" ), target->tname() );
-        } else {
-            add_msg( m_info, _( "You can't unload a %s!" ), target->tname() );
-        }
-        return false;
-    }
-
-    if( !target->magazine_current() && target->ammo_remaining() <= 0 && target->casings_count() <= 0 ) {
-        if( target->is_tool() ) {
-            add_msg( m_info, _( "Your %s isn't charged." ), target->tname() );
-        } else {
-            add_msg( m_info, _( "Your %s isn't loaded." ), target->tname() );
-        }
-        return false;
-    }
-
-    target->casings_handle( [&]( item & e ) {
-        return this->i_add_or_drop( e );
-    } );
-
-    if( target->is_magazine() ) {
-        // Calculate the time to remove the contained ammo (consuming half as much time as required to load the magazine)
-        int mv = 0;
-        int qty = 0;
-        std::vector<item *> remove_contained;
-        for( item *contained : it.contents.all_items_top() ) {
-            mv += this->item_reload_cost( it, *contained, contained->charges ) / 2;
-            if( add_or_drop_with_msg( *contained, true ) ) {
-                qty += contained->charges;
-                remove_contained.push_back( contained );
-            }
-        }
-        // remove the ammo leads in the belt
-        for( item *remove : remove_contained ) {
-            it.remove_item( *remove );
-        }
-
-        // remove the belt linkage
-        if( it.is_ammo_belt() ) {
-            if( it.type->magazine->linkage ) {
-                item link( *it.type->magazine->linkage, calendar::turn, qty );
-                add_or_drop_with_msg( link, true );
-            }
-            add_msg( _( "You disassemble your %s." ), it.tname() );
-        } else {
-            add_msg( _( "You unload your %s." ), it.tname() );
-        }
-
-        mod_moves( -std::min( 200, mv ) );
-
-        return true;
-
-    } else if( target->magazine_current() ) {
-        if( !this->add_or_drop_with_msg( *target->magazine_current(), true ) ) {
-            return false;
-        }
-        // Eject magazine consuming half as much time as required to insert it
-        this->moves -= this->item_reload_cost( *target, *target->magazine_current(), -1 ) / 2;
-
-        target->remove_items_with( [&target]( const item & e ) {
-            return target->magazine_current() == &e;
-        } );
-
-    } else if( target->ammo_remaining() ) {
-        int qty = target->ammo_remaining();
-
-        if( target->ammo_current() == "plut_cell" ) {
-            qty = target->ammo_remaining() / PLUTONIUM_CHARGES;
-            if( qty > 0 ) {
-                add_msg( _( "You recover %i unused plutonium." ), qty );
-            } else {
-                add_msg( m_info, _( "You can't remove partially depleted plutonium!" ) );
-                return false;
-            }
-        }
-
-        // Construct a new ammo item and try to drop it
-        item ammo( target->ammo_current(), calendar::turn, qty );
-        if( target->is_filthy() ) {
-            ammo.set_flag( "FILTHY" );
-        }
-
-        if( ammo.made_of( LIQUID ) ) {
-            if( !this->add_or_drop_with_msg( ammo ) ) {
-                qty -= ammo.charges; // only handled part (or none) of the liquid
-            }
-            if( qty <= 0 ) {
-                return false; // no liquid was moved
-            }
-
-        } else if( !this->add_or_drop_with_msg( ammo, qty > 1 ) ) {
-            return false;
-        }
-
-        // If successful remove appropriate qty of ammo consuming half as much time as required to load it
-        this->moves -= this->item_reload_cost( *target, ammo, qty ) / 2;
-
-        if( target->ammo_current() == "plut_cell" ) {
-            qty *= PLUTONIUM_CHARGES;
-        }
-
-        target->ammo_set( target->ammo_current(), target->ammo_remaining() - qty );
-    }
-
-    // Turn off any active tools
-    if( target->is_tool() && target->active && target->ammo_remaining() == 0 ) {
-        target->type->invoke( *this, *target, this->pos() );
-    }
-
-    add_msg( _( "You unload your %s." ), target->tname() );
-    return true;
-}
 
 void player::use_wielded()
 {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3106,7 +3106,7 @@ bool player::unload( item_location loc )
 }
 
 
-inline bool unload_internal( item_location loc )
+bool player::unload_internal( item_location loc )
 {
     item &it = *loc.get_item();
     // Unload a container consuming moves per item successfully removed

--- a/src/player.h
+++ b/src/player.h
@@ -430,7 +430,7 @@ class player : public Character
         /** So far only called by unload() from game.cpp */
         bool add_or_drop_with_msg( item &it, bool unloading = false );
 
-        bool unload( item_location& loc );
+        bool unload( item_location loc );
 
         /**
          * Try to wield a contained item consuming moves proportional to weapon skill and volume.
@@ -489,7 +489,7 @@ class player : public Character
         /** last time we checked for sleep */
         time_point last_sleep_check = calendar::turn_zero;
         bool bio_soporific_powered_at_last_sleep_check;
-        bool unload_internal( item_location &loc );
+        bool unload_internal( item_location loc );
 
     public:
         /** Returns a value from 1.0 to 5.0 that acts as a multiplier

--- a/src/player.h
+++ b/src/player.h
@@ -489,6 +489,7 @@ class player : public Character
         /** last time we checked for sleep */
         time_point last_sleep_check = calendar::turn_zero;
         bool bio_soporific_powered_at_last_sleep_check;
+        bool unload_internal( item_location loc );
 
     public:
         /** Returns a value from 1.0 to 5.0 that acts as a multiplier

--- a/src/player.h
+++ b/src/player.h
@@ -430,7 +430,7 @@ class player : public Character
         /** So far only called by unload() from game.cpp */
         bool add_or_drop_with_msg( item &it, bool unloading = false );
 
-        bool unload( item &it );
+        bool unload( item_location& loc );
 
         /**
          * Try to wield a contained item consuming moves proportional to weapon skill and volume.
@@ -489,6 +489,7 @@ class player : public Character
         /** last time we checked for sleep */
         time_point last_sleep_check = calendar::turn_zero;
         bool bio_soporific_powered_at_last_sleep_check;
+        bool unload_internal( item_location &loc );
 
     public:
         /** Returns a value from 1.0 to 5.0 that acts as a multiplier

--- a/src/player.h
+++ b/src/player.h
@@ -489,7 +489,6 @@ class player : public Character
         /** last time we checked for sleep */
         time_point last_sleep_check = calendar::turn_zero;
         bool bio_soporific_powered_at_last_sleep_check;
-        bool unload_internal( item_location loc );
 
     public:
         /** Returns a value from 1.0 to 5.0 that acts as a multiplier

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2114,7 +2114,8 @@ void vehicle::interact_with( const tripoint &pos, int interact_part )
             return;
         }
         case UNLOAD_TURRET: {
-            g->unload( *turret.base() );
+            item_location loc = turret.base();
+            g->unload( loc );
             return;
         }
         case RELOAD_TURRET: {

--- a/tests/reloading_test.cpp
+++ b/tests/reloading_test.cpp
@@ -101,7 +101,8 @@ TEST_CASE( "reload_gun_with_swappable_magazine", "[reload],[gun]" )
     REQUIRE( gun_pos != INT_MIN );
     item &glock = dummy.i_at( gun_pos );
     // We're expecting the magazine to end up in the inventory.
-    g->unload( glock );
+    item_location glock_loc( dummy, &glock );
+    REQUIRE( g->unload( glock_loc ) );
     int magazine_pos = dummy.inv.position_by_type( "glockmag" );
     REQUIRE( magazine_pos != INT_MIN );
     item &magazine = dummy.inv.find_item( magazine_pos );


### PR DESCRIPTION
Fix for Unloaded ammo belt doesn't disappear

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
Bugfixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/49
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->


#### Purpose of change
Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/49
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->


#### Describe the solution
Bug happens only if player Unloads ammo belt by using U command (not from inventory). But belt removal was used only for avatar action. Solution is move belt removal to player::unload.

Partially implementing this: https://github.com/CleverRaven/Cataclysm-DDA/pull/40541

Transofrm 

`bool player::unload( item &it)`
to
`bool player::unload( item_location loc )`

Do essesary modfications to all references

Add "MAG_DESTROY" item removal to magazine handling in
`bool player::unload( item_location loc )`

Remove "MAG_DESTROY" removal from
`avatar_action::unload( avatar &you )`

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Spawn 5.56x45mm ammo belt
2) Unload it from item menu and form U menu
3) In both cases you must get only ammo and linkages without emepty belt.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
