### PR TITLE
Fix (workaround) for Landmine does almost no damage

### DIFF
--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -618,6 +618,7 @@ static explosion_data get_basic_explosion_data()
     fragment.speed = 1000;
     fragment.impact.add_damage( DT_CUT, 80, 0, 3.0F );
     data.fragment = fragment;
+    return data;
 }
 
 bool trapfunc::landmine( const tripoint &p, Creature *c, item * )

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -617,7 +617,7 @@ bool trapfunc::landmine( const tripoint &p, Creature *c, item * )
         c->add_msg_player_or_npc( m_bad, _( "You trigger a land mine!" ),
                                   _( "<npcname> triggers a land mine!" ) );
     }
-    explosion_handler::explosion( p, 18, 0.5, false, 8 );
+    explosion_handler::explosion( p, get_basic_explosion_data() );
     g->m.remove_trap( p );
     return true;
 }
@@ -628,9 +628,22 @@ bool trapfunc::boobytrap( const tripoint &p, Creature *c, item * )
         c->add_msg_player_or_npc( m_bad, _( "You trigger a booby trap!" ),
                                   _( "<npcname> triggers a booby trap!" ) );
     }
-    explosion_handler::explosion( p, 18, 0.6, false, 12 );
+    explosion_handler::explosion( p, get_basic_explosion_data() );
     g->m.remove_trap( p );
     return true;
+}
+
+explosion_data get_basic_explosion_data()
+{
+    // equivalent of grenade explosion
+    explosion_data data;
+    data.damage = 40;
+    data.radius = 3;
+    projectile fragment;
+    fragment.range = 6;
+    fragment.speed = 1000;
+    fragment.impact.add_damage( DT_CUT, 80, 0, 3.0F );
+    data.fragment = fragment;
 }
 
 bool trapfunc::telepad( const tripoint &p, Creature *c, item * )

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -607,6 +607,19 @@ bool trapfunc::snare_heavy( const tripoint &p, Creature *c, item * )
     return true;
 }
 
+static explosion_data get_basic_explosion_data()
+{
+    // equivalent of grenade explosion
+    explosion_data data;
+    data.damage = 40;
+    data.radius = 3;
+    projectile fragment;
+    fragment.range = 6;
+    fragment.speed = 1000;
+    fragment.impact.add_damage( DT_CUT, 80, 0, 3.0F );
+    data.fragment = fragment;
+}
+
 bool trapfunc::landmine( const tripoint &p, Creature *c, item * )
 {
     // tiny animals are too light to trigger land mines
@@ -631,19 +644,6 @@ bool trapfunc::boobytrap( const tripoint &p, Creature *c, item * )
     explosion_handler::explosion( p, get_basic_explosion_data() );
     g->m.remove_trap( p );
     return true;
-}
-
-explosion_data get_basic_explosion_data()
-{
-    // equivalent of grenade explosion
-    explosion_data data;
-    data.damage = 40;
-    data.radius = 3;
-    projectile fragment;
-    fragment.range = 6;
-    fragment.speed = 1000;
-    fragment.impact.add_damage( DT_CUT, 80, 0, 3.0F );
-    data.fragment = fragment;
 }
 
 bool trapfunc::telepad( const tripoint &p, Creature *c, item * )


### PR DESCRIPTION
Fix (workaround) for Landmine does almost no damage

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
Bugfixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/60
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/60
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution

Connected issue:
https://github.com/CleverRaven/Cataclysm-DDA/issues/37724
>I believe you should check function trapfunc::landmine() at src/trapfunc.cpp:L605
It clearly uses same explosion() function but uses preset values so I think that landmine probably does not use JSON set values at all.

Confirmed. Landmine triggers:

```
bool trapfunc::landmine( const tripoint &p, Creature *c, item * )
{
    // tiny animals are too light to trigger land mines
    if( c != nullptr && c->get_size() == MS_TINY ) {
        return false;
    }
    if( c != nullptr ) {
        c->add_msg_player_or_npc( m_bad, _( "You trigger a land mine!" ),
                                  _( "<npcname> triggers a land mine!" ) );
    }
    explosion_handler::explosion( p, 18, 0.5, false, 8 );
    g->m.remove_trap( p );
    return true;
}
```
Explosive triggers with hardcoded values.

For now lets set explosion data to adequaete values. Used values from greande explosion.
Applied to boody trap as well.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Set a mine
2) Step on a mine
3) Observe damage. It should be comparable to grenade explosion. Previosly it barely did any damage due bug.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
