### PR TITLE
Restore atomic car and bubble car

### DIFF
--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -57,7 +57,9 @@
       [ "food_truck", 50 ],
       [ "wienermobile", 5 ],
       [ "tatra_truck", 100 ],
-      [ "4x4_car", 500 ]
+      [ "4x4_car", 500 ],
+      [ "car_sports_atomic", 15 ],
+      [ "bubble_car", 20 ]
     ]
   },
   {
@@ -240,7 +242,8 @@
       [ "food_truck", 20 ],
       [ "wienermobile", 5 ],
       [ "portable_generator", 50 ],
-      [ "4x4_car", 200 ]
+      [ "4x4_car", 200 ],
+      [ "bubble_car", 50 ]
     ]
   },
   {
@@ -529,7 +532,8 @@
       [ "suv_electric", 70 ],
       [ "rara_x", 40 ],
       [ "car_sports", 30 ],
-      [ "car_sports_electric", 20 ]
+      [ "car_sports_electric", 20 ],
+      [ "car_sports_atomic", 5 ]
     ]
   },
   {
@@ -614,7 +618,8 @@
       [ "motorcycle_enduro", 50 ],
       [ "superbike", 50 ],
       [ "motorcycle_sidecart", 50 ],
-      [ "car_sports", 30 ]
+      [ "car_sports", 30 ],
+      [ "car_sports_atomic", 5 ]
     ]
   },
   {


### PR DESCRIPTION
Restore atomic car and bubble car.
https://github.com/cataclysmbnteam/Cataclysm-BN/issues/59#issuecomment-694273374

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
Restore atomic car and bubble car.
SUMMARY: [Content] "[Restore atomic car and bubble car]"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Restoring removed content. Bubble car was restored as well, since it is bacically on the same level of  atomic car.
https://github.com/cataclysmbnteam/Cataclysm-BN/issues/59#issuecomment-694273374
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Atomic cars and buble cars were still in game jsons and was not obsoleted. I've just needed to add this cars back to spawn.
Reactors appears operational. Reloading via plutonium cells working.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game loads correctly
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
