### PR TITLE
Rename Schizophrenic

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1077,9 +1077,9 @@
   {
     "type": "mutation",
     "id": "SCHIZOPHRENIC",
-    "name": { "str": "Schizophrenic" },
+    "name": { "str": "Kaluptic Psychosis" },
     "points": -3,
-    "description": "You will periodically suffer from delusions, ranging from minor effects to full visual hallucinations.  Some of these effects may be controlled through the use of Thorazine.",
+    "description": "Ever since the sky first broke you have felt unwell, with your head split by alien thoughts.  You will periodically suffer from delusions, ranging from minor effects to full visual hallucinations.  Some of these effects may be controlled through the use of Thorazine.",
     "starting_trait": true,
     "valid": false,
     "category": [ "MEDICAL" ]


### PR DESCRIPTION
(cherry picked from commit [7f91078d142424d3ae3a3b1621fd42dc3da72e3b](https://github.com/CleverRaven/Cataclysm-DDA/pull/43195) from main CDDA branch)

#### Summary
SUMMARY: Content "Rename Schizophrenic"

#### Purpose of change

With Candlebury's blessing, I'm requesting the rename of Schizophrenic into something more fictional. It's a highly inaccurate representation of what schizophrenia actually is, and we don't really need to contribute to that stereotype.

#### Describe the solution

It's just a rename to `Kaluptic Psychosis`. The name origin being "kaluptic being some sort of bastardization of kalúptō, which is half of the greek word for apocalypse".

#### Describe alternatives you've considered

Use a different name, leaving it alone, removing it entirely (???)

#### Testing

It works
