### PR TITLE
Remove lockpicking skill

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -384,7 +384,6 @@
       { "level": 2, "name": "gun" },
       { "level": 2, "name": "rifle" },
       { "level": 2, "name": "melee" },
-      { "level": 2, "name": "lockpick" },
       { "level": 2, "name": "cutting" },
       { "level": 1, "name": "bashing" }
     ],
@@ -611,8 +610,7 @@
       { "level": 1, "name": "stabbing" },
       { "level": 1, "name": "unarmed" },
       { "level": 1, "name": "dodge" },
-      { "level": 1, "name": "barter" },
-      { "level": 1, "name": "lockpick" }
+      { "level": 1, "name": "barter" }
     ],
     "items": {
       "both": {
@@ -789,7 +787,6 @@
       { "level": 2, "name": "cutting" },
       { "level": 2, "name": "melee" },
       { "level": 2, "name": "dodge" },
-      { "level": 2, "name": "lockpick" },
       { "level": 1, "name": "firstaid" },
       { "level": 1, "name": "swimming" },
       { "level": 1, "name": "survival" }
@@ -1012,8 +1009,7 @@
       { "level": 2, "name": "fabrication" },
       { "level": 2, "name": "cooking" },
       { "level": 2, "name": "firstaid" },
-      { "level": 2, "name": "swimming" },
-      { "level": 1, "name": "lockpick" }
+      { "level": 2, "name": "swimming" }
     ],
     "items": {
       "both": {
@@ -1492,7 +1488,7 @@
     "name": { "male": "Handy Man", "female": "Handy Woman" },
     "description": "You used to work at a local hardware store, and you did a lot of home renovations yourself.  Now you look out at the horizon of a ruined world, and wonder - are your meager skills, and the few supplies you grabbed on the way out, sufficient to help it rebuild?",
     "points": 1,
-    "skills": [ { "level": 2, "name": "fabrication" }, { "level": 1, "name": "lockpick" } ],
+    "skills": [ { "level": 2, "name": "fabrication" } ],
     "items": {
       "both": {
         "items": [ "tank_top", "socks", "boots_steel", "pants", "multitool", "wristwatch" ],
@@ -1670,7 +1666,7 @@
     "description": "You have done many high profile heists, but your gains mean nothing in this world.  All you have left are the tools of your trade and your impeccable style.",
     "points": 4,
     "CBMs": [ "bio_batteries", "bio_lockpick", "bio_fingerhack", "bio_power_storage_mkII" ],
-    "skills": [ { "level": 1, "name": "gun" }, { "level": 1, "name": "smg" }, { "level": 3, "name": "lockpick" } ],
+    "skills": [ { "level": 1, "name": "gun" }, { "level": 1, "name": "smg" } ],
     "items": {
       "both": {
         "items": [ "waistcoat", "pants", "dress_shirt", "socks", "dress_shoes", "knit_scarf", "gold_watch", "smart_phone" ],
@@ -2427,7 +2423,7 @@
     "name": "Convict",
     "description": "The Cataclysm gave you a chance to escape, but freedom comes with a steep price.",
     "points": 0,
-    "skills": [ { "level": 1, "name": "melee" }, { "level": 1, "name": "lockpick" } ],
+    "skills": [ { "level": 1, "name": "melee" } ],
     "items": {
       "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "glass_shiv" ],
       "male": [ "briefs" ],
@@ -2517,8 +2513,7 @@
     "ident": "burglar",
     "name": "Burglar",
     "description": "You thought this would be your lucky break.  Does it count as breaking and entering if everyone in town is undead?",
-    "points": 3,
-    "skills": [ { "level": 4, "name": "lockpick" } ],
+    "points": 1,
     "//": "A ski mask would fit the stereotype better, but wool allergy breaks this.",
     "items": {
       "both": [
@@ -3404,8 +3399,7 @@
     "skills": [
       { "level": 1, "name": "survival" },
       { "level": 1, "name": "fabrication" },
-      { "level": 1, "name": "firstaid" },
-      { "level": 1, "name": "lockpick" }
+      { "level": 1, "name": "firstaid" }
     ],
     "items": {
       "both": {

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3396,11 +3396,7 @@
     "name": "Survivalist Jr.",
     "description": "Your parents were crazy preppers who thought some \"Cataclysm\" was coming, and insisted on preparing you for it.  Turns out they were right.  You didn't get a chance to thank them.  The only thing you can do for them now is what they always hoped you would do in the dark days ahead: survive.",
     "points": 3,
-    "skills": [
-      { "level": 1, "name": "survival" },
-      { "level": 1, "name": "fabrication" },
-      { "level": 1, "name": "firstaid" }
-    ],
+    "skills": [ { "level": 1, "name": "survival" }, { "level": 1, "name": "fabrication" }, { "level": 1, "name": "firstaid" } ],
     "items": {
       "both": {
         "items": [

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -212,7 +212,6 @@ static const skill_id skill_computer( "computer" );
 static const skill_id skill_electronics( "electronics" );
 static const skill_id skill_fabrication( "fabrication" );
 static const skill_id skill_firstaid( "firstaid" );
-static const skill_id skill_lockpick( "lockpick" );
 static const skill_id skill_mechanics( "mechanics" );
 static const skill_id skill_survival( "survival" );
 
@@ -2581,14 +2580,12 @@ void activity_handlers::lockpicking_finish( player_activity *act, player *p )
 
     /** @EFFECT_DEX improves chances of successfully picking door lock, reduces chances of bad outcomes */
     /** @EFFECT_MECHANICS improves chances of successfully picking door lock, reduces chances of bad outcomes */
-    /** @EFFECT_LOCKPICK greatly improves chances of successfully picking door lock, reduces chances of bad outcomes */
-    int pick_roll = std::pow( 1.5, p->get_skill_level( skill_lockpick ) ) *
+    int pick_roll = 5 *
                     ( std::pow( 1.3, p->get_skill_level( skill_mechanics ) ) +
                       it->get_quality( qual_LOCKPICK ) - it->damage() / 2000.0 ) +
                     p->dex_cur / 4.0;
     int lock_roll = rng( 1, 120 );
     if( pick_roll >= lock_roll ) {
-        p->practice( skill_lockpick, lock_roll );
         g->m.has_furn( act->placement ) ?
         g->m.furn_set( act->placement, new_furn_type ) :
         static_cast<void>( g->m.ter_set( act->placement, new_ter_type ) );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -112,7 +112,6 @@ static const skill_id skill_cooking( "cooking" );
 static const skill_id skill_electronics( "electronics" );
 static const skill_id skill_fabrication( "fabrication" );
 static const skill_id skill_firstaid( "firstaid" );
-static const skill_id skill_lockpick( "lockpick" );
 static const skill_id skill_mechanics( "mechanics" );
 static const skill_id skill_survival( "survival" );
 


### PR DESCRIPTION
Lockpick skill removed. Will cause debugmsgs if mods use it.

Numbers are not tested and need tweaking. More precisely, an idea of how hard should lockpicking be.