### PR TITLE
Fix Mess kit cannot be used for boiling when loaded with batteries

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4946,7 +4946,7 @@ int item::get_quality( const quality_id &id ) const
         return false;
     };
     if( id == quality_id( "BOIL" ) && ( !contents.empty() ||
-                                         ( is_tool() && !has_item_with( boil_filter ) ) ) ) {
+                                        ( is_tool() && !has_item_with( boil_filter ) ) ) ) {
         return INT_MIN;
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4945,7 +4945,7 @@ int item::get_quality( const quality_id &id ) const
         }
         return false;
     };
-    if( id == quality_id( "BOIL" ) && !( contents.empty() ||
+    if( id == quality_id( "BOIL" ) && ( !contents.empty() ||
                                          ( is_tool() && !has_item_with( boil_filter ) ) ) ) {
         return INT_MIN;
     }


### PR DESCRIPTION
Fix Mess kit cannot be used for boiling when loaded with batteries

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfix "[Fix Mess kit cannot be used for boiling when loaded with batteries]"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/75
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->
Before
```
   if( id == quality_id( "BOIL" ) && !( contents.empty() ||
                                         ( is_tool() && !has_item_with( boil_filter ) ) ) ) {
        return INT_MIN;
    }
```
After
```
   if( id == quality_id( "BOIL" ) && ( !contents.empty() ||
                                         ( is_tool() && !has_item_with( boil_filter ) ) ) ) {
        return INT_MIN;
    }
```
Proper logic is 
```
if (Can Boil  AND ( It is not empty OR (It is tool AND  It contains something else rather then its ammo) ) )
then
   Do not Boil
```
Maybe it was just a typo with "!"

Looks like

`has_item_with( boil_filter )`
was ok

#### Describe alternatives you've considered
This case could be potentially dropped for QOL measures. We can pretend that player temporary storing contents of boiling container elsewhere while using it for boiling.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Obtain mess kit and battery, load mess kit.
2) Make sure there are no other boiling tools nearby.
3) Open crafting menu, examine a recipe that requires boiling (e.g. clean water). 
4) Boiling should be availible

Additnally try to boil with non emepty container that can boil (like filled steel bottle). Boiling with non emepty boiling container should not be possible as before

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
