### PR TITLE
[CR]Medical zombies

### DIFF
--- a/data/json/monster_attacks.json
+++ b/data/json/monster_attacks.json
@@ -66,6 +66,31 @@
     "no_dmg_msg_npc": "The %1$s tries to slam into <npcname>, but fails to."
   },
   {
+    "type": "monster_attack",
+    "attack_type": "melee",
+    "id": "inject",
+    "cooldown": 1,
+    "move_cost": 200,
+    "damage_max_instance": [ { "damage_type": "stab", "amount": 5, "armor_multiplier": 0.25 } ],
+    "body_parts": [
+      [ "FOOT_L", 2 ],
+      [ "FOOT_R", 2 ],
+      [ "LEG_L", 3 ],
+      [ "LEG_R", 3 ],
+      [ "HAND_L", 2 ],
+      [ "HAND_R", 2 ],
+      [ "HEAD", 3 ],
+      [ "ARM_L", 3 ],
+      [ "ARM_R", 3 ],
+      [ "TORSO", 8 ]
+    ],
+    "effects": [ { "id": "bleed", "duration": 10, "affect_hit_bp": true }, { "id": "poison", "duration": 30, "bp": "TORSO" } ],
+    "hit_dmg_u": "The %1$s stabs you!",
+    "hit_dmg_npc": "The %1$s stabs <npcname>!",
+    "no_dmg_msg_u": "The %1$s tries to stab you, but fails to penetrate your armor.",
+    "no_dmg_msg_npc": "The %1$s tries to stab <npcname>, but fails to penetrate their armor!."
+  },
+  {
     "id": "acid_spray",
     "type": "GUN",
     "copy-from": "fake_item",

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -105,6 +105,7 @@
       { "monster": "mon_beekeeper", "freq": 1, "cost_multiplier": 5 },
       { "monster": "mon_zombie_technician", "freq": 1, "cost_multiplier": 12 },
       { "monster": "mon_zombie_runner", "freq": 20, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_zombie_nurse", "freq": 25, "cost_multiplier": 3, "pack_size": [ 1, 2 ] },
       { "monster": "mon_zombie_brainless", "freq": 65, "cost_multiplier": 1 }
     ]
   },
@@ -202,6 +203,7 @@
       { "monster": "mon_zombie_static", "freq": 30, "cost_multiplier": 5 },
       { "monster": "mon_zombie_survivor", "freq": 1, "cost_multiplier": 25 },
       { "monster": "mon_zombie_survivor_elite", "freq": 1, "cost_multiplier": 25, "starts": 1440 },
+      { "monster": "mon_zombie_nurse", "freq": 50, "cost_multiplier": 2 },
       { "monster": "mon_zombie_runner", "freq": 130, "cost_multiplier": 3 }
     ]
   },
@@ -339,7 +341,8 @@
       { "monster": "mon_zombie_brute", "freq": 23, "cost_multiplier": 15 },
       { "monster": "mon_zombie_master", "freq": 2, "cost_multiplier": 30 },
       { "monster": "mon_zombie_hollow", "freq": 3, "cost_multiplier": 10 },
-      { "monster": "mon_zombie_thorny", "freq": 13, "cost_multiplier": 5 }
+      { "monster": "mon_zombie_thorny", "freq": 13, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_nurse", "freq": 10, "cost_multiplier": 3 }
     ]
   },
   {
@@ -492,6 +495,7 @@
       { "monster": "mon_beekeeper", "freq": 1, "cost_multiplier": 5 },
       { "monster": "mon_zombie_technician", "freq": 1, "cost_multiplier": 12 },
       { "monster": "mon_zombie_runner", "freq": 20, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_zombie_nurse", "freq": 50, "cost_multiplier": 4, "pack_size": [ 2, 3 ] },
       { "monster": "mon_zombie_brainless", "freq": 55, "cost_multiplier": 1 }
     ]
   },
@@ -541,7 +545,8 @@
       { "monster": "mon_zombie_cop", "freq": 250, "cost_multiplier": 2 },
       { "monster": "mon_zombie_swat", "freq": 125, "cost_multiplier": 2 },
       { "monster": "mon_zombie", "freq": 150, "cost_multiplier": 1 },
-      { "monster": "mon_zombie_swimmer", "freq": 100, "cost_multiplier": 2 }
+      { "monster": "mon_zombie_swimmer", "freq": 100, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_nurse", "freq": 10, "cost_multiplier": 2 }
     ]
   },
   {

--- a/data/json/monsters/zed_medical.json
+++ b/data/json/monsters/zed_medical.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "mon_zombie_nurse",
+    "type": "MONSTER",
+    "name": { "str": "nurse" },
+    "description": "Instead of one of its forearms, this zombie has a muscular tube ending in a stinger that is moist with stringy slime.  It is single-mindedly focused on using just that one limb to fight.",
+    "default_faction": "zombie",
+    "bodytype": "human",
+    "categories": [ "CLASSIC" ],
+    "species": [ "ZOMBIE", "HUMAN" ],
+    "volume": "62500 ml",
+    "weight": "81500 g",
+    "hp": 100,
+    "speed": 110,
+    "material": [ "flesh" ],
+    "symbol": "Z",
+    "color": "green_white",
+    "aggression": 100,
+    "morale": 100,
+    "melee_skill": 3,
+    "armor_acid": 4,
+    "vision_night": 3,
+    "harvest": "zombie",
+    "path_settings": { "max_dist": 3 },
+    "special_attacks": [ { "id": "inject" } ],
+    "death_drops": "default_zombie_death_drops",
+    "death_function": [ "NORMAL" ],
+    "burn_into": "mon_zombie_scorched",
+    "upgrades": { "half_life": 14, "into": "mon_zombie_surgeon" },
+    "flags": [ "SEES", "HEARS", "WARM", "POISON", "BLEED", "NO_BREATHE", "REVIVES", "FILTHY" ]
+  },
+  {
+    "id": "mon_zombie_surgeon",
+    "type": "MONSTER",
+    "copy-from": "mon_zombie_nurse",
+    "name": { "str": "surgeon" },
+    "description": "A dripping stinger where one hand would be, a set of razor-like claws in place of the other one.  This zombie's cold, focused eyes look down at you from above a \"mask\" of melded flesh.",
+    "default_faction": "zombie",
+    "hp": 200,
+    "color": "light_green_white",
+    "melee_skill": 4,
+    "armor_acid": 10,
+    "vision_day": 45,
+    "vision_night": 5,
+    "harvest": "zombie",
+    "path_settings": { "max_dist": 5 },
+    "special_attacks": [
+      {
+        "id": "scratch",
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 24, "armor_multiplier": 2 } ],
+        "effects": [ { "id": "bleed", "duration": 100, "affect_hit_bp": true } ]
+      },
+      { "id": "inject", "move_cost": 50, "effects": [ { "id": "poison", "duration": 90, "bp": "TORSO" } ] }
+    ],
+    "upgrades": { "half_life": 14, "into": "mon_zombie_vivisector" }
+  },
+  {
+    "id": "mon_zombie_vivisector",
+    "type": "MONSTER",
+    "copy-from": "mon_zombie_surgeon",
+    "name": { "str": "vivisector" },
+    "description": "This humanoid has a long bone \"syringe\" in place of one forearm, a large saw as the opposing hand, and a pair of digitigrade legs ending in raptor-like feet.  Its head is featureless, except for its \"human\" eyes, which smile with inhuman malice and scorn.",
+    "default_faction": "zombie",
+    "color": "light_green_white",
+    "melee_skill": 5,
+    "armor_stab": 6,
+    "armor_acid": 20,
+    "vision_day": 50,
+    "vision_night": 10,
+    "harvest": "zombie",
+    "path_settings": { "max_dist": 10 },
+    "special_attacks": [
+      { "type": "leap", "cooldown": 5, "max_range": 5, "max_consider_range": 5, "move_cost": 0 },
+      {
+        "id": "scratch",
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 30, "armor_multiplier": 2 } ],
+        "effects": [ { "id": "bleed", "duration": 500, "affect_hit_bp": true } ]
+      },
+      {
+        "id": "inject",
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 5, "armor_multiplier": 0.2 }, { "damage_type": "acid", "amount": 5 } ],
+        "effects": [ { "id": "poison", "duration": 90, "bp": "TORSO" }, { "id": "badpoison", "duration": 30, "bp": "TORSO" } ]
+      }
+    ],
+    "upgrades": false
+  }
+]


### PR DESCRIPTION
A new tree of zombie evolution:
* Nurse - walks fast, but attacks (injects) once per ~1.9 turn, causing low armor-piercing damage, light bleeding and poison. Can't bash, no armor except vs acid. Can't smell (nurse is too "mechanical" mentally, surgeon has no face).
* Surgeon - as nurse, but better. Injects once per turn, then (once per 20 turns) scratches for high damage and some bleed but armor is doubled against this attack.
* Vivisector - Surgeon but with stats and attacks boosted, zero movecost leap added, inject having stronger poison, and light stab armor.

Overall they are closer to support than main damage dealing force.
Bad armor and no dodge means even a mediocre combatant may be able to kill one in melee (8/8/8/8+3 skills+knife spear+hoodie/jeans was able to kill a Vivisector), but heavy debuffs it applies will make subsequent fights tougher for few minutes.