### PR TITLE
Display contained items like "water (plastic bottle)" instead of "plastic bottle of water"

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4207,16 +4207,13 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         maintext += string_format( " (%d%%)", percent_progress );
     } else if( contents.num_item_stacks() == 1 ) {
         const item &contents_item = contents.front();
-        if( contents_item.made_of( LIQUID ) || contents_item.is_food() ) {
-            const unsigned contents_count = contents_item.charges > 1 ? contents_item.charges : quantity;
-            //~ %1$s: item name, %2$s: content liquid, food, or drink name
-            maintext = string_format( pgettext( "item name", "%1$s of %2$s" ), label( quantity ),
-                                      contents_item.tname( contents_count, with_prefix ) );
-        } else {
-            //~ %1$s: item name, %2$s: non-liquid, non-food, non-drink content item name
-            maintext = string_format( pgettext( "item name", "%1$s with %2$s" ), label( quantity ),
-                                      contents_item.tname( quantity, with_prefix ) );
-        }
+        const unsigned contents_count =
+            ( ( contents_item.made_of( LIQUID ) || contents_item.is_food() ) &&
+              contents_item.charges > 1 )
+            ? contents_item.charges
+            : quantity;
+        maintext = string_format( pgettext( "item name", "%2$s (%1$s)" ), label( quantity ),
+                                  contents_item.tname( contents_count, with_prefix ) );
     } else if( !contents.empty() ) {
         maintext = string_format( npgettext( "item name",
                                              //~ %1$s: item name, %2$zd: content size


### PR DESCRIPTION
#### Summary

SUMMARY: Interface "Display contained items like 'water (plastic bottle)' instead of 'plastic bottle of water'"

#### Purpose of change

The way item names are displayed currently puts the container of an item before the contained item. When the display is relatively narrow (e.g., you have low vision like me, so you use huge fonts), this leaves relatively few characters for the contained item in contexts where item names are truncated. Generally, the content is more important than the container.

#### Describe the solution

The container now comes after the content in item names. For plurals, this works out as "2 clean water (plastic bottles)".

#### Describe alternatives you've considered

It might be nice to use this form for lists (like the inventory or the `X` command) and the old, more prose-like form for running text (like the message log). But I don't know if Cata already has any support to display different item names in these two contexts.