### PR TITLE
Rename "housecoat" to "bathrobe" and add some description.

### DIFF
--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -376,8 +376,8 @@
   {
     "id": "house_coat",
     "type": "ARMOR",
-    "name": { "str": "housecoat" },
-    "description": "Makes you wish you had running water to take a shower.",
+    "name": { "str": "bathrobe" },
+    "description": "An outer garment of absorbent, towel-like material traditionally worn to cover one's nakedness to and from the bath.  It makes you wish you had running water to bathe with.",
     "weight": "580 g",
     "volume": "2 L",
     "price": 2200,


### PR DESCRIPTION
(Copy of https://github.com/CleverRaven/Cataclysm-DDA/pull/44553)

#### Summary

SUMMARY: Balance "Rename 'housecoat' to 'bathrobe' and add some description."

#### Purpose of change

"Bathrobe" is the much more common term, judging by Google Ngrams and Google Trends.