### PR TITLE
Make vehicles outside of garages and showrooms slightly damaged

### DIFF
--- a/data/json/mapgen/bus_station.json
+++ b/data/json/mapgen/bus_station.json
@@ -94,8 +94,8 @@
       },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 3, 17 ], "y": [ 13, 15 ] } ],
       "place_vehicles": [
-        { "vehicle": "buses", "x": 35, "y": [ 6, 7 ], "chance": 35, "status": 0, "rotation": 360 },
-        { "vehicle": "buses", "x": 35, "y": [ 16, 17 ], "chance": 35, "status": 0, "rotation": 360 }
+        { "vehicle": "buses", "x": 35, "y": [ 6, 7 ], "chance": 35, "rotation": 360 },
+        { "vehicle": "buses", "x": 35, "y": [ 16, 17 ], "chance": 35, "rotation": 360 }
       ],
       "vendingmachines": { "8": { "item_group": "vending_drink" }, "9": { "item_group": "vending_food" } },
       "toilets": { "T": {  } }

--- a/data/json/mapgen/campground.json
+++ b/data/json/mapgen/campground.json
@@ -31,7 +31,7 @@
       "place_vehicles": [
         { "chance": 25, "fuel": 15, "rotation": 270, "status": -1, "vehicle": "campground_vehicles", "x": 16, "y": 2 },
         { "chance": 25, "fuel": -1, "rotation": 180, "status": -1, "vehicle": "campground_vehicles", "x": 5, "y": 19 },
-        { "chance": 50, "fuel": 20, "rotation": 0, "status": 0, "vehicle": "lux_rv", "x": 43, "y": 18 },
+        { "chance": 50, "fuel": 20, "rotation": 0, "status": -1, "vehicle": "lux_rv", "x": 43, "y": 18 },
         {
           "chance": 25,
           "fuel": 15,

--- a/data/json/mapgen/campground_npc.json
+++ b/data/json/mapgen/campground_npc.json
@@ -18,7 +18,7 @@
       "place_vehicles": [
         { "chance": 5, "fuel": 15, "rotation": 270, "status": -1, "vehicle": "campground_vehicles", "x": 16, "y": 2 },
         { "chance": 5, "fuel": -1, "rotation": 180, "status": -1, "vehicle": "campground_vehicles", "x": 5, "y": 19 },
-        { "chance": 20, "fuel": 20, "rotation": 0, "status": 0, "vehicle": "lux_rv", "x": 43, "y": 18 },
+        { "chance": 20, "fuel": 20, "rotation": 0, "status": -1, "vehicle": "lux_rv", "x": 43, "y": 18 },
         { "chance": 5, "fuel": 15, "rotation": 180, "status": -1, "vehicle": "campground_vehicles", "x": 26, "y": 14 },
         { "chance": 5, "fuel": 15, "rotation": 360, "status": -1, "vehicle": "campground_vehicles", "x": 18, "y": 32 },
         { "chance": 5, "fuel": -1, "rotation": 0, "status": -1, "vehicle": "campground_vehicles", "x": 7, "y": 34 },

--- a/data/json/mapgen/construction_site.json
+++ b/data/json/mapgen/construction_site.json
@@ -62,7 +62,7 @@
         { "item": "hardware_trash", "x": 22, "y": 4, "chance": 15 },
         { "item": "hardware_trash", "x": 6, "y": 1, "chance": 15 }
       ],
-      "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 11, "y": 22, "chance": 50, "fuel": 20, "status": 0 } ]
+      "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 11, "y": 22, "chance": 50, "fuel": 20 } ]
     }
   },
   {
@@ -126,7 +126,7 @@
         { "item": "tools_construction", "x": 11, "y": 12, "chance": 20 },
         { "item": "hardware_trash", "x": 22, "y": [ 18, 19 ], "chance": 35 }
       ],
-      "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 12, "y": 2, "chance": 50, "fuel": 20, "status": 0, "rotation": 270 } ]
+      "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 12, "y": 2, "chance": 50, "fuel": 20, "rotation": 270 } ]
     }
   },
   {
@@ -194,7 +194,7 @@
         { "item": "hardware_trash", "x": [ 13, 14 ], "y": 21, "chance": 35 }
       ],
       "place_item": [ { "item": "2x4", "x": 9, "y": 16 }, { "item": "2x4", "x": 10, "y": 16 }, { "item": "2x4", "x": 11, "y": 16 } ],
-      "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 14, "y": 2, "chance": 50, "fuel": 20, "status": 0 } ]
+      "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 14, "y": 2, "chance": 50, "fuel": 20 } ]
     }
   },
   {
@@ -272,7 +272,7 @@
         { "item": "clothing_work_hat", "x": 21, "y": 13, "chance": 25 },
         { "item": "hardware_trash", "x": 10, "y": 14, "chance": 45 }
       ],
-      "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 17, "y": 2, "chance": 50, "fuel": 20, "status": 0, "rotation": 270 } ]
+      "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 17, "y": 2, "chance": 50, "fuel": 20, "rotation": 270 } ]
     }
   },
   {
@@ -411,7 +411,7 @@
         { "item": "tools_construction", "x": 9, "y": 20, "chance": 25 },
         { "item": "tools_carpentry", "x": 9, "y": 19, "chance": 25 }
       ],
-      "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 16, "y": 2, "chance": 50, "fuel": 20, "status": 0, "rotation": 270 } ]
+      "place_vehicles": [ { "vehicle": "small_utility_vehicles", "x": 16, "y": 2, "chance": 50, "fuel": 20, "rotation": 270 } ]
     }
   },
   {

--- a/data/json/mapgen/daycare.json
+++ b/data/json/mapgen/daycare.json
@@ -91,10 +91,7 @@
         { "monster": "GROUP_SCHOOL", "x": [ 3, 7 ], "y": [ 12, 16 ] },
         { "monster": "GROUP_SCHOOL", "x": [ 3, 10 ], "y": [ 4, 8 ] }
       ],
-      "place_vehicles": [
-        { "vehicle": "tricycle", "x": 12, "y": 17, "chance": 5, "status": 0 },
-        { "vehicle": "tricycle", "x": 2, "y": 10, "chance": 15, "status": 0 }
-      ]
+      "place_vehicles": [ { "vehicle": "tricycle", "x": 12, "y": 17, "chance": 5 }, { "vehicle": "tricycle", "x": 2, "y": 10, "chance": 15 } ]
     }
   },
   {

--- a/data/json/mapgen/farm_dairy.json
+++ b/data/json/mapgen/farm_dairy.json
@@ -161,7 +161,7 @@
       "place_vehicles": [
         { "vehicle": "cube_van_cheap", "x": 7, "y": 5, "chance": 50, "fuel": 300, "status": -1, "rotation": 0 },
         { "vehicle": "quad_bike", "x": 15, "y": 6, "chance": 30, "fuel": 200, "status": -1, "rotation": 0 },
-        { "vehicle": "bicycle", "x": 13, "y": 8, "chance": 80, "fuel": 0, "status": 0, "rotation": 0 }
+        { "vehicle": "bicycle", "x": 13, "y": 8, "chance": 80, "fuel": 0, "status": -1, "rotation": 0 }
       ]
     }
   },

--- a/data/json/mapgen/jewel_store.json
+++ b/data/json/mapgen/jewel_store.json
@@ -88,7 +88,7 @@
         "L": { "item": "jackets", "chance": 20 },
         "9": { "item": "softdrugs", "chance": 20 }
       },
-      "place_vehicles": [ { "vehicle": "security_van", "x": 11, "y": 2, "chance": 20, "fuel": 20, "status": 0, "rotation": 0 } ]
+      "place_vehicles": [ { "vehicle": "security_van", "x": 11, "y": 2, "chance": 20, "fuel": 20, "rotation": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/lot_empty_commercial.json
+++ b/data/json/mapgen/lot_empty_commercial.json
@@ -77,8 +77,8 @@
         { "chance": 25, "item": "trash", "x": 20, "y": 7 }
       ],
       "place_vehicles": [
-        { "chance": 75, "fuel": 0, "rotation": 180, "status": 0, "vehicle": "food_cart", "x": 20, "y": 17 },
-        { "chance": 75, "fuel": 0, "rotation": 270, "status": 0, "vehicle": "food_cart", "x": 6, "y": 19 }
+        { "chance": 75, "rotation": 180, "vehicle": "food_cart", "x": 20, "y": 17 },
+        { "chance": 75, "rotation": 270, "vehicle": "food_cart", "x": 6, "y": 19 }
       ],
       "rows": [
         "...._..._..._..._....g_.",

--- a/data/json/mapgen/park_skate.json
+++ b/data/json/mapgen/park_skate.json
@@ -58,7 +58,7 @@
         { "vehicle": "bicycle", "x": 10, "y": 7, "chance": 3, "status": 0, "rotation": 270 },
         { "vehicle": "bicycle", "x": 17, "y": 8, "chance": 2, "status": 0, "rotation": 180 },
         { "vehicle": "scooter", "x": 16, "y": 12, "chance": 5 },
-        { "vehicle": "bicycle", "x": 16, "y": 19, "chance": 7, "status": 0 }
+        { "vehicle": "bicycle", "x": 16, "y": 19, "chance": 7 }
       ]
     }
   }

--- a/data/json/mapgen/pizza_parlor.json
+++ b/data/json/mapgen/pizza_parlor.json
@@ -276,7 +276,7 @@
         "T": { "item": "pizza_table", "chance": 25 },
         "c": { "item": "pizza_soda", "chance": 25 }
       },
-      "place_vehicles": [ { "vehicle": "bicycle", "x": [ 1, 3 ], "y": [ 20, 23 ], "chance": 35, "status": 0, "rotation": 270 } ]
+      "place_vehicles": [ { "vehicle": "bicycle", "x": [ 1, 3 ], "y": [ 20, 23 ], "chance": 35, "rotation": 270 } ]
     }
   },
   {

--- a/data/json/mapgen/post_office.json
+++ b/data/json/mapgen/post_office.json
@@ -100,7 +100,7 @@
       ],
       "place_vehicles": [
         { "vehicle": "beetle", "x": 3, "y": 3, "chance": 10, "fuel": 10, "rotation": 270 },
-        { "vehicle": "motorcycle_sidecart", "x": 8, "y": 4, "chance": 25, "fuel": 15, "status": 0, "rotation": 270 },
+        { "vehicle": "motorcycle_sidecart", "x": 8, "y": 4, "chance": 25, "fuel": 15, "rotation": 270 },
         { "vehicle": "shopping_cart", "x": 8, "y": 20, "chance": 50 },
         { "vehicle": "shopping_cart", "x": 14, "y": 22, "chance": 50 }
       ]

--- a/data/json/mapgen/public_works.json
+++ b/data/json/mapgen/public_works.json
@@ -135,7 +135,7 @@
         { "monster": "GROUP_PUBLICWORKERS", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 1, 2 ], "density": 0.3 },
         { "monster": "GROUP_PUBLICWORKERS", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 1, 2 ], "density": 0.1 }
       ],
-      "place_vehicles": [ { "vehicle": "industrial_vehicles", "x": 24, "y": 10, "chance": 50, "fuel": 0, "status": 0, "rotation": 90 } ]
+      "place_vehicles": [ { "vehicle": "industrial_vehicles", "x": 24, "y": 10, "chance": 50, "fuel": 0, "rotation": 90 } ]
     }
   },
   {

--- a/data/json/mapgen/school_1.json
+++ b/data/json/mapgen/school_1.json
@@ -99,7 +99,7 @@
         { "monster": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 49, 70 ], "repeat": [ 1, 2 ], "density": 0.1 }
       ],
       "place_monster": [ { "monster": [ "mon_nursebot", "mon_nursebot_defective" ], "x": [ 27, 33 ], "y": [ 20, 23 ], "chance": 50 } ],
-      "place_vehicles": [ { "vehicle": "school_vehicles", "x": 9, "y": 7, "chance": 25, "fuel": 0, "status": 0, "rotation": 0 } ]
+      "place_vehicles": [ { "vehicle": "school_vehicles", "x": 9, "y": 7, "chance": 25, "rotation": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/ws_biker_dump.json
+++ b/data/json/mapgen/ws_biker_dump.json
@@ -100,14 +100,14 @@
         "w": { "item": "oa_ig_rd_metal_trash", "chance": 45 }
       },
       "place_vehicles": [
-        { "vehicle": "motorcycle", "x": 56, "y": 16, "rotation": 180, "chance": 50, "status": 0 },
-        { "vehicle": "motorcycle_cross", "x": 56, "y": 18, "rotation": 180, "chance": 50, "status": 0 },
-        { "vehicle": "motorcycle_enduro", "x": 56, "y": 20, "rotation": 180, "chance": 50, "status": 0 },
-        { "vehicle": "superbike", "x": 56, "y": 22, "rotation": 180, "chance": 50, "status": 0 },
-        { "vehicle": "motorcycle_sidecart", "x": 66, "y": 16, "rotation": 180, "chance": 50, "status": 0 },
-        { "vehicle": "scooter", "x": 64, "y": 18, "rotation": 180, "chance": 50, "status": 0 },
-        { "vehicle": "motorcycle", "x": 64, "y": 20, "rotation": 180, "chance": 50, "status": 0 },
-        { "vehicle": "motorcycle", "x": 64, "y": 22, "rotation": 180, "chance": 50, "status": 0 }
+        { "vehicle": "motorcycle", "x": 56, "y": 16, "rotation": 180, "chance": 50 },
+        { "vehicle": "motorcycle_cross", "x": 56, "y": 18, "rotation": 180, "chance": 50 },
+        { "vehicle": "motorcycle_enduro", "x": 56, "y": 20, "rotation": 180, "chance": 50 },
+        { "vehicle": "superbike", "x": 56, "y": 22, "rotation": 180, "chance": 50 },
+        { "vehicle": "motorcycle_sidecart", "x": 66, "y": 16, "rotation": 180, "chance": 50 },
+        { "vehicle": "scooter", "x": 64, "y": 18, "rotation": 180, "chance": 50 },
+        { "vehicle": "motorcycle", "x": 64, "y": 20, "rotation": 180, "chance": 50 },
+        { "vehicle": "motorcycle", "x": 64, "y": 22, "rotation": 180, "chance": 50 }
       ]
     }
   },


### PR DESCRIPTION
#### Summary

SUMMARY: Balance "Make vehicles outside of garages and showrooms slightly damaged"

#### Purpose of change

There were a few places with completely intact vehicles where it didn't make any sense lore- or gameplay-wise. The worst offender was brand new Luxury RV in a campground surrounded by many half-broken cars and vans.

#### Describe the solution

Make all previously intact vehicles that aren't protected from elements (i.e. not in showrooms or otherwise enclosed buildings) slightly damaged.

There are two locations that I wasn't sure what to do with:

* Parking garage - is it enclosed enough to warrant intact vehicles? It's easy to get into and there are rarely many zombies around, making it a very easy way to get mostly unscathed vehicle once you smash through security system.
* `lab/lab_surface/lab_surface_big_*` locations - I don't think I've ever seen this one in game, but it seems to have a big parking lot with regular cars.