### PR TITLE
Workaround for effect-related crash

### DIFF
--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -32,6 +32,12 @@ enum body_part : int {
     num_bp
 };
 
+template <typename T>
+inline bool operator<( body_part a, T b )
+{
+    return static_cast<int>( a ) < static_cast<int>( b );
+}
+
 template<>
 struct enum_traits<body_part> {
     static constexpr auto last = body_part::num_bp;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8778,9 +8778,8 @@ void Character::check_and_recover_morale()
         test_morale.on_mutation_gain( mut );
     }
 
-    for( std::pair<const efftype_id, std::unordered_map<body_part, effect, std::hash<int>>> &elem :
-         *effects ) {
-        for( std::pair<const body_part, effect> &_effect_it : elem.second ) {
+    for( const auto &elem : *effects ) {
+        for( const std::pair<const body_part, effect> &_effect_it : elem.second ) {
             const effect &e = _effect_it.second;
             test_morale.on_effect_int_change( e.get_id(), e.get_intensity(), e.get_bp() );
         }

--- a/src/effect.h
+++ b/src/effect.h
@@ -303,7 +303,7 @@ std::string texitify_healing_power( int power );
 // Inheritance here allows forward declaration of the map in class Creature.
 // Storing body_part as an int to make things easier for hash and JSON
 class effects_map : public
-    std::unordered_map<efftype_id, std::unordered_map<body_part, effect, std::hash<int>>>
+    std::map<efftype_id, std::map<body_part, effect>>
 {
 };
 


### PR DESCRIPTION
Effect map is an unordered map (of unordered maps), meaning that adding new effect can invalidate iterators to existing ones.
This can cause crashes when adding an effect during effect processing, as effect processing iterates over all effects and some effects add new effects.

The simplest fix is to simply change both maps to ordered ones, which may be slower (could use a test).
According to https://stackoverflow.com/questions/6438086/iterator-invalidation-rules references to `unordered_map` elements should not be invalidated by inserting new elements, which hints at a possible different solution.