### PR TITLE
Sleep, sleep deprivation and meth changes 

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -1231,7 +1231,7 @@
       "vomit_chance": [ 2000 ],
       "stamina_min": [ -4 ]
     },
-    "scaling_mods": { "speed_mod": [ 30 ], "str_mod": [ 4 ], "dex_mod": [ 4 ], "int_mod": [ 1 ], "per_mod": [ 5 ], "stamina_min": [ 8 ] }
+    "scaling_mods": { "speed_mod": [ 30 ], "str_mod": [ 3 ], "dex_mod": [ 2 ], "int_mod": [ 1 ], "per_mod": [ 4 ], "stamina_min": [ 6 ] }
   },
   {
     "type": "effect_type",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -508,10 +508,16 @@
     "name": [ "Sleep Deprived" ],
     "desc": [ "Your sleep debt has been steadily increasing for a while.  You should get some rest." ],
     "rating": "bad",
-    "max_intensity": 20160,
-    "int_dur_factor": 240,
-    "base_mods": { "speed_mod": [ -5 ] },
-    "scaling_mods": { "speed_mod": [ -1 ], "int_mod": [ -0.33 ], "per_mod": [ -0.33 ], "str_mod": [ -0.17 ], "dex_mod": [ -0.17 ] },
+    "max_intensity": 100,
+    "int_dur_factor": 480,
+    "resist_effects": [ "meth" ],
+    "scaling_mods": {
+      "speed_mod": [ -2, -1 ],
+      "int_mod": [ -0.3, -0.1 ],
+      "per_mod": [ -0.3, -0.1 ],
+      "str_mod": [ -0.2, -0.1 ],
+      "dex_mod": [ -0.2, -0.1 ]
+    },
     "apply_message": "You feel weary, your body tired from lack of quality sleep.",
     "remove_message": "You have finally caught up with your lost sleep, and you feel refreshed and awake for a change."
   },
@@ -1219,19 +1225,18 @@
   {
     "type": "effect_type",
     "id": "meth",
-    "name": [ "Meth comedown", "High on Meth" ],
-    "max_intensity": 2,
-    "int_dur_factor": "200 s",
+    "name": [ "High on Meth" ],
+    "max_duration": "1 d",
     "base_mods": {
-      "speed_mod": [ -20 ],
-      "str_mod": [ -3 ],
-      "dex_mod": [ -2 ],
-      "int_mod": [ -1 ],
-      "per_mod": [ -2 ],
-      "vomit_chance": [ 2000 ],
-      "stamina_min": [ -4 ]
-    },
-    "scaling_mods": { "speed_mod": [ 30 ], "str_mod": [ 3 ], "dex_mod": [ 2 ], "int_mod": [ 1 ], "per_mod": [ 4 ], "stamina_min": [ 6 ] }
+      "speed_mod": [ 5 ],
+      "per_mod": [ 1 ],
+      "fatigue_min": [ -10 ],
+      "health_min": [ -1 ],
+      "health_tick": [ 7200 ],
+      "h_mod_min": [ -1 ],
+      "h_mod_min_val": [ -50 ],
+      "h_mod_tick": [ 720 ]
+    }
   },
   {
     "type": "effect_type",
@@ -1458,8 +1463,7 @@
     "id": "sleep",
     "apply_message": "You fall asleep.",
     "remove_message": "You wake up.",
-    "rating": "neutral",
-    "max_intensity": 24
+    "rating": "neutral"
   },
   {
     "type": "effect_type",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1172,14 +1172,22 @@
     "symbol": "!",
     "color": "light_cyan",
     "container": "bag_zipper",
-    "quench": -2,
     "stim": 20,
     "healthy": -7,
     "fun": 30,
     "addiction_potential": 50,
     "addiction_type": "amphetamine",
     "flags": [ "NO_INGEST" ],
-    "use_action": "METH"
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You smoke some meth.",
+      "effects": [ { "id": "meth", "duration": "12 h" } ],
+      "stat_adjustments": { "hunger": -100, "thirst": -100 },
+      "fields_produced": { "fd_methsmoke": 2 },
+      "charges_needed": { "fire": 1 },
+      "tools_needed": { "apparatus": -1 },
+      "moves": 250
+    }
   },
   {
     "id": "morphine",

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2365,7 +2365,7 @@ void activity_handlers::hand_crank_do_turn( player_activity *act, player *p )
             add_msg( m_info, _( "You've charged the battery completely." ) );
         }
     }
-    if( p->get_fatigue() >= DEAD_TIRED ) {
+    if( p->get_fatigue() >= fatigue_levels::dead_tired ) {
         act->moves_left = 0;
         add_msg( m_info, _( "You're too exhausted to keep cranking." ) );
     }
@@ -2399,7 +2399,7 @@ void activity_handlers::vibe_do_turn( player_activity *act, player *p )
         }
     }
     // Dead Tired: different kind of relaxation needed
-    if( p->get_fatigue() >= DEAD_TIRED ) {
+    if( p->get_fatigue() >= fatigue_levels::dead_tired ) {
         act->moves_left = 0;
         add_msg( m_info, _( "You're too tired to continue." ) );
     }

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -14,6 +14,7 @@
 #include "translations.h"
 
 static const efftype_id effect_hallu( "hallu" );
+static const efftype_id effect_meth( "meth" );
 static const efftype_id effect_shakes( "shakes" );
 
 static const trait_id trait_MUT_JUNKIE( "MUT_JUNKIE" );
@@ -160,9 +161,12 @@ void addict_effect( Character &u, addiction &add )
             break;
 
         case add_type::SPEED: {
+            if( u.has_effect( effect_meth ) ) {
+                break;
+            }
             u.mod_int_bonus( -1 );
             u.mod_str_bonus( -1 );
-            if( current_stim > -100 && x_in_y( in, 20 ) ) {
+            if( current_stim > in * -5 && calendar::once_every( 3_minutes ) ) {
                 u.mod_stim( -1 );
             }
             if( rng( 0, 150 ) <= in ) {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -990,16 +990,16 @@ void avatar::disp_morale()
     int equilibrium = calc_focus_equilibrium();
 
     int fatigue_penalty = 0;
-    if( get_fatigue() >= MASSIVE_FATIGUE && equilibrium > 20 ) {
+    if( get_fatigue() >= fatigue_levels::massive && equilibrium > 20 ) {
         fatigue_penalty = equilibrium - 20;
         equilibrium = 20;
-    } else if( get_fatigue() >= EXHAUSTED && equilibrium > 40 ) {
+    } else if( get_fatigue() >= fatigue_levels::exhausted && equilibrium > 40 ) {
         fatigue_penalty = equilibrium - 40;
         equilibrium = 40;
-    } else if( get_fatigue() >= DEAD_TIRED && equilibrium > 60 ) {
+    } else if( get_fatigue() >= fatigue_levels::dead_tired && equilibrium > 60 ) {
         fatigue_penalty = equilibrium - 60;
         equilibrium = 60;
-    } else if( get_fatigue() >= TIRED && equilibrium > 80 ) {
+    } else if( get_fatigue() >= fatigue_levels::tired && equilibrium > 80 ) {
         fatigue_penalty = equilibrium - 80;
         equilibrium = 80;
     }
@@ -1098,10 +1098,10 @@ int avatar::calc_focus_change() const
     gain *= base_change;
 
     // Fatigue will incrementally decrease any focus above related cap
-    if( ( get_fatigue() >= TIRED && focus_pool > 80 ) ||
-        ( get_fatigue() >= DEAD_TIRED && focus_pool > 60 ) ||
-        ( get_fatigue() >= EXHAUSTED && focus_pool > 40 ) ||
-        ( get_fatigue() >= MASSIVE_FATIGUE && focus_pool > 20 ) ) {
+    if( ( get_fatigue() >= fatigue_levels::tired && focus_pool > 80 ) ||
+        ( get_fatigue() >= fatigue_levels::dead_tired && focus_pool > 60 ) ||
+        ( get_fatigue() >= fatigue_levels::exhausted && focus_pool > 40 ) ||
+        ( get_fatigue() >= fatigue_levels::massive && focus_pool > 20 ) ) {
 
         //it can fall faster then 1
         if( gain > -1 ) {
@@ -1226,7 +1226,7 @@ void avatar::reset_stats()
         mod_int_bonus( -get_thirst() / 200 );
         mod_per_bonus( -get_thirst() / 200 );
     }
-    if( get_sleep_deprivation() >= SLEEP_DEPRIVATION_HARMLESS ) {
+    if( get_sleep_deprivation() >= sleep_deprivation_levels::harmless ) {
         set_fake_effect_dur( effect_sleep_deprived, 1_turns * get_sleep_deprivation() );
     } else if( has_effect( effect_sleep_deprived ) ) {
         remove_effect( effect_sleep_deprived );

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1098,15 +1098,12 @@ int avatar::calc_focus_change() const
     gain *= base_change;
 
     // Fatigue will incrementally decrease any focus above related cap
-    if( ( get_fatigue() >= fatigue_levels::tired && focus_pool > 80 ) ||
-        ( get_fatigue() >= fatigue_levels::dead_tired && focus_pool > 60 ) ||
-        ( get_fatigue() >= fatigue_levels::exhausted && focus_pool > 40 ) ||
-        ( get_fatigue() >= fatigue_levels::massive && focus_pool > 20 ) ) {
+    if( ( get_fatigue() >= fatigue_levels::tired && focus_pool > 100 ) ||
+        ( get_fatigue() >= fatigue_levels::dead_tired && focus_pool > 75 ) ||
+        ( get_fatigue() >= fatigue_levels::exhausted && focus_pool > 50 ) ||
+        ( get_fatigue() >= fatigue_levels::massive && focus_pool > 25 ) ) {
 
-        //it can fall faster then 1
-        if( gain > -1 ) {
-            gain = -1;
-        }
+        gain = std::min( gain, -1 );
     }
     return gain;
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -145,6 +145,7 @@ static const efftype_id effect_lack_sleep( "lack_sleep" );
 static const efftype_id effect_lightsnare( "lightsnare" );
 static const efftype_id effect_lying_down( "lying_down" );
 static const efftype_id effect_melatonin_supplements( "melatonin" );
+static const efftype_id effect_meth( "meth" );
 static const efftype_id effect_masked_scent( "masked_scent" );
 static const efftype_id effect_mending( "mending" );
 static const efftype_id effect_narcosis( "narcosis" );
@@ -4179,13 +4180,13 @@ std::pair<std::string, nc_color> Character::get_fatigue_description() const
     int fatigue = get_fatigue();
     std::string fatigue_string;
     nc_color fatigue_color = c_white;
-    if( fatigue > EXHAUSTED ) {
+    if( fatigue > fatigue_levels::exhausted ) {
         fatigue_color = c_red;
         fatigue_string = _( "Exhausted" );
-    } else if( fatigue > DEAD_TIRED ) {
+    } else if( fatigue > fatigue_levels::dead_tired ) {
         fatigue_color = c_light_red;
         fatigue_string = _( "Dead Tired" );
-    } else if( fatigue > TIRED ) {
+    } else if( fatigue > fatigue_levels::tired ) {
         fatigue_color = c_yellow;
         fatigue_string = _( "Tired" );
     }
@@ -4229,7 +4230,7 @@ void Character::set_fatigue( int nfatigue )
 
 void Character::set_sleep_deprivation( int nsleep_deprivation )
 {
-    sleep_deprivation = std::min( static_cast< int >( SLEEP_DEPRIVATION_MASSIVE ), std::max( 0,
+    sleep_deprivation = std::min( static_cast< int >( sleep_deprivation_levels::massive ), std::max( 0,
                                   nsleep_deprivation ) );
 }
 
@@ -4561,7 +4562,7 @@ void Character::update_needs( int rate_multiplier )
 
     needs_rates rates = calc_needs_rates();
 
-    const bool wasnt_fatigued = get_fatigue() <= DEAD_TIRED;
+    const bool wasnt_fatigued = get_fatigue() <= fatigue_levels::dead_tired;
     // Don't increase fatigue if sleeping or trying to sleep or if we're at the cap.
     if( get_fatigue() < 1050 && !asleep && !debug_ls ) {
         if( rates.fatigue > 0.0f ) {
@@ -4578,8 +4579,8 @@ void Character::update_needs( int rate_multiplier )
                 mod_sleep_deprivation( fatigue_roll * 5 );
             }
 
-            if( npc_no_food && get_fatigue() > TIRED ) {
-                set_fatigue( TIRED );
+            if( npc_no_food && get_fatigue() > fatigue_levels::tired ) {
+                set_fatigue( static_cast<int>( fatigue_levels::tired ) );
                 set_sleep_deprivation( 0 );
             }
         }
@@ -4597,35 +4598,25 @@ void Character::update_needs( int rate_multiplier )
                 }
                 mod_fatigue( -recovered );
 
-                // Sleeping on the ground, no bionic = 1x rest_modifier
-                // Sleeping on a bed, no bionic      = 2x rest_modifier
-                // Sleeping on a comfy bed, no bionic= 3x rest_modifier
-
-                // Sleeping on the ground, bionic    = 3x rest_modifier
-                // Sleeping on a bed, bionic         = 6x rest_modifier
-                // Sleeping on a comfy bed, bionic   = 9x rest_modifier
-                float rest_modifier = ( has_active_bionic( bio_synaptic_regen ) ? 3 : 1 );
+                float rest_modifier = 10;
+                // Bionic doubles the base regen
+                if( has_active_bionic( bio_synaptic_regen ) ) {
+                    rest_modifier += 10;
+                }
                 // Melatonin supplements also add a flat bonus to recovery speed
                 if( has_effect( effect_melatonin_supplements ) ) {
-                    rest_modifier += 1;
+                    rest_modifier += 5;
                 }
 
                 const comfort_level comfort = base_comfort_value( pos() ).level;
 
+                // Best possible bed increases recovery by 50% of base
                 if( comfort >= comfort_level::very_comfortable ) {
-                    rest_modifier *= 3;
+                    rest_modifier += 5;
                 } else  if( comfort >= comfort_level::comfortable ) {
-                    rest_modifier *= 2.5;
+                    rest_modifier += 3;
                 } else if( comfort >= comfort_level::slightly_comfortable ) {
-                    rest_modifier *= 2;
-                }
-
-                // If we're just tired, we'll get a decent boost to our sleep quality.
-                // The opposite is true for very tired characters.
-                if( get_fatigue() < DEAD_TIRED ) {
-                    rest_modifier += 2;
-                } else if( get_fatigue() >= EXHAUSTED ) {
-                    rest_modifier = ( rest_modifier > 2 ) ? rest_modifier - 2 : 1;
+                    rest_modifier += 5;
                 }
 
                 // Recovered is multiplied by 2 as well, since we spend 1/3 of the day sleeping
@@ -4634,7 +4625,7 @@ void Character::update_needs( int rate_multiplier )
             }
         }
     }
-    if( is_player() && wasnt_fatigued && get_fatigue() > DEAD_TIRED && !lying ) {
+    if( is_player() && wasnt_fatigued && get_fatigue() > fatigue_levels::dead_tired && !lying ) {
         if( !activity ) {
             add_msg_if_player( m_warning, _( "You're feeling tired.  %s to lie down for sleep." ),
                                press_x( ACTION_SLEEP ) );
@@ -4821,8 +4812,8 @@ void Character::check_needs_extremes()
     }
 
     // Check if we're falling asleep, unless we're sleeping
-    if( get_fatigue() >= EXHAUSTED + 25 && !in_sleep_state() ) {
-        if( get_fatigue() >= MASSIVE_FATIGUE ) {
+    if( get_fatigue() >= fatigue_levels::exhausted + 25 && !in_sleep_state() ) {
+        if( get_fatigue() >= fatigue_levels::massive ) {
             add_msg_if_player( m_bad, _( "Survivor sleep now." ) );
             g->events().send<event_type::falls_asleep_from_exhaustion>( getID() );
             mod_fatigue( -10 );
@@ -4836,7 +4827,7 @@ void Character::check_needs_extremes()
 
     // Even if we're not Exhausted, we really should be feeling lack/sleep earlier
     // Penalties start at Dead Tired and go from there
-    if( get_fatigue() >= DEAD_TIRED && !in_sleep_state() ) {
+    if( get_fatigue() >= fatigue_levels::dead_tired && !in_sleep_state() ) {
         if( get_fatigue() >= 700 ) {
             if( calendar::once_every( 30_minutes ) ) {
                 add_msg_if_player( m_warning, _( "You're too physically tired to stop yawning." ) );
@@ -4844,10 +4835,9 @@ void Character::check_needs_extremes()
             }
             /** @EFFECT_INT slightly decreases occurrence of short naps when dead tired */
             if( one_in( 50 + int_cur ) ) {
-                // Rivet's idea: look out for microsleeps!
                 fall_asleep( 30_seconds );
             }
-        } else if( get_fatigue() >= EXHAUSTED ) {
+        } else if( get_fatigue() >= fatigue_levels::exhausted ) {
             if( calendar::once_every( 30_minutes ) ) {
                 add_msg_if_player( m_warning, _( "How much longer until bedtime?" ) );
                 add_effect( effect_lack_sleep, 30_minutes + 1_turns );
@@ -4856,7 +4846,7 @@ void Character::check_needs_extremes()
             if( one_in( 100 + int_cur ) ) {
                 fall_asleep( 30_seconds );
             }
-        } else if( get_fatigue() >= DEAD_TIRED && calendar::once_every( 30_minutes ) ) {
+        } else if( get_fatigue() >= fatigue_levels::dead_tired && calendar::once_every( 30_minutes ) ) {
             add_msg_if_player( m_warning, _( "*yawn* You should really get some sleep." ) );
             add_effect( effect_lack_sleep, 30_minutes + 1_turns );
         }
@@ -4864,15 +4854,16 @@ void Character::check_needs_extremes()
 
     // Sleep deprivation kicks in if lack of sleep is avoided with stimulants or otherwise for long periods of time
     int sleep_deprivation = get_sleep_deprivation();
-    float sleep_deprivation_pct = sleep_deprivation / static_cast<float>( SLEEP_DEPRIVATION_MASSIVE );
+    float sleep_deprivation_pct = sleep_deprivation / static_cast<float>
+                                  ( sleep_deprivation_levels::massive );
 
-    if( sleep_deprivation >= SLEEP_DEPRIVATION_HARMLESS && !in_sleep_state() ) {
+    if( sleep_deprivation >= sleep_deprivation_levels::harmless && !in_sleep_state() ) {
         if( calendar::once_every( 60_minutes ) ) {
-            if( sleep_deprivation < SLEEP_DEPRIVATION_MINOR ) {
+            if( sleep_deprivation < sleep_deprivation_levels::minor ) {
                 add_msg_if_player( m_warning,
                                    _( "Your mind feels tired.  It's been a while since you've slept well." ) );
                 mod_fatigue( 1 );
-            } else if( sleep_deprivation < SLEEP_DEPRIVATION_SERIOUS ) {
+            } else if( sleep_deprivation < sleep_deprivation_levels::serious ) {
                 add_msg_if_player( m_bad,
                                    _( "Your mind feels foggy from lack of good sleep, and your eyes keep trying to close against your will." ) );
                 mod_fatigue( 5 );
@@ -4880,48 +4871,48 @@ void Character::check_needs_extremes()
                 if( one_in( 10 ) ) {
                     mod_healthy_mod( -1, 0 );
                 }
-            } else if( sleep_deprivation < SLEEP_DEPRIVATION_MAJOR ) {
+            } else if( sleep_deprivation < sleep_deprivation_levels::major ) {
                 add_msg_if_player( m_bad,
                                    _( "Your mind feels weary, and you dread every wakeful minute that passes.  You crave sleep, and feel like you're about to collapse." ) );
                 mod_fatigue( 10 );
 
                 if( one_in( 5 ) ) {
-                    mod_healthy_mod( -2, 0 );
+                    mod_healthy_mod( -2, -20 );
                 }
-            } else if( sleep_deprivation < SLEEP_DEPRIVATION_MASSIVE ) {
+            } else if( sleep_deprivation < sleep_deprivation_levels::massive ) {
                 add_msg_if_player( m_bad,
                                    _( "You haven't slept decently for so long that your whole body is screaming for mercy.  It's a miracle that you're still awake, but it just feels like a curse now." ) );
                 mod_fatigue( 40 );
 
-                mod_healthy_mod( -5, 0 );
+                mod_healthy_mod( -5, -50 );
             }
             // else you pass out for 20 hours, guaranteed
 
             // Microsleeps are slightly worse if you're sleep deprived, but not by much. (chance: 1 in (75 + int_cur) at lethal sleep deprivation)
             // Note: these can coexist with fatigue-related microsleeps
             /** @EFFECT_INT slightly decreases occurrence of short naps when sleep deprived */
-            if( one_in( static_cast<int>( sleep_deprivation_pct * 75 ) + int_cur ) ) {
+            if( one_in( static_cast<int>( 1.0f - sleep_deprivation_pct * 75 ) + int_cur ) ) {
                 fall_asleep( 30_seconds );
             }
 
-            // Stimulants can be used to stay awake a while longer, but after a while you'll just collapse.
-            bool can_pass_out = ( get_stim() < 30 && sleep_deprivation >= SLEEP_DEPRIVATION_MINOR ) ||
-                                sleep_deprivation >= SLEEP_DEPRIVATION_MAJOR;
+            // Meth prevents falling asleep
+            bool can_pass_out = sleep_deprivation >= sleep_deprivation_levels::major &&
+                                !has_effect( effect_meth );
 
             if( can_pass_out && calendar::once_every( 10_minutes ) ) {
                 /** @EFFECT_PER slightly increases resilience against passing out from sleep deprivation */
-                if( one_in( static_cast<int>( ( 1 - sleep_deprivation_pct ) * 100 ) + per_cur ) ||
-                    sleep_deprivation >= SLEEP_DEPRIVATION_MASSIVE ) {
+                if( one_in( static_cast<int>( ( 1.0f - sleep_deprivation_pct ) * 100 ) + per_cur ) ||
+                    sleep_deprivation >= sleep_deprivation_levels::massive ) {
                     add_msg_player_or_npc( m_bad,
                                            _( "Your body collapses due to sleep deprivation, your neglected fatigue rushing back all at once, and you pass out on the spot." )
                                            , _( "<npcname> collapses to the ground from exhaustion." ) );
-                    if( get_fatigue() < EXHAUSTED ) {
-                        set_fatigue( EXHAUSTED );
+                    if( get_fatigue() < fatigue_levels::exhausted ) {
+                        set_fatigue( static_cast<int>( fatigue_levels::exhausted ) );
                     }
 
-                    if( sleep_deprivation >= SLEEP_DEPRIVATION_MAJOR ) {
+                    if( sleep_deprivation >= sleep_deprivation_levels::major ) {
                         fall_asleep( 20_hours );
-                    } else if( sleep_deprivation >= SLEEP_DEPRIVATION_SERIOUS ) {
+                    } else if( sleep_deprivation >= sleep_deprivation_levels::serious ) {
                         fall_asleep( 16_hours );
                     } else {
                         fall_asleep( 12_hours );
@@ -8940,6 +8931,9 @@ void Character::fall_asleep()
 
 void Character::fall_asleep( const time_duration &duration )
 {
+    if( has_effect( effect_meth ) ) {
+        return;
+    }
     if( activity ) {
         if( activity.id() == "ACT_TRY_SLEEP" ) {
             activity.set_to_null();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4584,45 +4584,45 @@ void Character::update_needs( int rate_multiplier )
                 set_sleep_deprivation( 0 );
             }
         }
-    } else if( asleep ) {
-        if( rates.recovery > 0.0f ) {
-            int recovered = roll_remainder( rates.recovery * rate_multiplier );
-            // Hibernation prevents waking up until you're hungry or thirsty
-            if( get_fatigue() - recovered < -20 && !is_hibernating() ) {
-                // Should be wake up, but that could prevent some retroactive regeneration
-                sleep.set_duration( 1_turns );
-                mod_fatigue( -25 );
-            } else {
-                if( has_effect( effect_recently_coughed ) ) {
-                    recovered *= .5;
-                }
-                mod_fatigue( -recovered );
-
-                float rest_modifier = 10;
-                // Bionic doubles the base regen
-                if( has_active_bionic( bio_synaptic_regen ) ) {
-                    rest_modifier += 10;
-                }
-                // Melatonin supplements also add a flat bonus to recovery speed
-                if( has_effect( effect_melatonin_supplements ) ) {
-                    rest_modifier += 5;
-                }
-
-                const comfort_level comfort = base_comfort_value( pos() ).level;
-
-                // Best possible bed increases recovery by 50% of base
-                if( comfort >= comfort_level::very_comfortable ) {
-                    rest_modifier += 5;
-                } else  if( comfort >= comfort_level::comfortable ) {
-                    rest_modifier += 3;
-                } else if( comfort >= comfort_level::slightly_comfortable ) {
-                    rest_modifier += 5;
-                }
-
-                // Recovered is multiplied by 2 as well, since we spend 1/3 of the day sleeping
-                mod_sleep_deprivation( -rest_modifier * ( recovered * 2 ) );
-
+    } else if( asleep && rates.recovery > 0.0f ) {
+        int recovered = roll_remainder( rates.recovery * rate_multiplier );
+        // Hibernation prevents waking up until you're hungry or thirsty
+        if( get_fatigue() - recovered < -20 && !is_hibernating() ) {
+            // Should be wake up, but that could prevent some retroactive regeneration
+            sleep.set_duration( 1_turns );
+            mod_fatigue( -25 );
+        } else {
+            if( has_effect( effect_recently_coughed ) ) {
+                recovered *= .5;
             }
+            mod_fatigue( -recovered );
+
+            float rest_modifier = 1.0f;
+            // Bionic doubles the base regen
+            if( has_active_bionic( bio_synaptic_regen ) ) {
+                rest_modifier += 1.0f;
+            }
+            if( has_effect( effect_melatonin_supplements ) ) {
+                rest_modifier += 0.2f;
+            }
+
+            const comfort_level comfort = base_comfort_value( pos() ).level;
+
+            // Best possible bed increases recovery by 30% of base
+            if( comfort >= comfort_level::very_comfortable ) {
+                rest_modifier += 0.3f;
+            } else  if( comfort >= comfort_level::comfortable ) {
+                rest_modifier += 0.2f;
+            } else if( comfort >= comfort_level::slightly_comfortable ) {
+                rest_modifier += 0.1f;
+            }
+
+            // 6 hours of sleep per day will let you avoid deprivation
+            // 4 hours if on great bed plus melatonin
+            // Math: 5 (fatigue to minutes), 3 (1:3 sleep to waking),
+            // 2 (legacy sleep non-linearity thing)
+            mod_sleep_deprivation( -rest_modifier * ( recovered * 3.0f * 5.0f / 2.0f ) );
+
         }
     }
     if( is_player() && wasnt_fatigued && get_fatigue() > fatigue_levels::dead_tired && !lying ) {
@@ -4697,18 +4697,10 @@ needs_rates Character::calc_needs_rates() const
 
     if( asleep ) {
         static const std::string fatigue_regen_modifier( "fatigue_regen_modifier" );
-        rates.recovery = 1.0f + mutation_value( fatigue_regen_modifier );
-        if( !is_hibernating() ) {
-            // Hunger and thirst advance more slowly while we sleep. This is the standard rate.
-            rates.hunger *= 0.5f;
-            rates.thirst *= 0.5f;
-            const int intense = sleep.is_null() ? 0 : sleep.get_intensity();
-            // Accelerated recovery capped to 2x over 2 hours
-            // After 16 hours of activity, equal to 7.25 hours of rest
-            const int accelerated_recovery_chance = 24 - intense + 1;
-            const float accelerated_recovery_rate = 1.0f / accelerated_recovery_chance;
-            rates.recovery += accelerated_recovery_rate;
-        } else {
+        // Multiplied by 2 to account for legacy (bugged to always apply)
+        // bonus for sleeping over 2 hours
+        rates.recovery = 2.0f * ( 1.0f + mutation_value( fatigue_regen_modifier ) );
+        if( is_hibernating() ) {
             // Hunger and thirst advance *much* more slowly whilst we hibernate.
             rates.hunger *= ( 1.0f / 7.0f );
             rates.thirst *= ( 1.0f / 7.0f );
@@ -4857,69 +4849,64 @@ void Character::check_needs_extremes()
     float sleep_deprivation_pct = sleep_deprivation / static_cast<float>
                                   ( sleep_deprivation_levels::massive );
 
-    if( sleep_deprivation >= sleep_deprivation_levels::harmless && !in_sleep_state() ) {
-        if( calendar::once_every( 60_minutes ) ) {
-            if( sleep_deprivation < sleep_deprivation_levels::minor ) {
-                add_msg_if_player( m_warning,
-                                   _( "Your mind feels tired.  It's been a while since you've slept well." ) );
-                mod_fatigue( 1 );
-            } else if( sleep_deprivation < sleep_deprivation_levels::serious ) {
-                add_msg_if_player( m_bad,
-                                   _( "Your mind feels foggy from lack of good sleep, and your eyes keep trying to close against your will." ) );
-                mod_fatigue( 5 );
+    if( sleep_deprivation >= sleep_deprivation_levels::harmless && !in_sleep_state() &&
+        calendar::once_every( 60_minutes ) &&
+        ( !has_effect( effect_meth ) || sleep_deprivation >= sleep_deprivation_levels::massive ) ) {
+        if( sleep_deprivation < sleep_deprivation_levels::minor ) {
+            add_msg_if_player( m_warning,
+                               _( "Your mind feels tired.  It's been a while since you've slept well." ) );
+            mod_fatigue( 1 );
+        } else if( sleep_deprivation < sleep_deprivation_levels::serious ) {
+            add_msg_if_player( m_bad,
+                               _( "Your mind feels foggy from lack of good sleep, and your eyes keep trying to close against your will." ) );
+            mod_fatigue( 5 );
 
-                if( one_in( 10 ) ) {
-                    mod_healthy_mod( -1, 0 );
-                }
-            } else if( sleep_deprivation < sleep_deprivation_levels::major ) {
-                add_msg_if_player( m_bad,
-                                   _( "Your mind feels weary, and you dread every wakeful minute that passes.  You crave sleep, and feel like you're about to collapse." ) );
-                mod_fatigue( 10 );
-
-                if( one_in( 5 ) ) {
-                    mod_healthy_mod( -2, -20 );
-                }
-            } else if( sleep_deprivation < sleep_deprivation_levels::massive ) {
-                add_msg_if_player( m_bad,
-                                   _( "You haven't slept decently for so long that your whole body is screaming for mercy.  It's a miracle that you're still awake, but it just feels like a curse now." ) );
-                mod_fatigue( 40 );
-
-                mod_healthy_mod( -5, -50 );
+            if( one_in( 10 ) ) {
+                mod_healthy_mod( -1, 0 );
             }
-            // else you pass out for 20 hours, guaranteed
+        } else if( sleep_deprivation < sleep_deprivation_levels::major ) {
+            add_msg_if_player( m_bad,
+                               _( "Your mind feels weary, and you dread every wakeful minute that passes.  You crave sleep, and feel like you're about to collapse." ) );
+            mod_fatigue( 10 );
 
-            // Microsleeps are slightly worse if you're sleep deprived, but not by much. (chance: 1 in (75 + int_cur) at lethal sleep deprivation)
-            // Note: these can coexist with fatigue-related microsleeps
-            /** @EFFECT_INT slightly decreases occurrence of short naps when sleep deprived */
-            if( one_in( static_cast<int>( 1.0f - sleep_deprivation_pct * 75 ) + int_cur ) ) {
-                fall_asleep( 30_seconds );
+            if( one_in( 5 ) ) {
+                mod_healthy_mod( -2, -20 );
             }
+        } else if( sleep_deprivation < sleep_deprivation_levels::massive ) {
+            add_msg_if_player( m_bad,
+                               _( "You haven't slept decently for so long that your whole body is screaming for mercy.  It's a miracle that you're still awake, but it just feels like a curse now." ) );
+            mod_fatigue( 40 );
 
-            // Meth prevents falling asleep
-            bool can_pass_out = sleep_deprivation >= sleep_deprivation_levels::major &&
-                                !has_effect( effect_meth );
+            mod_healthy_mod( -5, -50 );
+        }
+        // else you pass out for 20 hours, guaranteed
 
-            if( can_pass_out && calendar::once_every( 10_minutes ) ) {
+        // Microsleeps are slightly worse if you're sleep deprived, but not by much. (chance: 1 in (75 + per_cur) at lethal sleep deprivation)
+        // Note: these can coexist with fatigue-related microsleeps
+        /** @EFFECT_PER slightly decreases occurrence of short naps when sleep deprived */
+        if( one_in( static_cast<int>( 1.0f - sleep_deprivation_pct * 75 ) + get_per() ) ) {
+            fall_asleep( 30_seconds );
+        }
+
+
+        if( sleep_deprivation >= sleep_deprivation_levels::massive ||
+            ( ( calendar::once_every( 10_minutes ) && sleep_deprivation >= sleep_deprivation_levels::major &&
                 /** @EFFECT_PER slightly increases resilience against passing out from sleep deprivation */
-                if( one_in( static_cast<int>( ( 1.0f - sleep_deprivation_pct ) * 100 ) + per_cur ) ||
-                    sleep_deprivation >= sleep_deprivation_levels::massive ) {
-                    add_msg_player_or_npc( m_bad,
-                                           _( "Your body collapses due to sleep deprivation, your neglected fatigue rushing back all at once, and you pass out on the spot." )
-                                           , _( "<npcname> collapses to the ground from exhaustion." ) );
-                    if( get_fatigue() < fatigue_levels::exhausted ) {
-                        set_fatigue( static_cast<int>( fatigue_levels::exhausted ) );
-                    }
-
-                    if( sleep_deprivation >= sleep_deprivation_levels::major ) {
-                        fall_asleep( 20_hours );
-                    } else if( sleep_deprivation >= sleep_deprivation_levels::serious ) {
-                        fall_asleep( 16_hours );
-                    } else {
-                        fall_asleep( 12_hours );
-                    }
-                }
+                one_in( static_cast<int>( ( 1.0f - sleep_deprivation_pct ) * 100 ) + get_per() ) ) ) ) {
+            add_msg_player_or_npc( m_bad,
+                                   _( "Your body collapses due to sleep deprivation, your neglected fatigue rushing back all at once, and you pass out on the spot." )
+                                   , _( "<npcname> collapses to the ground from exhaustion." ) );
+            if( get_fatigue() < fatigue_levels::exhausted ) {
+                set_fatigue( static_cast<int>( fatigue_levels::exhausted ) );
             }
 
+            if( sleep_deprivation >= sleep_deprivation_levels::major ) {
+                fall_asleep( 20_hours );
+            } else if( sleep_deprivation >= sleep_deprivation_levels::serious ) {
+                fall_asleep( 16_hours );
+            } else {
+                fall_asleep( 12_hours );
+            }
         }
     }
 }
@@ -8931,9 +8918,6 @@ void Character::fall_asleep()
 
 void Character::fall_asleep( const time_duration &duration )
 {
-    if( has_effect( effect_meth ) ) {
-        return;
-    }
     if( activity ) {
         if( activity.id() == "ACT_TRY_SLEEP" ) {
             activity.set_to_null();

--- a/src/character.h
+++ b/src/character.h
@@ -107,29 +107,148 @@ struct enum_traits<character_movemode> {
     static constexpr auto last = character_movemode::CMM_COUNT;
 };
 
-enum fatigue_levels {
-    TIRED = 191,
-    DEAD_TIRED = 383,
-    EXHAUSTED = 575,
-    MASSIVE_FATIGUE = 1000
+enum class fatigue_levels : int {
+    tired = 191,
+    dead_tired = 383,
+    exhausted = 575,
+    massive = 1000
 };
+
+constexpr inline bool operator>=( const fatigue_levels &lhs, const fatigue_levels &rhs )
+{
+    return static_cast<int>( lhs ) >= static_cast<int>( rhs );
+}
+
+constexpr inline bool operator<( const fatigue_levels &lhs, const fatigue_levels &rhs )
+{
+    return static_cast<int>( lhs ) < static_cast<int>( rhs );
+}
+
+template<typename T>
+constexpr inline bool operator>=( const T &lhs, const fatigue_levels &rhs )
+{
+    return lhs >= static_cast<T>( rhs );
+}
+
+template<typename T>
+constexpr inline bool operator>( const T &lhs, const fatigue_levels &rhs )
+{
+    return lhs > static_cast<T>( rhs );
+}
+
+template<typename T>
+constexpr inline bool operator<=( const T &lhs, const fatigue_levels &rhs )
+{
+    return lhs <= static_cast<T>( rhs );
+}
+
+template<typename T>
+constexpr inline bool operator<( const T &lhs, const fatigue_levels &rhs )
+{
+    return lhs < static_cast<T>( rhs );
+}
+
+template<typename T>
+constexpr inline int operator/( const fatigue_levels &lhs, const T &rhs )
+{
+    return static_cast<T>( lhs ) / rhs;
+}
+
+template<typename T>
+constexpr inline int operator+( const fatigue_levels &lhs, const T &rhs )
+{
+    return static_cast<T>( lhs ) + rhs;
+}
+
+template<typename T>
+constexpr inline int operator-( const fatigue_levels &lhs, const T &rhs )
+{
+    return static_cast<T>( lhs ) - rhs;
+}
+
+template<typename T>
+constexpr inline int operator-( const T &lhs, const fatigue_levels &rhs )
+{
+    return lhs - static_cast<T>( rhs );
+}
+
 const std::unordered_map<std::string, fatigue_levels> fatigue_level_strs = { {
-        { "TIRED", TIRED },
-        { "DEAD_TIRED", DEAD_TIRED },
-        { "EXHAUSTED", EXHAUSTED },
-        { "MASSIVE_FATIGUE", MASSIVE_FATIGUE }
+        { "TIRED", fatigue_levels::tired },
+        { "DEAD_TIRED", fatigue_levels::dead_tired },
+        { "EXHAUSTED", fatigue_levels::exhausted },
+        { "MASSIVE_FATIGUE", fatigue_levels::massive }
     }
 };
 
 // Sleep deprivation is defined in minutes, and although most calculations scale linearly,
 // maluses are bestowed only upon reaching the tiers defined below.
-enum sleep_deprivation_levels {
-    SLEEP_DEPRIVATION_HARMLESS = 2 * 24 * 60,
-    SLEEP_DEPRIVATION_MINOR = 4 * 24 * 60,
-    SLEEP_DEPRIVATION_SERIOUS = 7 * 24 * 60,
-    SLEEP_DEPRIVATION_MAJOR = 10 * 24 * 60,
-    SLEEP_DEPRIVATION_MASSIVE = 14 * 24 * 60
+enum class sleep_deprivation_levels : int {
+    harmless = 2 * 24 * 60,
+    minor = 4 * 24 * 60,
+    serious = 7 * 24 * 60,
+    major = 10 * 24 * 60,
+    massive = 14 * 24 * 60
 };
+
+constexpr inline bool operator>=( const sleep_deprivation_levels &lhs,
+                                  const sleep_deprivation_levels &rhs )
+{
+    return static_cast<int>( lhs ) >= static_cast<int>( rhs );
+}
+
+constexpr inline bool operator<( const sleep_deprivation_levels &lhs,
+                                 const sleep_deprivation_levels &rhs )
+{
+    return static_cast<int>( lhs ) < static_cast<int>( rhs );
+}
+
+template<typename T>
+constexpr inline bool operator>=( const T &lhs, const sleep_deprivation_levels &rhs )
+{
+    return lhs >= static_cast<T>( rhs );
+}
+
+template<typename T>
+constexpr inline bool operator>( const T &lhs, const sleep_deprivation_levels &rhs )
+{
+    return lhs > static_cast<T>( rhs );
+}
+
+template<typename T>
+constexpr inline bool operator<=( const T &lhs, const sleep_deprivation_levels &rhs )
+{
+    return lhs <= static_cast<T>( rhs );
+}
+
+template<typename T>
+constexpr inline bool operator<( const T &lhs, const sleep_deprivation_levels &rhs )
+{
+    return lhs < static_cast<T>( rhs );
+}
+
+template<typename T>
+constexpr inline int operator/( const sleep_deprivation_levels &lhs, const T &rhs )
+{
+    return static_cast<T>( lhs ) / rhs;
+}
+
+template<typename T>
+constexpr inline int operator+( const sleep_deprivation_levels &lhs, const T &rhs )
+{
+    return static_cast<T>( lhs ) + rhs;
+}
+
+template<typename T>
+constexpr inline int operator-( const sleep_deprivation_levels &lhs, const T &rhs )
+{
+    return static_cast<T>( lhs ) - rhs;
+}
+
+template<typename T>
+constexpr inline int operator-( const T &lhs, const sleep_deprivation_levels &rhs )
+{
+    return lhs - static_cast<T>( rhs );
+}
 
 // This tries to represent both rating and
 // character's decision to respect said rating

--- a/src/character.h
+++ b/src/character.h
@@ -184,10 +184,10 @@ const std::unordered_map<std::string, fatigue_levels> fatigue_level_strs = { {
 // maluses are bestowed only upon reaching the tiers defined below.
 enum class sleep_deprivation_levels : int {
     harmless = 2 * 24 * 60,
-    minor = 4 * 24 * 60,
-    serious = 7 * 24 * 60,
-    major = 10 * 24 * 60,
-    massive = 14 * 24 * 60
+    minor = 3 * 24 * 60,
+    serious = 4 * 24 * 60,
+    major = 5 * 24 * 60,
+    massive = 6 * 24 * 60
 };
 
 constexpr inline bool operator>=( const sleep_deprivation_levels &lhs,

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -65,6 +65,7 @@
 #include "sounds.h"
 #include "string_formatter.h"
 #include "string_id.h"
+#include "string_input_popup.h"
 #include "translations.h"
 #include "ui.h"
 #include "units.h"
@@ -890,15 +891,13 @@ static void wait()
             as_m.addentry( 12, true, 'w', _( "Wait until you catch your breath" ) );
             durations.emplace( 12, 15_minutes ); // to hide it from showing
         }
-        add_menu_item( 1, '1', !has_watch ? _( "Wait 300 heartbeats" ) : "", 5_minutes );
-        add_menu_item( 2, '2', !has_watch ? _( "Wait 1800 heartbeats" ) : "", 30_minutes );
-
-        if( has_watch ) {
-            add_menu_item( 3, '3', "", 1_hours );
-            add_menu_item( 4, '4', "", 2_hours );
-            add_menu_item( 5, '5', "", 3_hours );
-            add_menu_item( 6, '6', "", 6_hours );
-        }
+        add_menu_item( 1, '1', "", 5_minutes );
+        add_menu_item( 2, '2', "", 30_minutes );
+        add_menu_item( 3, '3', "", 1_hours );
+        add_menu_item( 4, '4', "", 2_hours );
+        add_menu_item( 5, '5', "", 3_hours );
+        add_menu_item( 6, '6', "", 6_hours );
+        as_m.addentry( 13, true, 'c', _( "Custom input" ) );
     }
 
     if( g->get_levz() >= 0 || has_watch ) {
@@ -938,11 +937,21 @@ static void wait()
     as_m.text += setting_alarm ? _( "Set alarm for when?" ) : _( "Wait for how long?" );
     as_m.query(); /* calculate key and window variables, generate window, and loop until we get a valid answer */
 
-    const auto dur_iter = durations.find( as_m.ret );
-    if( dur_iter == durations.end() ) {
-        return;
+    time_duration time_to_wait;
+    if( as_m.ret == 13 ) {
+        int minutes = string_input_popup()
+                      .title( _( "How long? (in minutes)" ) )
+                      .identifier( "wait_duration" )
+                      .query_int();
+        time_to_wait = minutes * 1_minutes;
+    } else {
+
+        const auto dur_iter = durations.find( as_m.ret );
+        if( dur_iter == durations.end() ) {
+            return;
+        }
+        time_to_wait = dur_iter->second;
     }
-    const time_duration time_to_wait = dur_iter->second;
 
     if( setting_alarm ) {
         // Setting alarm

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4425,7 +4425,7 @@ int iuse::hand_crank( player *p, item *it, bool, const tripoint & )
         p->add_msg_if_player( m_info, _( "It's not waterproof enough to work underwater." ) );
         return 0;
     }
-    if( p->get_fatigue() >= DEAD_TIRED ) {
+    if( p->get_fatigue() >= fatigue_levels::dead_tired ) {
         p->add_msg_if_player( m_info, _( "You're too exhausted to keep cranking." ) );
         return 0;
     }
@@ -4470,7 +4470,7 @@ int iuse::vibe( player *p, item *it, bool, const tripoint & )
         p->add_msg_if_player( m_info, _( "The %s's batteries are dead." ), it->tname() );
         return 0;
     }
-    if( p->get_fatigue() >= DEAD_TIRED ) {
+    if( p->get_fatigue() >= fatigue_levels::dead_tired ) {
         p->add_msg_if_player( m_info, _( "*Your* batteries are dead." ) );
         return 0;
     } else {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -668,7 +668,7 @@ bool spell::can_cast( const Character &guy ) const
         case bionic_energy:
             return guy.get_power_level() >= units::from_kilojoule( energy_cost( guy ) );
         case fatigue_energy:
-            return guy.get_fatigue() < EXHAUSTED;
+            return guy.get_fatigue() < fatigue_levels::exhausted;
         case none_energy:
         default:
             return true;
@@ -1448,7 +1448,7 @@ bool known_magic::has_enough_energy( const Character &guy, spell &sp ) const
             }
             return false;
         case fatigue_energy:
-            return guy.get_fatigue() < EXHAUSTED;
+            return guy.get_fatigue() < fatigue_levels::exhausted;
         case none_energy:
             return true;
         default:

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -487,7 +487,7 @@ void Character::activate_mutation( const trait_id &mut )
     // Fatigue can go to Exhausted.
     if( ( mdata.hunger && get_kcal_percent() < 0.5f ) || ( mdata.thirst &&
             get_thirst() >= 260 ) ||
-        ( mdata.fatigue && get_fatigue() >= EXHAUSTED ) ) {
+        ( mdata.fatigue && get_fatigue() >= fatigue_levels::exhausted ) ) {
         // Insufficient Foo to *maintain* operation is handled in player::suffer
         add_msg_if_player( m_warning, _( "You feel like using your %s would kill you!" ),
                            mdata.name() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1854,10 +1854,10 @@ npc_action npc::address_needs( float danger )
 
     const auto could_sleep = [&]() {
         if( danger <= 0.01 ) {
-            if( get_fatigue() >= TIRED ) {
+            if( get_fatigue() >= fatigue_levels::tired ) {
                 return true;
             } else if( is_walking_with() && g->u.in_sleep_state() &&
-                       get_fatigue() > ( TIRED / 2 ) ) {
+                       get_fatigue() > ( fatigue_levels::tired / 2 ) ) {
                 return true;
             }
         }
@@ -1871,7 +1871,7 @@ npc_action npc::address_needs( float danger )
             return npc_undecided;
         }
 
-        if( rules.has_flag( ally_rule::allow_sleep ) || get_fatigue() > MASSIVE_FATIGUE ) {
+        if( rules.has_flag( ally_rule::allow_sleep ) || get_fatigue() > fatigue_levels::massive ) {
             return npc_sleep;
         } else if( g->u.in_sleep_state() ) {
             // TODO: "Guard me while I sleep" command
@@ -4414,8 +4414,9 @@ bool npc::complain()
 
     // When tired, complain every 30 minutes
     // If massively tired, ignore restrictions
-    if( get_fatigue() > TIRED && complain_about( fatigue_string, 30_minutes, _( "<yawn>" ),
-            get_fatigue() > MASSIVE_FATIGUE - 100 ) )  {
+    if( get_fatigue() > fatigue_levels::tired &&
+        complain_about( fatigue_string, 30_minutes, _( "<yawn>" ),
+                        get_fatigue() > fatigue_levels::massive - 100 ) )  {
         return true;
     }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1078,16 +1078,16 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
         needs_rates rates = p->calc_needs_rates();
         if( ability >= 100 - ( p->get_fatigue() / 10 ) ) {
             std::string how_tired;
-            if( p->get_fatigue() > EXHAUSTED ) {
+            if( p->get_fatigue() > fatigue_levels::exhausted ) {
                 how_tired = _( "Exhausted" );
-            } else if( p->get_fatigue() > DEAD_TIRED ) {
+            } else if( p->get_fatigue() > fatigue_levels::dead_tired ) {
                 how_tired = _( "Dead tired" );
-            } else if( p->get_fatigue() > TIRED ) {
+            } else if( p->get_fatigue() > fatigue_levels::tired ) {
                 how_tired = _( "Tired" );
             } else {
                 how_tired = _( "Not tired" );
                 if( ability >= 100 ) {
-                    time_duration sleep_at = 5_minutes * ( TIRED - p->get_fatigue() ) /
+                    time_duration sleep_at = 5_minutes * ( fatigue_levels::tired - p->get_fatigue() ) /
                                              rates.fatigue;
                     how_tired += _( ".  Will need sleep in " ) + to_string_approx( sleep_at );
                 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3941,14 +3941,14 @@ int player::sleep_spot( const tripoint &p ) const
     if( has_trait( trait_EASYSLEEPER ) ) {
         // Low fatigue (being rested) has a much stronger effect than high fatigue
         // so it's OK for the value to be that much higher
-        sleepy += 24;
+        sleepy += 40;
     }
     if( has_active_bionic( bio_soporific ) ) {
         sleepy += 30;
     }
     if( has_trait( trait_EASYSLEEPER2 ) ) {
-        // Mousefolk can sleep just about anywhere.
-        sleepy += 40;
+        // At this point, the only limit to sleep is tiredness
+        sleepy += 100;
     }
     if( watersleep && g->m.has_flag_ter( "SWIMMABLE", pos() ) ) {
         sleepy += 10; //comfy water!

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3954,10 +3954,10 @@ int player::sleep_spot( const tripoint &p ) const
         sleepy += 10; //comfy water!
     }
 
-    if( get_fatigue() < TIRED + 1 ) {
-        sleepy -= static_cast<int>( ( TIRED + 1 - get_fatigue() ) / 4 );
+    if( get_fatigue() < fatigue_levels::tired + 1 ) {
+        sleepy -= static_cast<int>( ( fatigue_levels::tired + 1 - get_fatigue() ) / 4 );
     } else {
-        sleepy += static_cast<int>( ( get_fatigue() - TIRED + 1 ) / 16 );
+        sleepy += static_cast<int>( ( get_fatigue() - fatigue_levels::tired + 1 ) / 16 );
     }
 
     if( current_stim > 0 || !has_trait( trait_INSOMNIA ) ) {

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1048,7 +1048,7 @@ void player::hardcoded_effects( effect &it )
 
         if( get_fatigue() <= 0 && get_fatigue() > -20 && !has_effect( effect_narcosis ) ) {
             mod_fatigue( -25 );
-            if( get_sleep_deprivation() < SLEEP_DEPRIVATION_HARMLESS ) {
+            if( get_sleep_deprivation() < sleep_deprivation_levels::harmless ) {
                 add_msg_if_player( m_good, _( "You feel well rested." ) );
             } else {
                 add_msg_if_player( m_warning,

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2766,7 +2766,7 @@ static void CheckMessages()
                 }
 
                 // Check if we're dead tired - if so, add sleep
-                if( g->u.get_fatigue() > DEAD_TIRED ) {
+                if( g->u.get_fatigue() > fatigue_levels::dead_tired ) {
                     actions.insert( ACTION_SLEEP );
                 }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -226,7 +226,7 @@ void Character::suffer_mutation_power( const mutation_branch &mdata,
         if( mdata.fatigue ) {
             mod_fatigue( mdata.cost );
             // Exhausted
-            if( get_fatigue() >= EXHAUSTED ) {
+            if( get_fatigue() >= fatigue_levels::exhausted ) {
                 add_msg_if_player( m_warning,
                                    _( "You're too exhausted to keep your %s going." ),
                                    mdata.name() );
@@ -1322,7 +1322,7 @@ void Character::suffer_from_stimulants( const int current_stim )
 void Character::suffer_without_sleep( const int sleep_deprivation )
 {
     // redo as a snippet?
-    if( sleep_deprivation >= SLEEP_DEPRIVATION_HARMLESS ) {
+    if( sleep_deprivation >= sleep_deprivation_levels::harmless ) {
         if( one_turn_in( 50_minutes ) ) {
             switch( dice( 1, 4 ) ) {
                 default:
@@ -1346,7 +1346,7 @@ void Character::suffer_without_sleep( const int sleep_deprivation )
         }
     }
     // Minor discomfort
-    if( sleep_deprivation >= SLEEP_DEPRIVATION_MINOR ) {
+    if( sleep_deprivation >= sleep_deprivation_levels::minor ) {
         if( one_turn_in( 75_minutes ) ) {
             add_msg_if_player( m_warning, _( "You feel lightheaded for a moment." ) );
             moves -= 10;
@@ -1361,7 +1361,7 @@ void Character::suffer_without_sleep( const int sleep_deprivation )
         }
     }
     // Slight disability
-    if( sleep_deprivation >= SLEEP_DEPRIVATION_SERIOUS ) {
+    if( sleep_deprivation >= sleep_deprivation_levels::serious ) {
         if( one_turn_in( 75_minutes ) ) {
             add_msg_if_player( m_bad, _( "Your mind lapses into unawareness briefly." ) );
             moves -= rng( 20, 80 );
@@ -1376,7 +1376,7 @@ void Character::suffer_without_sleep( const int sleep_deprivation )
         }
     }
     // Major disability, high chance of passing out also relevant
-    if( sleep_deprivation >= SLEEP_DEPRIVATION_MAJOR ) {
+    if( sleep_deprivation >= sleep_deprivation_levels::major ) {
         if( !has_effect( effect_nausea ) && one_turn_in( 500_minutes ) ) {
             add_msg_if_player( m_bad, _( "You feel heartburn and an acid taste in your mouth." ) );
             mod_pain( 5 );
@@ -1581,7 +1581,7 @@ void Character::mend( int rate_multiplier )
     // Bed rest speeds up mending
     if( has_effect( effect_sleep ) ) {
         healing_factor *= 4.0;
-    } else if( get_fatigue() > DEAD_TIRED ) {
+    } else if( get_fatigue() > fatigue_levels::dead_tired ) {
         // but being dead tired does not...
         healing_factor *= 0.75;
     } else {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -92,6 +92,7 @@ static const efftype_id effect_hallu( "hallu" );
 static const efftype_id effect_iodine( "iodine" );
 static const efftype_id effect_masked_scent( "masked_scent" );
 static const efftype_id effect_mending( "mending" );
+static const efftype_id effect_meth( "meth" );
 static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_nausea( "nausea" );
 static const efftype_id effect_onfire( "onfire" );
@@ -1285,7 +1286,7 @@ void Character::suffer_from_stimulants( const int current_stim )
         }
     }
     if( current_stim > 75 ) {
-        if( !one_turn_in( 2_minutes ) && !has_effect( effect_nausea ) ) {
+        if( calendar::once_every( 5_minutes ) && !has_effect( effect_nausea ) ) {
             add_msg( _( "You feel nauseous…" ) );
             add_effect( effect_nausea, 5_minutes );
         }
@@ -1297,18 +1298,7 @@ void Character::suffer_from_stimulants( const int current_stim )
             add_msg_if_player( m_bad, _( "You black out!" ) );
             const time_duration dur = rng( 30_minutes, 60_minutes );
             add_effect( effect_downed, dur );
-            add_effect( effect_blind, dur );
             fall_asleep( dur );
-        }
-    }
-    if( current_stim < -85 || get_painkiller() > 145 ) {
-        if( one_turn_in( 15_seconds ) && !has_effect( effect_sleep ) ) {
-            add_msg_if_player( m_bad, _( "You feel dizzy for a moment." ) );
-            mod_moves( -rng( 10, 30 ) );
-            if( one_in( 3 ) && !has_effect( effect_downed ) ) {
-                add_msg_if_player( m_bad, _( "You stumble and fall over!" ) );
-                add_effect( effect_downed, rng( 3_turns, 10_turns ) );
-            }
         }
     }
     if( current_stim < -60 || get_painkiller() > 130 ) {
@@ -1321,6 +1311,9 @@ void Character::suffer_from_stimulants( const int current_stim )
 
 void Character::suffer_without_sleep( const int sleep_deprivation )
 {
+    if( has_effect( effect_meth ) ) {
+        return;
+    }
     // redo as a snippet?
     if( sleep_deprivation >= sleep_deprivation_levels::harmless ) {
         if( one_turn_in( 50_minutes ) ) {

--- a/tests/fatigue_test.cpp
+++ b/tests/fatigue_test.cpp
@@ -1,0 +1,73 @@
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <sstream>
+#include <vector>
+
+#include "calendar.h"
+#include "catch/catch.hpp"
+#include "enums.h"
+#include "npc.h"
+
+
+static const efftype_id effect_sleep( "sleep" );
+
+static void update_body_for( Character &dude, time_duration time )
+{
+    const time_point start = calendar::turn_zero;
+    const time_point end = start + time;
+    for( time_point now = start; now < end; now += 5_minutes ) {
+        dude.update_body( now, now + 5_minutes );
+    }
+}
+
+TEST_CASE( "must_sleep_8_hours", "[fatigue]" )
+{
+    standard_npc dude( "sleeper", tripoint( -1, -1, 0 ) );
+    dude.set_fatigue( 0 );
+    WHEN( "The character is active for 16 hours" ) {
+        update_body_for( dude, 16_hours );
+        int fatigue_before_sleep = dude.get_fatigue();
+        CAPTURE( fatigue_before_sleep );
+        AND_WHEN( "The character sleeps for 7 hours and 30 minutes" ) {
+            dude.add_effect( effect_sleep, 24_hours );
+            update_body_for( dude, 7_hours + 30_minutes );
+            THEN( "The character is not fully rested" ) {
+                CHECK( dude.get_fatigue() > 0 );
+            }
+        }
+        AND_WHEN( "The character sleeps for 8 hours" ) {
+            dude.add_effect( effect_sleep, 24_hours );
+            update_body_for( dude, 8_hours );
+            THEN( "The character is fully rested" ) {
+                CHECK( dude.get_fatigue() == 0 );
+            }
+        }
+    }
+}
+
+TEST_CASE( "sleep_deprivation_rate", "[fatigue]" )
+{
+    standard_npc dude( "sleeper", tripoint( -1, -1, 0 ) );
+    dude.set_fatigue( 0 );
+    dude.set_sleep_deprivation( 0 );
+    WHEN( "The character is active for 18 hours" ) {
+        update_body_for( dude, 18_hours );
+        int deprivation_before_sleep = dude.get_sleep_deprivation();
+        CAPTURE( deprivation_before_sleep );
+        AND_WHEN( "The character sleeps for 5 hours and 30 minutes" ) {
+            dude.add_effect( effect_sleep, 24_hours );
+            update_body_for( dude, 5_hours + 30_minutes );
+            THEN( "The character has some sleep deprivation" ) {
+                CHECK( dude.get_sleep_deprivation() > 0 );
+            }
+        }
+        AND_WHEN( "The character sleeps for 6 hours" ) {
+            dude.add_effect( effect_sleep, 24_hours );
+            update_body_for( dude, 6_hours );
+            THEN( "The character has no sleep deprivation" ) {
+                CHECK( dude.get_sleep_deprivation() == 0 );
+            }
+        }
+    }
+}

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -365,7 +365,7 @@ TEST_CASE( "npc_talk_needs", "[npc_talk]" )
     CHECK( d.responses[0].text == "This is a basic test response." );
     talker_npc.set_thirst( 90 );
     talker_npc.set_stored_kcal( 100 );
-    talker_npc.set_fatigue( EXHAUSTED );
+    talker_npc.set_fatigue( static_cast<int>( fatigue_levels::exhausted ) );
     gen_response_lines( d, 4 );
     CHECK( d.responses[0].text == "This is a basic test response." );
     CHECK( d.responses[1].text == "This is a npc thirst test response." );


### PR DESCRIPTION
* Sleep no longer conserves kcal/water - used to drain at 50% speed. Average character now needs 125 more kcal per day.
* Being just tired no longer drains focus. Other levels drain less: dead tired caps at 75, exhausted 50, massive exhaustion 25
* Made sleep deprivation more stable. Sleeping without a bed will be enough to keep it at bay, sleeping in bed doesn't triple healing time, just 150%.
* Sleep deprivation has lower max cap. 6 days of sleep deprivation results in collapsing.
* Meth lasts 12 hours, stacks up to 24 hours, gives small bonus, negates tiredness. 5 speed, 1 perception. Unhealthy, but not devastating.
* Meth halves sleep deprivation penalties and negates its effects (except collapse).
* Using meth significantly lowers thirst and hunger.
* Nerfed meth addiction. Won't drop you to 100 depressants if you did just one meth too many. Doesn't do anything if you're under the effects of meth right now (addiction mechanics trigger a bit fast).

So meth is no longer a "potion of speed", but a long buff that helps you a little bit with everything.
The idea is so that being permanently addicted to meth is actually worth considering, especially if you're going fast and expect to win or die before having to deal with the effects of addiction.