### PR TITLE
Remove the trench knife's unarmed weapon status

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -227,7 +227,7 @@
     "color": "dark_gray",
     "techniques": [ "WBLOCK_1" ],
     "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 19 ] ],
-    "flags": [ "DURABLE_MELEE", "STAB", "SHEATH_KNIFE", "UNARMED_WEAPON" ]
+    "flags": [ "DURABLE_MELEE", "STAB", "SHEATH_KNIFE" ]
   },
   {
     "id": "makeshift_knife",


### PR DESCRIPTION
Remove the trench knife's unarmed weapon status

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Rebalance "Remove the trench knife's unarmed weapon status"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/137
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Remove UNARMED_WEAPON flag from trench knife. Now it trains melee and piercing weapons.

>Fire-and-Glory 
> Currently the trench knife is an unarmed weapon, meaning:
> A. You can use it in unarmed martial arts, like boxing, karate, etc.
> 
> B. It trains solely the unarmed combat skill.
> 
> Apparently this was an intentional addition to CDDA some years back under the premise that since half of the weapon is a knuckle-duster, you should be able to use it in martial arts like other fist weapons.
> While in real life this makes a certain amount of sense, in game it is nonsensical since if you're punching zombies, you're not using the spike, yet all of the piercing damage is added in.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Implement switching mode for trench knife (brass knuckles/knife).
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Wield trench knife
2) Spawn debug monster
3) Hit deug monter few times
4) Melee and piercing weapons skills should be incresing but not unarmed melee.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
