### PR TITLE
[HOLD UP] Nerf ESAPI vest

### DIFF
--- a/data/json/items/armor/ballistic_armor.json
+++ b/data/json/items/armor/ballistic_armor.json
@@ -39,7 +39,7 @@
     "coverage": 85,
     "encumbrance": 10,
     "warmth": 15,
-    "material_thickness": 20,
+    "material_thickness": 7,
     "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "NO_REPAIR" ]
   },
   {

--- a/data/json/items/armor/ballistic_armor.json
+++ b/data/json/items/armor/ballistic_armor.json
@@ -18,7 +18,7 @@
     "coverage": 85,
     "encumbrance": 6,
     "warmth": 15,
-    "material_thickness": 6,
+    "material_thickness": 2,
     "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY" ]
   },
   {
@@ -29,8 +29,8 @@
     "description": "Ballistic armor with ESAPI ceramic armor plates.",
     "weight": "9911 g",
     "volume": "6 L",
-    "price": 280000,
-    "price_postapoc": 8000,
+    "price": 290000,
+    "price_postapoc": 3500,
     "material": [ "nylon", "ceramic" ],
     "symbol": "[",
     "looks_like": "modularvestceramic",

--- a/data/json/items/armor/ballistic_armor.json
+++ b/data/json/items/armor/ballistic_armor.json
@@ -29,7 +29,7 @@
     "description": "Ballistic armor with ESAPI ceramic armor plates.",
     "weight": "9911 g",
     "volume": "6 L",
-    "price": 290000,
+    "price": 280000,
     "price_postapoc": 3500,
     "material": [ "nylon", "ceramic" ],
     "symbol": "[",


### PR DESCRIPTION
Nerf ESAPI vest

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Rebalance "Nerf ESAPI vest"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/111
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
ESABI vest had insane stats. It was on pair with light combat exskeleton.
Now it is nerfed. Used stast somewhere between MBR kevlar and MBR cerramic.
It will be comparable with SWAT armor, but somewhat better.
Also changed price and post apoc price to reflect changes.
Nerfed empty ESAPI vest without plates as well.
![esapi_new](https://user-images.githubusercontent.com/17512620/97144965-774c4900-1776-11eb-9d7c-abbec1f79270.png)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
**Just revert: https://github.com/CleverRaven/Cataclysm-DDA/pull/36920**
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Spawn ESABI vest
2) Combapre its stat with SWAT armor, obsolated MBR with kevlar plates and obsolated MBR with cerramic plates.
3) ESAPI west should be between old MBR kevlar vest and MBR cerramic vest. Considering that MBR always has kevlar as material.
4) Check emepty ESAPI vest. Now it is just piece of farbric with almost no protection.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
