### PR TITLE
Rail crossbow mod buff

### DIFF
--- a/data/json/items/gunmod/rail.json
+++ b/data/json/items/gunmod/rail.json
@@ -18,7 +18,7 @@
       "skill": "rifle",
       "range": 8,
       "ranged_damage": { "damage_type": "stab", "amount": 28 },
-      "dispersion": 375,
+      "dispersion": 388,
       "durability": 10,
       "clip_size": 1
     },

--- a/data/json/items/gunmod/rail.json
+++ b/data/json/items/gunmod/rail.json
@@ -17,8 +17,8 @@
       "ammo": "bolt",
       "skill": "rifle",
       "range": 8,
-      "ranged_damage": { "damage_type": "stab", "amount": 3 },
-      "dispersion": 180,
+      "ranged_damage": { "damage_type": "stab", "amount": 28 },
+      "dispersion": 375,
       "durability": 10,
       "clip_size": 1
     },

--- a/data/json/items/gunmod/rail.json
+++ b/data/json/items/gunmod/rail.json
@@ -18,7 +18,7 @@
       "skill": "rifle",
       "range": 8,
       "ranged_damage": { "damage_type": "stab", "amount": 28 },
-      "dispersion": 388,
+      "dispersion": 387,
       "durability": 10,
       "clip_size": 1
     },


### PR DESCRIPTION
Rail crossbow mod buff
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Rebalance "Rail crossbow mod buff"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
![rail crossbow](https://user-images.githubusercontent.com/17512620/97175108-0885e480-17a4-11eb-8af8-31792db75217.png)
Rail crossbow using pre-rebalance values.  Found thanks to **Displeased man**
 Looks like it was missed during:
BALANCE Fiddle with archery and crossbow numbers: https://github.com/cataclysmbnteam/Cataclysm-BN/commits/upload?after=dbd818236acb45b6ee6d3c75f98f3e33eceece62+209&branch=upload
Currently it has very low damage but assault rifle accuracy. It has to be changed due to balance concerns.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution

- Increase damage for rail crossbow. Set it between hand crossbow and usual crossbow
- Increase dispersion. Dispersion for Rail crossbow was very low. Set dispersion between hand crossbow and usual crossbow

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Spawn and install Rail crossbow weapon mod
2) Observe the stats.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
