### PR TITLE
Tweak thirst numbers

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -1933,5 +1933,30 @@
     "remove_message": "You no longer feel so full.",
     "rating": "bad",
     "max_duration": "10 m"
+  },
+  {
+    "type": "effect_type",
+    "id": "thirsty",
+    "name": [ "Thirsty", "Thirsty" ],
+    "desc": [
+      "You're weakened by thirst."
+    ],
+    "miss_messages": [ [ "You're weak from thirst.", 1 ] ],
+    "//": "Speed penalty hardcoded, because it's not linear",
+    "base_mods": {
+      "str_mod": [ -1 ],
+      "dex_mod": [ -1 ],
+      "int_mod": [ -1 ],
+      "per_mod": [ -1 ]
+    },
+    "scaling_mods": {
+      "str_mod": [ -0.005 ],
+      "dex_mod": [ -0.005 ],
+      "int_mod": [ -0.005 ],
+      "per_mod": [ -0.005 ]
+    },
+    "max_intensity": 1000,
+    "int_dur_factor": "1 s",
+    "rating": "bad"
   }
 ]

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -91,6 +91,7 @@ static const efftype_id effect_sleep_deprived( "sleep_deprived" );
 static const efftype_id effect_slept_through_alarm( "slept_through_alarm" );
 static const efftype_id effect_stim( "stim" );
 static const efftype_id effect_stim_overdose( "stim_overdose" );
+static const efftype_id effect_thirsty( "thirsty" );
 
 static const trait_id trait_ARACHNID_ARMS( "ARACHNID_ARMS" );
 static const trait_id trait_ARACHNID_ARMS_OK( "ARACHNID_ARMS_OK" );
@@ -1214,15 +1215,7 @@ void avatar::reset_stats()
         mod_int_bonus( -( str_penalty / 2 ) );
     }
     // Thirst
-    if( get_thirst() >= 200 ) {
-        // We die at 1200
-        const int dex_mod = -get_thirst() / 200;
-        add_miss_reason( _( "You're weak from thirst." ), static_cast<unsigned>( -dex_mod ) );
-        mod_str_bonus( -get_thirst() / 200 );
-        mod_dex_bonus( dex_mod );
-        mod_int_bonus( -get_thirst() / 200 );
-        mod_per_bonus( -get_thirst() / 200 );
-    }
+    set_fake_effect_dur( effect_thirsty, 1_turns * ( get_thirst() - thirst_levels::very_thirsty ) );
     if( get_sleep_deprivation() >= sleep_deprivation_levels::harmless ) {
         set_fake_effect_dur( effect_sleep_deprived, 1_turns * get_sleep_deprivation() );
     } else if( has_effect( effect_sleep_deprived ) ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1551,7 +1551,7 @@ void Character::process_bionic( int b )
             mod_thirst( -water_available );
         }
 
-        if( get_thirst() < -40 ) {
+        if( get_thirst() <= thirst_levels::hydrated ) {
             add_msg_if_player( m_good,
                                _( "You are properly hydrated.  Your %s chirps happily." ),
                                bio.info().name );

--- a/src/character.h
+++ b/src/character.h
@@ -30,6 +30,7 @@
 #include "cursesdef.h"
 #include "damage.h"
 #include "enums.h"
+#include "enum_int_operators.h"
 #include "flat_set.h"
 #include "game_constants.h"
 #include "inventory.h"
@@ -114,63 +115,7 @@ enum class fatigue_levels : int {
     massive = 1000
 };
 
-constexpr inline bool operator>=( const fatigue_levels &lhs, const fatigue_levels &rhs )
-{
-    return static_cast<int>( lhs ) >= static_cast<int>( rhs );
-}
-
-constexpr inline bool operator<( const fatigue_levels &lhs, const fatigue_levels &rhs )
-{
-    return static_cast<int>( lhs ) < static_cast<int>( rhs );
-}
-
-template<typename T>
-constexpr inline bool operator>=( const T &lhs, const fatigue_levels &rhs )
-{
-    return lhs >= static_cast<T>( rhs );
-}
-
-template<typename T>
-constexpr inline bool operator>( const T &lhs, const fatigue_levels &rhs )
-{
-    return lhs > static_cast<T>( rhs );
-}
-
-template<typename T>
-constexpr inline bool operator<=( const T &lhs, const fatigue_levels &rhs )
-{
-    return lhs <= static_cast<T>( rhs );
-}
-
-template<typename T>
-constexpr inline bool operator<( const T &lhs, const fatigue_levels &rhs )
-{
-    return lhs < static_cast<T>( rhs );
-}
-
-template<typename T>
-constexpr inline int operator/( const fatigue_levels &lhs, const T &rhs )
-{
-    return static_cast<T>( lhs ) / rhs;
-}
-
-template<typename T>
-constexpr inline int operator+( const fatigue_levels &lhs, const T &rhs )
-{
-    return static_cast<T>( lhs ) + rhs;
-}
-
-template<typename T>
-constexpr inline int operator-( const fatigue_levels &lhs, const T &rhs )
-{
-    return static_cast<T>( lhs ) - rhs;
-}
-
-template<typename T>
-constexpr inline int operator-( const T &lhs, const fatigue_levels &rhs )
-{
-    return lhs - static_cast<T>( rhs );
-}
+DEFINE_INTEGER_OPERATORS( fatigue_levels )
 
 const std::unordered_map<std::string, fatigue_levels> fatigue_level_strs = { {
         { "TIRED", fatigue_levels::tired },
@@ -190,65 +135,20 @@ enum class sleep_deprivation_levels : int {
     massive = 6 * 24 * 60
 };
 
-constexpr inline bool operator>=( const sleep_deprivation_levels &lhs,
-                                  const sleep_deprivation_levels &rhs )
-{
-    return static_cast<int>( lhs ) >= static_cast<int>( rhs );
-}
+DEFINE_INTEGER_OPERATORS( sleep_deprivation_levels )
 
-constexpr inline bool operator<( const sleep_deprivation_levels &lhs,
-                                 const sleep_deprivation_levels &rhs )
-{
-    return static_cast<int>( lhs ) < static_cast<int>( rhs );
-}
+enum class thirst_levels : int {
+    turgid = INT_MIN,
+    hydrated = 0,
+    slaked = 60,
+    thirsty = 120,
+    very_thirsty = 240,
+    dehydrated = 480,
+    parched = 600,
+    dead = 1200
+};
 
-template<typename T>
-constexpr inline bool operator>=( const T &lhs, const sleep_deprivation_levels &rhs )
-{
-    return lhs >= static_cast<T>( rhs );
-}
-
-template<typename T>
-constexpr inline bool operator>( const T &lhs, const sleep_deprivation_levels &rhs )
-{
-    return lhs > static_cast<T>( rhs );
-}
-
-template<typename T>
-constexpr inline bool operator<=( const T &lhs, const sleep_deprivation_levels &rhs )
-{
-    return lhs <= static_cast<T>( rhs );
-}
-
-template<typename T>
-constexpr inline bool operator<( const T &lhs, const sleep_deprivation_levels &rhs )
-{
-    return lhs < static_cast<T>( rhs );
-}
-
-template<typename T>
-constexpr inline int operator/( const sleep_deprivation_levels &lhs, const T &rhs )
-{
-    return static_cast<T>( lhs ) / rhs;
-}
-
-template<typename T>
-constexpr inline int operator+( const sleep_deprivation_levels &lhs, const T &rhs )
-{
-    return static_cast<T>( lhs ) + rhs;
-}
-
-template<typename T>
-constexpr inline int operator-( const sleep_deprivation_levels &lhs, const T &rhs )
-{
-    return static_cast<T>( lhs ) - rhs;
-}
-
-template<typename T>
-constexpr inline int operator-( const T &lhs, const sleep_deprivation_levels &rhs )
-{
-    return lhs - static_cast<T>( rhs );
-}
+DEFINE_INTEGER_OPERATORS( thirst_levels )
 
 // This tries to represent both rating and
 // character's decision to respect said rating

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -38,7 +38,7 @@ status_t character_oracle_t::needs_warmth_badly() const
 status_t character_oracle_t::needs_water_badly() const
 {
     // Check thirst threshold.
-    if( subject->get_thirst() > 520 ) {
+    if( subject->get_thirst() > thirst_levels::parched ) {
         return running;
     }
     return success;

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1120,7 +1120,7 @@ bool Character::consume_effects( item &food )
     // Moved here and changed a bit - it was too complex
     // Incredibly minor stuff like this shouldn't require complexity
     if( !is_npc() && has_trait( trait_SLIMESPAWNER ) &&
-        max_stored_calories() < get_stored_kcal() + 4000 && get_thirst() < 40 ) {
+        max_stored_calories() < get_stored_kcal() + 4000 && get_thirst() < thirst_levels::slaked ) {
         add_msg_if_player( m_mixed,
                            _( "You feel as though you're going to split open!  In a good way?" ) );
         mod_pain( 5 );

--- a/src/enum_int_operators.h
+++ b/src/enum_int_operators.h
@@ -1,0 +1,72 @@
+#pragma once
+#ifndef CATA_SRC_ENUM_INT_OPERATORS_H
+#define CATA_SRC_ENUM_INT_OPERATORS_H
+
+#define DEFINE_INTEGER_OPERATORS(Type) \
+    \
+    constexpr inline bool operator>=( const Type &lhs,\
+                                      const Type &rhs )\
+    {\
+        return static_cast<int>( lhs ) >= static_cast<int>( rhs );\
+    }\
+    \
+    constexpr inline bool operator<( const Type &lhs,\
+                                     const Type &rhs )\
+    {\
+        return static_cast<int>( lhs ) < static_cast<int>( rhs );\
+    }\
+    template<typename T>\
+    constexpr inline bool operator>=( const T &lhs, const Type &rhs )\
+    {\
+        return lhs >= static_cast<T>( rhs );\
+    }\
+    \
+    template<typename T>\
+    constexpr inline bool operator>( const T &lhs, const Type &rhs )\
+    {\
+        return lhs > static_cast<T>( rhs );\
+    }\
+    \
+    template<typename T>\
+    constexpr inline bool operator<=( const T &lhs, const Type &rhs )\
+    {\
+        return lhs <= static_cast<T>( rhs );\
+    }\
+    \
+    template<typename T>\
+    constexpr inline bool operator<( const T &lhs, const Type &rhs )\
+    {\
+        return lhs < static_cast<T>( rhs );\
+    }\
+    \
+    template<typename T>\
+    constexpr inline int operator/( const Type &lhs, const T &rhs )\
+    {\
+        return static_cast<T>( lhs ) / rhs;\
+    }\
+    \
+    template<typename T>\
+    constexpr inline int operator+( const Type &lhs, const T &rhs )\
+    {\
+        return static_cast<T>( lhs ) + rhs;\
+    }\
+    \
+    template<typename T>\
+    constexpr inline int operator-( const Type &lhs, const T &rhs )\
+    {\
+        return static_cast<T>( lhs ) - rhs;\
+    }\
+    \
+    template<typename T>\
+    constexpr inline int operator-( const T &lhs, const Type &rhs )\
+    {\
+        return lhs - static_cast<T>( rhs );\
+    }\
+    \
+    /* For easy casting: +t is static_cast<int>(t) */\
+    constexpr int operator+(Type t) noexcept\
+    {\
+        return static_cast<int>(t);\
+    }
+
+#endif

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2133,7 +2133,8 @@ void iexamine::harvest_plant( player &p, const tripoint &examp, bool from_activi
     } else if( seedType == "marloss_seed" ) {
         fungus( p, examp );
         g->m.i_clear( examp );
-        if( p.has_trait( trait_M_DEPENDENT ) && ( p.get_kcal_percent() < 0.8f || p.get_thirst() > 300 ) ) {
+        if( p.has_trait( trait_M_DEPENDENT ) && ( p.get_kcal_percent() < 0.8f ||
+                p.get_thirst() > thirst_levels::very_thirsty ) ) {
             g->m.ter_set( examp, t_marloss );
             add_msg( m_info,
                      _( "We have altered this unit's configuration to extract and provide local nutriment.  The Mycus provides." ) );

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -486,7 +486,7 @@ void Character::activate_mutation( const trait_id &mut )
     // You can take yourself halfway to Near Death levels of hunger/thirst.
     // Fatigue can go to Exhausted.
     if( ( mdata.hunger && get_kcal_percent() < 0.5f ) || ( mdata.thirst &&
-            get_thirst() >= 260 ) ||
+            get_thirst() >= thirst_levels::dehydrated ) ||
         ( mdata.fatigue && get_fatigue() >= fatigue_levels::exhausted ) ) {
         // Insufficient Foo to *maintain* operation is handled in player::suffer
         add_msg_if_player( m_warning, _( "You feel like using your %s would kill you!" ),

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -338,7 +338,7 @@ void player::power_mutations()
                                 // Action done, leave screen
                                 exit = true;
                             } else if( ( !mut_data.hunger || get_kcal_percent() >= 0.8f ) &&
-                                       ( !mut_data.thirst || get_thirst() <= 400 ) &&
+                                       ( !mut_data.thirst || get_thirst() <= thirst_levels::dehydrated ) &&
                                        ( !mut_data.fatigue || get_fatigue() <= 400 ) ) {
                                 if( trans && !trans->msg_transform.empty() ) {
                                     add_msg_if_player( m_neutral, trans->msg_transform );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1751,8 +1751,8 @@ int npc::value( const item &it, int market_price ) const
         if( get_hunger() > 40 ) {
             comestval += ( nutrition_for( it ) + get_hunger() - 40 ) / 6;
         }
-        if( get_thirst() > 40 ) {
-            comestval += ( it.get_comestible()->quench + get_thirst() - 40 ) / 4;
+        if( get_thirst() > thirst_levels::thirsty ) {
+            comestval += ( it.get_comestible()->quench + get_thirst() - thirst_levels::thirsty ) / 4;
         }
         if( comestval > 0 && will_eat( it ).success() ) {
             ret += comestval;
@@ -2790,7 +2790,7 @@ void npc::process_turn()
     }
 
     if( is_player_ally() && calendar::once_every( 1_hours ) &&
-        get_hunger() < 200 && get_thirst() < 100 && op_of_u.trust < 5 ) {
+        get_hunger() < 200 && get_thirst() < thirst_levels::very_thirsty && op_of_u.trust < 5 ) {
         // Friends who are well fed will like you more
         // 24 checks per day, best case chance at trust 0 is 1 in 48 for +1 trust per 2 days
         float trust_chance = 5 - op_of_u.trust;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1807,7 +1807,7 @@ npc_action npc::address_needs( float danger )
     }
 
     // Extreme thirst or hunger, bypass safety check.
-    if( get_thirst() > 80 ||
+    if( get_thirst() > thirst_levels::dehydrated ||
         get_stored_kcal() + stomach.get_calories() < get_healthy_kcal() * 0.75 ) {
         if( consume_food_from_camp() ) {
             return npc_noop;
@@ -1827,7 +1827,7 @@ npc_action npc::address_needs( float danger )
         return npc_undecided;
     }
 
-    if( one_in( 3 ) && ( get_thirst() > 40 ||
+    if( one_in( 3 ) && ( get_thirst() > thirst_levels::thirsty ||
                          get_stored_kcal() + stomach.get_calories() < get_healthy_kcal() * 0.95 ) ) {
         if( consume_food_from_camp() ) {
             return npc_noop;
@@ -3784,7 +3784,7 @@ bool npc::consume_food_from_camp()
         return false;
     }
     basecamp *bcp = *potential_bc;
-    if( get_thirst() > 40 && bcp->has_water() ) {
+    if( get_thirst() > thirst_levels::thirsty && bcp->has_water() ) {
         set_thirst( 0 );
         return true;
     }
@@ -4441,7 +4441,8 @@ bool npc::complain()
 
     // Thirst every 2 hours
     // Since NPCs can't dry to death, respect the rules
-    if( get_thirst() > 80 && complain_about( thirst_string, 2_hours, _( "<thirsty>" ) ) ) {
+    if( get_thirst() > thirst_levels::very_thirsty &&
+        complain_about( thirst_string, 2_hours, _( "<thirsty>" ) ) ) {
         return true;
     }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1095,8 +1095,8 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
             info += "\n" + how_tired;
         }
         if( ability >= 100 ) {
-            if( p->get_thirst() < 100 ) {
-                time_duration thirst_at = 5_minutes * ( 100 - p->get_thirst() ) / rates.thirst;
+            if( p->get_thirst() < thirst_levels::thirsty ) {
+                time_duration thirst_at = 5_minutes * ( thirst_levels::thirsty - p->get_thirst() ) / rates.thirst;
                 if( thirst_at > 1_hours ) {
                     info += _( "\nWill need water in " ) + to_string_approx( thirst_at );
                 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -477,10 +477,10 @@ int player::thirst_speed_penalty( int thirst )
     // We die at 1200 thirst
     // Start by dropping speed really fast, but then level it off a bit
     static const std::vector<std::pair<float, float>> thirst_thresholds = {{
-            std::make_pair( 120.0f, 0.0f ),
-            std::make_pair( 300.0f, -25.0f ),
-            std::make_pair( 600.0f, -50.0f ),
-            std::make_pair( 1200.0f, -75.0f )
+            std::make_pair( +thirst_levels::very_thirsty, 0.0f ),
+            std::make_pair( +thirst_levels::dehydrated, -25.0f ),
+            std::make_pair( +thirst_levels::parched, -50.0f ),
+            std::make_pair( +thirst_levels::dead, -75.0f )
         }
     };
     return static_cast<int>( multi_lerp( thirst_thresholds, thirst ) );
@@ -497,7 +497,7 @@ void player::recalc_speed_bonus()
 
     mod_speed_bonus( -get_pain_penalty().speed );
 
-    if( get_thirst() > 120 ) {
+    if( get_thirst() > thirst_levels::very_thirsty ) {
         mod_speed_bonus( thirst_speed_penalty( get_thirst() ) );
     }
     // when underweight, you get slower. cumulative with hunger

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -257,7 +257,7 @@ void player_activity::do_turn( player &p )
                 no_food_nearby_for_auto_consume = true;
             }
         }
-        if( p.get_thirst() > 130 && !no_drink_nearby_for_auto_consume ) {
+        if( p.get_thirst() > thirst_levels::thirsty && !no_drink_nearby_for_auto_consume ) {
             if( !find_auto_consume( p, false ) ) {
                 no_drink_nearby_for_auto_consume = true;
             }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1059,7 +1059,7 @@ static void draw_initial_windows( const catacurses::window &w_stats,
                    pgettext( "speed penalty", "Pain                -%2d%%" ), pen );
         line++;
     }
-    if( you.get_thirst() > 120 ) {
+    if( you.get_thirst() > thirst_levels::very_thirsty ) {
         pen = std::abs( player::thirst_speed_penalty( you.get_thirst() ) );
         mvwprintz( w_speed, point( 1, line ), c_red,
                    pgettext( "speed penalty", "Thirst              -%2d%%" ), pen );

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1066,7 +1066,7 @@ void player::hardcoded_effects( effect &it )
                     if( get_hunger() >= -30 ) {
                         mod_hunger( -5 );
                     }
-                    if( get_thirst() >= -30 ) {
+                    if( get_thirst() >= thirst_levels::turgid ) {
                         mod_thirst( -5 );
                     }
                 }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2761,7 +2761,7 @@ static void CheckMessages()
                 }
 
                 // Check if we're significantly hungry or thirsty - if so, add eat
-                if( g->u.get_hunger() > 100 || g->u.get_thirst() > 40 ) {
+                if( g->u.get_hunger() > 100 || g->u.get_thirst() > thirst_levels::thirsty ) {
                     actions.insert( ACTION_EAT );
                 }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -217,7 +217,7 @@ void Character::suffer_mutation_power( const mutation_branch &mdata,
         if( mdata.thirst ) {
             mod_thirst( mdata.cost );
             // Well into Dehydrated
-            if( get_thirst() >= 260 ) {
+            if( get_thirst() >= thirst_levels::dehydrated ) {
                 add_msg_if_player( m_warning,
                                    _( "You're too dehydrated to keep your %s going." ),
                                    mdata.name() );
@@ -258,7 +258,7 @@ void Character::suffer_while_underwater()
         }
     }
     if( has_trait( trait_FRESHWATEROSMOSIS ) && !g->m.has_flag_ter( "SALT_WATER", pos() ) &&
-        get_thirst() > -60 ) {
+        get_thirst() > thirst_levels::turgid ) {
         mod_thirst( -1 );
     }
 }
@@ -893,7 +893,7 @@ void Character::suffer_from_other_mutations()
     int root_water = 0;
     if( has_trait( trait_ROOTS3 ) && g->m.has_flag( flag_PLOWABLE, pos() ) && !wearing_shoes ) {
         root_vitamins += 1;
-        if( get_thirst() <= -2000 ) {
+        if( get_thirst() <= thirst_levels::turgid ) {
             root_water += 51;
         }
     }
@@ -1589,8 +1589,9 @@ void Character::mend( int rate_multiplier )
     // square rooting the value makes the numbers drop off faster when below 1
     healing_factor *= std::sqrt( static_cast<float>( get_stored_kcal() ) / static_cast<float>
                                  ( get_healthy_kcal() ) );
-    // Similar for thirst - starts at very thirsty, drops to 0 ~halfway between two last statuses
-    healing_factor *= 1.0f - clamp( ( get_thirst() - 80.0f ) / 300.0f, 0.0f, 1.0f );
+    // Similar for thirst - starts at very thirsty, drops to 0 at parched
+    healing_factor *= 1.0f - clamp( 1.0f * ( get_thirst() - thirst_levels::very_thirsty ) /
+                                    +thirst_levels::parched, 0.0f, 1.0f );
 
     // Mutagenic healing factor!
     bool needs_splint = true;


### PR DESCRIPTION
Thirst display is a bit weird, with "you're full! are you sure you want to get bloated?" happening with nothing on display.

Also, thirst penalties happened too soon after drinking, which is just tedium, considering the ease of finding water. While the proper solution may be to get rid of thirst altogether, it would be a big change, so a minor fix for now.

Level | Starts at | Was
--- | --- | ---
turgid | -inf | -inf
hydrated | 0 | -60
slaked | gone | -20
no display | 60 | 0
thirsty | 120 | 60
very thirsty | 240 | 120
dehydrated | 480 | 240
parched | 600 | 520
dead | 1200 | 1200

This is more comparable to the old version, where you can drink yourself into -60 thirst.
The meaning of "Hydrated" is now "you probably won't be able to drink more water".