### PR TITLE
Draw lines of fire when aiming vehicle turrets

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -942,6 +942,12 @@
   },
   {
     "type": "keybinding",
+    "id": "TOGGLE_TURRET_LINES",
+    "name": "Toggle turret lines",
+    "bindings": [ { "input_method": "keyboard", "key": "t" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "SELECT",
     "name": "Select",
     "bindings": [ { "input_method": "mouse", "key": "MOUSE_LEFT" } ]

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -556,8 +556,8 @@ void game::draw_hit_player( const Character &p, const int dam )
 /* Line drawing code, not really an animation but should be separated anyway */
 namespace
 {
-void draw_line_curses( game &g, const tripoint &/*pos*/, const tripoint &center,
-                       const std::vector<tripoint> &ret )
+void draw_line_curses( game &g, const tripoint &center, const std::vector<tripoint> &ret,
+                       bool noreveal )
 {
     for( const tripoint &p : ret ) {
         const auto critter = g.critter_at( p, true );
@@ -565,7 +565,16 @@ void draw_line_curses( game &g, const tripoint &/*pos*/, const tripoint &center,
         // NPCs and monsters get drawn with inverted colors
         if( critter && g.u.sees( *critter ) ) {
             critter->draw( g.w_terrain, center, true );
+        } else if( noreveal && !g.u.sees( p ) ) {
+            // Draw a meaningless symbol. Avoids revealing tile, but keeps feedback
+            const char sym = '?';
+            const nc_color col = c_dark_gray;
+            const catacurses::window &w = g.w_terrain;
+            const int k = p.x + getmaxx( w ) / 2 - center.x;
+            const int j = p.y + getmaxy( w ) / 2 - center.y;
+            mvwputch( w, point( k, j ), col, sym );
         } else {
+            // This function reveals tile at p and writes it to the player's memory
             g.m.drawsq( g.w_terrain, g.u, p, true, true, center );
         }
     }
@@ -574,15 +583,14 @@ void draw_line_curses( game &g, const tripoint &/*pos*/, const tripoint &center,
 
 #if defined(TILES)
 void game::draw_line( const tripoint &p, const tripoint &center,
-                      const std::vector<tripoint> &points )
+                      const std::vector<tripoint> &points, bool noreveal )
 {
     if( !u.sees( p ) ) {
         return;
     }
 
-    // TODO: needed for tiles ver too??
     if( !use_tiles ) {
-        draw_line_curses( *this, p, center, points );
+        draw_line_curses( *this, center, points, noreveal );
         return;
     }
 
@@ -590,13 +598,13 @@ void game::draw_line( const tripoint &p, const tripoint &center,
 }
 #else
 void game::draw_line( const tripoint &p, const tripoint &center,
-                      const std::vector<tripoint> &points )
+                      const std::vector<tripoint> &points, bool noreveal )
 {
     if( !u.sees( p ) ) {
         return;
     }
 
-    draw_line_curses( *this, p, center, points );
+    draw_line_curses( *this, center, points, noreveal );
 }
 #endif
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3455,7 +3455,7 @@ void game::draw_ter( const tripoint &center, const bool looking, const bool draw
         // Draw auto-move preview trail
         const tripoint &final_destination = destination_preview.back();
         tripoint line_center = u.pos() + u.view_offset;
-        draw_line( final_destination, line_center, destination_preview );
+        draw_line( final_destination, line_center, destination_preview, true );
         mvwputch( w_terrain, final_destination.xy() - u.view_offset.xy() + point( POSX - u.posx(),
                   POSY - u.posy() ), c_white, 'X' );
     }

--- a/src/game.h
+++ b/src/game.h
@@ -656,7 +656,7 @@ class game
         void draw_hit_mon( const tripoint &p, const monster &m, bool dead = false );
         void draw_hit_player( const Character &p, int dam );
         void draw_line( const tripoint &p, const tripoint &center_point,
-                        const std::vector<tripoint> &points );
+                        const std::vector<tripoint> &points, bool noreveal = false );
         void draw_line( const tripoint &p, const std::vector<tripoint> &points );
         void draw_weather( const weather_printable &wPrint );
         void draw_sct();

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1680,8 +1680,13 @@ std::vector<tripoint> target_handler::target_ui( player &pc, target_mode mode,
                 int available_lines = compact ? 1 : ( height - num_instruction_lines - line_number - 12 );
                 line_number = critter->print_info( w_target, line_number, available_lines, 1 );
             } else {
-                mvwputch( g->w_terrain, -center.xy() + dst.xy() + point( POSX, POSY ),
-                          c_red, '*' );
+                if( use_tiles ) {
+                    if( dst.z == center.z ) {
+                        g->draw_cursor( dst );
+                    }
+                } else {
+                    mvwputch( g->w_terrain, -center.xy() + dst.xy() + point( POSX, POSY ), c_red, '*' );
+                }
             }
 
             // Assumes that relevant == null means firing turrets (maybe even multiple at once),


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Interface "Draw lines of fire when aiming vehicle turrets"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
1. Fix exploit with automove on CURSES (cherry-picked CleverRaven#40194; required for the next change)
2. Draw approx. lines of fire when aiming vehicle turrets to avoid confusion (CleverRaven#40198 adapted for BN)
3. Prevent aiming cursor on TILES from disappearing when aiming at a tile out of sight (just an annoying visual bug, fixed in mainline as part of CleverRaven#39785)
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Cherry-pick and/or adapt code from the mainline

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Cherry-picking CleverRaven#39785 for the bugfixes first, but it had accumulated a billion merge conflicts/its own changes by now. I could try to port all of that to BN and make a big PR (3k-4k lines of C++) - if you're willing to have these changes / review them?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
(On CURSES) Clicked on tiles at the edge of FoV to trigger the exploit - the path shows as dark grey `?` signs.

(On TILES and CURSES) Installed a bunch of turrets on a vehicle - aiming them draw individual trajectories, and pressing `t` toggles the display to avoid overcrowding.

(On TILES) Tried aiming with a gun at a tile outside FoV - aiming cursor remains visible
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
