### PR TITLE
Port over active enchantment condition

### DIFF
--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -2,7 +2,7 @@
   {
     "type": "enchantment",
     "id": "ENCH_INVISIBILITY",
-    "condition": "ALWAYS",
+    "condition": "ACTIVE",
     "ench_effects": [ { "effect": "invisibility", "intensity": 1 } ]
   }
 ]

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -204,7 +204,7 @@ You can assign a spell as a special attack for a monster.
 |---                          |---
 | id                          | Unique ID. Must be one continuous word, use underscores if necessary.
 | has                         | How an enchantment determines if it is in the right location in order to qualify for being active. "WIELD" - when wielded in your hand * "WORN" - when worn as armor * "HELD" - when in your inventory
-| condition                   | How an enchantment determines if you are in the right environments in order for the enchantment to qualify for being active. * "ALWAYS" - Always and forevermore * "UNDERGROUND" - When the owner of the item is below Z-level 0 * "UNDERWATER" - When the owner is in swimmable terrain
+| condition                   | How an enchantment determines if you are in the right environments in order for the enchantment to qualify for being active. * "ALWAYS" - Always and forevermore * "UNDERGROUND" - When the owner of the item is below Z-level 0 * "UNDERWATER" - When the owner is in swimmable terrain * "ACTIVE" - whenever the item, mutation, bionic, or whatever the enchantment is attached to is active.
 | hit_you_effect              | A spell that activates when you melee_attack a creature.  The spell is centered on the location of the creature unless self = true, then it is centered on your location.  Follows the template for defining "fake_spell"
 | hit_me_effect               | A spell that activates when you are hit by a creature.  The spell is centered on your location.  Follows the template for defining "fake_spell"
 | intermittent_activation     | Spells that activate centered on you depending on the duration.  The spells follow the "fake_spell" template.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7634,14 +7634,9 @@ void Character::recalculate_enchantment_cache()
     for( const std::pair<const trait_id, trait_data> &mut_map : my_mutations ) {
         const mutation_branch &mut = mut_map.first.obj();
 
-        // only add the passive or powered active mutations
-        if( mut.activated && !mut_map.second.powered ) {
-            continue;
-        }
-
         for( const enchantment_id &ench_id : mut.enchantments ) {
             const enchantment &ench = ench_id.obj();
-            if( ench.is_active( *this ) ) {
+            if( ench.is_active( *this, mut.activated && mut_map.second.powered ) ) {
                 enchantment_cache.force_add( ench );
             }
         }
@@ -7649,13 +7644,10 @@ void Character::recalculate_enchantment_cache()
 
     for( const bionic &bio : *my_bionics ) {
         const bionic_id &bid = bio.id;
-        if( bid->toggled && !bio.powered ) {
-            continue;
-        }
 
         for( const enchantment_id &ench_id : bid->enchantments ) {
             const enchantment &ench = ench_id.obj();
-            if( ench.is_active( *this ) ) {
+            if( ench.is_active( *this, bio.powered && bid->toggled ) ) {
                 enchantment_cache.force_add( ench );
             }
         }

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -60,6 +60,7 @@ namespace io
         case enchantment::condition::ALWAYS: return "ALWAYS";
         case enchantment::condition::UNDERGROUND: return "UNDERGROUND";
         case enchantment::condition::UNDERWATER: return "UNDERWATER";
+        case enchantment::condition::ACTIVE: return "ACTIVE";
         case enchantment::condition::NUM_CONDITION: break;
         }
         debugmsg( "Invalid enchantment::condition" );
@@ -180,11 +181,14 @@ bool enchantment::is_active( const Character &guy, const item &parent ) const
         return false;
     }
 
-    return is_active( guy );
+    return is_active( guy, parent.active );
 }
 
-bool enchantment::is_active( const Character &guy ) const
+bool enchantment::is_active( const Character &guy, const bool active ) const
 {
+    if( active_conditions.second == condition::ACTIVE ) {
+        return active;
+    }
 
     if( active_conditions.second == condition::ALWAYS ) {
         return true;

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -34,6 +34,7 @@ class enchantment
             ALWAYS,
             UNDERGROUND,
             UNDERWATER,
+            ACTIVE, // the item, mutation, etc. is active
             NUM_CONDITION
         };
         // the different types of values that can be modified by enchantments
@@ -123,8 +124,8 @@ class enchantment
         // this enchantment has a valid condition and is in the right location
         bool is_active( const Character &guy, const item &parent ) const;
 
-        // this enchantment has a valid item independent conditions
-        bool is_active( const Character &guy ) const;
+        // @active means the container for the enchantment is active, for comparison to active flag.
+        bool is_active( const Character &guy, bool active ) const;
 
         // this enchantment is active when wielded.
         // shows total conditional values, so only use this when Character is not available

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -518,6 +518,10 @@ void Character::activate_mutation( const trait_id &mut )
         recalc_sight_limits();
     }
 
+    if( !mut->enchantments.empty() ) {
+        recalculate_enchantment_cache();
+    }
+
     if( mdata.transform ) {
         const cata::value_ptr<mut_transform> trans = mdata.transform;
         mod_moves( - trans->moves );
@@ -655,6 +659,10 @@ void Character::deactivate_mutation( const trait_id &mut )
         const cata::value_ptr<mut_transform> trans = mdata.transform;
         mod_moves( -trans->moves );
         switch_mutations( mut, trans->target, trans->active );
+    }
+
+    if( !mut->enchantments.empty() ) {
+        recalculate_enchantment_cache();
     }
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Features "Port over ACTIVE enchantment condition" 

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

First part of my work to port over any post-nested CDDA features that will be useful once I start updating third-party mods to have versions compatible with Bright Nights.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Updated magic_enchantment.cpp with changes to enchantment condition checking.
2. Updated magic_enchantment.cpp with changes to enchantment condition enum and is_active definition.
3. Updated character.cpp with changes to the checks for whether an enchanted mutation or bionic is active, updated according to the difference in how BN's code checks for if a CBM is toggled.
4. Updated MAGIC.md with the provided mention of active enchantment condition.
5. Updated ENCH_INVISIBILITY in enchantments.json to use ACTIVE condition.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Since artifact effects still exist in BN alongside relic data, transforming relics can also be set up to use artifact effects as needed, but porting over the ability to ping relic effects when an item is toggled on adds a lot more options.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Implemented every file change except step five.
2. Compiled and started up a world.
3. Debug installed Cloaking System CBM, to confirm that invisibility effect would trigger even with it inactive.
4. Closed game to implement final file change.
5. Started up world again.
6. Debug installed Cloaking System CBM along with some power and powergen, to confirm that invisibility effect would now only trigger when CBM is turned on.
7. Add the following debug items to the JSON:
```
  {
    "id": "debug_active_relic_test",
    "type": "TOOL",
    "name": { "str": "Cube of Shame", "str_pl": "Cubes of Shame" },
    "description": "This is a debug-only item for testing relic activation, powered by batteries.  Turn it on to lose intelligence and perception.",
    "material": [ "steel" ],
    "symbol": ";",
    "color": "blue",
    "weight": "400 g",
    "volume": "500 ml",
    "charges_per_use": 1,
    "ammo": "battery",
    "use_action": {
      "type": "transform",
      "msg": "You inject yourself into the Cube of Shame.",
      "target": "debug_active_relic_test_on",
      "active": true,
      "need_charges": 1,
      "need_charges_msg": "Batteries not included."
    },
    "magazines": [
      [
        "battery",
        [
          "light_disposable_cell",
          "light_minus_disposable_cell",
          "light_battery_cell",
          "light_plus_battery_cell",
          "light_minus_battery_cell",
          "light_atomic_battery_cell",
          "light_minus_atomic_battery_cell"
        ]
      ]
    ],
    "magazine_well": 1,
    "relic_data": {
      "passive_effects": [
        {
          "has": "HELD",
          "condition": "ACTIVE",
          "values": [ { "value": "INTELLIGENCE", "add": -4 }, { "value": "PERCEPTION", "add": -4 } ]
        }
      ]
    }
  },
  {
    "id": "debug_active_relic_test_on",
    "copy-from": "debug_active_relic_test",
    "type": "TOOL",
    "name": { "str": "Cube of Shame (on)", "str_pl": "Cube of Shame (on)" },
    "description": "This is a debug-only item for testing relic activation, powered by batteries.  Drop it or turn it off to retrieve your mind.",
    "power_draw": 10000,
    "revert_to": "debug_active_relic_test",
    "use_action": {
      "menu_text": "Turn off",
      "type": "transform",
      "msg": "You extract yourself from the Cube of Shame.",
      "target": "debug_active_relic_test"
    }
  }
```
8. Spawn in the first debug item, confirm that stats only change when holding it while it's active.

Occurrence of the long-standing bug where enchantment stat changes trigger twice (https://github.com/CleverRaven/Cataclysm-DDA/issues/42452) was detected during testing, I guess I'll add that to my to-do list.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

PR being ported: https://github.com/CleverRaven/Cataclysm-DDA/pull/43351

File changes not ported over:
1. Change to ENCH_SHADOW_CLOUD in, since it's contingent on that enchantment existing, which is a consequence of the field light override PR.
2. Changes to two files in TEST_DATA mod (bionics.json and mutations.json) that do not exist in BN.
3. Changes to enchantment_test.cpp in the test folder, which does not exist in BN.

One error reported while compiler was at player.cpp, a file that was not altered while porting changes over, cause uncertain:
```
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\include\utility(248,16): warning C4244: 'initializing': conversion from '_Ty' to '_Ty1', possible loss of data
1>        with
1>        [
1>            _Ty=double
1>        ]
1>        and
1>        [
1>            _Ty1=float
1>        ] (compiling source file ..\src\player.cpp)
1>C:\Users\V\Documents\GitHub\Cataclysm-BN\src\player.cpp(467): message : see reference to function template instantiation 'std::pair<float,float>::pair<double,float,0>(std::pair<double,float> &&) noexcept' being compiled
1>C:\Users\V\Documents\GitHub\Cataclysm-BN\src\player.cpp(461): message : see reference to function template instantiation 'std::pair<float,float>::pair<double,float,0>(std::pair<double,float> &&) noexcept' being compiled
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.27.29110\include\utility(248,16): warning C4244: 'initializing': conversion from '_Ty' to '_Ty1', possible loss of data
1>        with
1>        [
1>            _Ty=int
1>        ]
1>        and
1>        [
1>            _Ty1=float
1>        ] (compiling source file ..\src\player.cpp)
1>C:\Users\V\Documents\GitHub\Cataclysm-BN\src\player.cpp(485): message : see reference to function template instantiation 'std::pair<float,float>::pair<int,float,0>(std::pair<int,float> &&) noexcept' being compiled
1>C:\Users\V\Documents\GitHub\Cataclysm-BN\src\player.cpp(479): message : see reference to function template instantiation 'std::pair<float,float>::pair<int,float,0>(std::pair<int,float> &&) noexcept' being compiled
```

No further errors were reported, compiling continued as normal without failure.
