### PR TITLE
Fix relic stat changes applying twice

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1571,8 +1571,6 @@ void Character::process_turn()
     }
 
     Creature::process_turn();
-
-    enchantment_cache.activate_passive( *this );
 }
 
 void Character::recalc_hp()


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix relic stat changes applying twice"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Second part of the "fix/update magic stuff for later use" series, this time going with a very easy one to port over.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Removed redundant line in character.cpp that causes stat changes from relics to double.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Changing the JSON for every relic in the game so their stat changes take into account being applied twice.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested game.
2. Re-introduced our dear friend the Cube of Shame from the preceding magic-related PR:
```
  {
    "id": "debug_active_relic_test",
    "type": "TOOL",
    "name": { "str": "Cube of Shame", "str_pl": "Cubes of Shame" },
    "description": "This is a debug-only item for testing relic activation, powered by batteries.  Turn it on to lose intelligence and perception.",
    "material": [ "steel" ],
    "symbol": ";",
    "color": "blue",
    "weight": "400 g",
    "volume": "500 ml",
    "charges_per_use": 1,
    "ammo": "battery",
    "use_action": {
      "type": "transform",
      "msg": "You inject yourself into the Cube of Shame.",
      "target": "debug_active_relic_test_on",
      "active": true,
      "need_charges": 1,
      "need_charges_msg": "Batteries not included."
    },
    "magazines": [
      [
        "battery",
        [
          "light_disposable_cell",
          "light_minus_disposable_cell",
          "light_battery_cell",
          "light_plus_battery_cell",
          "light_minus_battery_cell",
          "light_atomic_battery_cell",
          "light_minus_atomic_battery_cell"
        ]
      ]
    ],
    "magazine_well": 1,
    "relic_data": {
      "passive_effects": [
        {
          "has": "HELD",
          "condition": "ACTIVE",
          "values": [ { "value": "INTELLIGENCE", "add": -4 }, { "value": "PERCEPTION", "add": -4 } ]
        }
      ]
    }
  },
  {
    "id": "debug_active_relic_test_on",
    "copy-from": "debug_active_relic_test",
    "type": "TOOL",
    "name": { "str": "Cube of Shame (on)", "str_pl": "Cube of Shame (on)" },
    "description": "This is a debug-only item for testing relic activation, powered by batteries.  Drop it or turn it off to retrieve your mind.",
    "power_draw": 10000,
    "revert_to": "debug_active_relic_test",
    "use_action": {
      "menu_text": "Turn off",
      "type": "transform",
      "msg": "You extract yourself from the Cube of Shame.",
      "target": "debug_active_relic_test"
    }
  }
```
3. Spawned said item in and activated it, confirming that intelligence and perception only go down by 4 as intended.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Relevant DDA PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/42700

I'm wondering if the Cube of Shame is going to see enough use for testing these PRs to warrant actually adding it to the repo as a debug item...
