### PR TITLE
Port over mutations granting effects (and fix)

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -626,6 +626,13 @@
   },
   {
     "type": "effect_type",
+    "id": "debug_clairvoyance",
+    "name": [ "Debug Clairvoyance" ],
+    "desc": [ "You can see through everything!" ],
+    "flags": [ "EFFECT_SUPER_CLAIRVOYANCE" ]
+  },
+  {
+    "type": "effect_type",
     "id": "took_flumed"
   },
   {

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -734,6 +734,24 @@
     "type": "json_flag"
   },
   {
+    "id": "EFFECT_CLAIRVOYANCE",
+    "context": [  ],
+    "type": "json_flag",
+    "//": "Effect flag, grants same abilities as a source of AEP_CLAIRVOYANCE would."
+  },
+  {
+    "id": "EFFECT_CLAIRVOYANCE_PLUS",
+    "context": [  ],
+    "type": "json_flag",
+    "//": "Effect flag, grants same abilities as a source of VISION_CLAIRVOYANCE_PLUS would."
+  },
+  {
+    "id": "EFFECT_SUPER_CLAIRVOYANCE",
+    "context": [  ],
+    "type": "json_flag",
+    "//": "Effect flag, grants same abilities as a source of AEP_SUPER_CLAIRVOYANCE would."
+  },
+  {
     "id": "ELECTRIC_IMMUNE",
     "context": [  ],
     "type": "json_flag"

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -150,6 +150,68 @@
     }
   },
   {
+    "id": "debug_active_relic_test",
+    "type": "TOOL",
+    "name": { "str": "Cube of Shame", "str_pl": "Cubes of Shame" },
+    "description": "This is a debug-only item for testing relic properties, powered by batteries.  Turn it on to lose intelligence and perception, but gain clairvoyance",
+    "material": [ "steel" ],
+    "symbol": ";",
+    "color": "blue",
+    "weight": "400 g",
+    "volume": "500 ml",
+    "charges_per_use": 1,
+    "ammo": "battery",
+    "use_action": {
+      "type": "transform",
+      "msg": "You inject yourself into the Cube of Shame.",
+      "target": "debug_active_relic_test_on",
+      "active": true,
+      "need_charges": 1,
+      "need_charges_msg": "Batteries not included."
+    },
+    "magazines": [
+      [
+        "battery",
+        [
+          "light_disposable_cell",
+          "light_minus_disposable_cell",
+          "light_battery_cell",
+          "light_plus_battery_cell",
+          "light_minus_battery_cell",
+          "light_atomic_battery_cell",
+          "light_minus_atomic_battery_cell"
+        ]
+      ]
+    ],
+    "magazine_well": 1,
+    "relic_data": {
+      "passive_effects": [
+        { "has": "HELD", "condition": "ALWAYS", "mutations": [ "SCHIZOPHRENIC" ] },
+        {
+          "has": "HELD",
+          "condition": "ACTIVE",
+          "values": [ { "value": "INTELLIGENCE", "add": -4 }, { "value": "PERCEPTION", "add": -4 } ],
+          "ench_effects": [ { "effect": "debug_clairvoyance", "intensity": 1 } ]
+        }
+      ]
+    }
+  },
+  {
+    "id": "debug_active_relic_test_on",
+    "copy-from": "debug_active_relic_test",
+    "type": "TOOL",
+    "name": { "str": "Cube of Shame (on)", "str_pl": "Cube of Shame (on)" },
+    "description": "This is a debug-only item for testing relic properties, powered by batteries.  Drop it or turn it off to retrieve your mind.",
+    "power_draw": 10000,
+    "revert_to": "debug_active_relic_test",
+    "use_action": {
+      "menu_text": "Turn off",
+      "type": "transform",
+      "msg": "You extract yourself from the Cube of Shame.",
+      "target": "debug_active_relic_test"
+    }
+  },
+  {
     "id": "e_tool",
     "type": "TOOL",
     "name": { "str": "entrenching tool" },

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -205,9 +205,11 @@ You can assign a spell as a special attack for a monster.
 | id                          | Unique ID. Must be one continuous word, use underscores if necessary.
 | has                         | How an enchantment determines if it is in the right location in order to qualify for being active. "WIELD" - when wielded in your hand * "WORN" - when worn as armor * "HELD" - when in your inventory
 | condition                   | How an enchantment determines if you are in the right environments in order for the enchantment to qualify for being active. * "ALWAYS" - Always and forevermore * "UNDERGROUND" - When the owner of the item is below Z-level 0 * "UNDERWATER" - When the owner is in swimmable terrain * "ACTIVE" - whenever the item, mutation, bionic, or whatever the enchantment is attached to is active.
+| ench_effects                | Grants effects of specified "intensity" as long as this enchantment is applicable. Use intensity of 1 will work for effects that do not actually have intensities.
 | hit_you_effect              | A spell that activates when you melee_attack a creature.  The spell is centered on the location of the creature unless self = true, then it is centered on your location.  Follows the template for defining "fake_spell"
 | hit_me_effect               | A spell that activates when you are hit by a creature.  The spell is centered on your location.  Follows the template for defining "fake_spell"
 | intermittent_activation     | Spells that activate centered on you depending on the duration.  The spells follow the "fake_spell" template.
+| mutations                   | Which mutations are granted by this enchantment, mimicking their effects.
 | values                      | Anything that is a number that can be modified.  The id field is required, and "add" and "multiply" are optional.  A "multiply" value of -1 is -100% and a multiply of 2.5 is +250%.  Add is always before multiply. See allowed id below.
 
 
@@ -234,6 +236,7 @@ You can assign a spell as a special attack for a monster.
     "has": "WIELD",
     "hit_you_effect": [ { "id": "AEA_FIREBALL" } ],
     "hit_me_effect": [ { "id": "AEA_HEAL" } ],
+    "mutations": [ "KILLER", "PARKOUR" ],
     "values": [ { "value": "STRENGTH", "multiply": 1.1, "add": -5 } ],
     "intermittent_activation": {
       "effects": [ 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1691,15 +1691,11 @@ void Character::recalc_sight_limits()
         vision_mode_cache.set( IR_VISION );
     }
 
-    if( has_artifact_with( AEP_SUPER_CLAIRVOYANCE ) ) {
+    if( has_artifact_with( AEP_SUPER_CLAIRVOYANCE ) || has_effect_with_flag( "EFFECT_SUPER_CLAIRVOYANCE" ) ) {
         vision_mode_cache.set( VISION_CLAIRVOYANCE_SUPER );
-    }
-
-    if( has_artifact_with( AEP_CLAIRVOYANCE_PLUS ) ) {
+    } else if( has_artifact_with( AEP_CLAIRVOYANCE_PLUS ) || has_effect_with_flag( "EFFECT_CLAIRVOYANCE_PLUS" ) ) {
         vision_mode_cache.set( VISION_CLAIRVOYANCE_PLUS );
-    }
-
-    if( has_artifact_with( AEP_CLAIRVOYANCE ) ) {
+    } else if( has_artifact_with( AEP_CLAIRVOYANCE ) || has_effect_with_flag( "EFFECT_CLAIRVOYANCE" ) ) {
         vision_mode_cache.set( VISION_CLAIRVOYANCE );
     }
 }
@@ -7620,19 +7616,14 @@ void Character::recalculate_enchantment_cache()
     // start by resetting the cache to all inventory items
     enchantment_cache = inv.get_active_enchantment_cache( *this );
 
-    for( const enchantment &ench : weapon.get_enchantments() ) {
-        if( ench.is_active( *this, weapon ) ) {
-            enchantment_cache.force_add( ench );
-        }
-    }
-
-    for( const item &worn_it : worn ) {
-        for( const enchantment &ench : worn_it.get_enchantments() ) {
-            if( ench.is_active( *this, worn_it ) ) {
+    visit_items( [&]( const item * it ) {
+        for( const enchantment &ench : it->get_enchantments() ) {
+            if( ench.is_active( *this, *it ) ) {
                 enchantment_cache.force_add( ench );
             }
         }
-    }
+        return VisitResponse::NEXT;
+    } );
 
     // get from traits/ mutations
     for( const std::pair<const trait_id, trait_data> &mut_map : my_mutations ) {
@@ -9382,11 +9373,29 @@ void Character::on_worn_item_washed( const item &it )
 
 void Character::on_item_wear( const item &it )
 {
+    for( const trait_id &mut : it.mutations_from_wearing( *this ) ) {
+        mutation_effect( mut, true );
+        recalc_sight_limits();
+        calc_encumbrance();
+
+        // If the stamina is higher than the max (Languorous), set it back to max
+        if( get_stamina() > get_stamina_max() ) {
+            set_stamina( get_stamina_max() );
+        }
+    }
     morale->on_item_wear( it );
 }
 
 void Character::on_item_takeoff( const item &it )
 {
+    for( const trait_id &mut : it.mutations_from_wearing( *this ) ) {
+        mutation_loss_effect( mut );
+        recalc_sight_limits();
+        calc_encumbrance();
+        if( get_stamina() > get_stamina_max() ) {
+            set_stamina( get_stamina_max() );
+        }
+    }
     morale->on_item_takeoff( it );
 }
 

--- a/src/character.h
+++ b/src/character.h
@@ -945,7 +945,7 @@ class Character : public Creature, public visitable<Character>
         float mabuff_attack_cost_mult() const;
 
         /** Handles things like destruction of armor, etc. */
-        void mutation_effect( const trait_id &mut );
+        void mutation_effect( const trait_id &mut, bool worn_destroyed_override );
         /** Handles what happens when you lose a mutation. */
         void mutation_loss_effect( const trait_id &mut );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8470,6 +8470,34 @@ void item::process_artifact( player *carrier, const tripoint & /*pos*/ )
     }
 }
 
+
+std::vector<trait_id> item::mutations_from_wearing( const Character &guy ) const
+{
+    if( !is_relic() ) {
+        return std::vector<trait_id> {};
+    }
+    std::vector<trait_id> muts;
+
+    for( const enchantment &ench : relic_data->get_enchantments() ) {
+        for( const trait_id &mut : ench.get_mutations() ) {
+            // this may not be perfectly accurate due to conditions
+            muts.push_back( mut );
+        }
+    }
+
+    for( const trait_id &char_mut : guy.get_mutations() ) {
+        for( auto iter = muts.begin(); iter != muts.end(); ) {
+            if( char_mut == *iter ) {
+                iter = muts.erase( iter );
+            } else {
+                ++iter;
+            }
+        }
+    }
+
+    return muts;
+}
+
 void item::process_relic( Character *carrier )
 {
     if( !is_relic() ) {

--- a/src/item.h
+++ b/src/item.h
@@ -1280,6 +1280,8 @@ class item : public visitable<item>
          */
         void on_damage( int qty, damage_type dt );
 
+        std::vector<trait_id> mutations_from_wearing( const Character &guy ) const;
+
         /**
          * Name of the item type (not the item), with proper plural.
          * This is only special when the item itself has a special name ("name" entry in

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -250,6 +250,8 @@ void enchantment::load( const JsonObject &jo, const std::string & )
         ench_effects.emplace( efftype_id( jsobj.get_string( "effect" ) ), jsobj.get_int( "intensity" ) );
     }
 
+    optional( jo, was_loaded, "mutations", mutations );
+
     if( jo.has_array( "values" ) ) {
         for( const JsonObject value_obj : jo.get_array( "values" ) ) {
             const enchantment::mod value = io::string_to_enum<mod>( value_obj.get_string( "value" ) );
@@ -303,6 +305,8 @@ void enchantment::serialize( JsonOut &jsout ) const
         }
         jsout.end_object();
     }
+
+    jsout.member( "mutations", mutations );
 
     jsout.member( "values" );
     jsout.start_array();
@@ -359,6 +363,10 @@ void enchantment::force_add( const enchantment &rhs )
 
     if( rhs.emitter ) {
         emitter = rhs.emitter;
+    }
+
+    for( const trait_id &branch : rhs.mutations ) {
+        mutations.emplace( branch );
     }
 
     for( const std::pair<const time_duration, std::vector<fake_spell>> &act_pair :

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -144,7 +144,12 @@ class enchantment
         void cast_hit_you( Character &caster, const Creature &target ) const;
         // casts all the hit_me_effects on self or a target depending on the enchantment definition
         void cast_hit_me( Character &caster, const Creature *target ) const;
+
+        std::set<trait_id> get_mutations() const {
+            return mutations;
+        }
     private:
+        std::set<trait_id> mutations;
         cata::optional<emit_id> emitter;
         std::map<efftype_id, int> ench_effects;
         // values that add to the base value

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2771,6 +2771,20 @@ std::vector<trait_id> Character::get_mutations( bool include_hidden ) const
             result.push_back( t.first );
         }
     }
+    for( const trait_id &ench_trait : enchantment_cache.get_mutations() ) {
+        if( include_hidden || ench_trait->player_display ) {
+            bool found = false;
+            for( const trait_id &exist : result ) {
+                if( exist == ench_trait ) {
+                    found = true;
+                    break;
+                }
+            }
+            if( !found ) {
+                result.push_back( ench_trait );
+            }
+        }
+    }
     return result;
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Features "Port over changes allowing enchantments to grant mutations, more flexible implementation of relic-based clairvoyance."

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Adds the code changes from the PRs that allow for enchantments to grant the effects of mutations. This includes the clairvoyance update that was added at the same time as the first PR, and the code changes in the followup PR so that it wasn't pretty much only applying mutation flag effects.

However, instead of tying clairvoyance to a mutation flag, I implemented it via effect flag instead. This is more versatile, not only can any source of enchantments thus provide clairvoyance via granting an effect, but likewise any source of effects (not just enchantments) can do so.

This will likely go well with future plans to JSONize more hardcoded checks to allow using effect flags.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Ported over changes to character.cpp, but with checks for effect flags instead of mutation flags, while also retaining the AEP checks since artifacts aren't quite gone yet.
2. Ported over changes to item.cpp and item.h from the fix PR.
3. Ported over changes to magic_enchantment.cpp and magic_enchantmemt.h allowing enchantments to add mutations.
4. Ported over changes to mutation.cpp from the fix PR.
5. Ported over changes to newcharacter.cpp also supporting this feature.
6. Added the Debug Clairvoyance trait from the PR for testing.
7. Added the debug testing relic from the last couple PRs, this time with a mutation effect added to it and an enchantment effect. Will alter its relic data as subsequent PRs warrant, making it a testbed for subsequent features being ported over.
8. Added definitions for the flags to flags.json, not necessary but it's useful for reference since effect flags are not yet documented.
9. Updated MAGIC.md to describe mutations from enchantments as well as effects from enchantments, added a demonstration of the former to the example mutation after that section.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Adding in the stranger method of checking for clairvoyance via mutation flag anyway. I was intially tempted to just add both to the code since it wouldn't really hurt, but I realized that using an effect flag for it can ALREADY do everything that the mutation flag can do, making the mutation flag method redundant.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Testing:
1. Compile and load test.
2. Start up game and spawn in the current edition of the Cube of Shame.
3. Wield cube and wait a bit, confirming that effects of Psychosis start to take effect.
4. Activate cube and check that debug clairvoyance is on the effect list, and that you can see through walls.
5. Drop or deactivate cube, to confirm that clairvoyance effect goes away.
6. Drop cube and confirm that Psychosis trait is gone.
7. Debug in Psychosis trait onto the player.
8. Pick up and drop cube again to confirm it does not remove the existing mutation.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Relevant PRs:
1. https://github.com/CleverRaven/Cataclysm-DDA/pull/42199
2. https://github.com/CleverRaven/Cataclysm-DDA/pull/42950

Not ported over:
1. The changes that turn the Architect's Cube from a generated-on-command artifact to a JSON-defined relic, since I added the Cube of Shame for general relic testing.
2. Debug Clairvoyance trait, since mutations can grant enchantments, enchantments are about to be able to grant mutations, and enchantments can grant effects, etc etc.

Feel free to request any mutation checks that might be desirable to convert into an effect-flag check. Reasonably easy for me to do.