### PR TITLE
Misc UI changes from DDA 2

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -253,6 +253,7 @@
     "stim": 12,
     "addiction_potential": 3,
     "addiction_type": "caffeine",
+    "use_action": { "type": "consume_drug", "activation_message": "You take a caffeine pill." },
     "fatigue_mod": 9
   },
   {

--- a/data/json/npcs/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/TALK_COMMON_OTHER.json
@@ -122,7 +122,8 @@
         "trial": { "type": "INTIMIDATE", "difficulty": 20, "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ] },
         "success": { "topic": "TALK_AGREE_FOLLOW", "effect": "follow", "opinion": { "trust": -4, "fear": 3, "value": -1, "anger": 4 } },
         "failure": { "topic": "TALK_DENY_FOLLOW", "effect": "deny_follow", "opinion": { "trust": 4, "value": -5, "anger": 10 } }
-      }
+      },
+      { "switch": true, "default": true, "text": "Nevermind.", "topic": "TALK_NONE" }
     ]
   },
   {

--- a/data/json/npcs/talk_tags.json
+++ b/data/json/npcs/talk_tags.json
@@ -1347,6 +1347,38 @@
   },
   {
     "type": "snippet",
+    "category": "<camp_water_thanks>",
+    "//": "NPCs say this after drinking water from a camp well.",
+    "text": [
+      "Clean water, the taste that refreshes!",
+      "I was parched, but not I am not.",
+      "Water is nice, but I should get a grog ration.",
+      "That wasn't Evian, but I'm not thirsty."
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "<camp_food_thanks>",
+    "//": "NPCs say this after eating food from a basecamp larder.",
+    "text": [
+      "And now I have eaten and am not hungry.",
+      "That food was good, but I miss real restaurants.",
+      "Well, that satisfied me.",
+      "I just had some food, but I'm still peckish.  Would you mind if I ate more?"
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "<camp_larder_empty>",
+    "//": "NPCs say this after trying to eat from a basecamp larder with no food.",
+    "text": [
+      "Hey, <name_g>, we're out of food.",
+      "Hey, the larder is empty!  We're going to starve.",
+      "Uhm, <name_g>, I don't meant to criticize, but we should focus on distributing some food into the basecamp larder."
+    ]
+  },
+  {
+    "type": "snippet",
     "category": "<danger_close_distance>",
     "//": "A threat is very close.",
     "text": [ "right on top of us!", "right there!", "danger close!", "almost in melee range!", "too close for comfort!" ]

--- a/data/json/npcs/talk_tags.json
+++ b/data/json/npcs/talk_tags.json
@@ -1347,6 +1347,30 @@
   },
   {
     "type": "snippet",
+    "category": "<danger_close_distance>",
+    "//": "A threat is very close.",
+    "text": [ "right on top of us!", "right there!", "danger close!", "almost in melee range!", "too close for comfort!" ]
+  },
+  {
+    "type": "snippet",
+    "category": "<close_distance>",
+    "//": "A threat is close.",
+    "text": [ "within shooting range.", "only a couple of seconds' away.", "just a bit away.", "closer than I'd like." ]
+  },
+  {
+    "type": "snippet",
+    "category": "<medium_distance>",
+    "//": "A threat is nearby.",
+    "text": [ "near enough to see us.", "quite a bit away.", "maybe within shooting range.", "at a good distance." ]
+  },
+  {
+    "type": "snippet",
+    "category": "<far_distance>",
+    "//": "A threat is on the horizon.",
+    "text": [ "far enough away that we could make sneak away.", "out on the horizon, so don't worry much.", "at a long distance." ]
+  },
+  {
+    "type": "snippet",
     "category": "<ally_rule_use_guns_true_text>",
     "text": "<mypronoun> will use ranged weapons."
   },

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5810,10 +5810,10 @@ void game::print_all_tile_info( const tripoint &lp, const catacurses::window &w_
     if( inbounds ) {
         visibility = m.get_visibility( m.apparent_light_at( lp, cache ), cache );
     }
+    const Creature *creature = critter_at( lp, true );
     switch( visibility ) {
         case VIS_CLEAR: {
             const optional_vpart_position vp = m.veh_at( lp );
-            const Creature *creature = critter_at( lp, true );
             print_terrain_info( lp, w_look, area_name, column, line );
             print_fields_info( lp, w_look, column, line );
             print_trap_info( lp, w_look, column, line );
@@ -5838,6 +5838,34 @@ void game::print_all_tile_info( const tripoint &lp, const catacurses::window &w_
         case VIS_LIT:
         case VIS_HIDDEN:
             print_visibility_info( w_look, column, line, visibility );
+
+            if( creature != nullptr ) {
+                if( u.sees_with_infrared( *creature ) ) {
+                    std::string size_str;
+                    switch( creature->get_size() ) {
+                        case MS_TINY:
+                            size_str = pgettext( "infrared size", "tiny" );
+                            break;
+                        case MS_SMALL:
+                            size_str = pgettext( "infrared size", "small" );
+                            break;
+                        case MS_MEDIUM:
+                            size_str = pgettext( "infrared size", "medium" );
+                            break;
+                        case MS_LARGE:
+                            size_str = pgettext( "infrared size", "large" );
+                            break;
+                        case MS_HUGE:
+                            size_str = pgettext( "infrared size", "huge" );
+                            break;
+                    }
+                    mvwprintw( w_look, point( 1, ++line ), _( "You see a figure radiating heat." ) );
+                    mvwprintw( w_look, point( 1, ++line ), _( "It is %s in size." ),
+                               size_str );
+                } else if( u.sees_with_specials( *creature ) ) {
+                    mvwprintw( w_look, point( 1, ++line ), _( "You sense a creature here." ) );
+                }
+            }
 
             if( draw_terrain_indicators && !liveview.is_enabled() ) {
                 print_visibility_indicator( visibility );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5589,6 +5589,10 @@ static std::string get_fire_fuel_string( const tripoint &examp )
 
 void game::examine( const tripoint &examp )
 {
+    if( disable_robot( examp ) ) {
+        return;
+    }
+
     Creature *c = critter_at( examp );
     if( c != nullptr ) {
         monster *mon = dynamic_cast<monster *>( c );

--- a/src/npc.h
+++ b/src/npc.h
@@ -1041,7 +1041,7 @@ class npc : public player
         // wrapper for complain_about that warns about a specific type of threat, with
         // different warnings for hostile or friendly NPCs and hostile NPCs always complaining
         void warn_about( const std::string &type, const time_duration &d = 10_minutes,
-                         const std::string &name = "" );
+                         const std::string &name = "", int range = -1, const tripoint &danger_pos = tripoint_zero );
         // Finds something to complain about and complains. Returns if complained.
         bool complain();
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -444,10 +444,11 @@ void npc::assess_danger()
         }
         float critter_threat = evaluate_enemy( critter );
         // warn and consider the odds for distant enemies
+        int dist = rl_dist( pos(), critter.pos() );
         if( ( is_enemy() || !critter.friendly ) ) {
             assessment += critter_threat;
             if( critter_threat > ( 8.0f + personality.bravery + rng( 0, 5 ) ) ) {
-                warn_about( "monster", 10_minutes, critter.type->nname() );
+                warn_about( "monster", 10_minutes, critter.type->nname(), dist, critter.pos() );
             }
         }
         // ignore targets behind glass even if we can see them
@@ -455,7 +456,6 @@ void npc::assess_danger()
             continue;
         }
 
-        int dist = rl_dist( pos(), critter.pos() );
         float scaled_distance = std::max( 1.0f, dist / critter.speed_rating() );
         float hp_percent = 1.0f - static_cast<float>( critter.get_hp() ) / critter.get_hp_max();
         float critter_danger = std::max( critter_threat * ( hp_percent * 0.5f + 0.5f ),
@@ -500,11 +500,11 @@ void npc::assess_danger()
     }
     const auto handle_hostile = [&]( const player & foe, float foe_threat,
     const std::string & bogey, const std::string & warning ) {
+        int dist = rl_dist( pos(), foe.pos() );
         if( foe_threat > ( 8.0f + personality.bravery + rng( 0, 5 ) ) ) {
-            warn_about( "monster", 10_minutes, bogey );
+            warn_about( "monster", 10_minutes, bogey, dist, foe.pos() );
         }
 
-        int dist = rl_dist( pos(), foe.pos() );
         int scaled_distance = std::max( 1, ( 100 * dist ) / foe.get_speed() );
         ai_cache.total_danger += foe_threat / scaled_distance;
         // ignore targets behind glass even if we can see them
@@ -4297,7 +4297,21 @@ static body_part bp_affected( npc &who, const efftype_id &effect_type )
     return ret;
 }
 
-void npc::warn_about( const std::string &type, const time_duration &d, const std::string &name )
+static std::string distance_string( int range )
+{
+    if( range < 6 ) {
+        return "<danger_close_distance>";
+    } else if( range < 11 ) {
+        return "<close_distance>";
+    } else if( range < 26 ) {
+        return "<medium_distance>";
+    } else {
+        return "<far_distance>";
+    }
+}
+
+void npc::warn_about( const std::string &type, const time_duration &d, const std::string &name,
+                      int range, const tripoint &danger_pos )
 {
     std::string snip;
     sounds::sound_t spriority = sounds::sound_t::alert;
@@ -4337,9 +4351,16 @@ void npc::warn_about( const std::string &type, const time_duration &d, const std
         return;
     }
     const std::string warning_name = "warning_" + type + name;
-    const std::string speech = name.empty() ? snip :
-                               string_format( _( "%s %s<punc>" ), snip, name );
-    complain_about( warning_name, d, speech, is_enemy(), spriority );
+    if( name.empty() ) {
+        complain_about( warning_name, d, snip, is_enemy(), spriority );
+    } else {
+        const std::string range_str = range < 1 ? "<punc>" :
+                                      string_format( _( " %s, %s" ),
+                                              direction_name( direction_from( pos(), danger_pos ) ),
+                                              distance_string( range ) );
+        const std::string speech = string_format( _( "%s %s%s" ), snip, name, range_str );
+        complain_about( warning_name, d, speech, is_enemy(), spriority );
+    }
 }
 
 bool npc::complain_about( const std::string &issue, const time_duration &dur,

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3785,6 +3785,7 @@ bool npc::consume_food_from_camp()
     }
     basecamp *bcp = *potential_bc;
     if( get_thirst() > thirst_levels::thirsty && bcp->has_water() ) {
+        complain_about( "camp_water_thanks", 1_hours, "<camp_water_thanks>", false );
         set_thirst( 0 );
         return true;
     }
@@ -3792,11 +3793,13 @@ bool npc::consume_food_from_camp()
     int camp_kcals = std::min( std::max( 0, 19 * get_healthy_kcal() / 20 - get_stored_kcal() -
                                          stomach.get_calories() ), yours->food_supply );
     if( camp_kcals > 0 ) {
+        complain_about( "camp_food_thanks", 1_hours, "<camp_food_thanks>", false );
         mod_hunger( -camp_kcals );
         mod_stored_kcal( camp_kcals );
         yours->food_supply -= camp_kcals;
         return true;
     }
+    complain_about( "camp_larder_empty", 1_hours, "<camp_larder_empty>", false );
     return false;
 }
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -134,6 +134,10 @@ class uilist;
 class uilist_callback
 {
     public:
+
+        /**
+        * After a new item is selected, call this once
+        */
         virtual void select( uilist * ) {}
         virtual bool key( const input_context &, const input_event &/*key*/, int /*entnum*/,
                           uilist * ) {

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -457,6 +457,18 @@ class wish_item_callback: public uilist_callback
         wish_item_callback( const std::vector<const itype *> &ids ) :
             incontainer( false ), has_flag( false ), spawn_everything( false ), standard_itype_ids( ids ) {
         }
+
+        void select( uilist *menu ) override {
+            if( menu->selected < 0 ) {
+                return;
+            }
+            if( standard_itype_ids[menu->selected]->phase == phase_id::LIQUID ) {
+                incontainer = true;
+            } else {
+                incontainer = false;
+            }
+        }
+
         bool key( const input_context &, const input_event &event, int /*entnum*/,
                   uilist * /*menu*/ ) override {
             if( event.get_first_input() == 'f' ) {

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -638,7 +638,10 @@ void worldfactory::draw_mod_list( const catacurses::window &w, int &start, size_
         mSortCategory[0] = sLastCategoryName;
 
         for( size_t i = 0; i < mods.size(); ++i ) {
-            const std::string category_name = _( mods[i]->category.second );
+            std::string category_name = _( "MISSING MODS" );
+            if( mods[i].is_valid() ) {
+                category_name = mods[i]->obsolete ? _( "OBSOLETE MODS" ) : _( mods[i]->category.second );
+            }
             if( sLastCategoryName != category_name ) {
                 sLastCategoryName = category_name;
                 mSortCategory[ i + iCatSortNum++ ] = sLastCategoryName;
@@ -688,8 +691,21 @@ void worldfactory::draw_mod_list( const catacurses::window &w, int &start, size_
                         }
                     }
 
-                    const MOD_INFORMATION &mod = **iter;
-                    trim_and_print( w, point( 4, iNum - start ), wwidth, c_white, mod.name() );
+                    const mod_id &mod_entry_id = *iter;
+                    std::string mod_entry_name = string_format( _( " [%s]" ), mod_entry_id.str() );
+                    nc_color mod_entry_color = c_white;
+                    if( mod_entry_id.is_valid() ) {
+                        const MOD_INFORMATION &mod = *mod_entry_id;
+                        mod_entry_name = mod.name() + mod_entry_name;
+                        if( mod.obsolete ) {
+                            mod_entry_color = c_dark_gray;
+                        }
+                    } else {
+                        mod_entry_color = c_light_red;
+                        mod_entry_name = _( "N/A" ) + mod_entry_name;
+
+                    }
+                    trim_and_print( w, point( 4, iNum - start ), wwidth, mod_entry_color, mod_entry_name );
 
                     if( w_shift ) {
                         // get shift information for the active item


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: None
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Port usability/flavor changes for UI from DDA
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
CleverRaven#41017 (squashed with CleverRaven#43124)
CleverRaven#42154
CleverRaven#42510
CleverRaven#42424 (squashed with CleverRaven#44531; tweaked to prompt only once if there are many acidic corpses in the pile)
CleverRaven#40464
CleverRaven#40624 (squashed with CleverRaven#40702)
CleverRaven#40632
CleverRaven#41781
CleverRaven#43381

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Created a new world, obsoleted/removed some mods, queried for list of mods - obsoleted/removed ones have their own category.
Asked NPC to travel with me - 'Nevermind' shows up and works.
Tried pulping a pile of corpses with acidic ones in them - the game warns about acid.
Used 'look around' menu while wearing IR goggles - flavor text shows up.
'Wish for item' menu auto-enables container for liquids, does not crash.
Caffeine pill shows up in `a`ctivate menu; activating a pill consumes it.
Spawned a bunch of vehicles in various conditions; played around with battery charge levels.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
