### PR TITLE
Npc ai fixes

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -409,6 +409,8 @@ void npc::assess_danger()
     if( is_player_ally() && rules.engagement == combat_engagement::FREE_FIRE ) {
         def_radius = std::max( 6, max_range );
     }
+    const bool must_retreat = rules.has_flag( ally_rule::follow_close ) &&
+                              !too_close( pos(), player_character.pos(), def_radius );
     // find our Character friends and enemies
     std::vector<weak_ptr_fast<Creature>> hostile_guys;
     for( const npc &guy : g->all_npcs() ) {
@@ -449,6 +451,9 @@ void npc::assess_danger()
             if( critter_threat > ( 8.0f + personality.bravery + rng( 0, 5 ) ) ) {
                 warn_about( "monster", 10_minutes, critter.type->nname() );
             }
+        }
+        if( must_retreat ) {
+            continue;
         }
         // ignore targets behind glass even if we can see them
         if( !clear_shot_reach( pos(), critter.pos(), false ) ) {
@@ -507,6 +512,9 @@ void npc::assess_danger()
         int dist = rl_dist( pos(), foe.pos() );
         int scaled_distance = std::max( 1, ( 100 * dist ) / foe.get_speed() );
         ai_cache.total_danger += foe_threat / scaled_distance;
+        if( must_retreat ) {
+            return 0.0f;
+        }
         // ignore targets behind glass even if we can see them
         if( !clear_shot_reach( pos(), foe.pos(), false ) ) {
             return 0.0f;
@@ -834,7 +842,8 @@ void npc::move()
         }
     }
     if( action == npc_undecided ) {
-        // an interrupted activity can cause this situation. stops allied NPCs zooming off like random NPCs
+        // an interrupted activity can cause this situation. stops allied NPCs zooming off
+        // like random NPCs
         if( attitude == NPCATT_ACTIVITY && !activity ) {
             revert_after_activity();
             if( is_ally( g->u ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -804,6 +804,11 @@ void npc::move()
         }
     }
 
+    // check if in vehicle before doing any other follow activities
+    if( action == npc_undecided && is_walking_with() && g->u.in_vehicle && !in_vehicle ) {
+        action = npc_follow_embarked;
+    }
+
     if( action == npc_undecided && is_walking_with() && rules.has_flag( ally_rule::follow_close ) &&
         rl_dist( pos(), g->u.pos() ) > follow_distance() ) {
         action = npc_follow_player;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -362,7 +362,7 @@ void npc::assess_danger()
     const bool self_defense_only = rules.engagement == combat_engagement::NO_MOVE ||
                                    rules.engagement == combat_engagement::NONE;
     const bool no_fighting = rules.has_flag( ally_rule::forbid_engage );
-    const bool must_retreat = rules.has_flag( ally_rule::follow_close ) &&
+    const bool must_retreat = is_walking_with() && rules.has_flag( ally_rule::follow_close ) &&
                               !too_close( pos(), g->u.pos(), follow_distance() );
 
     if( is_player_ally() ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -358,6 +358,23 @@ void npc::assess_danger()
         invalidate_range_cache();
         max_range = *confident_range_cache;
     }
+
+    const bool self_defense_only = rules.engagement == combat_engagement::NO_MOVE ||
+                                   rules.engagement == combat_engagement::NONE;
+    const bool no_fighting = rules.has_flag( ally_rule::forbid_engage );
+    const bool must_retreat = rules.has_flag( ally_rule::follow_close ) &&
+                              !too_close( pos(), g->u.pos(), follow_distance() );
+
+    if( is_player_ally() ) {
+        if( rules.engagement == combat_engagement::FREE_FIRE ) {
+            def_radius = std::max( 6, max_range );
+        } else if( self_defense_only ) {
+            def_radius = max_range;
+        } else if( no_fighting ) {
+            def_radius = 1;
+        }
+    }
+
     const auto ok_by_rules = [max_range, def_radius, this]( const Creature & c, int dist,
     int scaled_dist ) {
         // If we're forbidden to attack, no need to check engagement rules
@@ -406,11 +423,7 @@ void npc::assess_danger()
             }
         }
     }
-    if( is_player_ally() && rules.engagement == combat_engagement::FREE_FIRE ) {
-        def_radius = std::max( 6, max_range );
-    }
-    const bool must_retreat = rules.has_flag( ally_rule::follow_close ) &&
-                              !too_close( pos(), player_character.pos(), def_radius );
+
     // find our Character friends and enemies
     std::vector<weak_ptr_fast<Creature>> hostile_guys;
     for( const npc &guy : g->all_npcs() ) {
@@ -452,7 +465,7 @@ void npc::assess_danger()
                 warn_about( "monster", 10_minutes, critter.type->nname() );
             }
         }
-        if( must_retreat ) {
+        if( must_retreat || no_fighting ) {
             continue;
         }
         // ignore targets behind glass even if we can see them
@@ -467,10 +480,10 @@ void npc::assess_danger()
                                          NPC_DANGER_VERY_LOW );
         ai_cache.total_danger += critter_danger / scaled_distance;
 
-        // don't ignore monsters that are too close or too close to an ally
+        // don't ignore monsters that are too close or too close to an ally if we can move
         bool is_too_close = dist <= def_radius;
         for( const weak_ptr_fast<Creature> &guy : ai_cache.friends ) {
-            if( is_too_close ) {
+            if( is_too_close || self_defense_only ) {
                 break;
             }
             // HACK: Bit of a dirty hack - sometimes shared_from, returns nullptr or bad weak_ptr for
@@ -512,7 +525,7 @@ void npc::assess_danger()
         int dist = rl_dist( pos(), foe.pos() );
         int scaled_distance = std::max( 1, ( 100 * dist ) / foe.get_speed() );
         ai_cache.total_danger += foe_threat / scaled_distance;
-        if( must_retreat ) {
+        if( must_retreat || no_fighting ) {
             return 0.0f;
         }
         // ignore targets behind glass even if we can see them
@@ -521,6 +534,9 @@ void npc::assess_danger()
         }
         bool is_too_close = dist <= def_radius;
         for( const weak_ptr_fast<Creature> &guy : ai_cache.friends ) {
+            if( self_defense_only ) {
+                break;
+            }
             is_too_close |= too_close( foe.pos(), guy.lock()->pos(), def_radius );
             if( is_too_close ) {
                 break;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfixes "Port some NPC AI fixes from DDA"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Port some NPC AI fixes from DDA
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Port CleverRaven#42304 and patch an edge case in that PR:
NPCs with 'stick close to me, no matter what' rule do not defend themselves when assigned to guard a position if player moves too far away (threat assessment ignores threats in favor of catching up with the player, but NPC doesn't need to catch up with the player, and that makes them stay in place and ignore enemies).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Repeated tests from the linked PR
Left an NPC with 'stay close, no matter what' rule to guard a position - they fight back when zombies try to eat them.

NPCs do not defend themselves if issued a temporary order (via `C` menu) to forbid engagement and then assigned to guard a position. Not sure what to do about this.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
If NPC has a reach melee weapon (e.g. spear), they move around a bit when defending themselves, but don't return to the original spot. That's an existing issue though (and not a big deal, I guess)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
