### PR TITLE
Finish ui_adaptor migration (part 1)

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2929,5 +2929,40 @@
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe terrain",
     "bindings": [ { "input_method": "keyboard", "key": "t" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "SWITCH_LISTS",
+    "category": "NPC_TRADE",
+    "name": "Switch lists",
+    "bindings": [ { "input_method": "keyboard", "key": "TAB" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "PAGE_UP",
+    "category": "NPC_TRADE",
+    "name": "Back",
+    "bindings": [ { "input_method": "keyboard", "key": "PPAGE" }, { "input_method": "keyboard", "key": "<" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "PAGE_DOWN",
+    "category": "NPC_TRADE",
+    "name": "More",
+    "bindings": [ { "input_method": "keyboard", "key": "NPAGE" }, { "input_method": "keyboard", "key": ">" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "EXAMINE",
+    "category": "NPC_TRADE",
+    "name": "Examine item",
+    "bindings": [ { "input_method": "keyboard", "key": "/" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "QUIT",
+    "category": "NPC_TRADE",
+    "name": "Cancel trading",
+    "bindings": [ { "input_method": "keyboard", "key": "ESC" } ]
   }
 ]

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1627,7 +1627,7 @@ bool advanced_inventory::query_destination( aim_location &def )
     uilist menu;
     menu.text = _( "Select destination" );
     /* free space for the squares */
-    menu.pad_left = 9;
+    menu.pad_left_setup = 9;
     query_destination_callback cb( *this );
     menu.callback = &cb;
 

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -220,8 +220,7 @@ void draw_mid_pane( const catacurses::window &w_sort_middle,
                 case AURA_LAYER:
                     return _( "an <color_light_blue>aura</color> around you" );
                 default:
-                    debugmsg( "Unexpected layer" );
-                    return "";
+                    return _( "Unexpected layer" );
             }
         }
         ();
@@ -458,16 +457,15 @@ void player::sort_armor()
     */
     const int req_mid_h = 3 + 1 + 8 + 13 + num_bp + 1;
 
-    const int win_h = std::min( TERMY, std::max( FULL_SCREEN_HEIGHT,
-                                std::max( req_right_h, req_mid_h ) ) );
-    const int win_w = FULL_SCREEN_WIDTH + ( TERMX - FULL_SCREEN_WIDTH ) * 3 / 4;
-    const int win_x = TERMX / 2 - win_w / 2;
-    const int win_y = TERMY / 2 - win_h / 2;
+    int win_h = 0;
+    int win_w = 0;
+    int win_x = 0;
+    int win_y = 0;
 
-    int cont_h   = win_h - 4;
-    int left_w   = ( win_w - 4 ) / 3;
-    int right_w  = left_w;
-    int middle_w = ( win_w - 4 ) - left_w - right_w;
+    int cont_h   = 0;
+    int left_w   = 0;
+    int right_w  = 0;
+    int middle_w = 0;
 
     int tabindex = num_bp;
     const int tabcount = num_bp + 1;
@@ -478,6 +476,9 @@ void player::sort_armor()
 
     int rightListOffset = 0;
 
+    int leftListLines = 0;
+    int rightListLines = 0;
+
     std::vector<std::list<item>::iterator> tmp_worn;
     std::array<std::string, 13> armor_cat = {{
             _( "Torso" ), _( "Head" ), _( "Eyes" ), _( "Mouth" ), _( "L. Arm" ), _( "R. Arm" ),
@@ -487,18 +488,37 @@ void player::sort_armor()
     };
 
     // Layout window
-    catacurses::window w_sort_armor = catacurses::newwin( win_h, win_w, point( win_x, win_y ) );
-    draw_grid( w_sort_armor, left_w, middle_w );
+    catacurses::window w_sort_armor;
     // Subwindows (between lines)
-    catacurses::window w_sort_cat = catacurses::newwin( 1, win_w - 4, point( win_x + 2, win_y + 1 ) );
-    catacurses::window w_sort_left = catacurses::newwin( cont_h, left_w,   point( win_x + 1,
-                                     win_y + 3 ) );
-    catacurses::window w_sort_middle = catacurses::newwin( cont_h - num_bp - 1, middle_w,
-                                       point( win_x + left_w + 2, win_y + 3 ) );
-    catacurses::window w_sort_right = catacurses::newwin( cont_h, right_w,
-                                      point( win_x + left_w + middle_w + 3, win_y + 3 ) );
-    catacurses::window w_encumb = catacurses::newwin( num_bp + 1, middle_w,
-                                  point( win_x + left_w + 2, win_y + 3 + cont_h - num_bp - 1 ) );
+    catacurses::window w_sort_cat;
+    catacurses::window w_sort_left;
+    catacurses::window w_sort_middle;
+    catacurses::window w_sort_right;
+    catacurses::window w_encumb;
+
+    ui_adaptor ui;
+    ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+        win_h = std::min( TERMY, std::max( { FULL_SCREEN_HEIGHT, req_right_h, req_mid_h } ) );
+        win_w = FULL_SCREEN_WIDTH + ( TERMX - FULL_SCREEN_WIDTH ) * 3 / 4;
+        win_x = TERMX / 2 - win_w / 2;
+        win_y = TERMY / 2 - win_h / 2;
+        cont_h = win_h - 4;
+        left_w = ( win_w - 4 ) / 3;
+        right_w = left_w;
+        middle_w = ( win_w - 4 ) - left_w - right_w;
+        leftListLines = rightListLines = cont_h - 2;
+        w_sort_armor = catacurses::newwin( win_h, win_w, point( win_x, win_y ) );
+        w_sort_cat = catacurses::newwin( 1, win_w - 4, point( win_x + 2, win_y + 1 ) );
+        w_sort_left = catacurses::newwin( cont_h, left_w, point( win_x + 1, win_y + 3 ) );
+        w_sort_middle = catacurses::newwin( cont_h - num_bp - 1, middle_w,
+                                            point( win_x + left_w + 2, win_y + 3 ) );
+        w_sort_right = catacurses::newwin( cont_h, right_w,
+                                           point( win_x + left_w + middle_w + 3, win_y + 3 ) );
+        w_encumb = catacurses::newwin( num_bp + 1, middle_w,
+                                       point( win_x + left_w + 2, win_y + 3 + cont_h - num_bp - 1 ) );
+        ui.position_from_window( w_sort_armor );
+    } );
+    ui.mark_resize();
 
     input_context ctxt( "SORT_ARMOR" );
     ctxt.register_cardinal();
@@ -521,28 +541,12 @@ void player::sort_armor()
         g->u.activity.moves_left = INT_MAX;
     };
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    int leftListSize = 0;
+    int rightListSize = 0;
 
-    bool exit = false;
-    while( !exit ) {
-        if( is_player() ) {
-            // Totally hoisted this from advanced_inv
-            if( g->u.moves < 0 ) {
-                do_return_entry();
-                return;
-            }
-        } else {
-            // Player is sorting NPC's armor here
-            if( rl_dist( g->u.pos(), pos() ) > 1 ) {
-                add_msg_if_npc( m_bad, _( "%s is too far to sort armor." ), name );
-                return;
-            }
-            if( attitude_to( g->u ) != Creature::A_FRIENDLY ) {
-                add_msg_if_npc( m_bad, _( "%s is not friendly!" ), name );
-                return;
-            }
-        }
+    ui.on_redraw( [&]( const ui_adaptor & ) {
+        draw_grid( w_sort_armor, left_w, middle_w );
+
         werase( w_sort_cat );
         werase( w_sort_left );
         werase( w_sort_middle );
@@ -558,35 +562,25 @@ void player::sort_armor()
                          ctxt.get_desc( "USAGE_HELP" ),
                          ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
 
-        // Create ptr list of items to display
-        tmp_worn.clear();
-        if( tabindex == num_bp ) {
-            // All
-            for( auto it = worn.begin(); it != worn.end(); ++it ) {
-                tmp_worn.push_back( it );
-            }
-        } else {
-            // bp_*
-            body_part bp = static_cast<body_part>( tabindex );
-            for( auto it = worn.begin(); it != worn.end(); ++it ) {
-                if( it->covers( bp ) ) {
-                    tmp_worn.push_back( it );
-                }
-            }
+        leftListSize = tmp_worn.size();
+        if( leftListLines > leftListSize ) {
+            leftListOffset = 0;
+        } else if( leftListOffset + leftListLines > leftListSize ) {
+            leftListOffset = leftListSize - leftListLines;
         }
-        int leftListSize = ( static_cast<int>( tmp_worn.size() ) < cont_h - 2 ) ? static_cast<int>
-                           ( tmp_worn.size() ) : cont_h - 2;
-
-        // Ensure leftListIndex is in bounds
-        int new_index_upper_bound = std::max( 0, static_cast<int>( tmp_worn.size() ) - 1 );
-        leftListIndex = std::min( leftListIndex, new_index_upper_bound );
+        if( leftListOffset > leftListIndex ) {
+            leftListOffset = leftListIndex;
+        } else if( leftListOffset + leftListLines <= leftListIndex ) {
+            leftListOffset = leftListIndex + 1 - leftListLines;
+        }
 
         // Left header
         mvwprintz( w_sort_left, point_zero, c_light_gray, _( "(Innermost)" ) );
         right_print( w_sort_left, 0, 0, c_light_gray, string_format( _( "Storage (%s)" ),
                      volume_units_abbr() ) );
         // Left list
-        for( int drawindex = 0; drawindex < leftListSize; drawindex++ ) {
+        const int max_drawindex = std::min( leftListSize - leftListOffset, leftListLines );
+        for( int drawindex = 0; drawindex < max_drawindex; drawindex++ ) {
             int itemindex = leftListOffset + drawindex;
 
             if( itemindex == leftListIndex ) {
@@ -606,7 +600,7 @@ void player::sort_armor()
 
         // Left footer
         mvwprintz( w_sort_left, point( 0, cont_h - 1 ), c_light_gray, _( "(Outermost)" ) );
-        if( leftListSize > static_cast<int>( tmp_worn.size() ) ) {
+        if( leftListOffset + leftListLines < leftListSize ) {
             // TODO: replace it by right_print()
             mvwprintz( w_sort_left, point( left_w - utf8_width( _( "<more>" ) ), cont_h - 1 ),
                        c_light_blue, _( "<more>" ) );
@@ -633,22 +627,37 @@ void player::sort_armor()
         mvwprintz( w_sort_right, point_zero, c_light_gray, _( "(Innermost)" ) );
         right_print( w_sort_right, 0, 0, c_light_gray, _( "Encumbrance" ) );
 
+        const auto &combine_bp = [this]( const int cover ) -> bool {
+            return cover > 3 && cover % 2 == 0 &&
+            items_cover_bp( *this, cover ) == items_cover_bp( *this, cover + 1 );
+        };
+
         // Right list
-        int rightListSize = 0;
-        for( int cover = 0, pos = 1; cover < num_bp; cover++ ) {
+        rightListSize = 0;
+        for( int cover = 0; cover < num_bp; cover++ ) {
+            rightListSize += items_cover_bp( *this, cover ).size() + 1;
+            if( combine_bp( cover ) ) {
+                cover++;
+            }
+        }
+        if( rightListLines > rightListSize ) {
+            rightListOffset = 0;
+        } else if( rightListOffset + rightListLines > rightListSize ) {
+            rightListOffset = rightListSize - rightListLines;
+        }
+        for( int cover = 0, pos = 1, curr = 0; cover < num_bp; cover++ ) {
             bool combined = false;
-            if( cover > 3 && cover % 2 == 0 &&
-                items_cover_bp( *this, cover ) == items_cover_bp( *this, cover + 1 ) ) {
+            if( combine_bp( cover ) ) {
                 combined = true;
             }
-            if( rightListSize >= rightListOffset && pos <= cont_h - 2 ) {
+            if( curr >= rightListOffset && pos <= rightListLines ) {
                 mvwprintz( w_sort_right, point( 1, pos ), ( cover == tabindex ? c_yellow : c_white ),
                            "%s:", body_part_name_as_heading( all_body_parts[cover], combined ? 2 : 1 ) );
                 pos++;
             }
-            rightListSize++;
+            curr++;
             for( layering_item_info &elem : items_cover_bp( *this, cover ) ) {
-                if( rightListSize >= rightListOffset && pos <= cont_h - 2 ) {
+                if( curr >= rightListOffset && pos <= rightListLines ) {
                     nc_color color = elem.penalties.color_for_stacking_badness();
                     trim_and_print( w_sort_right, point( 2, pos ), right_w - 5, color,
                                     elem.name );
@@ -657,7 +666,7 @@ void player::sort_armor()
                                elem.encumber, plus );
                     pos++;
                 }
-                rightListSize++;
+                curr++;
             }
             if( combined ) {
                 cover++;
@@ -666,7 +675,7 @@ void player::sort_armor()
 
         // Right footer
         mvwprintz( w_sort_right, point( 0, cont_h - 1 ), c_light_gray, _( "(Outermost)" ) );
-        if( rightListSize > cont_h - 2 ) {
+        if( rightListOffset + rightListLines < rightListSize ) {
             // TODO: replace it by right_print()
             mvwprintz( w_sort_right, point( right_w - utf8_width( _( "<more>" ) ), cont_h - 1 ), c_light_blue,
                        _( "<more>" ) );
@@ -677,7 +686,50 @@ void player::sort_armor()
         wrefresh( w_sort_middle );
         wrefresh( w_sort_right );
         wrefresh( w_encumb );
+    } );
 
+    bool exit = false;
+    while( !exit ) {
+        if( is_player() ) {
+            // Totally hoisted this from advanced_inv
+            if( g->u.moves < 0 ) {
+                do_return_entry();
+                return;
+            }
+        } else {
+            // Player is sorting NPC's armor here
+            if( rl_dist( g->u.pos(), pos() ) > 1 ) {
+                add_msg_if_npc( m_bad, _( "%s is too far to sort armor." ), name );
+                return;
+            }
+            if( attitude_to( g->u ) != Creature::A_FRIENDLY ) {
+                add_msg_if_npc( m_bad, _( "%s is not friendly!" ), name );
+                return;
+            }
+        }
+
+        // Create ptr list of items to display
+        tmp_worn.clear();
+        if( tabindex == num_bp ) {
+            // All
+            for( auto it = worn.begin(); it != worn.end(); ++it ) {
+                tmp_worn.push_back( it );
+            }
+        } else {
+            // bp_*
+            body_part bp = static_cast<body_part>( tabindex );
+            for( auto it = worn.begin(); it != worn.end(); ++it ) {
+                if( it->covers( bp ) ) {
+                    tmp_worn.push_back( it );
+                }
+            }
+        }
+
+        // Ensure leftListIndex is in bounds
+        int new_index_upper_bound = std::max( 0, leftListSize - 1 );
+        leftListIndex = std::min( leftListIndex, new_index_upper_bound );
+
+        ui_manager::redraw();
         const std::string action = ctxt.handle_input();
         if( is_npc() && action == "ASSIGN_INVLETS" ) {
             // It doesn't make sense to assign invlets to NPC items
@@ -698,28 +750,30 @@ void player::sort_armor()
         };
 
         if( action == "UP" && leftListSize > 0 ) {
-            leftListIndex--;
-            if( leftListIndex < 0 ) {
-                leftListIndex = tmp_worn.size() - 1;
-            }
-
-            // Scrolling logic
-            leftListOffset = ( leftListIndex < leftListOffset ) ? leftListIndex : leftListOffset;
-            if( !( ( leftListIndex >= leftListOffset ) &&
-                   ( leftListIndex < leftListOffset + leftListSize ) ) ) {
-                leftListOffset = leftListIndex - leftListSize + 1;
-                leftListOffset = ( leftListOffset > 0 ) ? leftListOffset : 0;
+            if( leftListIndex > 0 ) {
+                leftListIndex--;
+                if( leftListIndex < leftListOffset ) {
+                    leftListOffset = leftListIndex;
+                }
+            } else {
+                leftListIndex = leftListSize - 1;
+                if( leftListLines >= leftListSize ) {
+                    leftListOffset = 0;
+                } else {
+                    leftListOffset = leftListSize - leftListLines;
+                }
             }
 
             shift_selected_item();
         } else if( action == "DOWN" && leftListSize > 0 ) {
-            leftListIndex = ( leftListIndex + 1 ) % tmp_worn.size();
-
-            // Scrolling logic
-            if( !( ( leftListIndex >= leftListOffset ) &&
-                   ( leftListIndex < leftListOffset + leftListSize ) ) ) {
-                leftListOffset = leftListIndex - leftListSize + 1;
-                leftListOffset = ( leftListOffset > 0 ) ? leftListOffset : 0;
+            if( leftListIndex + 1 < leftListSize ) {
+                leftListIndex++;
+                if( leftListIndex >= leftListOffset + leftListLines ) {
+                    leftListOffset = leftListIndex + 1 - leftListLines;
+                }
+            } else {
+                leftListIndex = 0;
+                leftListOffset = 0;
             }
 
             shift_selected_item();
@@ -735,14 +789,12 @@ void player::sort_armor()
             leftListIndex = leftListOffset = 0;
             selected = -1;
         } else if( action == "NEXT_TAB" ) {
-            rightListOffset++;
-            if( rightListOffset + cont_h - 2 > rightListSize ) {
-                rightListOffset = rightListSize - cont_h + 2;
+            if( rightListOffset + rightListLines < rightListSize ) {
+                rightListOffset++;
             }
         } else if( action == "PREV_TAB" ) {
-            rightListOffset--;
-            if( rightListOffset < 0 ) {
-                rightListOffset = 0;
+            if( rightListOffset > 0 ) {
+                rightListOffset--;
             }
         } else if( action == "MOVE_ARMOR" ) {
             if( selected >= 0 ) {
@@ -751,12 +803,11 @@ void player::sort_armor()
                 selected = leftListIndex;
             }
         } else if( action == "CHANGE_SIDE" ) {
-            if( leftListIndex < static_cast<int>( tmp_worn.size() ) && tmp_worn[leftListIndex]->is_sided() ) {
+            if( leftListIndex < leftListSize && tmp_worn[leftListIndex]->is_sided() ) {
                 if( g->u.query_yn( _( "Swap side for %s?" ),
                                    colorize( tmp_worn[leftListIndex]->tname(),
                                              tmp_worn[leftListIndex]->color_in_inventory() ) ) ) {
                     change_side( *tmp_worn[leftListIndex] );
-                    wrefresh( w_sort_armor );
                 }
             }
         } else if( action == "SORT_ARMOR" ) {
@@ -797,7 +848,6 @@ void player::sort_armor()
                     popup( _( "Can't put this on!" ) );
                 }
             }
-            draw_grid( w_sort_armor, left_w, middle_w );
         } else if( action == "EQUIP_ARMOR_HERE" ) {
             // filter inventory for all items that are armor/clothing
             item_location loc = game_menus::inv::wear( *this );
@@ -816,10 +866,9 @@ void player::sort_armor()
                     popup( _( "Can't put this on!" ) );
                 }
             }
-            draw_grid( w_sort_armor, left_w, middle_w );
         } else if( action == "REMOVE_ARMOR" ) {
             // query (for now)
-            if( leftListIndex < static_cast<int>( tmp_worn.size() ) ) {
+            if( leftListIndex < leftListSize ) {
                 if( g->u.query_yn( _( "Remove selected armor?" ) ) ) {
                     do_return_entry();
                     // remove the item, asking to drop it if necessary
@@ -830,8 +879,6 @@ void player::sort_armor()
                         return;
                     }
                     g->u.cancel_activity();
-                    draw_grid( w_sort_armor, left_w, middle_w );
-                    wrefresh( w_sort_armor );
                     selected = -1;
                 }
             }
@@ -886,9 +933,6 @@ void player::sort_armor()
                 ctxt.get_desc( "EQUIP_ARMOR_HERE" ),
                 ctxt.get_desc( "REMOVE_ARMOR" )
             );
-            draw_grid( w_sort_armor, left_w, middle_w );
-        } else if( action == "HELP_KEYBINDINGS" ) {
-            draw_grid( w_sort_armor, left_w, middle_w );
         } else if( action == "QUIT" ) {
             exit = true;
         }

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -529,4 +529,19 @@ class on_out_of_scope
         }
 };
 
+template<typename T>
+class restore_on_out_of_scope
+{
+    private:
+        T &t;
+        T orig_t;
+        on_out_of_scope impl;
+    public:
+        // *INDENT-OFF*
+        restore_on_out_of_scope( T &t_in ): t( t_in ), orig_t( t_in ),
+            impl( [this]() { t = orig_t; } ) {
+        }
+        // *INDENT-ON*
+};
+
 #endif // CATA_SRC_CATA_UTILITY_H

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -734,12 +734,16 @@ void color_manager::show_gui()
     catacurses::window w_colors_header;
     catacurses::window w_colors;
 
+    const auto calc_offset_y = []() -> int {
+        return TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
+    };
+
     ui_adaptor ui;
     const auto init_windows = [&]( ui_adaptor & ui ) {
         iContentHeight = FULL_SCREEN_HEIGHT - 2 - iHeaderHeight;
 
         iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-        iOffsetY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
+        iOffsetY = calc_offset_y();
 
         w_colors_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
                                               point( iOffsetX, iOffsetY ) );
@@ -888,8 +892,10 @@ void color_manager::show_gui()
 
             if( !vFiles.empty() ) {
                 uilist ui_templates;
-                ui_templates.w_y = iHeaderHeight + 1 + iOffsetY;
-                ui_templates.w_height = 18;
+                ui_templates.w_y_setup = [&]( int ) -> int {
+                    return iHeaderHeight + 1 + calc_offset_y();
+                };
+                ui_templates.w_height_setup = 18;
 
                 ui_templates.text = _( "Color templates:" );
 
@@ -918,8 +924,10 @@ void color_manager::show_gui()
 
         } else if( action == "CONFIRM" ) {
             uilist ui_colors;
-            ui_colors.w_y = iHeaderHeight + 1 + iOffsetY;
-            ui_colors.w_height = 18;
+            ui_colors.w_y_setup = [&]( int ) -> int {
+                return iHeaderHeight + 1 + calc_offset_y();
+            };
+            ui_colors.w_height_setup = 18;
 
             const auto &entry = std::next( name_color_map.begin(), iCurrentLine )->second;
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -456,7 +456,7 @@ void character_edit_menu()
 
     pointmenu_cb callback( locations );
     charmenu.callback = &callback;
-    charmenu.w_y = 0;
+    charmenu.w_y_setup = 0;
     charmenu.query();
     if( charmenu.ret < 0 || static_cast<size_t>( charmenu.ret ) >= locations.size() ) {
         return;

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -920,10 +920,12 @@ void editmap::edit_feature()
     using T_id = decltype( T_t().id.id() );
 
     uilist emenu;
-    emenu.w_width = width;
-    emenu.w_height = TERMY - infoHeight;
-    emenu.w_y = 0;
-    emenu.w_x = offsetX;
+    emenu.w_width_setup = width;
+    emenu.w_height_setup = [this]() -> int {
+        return TERMY - infoHeight;
+    };
+    emenu.w_y_setup = 0;
+    emenu.w_x_setup = offsetX;
     emenu.desc_enabled = true;
     emenu.input_category = "EDITMAP_FEATURE";
     emenu.additional_actions = {
@@ -1044,10 +1046,12 @@ void editmap::setup_fmenu( uilist &fmenu )
 void editmap::edit_fld()
 {
     uilist fmenu;
-    fmenu.w_width = width;
-    fmenu.w_height = TERMY - infoHeight;
-    fmenu.w_y = 0;
-    fmenu.w_x = offsetX;
+    fmenu.w_width_setup = width;
+    fmenu.w_height_setup = [this]() -> int {
+        return TERMY - infoHeight;
+    };
+    fmenu.w_y_setup = 0;
+    fmenu.w_x_setup = offsetX;
     setup_fmenu( fmenu );
     fmenu.input_category = "EDIT_FIELDS";
     fmenu.additional_actions = {
@@ -1095,10 +1099,12 @@ void editmap::edit_fld()
             int fsel_intensity = field_intensity;
             if( fmenu.ret > 0 ) {
                 uilist femenu;
-                femenu.w_width = width;
-                femenu.w_height = infoHeight;
-                femenu.w_y = fmenu.w_height;
-                femenu.w_x = offsetX;
+                femenu.w_width_setup = width;
+                femenu.w_height_setup = infoHeight;
+                femenu.w_y_setup = [this]( int ) -> int {
+                    return TERMY - infoHeight;
+                };
+                femenu.w_x_setup = offsetX;
 
                 femenu.text = field_intensity < 1 ? "" : ftype.get_name( field_intensity - 1 );
                 femenu.addentry( pgettext( "map editor: used to describe a clean field (e.g. without blood)",
@@ -1198,10 +1204,12 @@ enum editmap_imenu_ent {
 void editmap::edit_itm()
 {
     uilist ilmenu;
-    ilmenu.w_x = offsetX;
-    ilmenu.w_y = 0;
-    ilmenu.w_width = width;
-    ilmenu.w_height = TERMY - infoHeight - 1;
+    ilmenu.w_x_setup = offsetX;
+    ilmenu.w_y_setup = 0;
+    ilmenu.w_width_setup = width;
+    ilmenu.w_height_setup = [this]() -> int {
+        return TERMY - infoHeight - 1;
+    };
     auto items = g->m.i_at( target );
     int i = 0;
     for( auto &an_item : items ) {
@@ -1221,10 +1229,14 @@ void editmap::edit_itm()
         if( ilmenu.ret >= 0 && ilmenu.ret < static_cast<int>( items.size() ) ) {
             item &it = *items.get_iterator_from_index( ilmenu.ret );
             uilist imenu;
-            imenu.w_x = ilmenu.w_x;
-            imenu.w_y = ilmenu.w_height;
-            imenu.w_height = TERMX - ilmenu.w_height;
-            imenu.w_width = ilmenu.w_width;
+            imenu.w_x_setup = offsetX;
+            imenu.w_y_setup = [this]( int ) -> int {
+                return TERMY - infoHeight - 1;
+            };
+            imenu.w_height_setup = [this]() -> int {
+                return infoHeight + 1;
+            };
+            imenu.w_width_setup = width;
             imenu.addentry( imenu_bday, true, -1, pgettext( "item manipulation debug menu entry", "bday: %d" ),
                             to_turn<int>( it.birthday() ) );
             imenu.addentry( imenu_damage, true, -1, pgettext( "item manipulation debug menu entry",
@@ -1476,7 +1488,7 @@ int editmap::select_shape( shapetype shape, int mode )
                 const int offset = 16;
                 uilist smenu;
                 smenu.text = _( "Selection type" );
-                smenu.w_x = ( offsetX + offset ) / 2;
+                smenu.w_x_setup = ( offsetX + offset ) / 2;
                 smenu.addentry( editmap_rect, true, 'r', pgettext( "shape", "Rectangle" ) );
                 smenu.addentry( editmap_rect_filled, true, 'f', pgettext( "shape", "Filled Rectangle" ) );
                 smenu.addentry( editmap_line, true, 'l', pgettext( "shape", "Line" ) );
@@ -1578,10 +1590,12 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
     gmenu.show();
 
     uilist gpmenu;
-    gpmenu.w_width = width;
-    gpmenu.w_height = infoHeight - 4;
-    gpmenu.w_y = gmenu.w_height;
-    gpmenu.w_x = offsetX;
+    gpmenu.w_width_setup = width;
+    gpmenu.w_height_setup = infoHeight - 4;
+    gpmenu.w_y_setup = [this]( int ) -> int {
+        return TERMY - infoHeight;
+    };
+    gpmenu.w_x_setup = offsetX;
     gpmenu.addentry( pgettext( "map generator", "Regenerate" ) );
     gpmenu.addentry( pgettext( "map generator", "Rotate" ) );
     gpmenu.addentry( pgettext( "map generator", "Apply" ) );
@@ -1888,10 +1902,12 @@ void editmap::mapgen_retarget()
 void editmap::edit_mapgen()
 {
     uilist gmenu;
-    gmenu.w_width = width;
-    gmenu.w_height = TERMY - infoHeight;
-    gmenu.w_y = 0;
-    gmenu.w_x = offsetX;
+    gmenu.w_width_setup = width;
+    gmenu.w_height_setup = [this]() -> int {
+        return TERMY - infoHeight;
+    };
+    gmenu.w_y_setup = 0;
+    gmenu.w_x_setup = offsetX;
     gmenu.input_category = "EDIT_MAPGEN";
     gmenu.additional_actions = {
         { "EDITMAP_MOVE", translation() },

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -176,10 +176,6 @@ void edit_json( SAVEOBJ &it )
 
 editmap::editmap()
 {
-    width = 45;
-    height = TERMY;
-    offsetX = 0;
-    infoHeight = 0;
     sel_field = -1;
     sel_field_intensity = -1;
 
@@ -190,7 +186,6 @@ editmap::editmap()
     editshape = editmap_rect;
     refresh_mplans = true;
 
-    tmax = point( getmaxx( g->w_terrain ), getmaxy( g->w_terrain ) );
     target_list.clear();
     hilights.clear();
     hilights["mplan"].blink_interval.push_back( true );
@@ -289,6 +284,27 @@ bool editmap::eget_direction( tripoint &p, const std::string &action ) const
     return true;
 }
 
+shared_ptr_fast<ui_adaptor> editmap::create_or_get_ui_adaptor()
+{
+    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    if( !current_ui ) {
+        ui = current_ui = make_shared_fast<ui_adaptor>();
+        current_ui->on_screen_resize( [this]( ui_adaptor & ui ) {
+            w_info = catacurses::newwin( infoHeight, width, point( offsetX, TERMY - infoHeight ) );
+            tmax = point( getmaxx( g->w_terrain ), getmaxy( g->w_terrain ) );
+            // We redraw the entire terrain window along with our own window, so
+            // set the position to that of catacurses::stdscr.
+            ui.position_from_window( catacurses::stdscr );
+        } );
+        current_ui->mark_resize();
+
+        current_ui->on_redraw( [this]( const ui_adaptor & ) {
+            update_view_with_help( info_txt_curr, info_title_curr );
+        } );
+    }
+    return current_ui;
+}
+
 cata::optional<tripoint> editmap::edit()
 {
     target = g->u.pos() + g->u.view_offset;
@@ -316,13 +332,15 @@ cata::optional<tripoint> editmap::edit()
     std::string action;
 
     uberdraw = uistate.editmap_nsa_viewmode;
-    infoHeight = 20;
     blink = true;
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope invalidate_current_ui( [current_ui]() {
+        current_ui->invalidate_ui();
+    } );
+    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
 
-    w_info = catacurses::newwin( infoHeight, width, point( offsetX, TERMY - infoHeight ) );
     do {
         if( target_list.empty() ) {
             target_list.push_back( target ); // 'editmap.target_list' always has point 'editmap.target' at least
@@ -330,19 +348,24 @@ cata::optional<tripoint> editmap::edit()
         if( target_list.size() == 1 ) {
             origin = target;               // 'editmap.origin' only makes sense if we have a list of target points.
         }
+
         // \u00A0 is the non-breaking space
-        update_view_with_help( string_format( pgettext( "keybinding descriptions",
-                                              "%s, %s, [%s,%s,%s,%s]\u00A0fast scroll, %s, %s, %s, %s, %s, %s" ),
-                                              ctxt.describe_key_and_name( "EDIT_TRAPS" ),
-                                              ctxt.describe_key_and_name( "EDIT_FIELDS" ),
-                                              ctxt.get_desc( "LEFT_WIDE", 1 ), ctxt.get_desc( "RIGHT_WIDE", 1 ),
-                                              ctxt.get_desc( "UP_WIDE", 1 ), ctxt.get_desc( "DOWN_WIDE", 1 ),
-                                              ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ),
-                                              ctxt.describe_key_and_name( "EDIT_TERRAIN" ),
-                                              ctxt.describe_key_and_name( "EDIT_FURNITURE" ),
-                                              ctxt.describe_key_and_name( "EDIT_OVERMAP" ),
-                                              ctxt.describe_key_and_name( "EDIT_ITEMS" ),
-                                              ctxt.describe_key_and_name( "QUIT" ) ), pgettext( "map editor state", "Looking around" ) );
+        info_txt_curr = string_format( pgettext( "keybinding descriptions",
+                                       "%s, %s, [%s,%s,%s,%s]\u00A0fast scroll, %s, %s, %s, %s, %s, %s" ),
+                                       ctxt.describe_key_and_name( "EDIT_TRAPS" ),
+                                       ctxt.describe_key_and_name( "EDIT_FIELDS" ),
+                                       ctxt.get_desc( "LEFT_WIDE", 1 ), ctxt.get_desc( "RIGHT_WIDE", 1 ),
+                                       ctxt.get_desc( "UP_WIDE", 1 ), ctxt.get_desc( "DOWN_WIDE", 1 ),
+                                       ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ),
+                                       ctxt.describe_key_and_name( "EDIT_TERRAIN" ),
+                                       ctxt.describe_key_and_name( "EDIT_FURNITURE" ),
+                                       ctxt.describe_key_and_name( "EDIT_OVERMAP" ),
+                                       ctxt.describe_key_and_name( "EDIT_ITEMS" ),
+                                       ctxt.describe_key_and_name( "QUIT" ) );
+        info_title_curr = pgettext( "map editor state", "Looking around" );
+        current_ui->invalidate_ui();
+
+        ui_manager::redraw();
 
         action = ctxt.handle_input( BLINK_SPEED );
 
@@ -545,6 +568,87 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
         mvwputch( g->w_terrain, point( mp.x, tmax.y - 1 ), c_yellow, 'v' );
     }
 
+    if( tmpmap_ptr ) {
+        tinymap &tmpmap = *tmpmap_ptr;
+#ifdef TILES
+        if( use_tiles ) {
+            const point origin_p = target.xy() + point( 1 - SEEX, 1 - SEEY );
+            for( int x = 0; x < SEEX * 2; x++ ) {
+                for( int y = 0; y < SEEY * 2; y++ ) {
+                    const tripoint tmp_p( x, y, target.z );
+                    const tripoint map_p = origin_p + tmp_p;
+                    g->draw_radiation_override( map_p, tmpmap.get_radiation( tmp_p ) );
+                    // scent is managed in `game` instead of `map`, so there's no override for it
+                    // temperature is managed in `game` instead of `map`, so there's no override for it
+                    // TODO: visibility could be affected by both the actual map and the preview map,
+                    // which complicates calculation, so there's no override for it (yet)
+                    g->draw_terrain_override( map_p, tmpmap.ter( tmp_p ) );
+                    g->draw_furniture_override( map_p, tmpmap.furn( tmp_p ) );
+                    g->draw_graffiti_override( map_p, tmpmap.has_graffiti_at( tmp_p ) );
+                    g->draw_trap_override( map_p, tmpmap.tr_at( tmp_p ).loadid );
+                    g->draw_field_override( map_p, tmpmap.field_at( tmp_p ).displayed_field_type() );
+                    const maptile &tile = tmpmap.maptile_at( tmp_p );
+                    if( tmpmap.sees_some_items( tmp_p, g->u.pos() - origin_p ) ) {
+                        const item &itm = tile.get_uppermost_item();
+                        const mtype *const mon = itm.get_mtype();
+                        g->draw_item_override( map_p, itm.typeId(), mon ? mon->id : mtype_id::NULL_ID(),
+                                               tile.get_item_count() > 1 );
+                    } else {
+                        g->draw_item_override( map_p, "null", mtype_id::NULL_ID(), false );
+                    }
+                    const optional_vpart_position vp = tmpmap.veh_at( tmp_p );
+                    if( vp ) {
+                        const vehicle &veh = vp->vehicle();
+                        const int veh_part = vp->part_index();
+                        char part_mod = 0;
+                        const vpart_id &vp_id = veh.part_id_string( veh_part, part_mod );
+                        const cata::optional<vpart_reference> cargopart = vp.part_with_feature( "CARGO", true );
+                        bool draw_highlight = cargopart && !veh.get_items( cargopart->part_index() ).empty();
+                        int veh_dir = veh.face.dir();
+                        g->draw_vpart_override( map_p, vp_id, part_mod, veh_dir, draw_highlight, vp->mount() );
+                    } else {
+                        g->draw_vpart_override( map_p, vpart_id::NULL_ID(), 0, 0, false, point_zero );
+                    }
+                    g->draw_below_override( map_p, g->m.has_zlevels() &&
+                                            tmpmap.ter( tmp_p ).obj().has_flag( TFLAG_NO_FLOOR ) );
+                }
+            }
+            // int: count, bool: more than 1 spawn data
+            std::map<tripoint, std::tuple<mtype_id, int, bool, Creature::Attitude>> spawns;
+            for( int x = 0; x < 2; x++ ) {
+                for( int y = 0; y < 2; y++ ) {
+                    submap *sm = tmpmap.get_submap_at_grid( { x, y, target.z } );
+                    if( sm ) {
+                        const tripoint sm_origin = origin_p + tripoint( x * SEEX, y * SEEY, target.z );
+                        for( const auto &sp : sm->spawns ) {
+                            const tripoint spawn_p = sm_origin + sp.pos;
+                            const auto spawn_it = spawns.find( spawn_p );
+                            if( spawn_it == spawns.end() ) {
+                                const Creature::Attitude att = sp.friendly ? Creature::A_FRIENDLY : Creature::A_ANY;
+                                spawns.emplace( spawn_p, std::make_tuple( sp.type, sp.count, false, att ) );
+                            } else {
+                                std::get<2>( spawn_it->second ) = true;
+                            }
+                        }
+                    }
+                }
+            }
+            for( const auto &it : spawns ) {
+                g->draw_monster_override( it.first, std::get<0>( it.second ), std::get<1>( it.second ),
+                                          std::get<2>( it.second ), std::get<3>( it.second ) );
+            }
+        } else {
+#endif
+            hilights["mapgentgt"].draw( *this, true );
+            tmpmap.reset_vehicle_cache( target.z );
+            const tripoint center( SEEX - 1, SEEY - 1, target.z );
+            for( const tripoint &p : tmpmap.points_on_zlevel() ) {
+                tmpmap.drawsq( g->w_terrain, g->u, p, false, true, center, false, true );
+            }
+#ifdef TILES
+        }
+#endif
+    }
     wrefresh( g->w_terrain );
     g->draw_panels();
 
@@ -959,6 +1063,13 @@ void editmap::edit_feature()
     int current_feature = emenu.selected = feature<T_id>( target ).to_i();
     emenu.entries[current_feature].text_color = c_green;
 
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope invalidate_current_ui( [current_ui]() {
+        current_ui->invalidate_ui();
+    } );
+    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+
     blink = true;
     bool quit = false;
     do {
@@ -970,14 +1081,17 @@ void editmap::edit_feature()
         } else {
             draw_target_override = nullptr;
         }
+
         input_context ctxt( emenu.input_category );
-        update_view_with_help( string_format( pgettext( "keybinding descriptions", "%s, %s, %s, %s, %s" ),
-                                              ctxt.describe_key_and_name( "CONFIRM" ),
-                                              ctxt.describe_key_and_name( "CONFIRM_QUIT" ),
-                                              ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ),
-                                              ctxt.describe_key_and_name( "EDITMAP_TAB" ),
-                                              ctxt.describe_key_and_name( "EDITMAP_MOVE" ) ),
-                               info_title<T_t>() );
+        info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s, %s, %s, %s, %s" ),
+                                       ctxt.describe_key_and_name( "CONFIRM" ),
+                                       ctxt.describe_key_and_name( "CONFIRM_QUIT" ),
+                                       ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ),
+                                       ctxt.describe_key_and_name( "EDITMAP_TAB" ),
+                                       ctxt.describe_key_and_name( "EDITMAP_MOVE" ) );
+        info_title_curr = info_title<T_t>();
+        current_ui->invalidate_ui();
+
         emenu.query( false, BLINK_SPEED );
         if( emenu.ret == UILIST_CANCEL ) {
             quit = true;
@@ -1064,6 +1178,13 @@ void editmap::edit_fld()
     };
     fmenu.allow_additional = true;
 
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope invalidate_current_ui( [current_ui]() {
+        current_ui->invalidate_ui();
+    } );
+    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+
     blink = true;
     do {
         const field_type_id override( fmenu.selected );
@@ -1074,17 +1195,20 @@ void editmap::edit_fld()
         } else {
             draw_target_override = nullptr;
         }
+
         input_context ctxt( fmenu.input_category );
         // \u00A0 is the non-breaking space
-        update_view_with_help( string_format( pgettext( "keybinding descriptions",
-                                              "%s, %s, [%s,%s]\u00A0intensity, %s, %s, %s" ),
-                                              ctxt.describe_key_and_name( "EDITMAP_TAB" ),
-                                              ctxt.describe_key_and_name( "EDITMAP_MOVE" ),
-                                              ctxt.get_desc( "LEFT", 1 ), ctxt.get_desc( "RIGHT", 1 ),
-                                              ctxt.describe_key_and_name( "CONFIRM" ),
-                                              ctxt.describe_key_and_name( "QUIT" ),
-                                              ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ) ),
-                               pgettext( "Map editor: Editing field effects", "Field effects" ) );
+        info_txt_curr = string_format( pgettext( "keybinding descriptions",
+                                       "%s, %s, [%s,%s]\u00A0intensity, %s, %s, %s" ),
+                                       ctxt.describe_key_and_name( "EDITMAP_TAB" ),
+                                       ctxt.describe_key_and_name( "EDITMAP_MOVE" ),
+                                       ctxt.get_desc( "LEFT", 1 ), ctxt.get_desc( "RIGHT", 1 ),
+                                       ctxt.describe_key_and_name( "CONFIRM" ),
+                                       ctxt.describe_key_and_name( "QUIT" ),
+                                       ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ) );
+        info_title_curr = pgettext( "Map editor: Editing field effects", "Field effects" );
+        current_ui->invalidate_ui();
+
         fmenu.query( false, BLINK_SPEED );
         if( ( fmenu.ret > 0 && static_cast<size_t>( fmenu.ret ) < field_type::count() ) ||
             ( fmenu.ret == UILIST_ADDITIONAL && ( fmenu.ret_act == "LEFT" || fmenu.ret_act == "RIGHT" ) ) ) {
@@ -1098,6 +1222,8 @@ void editmap::edit_fld()
             const field_type &ftype = idx.obj();
             int fsel_intensity = field_intensity;
             if( fmenu.ret > 0 ) {
+                shared_ptr_fast<ui_adaptor> fmenu_ui = fmenu.create_or_get_ui_adaptor();
+
                 uilist femenu;
                 femenu.w_width_setup = width;
                 femenu.w_height_setup = infoHeight;
@@ -1223,8 +1349,20 @@ void editmap::edit_itm()
     };
     ilmenu.allow_additional = true;
 
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope invalidate_current_ui( [current_ui]() {
+        current_ui->invalidate_ui();
+    } );
+    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+
+    shared_ptr_fast<ui_adaptor> ilmenu_ui = ilmenu.create_or_get_ui_adaptor();
+
     do {
-        update_view_with_help( "", "" );
+        info_txt_curr.clear();
+        info_title_curr.clear();
+        current_ui->invalidate_ui();
+
         ilmenu.query();
         if( ilmenu.ret >= 0 && ilmenu.ret < static_cast<int>( items.size() ) ) {
             item &it = *items.get_iterator_from_index( ilmenu.ret );
@@ -1253,8 +1391,9 @@ void editmap::edit_itm()
             };
             imenu.allow_additional = true;
 
+            shared_ptr_fast<ui_adaptor> imenu_ui = imenu.create_or_get_ui_adaptor();
+
             do {
-                ilmenu.show();
                 imenu.query();
                 if( imenu.ret >= 0 && imenu.ret < imenu_savetest ) {
                     int intval = -1;
@@ -1294,9 +1433,6 @@ void editmap::edit_itm()
                 } else if( imenu.ret == imenu_savetest ) {
                     edit_json( it );
                 }
-                g->draw_ter( target );
-                wrefresh( g->w_terrain );
-                g->draw_panels();
             } while( imenu.ret != UILIST_CANCEL );
         } else if( ilmenu.ret == static_cast<int>( items.size() ) ) {
             debug_menu::wishitem( nullptr, target );
@@ -1458,30 +1594,36 @@ int editmap::select_shape( shapetype shape, int mode )
     }
     altblink = moveall;
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope invalidate_current_ui( [current_ui]() {
+        current_ui->invalidate_ui();
+    } );
+    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
 
     do {
         if( moveall ) {
-            update_view_with_help( string_format( pgettext( "keybinding descriptions", "%s, %s, %s, %s, %s" ),
-                                                  ctxt.describe_key_and_name( "RESIZE" ),
-                                                  ctxt.describe_key_and_name( "SWAP" ),
-                                                  ctxt.describe_key_and_name( "CONFIRM" ),
-                                                  ctxt.describe_key_and_name( "QUIT" ),
-                                                  ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ) ),
-                                   _( "Moving selection" ) );
+            info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s, %s, %s, %s, %s" ),
+                                           ctxt.describe_key_and_name( "RESIZE" ),
+                                           ctxt.describe_key_and_name( "SWAP" ),
+                                           ctxt.describe_key_and_name( "CONFIRM" ),
+                                           ctxt.describe_key_and_name( "QUIT" ),
+                                           ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ) );
+            info_title_curr = _( "Moving selection" );
         } else {
-            update_view_with_help( string_format( pgettext( "keybinding descriptions",
-                                                  "%s, %s, %s, %s, %s, %s, %s" ),
-                                                  ctxt.describe_key_and_name( "EDITMAP_MOVE" ),
-                                                  ctxt.describe_key_and_name( "RESIZE" ),
-                                                  ctxt.describe_key_and_name( "SWAP" ),
-                                                  ctxt.describe_key_and_name( "START" ),
-                                                  ctxt.describe_key_and_name( "CONFIRM" ),
-                                                  ctxt.describe_key_and_name( "QUIT" ),
-                                                  ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ) ),
-                                   _( "Resizing selection" ) );
+            info_txt_curr = string_format( pgettext( "keybinding descriptions",
+                                           "%s, %s, %s, %s, %s, %s, %s" ),
+                                           ctxt.describe_key_and_name( "EDITMAP_MOVE" ),
+                                           ctxt.describe_key_and_name( "RESIZE" ),
+                                           ctxt.describe_key_and_name( "SWAP" ),
+                                           ctxt.describe_key_and_name( "START" ),
+                                           ctxt.describe_key_and_name( "CONFIRM" ),
+                                           ctxt.describe_key_and_name( "QUIT" ),
+                                           ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ) );
+            info_title_curr = _( "Resizing selection" );
         }
+        current_ui->invalidate_ui();
+        ui_manager::redraw();
         action = ctxt.handle_input( BLINK_SPEED );
         if( action == "RESIZE" ) {
             if( !moveall ) {
@@ -1499,8 +1641,18 @@ int editmap::select_shape( shapetype shape, int mode )
                     { "HELP_KEYBINDINGS", translation() } // to refresh the view after exiting from keybindings
                 };
                 smenu.allow_additional = true;
+
+                on_out_of_scope invalidate_current_ui_2( [current_ui]() {
+                    current_ui->invalidate_ui();
+                } );
+                restore_on_out_of_scope<std::string> info_txt_prev_2( info_txt_curr );
+                restore_on_out_of_scope<std::string> info_title_prev_2( info_title_curr );
+
                 do {
-                    update_view_with_help( "", pgettext( "map editor state", "Select a shape" ) );
+                    info_txt_curr.clear();
+                    info_title_curr = pgettext( "map editor state", "Select a shape" );
+                    current_ui->invalidate_ui();
+
                     smenu.query();
                     if( smenu.ret == UILIST_CANCEL ) {
                         // canceled
@@ -1582,12 +1734,9 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
     // TODO: keep track of generated submaps to delete them properly and to avoid memory leaks
     tmpmap.generate( tripoint( omt_pos.x * 2, omt_pos.y * 2, target.z ), calendar::turn );
 
-    tripoint pofs = pos2screen( target + point( 1 - SEEX, 1 - SEEY ) );
-    catacurses::window w_preview = catacurses::newwin( SEEX * 2, SEEY * 2, pofs.xy() );
-
     gmenu.border_color = c_light_gray;
     gmenu.hilight_color = c_black_white;
-    gmenu.show();
+    gmenu.create_or_get_ui_adaptor()->invalidate_ui();
 
     uilist gpmenu;
     gpmenu.w_width_setup = width;
@@ -1609,6 +1758,14 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
     };
     gpmenu.allow_additional = true;
 
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope invalidate_current_ui( [current_ui]() {
+        current_ui->invalidate_ui();
+    } );
+    restore_on_out_of_scope<tinymap *> tinymap_ptr_prev( tmpmap_ptr );
+    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+
     int lastsel = gmenu.selected;
     bool showpreview = true;
     do {
@@ -1618,100 +1775,24 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
             cleartmpmap( tmpmap );
             tmpmap.generate( tripoint( omt_pos.x * 2, omt_pos.y * 2, target.z ), calendar::turn );
         }
+
+        if( showpreview ) {
+            tmpmap_ptr = &tmpmap;
+        } else {
+            tmpmap_ptr = nullptr;
+        }
         input_context ctxt( gpmenu.input_category );
-#ifdef TILES
-        if( use_tiles && showpreview ) {
-            const point origin_p = target.xy() + point( 1 - SEEX, 1 - SEEY );
-            for( int x = 0; x < SEEX * 2; x++ ) {
-                for( int y = 0; y < SEEY * 2; y++ ) {
-                    const tripoint tmp_p( x, y, target.z );
-                    const tripoint map_p = origin_p + tmp_p;
-                    g->draw_radiation_override( map_p, tmpmap.get_radiation( tmp_p ) );
-                    // scent is managed in `game` instead of `map`, so there's no override for it
-                    // temperature is managed in `game` instead of `map`, so there's no override for it
-                    // TODO: visibility could be affected by both the actual map and the preview map,
-                    // which complicates calculation, so there's no override for it (yet)
-                    g->draw_terrain_override( map_p, tmpmap.ter( tmp_p ) );
-                    g->draw_furniture_override( map_p, tmpmap.furn( tmp_p ) );
-                    g->draw_graffiti_override( map_p, tmpmap.has_graffiti_at( tmp_p ) );
-                    g->draw_trap_override( map_p, tmpmap.tr_at( tmp_p ).loadid );
-                    g->draw_field_override( map_p, tmpmap.field_at( tmp_p ).displayed_field_type() );
-                    const maptile &tile = tmpmap.maptile_at( tmp_p );
-                    if( tmpmap.sees_some_items( tmp_p, g->u.pos() - origin_p ) ) {
-                        const item &itm = tile.get_uppermost_item();
-                        const mtype *const mon = itm.get_mtype();
-                        g->draw_item_override( map_p, itm.typeId(), mon ? mon->id : mtype_id::NULL_ID(),
-                                               tile.get_item_count() > 1 );
-                    } else {
-                        g->draw_item_override( map_p, "null", mtype_id::NULL_ID(), false );
-                    }
-                    const optional_vpart_position vp = tmpmap.veh_at( tmp_p );
-                    if( vp ) {
-                        const vehicle &veh = vp->vehicle();
-                        const int veh_part = vp->part_index();
-                        char part_mod = 0;
-                        const vpart_id &vp_id = veh.part_id_string( veh_part, part_mod );
-                        const cata::optional<vpart_reference> cargopart = vp.part_with_feature( "CARGO", true );
-                        bool draw_highlight = cargopart && !veh.get_items( cargopart->part_index() ).empty();
-                        int veh_dir = veh.face.dir();
-                        g->draw_vpart_override( map_p, vp_id, part_mod, veh_dir, draw_highlight, vp->mount() );
-                    } else {
-                        g->draw_vpart_override( map_p, vpart_id::NULL_ID(), 0, 0, false, point_zero );
-                    }
-                    g->draw_below_override( map_p, g->m.has_zlevels() &&
-                                            tmpmap.ter( tmp_p ).obj().has_flag( TFLAG_NO_FLOOR ) );
-                }
-            }
-            // int: count, bool: more than 1 spawn data
-            std::map<tripoint, std::tuple<mtype_id, int, bool, Creature::Attitude>> spawns;
-            for( int x = 0; x < 2; x++ ) {
-                for( int y = 0; y < 2; y++ ) {
-                    submap *sm = tmpmap.get_submap_at_grid( { x, y, target.z } );
-                    if( sm ) {
-                        const tripoint sm_origin = origin_p + tripoint( x * SEEX, y * SEEY, target.z );
-                        for( const auto &sp : sm->spawns ) {
-                            const tripoint spawn_p = sm_origin + sp.pos;
-                            const auto spawn_it = spawns.find( spawn_p );
-                            if( spawn_it == spawns.end() ) {
-                                const Creature::Attitude att = sp.friendly ? Creature::A_FRIENDLY : Creature::A_ANY;
-                                spawns.emplace( spawn_p, std::make_tuple( sp.type, sp.count, false, att ) );
-                            } else {
-                                std::get<2>( spawn_it->second ) = true;
-                            }
-                        }
-                    }
-                }
-            }
-            for( const auto &it : spawns ) {
-                g->draw_monster_override( it.first, std::get<0>( it.second ), std::get<1>( it.second ),
-                                          std::get<2>( it.second ), std::get<3>( it.second ) );
-            }
-        }
-#endif
         // \u00A0 is the non-breaking space
-        update_view_with_help( string_format( pgettext( "keybinding descriptions",
-                                              "[%s,%s]\u00A0prev/next oter type, [%s,%s]\u00A0select, %s, %s" ),
-                                              ctxt.get_desc( "LEFT", 1 ), ctxt.get_desc( "RIGHT", 1 ),
-                                              ctxt.get_desc( "UP", 1 ), ctxt.get_desc( "DOWN", 1 ),
-                                              ctxt.describe_key_and_name( "CONFIRM" ),
-                                              ctxt.describe_key_and_name( "QUIT" ) ),
-                               string_format( pgettext( "map editor state", "Mapgen: %s" ),
-                                              oter_id( gmenu.selected ).id().str() ) );
-#ifdef TILES
-        const bool drawsq_preview = !use_tiles && showpreview;
-#else
-        const bool drawsq_preview = showpreview;
-#endif
-        if( drawsq_preview ) {
-            hilights["mapgentgt"].draw( *this, true );
-            g->draw_panels();
-            tmpmap.reset_vehicle_cache( target.z );
-            for( const tripoint &p : tmpmap.points_on_zlevel() ) {
-                tmpmap.drawsq( w_preview, g->u, p, false, true, tripoint( SEEX, SEEY, target.z ), false, true );
-            }
-            wrefresh( w_preview );
-        }
-        gmenu.show();
+        info_txt_curr = string_format( pgettext( "keybinding descriptions",
+                                       "[%s,%s]\u00A0prev/next oter type, [%s,%s]\u00A0select, %s, %s" ),
+                                       ctxt.get_desc( "LEFT", 1 ), ctxt.get_desc( "RIGHT", 1 ),
+                                       ctxt.get_desc( "UP", 1 ), ctxt.get_desc( "DOWN", 1 ),
+                                       ctxt.describe_key_and_name( "CONFIRM" ),
+                                       ctxt.describe_key_and_name( "QUIT" ) );
+        info_title_curr = string_format( pgettext( "map editor state", "Mapgen: %s" ),
+                                         oter_id( gmenu.selected ).id().str() );
+        current_ui->invalidate_ui();
+
         gpmenu.query( false, BLINK_SPEED * 3 );
 
         if( gpmenu.ret == 0 ) {
@@ -1769,10 +1850,10 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
         } else if( gpmenu.ret == UILIST_ADDITIONAL ) {
             if( gpmenu.ret_act == "LEFT" ) {
                 gmenu.scrollby( -1 );
-                gmenu.show();
+                gmenu.create_or_get_ui_adaptor()->invalidate_ui();
             } else if( gpmenu.ret_act == "RIGHT" ) {
                 gmenu.scrollby( 1 );
-                gmenu.show();
+                gmenu.create_or_get_ui_adaptor()->invalidate_ui();
             }
         }
         showpreview = gpmenu.ret == UILIST_TIMEOUT ? !showpreview : true;
@@ -1784,6 +1865,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
     }
     gmenu.border_color = c_magenta;
     gmenu.hilight_color = h_white;
+    gmenu.create_or_get_ui_adaptor()->invalidate_ui();
     hilights["mapgentgt"].points.clear();
     cleartmpmap( tmpmap );
 }
@@ -1860,15 +1942,22 @@ void editmap::mapgen_retarget()
     std::string action;
     tripoint origm = target;
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope invalidate_current_ui( [current_ui]() {
+        current_ui->invalidate_ui();
+    } );
+    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
 
     blink = true;
     do {
-        update_view_with_help( string_format( pgettext( "keybinding descriptions", "%s, %s" ),
-                                              ctxt.describe_key_and_name( "CONFIRM" ),
-                                              ctxt.describe_key_and_name( "QUIT" ) ),
-                               pgettext( "map generator", "Mapgen: Moving target" ) );
+        info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s, %s" ),
+                                       ctxt.describe_key_and_name( "CONFIRM" ),
+                                       ctxt.describe_key_and_name( "QUIT" ) );
+        info_title_curr = pgettext( "map generator", "Mapgen: Moving target" );
+        current_ui->invalidate_ui();
+
+        ui_manager::redraw();
         action = ctxt.handle_input( BLINK_SPEED );
         if( const cata::optional<tripoint> vec = ctxt.get_direction( action ) ) {
             point vec_ms = omt_to_ms_copy( vec->xy() );
@@ -1925,6 +2014,13 @@ void editmap::edit_mapgen()
     }
     real_coords tc;
 
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+    on_out_of_scope invalidate_current_ui( [current_ui]() {
+        current_ui->invalidate_ui();
+    } );
+    restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
+    restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
+
     do {
         tc.fromabs( g->m.getabs( target.xy() ) );
         point omt_lpos = g->m.getlocal( tc.begin_om_pos() );
@@ -1945,16 +2041,20 @@ void editmap::edit_mapgen()
         }
 
         blink = true;
+
         input_context ctxt( gmenu.input_category );
-        update_view_with_help( string_format( pgettext( "keybinding descriptions", "%s, %s, %s" ),
-                                              ctxt.describe_key_and_name( "EDITMAP_MOVE" ),
-                                              ctxt.describe_key_and_name( "CONFIRM" ),
-                                              ctxt.describe_key_and_name( "QUIT" ) ),
-                               pgettext( "map generator", "Mapgen stamp" ) );
+        info_txt_curr = string_format( pgettext( "keybinding descriptions", "%s, %s, %s" ),
+                                       ctxt.describe_key_and_name( "EDITMAP_MOVE" ),
+                                       ctxt.describe_key_and_name( "CONFIRM" ),
+                                       ctxt.describe_key_and_name( "QUIT" ) );
+        info_title_curr = pgettext( "map generator", "Mapgen stamp" );
+        current_ui->invalidate_ui();
+
         gmenu.query();
 
         if( gmenu.ret >= 0 ) {
             blink = false;
+            shared_ptr_fast<ui_adaptor> gmenu_ui = gmenu.create_or_get_ui_adaptor();
             mapgen_preview( tc, gmenu );
             blink = true;
         } else if( gmenu.ret == UILIST_ADDITIONAL ) {

--- a/src/editmap.h
+++ b/src/editmap.h
@@ -10,12 +10,14 @@
 #include "optional.h"
 #include "color.h"
 #include "cursesdef.h"
+#include "memory_fast.h"
 #include "point.h"
 #include "type_id.h"
 
 struct real_coords;
 class Creature;
 class field;
+class ui_adaptor;
 class uilist;
 class vehicle;
 class map;
@@ -69,10 +71,6 @@ class editmap
         void update_fmenu_entry( uilist &fmenu, field &field, const field_type_id &idx );
         void setup_fmenu( uilist &fmenu );
         catacurses::window w_info;
-        int width;
-        int height;
-        int offsetX;
-        int infoHeight;
 
         void recalc_target( shapetype shape );
         bool move_target( const std::string &action, int moveorigin = -1 );
@@ -91,11 +89,26 @@ class editmap
         std::map<std::string, editmap_hilight> hilights;
         bool blink;
         bool altblink;
-        point tmax;
         bool uberdraw;
 
         editmap();
         ~editmap();
+
+    private:
+        shared_ptr_fast<ui_adaptor> create_or_get_ui_adaptor();
+
+        weak_ptr_fast<ui_adaptor> ui;
+
+        std::string info_txt_curr;
+        std::string info_title_curr;
+
+        tinymap *tmpmap_ptr = nullptr;
+
+        const int width = 45;
+        const int offsetX = 0;
+        const int infoHeight = 20;
+
+        point tmax;
 };
 
 #endif // CATA_SRC_EDITMAP_H

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2127,16 +2127,25 @@ int game::inventory_item_menu( item_location locThisItem, int iStartX, int iWidt
         // Default menu border color is different, this matches the border of the item info window.
         action_menu.border_color = BORDER_COLOR;
 
-        // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-        ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+        item_info_data data( oThisItem.tname(), oThisItem.type_name(), vThisItem, vDummy, iScrollPos );
+        data.without_getch = true;
+
+        catacurses::window w_info;
+        int iScrollHeight = 0;
+
+        ui_adaptor ui;
+        ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+            w_info = catacurses::newwin( TERMY, iWidth, point( iStartX, 0 ) );
+            iScrollHeight = TERMY - 2;
+            ui.position_from_window( w_info );
+        } );
+        ui.mark_resize();
+
+        ui.on_redraw( [&]( const ui_adaptor & ) {
+            draw_item_info( w_info, data );
+        } );
 
         do {
-            item_info_data data( oThisItem.tname(), oThisItem.type_name(), vThisItem, vDummy, iScrollPos );
-            data.without_getch = true;
-            const int iHeight = TERMY;
-            const int iScrollHeight = iHeight - 2;
-
-            draw_item_info( iStartX, iWidth, 0, iHeight, data );
             const int prev_selected = action_menu.selected;
             action_menu.query( false );
             if( action_menu.ret >= 0 ) {
@@ -2207,9 +2216,11 @@ int game::inventory_item_menu( item_location locThisItem, int iStartX, int iWidt
                     break;
                 case KEY_PPAGE:
                     iScrollPos -= iScrollHeight;
+                    ui.invalidate_ui();
                     break;
                 case KEY_NPAGE:
                     iScrollPos += iScrollHeight;
+                    ui.invalidate_ui();
                     break;
                 case '+':
                     if( !bHPR ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2057,7 +2057,6 @@ int game::inventory_item_menu( item_location locThisItem, int iStartX, int iWidt
         const hint_rating rate_drop_item = u.weapon.has_flag( "NO_UNWIELD" ) ? hint_rating::cant :
                                            hint_rating::good;
 
-        int max_text_length = 0;
         uilist action_menu;
         action_menu.allow_anykey = true;
         const auto addentry = [&]( const char key, const std::string & text, const hint_rating hint ) {
@@ -2075,7 +2074,6 @@ int game::inventory_item_menu( item_location locThisItem, int iStartX, int iWidt
                     entry.text_color = c_light_green;
                     break;
             }
-            max_text_length = std::max( max_text_length, utf8_width( text ) );
         };
         addentry( 'a', pgettext( "action", "activate" ), u.rate_action_use( oThisItem ) );
         addentry( 'R', pgettext( "action", "read" ), u.rate_action_read( oThisItem ) );
@@ -2109,30 +2107,21 @@ int game::inventory_item_menu( item_location locThisItem, int iStartX, int iWidt
         int iScrollPos = 0;
         oThisItem.info( true, vThisItem );
 
-        // +2+2 for border and adjacent spaces, +2 for '<hotkey><space>'
-        int popup_width = max_text_length + 2 + 2 + 2;
-        int popup_x = 0;
-        switch( position ) {
-            case RIGHT_TERMINAL_EDGE:
-                popup_x = 0;
-                break;
-            case LEFT_OF_INFO:
-                popup_x = iStartX - popup_width;
-                break;
-            case RIGHT_OF_INFO:
-                popup_x = iStartX + iWidth;
-                break;
-            case LEFT_TERMINAL_EDGE:
-                popup_x = TERMX - popup_width;
-                break;
-        }
-
-        // TODO: Ideally the setup of uilist would be split into calculate variables (size, width...),
-        // and actual window creation. This would allow us to let uilist calculate the width, we can
-        // use that to adjust its location afterwards.
-        action_menu.w_y = 0;
-        action_menu.w_x = popup_x;
-        action_menu.w_width = popup_width;
+        action_menu.w_y_setup = 0;
+        action_menu.w_x_setup = [&]( const int popup_width ) -> int {
+            switch( position )
+            {
+                default:
+                case RIGHT_TERMINAL_EDGE:
+                    return 0;
+                case LEFT_OF_INFO:
+                    return iStartX - popup_width;
+                case RIGHT_OF_INFO:
+                    return iStartX + iWidth;
+                case LEFT_TERMINAL_EDGE:
+                    return TERMX - popup_width;
+            }
+        };
         // Filtering isn't needed, the number of entries is manageable.
         action_menu.filtering = false;
         // Default menu border color is different, this matches the border of the item info window.
@@ -11361,7 +11350,7 @@ void game::display_visibility()
 
             pointmenu_cb callback( locations );
             creature_menu.callback = &callback;
-            creature_menu.w_y = 0;
+            creature_menu.w_y_setup = 0;
             creature_menu.query();
             if( creature_menu.ret >= 0 && static_cast<size_t>( creature_menu.ret ) < locations.size() ) {
                 Creature *creature = critter_at<Creature>( locations[creature_menu.ret] );
@@ -11390,7 +11379,7 @@ void game::display_lighting()
             lighting_menu.addentry( count++, true, MENU_AUTOASSIGN, "%s", menu_str );
         }
 
-        lighting_menu.w_y = 0;
+        lighting_menu.w_y_setup = 0;
         lighting_menu.query();
         if( ( lighting_menu.ret >= 0 ) &&
             ( static_cast<size_t>( lighting_menu.ret ) < lighting_menu_strings.size() ) ) {

--- a/src/game.h
+++ b/src/game.h
@@ -985,8 +985,6 @@ class game
         catacurses::window w_pixel_minimap;
         //only a pointer, can refer to w_messages_short or w_messages_long
 
-        catacurses::window w_blackspace;
-
         // View offset based on the driving speed (if any)
         // that has been added to u.view_offset,
         // Don't write to this directly, always use set_driving_view_offset

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -168,7 +168,6 @@ static item_location inv_internal( player &u, const inventory_selector_preset &p
         has_init_filter = true;
     }
 
-    bool need_refresh = true;
     do {
         u.inv.restack( u );
 
@@ -176,18 +175,14 @@ static item_location inv_internal( player &u, const inventory_selector_preset &p
         inv_s.add_character_items( u );
         inv_s.add_nearby_items( radius );
 
-        if( init_selection || has_init_filter ) {
-            inv_s.update( need_refresh );
-            if( has_init_filter ) {
-                inv_s.set_filter( init_filter );
-                has_init_filter = false;
-                inv_s.update( need_refresh );
-            }
-            // Set position after filter to keep cursor at the right position
-            if( init_selection ) {
-                inv_s.select_position( init_pair );
-                init_selection = false;
-            }
+        if( has_init_filter ) {
+            inv_s.set_filter( init_filter );
+            has_init_filter = false;
+        }
+        // Set position after filter to keep cursor at the right position
+        if( init_selection ) {
+            inv_s.select_position( init_pair );
+            init_selection = false;
         }
 
         if( inv_s.empty() ) {
@@ -233,12 +228,10 @@ void game_menus::inv::common( avatar &you )
 
     int res = 0;
 
-    bool need_refresh = true;
     do {
         you.inv.restack( you );
         inv_s.clear_items();
         inv_s.add_character_items( you );
-        inv_s.update( need_refresh );
 
         const item_location &location = inv_s.execute();
 
@@ -1590,21 +1583,12 @@ static item_location autodoc_internal( player &u, player &patient,
     inv_s.set_hint( hint );
     inv_s.set_display_stats( false );
 
-    std::pair<size_t, size_t> init_pair;
-    bool init_selection = false;
-    bool need_refresh = true;
     do {
         u.inv.restack( u );
 
         inv_s.clear_items();
         inv_s.add_character_items( u );
         inv_s.add_nearby_items( radius );
-
-        if( init_selection ) {
-            inv_s.update( need_refresh );
-            inv_s.select_position( init_pair );
-            init_selection = false;
-        }
 
         if( inv_s.empty() ) {
             popup( _( "You don't have any bionics to install." ), PF_GET_KEY );
@@ -1956,21 +1940,12 @@ static item_location autoclave_internal( player &u,
     inv_s.set_hint( _( "<color_yellow>Select one CBM to sterilize</color>" ) );
     inv_s.set_display_stats( false );
 
-    std::pair<size_t, size_t> init_pair;
-    bool init_selection = false;
-    bool need_refresh = true;
     do {
         u.inv.restack( u );
 
         inv_s.clear_items();
         inv_s.add_character_items( u );
         inv_s.add_nearby_items( radius );
-
-        if( init_selection ) {
-            inv_s.update( need_refresh );
-            inv_s.select_position( init_pair );
-            init_selection = false;
-        }
 
         if( inv_s.empty() ) {
             popup( _( "You don't have any CBM to sterilize." ), PF_GET_KEY );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -473,9 +473,10 @@ const inventory_column::entry_cell_cache_t &inventory_column::get_entry_cell_cac
     return entries_cell_cache[index];
 }
 
-void inventory_column::set_width( const size_t new_width )
+void inventory_column::set_width( const size_t new_width,
+                                  const std::vector<inventory_column *> &all_columns )
 {
-    reset_width();
+    reset_width( all_columns );
     int width_gap = get_width() - new_width;
     // Now adjust the width if we must
     while( width_gap != 0 ) {
@@ -551,7 +552,7 @@ void inventory_column::expand_to_fit( const inventory_entry &entry )
     }
 }
 
-void inventory_column::reset_width()
+void inventory_column::reset_width( const std::vector<inventory_column *> & )
 {
     for( auto &elem : cells ) {
         elem = cell_t();
@@ -743,6 +744,7 @@ void inventory_column::prepare_paging( const std::string &filter )
         return preset.get_filter( filter );
     } );
 
+    // FIXME: toggled status of multiselect menu resets when filtering the menu
     // First, remove all non-items
     const auto new_end = std::remove_if( entries.begin(),
     entries.end(), [&filter_fn]( const inventory_entry & entry ) {
@@ -980,6 +982,25 @@ selection_column::selection_column( const std::string &id, const std::string &na
 
 selection_column::~selection_column() = default;
 
+void selection_column::reset_width( const std::vector<inventory_column *> &all_columns )
+{
+    inventory_column::reset_width( all_columns );
+
+    const auto always_yes = []( const inventory_entry & ) {
+        return true;
+    };
+
+    for( const inventory_column *const col : all_columns ) {
+        if( col && !dynamic_cast<const selection_column *>( col ) ) {
+            for( const inventory_entry *const ent : col->get_entries( always_yes ) ) {
+                if( ent ) {
+                    expand_to_fit( *ent );
+                }
+            }
+        }
+    }
+}
+
 void selection_column::prepare_paging( const std::string &filter )
 {
     inventory_column::prepare_paging( filter );
@@ -1122,9 +1143,11 @@ void inventory_selector::add_entry( inventory_column &target_column,
                            preset.get_denial( locations.front() ).empty() );
 
     target_column.add_entry( entry );
-    on_entry_add( entry );
 
-    layout_is_valid = false;
+    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    if( current_ui ) {
+        current_ui->mark_resize();
+    }
 }
 
 void inventory_selector::add_item( inventory_column &target_column,
@@ -1263,6 +1286,8 @@ inventory_entry *inventory_selector::find_entry_by_invlet( int invlet ) const
     return nullptr;
 }
 
+// FIXME: if columns are merged due to low screen width, they will not be splitted
+// once screen width becomes enough for the columns.
 void inventory_selector::rearrange_columns( size_t client_width )
 {
     while( is_overflown( client_width ) ) {
@@ -1281,6 +1306,7 @@ void inventory_selector::prepare_layout( size_t client_width, size_t client_heig
     // This block adds categories and should go before any width evaluations
     for( auto &elem : columns ) {
         elem->set_height( client_height );
+        elem->reset_width( columns );
         elem->prepare_paging( filter );
     }
     // Handle screen overflow
@@ -1289,7 +1315,7 @@ void inventory_selector::prepare_layout( size_t client_width, size_t client_heig
     // the available with -> expand it
     auto visible_columns = get_visible_columns();
     if( visible_columns.size() == 1 && are_columns_centered( client_width ) ) {
-        visible_columns.front()->set_width( client_width );
+        visible_columns.front()->set_width( client_width, columns );
     }
 
     int custom_invlet = '0';
@@ -1303,14 +1329,6 @@ void inventory_selector::prepare_layout( size_t client_width, size_t client_heig
 
 void inventory_selector::prepare_layout()
 {
-    for( auto &elem : columns ) {
-        elem->prepare_paging();
-    }
-
-    if( layout_is_valid ) {
-        return;
-    }
-
     const auto snap = []( size_t cur_dim, size_t max_dim ) {
         return cur_dim + 2 * max_win_snap_distance >= max_dim ? max_dim : cur_dim;
     };
@@ -1327,7 +1345,23 @@ void inventory_selector::prepare_layout()
     prepare_layout( win_width - nc_width, win_height - nc_height );
 
     resize_window( win_width, win_height );
-    layout_is_valid = true;
+}
+
+shared_ptr_fast<ui_adaptor> inventory_selector::create_or_get_ui_adaptor()
+{
+    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    if( !current_ui ) {
+        ui = current_ui = make_shared_fast<ui_adaptor>();
+        current_ui->on_screen_resize( [this]( ui_adaptor & ) {
+            prepare_layout();
+        } );
+        current_ui->mark_resize();
+
+        current_ui->on_redraw( [this]( const ui_adaptor & ) {
+            refresh_window();
+        } );
+    }
+    return current_ui;
 }
 
 size_t inventory_selector::get_layout_width() const
@@ -1477,9 +1511,14 @@ std::vector<std::string> inventory_selector::get_stats() const
 
 void inventory_selector::resize_window( int width, int height )
 {
-    if( !w_inv || width != getmaxx( w_inv ) || height != getmaxy( w_inv ) ) {
-        w_inv = catacurses::newwin( height, width,
-                                    point( ( TERMX - width ) / 2, ( TERMY - height ) / 2 ) );
+    w_inv = catacurses::newwin( height, width,
+                                point( ( TERMX - width ) / 2, ( TERMY - height ) / 2 ) );
+    if( spopup ) {
+        spopup->window( w_inv, point( 4, getmaxy( w_inv ) - 1 ), ( getmaxx( w_inv ) / 2 ) - 4 );
+    }
+    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    if( current_ui ) {
+        current_ui->position_from_window( w_inv );
     }
 }
 
@@ -1499,58 +1538,51 @@ void inventory_selector::refresh_window() const
 
 void inventory_selector::set_filter()
 {
-    string_input_popup spopup;
-    spopup.window( w_inv, point( 4, getmaxy( w_inv ) - 1 ), ( getmaxx( w_inv ) / 2 ) - 4 )
-    .max_length( 256 )
+    spopup = std::make_unique<string_input_popup>();
+    spopup->max_length( 256 )
     .text( filter );
+
+    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    if( current_ui ) {
+        current_ui->mark_resize();
+    }
 
     ime_sentry sentry;
 
     do {
-        mvwprintz( w_inv, point( 2, getmaxy( w_inv ) - 1 ), c_cyan, "< " );
-        mvwprintz( w_inv, point( ( getmaxx( w_inv ) / 2 ) - 4, getmaxy( w_inv ) - 1 ), c_cyan, " >" );
+        ui_manager::redraw();
+        spopup->query_string( /*loop=*/false );
+    } while( !spopup->confirmed() && !spopup->canceled() );
 
-        std::string new_filter = spopup.query_string( false );
-        if( spopup.context().get_raw_input().get_first_input() == KEY_ESCAPE ) {
-            filter.clear();
-        } else {
-            filter = new_filter;
+    if( spopup->confirmed() ) {
+        filter = spopup->text();
+        for( const auto elem : columns ) {
+            elem->set_filter( filter );
         }
-
-        wrefresh( w_inv );
-    } while( spopup.context().get_raw_input().get_first_input() != '\n' &&
-             spopup.context().get_raw_input().get_first_input() != KEY_ESCAPE );
-
-    for( const auto elem : columns ) {
-        elem->set_filter( filter );
+        if( current_ui ) {
+            current_ui->mark_resize();
+        }
     }
-    layout_is_valid = false;
+
+    spopup.reset();
 }
 
 void inventory_selector::set_filter( const std::string &str )
 {
+    prepare_layout();
     filter = str;
     for( const auto elem : columns ) {
         elem->set_filter( filter );
     }
-    layout_is_valid = false;
+    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    if( current_ui ) {
+        current_ui->mark_resize();
+    }
 }
 
 std::string inventory_selector::get_filter() const
 {
     return filter;
-}
-
-void inventory_selector::update( bool &need_refresh )
-{
-    if( need_refresh ) {
-        g->draw_ter();
-        wrefresh( g->w_terrain );
-        g->draw_panels( true );
-        need_refresh = false;
-    }
-    prepare_layout();
-    refresh_window();
 }
 
 void inventory_selector::draw_columns( const catacurses::window &w ) const
@@ -1612,30 +1644,37 @@ std::pair<std::string, nc_color> inventory_selector::get_footer( navigation_mode
 
 void inventory_selector::draw_footer( const catacurses::window &w ) const
 {
-    int filter_offset = 0;
-    if( has_available_choices() || !filter.empty() ) {
-        std::string text = string_format( filter.empty() ? _( "[%s] Filter" ) : _( "[%s] Filter: " ),
-                                          ctxt.get_desc( "INVENTORY_FILTER" ) );
-        filter_offset = utf8_width( text + filter ) + 6;
+    if( spopup ) {
+        mvwprintz( w_inv, point( 2, getmaxy( w_inv ) - 1 ), c_cyan, "< " );
+        mvwprintz( w_inv, point( ( getmaxx( w_inv ) / 2 ) - 4, getmaxy( w_inv ) - 1 ), c_cyan, " >" );
 
-        mvwprintz( w, point( 2, getmaxy( w ) - border ), c_light_gray, "< " );
-        wprintz( w, c_light_gray, text );
-        wprintz( w, c_white, filter );
-        wprintz( w, c_light_gray, " >" );
-    }
+        std::string new_filter = spopup->query_string( /*loop=*/false, /*draw_only=*/true );
+    } else {
+        int filter_offset = 0;
+        if( has_available_choices() || !filter.empty() ) {
+            std::string text = string_format( filter.empty() ? _( "[%s] Filter" ) : _( "[%s] Filter: " ),
+                                              ctxt.get_desc( "INVENTORY_FILTER" ) );
+            filter_offset = utf8_width( text + filter ) + 6;
 
-    const auto footer = get_footer( mode );
-    if( !footer.first.empty() ) {
-        const int string_width = utf8_width( footer.first );
-        const int x1 = filter_offset + std::max( getmaxx( w ) - string_width - filter_offset, 0 ) / 2;
-        const int x2 = x1 + string_width - 1;
-        const int y = getmaxy( w ) - border;
+            mvwprintz( w, point( 2, getmaxy( w ) - border ), c_light_gray, "< " );
+            wprintz( w, c_light_gray, text );
+            wprintz( w, c_white, filter );
+            wprintz( w, c_light_gray, " >" );
+        }
 
-        mvwprintz( w, point( x1, y ), footer.second, footer.first );
-        mvwputch( w, point( x1 - 1, y ), c_light_gray, ' ' );
-        mvwputch( w, point( x2 + 1, y ), c_light_gray, ' ' );
-        mvwputch( w, point( x1 - 2, y ), c_light_gray, LINE_XOXX );
-        mvwputch( w, point( x2 + 2, y ), c_light_gray, LINE_XXXO );
+        const auto footer = get_footer( mode );
+        if( !footer.first.empty() ) {
+            const int string_width = utf8_width( footer.first );
+            const int x1 = filter_offset + std::max( getmaxx( w ) - string_width - filter_offset, 0 ) / 2;
+            const int x2 = x1 + string_width - 1;
+            const int y = getmaxy( w ) - border;
+
+            mvwprintz( w, point( x1, y ), footer.second, footer.first );
+            mvwputch( w, point( x1 - 1, y ), c_light_gray, ' ' );
+            mvwputch( w, point( x2 + 1, y ), c_light_gray, ' ' );
+            mvwputch( w, point( x1 - 2, y ), c_light_gray, LINE_XOXX );
+            mvwputch( w, point( x2 + 2, y ), c_light_gray, LINE_XXXO );
+        }
     }
 }
 
@@ -1848,17 +1887,15 @@ std::string inventory_selector::action_bound_to_key( char key ) const
 
 item_location inventory_pick_selector::execute()
 {
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
-
-    bool need_refresh = true;
+    shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
     while( true ) {
-        update( need_refresh );
+        ui_manager::redraw();
+
         const inventory_input input = get_input();
 
         if( input.entry != nullptr ) {
             if( select( input.entry->any_item() ) ) {
-                refresh_window();
+                ui_manager::redraw();
             }
             return input.entry->any_item();
         } else if( input.action == "QUIT" ) {
@@ -1876,10 +1913,6 @@ item_location inventory_pick_selector::execute()
 
         if( input.action == "TOGGLE_FAVORITE" ) {
             return item_location();
-        }
-
-        if( input.action == "HELP_KEYBINDINGS" || input.action == "INVENTORY_FILTER" ) {
-            need_refresh = true;
         }
     }
 }
@@ -1906,24 +1939,14 @@ void inventory_multiselector::rearrange_columns( size_t client_width )
     selection_col->set_visibility( !is_overflown( client_width ) );
 }
 
-void inventory_multiselector::on_entry_add( const inventory_entry &entry )
-{
-    if( entry.is_item() ) {
-        dynamic_cast<selection_column *>( selection_col.get() )->expand_to_fit( entry );
-    }
-}
-
 inventory_compare_selector::inventory_compare_selector( player &p ) :
     inventory_multiselector( p, default_preset, _( "ITEMS TO COMPARE" ) ) {}
 
 std::pair<const item *, const item *> inventory_compare_selector::execute()
 {
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
-
-    bool need_refresh = true;
+    shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
     while( true ) {
-        update( need_refresh );
+        ui_manager::redraw();
 
         const inventory_input input = get_input();
 
@@ -1998,13 +2021,11 @@ inventory_iuse_selector::inventory_iuse_selector(
 {}
 drop_locations inventory_iuse_selector::execute()
 {
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
 
     int count = 0;
-    bool need_refresh = true;
     while( true ) {
-        update( need_refresh );
+        ui_manager::redraw();
 
         const inventory_input input = get_input();
 
@@ -2123,13 +2144,11 @@ void inventory_drop_selector::process_selected( int &count,
 
 drop_locations inventory_drop_selector::execute()
 {
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
 
     int count = 0;
-    bool need_refresh = true;
     while( true ) {
-        update( need_refresh );
+        ui_manager::redraw();
 
         const inventory_input input = get_input();
 
@@ -2200,7 +2219,6 @@ drop_locations inventory_drop_selector::execute()
             return drop_locations();
         } else if( input.action == "INVENTORY_FILTER" ) {
             set_filter();
-            need_refresh = true;
         } else if( input.action == "TOGGLE_FAVORITE" ) {
             // TODO: implement favoriting in multi selection menus while maintaining selection
         } else {

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -19,6 +19,7 @@
 #include "cursesdef.h"
 #include "input.h"
 #include "item_location.h"
+#include "memory_fast.h"
 #include "pimpl.h"
 #include "units.h"
 #include "item_category.h"
@@ -26,7 +27,9 @@
 class Character;
 class item;
 class player;
+class string_input_popup;
 struct tripoint;
+class ui_adaptor;
 
 enum class navigation_mode : int {
     ITEM = 0,
@@ -288,14 +291,14 @@ class inventory_column
             this->visibility = visibility;
         }
 
-        void set_width( size_t new_width );
+        void set_width( size_t new_width, const std::vector<inventory_column *> &all_columns );
         void set_height( size_t new_height );
         size_t get_width() const;
         size_t get_height() const;
         /** Expands the column to fit the new entry. */
         void expand_to_fit( const inventory_entry &entry );
         /** Resets width to original (unchanged). */
-        void reset_width();
+        virtual void reset_width( const std::vector<inventory_column *> &all_columns );
         /** Returns next custom inventory letter. */
         int reassign_custom_invlets( const player &p, int min_invlet, int max_invlet );
         /** Reorder entries, repopulate titles, adjust to the new height. */
@@ -409,6 +412,8 @@ class selection_column : public inventory_column
             return false;
         }
 
+        void reset_width( const std::vector<inventory_column *> &all_columns ) override;
+
         void prepare_paging( const std::string &filter = "" ) override;
 
         void on_change( const inventory_entry &entry ) override;
@@ -493,14 +498,11 @@ class inventory_selector
         /** Entry has been changed */
         void on_change( const inventory_entry &entry );
 
-        void prepare_layout( size_t client_width, size_t client_height );
-        void prepare_layout();
+        shared_ptr_fast<ui_adaptor> create_or_get_ui_adaptor();
 
         size_t get_layout_width() const;
         size_t get_layout_height() const;
 
-        void resize_window( int width, int height );
-        void refresh_window() const;
         void set_filter();
 
         /** Tackles screen overflow */
@@ -522,11 +524,6 @@ class inventory_selector
         size_t get_header_min_width() const;
         size_t get_footer_min_width() const;
 
-        void draw_header( const catacurses::window &w ) const;
-        void draw_footer( const catacurses::window &w ) const;
-        void draw_columns( const catacurses::window &w ) const;
-        void draw_frame( const catacurses::window &w ) const;
-
         /** @return an entry from all entries by its invlet */
         inventory_entry *find_entry_by_invlet( int invlet ) const;
 
@@ -535,10 +532,21 @@ class inventory_selector
         }
         std::vector<inventory_column *> get_visible_columns() const;
 
+    private:
+        // These functions are called from resizing/redraw callbacks of ui_adaptor
+        // and should not be made protected or public.
+        void prepare_layout( size_t client_width, size_t client_height );
+        void prepare_layout();
+
+        void resize_window( int width, int height );
+        void refresh_window() const;
+
+        void draw_header( const catacurses::window &w ) const;
+        void draw_footer( const catacurses::window &w ) const;
+        void draw_columns( const catacurses::window &w ) const;
+        void draw_frame( const catacurses::window &w ) const;
+
     public:
-
-        void update( bool &need_refresh );
-
         /**
          * Select a location
          * @param loc Location to select
@@ -551,6 +559,7 @@ class inventory_selector
         }
 
         void select_position( std::pair<size_t, size_t> position ) {
+            prepare_layout();
             set_active_column( position.first );
             get_active_column().select( position.second, scroll_direction::BACKWARD );
         }
@@ -597,13 +606,14 @@ class inventory_selector
         }
         void toggle_navigation_mode();
 
-        /** Entry has been added */
-        virtual void on_entry_add( const inventory_entry & ) {}
-
         const navigation_mode_data &get_navigation_data( navigation_mode m ) const;
 
     private:
         catacurses::window w_inv;
+
+        weak_ptr_fast<ui_adaptor> ui;
+
+        std::unique_ptr<string_input_popup> spopup;
 
         std::vector<inventory_column *> columns;
 
@@ -622,7 +632,6 @@ class inventory_selector
 
         bool is_empty = true;
         bool display_stats = true;
-        bool layout_is_valid = false;
 
     public:
         std::string action_bound_to_key( char key ) const;
@@ -648,7 +657,6 @@ class inventory_multiselector : public inventory_selector
                                  const std::string &selection_column_title = "" );
     protected:
         void rearrange_columns( size_t client_width ) override;
-        void on_entry_add( const inventory_entry &entry ) override;
 
     private:
         std::unique_ptr<inventory_column> selection_col;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8164,7 +8164,7 @@ static vehicle *pickveh( const tripoint &center, bool advanced )
 
     pointmenu_cb callback( locations );
     pmenu.callback = &callback;
-    pmenu.w_y = 0;
+    pmenu.w_y_setup = 0;
     pmenu.query();
 
     if( pmenu.ret < 0 || pmenu.ret >= static_cast<int>( vehs.size() ) ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2409,13 +2409,11 @@ int learn_spell_actor::use( player &p, item &, bool, const tripoint & ) const
     }
 
     spellbook_uilist.entries = uilist_initializer;
-    spellbook_uilist.w_height = 24;
-    spellbook_uilist.w_width = 80;
-    spellbook_uilist.w_x = ( TERMX - spellbook_uilist.w_width ) / 2;
-    spellbook_uilist.w_y = ( TERMY - spellbook_uilist.w_height ) / 2;
+    spellbook_uilist.w_height_setup = 24;
+    spellbook_uilist.w_width_setup = 80;
     spellbook_uilist.callback = &sp_cb;
     spellbook_uilist.title = _( "Study a spell:" );
-    spellbook_uilist.pad_left = 38;
+    spellbook_uilist.pad_left_setup = 38;
     spellbook_uilist.query();
     const int action = spellbook_uilist.ret;
     if( action < 0 ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1782,11 +1782,16 @@ int known_magic::select_spell( const Character &guy )
     std::vector<spell *> known_spells = get_spells();
 
     uilist spell_menu;
-    spell_menu.w_height = clamp( static_cast<int>( known_spells.size() ), 24, TERMY * 9 / 10 );
-    spell_menu.w_width = std::max( 80, TERMX * 3 / 8 );
-    spell_menu.w_x = ( TERMX - spell_menu.w_width ) / 2;
-    spell_menu.w_y = ( TERMY - spell_menu.w_height ) / 2;
-    spell_menu.pad_right = spell_menu.w_width - max_spell_name_length - 5;
+    spell_menu.w_height_setup = [&]() -> int {
+        return clamp( static_cast<int>( known_spells.size() ), 24, TERMY * 9 / 10 );
+    };
+    const auto calc_width = []() -> int {
+        return std::max( 80, TERMX * 3 / 8 );
+    };
+    spell_menu.w_width_setup = calc_width;
+    spell_menu.pad_right_setup = [&]() -> int {
+        return calc_width() - max_spell_name_length - 5;
+    };
     spell_menu.title = _( "Choose a Spell" );
     spell_menu.hilight_disabled = true;
     spellcasting_callback cb( known_spells, casting_ignore );

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -188,7 +188,7 @@ cata::optional<tripoint> teleporter_list::choose_teleport_location()
     g->refresh_all();
 
     uilist teleport_selector;
-    teleport_selector.w_height = 24;
+    teleport_selector.w_height_setup = 24;
 
     int index = 0;
     int column_width = 25;
@@ -201,10 +201,8 @@ cata::optional<tripoint> teleporter_list::choose_teleport_location()
     }
     teleporter_callback cb( index_pairs );
     teleport_selector.callback = &cb;
-    teleport_selector.w_width = 38 + column_width;
-    teleport_selector.pad_right = 33;
-    teleport_selector.w_x = ( TERMX - teleport_selector.w_width ) / 2;
-    teleport_selector.w_y = ( TERMY - teleport_selector.w_height ) / 2;
+    teleport_selector.w_width_setup = 38 + column_width;
+    teleport_selector.pad_right_setup = 33;
     teleport_selector.title = _( "Choose Translocator Gate" );
 
     teleport_selector.query();

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -408,7 +408,7 @@ class dialog
         dialog();
         void run();
     private:
-        void init();
+        void init( ui_adaptor &ui );
         void show();
         void input();
         void do_filter( const std::string &filter_str );
@@ -429,20 +429,27 @@ class dialog
         //        time_width       msg_width
         static constexpr int border_width = 1;
         static constexpr int padding_width = 1;
-        int time_width, msg_width;
+        int time_width = 0;
+        int msg_width = 0;
 
-        size_t max_lines; // Max number of lines the window can show at once
+        size_t max_lines = 0; // Max number of lines the window can show at once
 
-        int w_x, w_y, w_width, w_height; // Main window position
+        int w_x = 0;
+        int w_y = 0;
+        int w_width = 0;
+        int w_height = 0; // Main window position
         catacurses::window w; // Main window
 
-        int w_fh_x, w_fh_y, w_fh_width, w_fh_height; // Filter help window position
+        int w_fh_x = 0;
+        int w_fh_y = 0;
+        int w_fh_width = 0;
+        int w_fh_height = 0; // Filter help window position
         catacurses::window w_filter_help; // Filter help window
 
         std::vector<std::string> help_text; // Folded filter help text
 
         string_input_popup filter;
-        bool filtering;
+        bool filtering = false;
         std::string filter_str;
 
         input_context ctxt;
@@ -452,12 +459,14 @@ class dialog
         // Indices of filtered messages
         std::vector<size_t> folded_filtered;
 
-        size_t offset; // Index of the first printed message
+        size_t offset = 0; // Index of the first printed message
 
-        bool canceled;
-        bool errored;
+        bool canceled = false;
+        bool errored = false;
 
         cata::optional<ime_sentry> filter_sentry;
+
+        bool first_init = true;
 };
 } // namespace Messages
 
@@ -466,10 +475,9 @@ Messages::dialog::dialog()
       time_color( c_light_blue ), bracket_color( c_dark_gray ),
       filter_help_color( c_cyan )
 {
-    init();
 }
 
-void Messages::dialog::init()
+void Messages::dialog::init( ui_adaptor &ui )
 {
     w_width = std::min( TERMX, FULL_SCREEN_WIDTH );
     w_height = std::min( TERMY, FULL_SCREEN_HEIGHT );
@@ -478,24 +486,25 @@ void Messages::dialog::init()
 
     w = catacurses::newwin( w_height, w_width, point( w_x, w_y ) );
 
-    ctxt = input_context( "MESSAGE_LOG" );
-    ctxt.register_action( "UP", to_translation( "Scroll up" ) );
-    ctxt.register_action( "DOWN", to_translation( "Scroll down" ) );
-    ctxt.register_action( "PAGE_UP" );
-    ctxt.register_action( "PAGE_DOWN" );
-    ctxt.register_action( "FILTER" );
-    ctxt.register_action( "RESET_FILTER" );
-    ctxt.register_action( "QUIT" );
-    ctxt.register_action( "HELP_KEYBINDINGS" );
+    if( first_init ) {
+        ctxt = input_context( "MESSAGE_LOG" );
+        ctxt.register_action( "UP", to_translation( "Scroll up" ) );
+        ctxt.register_action( "DOWN", to_translation( "Scroll down" ) );
+        ctxt.register_action( "PAGE_UP" );
+        ctxt.register_action( "PAGE_DOWN" );
+        ctxt.register_action( "FILTER" );
+        ctxt.register_action( "RESET_FILTER" );
+        ctxt.register_action( "QUIT" );
+        ctxt.register_action( "HELP_KEYBINDINGS" );
 
-    // Calculate time string display width. The translated strings are expected to
-    // be aligned, so we choose an arbitrary duration here to calculate the width.
-    time_width = utf8_width( to_string_clipped( 1_turns, clipped_align::right ) );
+        // Calculate time string display width. The translated strings are expected to
+        // be aligned, so we choose an arbitrary duration here to calculate the width.
+        time_width = utf8_width( to_string_clipped( 1_turns, clipped_align::right ) );
+    }
 
     if( border_width * 2 + time_width + padding_width >= w_width ||
         border_width * 2 >= w_height ) {
 
-        debugmsg( "No enough space for the message window" );
         errored = true;
         return;
     }
@@ -513,7 +522,6 @@ void Messages::dialog::init()
     // Initialize filter input
     filter.window( w_filter_help, point( border_width + 2, w_fh_height - 1 ),
                    w_fh_width - border_width - 2 );
-    filtering = false;
 
     // Initialize folded messages
     folded_all.clear();
@@ -529,15 +537,11 @@ void Messages::dialog::init()
         }
     }
 
-    // Initialize scrolling offset
-    if( log_from_top || max_lines > folded_filtered.size() ) {
-        offset = 0;
-    } else {
-        offset = folded_filtered.size() - max_lines;
-    }
+    do_filter( filter_str );
 
-    canceled = false;
-    errored = false;
+    ui.position_from_window( w );
+
+    first_init = false;
 }
 
 void Messages::dialog::show()
@@ -744,11 +748,17 @@ void Messages::dialog::input()
 
 void Messages::dialog::run()
 {
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    ui_adaptor ui;
+    ui.on_screen_resize( [this]( ui_adaptor & ui ) {
+        init( ui );
+    } );
+    ui.mark_resize();
+    ui.on_redraw( [this]( const ui_adaptor & ) {
+        show();
+    } );
 
     while( !errored && !canceled ) {
-        show();
+        ui_manager::redraw();
         input();
     }
 }

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -968,7 +968,7 @@ npc *pick_follower()
     uilist menu;
     menu.text = _( "Select a follower" );
     menu.callback = &callback;
-    menu.w_y = 2;
+    menu.w_y_setup = 2;
 
     for( const npc *p : followers ) {
         menu.addentry( -1, true, MENU_AUTOASSIGN, p->name );

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -24,6 +24,7 @@
 #include "item_contents.h"
 #include "map_selector.h"
 #include "npc.h"
+#include "optional.h"
 #include "output.h"
 #include "player.h"
 #include "point.h"
@@ -234,19 +235,14 @@ void item_pricing::adjust_values( const double adjust, const faction *fac )
     }
 }
 
-void trading_window::setup_win( npc &np )
+void trading_window::setup_win( ui_adaptor &ui )
 {
+    const int win_they_w = TERMX / 2;
+    entries_per_page = std::min( TERMY - 7, 2 + ( 'z' - 'a' ) + ( 'Z' - 'A' ) );
     w_head = catacurses::newwin( 4, TERMX, point_zero );
     w_them = catacurses::newwin( TERMY - 4, win_they_w, point( 0, 4 ) );
     w_you = catacurses::newwin( TERMY - 4, TERMX - win_they_w, point( win_they_w, 4 ) );
-    mvwprintz( w_head, point_zero, c_white, header_message.c_str(), np.disp_name() );
-
-    // Set up line drawings
-    for( int i = 0; i < TERMX; i++ ) {
-        mvwputch( w_head, point( i, 3 ), c_white, LINE_OXOX );
-    }
-    wrefresh( w_head );
-    // End of line drawings
+    ui.position( point_zero, point( TERMX, TERMY ) );
 }
 
 // 'cost' is the cost of a service the NPC may be rendering, if any.
@@ -268,137 +264,150 @@ void trading_window::setup_trade( int cost, npc &np )
 
 void trading_window::update_win( npc &np, const std::string &deal )
 {
-    if( update ) { // Time to re-draw
-        update = false;
-        // Draw borders, one of which is highlighted
-        werase( w_them );
-        werase( w_you );
-        for( int i = 1; i < TERMX; i++ ) {
-            mvwputch( w_head, point( i, 3 ), c_white, LINE_OXOX );
+    // Draw borders, one of which is highlighted
+    werase( w_them );
+    werase( w_you );
+
+    std::set<item *> without;
+    std::vector<item *> added;
+
+    for( item_pricing &pricing : yours ) {
+        if( pricing.selected ) {
+            added.push_back( pricing.loc.get_item() );
         }
+    }
 
-        std::set<item *> without;
-        std::vector<item *> added;
-
-        for( item_pricing &pricing : yours ) {
-            if( pricing.selected ) {
-                added.push_back( pricing.loc.get_item() );
-            }
+    for( item_pricing &pricing : theirs ) {
+        if( pricing.selected ) {
+            without.insert( pricing.loc.get_item() );
         }
+    }
 
-        for( item_pricing &pricing : theirs ) {
-            if( pricing.selected ) {
-                without.insert( pricing.loc.get_item() );
-            }
-        }
+    bool npc_out_of_space = volume_left < 0_ml || weight_left < 0_gram;
 
-        bool npc_out_of_space = volume_left < 0_ml || weight_left < 0_gram;
+    // Colors for hinting if the trade will be accepted or not.
+    const nc_color trade_color       = npc_will_accept_trade( np ) ? c_green : c_red;
+    const nc_color trade_color_light = npc_will_accept_trade( np ) ? c_light_green : c_light_red;
 
-        // Colors for hinting if the trade will be accepted or not.
-        const nc_color trade_color       = npc_will_accept_trade( np ) ? c_green : c_red;
-        const nc_color trade_color_light = npc_will_accept_trade( np ) ? c_light_green : c_light_red;
+    input_context ctxt( "NPC_TRADE" );
 
-        mvwprintz( w_head, point( 2, 3 ),  npc_out_of_space ?  c_red : c_green,
-                   _( "Volume: %s %s, Weight: %.1f %s" ),
-                   format_volume( volume_left ), volume_units_abbr(),
-                   convert_weight( weight_left ), weight_units() );
+    werase( w_head );
+    fold_and_print( w_head, point_zero, getmaxx( w_head ), c_white,
+                    _( "Trading with %s.\n"
+                       "%s to switch lists, letters to pick items, "
+                       "%s to finalize, %s to quit, "
+                       "%s to get information on an item." ),
+                    np.disp_name(),
+                    ctxt.get_desc( "SWITCH_LISTS" ),
+                    ctxt.get_desc( "CONFIRM" ),
+                    ctxt.get_desc( "QUIT" ),
+                    ctxt.get_desc( "EXAMINE" ) );
 
-        std::string cost_str = _( "Exchange" );
-        if( !np.will_exchange_items_freely() ) {
-            cost_str = string_format( your_balance >= 0 ? _( "Credit %s" ) : _( "Debt %s" ),
-                                      format_money( std::abs( your_balance ) ) );
-        }
+    // Set up line drawings
+    for( int i = 0; i < TERMX; i++ ) {
+        mvwputch( w_head, point( i, 3 ), c_white, LINE_OXOX );
+    }
+    // End of line drawings
 
-        mvwprintz( w_head, point( TERMX / 2 + ( TERMX / 2 - utf8_width( cost_str ) ) / 2, 3 ),
-                   trade_color, cost_str );
+    mvwprintz( w_head, point( 2, 3 ),  npc_out_of_space ?  c_red : c_green,
+               _( "Volume: %s %s, Weight: %.1f %s" ),
+               format_volume( volume_left ), volume_units_abbr(),
+               convert_weight( weight_left ), weight_units() );
 
-        if( !deal.empty() ) {
-            mvwprintz( w_head, point( ( TERMX - utf8_width( deal ) ) / 2, 3 ),
-                       trade_color_light, deal );
-        }
-        draw_border( w_them, ( focus_them ? c_yellow : BORDER_COLOR ) );
-        draw_border( w_you, ( !focus_them ? c_yellow : BORDER_COLOR ) );
+    std::string cost_str = _( "Exchange" );
+    if( !np.will_exchange_items_freely() ) {
+        cost_str = string_format( your_balance >= 0 ? _( "Credit %s" ) : _( "Debt %s" ),
+                                  format_money( std::abs( your_balance ) ) );
+    }
 
-        mvwprintz( w_them, point( 2, 0 ), trade_color, np.name );
-        mvwprintz( w_you,  point( 2, 0 ), trade_color, _( "You" ) );
+    mvwprintz( w_head, point( TERMX / 2 + ( TERMX / 2 - utf8_width( cost_str ) ) / 2, 3 ),
+               trade_color, cost_str );
+
+    if( !deal.empty() ) {
+        mvwprintz( w_head, point( ( TERMX - utf8_width( deal ) ) / 2, 3 ),
+                   trade_color_light, deal );
+    }
+    draw_border( w_them, ( focus_them ? c_yellow : BORDER_COLOR ) );
+    draw_border( w_you, ( !focus_them ? c_yellow : BORDER_COLOR ) );
+
+    mvwprintz( w_them, point( 2, 0 ), trade_color, np.name );
+    mvwprintz( w_you,  point( 2, 0 ), trade_color, _( "You" ) );
 #if defined(__ANDROID__)
-        input_context ctxt( "NPC_TRADE" );
+    input_context ctxt( "NPC_TRADE" );
 #endif
-        // Draw lists of items, starting from offset
-        for( size_t whose = 0; whose <= 1; whose++ ) {
-            const bool they = whose == 0;
-            const std::vector<item_pricing> &list = they ? theirs : yours;
-            const size_t &offset = they ? them_off : you_off;
-            const player &person = they ? static_cast<player &>( np ) :
-                                   static_cast<player &>( g->u );
-            catacurses::window &w_whose = they ? w_them : w_you;
-            int win_w = getmaxx( w_whose );
-            // Borders
-            win_w -= 2;
-            for( size_t i = offset; i < list.size() && i < entries_per_page + offset; i++ ) {
-                const item_pricing &ip = list[i];
-                const item *it = ip.loc.get_item();
-                auto color = it == &person.weapon ? c_yellow : c_light_gray;
-                const int &owner_sells = they ? ip.u_has : ip.npc_has;
-                const int &owner_sells_charge = they ? ip.u_charges : ip.npc_charges;
-                std::string itname = it->display_name();
+    // Draw lists of items, starting from offset
+    for( size_t whose = 0; whose <= 1; whose++ ) {
+        const bool they = whose == 0;
+        const std::vector<item_pricing> &list = they ? theirs : yours;
+        const size_t &offset = they ? them_off : you_off;
+        const player &person = they ? static_cast<player &>( np ) :
+                               static_cast<player &>( g->u );
+        catacurses::window &w_whose = they ? w_them : w_you;
+        int win_w = getmaxx( w_whose );
+        // Borders
+        win_w -= 2;
+        for( size_t i = offset; i < list.size() && i < entries_per_page + offset; i++ ) {
+            const item_pricing &ip = list[i];
+            const item *it = ip.loc.get_item();
+            auto color = it == &person.weapon ? c_yellow : c_light_gray;
+            const int &owner_sells = they ? ip.u_has : ip.npc_has;
+            const int &owner_sells_charge = they ? ip.u_charges : ip.npc_charges;
+            std::string itname = it->display_name();
 
-                if( np.will_exchange_items_freely() && ip.loc.where() != item_location::type::character ) {
-                    itname = itname + " (" + ip.loc.describe( &g->u ) + ")";
-                    color = c_light_blue;
-                }
+            if( np.will_exchange_items_freely() && ip.loc.where() != item_location::type::character ) {
+                itname = itname + " (" + ip.loc.describe( &g->u ) + ")";
+                color = c_light_blue;
+            }
 
-                if( ip.charges > 0 && owner_sells_charge > 0 ) {
-                    itname += string_format( _( ": trading %d" ), owner_sells_charge );
-                } else {
-                    if( ip.count > 1 ) {
-                        itname += string_format( _( " (%d)" ), ip.count );
-                    }
-                    if( owner_sells ) {
-                        itname += string_format( _( ": trading %d" ), owner_sells );
-                    }
+            if( ip.charges > 0 && owner_sells_charge > 0 ) {
+                itname += string_format( _( ": trading %d" ), owner_sells_charge );
+            } else {
+                if( ip.count > 1 ) {
+                    itname += string_format( _( " (%d)" ), ip.count );
                 }
+                if( owner_sells ) {
+                    itname += string_format( _( ": trading %d" ), owner_sells );
+                }
+            }
 
-                if( ip.selected ) {
-                    color = c_white;
-                }
+            if( ip.selected ) {
+                color = c_white;
+            }
 
-                int keychar = i - offset + 'a';
-                if( keychar > 'z' ) {
-                    keychar = keychar - 'z' - 1 + 'A';
-                }
-                trim_and_print( w_whose, point( 1, i - offset + 1 ), win_w, color, "%c %c %s",
-                                static_cast<char>( keychar ), ip.selected ? '+' : '-', itname );
+            int keychar = i - offset + 'a';
+            if( keychar > 'z' ) {
+                keychar = keychar - 'z' - 1 + 'A';
+            }
+            trim_and_print( w_whose, point( 1, i - offset + 1 ), win_w, color, "%c %c %s",
+                            static_cast<char>( keychar ), ip.selected ? '+' : '-', itname );
 #if defined(__ANDROID__)
-                ctxt.register_manual_key( keychar, itname );
+            ctxt.register_manual_key( keychar, itname );
 #endif
 
-                std::string price_str = format_money( ip.price );
-                nc_color price_color = np.will_exchange_items_freely() ? c_dark_gray : ( ip.selected ? c_white :
-                                       c_light_gray );
-                mvwprintz( w_whose, point( win_w - utf8_width( price_str ), i - offset + 1 ),
-                           price_color, price_str );
-            }
-            if( offset > 0 ) {
-                mvwprintw( w_whose, point( 1, entries_per_page + 2 ), _( "< Back" ) );
-            }
-            if( offset + entries_per_page < list.size() ) {
-                mvwprintw( w_whose, point( 9, entries_per_page + 2 ), _( "More >" ) );
-            }
+            std::string price_str = format_money( ip.price );
+            nc_color price_color = np.will_exchange_items_freely() ? c_dark_gray : ( ip.selected ? c_white :
+                                   c_light_gray );
+            mvwprintz( w_whose, point( win_w - utf8_width( price_str ), i - offset + 1 ),
+                       price_color, price_str );
         }
-        wrefresh( w_head );
-        wrefresh( w_them );
-        wrefresh( w_you );
-    } // Done updating the screen
+        if( offset > 0 ) {
+            mvwprintw( w_whose, point( 1, entries_per_page + 2 ), _( "< Back" ) );
+        }
+        if( offset + entries_per_page < list.size() ) {
+            mvwprintw( w_whose, point( 9, entries_per_page + 2 ), _( "More >" ) );
+        }
+    }
+    wrefresh( w_head );
+    wrefresh( w_them );
+    wrefresh( w_you );
 }
 
-void trading_window::show_item_data( npc &np, size_t offset,
+void trading_window::show_item_data( size_t offset,
                                      std::vector<item_pricing> &target_list )
 {
     // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
     ui_adaptor ui( ui_adaptor::disable_uis_below {} );
 
-    update = true;
     catacurses::window w_tmp = catacurses::newwin( 3, 21, point( 30 + ( TERMX - FULL_SCREEN_WIDTH ) / 2,
                                1 + ( TERMY - FULL_SCREEN_HEIGHT ) / 2 ) );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -415,8 +424,6 @@ void trading_window::show_item_data( npc &np, size_t offset,
         return;
     }
 
-    mvwprintz( w_head, point_zero, c_white, header_message.c_str(), np.name );
-    wrefresh( w_head );
     help += offset;
     if( help < target_list.size() ) {
         popup( target_list[help].loc.get_item()->info( true ), PF_NONE );
@@ -442,8 +449,6 @@ int trading_window::get_var_trade( const item &it, int total_count )
 
 bool trading_window::perform_trade( npc &np, const std::string &deal )
 {
-    size_t ch;
-
     volume_left = np.volume_capacity() - np.volume_carried();
     weight_left = np.weight_capacity() - np.weight_carried();
 
@@ -453,142 +458,144 @@ bool trading_window::perform_trade( npc &np, const std::string &deal )
         weight_left = 5'000_kilogram;
     }
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    input_context ctxt( "NPC_TRADE" );
+    ctxt.register_action( "SWITCH_LISTS" );
+    ctxt.register_action( "PAGE_UP" );
+    ctxt.register_action( "PAGE_DOWN" );
+    ctxt.register_action( "EXAMINE" );
+    ctxt.register_action( "CONFIRM" );
+    ctxt.register_action( "QUIT" );
+    ctxt.register_action( "HELP_KEYBINDINGS" );
+    ctxt.register_action( "ANY_INPUT" );
 
-    do {
+    ui_adaptor ui;
+    ui.on_screen_resize( [this]( ui_adaptor & ui ) {
+        setup_win( ui );
+    } );
+    ui.mark_resize();
+
+    ui.on_redraw( [&]( const ui_adaptor & ) {
         update_win( np, deal );
-#if defined(__ANDROID__)
-        input_context ctxt( "NPC_TRADE" );
-        ctxt.register_manual_key( '\t', "Switch lists" );
-        ctxt.register_manual_key( '<', "Back" );
-        ctxt.register_manual_key( '>', "More" );
-        ctxt.register_manual_key( '?', "Examine item" );
-#endif
+    } );
+
+    bool confirm = false;
+    bool exit = false;
+    while( !exit ) {
+        ui_manager::redraw();
 
         std::vector<item_pricing> &target_list = focus_them ? theirs : yours;
         size_t &offset = focus_them ? them_off : you_off;
-        // TODO: use input context
-        ch = inp_mngr.get_input_event().get_first_input();
-        switch( ch ) {
-            case '\t':
-                focus_them = !focus_them;
-                update = true;
-                break;
-            case '<':
-                if( offset > 0 ) {
-                    offset -= entries_per_page;
-                    update = true;
-                }
-                break;
-            case '>':
-                if( offset + entries_per_page < target_list.size() ) {
-                    offset += entries_per_page;
-                    update = true;
-                }
-                break;
-            case '?':
-                show_item_data( np, offset, target_list );
-                ch = ' ';
-                break;
-            case '\n':
-                if( !npc_will_accept_trade( np ) ) {
+        const std::string action = ctxt.handle_input();
+        if( action == "SWITCH_LISTS" ) {
+            focus_them = !focus_them;
+        } else if( action == "PAGE_UP" ) {
+            if( offset > entries_per_page ) {
+                offset -= entries_per_page;
+            } else {
+                offset = 0;
+            }
+        } else if( action == "PAGE_DOWN" ) {
+            if( offset + entries_per_page < target_list.size() ) {
+                offset += entries_per_page;
+            }
+        } else if( action == "EXAMINE" ) {
+            show_item_data( offset, target_list );
+        } else if( action == "CONFIRM" ) {
+            if( !npc_will_accept_trade( np ) ) {
 
-                    if( np.max_credit_extended() == 0 ) {
-                        popup( _( "You'll need to offer me more than that." ) );
-                    } else {
-                        popup(
-                            _( "Sorry, I'm only willing to extend you %s in credit." ),
-                            format_money( np.max_credit_extended() )
-                        );
-                    }
-
-                    update = true;
-                    ch = ' ';
-                } else if( volume_left < 0_ml || weight_left < 0_gram ) {
-                    // Make sure NPC doesn't go over allowed volume
-                    popup( _( "%s can't carry all that." ), np.name );
-                    update = true;
-                    ch = ' ';
-                } else if( calc_npc_owes_you( np ) < your_balance ) {
-                    // NPC is happy with the trade, but isn't willing to remember the whole debt.
-                    const bool trade_ok = query_yn(
-                                              _( "I'm never going to be able to pay you back for all that.  The most I'm willing to owe you is %s.\n\nContinue with trade?" ),
-                                              format_money( np.max_willing_to_owe() )
-                                          );
-
-                    if( !trade_ok ) {
-                        update = true;
-                        ch = ' ';
-                    }
+                if( np.max_credit_extended() == 0 ) {
+                    popup( _( "You'll need to offer me more than that." ) );
                 } else {
-                    if( !query_yn( _( "Looks like a deal!  Accept this trade?" ) ) ) {
-                        update = true;
-                        ch = ' ';
+                    popup(
+                        _( "Sorry, I'm only willing to extend you %s in credit." ),
+                        format_money( np.max_credit_extended() )
+                    );
+                }
+            } else if( volume_left < 0_ml || weight_left < 0_gram ) {
+                // Make sure NPC doesn't go over allowed volume
+                popup( _( "%s can't carry all that." ), np.name );
+            } else if( calc_npc_owes_you( np ) < your_balance ) {
+                // NPC is happy with the trade, but isn't willing to remember the whole debt.
+                const bool trade_ok = query_yn(
+                                          _( "I'm never going to be able to pay you back for all that.  The most I'm willing to owe you is %s.\n\nContinue with trade?" ),
+                                          format_money( np.max_willing_to_owe() )
+                                      );
+
+                if( trade_ok ) {
+                    exit = true;
+                    confirm = true;
+                }
+            } else {
+                if( query_yn( _( "Looks like a deal!  Accept this trade?" ) ) ) {
+                    exit = true;
+                    confirm = true;
+                }
+            }
+        } else if( action == "QUIT" ) {
+            exit = true;
+            confirm = false;
+        } else if( action == "ANY_INPUT" ) {
+            const input_event evt = ctxt.get_raw_input();
+            if( evt.type != CATA_INPUT_KEYBOARD || evt.sequence.empty() ) {
+                continue;
+            }
+            size_t ch = evt.get_first_input();
+            // Letters & such
+            if( ch >= 'a' && ch <= 'z' ) {
+                ch -= 'a';
+            } else if( ch >= 'A' && ch <= 'Z' ) {
+                ch = ch - 'A' + ( 'z' - 'a' ) + 1;
+            } else {
+                continue;
+            }
+
+            ch += offset;
+            if( ch < target_list.size() ) {
+                item_pricing &ip = target_list[ch];
+                int change_amount = 1;
+                int &owner_sells = focus_them ? ip.u_has : ip.npc_has;
+                int &owner_sells_charge = focus_them ? ip.u_charges : ip.npc_charges;
+
+                if( ip.selected ) {
+                    if( owner_sells_charge > 0 ) {
+                        change_amount = owner_sells_charge;
+                        owner_sells_charge = 0;
+                    } else if( owner_sells > 0 ) {
+                        change_amount = owner_sells;
+                        owner_sells = 0;
                     }
-                }
-                break;
-            default:
-                // Letters & such
-                if( ch >= 'a' && ch <= 'z' ) {
-                    ch -= 'a';
-                } else if( ch >= 'A' && ch <= 'Z' ) {
-                    ch = ch - 'A' + ( 'z' - 'a' ) + 1;
+                } else if( ip.charges > 0 ) {
+                    change_amount = get_var_trade( *ip.loc.get_item(), ip.charges );
+                    if( change_amount < 1 ) {
+                        continue;
+                    }
+                    owner_sells_charge = change_amount;
                 } else {
-                    continue;
-                }
-
-                ch += offset;
-                if( ch < target_list.size() ) {
-                    item_pricing &ip = target_list[ch];
-                    int change_amount = 1;
-                    int &owner_sells = focus_them ? ip.u_has : ip.npc_has;
-                    int &owner_sells_charge = focus_them ? ip.u_charges : ip.npc_charges;
-
-                    if( ip.selected ) {
-                        if( owner_sells_charge > 0 ) {
-                            change_amount = owner_sells_charge;
-                            owner_sells_charge = 0;
-                        } else if( owner_sells > 0 ) {
-                            change_amount = owner_sells;
-                            owner_sells = 0;
-                        }
-                    } else if( ip.charges > 0 ) {
-                        change_amount = get_var_trade( *ip.loc.get_item(), ip.charges );
+                    if( ip.count > 1 ) {
+                        change_amount = get_var_trade( *ip.loc.get_item(), ip.count );
                         if( change_amount < 1 ) {
-                            ch = 0;
                             continue;
                         }
-                        owner_sells_charge = change_amount;
-                    } else {
-                        if( ip.count > 1 ) {
-                            change_amount = get_var_trade( *ip.loc.get_item(), ip.count );
-                            if( change_amount < 1 ) {
-                                ch = 0;
-                                continue;
-                            }
-                        }
-                        owner_sells = change_amount;
                     }
-                    update = true;
-                    ip.selected = !ip.selected;
-                    if( ip.selected != focus_them ) {
-                        change_amount *= -1;
-                    }
-                    int delta_price = ip.price * change_amount;
-                    if( !np.will_exchange_items_freely() ) {
-                        your_balance -= delta_price;
-                    }
-                    if( ip.loc.where() == item_location::type::character ) {
-                        volume_left += ip.vol * change_amount;
-                        weight_left += ip.weight * change_amount;
-                    }
+                    owner_sells = change_amount;
                 }
-                ch = 0;
+                ip.selected = !ip.selected;
+                if( ip.selected != focus_them ) {
+                    change_amount *= -1;
+                }
+                int delta_price = ip.price * change_amount;
+                if( !np.will_exchange_items_freely() ) {
+                    your_balance -= delta_price;
+                }
+                if( ip.loc.where() == item_location::type::character ) {
+                    volume_left += ip.vol * change_amount;
+                    weight_left += ip.weight * change_amount;
+                }
+            }
         }
-    } while( ch != KEY_ESCAPE && ch != '\n' );
+    }
 
-    return ch == '\n';
+    return confirm;
 }
 
 // Returns how much the NPC will owe you after this transaction.
@@ -631,7 +638,6 @@ bool npc_trading::trade( npc &np, int cost, const std::string &deal )
     np.drop_invalid_inventory();
 
     trading_window trade_win;
-    trade_win.setup_win( np );
     trade_win.setup_trade( cost, np );
 
     bool traded = trade_win.perform_trade( np, deal );

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -294,11 +294,14 @@ void trading_window::update_win( npc &np, const std::string &deal )
     werase( w_head );
     fold_and_print( w_head, point_zero, getmaxx( w_head ), c_white,
                     _( "Trading with %s.\n"
-                       "%s to switch lists, letters to pick items, "
-                       "%s to finalize, %s to quit, "
-                       "%s to get information on an item." ),
+                       "[<color_yellow>%s</color>] to switch lists, letters to pick items, "
+                       "[<color_yellow>%s</color>] and [<color_yellow>%s</color>] to switch pages, "
+                       "[<color_yellow>%s</color>] to finalize, [<color_yellow>%s</color>] to quit, "
+                       "[<color_yellow>%s</color>] to get information on an item." ),
                     np.disp_name(),
                     ctxt.get_desc( "SWITCH_LISTS" ),
+                    ctxt.get_desc( "PAGE_UP" ),
+                    ctxt.get_desc( "PAGE_DOWN" ),
                     ctxt.get_desc( "CONFIRM" ),
                     ctxt.get_desc( "QUIT" ),
                     ctxt.get_desc( "EXAMINE" ) );

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -405,28 +405,67 @@ void trading_window::update_win( npc &np, const std::string &deal )
 void trading_window::show_item_data( size_t offset,
                                      std::vector<item_pricing> &target_list )
 {
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    catacurses::window w_tmp;
+    ui_adaptor ui;
+    ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+        w_tmp = catacurses::newwin( 3, 21,
+                                    point( 30 + ( TERMX - FULL_SCREEN_WIDTH ) / 2,
+                                           1 + ( TERMY - FULL_SCREEN_HEIGHT ) / 2 ) );
+        ui.position_from_window( w_tmp );
+    } );
+    ui.mark_resize();
 
-    catacurses::window w_tmp = catacurses::newwin( 3, 21, point( 30 + ( TERMX - FULL_SCREEN_WIDTH ) / 2,
-                               1 + ( TERMY - FULL_SCREEN_HEIGHT ) / 2 ) );
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    mvwprintz( w_tmp, point( 1, 1 ), c_red, _( "Examine which item?" ) );
-    draw_border( w_tmp );
-    wrefresh( w_tmp );
-    // TODO: use input context
-    size_t help = inp_mngr.get_input_event().get_first_input();
-    if( help >= 'a' && help <= 'z' ) {
-        help -= 'a';
-    } else if( help >= 'A' && help <= 'Z' ) {
-        help = help - 'A' + 26;
-    } else {
-        return;
-    }
+    ui.on_redraw( [&]( const ui_adaptor & ) {
+        werase( w_tmp );
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        mvwprintz( w_tmp, point( 1, 1 ), c_red, _( "Examine which item?" ) );
+        draw_border( w_tmp );
+        wrefresh( w_tmp );
+    } );
 
-    help += offset;
-    if( help < target_list.size() ) {
-        popup( target_list[help].loc.get_item()->info( true ), PF_NONE );
+    input_context ctxt( "NPC_TRADE" );
+    ctxt.register_action( "QUIT" );
+    ctxt.register_action( "ANY_INPUT" );
+    ctxt.register_action( "HELP_KEYBINDINGS" );
+
+    bool exit = false;
+    while( !exit ) {
+        ui_manager::redraw();
+        const std::string action = ctxt.handle_input();
+        if( action == "QUIT" ) {
+            exit = true;
+        } else if( action == "ANY_INPUT" ) {
+            const input_event evt = ctxt.get_raw_input();
+            if( evt.type != CATA_INPUT_KEYBOARD || evt.sequence.empty() ) {
+                continue;
+            }
+            size_t help = evt.get_first_input();
+            if( help >= 'a' && help <= 'z' ) {
+                help -= 'a';
+            } else if( help >= 'A' && help <= 'Z' ) {
+                help = help - 'A' + 26;
+            } else {
+                continue;
+            }
+
+            help += offset;
+            if( help < target_list.size() ) {
+                std::vector<iteminfo> info;
+                const item &itm = *target_list[help].loc.get_item();
+                itm.info( true, info );
+                item_info_data data( itm.tname(),
+                                     itm.type_name(),
+                                     info, {} );
+                data.handle_scrolling = true;
+                data.any_input = false;
+                draw_item_info( []() -> catacurses::window {
+                    const int width = std::min( TERMX, FULL_SCREEN_WIDTH );
+                    const int height = std::min( TERMY, FULL_SCREEN_HEIGHT );
+                    return catacurses::newwin( height, width, point( ( TERMX - width ) / 2, ( TERMY - height ) / 2 ) );
+                }, data );
+                exit = true;
+            }
+        }
     }
 }
 

--- a/src/npctrade.h
+++ b/src/npctrade.h
@@ -21,6 +21,7 @@ class faction;
 class item;
 class npc;
 class player;
+class ui_adaptor;
 
 class item_pricing
 {
@@ -58,24 +59,19 @@ class trading_window
         std::vector<item_pricing> yours;
         int your_balance = 0;
 
-        void setup_win( npc &np );
         void setup_trade( int cost, npc &np );
-        void update_win( npc &np, const std::string &deal );
-        void show_item_data( npc &np, size_t offset, std::vector<item_pricing> &target_list );
         bool perform_trade( npc &np, const std::string &deal );
         void update_npc_owed( npc &np );
 
     private:
+        void setup_win( ui_adaptor &ui );
+        void update_win( npc &np, const std::string &deal );
+        void show_item_data( size_t offset, std::vector<item_pricing> &target_list );
+
         catacurses::window w_head;
         catacurses::window w_them;
         catacurses::window w_you;
-        const int win_they_w = TERMX / 2;
-        const std::string header_message =
-            _( "TAB key to switch lists, letters to pick items, < or > to switch page, "
-               "Enter to finalize, Esc to quit,\n"
-               "? to get information on an item." );
-        const size_t entries_per_page = std::min( TERMY - 7, 2 + ( 'z' - 'a' ) + ( 'Z' - 'A' ) );
-        bool update = true;
+        size_t entries_per_page = 0;
         bool focus_them = true; // Is the focus on them?
         size_t them_off = 0, you_off = 0; // Offset from the start of the list
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -944,7 +944,9 @@ input_event draw_item_info( const std::function<catacurses::window()> &init_wind
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
-    ctxt.register_action( "ANY_INPUT" );
+    if( data.any_input ) {
+        ctxt.register_action( "ANY_INPUT" );
+    }
 
     std::string action;
     do {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1822,56 +1822,6 @@ std::string get_labeled_bar( const double val, const int width, const std::strin
     return get_labeled_bar( val, width, label, ratings.begin(), ratings.end() );
 }
 
-/**
- * Display data in table, each cell contains one entry from the
- * data vector. Allows vertical scrolling if the data does not fit.
- * Data is displayed using fold_and_print_from, which allows coloring!
- * @param columns Number of columns, can be 1. Make sure each entry
- * of the data vector fits into one cell.
- * @param title The title text, displayed on top.
- * @param w The window to draw this in, the whole widow is used.
- * @param data Text data to fill.
- */
-void display_table( const catacurses::window &w, const std::string &title, int columns,
-                    const std::vector<std::string> &data )
-{
-    const int width = getmaxx( w ) - 2; // -2 for border
-    const int rows = getmaxy( w ) - 2 - 1; // -2 for border, -1 for title
-    const int col_width = width / columns;
-    int offset = 0;
-
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
-
-#if defined(__ANDROID__)
-    // no bindings, but give it its own input context so stale buttons don't hang around.
-    input_context ctxt( "DISPLAY_TABLE" );
-#endif
-    for( ;; ) {
-        werase( w );
-        draw_border( w, BORDER_COLOR, title, c_white );
-        for( int i = 0; i < rows * columns; i++ ) {
-            if( i + offset * columns >= static_cast<int>( data.size() ) ) {
-                break;
-            }
-            const int x = 2 + ( i % columns ) * col_width;
-            const int y = ( i / columns ) + 2;
-            fold_and_print_from( w, point( x, y ), col_width, 0, c_white, data[i + offset * columns] );
-        }
-        draw_scrollbar( w, offset, rows, ( data.size() + columns - 1 ) / columns, point( 0, 2 ) );
-        wrefresh( w );
-        // TODO: use input context
-        int ch = inp_mngr.get_input_event().get_first_input();
-        if( ch == KEY_DOWN && ( ( offset + 1 ) * columns ) < static_cast<int>( data.size() ) ) {
-            offset++;
-        } else if( ch == KEY_UP && offset > 0 ) {
-            offset--;
-        } else if( ch == ' ' || ch == '\n' || ch == KEY_ESCAPE ) {
-            break;
-        }
-    }
-}
-
 scrollingcombattext::cSCT::cSCT( const point &p_pos, const direction p_oDir,
                                  const std::string &p_sText, const game_message_type p_gmt,
                                  const std::string &p_sText2, const game_message_type p_gmt2,

--- a/src/output.h
+++ b/src/output.h
@@ -323,8 +323,6 @@ void center_print( const catacurses::window &w, int y, const nc_color &FG,
                    const std::string &text );
 int right_print( const catacurses::window &w, int line, int right_indent,
                  const nc_color &FG, const std::string &text );
-void display_table( const catacurses::window &w, const std::string &title, int columns,
-                    const std::vector<std::string> &data );
 void scrollable_text( const catacurses::window &w, const std::string &title,
                       const std::string &text );
 void scrollable_text( const std::function<catacurses::window()> &init_window,

--- a/src/output.h
+++ b/src/output.h
@@ -487,6 +487,7 @@ struct item_info_data {
         bool without_getch = false;
         bool without_border = false;
         bool handle_scrolling = false;
+        bool any_input = true;
         bool scrollbar_left = true;
         bool use_full_win = false;
         unsigned int padding = 1;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1462,8 +1462,6 @@ static tripoint display( const tripoint &orig, const draw_data_t &data = draw_da
     std::chrono::time_point<std::chrono::steady_clock> last_blink = std::chrono::steady_clock::now();
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
-        catacurses::erase();
-        catacurses::refresh();
         draw( g->w_overmap, g->w_omlegend, curs, orig, uistate.overmap_show_overlays,
               show_explored, fast_scroll, &ictxt, data );
     } );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1258,13 +1258,13 @@ static bool search( const ui_adaptor &om_ui, tripoint &curs, const tripoint &ori
     return true;
 }
 
-static void place_ter_or_special( tripoint &curs, const tripoint &orig, const bool show_explored,
-                                  const bool fast_scroll, std::string &action )
+static void place_ter_or_special( const ui_adaptor &om_ui, tripoint &curs,
+                                  const std::string &om_action )
 {
     uilist pmenu;
     // This simplifies overmap_special selection using uilist
     std::vector<const overmap_special *> oslist;
-    const bool terrain = action == "PLACE_TERRAIN";
+    const bool terrain = om_action == "PLACE_TERRAIN";
 
     if( terrain ) {
         pmenu.title = _( "Select terrain to place:" );
@@ -1290,12 +1290,22 @@ static void place_ter_or_special( tripoint &curs, const tripoint &orig, const bo
     pmenu.query();
 
     if( pmenu.ret >= 0 ) {
-        catacurses::window w_editor = catacurses::newwin( 15, 27, point( TERMX - 27, 3 ) );
+        catacurses::window w_editor;
+
+        ui_adaptor ui;
+        ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+            w_editor = catacurses::newwin( 15, 27, point( TERMX - 27, 3 ) );
+
+            ui.position_from_window( w_editor );
+        } );
+        ui.mark_resize();
+
         input_context ctxt( "OVERMAP_EDITOR" );
         ctxt.register_directions();
         ctxt.register_action( "CONFIRM" );
         ctxt.register_action( "ROTATE" );
         ctxt.register_action( "QUIT" );
+        ctxt.register_action( "HELP_KEYBINDINGS" );
         ctxt.register_action( "ANY_INPUT" );
 
         if( terrain ) {
@@ -1318,14 +1328,7 @@ static void place_ter_or_special( tripoint &curs, const tripoint &orig, const bo
             }
         }
 
-        // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-        ui_adaptor ui( ui_adaptor::disable_uis_below {} );
-
-        do {
-            // overmap::draw will handle actually showing the preview
-            draw( g->w_overmap, g->w_omlegend, curs, orig, uistate.overmap_show_overlays, show_explored,
-                  fast_scroll, nullptr, draw_data_t() );
-
+        ui.on_redraw( [&]( const ui_adaptor & ) {
             draw_border( w_editor );
             if( terrain ) {
                 // NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -1357,6 +1360,12 @@ static void place_ter_or_special( tripoint &curs, const tripoint &orig, const bo
                        ctxt.get_desc( "CONFIRM" ) );
             mvwprintz( w_editor, point( 1, 13 ), c_white, _( "[ESCAPE/Q] Cancel" ) );
             wrefresh( w_editor );
+        } );
+
+        std::string action;
+        do {
+            om_ui.invalidate_ui();
+            ui_manager::redraw();
 
             action = ctxt.handle_input( BLINK_SPEED );
 
@@ -1388,7 +1397,6 @@ static void place_ter_or_special( tripoint &curs, const tripoint &orig, const bo
 
         uistate.place_terrain = nullptr;
         uistate.place_special = nullptr;
-        action.clear();
     }
 }
 
@@ -1597,7 +1605,7 @@ static tripoint display( const tripoint &orig, const draw_data_t &data = draw_da
                 continue;
             }
         } else if( action == "PLACE_TERRAIN" || action == "PLACE_SPECIAL" ) {
-            place_ter_or_special( curs, orig, show_explored, fast_scroll, action );
+            place_ter_or_special( ui, curs, action );
         } else if( action == "MISSIONS" ) {
             g->list_missions();
         }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -182,6 +182,7 @@ static void update_note_preview( const std::string &note,
 
     const int npm_offset_x = 1;
     const int npm_offset_y = 1;
+    werase( *w_preview_map );
     draw_border( *w_preview_map, c_yellow );
     for( int i = 0; i < npm_height; i++ ) {
         for( int j = 0; j < npm_width; j++ ) {
@@ -321,19 +322,42 @@ class map_notes_callback : public uilist_callback
         overmapbuffer::t_notes_vector _notes;
         int _z;
         int _selected = 0;
+
+        catacurses::window w_preview;
+        catacurses::window w_preview_title;
+        catacurses::window w_preview_map;
+        std::tuple<catacurses::window *, catacurses::window *, catacurses::window *> preview_windows;
+        ui_adaptor ui;
+
         point point_selected() {
             return _notes[_selected].first;
         }
         tripoint note_location() {
             return tripoint( point_selected(), _z );
         }
-        std::string old_note() {
-            return overmap_buffer.note( note_location() );
-        }
     public:
-        map_notes_callback( const overmapbuffer::t_notes_vector &notes, int z ) {
-            _notes = notes;
-            _z = z;
+        map_notes_callback( const overmapbuffer::t_notes_vector &notes, int z )
+            : _notes( notes ), _z( z ) {
+            ui.on_screen_resize( [this]( ui_adaptor & ui ) {
+                w_preview = catacurses::newwin( npm_height + 2, max_note_display_length - npm_width - 1,
+                                                point( npm_width + 2, 2 ) );
+                w_preview_title = catacurses::newwin( 2, max_note_display_length + 1, point_zero );
+                w_preview_map = catacurses::newwin( npm_height + 2, npm_width + 2, point( 0, 2 ) );
+                preview_windows = std::make_tuple( &w_preview, &w_preview_title, &w_preview_map );
+
+                ui.position( point_zero, point( max_note_display_length + 1, npm_height + 4 ) );
+            } );
+            ui.mark_resize();
+
+            ui.on_redraw( [this]( const ui_adaptor & ) {
+                if( _selected >= 0 && static_cast<size_t>( _selected ) < _notes.size() ) {
+                    const tripoint note_pos = note_location();
+                    const auto map_around = get_overmap_neighbors( note_pos );
+                    update_note_preview( overmap_buffer.note( note_pos ), map_around, preview_windows );
+                } else {
+                    update_note_preview( {}, {}, preview_windows );
+                }
+            } );
         }
         bool key( const input_context &ctxt, const input_event &event, int, uilist *menu ) override {
             _selected = menu->selected;
@@ -377,21 +401,9 @@ class map_notes_callback : public uilist_callback
             }
             return false;
         }
-        void refresh( uilist *menu ) override {
+        void select( uilist *menu ) override {
             _selected = menu->selected;
-            if( _selected >= 0 && static_cast<size_t>( _selected ) < _notes.size() ) {
-                const auto map_around = get_overmap_neighbors( note_location() );
-                catacurses::window w_preview =
-                    catacurses::newwin( npm_height + 2, max_note_display_length - npm_width - 1,
-                                        point( npm_width + 2, 2 ) );
-                catacurses::window w_preview_title =
-                    catacurses::newwin( 2, max_note_display_length + 1, point_zero );
-                catacurses::window w_preview_map =
-                    catacurses::newwin( npm_height + 2, npm_width + 2, point( 0, 2 ) );
-                const std::tuple<catacurses::window *, catacurses::window *, catacurses::window *> preview_windows =
-                    std::make_tuple( &w_preview, &w_preview_title, &w_preview_map );
-                update_note_preview( old_note(), map_around, preview_windows );
-            }
+            ui.invalidate_ui();
         }
 };
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1072,15 +1072,29 @@ void create_note( const tripoint &curs )
     std::string new_note = old_note;
     auto map_around = get_overmap_neighbors( curs );
 
-    catacurses::window w_preview = catacurses::newwin( npm_height + 2,
-                                   max_note_display_length - npm_width - 1,
-                                   point( npm_width + 2, 2 ) );
-    catacurses::window w_preview_title = catacurses::newwin( 2, max_note_display_length + 1,
-                                         point_zero );
-    catacurses::window w_preview_map = catacurses::newwin( npm_height + 2, npm_width + 2, point( 0,
-                                       2 ) );
-    std::tuple<catacurses::window *, catacurses::window *, catacurses::window *> preview_windows =
-        std::make_tuple( &w_preview, &w_preview_title, &w_preview_map );
+    catacurses::window w_preview;
+    catacurses::window w_preview_title;
+    catacurses::window w_preview_map;
+    std::tuple<catacurses::window *, catacurses::window *, catacurses::window *> preview_windows;
+
+    ui_adaptor ui;
+    ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+        w_preview = catacurses::newwin( npm_height + 2,
+                                        max_note_display_length - npm_width - 1,
+                                        point( npm_width + 2, 2 ) );
+        w_preview_title = catacurses::newwin( 2, max_note_display_length + 1,
+                                              point_zero );
+        w_preview_map = catacurses::newwin( npm_height + 2, npm_width + 2,
+                                            point( 0, 2 ) );
+        preview_windows = std::make_tuple( &w_preview, &w_preview_title, &w_preview_map );
+
+        ui.position( point_zero, point( max_note_display_length + 1, npm_height + 4 ) );
+    } );
+    ui.mark_resize();
+
+    ui.on_redraw( [&]( const ui_adaptor & ) {
+        update_note_preview( new_note, map_around, preview_windows );
+    } );
 
     // this implies enable_ime() and ensures that ime mode is always restored on return
     ime_sentry sentry;
@@ -1097,19 +1111,14 @@ void create_note( const tripoint &curs )
     .string_color( c_yellow )
     .identifier( "map_note" );
 
-    update_note_preview( old_note, map_around, preview_windows );
-
     do {
         new_note = input_popup.query_string( false );
-        const int first_input = input_popup.context().get_raw_input().get_first_input();
-        if( first_input == KEY_ESCAPE ) {
+        if( input_popup.canceled() ) {
             new_note = old_note;
             esc_pressed = true;
             break;
-        } else if( first_input == '\n' ) {
+        } else if( input_popup.confirmed() ) {
             break;
-        } else {
-            update_note_preview( new_note, map_around, preview_windows );
         }
     } while( true );
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1365,20 +1365,17 @@ static void place_ter_or_special( tripoint &curs, const tripoint &orig, const bo
 
 static tripoint display( const tripoint &orig, const draw_data_t &data = draw_data_t() )
 {
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    ui_adaptor ui;
+    ui.on_screen_resize( []( ui_adaptor & ui ) {
+        /* please do not change point( TERMX - OVERMAP_LEGEND_WIDTH, 0 ) to point( OVERMAP_WINDOW_WIDTH, 0 ) */
+        /* because overmap legend will be absent */
+        g->w_omlegend = catacurses::newwin( TERMY, OVERMAP_LEGEND_WIDTH,
+                                            point( TERMX - OVERMAP_LEGEND_WIDTH, 0 ) );
+        g->w_overmap = catacurses::newwin( OVERMAP_WINDOW_HEIGHT, OVERMAP_WINDOW_WIDTH, point_zero );
 
-    /* please do not change point( TERMX - OVERMAP_LEGEND_WIDTH, 0 ) to point( OVERMAP_WINDOW_WIDTH, 0 ) */
-    /* because overmap legend will be absent */
-    g->w_omlegend = catacurses::newwin( TERMY, OVERMAP_LEGEND_WIDTH,
-                                        point( TERMX - OVERMAP_LEGEND_WIDTH, 0 ) );
-    g->w_overmap = catacurses::newwin( OVERMAP_WINDOW_HEIGHT, OVERMAP_WINDOW_WIDTH, point_zero );
-
-    // Draw black padding space to avoid gap between map and legend
-    // also clears the pixel minimap in TILES
-    g->w_blackspace = catacurses::newwin( TERMY, TERMX, point_zero );
-    mvwputch( g->w_blackspace, point_zero, c_black, ' ' );
-    wrefresh( g->w_blackspace );
+        ui.position_from_window( catacurses::stdscr );
+    } );
+    ui.mark_resize();
 
     tripoint ret = overmap::invalid_tripoint;
     tripoint curs( orig );
@@ -1425,14 +1422,17 @@ static tripoint display( const tripoint &orig, const draw_data_t &data = draw_da
     bool fast_scroll = false; /* fast scroll state should reset every time overmap UI is opened */
     int fast_scroll_offset = get_option<int>( "FAST_SCROLL_OFFSET" );
     cata::optional<tripoint> mouse_pos;
-    bool redraw = true;
     std::chrono::time_point<std::chrono::steady_clock> last_blink = std::chrono::steady_clock::now();
+
+    ui.on_redraw( [&]( const ui_adaptor & ) {
+        catacurses::erase();
+        catacurses::refresh();
+        draw( g->w_overmap, g->w_omlegend, curs, orig, uistate.overmap_show_overlays,
+              show_explored, fast_scroll, &ictxt, data );
+    } );
+
     do {
-        if( redraw ) {
-            draw( g->w_overmap, g->w_omlegend, curs, orig, uistate.overmap_show_overlays,
-                  show_explored, fast_scroll, &ictxt, data );
-        }
-        redraw = true;
+        ui_manager::redraw();
 #if (defined TILES || defined _WIN32 || defined WINDOWS )
         int scroll_timeout = get_option<int>( "EDGE_SCROLL" );
         // If EDGE_SCROLL is disabled, it will have a value of -1.
@@ -1450,9 +1450,7 @@ static tripoint display( const tripoint &orig, const draw_data_t &data = draw_da
             curs.y += vec->y * scroll_d;
         } else if( action == "MOUSE_MOVE" || action == "TIMEOUT" ) {
             tripoint edge_scroll = g->mouse_edge_scrolling_overmap( ictxt );
-            if( edge_scroll == tripoint_zero ) {
-                redraw = false;
-            } else {
+            if( edge_scroll != tripoint_zero ) {
                 if( action == "MOUSE_MOVE" ) {
                     edge_scroll *= 2;
                 }
@@ -1579,15 +1577,10 @@ static tripoint display( const tripoint &orig, const draw_data_t &data = draw_da
         if( now > last_blink + std::chrono::milliseconds( BLINK_SPEED ) ) {
             if( uistate.overmap_blinking ) {
                 uistate.overmap_show_overlays = !uistate.overmap_show_overlays;
-                redraw = true;
             }
             last_blink = now;
         }
     } while( action != "QUIT" && action != "CONFIRM" );
-    werase( g->w_overmap );
-    werase( g->w_omlegend );
-    catacurses::erase();
-    g->init_ui( true );
     return ret;
 }
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1146,8 +1146,7 @@ void create_note( const tripoint &curs )
 }
 
 // if false, search yielded no results
-static bool search( tripoint &curs, const tripoint &orig, const bool show_explored,
-                    const bool fast_scroll, std::string &action )
+static bool search( const ui_adaptor &om_ui, tripoint &curs, const tripoint &orig )
 {
     std::string term = string_input_popup()
                        .title( _( "Search term:" ) )
@@ -1194,8 +1193,17 @@ static bool search( tripoint &curs, const tripoint &orig, const bool show_explor
 
     int i = 0;
     //Navigate through results
-    tripoint tmp = curs;
-    catacurses::window w_search = catacurses::newwin( 13, 27, point( TERMX - 27, 3 ) );
+    const tripoint prev_curs = curs;
+
+    catacurses::window w_search;
+
+    ui_adaptor ui;
+    ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+        w_search = catacurses::newwin( 13, 27, point( TERMX - 27, 3 ) );
+
+        ui.position_from_window( w_search );
+    } );
+    ui.mark_resize();
 
     input_context ctxt( "OVERMAP_SEARCH" );
     ctxt.register_leftright();
@@ -1206,15 +1214,7 @@ static bool search( tripoint &curs, const tripoint &orig, const bool show_explor
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "ANY_INPUT" );
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
-
-    do {
-        tmp.x = locations[i].x;
-        tmp.y = locations[i].y;
-        draw( g->w_overmap, g->w_omlegend, tmp, orig, uistate.overmap_show_overlays, show_explored,
-              fast_scroll, nullptr,
-              draw_data_t() );
+    ui.on_redraw( [&]( const ui_adaptor & ) {
         //Draw search box
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         mvwprintz( w_search, point( 1, 1 ), c_light_blue, _( "Search:" ) );
@@ -1234,6 +1234,14 @@ static bool search( tripoint &curs, const tripoint &orig, const bool show_explor
         mvwprintz( w_search, point( 1, 11 ), c_white, _( "q or ESC to return." ) );
         draw_border( w_search );
         wrefresh( w_search );
+    } );
+
+    std::string action;
+    do {
+        curs.x = locations[i].x;
+        curs.y = locations[i].y;
+        om_ui.invalidate_ui();
+        ui_manager::redraw();
         action = ctxt.handle_input( BLINK_SPEED );
         if( uistate.overmap_blinking ) {
             uistate.overmap_show_overlays = !uistate.overmap_show_overlays;
@@ -1242,11 +1250,11 @@ static bool search( tripoint &curs, const tripoint &orig, const bool show_explor
             i = ( i + 1 ) % locations.size();
         } else if( action == "PREV_TAB" || action == "LEFT" ) {
             i = ( i + locations.size() - 1 ) % locations.size();
-        } else if( action == "CONFIRM" ) {
-            curs = tmp;
+        } else if( action == "QUIT" ) {
+            curs = prev_curs;
+            om_ui.invalidate_ui();
         }
     } while( action != "CONFIRM" && action != "QUIT" );
-    action.clear();
     return true;
 }
 
@@ -1585,7 +1593,7 @@ static tripoint display( const tripoint &orig, const draw_data_t &data = draw_da
         } else if( action == "TOGGLE_FOREST_TRAILS" ) {
             uistate.overmap_show_forest_trails = !uistate.overmap_show_forest_trails;
         } else if( action == "SEARCH" ) {
-            if( !search( curs, orig, show_explored, fast_scroll, action ) ) {
+            if( !search( ui, curs, orig ) ) {
                 continue;
             }
         } else if( action == "PLACE_TERRAIN" || action == "PLACE_SPECIAL" ) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2259,8 +2259,6 @@ item::reload_option player::select_ammo( const item &base,
     menu.text = string_format( base.is_watertight_container() ? _( "Refill %s" ) :
                                base.has_flag( "RELOAD_AND_SHOOT" ) ? _( "Select ammo for %s" ) : _( "Reload %s" ),
                                base.tname() );
-    menu.w_width = -1;
-    menu.w_height = -1;
 
     // Construct item names
     std::vector<std::string> names;
@@ -2809,7 +2807,7 @@ void player::mend_item( item_location &&obj, bool interactive )
         uilist menu;
         menu.text = _( "Mend which fault?" );
         menu.desc_enabled = true;
-        menu.desc_lines = 0; // Let uilist handle description height
+        menu.desc_lines_hint = 0; // Let uilist handle description height
 
         constexpr int fold_width = 80;
 

--- a/src/scores_ui.cpp
+++ b/src/scores_ui.cpp
@@ -69,7 +69,7 @@ static std::string get_scores_text( stats_tracker &stats )
 void show_scores_ui( const achievements_tracker &achievements, stats_tracker &stats,
                      const kill_tracker &kills )
 {
-    catacurses::window w = new_centered_win( TERMY - 2, FULL_SCREEN_WIDTH );
+    catacurses::window w;
 
     enum class tab_mode {
         achievements,
@@ -89,25 +89,37 @@ void show_scores_ui( const achievements_tracker &achievements, stats_tracker &st
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
 
-    catacurses::window w_view = catacurses::newwin( getmaxy( w ) - 4, getmaxx( w ) - 1,
-                                point( getbegx( w ), getbegy( w ) + 3 ) );
+    catacurses::window w_view;
     scrolling_text_view view( w_view );
     bool new_tab = true;
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    ui_adaptor ui;
+    const auto &init_windows = [&]( ui_adaptor & ui ) {
+        w = new_centered_win( TERMY - 2, FULL_SCREEN_WIDTH );
+        w_view = catacurses::newwin( getmaxy( w ) - 4, getmaxx( w ) - 1,
+                                     point( getbegx( w ), getbegy( w ) + 3 ) );
+        ui.position_from_window( w );
+    };
+    ui.on_screen_resize( init_windows );
+    // initialize explicitly here since w_view is used before first redraw
+    init_windows( ui );
 
-    while( true ) {
+    const std::vector<std::pair<tab_mode, std::string>> tabs = {
+        { tab_mode::achievements, _( "ACHIEVEMENTS" ) },
+        { tab_mode::scores, _( "SCORES" ) },
+        { tab_mode::kills, _( "KILLS" ) },
+    };
+
+    ui.on_redraw( [&]( const ui_adaptor & ) {
         werase( w );
-
-        const std::vector<std::pair<tab_mode, std::string>> tabs = {
-            { tab_mode::achievements, _( "ACHIEVEMENTS" ) },
-            { tab_mode::scores, _( "SCORES" ) },
-            { tab_mode::kills, _( "KILLS" ) },
-        };
         draw_tabs( w, tabs, tab );
         draw_border_below_tabs( w );
+        wrefresh( w );
 
+        view.draw( c_white );
+    } );
+
+    while( true ) {
         if( new_tab ) {
             switch( tab ) {
                 case tab_mode::achievements:
@@ -125,10 +137,7 @@ void show_scores_ui( const achievements_tracker &achievements, stats_tracker &st
             }
         }
 
-        wrefresh( w );
-
-        view.draw( c_white );
-
+        ui_manager::redraw();
         const std::string action = ctxt.handle_input();
         new_tab = false;
         if( action == "RIGHT" || action == "NEXT_TAB" ) {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1212,7 +1212,6 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
     } else if( g && w == g->w_terrain && map_font ) {
         // When the terrain updates, predraw a black space around its edge
         // to keep various former interface elements from showing through the gaps
-        // TODO: Maybe track down screen changes and use g->w_blackspace to draw this instead
 
         //calculate width differences between map_font and font
         int partial_width = std::max( TERRAIN_WINDOW_TERM_WIDTH * fontwidth - TERRAIN_WINDOW_WIDTH *
@@ -1245,15 +1244,6 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
         int offsetx = win->pos.x * map_font->fontwidth;
         int offsety = win->pos.y * map_font->fontheight;
         update = map_font->draw_window( w, point( offsetx, offsety ) );
-    } else if( g && w == g->w_blackspace ) {
-        // fill-in black space window skips draw code
-        // so as not to confuse framebuffer any more than necessary
-        int offsetx = win->pos.x * font->fontwidth;
-        int offsety = win->pos.y * font->fontheight;
-        int wwidth = win->width * font->fontwidth;
-        int wheight = win->height * font->fontheight;
-        FillRectDIB( point( offsetx, offsety ), wwidth, wheight, catacurses::black );
-        update = true;
     } else if( g && w == g->w_pixel_minimap && g->pixel_minimap_option ) {
         // ensure the space the minimap covers is "dirtied".
         // this is necessary when it's the only part of the sidebar being drawn

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -112,14 +112,21 @@ void string_input_popup::show_history( utf8_wrapper &ret )
     if( !hmenu.entries.empty() ) {
         hmenu.selected = hmenu.entries.size() - 1;
 
-        // number of lines that make up the menu window: 2*border+entries
-        hmenu.w_height = 2 + hmenu.entries.size();
-        hmenu.w_y = getbegy( w ) - hmenu.w_height;
-        if( hmenu.w_y < 0 ) {
-            hmenu.w_y = 0;
-            hmenu.w_height = std::max( getbegy( w ), 4 );
-        }
-        hmenu.w_x = getbegx( w );
+        hmenu.w_height_setup = [&]() -> int {
+            // number of lines that make up the menu window: 2*border+entries
+            int height = 2 + hmenu.entries.size();
+            if( getbegy( w ) < height )
+            {
+                height = std::max( getbegy( w ), 4 );
+            }
+            return height;
+        };
+        hmenu.w_x_setup = [&]( int ) -> int {
+            return getbegx( w );
+        };
+        hmenu.w_y_setup = [&]( const int height ) -> int {
+            return std::max( getbegy( w ) - height, 0 );
+        };
 
         bool finished = false;
         do {

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -458,7 +458,7 @@ void vehicle::turrets_set_targeting()
         menu.callback = &callback;
         menu.selected = sel;
         menu.fselected = sel;
-        menu.w_y = 2;
+        menu.w_y_setup = 2;
 
         for( auto &p : turrets ) {
             menu.addentry( -1, has_part( global_part_pos3( *p ), "TURRET_CONTROLS" ), MENU_AUTOASSIGN,
@@ -514,7 +514,7 @@ void vehicle::turrets_set_mode()
         menu.callback = &callback;
         menu.selected = sel;
         menu.fselected = sel;
-        menu.w_y = 2;
+        menu.w_y_setup = 2;
 
         for( auto &p : turrets ) {
             menu.addentry( -1, true, MENU_AUTOASSIGN, "%s [%s]",

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -39,6 +39,46 @@ catacurses::window new_centered_win( int nlines, int ncols )
 * @{
 */
 
+uilist::size_scalar &uilist::size_scalar::operator=( auto_assign )
+{
+    fun = nullptr;
+    return *this;
+}
+
+uilist::size_scalar &uilist::size_scalar::operator=( const int val )
+{
+    fun = [val]() -> int {
+        return val;
+    };
+    return *this;
+}
+
+uilist::size_scalar &uilist::size_scalar::operator=( const std::function<int()> &fun )
+{
+    this->fun = fun;
+    return *this;
+}
+
+uilist::pos_scalar &uilist::pos_scalar::operator=( auto_assign )
+{
+    fun = nullptr;
+    return *this;
+}
+
+uilist::pos_scalar &uilist::pos_scalar::operator=( const int val )
+{
+    fun = [val]( int ) -> int {
+        return val;
+    };
+    return *this;
+}
+
+uilist::pos_scalar &uilist::pos_scalar::operator=( const std::function<int( int )> &fun )
+{
+    this->fun = fun;
+    return *this;
+}
+
 uilist::uilist()
 {
     init();
@@ -53,18 +93,31 @@ uilist::uilist( const std::string &hotkeys_override )
 }
 
 uilist::uilist( const std::string &msg, const std::vector<uilist_entry> &opts )
-    : uilist( MENU_AUTOASSIGN_POS, MENU_AUTOASSIGN, msg, opts )
 {
+    init();
+    text = msg;
+    entries = opts;
+    query();
 }
 
 uilist::uilist( const std::string &msg, const std::vector<std::string> &opts )
-    : uilist( MENU_AUTOASSIGN_POS, MENU_AUTOASSIGN, msg, opts )
 {
+    init();
+    text = msg;
+    for( const std::string &opt : opts ) {
+        entries.emplace_back( opt );
+    }
+    query();
 }
 
 uilist::uilist( const std::string &msg, std::initializer_list<const char *const> opts )
-    : uilist( MENU_AUTOASSIGN_POS, MENU_AUTOASSIGN, msg, opts )
 {
+    init();
+    text = msg;
+    for( const char *const opt : opts ) {
+        entries.emplace_back( opt );
+    }
+    query();
 }
 
 uilist::uilist( const point &start, int width, const std::string &msg,
@@ -107,7 +160,13 @@ uilist::uilist( const point &start, int width, const std::string &msg,
     query();
 }
 
-uilist::~uilist() = default;
+uilist::~uilist()
+{
+    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    if( current_ui ) {
+        current_ui->reset();
+    }
+}
 
 /*
  * Enables oneshot construction -> running -> exit
@@ -123,11 +182,14 @@ uilist::operator int() const
 void uilist::init()
 {
     assert( !test_mode ); // uilist should not be used in tests where there's no place for it
-    w_x = MENU_AUTOASSIGN;              // starting position
-    w_y = MENU_AUTOASSIGN;              // -1 = auto center
-    w_width = MENU_AUTOASSIGN;          // MENU_AUTOASSIGN = based on text width or max entry width, -2 = based on max entry, folds text
-    w_height =
-        MENU_AUTOASSIGN; // -1 = autocalculate based on number of entries + number of lines in text // FIXME: scrolling list with offset
+    w_x_setup = pos_scalar::auto_assign {};
+    w_y_setup = pos_scalar::auto_assign {};
+    w_width_setup = size_scalar::auto_assign {};
+    w_height_setup = size_scalar::auto_assign {};
+    w_x = 0;
+    w_y = 0;
+    w_width = 0;
+    w_height = 0;
     ret = UILIST_WAIT_INPUT;
     text.clear();          // header text, after (maybe) folding, populates:
     textformatted.clear(); // folded to textwidth
@@ -139,10 +201,13 @@ void uilist::init()
     selected = 0;          // current highlight, for entries[index]
     entries.clear();       // uilist_entry(int returnval, bool enabled, int keycode, std::string text, ... TODO: submenu stuff)
     started = false;       // set to true when width and key calculations are done, and window is generated.
+    pad_left_setup = 0;
+    pad_right_setup = 0;
     pad_left = 0;          // make a blank space to the left
     pad_right = 0;         // or right
     desc_enabled = false;  // don't show option description by default
-    desc_lines = 6;        // default number of lines for description
+    desc_lines_hint = 6;   // default number of lines for description
+    desc_lines = 6;
     footer_text.clear();   // takes precedence over per-entry descriptions.
     border_color = c_magenta; // border color
     text_color = c_light_gray;  // text color
@@ -195,7 +260,7 @@ void uilist::filterlist()
         if( notfiltering || ( !nocase && static_cast<int>( entries[i].txt.find( filter ) ) != -1 ) ||
             lcmatch( entries[i].txt, fstr ) ) {
             fentries.push_back( i );
-            if( i == selected ) {
+            if( i == selected && ( hilight_disabled || entries[i].enabled ) ) {
                 fselected = f;
             } else if( i > selected && fselected == -1 ) {
                 // Past the previously selected entry, which has been filtered out,
@@ -297,8 +362,7 @@ static int find_minimum_fold_width( const std::string &str, int max_lines,
  */
 void uilist::setup()
 {
-    bool w_auto = ( w_width == -1 || w_width == -2 );
-    bool w_autofold = ( w_width == -2 );
+    bool w_auto = !w_width_setup.fun;
 
     // Space for a line between text and entries. Only needed if there is actually text.
     const int text_separator_line = text.empty() ? 0 : 1;
@@ -307,17 +371,24 @@ void uilist::setup()
         if( !title.empty() ) {
             w_width = utf8_width( title ) + 5;
         }
+    } else {
+        w_width = w_width_setup.fun();
     }
     const int max_desc_width = w_auto ? TERMX - 4 : w_width - 4;
 
-    bool h_auto = ( w_height == -1 );
+    bool h_auto = !w_height_setup.fun;
     if( h_auto ) {
         w_height = 4;
+    } else {
+        w_height = w_height_setup.fun();
     }
 
     max_entry_len = 0;
     max_column_len = 0;
+    desc_lines = desc_lines_hint;
     std::vector<int> autoassign;
+    pad_left = pad_left_setup.fun ? pad_left_setup.fun() : 0;
+    pad_right = pad_right_setup.fun ? pad_right_setup.fun() : 0;
     int pad = pad_left + pad_right + 2;
     int descwidth_final = 0; // for description width guard
     for( size_t i = 0; i < entries.size(); i++ ) {
@@ -360,7 +431,6 @@ void uilist::setup()
         if( entries[ i ].text_color == c_red_red ) {
             entries[ i ].text_color = text_color;
         }
-        fentries.push_back( i );
     }
     size_t next_free_hotkey = 0;
     for( auto it = autoassign.begin(); it != autoassign.end() &&
@@ -379,7 +449,6 @@ void uilist::setup()
     if( desc_enabled ) {
         if( descwidth_final > TERMX ) {
             desc_enabled = false; // give up
-            debugmsg( "description would exceed terminal width (%d vs %d available)", descwidth_final, TERMX );
         } else if( descwidth_final > w_width ) {
             w_width = descwidth_final;
         }
@@ -391,7 +460,7 @@ void uilist::setup()
         bool formattxt = true;
         int realtextwidth = 0;
         if( textwidth == -1 ) {
-            if( w_autofold || !w_auto ) {
+            if( !w_auto ) {
                 realtextwidth = w_width - 4;
             } else {
                 realtextwidth = twidth;
@@ -458,78 +527,36 @@ void uilist::setup()
 
     if( vmax + additional_lines > w_height ) {
         vmax = w_height - additional_lines;
-        if( vmax < 1 ) {
-            if( textformatted.empty() ) {
-                popup( "Can't display menu options, 0 %d available screen rows are occupied\nThis is probably a bug.\n",
-                       TERMY );
-            } else {
-                popup( "Can't display menu options, %zu %d available screen rows are occupied by\n'%s\n(snip)\n%s'\nThis is probably a bug.\n",
-                       textformatted.size(), TERMY, textformatted[ 0 ].c_str(),
-                       textformatted[ textformatted.size() - 1 ].c_str() );
-            }
-        }
     }
 
-    w_x_autoassigned = w_x == MENU_AUTOASSIGN;
-    if( w_x_autoassigned ) {
+    if( !w_x_setup.fun ) {
         w_x = static_cast<int>( ( TERMX - w_width ) / 2 );
+    } else {
+        w_x = w_x_setup.fun( w_width );
     }
-    w_y_autoassigned = w_y == MENU_AUTOASSIGN;
-    if( w_y_autoassigned ) {
+    if( !w_y_setup.fun ) {
         w_y = static_cast<int>( ( TERMY - w_height ) / 2 );
+    } else {
+        w_y  = w_y_setup.fun( w_height );
     }
 
     window = catacurses::newwin( w_height, w_width, point( w_x, w_y ) );
     if( !window ) {
-        debugmsg( "Window not created; probably trying to use uilist in test mode." );
         abort();
     }
 
-    fselected = selected;
-    if( fselected < 0 ) {
-        fselected = selected = 0;
-    } else if( fselected >= static_cast<int>( entries.size() ) ) {
-        fselected = selected = static_cast<int>( entries.size() ) - 1;
+    if( !started ) {
+        filterlist();
     }
-    if( !entries.empty() && !entries[fselected].enabled ) {
-        for( size_t i = 0; i < entries.size(); ++i ) {
-            if( entries[i].enabled ) {
-                fselected = selected = i;
-                break;
-            }
-        }
-    }
-    if( callback != nullptr ) {
-        callback->select( this );
-    }
+
     started = true;
 }
 
 void uilist::reposition( ui_adaptor &ui )
 {
-    if( !started ) {
-        setup();
-    } else if( w_x_autoassigned || w_y_autoassigned ) {
-        // because the way `setup()` works we cannot call it again here,
-        // so just move the window to the center of the screen instead.
-        if( w_x_autoassigned ) {
-            if( w_width >= TERMX ) {
-                w_x = 0;
-            } else {
-                w_x = ( TERMX - w_width ) / 2;
-            }
-        }
-        if( w_y_autoassigned ) {
-            if( w_height > TERMY ) {
-                w_y = 0;
-            } else {
-                w_y = ( TERMY - w_height ) / 2;
-            }
-        }
-        window = catacurses::newwin( w_height, w_width, point( w_x, w_y ) );
-        if( filter_popup ) {
-            filter_popup->window( window, point( 4, w_height - 1 ), w_width - 4 );
-        }
+    setup();
+    if( filter_popup ) {
+        filter_popup->window( window, point( 4, w_height - 1 ), w_width - 4 );
     }
     ui.position_from_window( window );
 }
@@ -773,6 +800,22 @@ bool uilist::scrollby( const int scrollby )
     return true;
 }
 
+shared_ptr_fast<ui_adaptor> uilist::create_or_get_ui_adaptor()
+{
+    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    if( !current_ui ) {
+        ui = current_ui = make_shared_fast<ui_adaptor>();
+        current_ui->on_redraw( [this]( const ui_adaptor & ) {
+            show();
+        } );
+        current_ui->on_screen_resize( [this]( ui_adaptor & ui ) {
+            reposition( ui );
+        } );
+        current_ui->mark_resize();
+    }
+    return current_ui;
+}
+
 /**
  * Handle input and update display
  *
@@ -804,14 +847,7 @@ void uilist::query( bool loop, int timeout )
     }
     hotkeys = ctxt.get_available_single_char_hotkeys( hotkeys );
 
-    ui_adaptor ui;
-    ui.on_redraw( [this]( const ui_adaptor & ) {
-        show();
-    } );
-    ui.on_screen_resize( [this]( ui_adaptor & ui ) {
-        reposition( ui );
-    } );
-    reposition( ui );
+    shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
 
     ui_manager::redraw();
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -11,6 +11,7 @@
 
 #include "color.h"
 #include "cursesdef.h"
+#include "memory_fast.h"
 #include "point.h"
 #include "string_formatter.h"
 
@@ -26,10 +27,7 @@ const int UILIST_UNBOUND = -1026;
 const int UILIST_CANCEL = -1027;
 const int UILIST_TIMEOUT = -1028;
 const int UILIST_ADDITIONAL = -1029;
-const int MENU_WIDTH_ENTRIES = -2;
 const int MENU_AUTOASSIGN = -1;
-// NOLINTNEXTLINE(cata-use-named-point-constants)
-constexpr point MENU_AUTOASSIGN_POS( MENU_AUTOASSIGN, MENU_AUTOASSIGN );
 
 class input_context;
 class string_input_popup;
@@ -154,6 +152,40 @@ class uilist_callback
 class uilist // NOLINT(cata-xy)
 {
     public:
+        class size_scalar
+        {
+            public:
+                struct auto_assign {
+                };
+
+                size_scalar &operator=( auto_assign );
+                size_scalar &operator=( int val );
+                size_scalar &operator=( const std::function<int()> &fun );
+
+                friend class uilist;
+
+            private:
+                std::function<int()> fun;
+        };
+
+        class pos_scalar
+        {
+            public:
+                struct auto_assign {
+                };
+
+                pos_scalar &operator=( auto_assign );
+                pos_scalar &operator=( int val );
+                // the parameter to the function is the corresponding size vector element
+                // (width for x, height for y)
+                pos_scalar &operator=( const std::function<int( int )> &fun );
+
+                friend class uilist;
+
+            private:
+                std::function<int( int )> fun;
+        };
+
         uilist();
         uilist( const std::string &hotkeys_override );
         // query() will be called at the end of these convenience constructors
@@ -194,6 +226,17 @@ class uilist // NOLINT(cata-xy)
 
         void reset();
 
+        // Can be called before `uilist::query` to keep the uilist on UI stack after
+        // `uilist::query` returns. The returned `ui_adaptor` is cleared when the
+        // `uilist` is deconstructed.
+        //
+        // Example:
+        //     shared_ptr_fast<ui_adaptor> ui = menu.create_or_get_ui_adaptor();
+        //     menu.query()
+        //     // before `ui` or `menu` is deconstructed, the menu will always be
+        //     // displayed on screen.
+        shared_ptr_fast<ui_adaptor> create_or_get_ui_adaptor();
+
         operator int() const;
 
     private:
@@ -225,12 +268,21 @@ class uilist // NOLINT(cata-xy)
 
         uilist_callback *callback;
 
+        pos_scalar w_x_setup;
+        pos_scalar w_y_setup;
+        size_scalar w_width_setup;
+        size_scalar w_height_setup;
+
         int textwidth;
 
-        int pad_left = 0;
-        int pad_right = 0;
+        size_scalar pad_left_setup;
+        size_scalar pad_right_setup;
 
-        int desc_lines;
+        // Maximum number of lines to be allocated for displaying descriptions.
+        // This only serves as a hint, not a hard limit, so the number of lines
+        // may still exceed this value when for example the description text is
+        // long enough.
+        int desc_lines_hint;
         bool desc_enabled;
 
         bool filtering;
@@ -261,6 +313,9 @@ class uilist // NOLINT(cata-xy)
         int w_width;
         int w_height;
 
+        int pad_left;
+        int pad_right;
+
         int vshift = 0;
 
         int fselected = 0;
@@ -268,6 +323,8 @@ class uilist // NOLINT(cata-xy)
     private:
         std::vector<int> fentries;
         std::map<int, int> keymap;
+
+        weak_ptr_fast<ui_adaptor> ui;
 
         std::unique_ptr<string_input_popup> filter_popup;
         std::string filter;
@@ -277,8 +334,7 @@ class uilist // NOLINT(cata-xy)
 
         int vmax = 0;
 
-        bool w_x_autoassigned = false;
-        bool w_y_autoassigned = false;
+        int desc_lines;
 
         bool started = false;
 

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -150,6 +150,13 @@ void ui_adaptor::invalidate_ui() const
     invalidation_consistency_and_optimization();
 }
 
+void ui_adaptor::reset()
+{
+    on_screen_resize( nullptr );
+    on_redraw( nullptr );
+    position( point_zero, point_zero );
+}
+
 void ui_adaptor::invalidate( const rectangle &rect )
 {
     if( rect.p_min.x >= rect.p_max.x || rect.p_min.y >= rect.p_max.y ) {

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -57,6 +57,9 @@ class ui_adaptor
         // to redraw.
         void invalidate_ui() const;
 
+        // Reset all callbacks and dimensions
+        void reset();
+
         static void invalidate( const rectangle &rect );
         static void redraw();
         static void screen_resized();

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -177,7 +177,7 @@ void vehicle::control_doors()
     pointmenu_cb callback( locations );
     pmenu.callback = &callback;
     // Move the menu so that we can see our vehicle
-    pmenu.w_y = 0;
+    pmenu.w_y_setup = 0;
     pmenu.query();
 
     if( pmenu.ret >= 0 ) {

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -47,7 +47,6 @@ class wish_mutate_callback: public uilist_callback
         std::vector<trait_id> vTraits;
         std::map<trait_id, bool> pTraits;
         player *p;
-        std::string padding;
 
         nc_color mcolor( const trait_id &m ) {
             if( pTraits[ m ] ) {
@@ -77,12 +76,13 @@ class wish_mutate_callback: public uilist_callback
         void refresh( uilist *menu ) override {
             if( !started ) {
                 started = true;
-                padding = std::string( menu->pad_right - 1, ' ' );
                 for( auto &traits_iter : mutation_branch::get_all() ) {
                     vTraits.push_back( traits_iter.id );
                     pTraits[traits_iter.id] = p->has_trait( traits_iter.id );
                 }
             }
+
+            const std::string padding = std::string( menu->pad_right - 1, ' ' );
 
             const int startx = menu->w_width - menu->pad_right;
             for( int i = 2; i < lastlen; i++ ) {
@@ -195,7 +195,7 @@ class wish_mutate_callback: public uilist_callback
             lastlen = line2 + 1;
 
             mvwprintz( menu->window, point( startx, menu->w_height - 3 ), c_green, msg );
-            msg = padding;
+            msg.clear();
             input_context ctxt( menu->input_category );
             mvwprintw( menu->window, point( startx, menu->w_height - 2 ),
                        _( "[%s] find, [%s] quit, [t] toggle base trait" ),
@@ -225,10 +225,13 @@ void debug_menu::wishmutate( player *p )
         }
         c++;
     }
-    wmenu.w_x = 0;
-    wmenu.w_width = TERMX;
-    // Disabled due to foldstring crash // ( TERMX - getmaxx(w_terrain) - 30 > 24 ? getmaxx(w_terrain) : TERMX );
-    wmenu.pad_right = wmenu.w_width - 40;
+    wmenu.w_x_setup = 0;
+    wmenu.w_width_setup = []() -> int {
+        return TERMX;
+    };
+    wmenu.pad_right_setup = []() -> int {
+        return TERMX - 40;
+    };
     wmenu.selected = uistate.wishmutate_selected;
     wish_mutate_callback cb;
     cb.p = p;
@@ -299,31 +302,16 @@ class wish_monster_callback: public uilist_callback
         bool hallucination;
         // Number of monsters to spawn.
         int group;
-        // ui_parent menu's padding area
-        catacurses::window w_info;
         // scrap critter for monster::print_info
         monster tmp;
-        // if unset, initialize window
-        bool started;
-        // ' ' x window width
-        std::string padding;
         const std::vector<const mtype *> &mtypes;
 
         wish_monster_callback( const std::vector<const mtype *> &mtypes )
             : mtypes( mtypes ) {
-            started = false;
             friendly = false;
             hallucination = false;
             group = 0;
             lastent = -2;
-        }
-
-        void setup( uilist *menu ) {
-            w_info = catacurses::newwin( menu->w_height - 2, menu->pad_right,
-                                         point( menu->w_x + menu->w_width - 1 - menu->pad_right, 1 ) );
-            padding = std::string( getmaxx( w_info ), ' ' );
-            werase( w_info );
-            wrefresh( w_info );
         }
 
         bool key( const input_context &, const input_event &event, int /*entnum*/,
@@ -348,10 +336,10 @@ class wish_monster_callback: public uilist_callback
         }
 
         void refresh( uilist *menu ) override {
-            if( !started ) {
-                started = true;
-                setup( menu );
-            }
+            catacurses::window w_info = catacurses::newwin( menu->w_height - 2, menu->pad_right,
+                                        point( menu->w_x + menu->w_width - 1 - menu->pad_right, 1 ) );
+            const std::string padding = std::string( getmaxx( w_info ), ' ' );
+
             const int entnum = menu->selected;
             const bool valid_entnum = entnum >= 0 && static_cast<size_t>( entnum ) < mtypes.size();
             if( entnum != lastent ) {
@@ -376,7 +364,7 @@ class wish_monster_callback: public uilist_callback
             }
 
             mvwprintz( w_info, point( 0, getmaxy( w_info ) - 3 ), c_green, msg );
-            msg = padding;
+            msg.clear();
             input_context ctxt( menu->input_category );
             mvwprintw( w_info, point( 0, getmaxy( w_info ) - 2 ),
                        _( "[%s] find, [f]riendly, [h]allucination, [i]ncrease group, [d]ecrease group, [%s] quit" ),
@@ -385,10 +373,7 @@ class wish_monster_callback: public uilist_callback
             wrefresh( w_info );
         }
 
-        ~wish_monster_callback() override {
-            werase( w_info );
-            wrefresh( w_info );
-        }
+        ~wish_monster_callback() override = default;
 };
 
 void debug_menu::wishmonster( const cata::optional<tripoint> &p )
@@ -396,10 +381,13 @@ void debug_menu::wishmonster( const cata::optional<tripoint> &p )
     std::vector<const mtype *> mtypes;
 
     uilist wmenu;
-    wmenu.w_x = 0;
-    wmenu.w_width = TERMX;
-    // Disabled due to foldstring crash //( TERMX - getmaxx(w_terrain) - 30 > 24 ? getmaxx(w_terrain) : TERMX );
-    wmenu.pad_right = wmenu.w_width - 30;
+    wmenu.w_x_setup = 0;
+    wmenu.w_width_setup = []() -> int {
+        return TERMX;
+    };
+    wmenu.pad_right_setup = []() -> int {
+        return TERMX - 30;
+    };
     wmenu.selected = uistate.wishmonster_selected;
     wish_monster_callback cb( mtypes );
     wmenu.callback = &cb;
@@ -539,17 +527,20 @@ void debug_menu::wishitem( player *p, const tripoint &pos )
     int prev_amount = 1;
     int amount = 1;
     uilist wmenu;
-    wmenu.w_x = 0;
-    wmenu.w_width = TERMX;
-    wmenu.pad_right = std::max( TERMX / 2, TERMX - 50 );
+    wmenu.w_x_setup = 0;
+    wmenu.w_width_setup = []() -> int {
+        return TERMX;
+    };
+    wmenu.pad_right_setup = []() -> int {
+        return std::max( TERMX / 2, TERMX - 50 );
+    };
     wmenu.selected = uistate.wishitem_selected;
     wish_item_callback cb( opts );
     wmenu.callback = &cb;
 
     for( size_t i = 0; i < opts.size(); i++ ) {
         item ity( opts[i], 0 );
-        wmenu.addentry( i, true, 0, string_format( _( "%.*s" ), wmenu.pad_right - 5,
-                        ity.tname( 1, false ) ) );
+        wmenu.addentry( i, true, 0, ity.tname( 1, false ) );
         mvwzstr &entry_extra_text = wmenu.entries[i].extratxt;
         entry_extra_text.txt = ity.symbol();
         entry_extra_text.color = ity.color();
@@ -648,6 +639,8 @@ void debug_menu::wishskill( player *p )
         origskills.push_back( level );
     }
 
+    shared_ptr_fast<ui_adaptor> skmenu_ui = skmenu.create_or_get_ui_adaptor();
+
     do {
         skmenu.query();
         int skill_id = -1;
@@ -666,9 +659,13 @@ void debug_menu::wishskill( player *p )
             const Skill &skill = *sorted_skills[skill_id];
             const int NUM_SKILL_LVL = 21;
             uilist sksetmenu;
-            sksetmenu.w_height = NUM_SKILL_LVL + 4;
-            sksetmenu.w_x = skmenu.w_x + skmenu.w_width + 1;
-            sksetmenu.w_y = std::max( 0, skmenu.w_y + ( skmenu.w_height - sksetmenu.w_height ) / 2 );
+            sksetmenu.w_height_setup = NUM_SKILL_LVL + 4;
+            sksetmenu.w_x_setup = [&]( int ) -> int {
+                return skmenu.w_x + skmenu.w_width + 1;
+            };
+            sksetmenu.w_y_setup = [&]( const int height ) {
+                return std::max( 0, skmenu.w_y + ( skmenu.w_height - height ) / 2 );
+            };
             sksetmenu.settext( string_format( _( "Set '%s' to…" ), skill.name() ) );
             const int skcur = p->get_skill_level( skill.ident() );
             sksetmenu.selected = skcur;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Interface "Port ui_adaptor-related changes from DDA for cleaner UI behavior"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Finish migration of game UIs to ui_adaptor for correct behavior when resizing game window / redrawing parts of game window / redrawing UI when higher layer (e.g. a confirmation popup) has been closed.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Cherry-picked, almost without changes, following PRs:

CleverRaven#40346
Many menus, e.g. debug wish for item

CleverRaven#40095
CleverRaven#40375
Over`m`ap viewer

CleverRaven#40094
`i`nventory; various menus like `e`at or `a`ctivate. Removed a single function for nested containers: it does not even exist in BN, and was failing to compile.

CleverRaven#40384
Message log UI [`P`].
NPC trade UI. Had a conflict with #183, re-implemented that as a separate commit.

CleverRaven#40430
debug map editor

CleverRaven#40438
Inventory item menu [`i` -> select item]
Achievements / scores / kills UI [`)` key]
Armor sorting menu [`+` key]

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
These changes were made shortly after BN was forked; there were no substantial merge conflicts, and I didn't find any mentions of any regressions (except that overmap_ui flickering thing), so I assume the changes will work out of the box.

Briefly went through changed menus to make sure resizing game window actually resizes those menus.

Found a kink in the overmap viewer: at a specific game window dimensions, there is a thin gap between overmap view & overmap legend - the sidebar is visible through that gap. That's a minor thing though, and might be fixed in one of the following ui_adaptor changes (if not, I'll look into it later - seems like an easy fix).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
