### PR TITLE
Throwing update

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1537,10 +1537,6 @@ bool avatar::wield( item &target )
     int mv = item_handling_cost( target, true,
                                  worn ? INVENTORY_HANDLING_PENALTY / 2 : INVENTORY_HANDLING_PENALTY );
 
-    if( worn ) {
-        target.on_takeoff( *this );
-    }
-
     add_msg( m_debug, "wielding took %d moves", mv );
     moves -= mv;
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -603,7 +603,7 @@ int Character::throw_dispersion_per_dodge( bool add_encumbrance ) const
 }
 
 // Perfect situation gives us 1000 dispersion at lvl 0
-// This goes down linearly to 250  dispersion at lvl 10
+// This goes down linearly to 200  dispersion at lvl 10
 int Character::throwing_dispersion( const item &to_throw, Creature *critter,
                                     bool is_blind_throw ) const
 {
@@ -623,10 +623,10 @@ int Character::throwing_dispersion( const item &to_throw, Creature *critter,
     const int weight_in_gram = units::to_gram( weight );
     throw_difficulty += std::max( 0, weight_in_gram - get_str() * 100 );
 
-    // Dispersion from difficult throws goes from 100% at lvl 0 to 25% at lvl 10
+    // Dispersion from difficult throws goes from 100% at lvl 0 to 20% at lvl 10
     ///\EFFECT_THROW increases throwing accuracy
     const int throw_skill = std::min( MAX_SKILL, get_skill_level( skill_throw ) );
-    int dispersion = 10 * throw_difficulty / ( 8 * throw_skill + 4 );
+    int dispersion = 10 * throw_difficulty / ( 6 * throw_skill + 20 );
     // If the target is a creature, it moves around and ruins aim
     // TODO: Inform projectile functions if the attacker actually aims for the critter or just the tile
     if( critter != nullptr ) {

--- a/tests/throwing_test.cpp
+++ b/tests/throwing_test.cpp
@@ -175,19 +175,19 @@ TEST_CASE( "basic_throwing_sanity_tests", "[throwing],[balance]" )
     clear_map();
 
     SECTION( "test_player_vs_zombie_rock_basestats" ) {
-        test_throwing_player_versus( p, "mon_zombie", "rock", 1, lo_skill_base_stats, { 0.78, 0.10 }, { 5, 3 } );
-        test_throwing_player_versus( p, "mon_zombie", "rock", 5, lo_skill_base_stats, { 0.07, 0.10 }, { 0.7, 2 } );
-        test_throwing_player_versus( p, "mon_zombie", "rock", 10, lo_skill_base_stats, { 0.04, 0.10 }, { 0.5, 2 } );
-        test_throwing_player_versus( p, "mon_zombie", "rock", 15, lo_skill_base_stats, { 0.03, 0.10 }, { 0.5, 2 } );
+        test_throwing_player_versus( p, "mon_zombie", "rock", 1, lo_skill_base_stats, { 0.99, 0.10 }, { 10, 3 } );
+        test_throwing_player_versus( p, "mon_zombie", "rock", 5, lo_skill_base_stats, { 0.77, 0.10 }, { 5.5, 2 } );
+        test_throwing_player_versus( p, "mon_zombie", "rock", 10, lo_skill_base_stats, { 0.27, 0.10 }, { 2, 2 } );
+        test_throwing_player_versus( p, "mon_zombie", "rock", 15, lo_skill_base_stats, { 0.13, 0.10 }, { 1, 2 } );
         test_throwing_player_versus( p, "mon_zombie", "rock", 20, lo_skill_base_stats, { 0.03, 0.10 }, { 0.5, 2 } );
         test_throwing_player_versus( p, "mon_zombie", "rock", 25, lo_skill_base_stats, { 0.03, 0.10 }, { 0.5, 2 } );
         test_throwing_player_versus( p, "mon_zombie", "rock", 30, lo_skill_base_stats, { 0.03, 0.10 }, { 0.5, 2 } );
     }
 
     SECTION( "test_player_vs_zombie_javelin_iron_basestats" ) {
-        test_throwing_player_versus( p, "mon_zombie", "javelin_iron", 1, lo_skill_base_stats, { 0.64, 0.10 }, { 11, 5 } );
-        test_throwing_player_versus( p, "mon_zombie", "javelin_iron", 5, lo_skill_base_stats, { 0.05, 0.10 }, { 1.5, 3 } );
-        test_throwing_player_versus( p, "mon_zombie", "javelin_iron", 10, lo_skill_base_stats, { 0.04, 0.10 }, { 1.50, 2 } );
+        test_throwing_player_versus( p, "mon_zombie", "javelin_iron", 1, lo_skill_base_stats, { 0.95, 0.10 }, { 28, 5 } );
+        test_throwing_player_versus( p, "mon_zombie", "javelin_iron", 5, lo_skill_base_stats, { 0.64, 0.10 }, { 13, 3 } );
+        test_throwing_player_versus( p, "mon_zombie", "javelin_iron", 10, lo_skill_base_stats, { 0.20, 0.10 }, { 4, 2 } );
         test_throwing_player_versus( p, "mon_zombie", "javelin_iron", 15, lo_skill_base_stats, { 0.03, 0.10 }, { 1.29, 3 } );
         test_throwing_player_versus( p, "mon_zombie", "javelin_iron", 20, lo_skill_base_stats, { 0.03, 0.10 }, { 1.66, 2 } );
         test_throwing_player_versus( p, "mon_zombie", "javelin_iron", 25, lo_skill_base_stats, { 0.03, 0.10 }, { 1.0, 2 } );
@@ -224,8 +224,8 @@ TEST_CASE( "throwing_skill_impact_test", "[throwing],[balance]" )
     // the throwing skill has while the sanity tests are more explicit.
     SECTION( "mid_skill_basestats_rock" ) {
         test_throwing_player_versus( p, "mon_zombie", "rock", 5, mid_skill_base_stats, { 1.00, 0.10 }, { 12, 6 } );
-        test_throwing_player_versus( p, "mon_zombie", "rock", 10, mid_skill_base_stats, { 0.86, 0.10 }, { 7.0, 4 } );
-        test_throwing_player_versus( p, "mon_zombie", "rock", 15, mid_skill_base_stats, { 0.52, 0.10 }, { 3, 2 } );
+        test_throwing_player_versus( p, "mon_zombie", "rock", 10, mid_skill_base_stats, { 0.86, 0.10 }, { 7, 4 } );
+        test_throwing_player_versus( p, "mon_zombie", "rock", 15, mid_skill_base_stats, { 0.62, 0.10 }, { 5, 2 } );
     }
 
     SECTION( "hi_skill_basestats_rock" ) {


### PR DESCRIPTION
Fixes #182

QoL: You can now throw items without wielding them first if you have enough free hands.
You need enough hands to wield current weapon and the thrown weapon. If you do have enough, you don't need to unwield and rewield current weapon every throw.

Rebalanced throwing accuracy at low levels. Level 1 throwing is comparable to old level 3 throwing. Level 10 is a tiny bit less accurate than old level 10.
This should prevent those situations where a character can't throw a grenade through a window without it hitting a wall on the side of it.