### PR TITLE
Fix Disassembling a laser turret drops a handheld laser cannon instead of a TX-5LR laser cannon

### DIFF
--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -149,6 +149,14 @@
     "flags": [ "NO_UNLOAD", "NON-FOULING", "NEEDS_NO_LUBE" ]
   },
   {
+    "id": "laser_cannon_turret_fake",
+    "copy-from": "laser_cannon",
+    "type": "GUN",
+    "looks_like": "ar15",
+    "name": { "str": "TX-5LR Laser Cannon" },
+    "description": "If you see it - it is bug!"
+  },
+  {
     "id": "laser_rifle",
     "looks_like": "ar15",
     "type": "GUN",

--- a/data/json/monsters/turrets.json
+++ b/data/json/monsters/turrets.json
@@ -51,7 +51,7 @@
       {
         "type": "gun",
         "cooldown": 1,
-        "gun_type": "laser_cannon",
+        "gun_type": "laser_cannon_turret_fake",
         "fake_skills": [ [ "gun", 4 ], [ "rifle", 8 ] ],
         "ranges": [ [ 0, 30, "DEFAULT" ] ],
         "require_sunlight": true,

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -870,7 +870,7 @@
       [ [ "targeting_module", 1 ] ],
       [ [ "identification_module", 1 ] ],
       [ [ "sensor_module", 1 ] ],
-      [ [ "laser_cannon", 1 ] ],
+      [ [ "cerberus_laser", 1 ] ],
       [ [ "medium_storage_battery", 1 ] ],
       [ [ "solar_cell", 4 ] ],
       [ [ "power_supply", 1 ] ],

--- a/data/json/recipes/recipe_electronics.json
+++ b/data/json/recipes/recipe_electronics.json
@@ -1280,7 +1280,7 @@
       [ [ "targeting_module", 1 ] ],
       [ [ "identification_module", 1 ] ],
       [ [ "sensor_module", 1 ] ],
-      [ [ "laser_cannon", 1 ] ],
+      [ [ "cerberus_laser", 1 ] ],
       [ [ "medium_storage_battery", 1 ] ],
       [ [ "solar_cell", 4 ] ],
       [ [ "power_supply", 1 ] ],


### PR DESCRIPTION
Fix Disassembling a laser turret drops a handheld laser cannon instead of a TX-5LR laser cannon

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfixes "Fix Disassembling a laser turret drops a handheld laser cannon instead of a TX-5LR laser cannon"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: Bugfixes "Fix Disassembling a laser turret drops a handheld laser cannon instead of a TX-5LR laser cannon"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Fix https://github.com/cataclysmbnteam/Cataclysm-BN/issues/143
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
It is make sense that laser turret should drop TX-5LR Laser Cannon but not handled version. Handрудв version can be created from cerberus laser cannon via craft.
Recipes (inlcuding deconstruction) were changed accordingly.
Additonally created fake for laser_cannon to disguise it as TX-5LR Laser Cannon in message log.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Spawn laser turret.
2) Check if it shoots from "TX-5LR Laser Cannon" but not "handheld laser cannon".
3) Destroy turret. Check deconstruction. It must contain "TX-5LR Laser Cannon" but not "handheld laser cannon".
4) Check recepie on laser turret. It should require "TX-5LR Laser Cannon" but not "handheld laser cannon".
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
By the way, laser turret is working. But now it does not spawn in active state anywhere. It should be changed. Military outpost- is good place for that turret. Probably further rebalancing is requred.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
