### PR TITLE
Finish ui_adaptor migration (part 2)

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -78,13 +78,8 @@ enum aim_exit {
 
 // *INDENT-OFF*
 advanced_inventory::advanced_inventory()
-    : head_height( 5 )
-    , min_w_height( 10 )
-    , min_w_width( FULL_SCREEN_WIDTH )
-    , max_w_width( get_option<bool>( "AIM_WIDTH" ) ? TERMX : std::max( 120, TERMX - 2 * ( panel_manager::get_manager().get_width_right() + panel_manager::get_manager().get_width_left() ) ) )
-    , inCategoryMode( false )
+    : inCategoryMode( false )
     , recalc( true )
-    , redraw( true )
     , src( left )
     , dest( right )
     , filter_edit( false )
@@ -216,27 +211,6 @@ void advanced_inventory::init()
 
     src = ( save_state->active_left ) ? left : right;
     dest = ( save_state->active_left ) ? right : left;
-
-    w_height = TERMY < min_w_height + head_height ? min_w_height : TERMY - head_height;
-    w_width = TERMX < min_w_width ? min_w_width : TERMX > max_w_width ? max_w_width :
-              static_cast<int>( TERMX );
-
-    //(TERMY>w_height)?(TERMY-w_height)/2:0;
-    headstart = 0;
-    colstart = TERMX > w_width ? ( TERMX - w_width ) / 2 : 0;
-
-    head = catacurses::newwin( head_height, w_width - minimap_width, point( colstart, headstart ) );
-    mm_border = catacurses::newwin( minimap_height + 2, minimap_width + 2,
-                                    point( colstart + ( w_width - ( minimap_width + 2 ) ), headstart ) );
-    minimap = catacurses::newwin( minimap_height, minimap_width,
-                                  point( colstart + ( w_width - ( minimap_width + 1 ) ), headstart + 1 ) );
-    panes[left].window = catacurses::newwin( w_height, w_width / 2, point( colstart,
-                         headstart + head_height ) );
-    panes[right].window = catacurses::newwin( w_height, w_width / 2, point( colstart + w_width / 2,
-                          headstart + head_height ) );
-
-    // 2 for the borders, 5 for the header stuff
-    itemsPerPage = w_height - 2 - 5;
 }
 
 void advanced_inventory::print_items( const advanced_inventory_pane &pane, bool active )
@@ -658,10 +632,7 @@ void advanced_inventory::redraw_pane( side p )
     auto &pane = panes[p];
     if( recalc || pane.recalc ) {
         recalc_pane( p );
-    } else if( !( redraw || pane.redraw ) ) {
-        return;
     }
-    pane.redraw = false;
     pane.fix_index();
 
     const bool active = p == src;
@@ -1078,7 +1049,7 @@ void advanced_inventory::redraw_sidebar()
     input_context ctxt( "ADVANCED_INVENTORY" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
 
-    if( redraw && !is_processing() ) {
+    if( !is_processing() ) {
         werase( head );
         werase( minimap );
         werase( mm_border );
@@ -1095,7 +1066,6 @@ void advanced_inventory::redraw_sidebar()
         wrefresh( head );
         refresh_minimap();
     }
-    redraw = false;
 }
 
 void advanced_inventory::change_square( const aim_location changeSquare,
@@ -1116,7 +1086,6 @@ void advanced_inventory::change_square( const aim_location changeSquare,
         } else {
             swap_panes();
         }
-        redraw = true;
         // we need to check the original area if we can place items in vehicle storage
     } else if( squares[changeSquare].canputitems( spane.get_cur_item_ptr() ) ) {
         bool in_vehicle_cargo = false;
@@ -1145,11 +1114,8 @@ void advanced_inventory::change_square( const aim_location changeSquare,
         if( dpane.get_area() == AIM_ALL ) {
             dpane.recalc = true;
         }
-        redraw = true;
     } else {
         popup( _( "You can't put items there!" ) );
-        // to clear the popup
-        redraw = true;
     }
 }
 
@@ -1255,8 +1221,6 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
         spane.get_area() != AIM_ALL &&
         spane.in_vehicle() == dpane.in_vehicle() ) {
         popup( _( "Source area is the same as destination (%s)." ), squares[destarea].name );
-        // popup has messed up the screen
-        redraw = true;
         return false;
     }
     assert( !sitem->items.empty() );
@@ -1273,7 +1237,6 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
     if( destarea == AIM_CONTAINER ) {
         if( !move_content( *sitem->items.front(),
                            *squares[destarea].get_container( to_vehicle ) ) ) {
-            redraw = true;
             return false;
         }
     } else if( srcarea == AIM_INVENTORY && destarea == AIM_WORN ) {
@@ -1342,8 +1305,12 @@ void advanced_inventory::action_examine( advanced_inv_listitem *sitem,
         advanced_inventory_pane &spane )
 {
     int ret = 0;
-    const int info_width = w_width / 2;
-    const int info_startx = colstart + ( src == advanced_inventory::side::left ? info_width : 0 );
+    const auto info_width = [this]() -> int {
+        return w_width / 2;
+    };
+    const auto info_startx = [this]() -> int {
+        return colstart + ( src == advanced_inventory::side::left ? w_width / 2 : 0 );
+    };
     if( spane.get_area() == AIM_INVENTORY || spane.get_area() == AIM_WORN ) {
         int idx = spane.get_area() == AIM_INVENTORY ? sitem->idx :
                   player::worn_position_to_index( sitem->idx );
@@ -1377,15 +1344,15 @@ void advanced_inventory::action_examine( advanced_inv_listitem *sitem,
         item_info_data data( it.tname(), it.type_name(), vThisItem, vDummy );
         data.handle_scrolling = true;
 
-        ret = draw_item_info( info_startx, info_width, 0, 0, data ).get_first_input();
+        ret = draw_item_info( [&]() -> catacurses::window {
+            return catacurses::newwin( 0, info_width(), point( info_startx(), 0 ) );
+        }, data ).get_first_input();
     }
     if( ret == KEY_NPAGE || ret == KEY_DOWN ) {
         spane.scroll_by( +1 );
     } else if( ret == KEY_PPAGE || ret == KEY_UP ) {
         spane.scroll_by( -1 );
     }
-    // item info window overwrote the other pane and the header
-    redraw = true;
 }
 
 void advanced_inventory::display()
@@ -1398,10 +1365,61 @@ void advanced_inventory::display()
 
     exit = false;
     recalc = true;
-    redraw = true;
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    std::unique_ptr<string_input_popup> spopup;
+    std::unique_ptr<ui_adaptor> ui;
+    if( !is_processing() ) {
+        ui = std::make_unique<ui_adaptor>();
+        ui->on_screen_resize( [&]( ui_adaptor & ui ) {
+            constexpr int min_w_height = 10;
+            const int min_w_width = FULL_SCREEN_WIDTH;
+            const int max_w_width = get_option<bool>( "AIM_WIDTH" ) ? TERMX : std::max( 120,
+                                    TERMX - 2 * ( panel_manager::get_manager().get_width_right() +
+                                                  panel_manager::get_manager().get_width_left() ) );
+
+            w_height = TERMY < min_w_height + head_height ? min_w_height : TERMY - head_height;
+            w_width = TERMX < min_w_width ? min_w_width : TERMX > max_w_width ? max_w_width :
+                      static_cast<int>( TERMX );
+
+            //(TERMY>w_height)?(TERMY-w_height)/2:0;
+            headstart = 0;
+            colstart = TERMX > w_width ? ( TERMX - w_width ) / 2 : 0;
+
+            head = catacurses::newwin( head_height, w_width - minimap_width, point( colstart, headstart ) );
+            mm_border = catacurses::newwin( minimap_height + 2, minimap_width + 2,
+                                            point( colstart + ( w_width - ( minimap_width + 2 ) ), headstart ) );
+            minimap = catacurses::newwin( minimap_height, minimap_width,
+                                          point( colstart + ( w_width - ( minimap_width + 1 ) ), headstart + 1 ) );
+            panes[left].window = catacurses::newwin( w_height, w_width / 2, point( colstart,
+                                 headstart + head_height ) );
+            panes[right].window = catacurses::newwin( w_height, w_width / 2, point( colstart + w_width / 2,
+                                  headstart + head_height ) );
+
+            // 2 for the borders, 5 for the header stuff
+            itemsPerPage = w_height - 2 - 5;
+
+            if( filter_edit && spopup ) {
+                spopup->window( panes[src].window, point( 4, w_height - 1 ), w_width / 2 - 4 );
+            }
+
+            ui.position( point( colstart, headstart ), point( w_width, head_height + w_height ) );
+        } );
+        ui->mark_resize();
+
+        ui->on_redraw( [&]( const ui_adaptor & ) {
+            redraw_pane( advanced_inventory::side::left );
+            redraw_pane( advanced_inventory::side::right );
+            redraw_sidebar();
+
+            if( filter_edit && spopup ) {
+                draw_item_filter_rules( panes[dest].window, 1, 11, item_filter_type::FILTER );
+                mvwprintz( panes[src].window, point( 2, getmaxy( panes[src].window ) - 1 ), c_cyan, "< " );
+                mvwprintz( panes[src].window, point( w_width / 2 - 4, getmaxy( panes[src].window ) - 1 ), c_cyan,
+                           " >" );
+                spopup->query_string( /*loop=*/false, /*draw_only=*/true );
+            }
+        } );
+    }
 
     while( !exit ) {
         if( g->u.moves < 0 ) {
@@ -1411,9 +1429,9 @@ void advanced_inventory::display()
         dest = src == advanced_inventory::side::left ? advanced_inventory::side::right :
                advanced_inventory::side::left;
 
-        redraw_pane( advanced_inventory::side::left );
-        redraw_pane( advanced_inventory::side::right );
-        redraw_sidebar();
+        if( ui ) {
+            ui_manager::redraw();
+        }
 
         recalc = false;
         // source and destination pane
@@ -1426,10 +1444,6 @@ void advanced_inventory::display()
         const std::string action = is_processing() ? "MOVE_ALL_ITEMS" : ctxt.handle_input();
         if( action == "CATEGORY_SELECTION" ) {
             inCategoryMode = !inCategoryMode;
-            // We redraw to force the color change of the highlighted line and header text.
-            spane.redraw = true;
-        } else if( action == "HELP_KEYBINDINGS" ) {
-            redraw = true;
         } else if( action == "ITEMS_DEFAULT" ) {
             for( side cside : {
                      left, right
@@ -1442,12 +1456,10 @@ void advanced_inventory::display()
                 }
                 pane.set_area( squares[location] );
             }
-            redraw = true;
         } else if( action == "SAVE_DEFAULT" ) {
             save_state->saved_area = panes[left].get_area();
             save_state->saved_area_right = panes[right].get_area();
             popup( _( "Default layout was saved." ) );
-            redraw = true;
         } else if( get_square( action, changeSquare ) ) {
             change_square( changeSquare, dpane, spane );
         } else if( action == "TOGGLE_FAVORITE" ) {
@@ -1459,7 +1471,6 @@ void advanced_inventory::display()
             }
             // In case we've merged faved and unfaved items
             recalc = true;
-            redraw = true;
         } else if( action == "MOVE_SINGLE_ITEM" ||
                    action == "MOVE_VARIABLE_ITEM" ||
                    action == "MOVE_ITEM_STACK" ) {
@@ -1471,35 +1482,31 @@ void advanced_inventory::display()
             if( show_sort_menu( spane ) ) {
                 recalc = true;
             }
-            redraw = true;
         } else if( action == "FILTER" ) {
-            string_input_popup spopup;
             std::string filter = spane.filter;
             filter_edit = true;
-            spopup.window( spane.window, point( 4, w_height - 1 ), w_width / 2 - 4 )
-            .max_length( 256 )
-            .text( filter );
-
-            draw_item_filter_rules( dpane.window, 1, 11, item_filter_type::FILTER );
+            if( ui ) {
+                spopup = std::make_unique<string_input_popup>();
+                spopup->max_length( 256 ).text( filter );
+                ui->mark_resize();
+            }
 
             ime_sentry sentry;
 
             do {
-                mvwprintz( spane.window, point( 2, getmaxy( spane.window ) - 1 ), c_cyan, "< " );
-                mvwprintz( spane.window, point( w_width / 2 - 4, getmaxy( spane.window ) - 1 ), c_cyan, " >" );
-                std::string new_filter = spopup.query_string( false );
-                if( spopup.context().get_raw_input().get_first_input() == KEY_ESCAPE ) {
+                if( ui ) {
+                    ui_manager::redraw();
+                }
+                std::string new_filter = spopup->query_string( false );
+                if( spopup->canceled() ) {
                     // restore original filter
                     spane.set_filter( filter );
                 } else {
                     spane.set_filter( new_filter );
                 }
-                redraw_pane( src );
-            } while( spopup.context().get_raw_input().get_first_input() != '\n' &&
-                     spopup.context().get_raw_input().get_first_input() != KEY_ESCAPE );
+            } while( !spopup->canceled() && !spopup->confirmed() );
             filter_edit = false;
-            spane.redraw = true;
-            dpane.redraw = true;
+            spopup = nullptr;
         } else if( action == "RESET_FILTER" ) {
             spane.set_filter( "" );
         } else if( action == "TOGGLE_AUTO_PICKUP" ) {
@@ -1539,13 +1546,10 @@ void advanced_inventory::display()
             }
         } else if( action == "LEFT" ) {
             src = left;
-            redraw = true;
         } else if( action == "RIGHT" ) {
             src = right;
-            redraw = true;
         } else if( action == "TOGGLE_TAB" ) {
             src = dest;
-            redraw = true;
         } else if( action == "TOGGLE_VEH" ) {
             if( squares[spane.get_area()].can_store_in_vehicle() ) {
                 // swap the panes if going vehicle will show the same tile
@@ -1560,12 +1564,9 @@ void advanced_inventory::display()
                     if( dpane.get_area() == AIM_ALL ) {
                         dpane.recalc = true;
                     }
-                    // make sure to update the minimap as well!
-                    redraw = true;
                 }
             } else {
                 popup( _( "No vehicle storage space there!" ) );
-                redraw = true;
             }
         }
     }
@@ -1619,8 +1620,6 @@ bool advanced_inventory::query_destination( aim_location &def )
             return true;
         }
         popup( _( "You can't put items there!" ) );
-        // the popup has messed the screen up.
-        redraw = true;
         return false;
     }
 
@@ -1659,8 +1658,6 @@ bool advanced_inventory::query_destination( aim_location &def )
     while( menu.ret == UILIST_WAIT_INPUT ) {
         menu.query( false );
     }
-    // the menu has messed the screen up.
-    redraw = true;
     if( menu.ret >= AIM_SOUTHWEST && menu.ret <= AIM_NORTHEAST ) {
         assert( squares[menu.ret].canputitems() );
         def = static_cast<aim_location>( menu.ret );
@@ -1735,7 +1732,6 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     // Includes moving from/to inventory and around on the map.
     if( it.made_of( LIQUID ) ) {
         popup( _( "You can't pick up a liquid." ) );
-        redraw = true;
         return false;
     }
 
@@ -1744,7 +1740,6 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     if( amount > room_for && squares[destarea].id != AIM_WORN ) {
         if( room_for <= 0 ) {
             popup( _( "Destination area is full.  Remove some items first." ) );
-            redraw = true;
             return false;
         }
         amount = std::min( room_for, amount );
@@ -1761,7 +1756,6 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
         } );
         if( cntmax <= 0 && !adds0 ) {
             popup( _( "Destination area has too many items.  Remove some first." ) );
-            redraw = true;
             return false;
         }
         // Items by charge count as a single item, regardless of the charges. As long as the
@@ -1779,7 +1773,6 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
             const int weightmax = max_weight / unitweight;
             if( weightmax <= 0 ) {
                 popup( _( "This is too heavy!" ) );
-                redraw = true;
                 return false;
             }
             amount = std::min( weightmax, amount );
@@ -1817,7 +1810,6 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
                      .query_int();
         }
         if( amount <= 0 ) {
-            redraw = true;
             return false;
         }
         if( amount > possible_max ) {
@@ -1922,7 +1914,6 @@ void advanced_inventory::swap_panes()
     std::swap( panes[left].window, panes[right].window );
     // Recalculation required for weight & volume
     recalc = true;
-    redraw = true;
 }
 
 void advanced_inventory::do_return_entry()

--- a/src/advanced_inv.h
+++ b/src/advanced_inv.h
@@ -57,10 +57,7 @@ class advanced_inventory
             right = 1,
             NUM_PANES = 2
         };
-        const int head_height = 0;
-        const int min_w_height = 0;
-        const int min_w_width = 0;
-        const int max_w_width = 0;
+        static constexpr int head_height = 5;
 
         // swap the panes and windows via std::swap()
         void swap_panes();
@@ -84,7 +81,6 @@ class advanced_inventory
         int colstart = 0;
 
         bool recalc = false;
-        bool redraw = false;
         /**
          * Which panels is active (item moved from there).
          */

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -225,7 +225,6 @@ void advanced_inventory_pane::scroll_by( int offset )
     }
     mod_index( offset );
     skip_category_headers( offset > 0 ? +1 : -1 );
-    redraw = true;
 }
 
 void advanced_inventory_pane::scroll_category( int offset )
@@ -261,7 +260,6 @@ void advanced_inventory_pane::scroll_category( int offset )
     }
     // Make sure we land on an item entry.
     skip_category_headers( offset > 0 ? +1 : -1 );
-    redraw = true;
 }
 
 advanced_inv_listitem *advanced_inventory_pane::get_cur_item_ptr()

--- a/src/advanced_inv_pane.h
+++ b/src/advanced_inv_pane.h
@@ -80,13 +80,8 @@ class advanced_inventory_pane
         std::string filter;
         /**
          * Whether to recalculate the content of this pane.
-         * Implies @ref redraw.
          */
         bool recalc = false;
-        /**
-         * Whether to redraw this pane.
-         */
-        bool redraw = false;
 
         void add_items_from_area( advanced_inv_area &square, bool vehicle_override = false );
         /**
@@ -103,7 +98,7 @@ class advanced_inventory_pane
          */
         bool is_filtered( const item &it ) const;
         /**
-         * Scroll @ref index, by given offset, set redraw to true,
+         * Scroll @ref index, by given offset,
          * @param offset Must not be 0.
          */
         void scroll_by( int offset );

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -238,7 +238,7 @@ struct dialogue {
         /** Missions that have been assigned by this npc to the player they currently speak to. */
         std::vector<mission *> missions_assigned;
 
-        talk_topic opt( dialogue_window &d_win, const talk_topic &topic );
+        talk_topic opt( dialogue_window &d_win, const std::string &npc_name, const talk_topic &topic );
 
         dialogue() = default;
 

--- a/src/dialogue_win.h
+++ b/src/dialogue_win.h
@@ -12,18 +12,21 @@
 
 using talk_data = std::pair<nc_color, std::string>;
 
+class ui_adaptor;
+
 class dialogue_window
 {
     public:
         dialogue_window() = default;
         void open_dialogue( bool text_only = false );
+        void resize_dialogue( ui_adaptor &ui );
         void print_header( const std::string &name );
 
         bool text_only = false;
 
         void clear_window_texts();
-        void display_responses( int hilight_lines, const std::vector<talk_data> &responses,
-                                const int &ch );
+        void handle_scrolling( int ch );
+        void display_responses( int hilight_lines, const std::vector<talk_data> &responses );
         void refresh_response_display();
         /**
          * Folds and adds the folded text to @ref history. Returns the number of added lines.

--- a/src/dialogue_win.h
+++ b/src/dialogue_win.h
@@ -10,7 +10,12 @@
 #include "color.h"
 #include "cursesdef.h"
 
-using talk_data = std::pair<nc_color, std::string>;
+/** Represents avatar response */
+struct talk_data {
+    char letter;
+    nc_color col;
+    std::string text;
+};
 
 class ui_adaptor;
 
@@ -44,15 +49,13 @@ class dialogue_window
          * window width and with separators between. Used for rendering, recalculated each time window size changes.
          */
         std::vector<std::pair<std::string, size_t>> draw_cache;
-        // yoffset of the current response window
-        int yoffset = 0;
+        /** Scroll position in response window (page number) */
+        size_t curr_page = 0;
         bool can_scroll_up = false;
         bool can_scroll_down = false;
 
         // Prints history. Automatically highlighting last message.
         void print_history();
-        // Prints responses. Takes care of line folding.
-        bool print_responses( int yoffset, const std::vector<talk_data> &responses );
 
         /**
          * Folds given message to current window width and adds it to drawing cache.

--- a/src/dialogue_win.h
+++ b/src/dialogue_win.h
@@ -26,13 +26,10 @@ class dialogue_window
 
         void clear_window_texts();
         void handle_scrolling( int ch );
-        void display_responses( int hilight_lines, const std::vector<talk_data> &responses );
+        void display_responses( const std::vector<talk_data> &responses );
         void refresh_response_display();
-        /**
-         * Folds and adds the folded text to @ref history. Returns the number of added lines.
-         */
-        size_t add_to_history( const std::string &text );
-        void add_history_separator();
+        /** Adds message to history. It must be already translated. */
+        void add_to_history( const std::string &msg );
 
     private:
         catacurses::window d_win;
@@ -40,16 +37,29 @@ class dialogue_window
          * This contains the exchanged words, it is basically like the global message log.
          * Each responses of the player character and the NPC are added as are information about
          * what each of them does (e.g. the npc drops their weapon).
-         * This will be displayed in the dialog window and should already be translated.
          */
         std::vector<std::string> history;
+        /**
+         * Drawing cache: basically all entries from @ref history, but folded to current
+         * window width and with separators between. Used for rendering, recalculated each time window size changes.
+         */
+        std::vector<std::pair<std::string, size_t>> draw_cache;
         // yoffset of the current response window
         int yoffset = 0;
         bool can_scroll_up = false;
         bool can_scroll_down = false;
 
-        void print_history( size_t hilight_lines );
+        // Prints history. Automatically highlighting last message.
+        void print_history();
+        // Prints responses. Takes care of line folding.
         bool print_responses( int yoffset, const std::vector<talk_data> &responses );
+
+        /**
+         * Folds given message to current window width and adds it to drawing cache.
+         * Also adds a separator (empty line).
+         * idx is this message's position within @ref history_raw
+         */
+        void cache_msg( const std::string &msg, size_t idx );
 
         std::string npc_name;
 };

--- a/src/dialogue_win.h
+++ b/src/dialogue_win.h
@@ -23,11 +23,8 @@ class dialogue_window
 {
     public:
         dialogue_window() = default;
-        void open_dialogue( bool text_only = false );
         void resize_dialogue( ui_adaptor &ui );
         void print_header( const std::string &name );
-
-        bool text_only = false;
 
         void clear_window_texts();
         void handle_scrolling( int ch );

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -284,6 +284,37 @@ bool editmap::eget_direction( tripoint &p, const std::string &action ) const
     return true;
 }
 
+class editmap::game_draw_callback_t_container
+{
+    public:
+        game_draw_callback_t_container( editmap *em ) : em( em ) {}
+        shared_ptr_fast<game::draw_callback_t> create_or_get();
+    private:
+        editmap *em;
+        weak_ptr_fast<game::draw_callback_t> cbw;
+};
+
+shared_ptr_fast<game::draw_callback_t> editmap::game_draw_callback_t_container::create_or_get()
+{
+    shared_ptr_fast<game::draw_callback_t> cb = cbw.lock();
+    if( !cb ) {
+        cbw = cb = make_shared_fast<game::draw_callback_t>(
+        [this]() {
+            em->draw_main_ui_overlay();
+        } );
+        g->add_draw_callback( cb );
+    }
+    return cb;
+}
+
+editmap::game_draw_callback_t_container &editmap::draw_cb_container()
+{
+    if( !draw_cb_container_ ) {
+        draw_cb_container_ = std::make_unique<game_draw_callback_t_container>( this );
+    }
+    return *draw_cb_container_;
+}
+
 shared_ptr_fast<ui_adaptor> editmap::create_or_get_ui_adaptor()
 {
     shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
@@ -292,9 +323,7 @@ shared_ptr_fast<ui_adaptor> editmap::create_or_get_ui_adaptor()
         current_ui->on_screen_resize( [this]( ui_adaptor & ui ) {
             w_info = catacurses::newwin( infoHeight, width, point( offsetX, TERMY - infoHeight ) );
             tmax = point( getmaxx( g->w_terrain ), getmaxy( g->w_terrain ) );
-            // We redraw the entire terrain window along with our own window, so
-            // set the position to that of catacurses::stdscr.
-            ui.position_from_window( catacurses::stdscr );
+            ui.position_from_window( w_info );
         } );
         current_ui->mark_resize();
 
@@ -307,6 +336,7 @@ shared_ptr_fast<ui_adaptor> editmap::create_or_get_ui_adaptor()
 
 cata::optional<tripoint> editmap::edit()
 {
+    restore_on_out_of_scope<tripoint> view_offset_prev( g->u.view_offset );
     target = g->u.pos() + g->u.view_offset;
     input_context ctxt( "EDITMAP" );
     ctxt.set_iso( true );
@@ -334,9 +364,10 @@ cata::optional<tripoint> editmap::edit()
     uberdraw = uistate.editmap_nsa_viewmode;
     blink = true;
 
+    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [current_ui]() {
-        current_ui->invalidate_ui();
+    on_out_of_scope invalidate_current_ui( [this]() {
+        do_ui_invalidation();
     } );
     restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
     restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
@@ -363,7 +394,7 @@ cata::optional<tripoint> editmap::edit()
                                        ctxt.describe_key_and_name( "EDIT_ITEMS" ),
                                        ctxt.describe_key_and_name( "QUIT" ) );
         info_title_curr = pgettext( "map editor state", "Looking around" );
-        current_ui->invalidate_ui();
+        do_ui_invalidation();
 
         ui_manager::redraw();
 
@@ -461,18 +492,22 @@ void editmap::uber_draw_ter( const catacurses::window &w, map *m )
     }
 }
 
-void editmap::update_view_with_help( const std::string &txt, const std::string &title )
+void editmap::do_ui_invalidation()
 {
-    // updating map
+    g->u.view_offset = target - g->u.pos();
+    g->invalidate_main_ui_adaptor();
+    create_or_get_ui_adaptor()->invalidate_ui();
+}
+
+void editmap::draw_main_ui_overlay()
+{
     const Creature *critter = g->critter_at( target );
 
-    werase( g->w_terrain );
-
+#if !defined( TILES )
     if( uberdraw ) {
         uber_draw_ter( g->w_terrain, &g->m ); // Bypassing the usual draw methods; not versatile enough
-    } else {
-        g->draw_ter( target ); // But it's optional
     }
+#endif
 
     // update target point
     if( critter != nullptr ) {
@@ -649,9 +684,10 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
         }
 #endif
     }
-    wrefresh( g->w_terrain );
-    g->draw_panels();
+}
 
+void editmap::update_view_with_help( const std::string &txt, const std::string &title )
+{
     // updating info
     werase( w_info );
 
@@ -743,6 +779,7 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
         off++; // 11
     }
 
+    const Creature *critter = g->critter_at( target );
     if( critter != nullptr ) {
         off = critter->print_info( w_info, off, 5, 1 );
     } else if( vp ) {
@@ -1063,9 +1100,10 @@ void editmap::edit_feature()
     int current_feature = emenu.selected = feature<T_id>( target ).to_i();
     emenu.entries[current_feature].text_color = c_green;
 
+    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [current_ui]() {
-        current_ui->invalidate_ui();
+    on_out_of_scope invalidate_current_ui( [this]() {
+        do_ui_invalidation();
     } );
     restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
     restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
@@ -1090,7 +1128,7 @@ void editmap::edit_feature()
                                        ctxt.describe_key_and_name( "EDITMAP_TAB" ),
                                        ctxt.describe_key_and_name( "EDITMAP_MOVE" ) );
         info_title_curr = info_title<T_t>();
-        current_ui->invalidate_ui();
+        do_ui_invalidation();
 
         emenu.query( false, BLINK_SPEED );
         if( emenu.ret == UILIST_CANCEL ) {
@@ -1178,9 +1216,10 @@ void editmap::edit_fld()
     };
     fmenu.allow_additional = true;
 
+    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [current_ui]() {
-        current_ui->invalidate_ui();
+    on_out_of_scope invalidate_current_ui( [this]() {
+        do_ui_invalidation();
     } );
     restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
     restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
@@ -1207,7 +1246,7 @@ void editmap::edit_fld()
                                        ctxt.describe_key_and_name( "QUIT" ),
                                        ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ) );
         info_title_curr = pgettext( "Map editor: Editing field effects", "Field effects" );
-        current_ui->invalidate_ui();
+        do_ui_invalidation();
 
         fmenu.query( false, BLINK_SPEED );
         if( ( fmenu.ret > 0 && static_cast<size_t>( fmenu.ret ) < field_type::count() ) ||
@@ -1349,9 +1388,10 @@ void editmap::edit_itm()
     };
     ilmenu.allow_additional = true;
 
+    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [current_ui]() {
-        current_ui->invalidate_ui();
+    on_out_of_scope invalidate_current_ui( [this]() {
+        do_ui_invalidation();
     } );
     restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
     restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
@@ -1361,7 +1401,7 @@ void editmap::edit_itm()
     do {
         info_txt_curr.clear();
         info_title_curr.clear();
-        current_ui->invalidate_ui();
+        do_ui_invalidation();
 
         ilmenu.query();
         if( ilmenu.ret >= 0 && ilmenu.ret < static_cast<int>( items.size() ) ) {
@@ -1594,9 +1634,10 @@ int editmap::select_shape( shapetype shape, int mode )
     }
     altblink = moveall;
 
+    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [current_ui]() {
-        current_ui->invalidate_ui();
+    on_out_of_scope invalidate_current_ui( [this]() {
+        do_ui_invalidation();
     } );
     restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
     restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
@@ -1622,7 +1663,7 @@ int editmap::select_shape( shapetype shape, int mode )
                                            ctxt.describe_key_and_name( "EDITMAP_SHOW_ALL" ) );
             info_title_curr = _( "Resizing selection" );
         }
-        current_ui->invalidate_ui();
+        do_ui_invalidation();
         ui_manager::redraw();
         action = ctxt.handle_input( BLINK_SPEED );
         if( action == "RESIZE" ) {
@@ -1642,8 +1683,8 @@ int editmap::select_shape( shapetype shape, int mode )
                 };
                 smenu.allow_additional = true;
 
-                on_out_of_scope invalidate_current_ui_2( [current_ui]() {
-                    current_ui->invalidate_ui();
+                on_out_of_scope invalidate_current_ui_2( [this]() {
+                    do_ui_invalidation();
                 } );
                 restore_on_out_of_scope<std::string> info_txt_prev_2( info_txt_curr );
                 restore_on_out_of_scope<std::string> info_title_prev_2( info_title_curr );
@@ -1651,7 +1692,7 @@ int editmap::select_shape( shapetype shape, int mode )
                 do {
                     info_txt_curr.clear();
                     info_title_curr = pgettext( "map editor state", "Select a shape" );
-                    current_ui->invalidate_ui();
+                    do_ui_invalidation();
 
                     smenu.query();
                     if( smenu.ret == UILIST_CANCEL ) {
@@ -1758,9 +1799,10 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
     };
     gpmenu.allow_additional = true;
 
+    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [current_ui]() {
-        current_ui->invalidate_ui();
+    on_out_of_scope invalidate_current_ui( [this]() {
+        do_ui_invalidation();
     } );
     restore_on_out_of_scope<tinymap *> tinymap_ptr_prev( tmpmap_ptr );
     restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
@@ -1791,7 +1833,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
                                        ctxt.describe_key_and_name( "QUIT" ) );
         info_title_curr = string_format( pgettext( "map editor state", "Mapgen: %s" ),
                                          oter_id( gmenu.selected ).id().str() );
-        current_ui->invalidate_ui();
+        do_ui_invalidation();
 
         gpmenu.query( false, BLINK_SPEED * 3 );
 
@@ -1942,9 +1984,10 @@ void editmap::mapgen_retarget()
     std::string action;
     tripoint origm = target;
 
+    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [current_ui]() {
-        current_ui->invalidate_ui();
+    on_out_of_scope invalidate_current_ui( [this]() {
+        do_ui_invalidation();
     } );
     restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
     restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
@@ -1955,7 +1998,7 @@ void editmap::mapgen_retarget()
                                        ctxt.describe_key_and_name( "CONFIRM" ),
                                        ctxt.describe_key_and_name( "QUIT" ) );
         info_title_curr = pgettext( "map generator", "Mapgen: Moving target" );
-        current_ui->invalidate_ui();
+        do_ui_invalidation();
 
         ui_manager::redraw();
         action = ctxt.handle_input( BLINK_SPEED );
@@ -2014,9 +2057,10 @@ void editmap::edit_mapgen()
     }
     real_coords tc;
 
+    shared_ptr_fast<game::draw_callback_t> editmap_cb = draw_cb_container().create_or_get();
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
-    on_out_of_scope invalidate_current_ui( [current_ui]() {
-        current_ui->invalidate_ui();
+    on_out_of_scope invalidate_current_ui( [this]() {
+        do_ui_invalidation();
     } );
     restore_on_out_of_scope<std::string> info_txt_prev( info_txt_curr );
     restore_on_out_of_scope<std::string> info_title_prev( info_title_curr );
@@ -2048,7 +2092,7 @@ void editmap::edit_mapgen()
                                        ctxt.describe_key_and_name( "CONFIRM" ),
                                        ctxt.describe_key_and_name( "QUIT" ) );
         info_title_curr = pgettext( "map generator", "Mapgen stamp" );
-        current_ui->invalidate_ui();
+        do_ui_invalidation();
 
         gmenu.query();
 

--- a/src/editmap.h
+++ b/src/editmap.h
@@ -109,6 +109,14 @@ class editmap
         const int infoHeight = 20;
 
         point tmax;
+
+        void draw_main_ui_overlay();
+        void do_ui_invalidation();
+
+        // work around the limitation that you can't forward declare an inner class
+        class game_draw_callback_t_container;
+        std::unique_ptr<game_draw_callback_t_container> draw_cb_container_;
+        game_draw_callback_t_container &draw_cb_container();
 };
 
 #endif // CATA_SRC_EDITMAP_H

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -898,7 +898,7 @@ void faction_manager::display() const
                 popup( _( "%s returns from their mission" ), guy->disp_name() );
             } else {
                 if( tab == tab_mode::TAB_FOLLOWERS && guy && ( interactable || radio_interactable ) ) {
-                    guy->talk_to_u( false, radio_interactable );
+                    guy->talk_to_u( radio_interactable );
                 } else if( tab == tab_mode::TAB_MYFACTION && camp ) {
                     camp->query_new_name();
                 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2039,7 +2039,9 @@ void game::handle_key_blocking_activity()
 * @param iWidth width of the item info window (height = height of terminal)
 * @return getch
 */
-int game::inventory_item_menu( item_location locThisItem, int iStartX, int iWidth,
+int game::inventory_item_menu( item_location locThisItem,
+                               const std::function<int()> &iStartX,
+                               const std::function<int()> &iWidth,
                                const inventory_item_menu_positon position )
 {
     int cMenu = static_cast<int>( '+' );
@@ -2117,9 +2119,9 @@ int game::inventory_item_menu( item_location locThisItem, int iStartX, int iWidt
                 case RIGHT_TERMINAL_EDGE:
                     return 0;
                 case LEFT_OF_INFO:
-                    return iStartX - popup_width;
+                    return iStartX() - popup_width;
                 case RIGHT_OF_INFO:
-                    return iStartX + iWidth;
+                    return iStartX() + iWidth();
                 case LEFT_TERMINAL_EDGE:
                     return TERMX - popup_width;
             }
@@ -2137,7 +2139,7 @@ int game::inventory_item_menu( item_location locThisItem, int iStartX, int iWidt
 
         ui_adaptor ui;
         ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-            w_info = catacurses::newwin( TERMY, iWidth, point( iStartX, 0 ) );
+            w_info = catacurses::newwin( TERMY, iWidth(), point( iStartX(), 0 ) );
             iScrollHeight = TERMY - 2;
             ui.position_from_window( w_info );
         } );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2137,18 +2137,19 @@ int game::inventory_item_menu( item_location locThisItem,
         catacurses::window w_info;
         int iScrollHeight = 0;
 
-        ui_adaptor ui;
-        ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+        std::unique_ptr<ui_adaptor> ui = std::make_unique<ui_adaptor>();
+        ui->on_screen_resize( [&]( ui_adaptor & ui ) {
             w_info = catacurses::newwin( TERMY, iWidth(), point( iStartX(), 0 ) );
             iScrollHeight = TERMY - 2;
             ui.position_from_window( w_info );
         } );
-        ui.mark_resize();
+        ui->mark_resize();
 
-        ui.on_redraw( [&]( const ui_adaptor & ) {
+        ui->on_redraw( [&]( const ui_adaptor & ) {
             draw_item_info( w_info, data );
         } );
 
+        bool exit = false;
         do {
             const int prev_selected = action_menu.selected;
             action_menu.query( false );
@@ -2167,6 +2168,11 @@ int game::inventory_item_menu( item_location locThisItem,
                 action_menu.vshift = 0;
             } else {
                 cMenu = 0;
+            }
+
+            if( action_menu.ret != UILIST_WAIT_INPUT && action_menu.ret != UILIST_UNBOUND ) {
+                exit = true;
+                ui = nullptr;
             }
 
             switch( cMenu ) {
@@ -2220,11 +2226,15 @@ int game::inventory_item_menu( item_location locThisItem,
                     break;
                 case KEY_PPAGE:
                     iScrollPos -= iScrollHeight;
-                    ui.invalidate_ui();
+                    if( ui ) {
+                        ui->invalidate_ui();
+                    }
                     break;
                 case KEY_NPAGE:
                     iScrollPos += iScrollHeight;
-                    ui.invalidate_ui();
+                    if( ui ) {
+                        ui->invalidate_ui();
+                    }
                     break;
                 case '+':
                     if( !bHPR ) {
@@ -2243,7 +2253,7 @@ int game::inventory_item_menu( item_location locThisItem,
                 default:
                     break;
             }
-        } while( action_menu.ret == UILIST_WAIT_INPUT || action_menu.ret == UILIST_UNBOUND );
+        } while( !exit );
     }
     return cMenu;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2263,12 +2263,6 @@ int game::inventory_item_menu( item_location locThisItem,
 bool game::handle_mouseview( input_context &ctxt, std::string &action )
 {
     cata::optional<tripoint> liveview_pos;
-    auto &mgr = panel_manager::get_manager();
-    const bool sidebar_right = get_option<std::string>( "SIDEBAR_POSITION" ) == "right";
-    int width = sidebar_right ? mgr.get_width_right() : mgr.get_width_left();
-
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
 
     do {
         action = ctxt.handle_input();
@@ -2277,15 +2271,11 @@ bool game::handle_mouseview( input_context &ctxt, std::string &action )
             if( mouse_pos && ( !liveview_pos || *mouse_pos != *liveview_pos ) ) {
                 liveview_pos = mouse_pos;
                 liveview.show( *liveview_pos );
-                draw_panels( true );
-                const catacurses::window &w = catacurses::newwin( TERMY / 2, width,
-                                              point( sidebar_right ? TERMX - width : 0, 0 ) );
-                liveview.draw( w, TERMY / 2 );
             } else if( !mouse_pos ) {
                 liveview_pos.reset();
                 liveview.hide();
-                draw_panels( true );
             }
+            ui_manager::redraw();
         }
     } while( action == "MOUSE_MOVE" ); // Freeze animation when moving the mouse
 
@@ -6174,18 +6164,19 @@ void game::print_items_info( const tripoint &lp, const catacurses::window &w_loo
         }
 
         const int max_width = getmaxx( w_look ) - column - 1;
-        for( const auto &it : item_names ) {
-            if( line >= last_line - 2 ) {
+        for( auto it = item_names.begin(); it != item_names.end(); ++it ) {
+            // last line but not last item
+            if( line + 1 >= last_line && std::next( it ) != item_names.end() ) {
                 mvwprintz( w_look, point( column, ++line ), c_yellow, _( "More items here…" ) );
                 break;
             }
 
-            if( it.second > 1 ) {
+            if( it->second > 1 ) {
                 trim_and_print( w_look, point( column, ++line ), max_width, c_white,
                                 pgettext( "%s is the name of the item.  %d is the quantity of that item.", "%s [%d]" ),
-                                it.first.c_str(), it.second );
+                                it->first.c_str(), it->second );
             } else {
-                trim_and_print( w_look, point( column, ++line ), max_width, c_white, it.first );
+                trim_and_print( w_look, point( column, ++line ), max_width, c_white, it->first );
             }
         }
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3274,7 +3274,96 @@ void game::invalidate_main_ui_adaptor() const
     }
 }
 
+game::draw_callback_t::draw_callback_t( const std::function<void()> &cb )
+    : cb( cb )
+{
+}
+
+game::draw_callback_t::~draw_callback_t()
+{
+    if( added ) {
+        g->invalidate_main_ui_adaptor();
+    }
+}
+
+void game::draw_callback_t::operator()()
+{
+    if( cb ) {
+        cb();
+    }
+}
+
+void game::add_draw_callback( shared_ptr_fast<draw_callback_t> cb )
+{
+    draw_callbacks.erase(
+        std::remove_if( draw_callbacks.begin(), draw_callbacks.end(),
+    []( const weak_ptr_fast<draw_callback_t> &cbw ) {
+        return cbw.expired();
+    } ),
+    draw_callbacks.end()
+    );
+    draw_callbacks.emplace_back( cb );
+    cb->added = true;
+    invalidate_main_ui_adaptor();
+}
+
 static void draw_trail( const tripoint &start, const tripoint &end, bool bDrawX );
+
+static shared_ptr_fast<game::draw_callback_t> create_zone_callback(
+    const cata::optional<tripoint> &zone_start,
+    const cata::optional<tripoint> &zone_end,
+    const bool &zone_blink,
+    const bool &zone_cursor
+)
+{
+    return make_shared_fast<game::draw_callback_t>(
+    [&]() {
+        if( zone_cursor ) {
+            if( zone_end ) {
+                g->draw_cursor( zone_end.value() );
+            } else if( zone_start ) {
+                g->draw_cursor( zone_start.value() );
+            }
+        }
+        if( zone_blink && zone_start && zone_end ) {
+            const int offset_x = ( g->u.posx() + g->u.view_offset.x ) - getmaxx( g->w_terrain ) / 2;
+            const int offset_y = ( g->u.posy() + g->u.view_offset.y ) - getmaxy( g->w_terrain ) / 2;
+
+            tripoint offset;
+#if defined(TILES)
+            if( use_tiles ) {
+                offset = tripoint_zero; //TILES
+            } else {
+#endif
+                offset = tripoint( offset_x, offset_y, 0 ); //CURSES
+#if defined(TILES)
+            }
+#endif
+
+            const tripoint start( std::min( zone_start->x, zone_end->x ),
+                                  std::min( zone_start->y, zone_end->y ),
+                                  zone_end->z );
+            const tripoint end( std::max( zone_start->x, zone_end->x ),
+                                std::max( zone_start->y, zone_end->y ),
+                                zone_end->z );
+            g->draw_zones( start, end, offset );
+        }
+    } );
+}
+
+static shared_ptr_fast<game::draw_callback_t> create_trail_callback(
+    const cata::optional<tripoint> &trail_start,
+    const cata::optional<tripoint> &trail_end,
+    const bool &trail_end_x
+)
+{
+    return make_shared_fast<game::draw_callback_t>(
+    [&]() {
+        if( trail_start && trail_end ) {
+            draw_trail( trail_start.value(), trail_end.value(), trail_end_x );
+        }
+    } );
+}
 
 void game::draw()
 {
@@ -3289,42 +3378,15 @@ void game::draw()
 
     werase( w_terrain );
     draw_ter();
-
-    if( zone_cursor ) {
-        if( zone_end ) {
-            g->draw_cursor( zone_end.value() );
-        } else if( zone_start ) {
-            g->draw_cursor( zone_start.value() );
-        }
-    }
-    if( zone_blink && zone_start && zone_end ) {
-        const int offset_x = ( u.posx() + u.view_offset.x ) - getmaxx( w_terrain ) / 2;
-        const int offset_y = ( u.posy() + u.view_offset.y ) - getmaxy( w_terrain ) / 2;
-
-        tripoint offset;
-#if defined(TILES)
-        if( use_tiles ) {
-            offset = tripoint_zero; //TILES
+    for( auto it = draw_callbacks.begin(); it != draw_callbacks.end(); ) {
+        shared_ptr_fast<draw_callback_t> cb = it->lock();
+        if( cb ) {
+            ( *cb )();
+            ++it;
         } else {
-#endif
-            offset = tripoint( offset_x, offset_y, 0 ); //CURSES
-#if defined(TILES)
+            it = draw_callbacks.erase( it );
         }
-#endif
-
-        const tripoint start( std::min( zone_start->x, zone_end->x ),
-                              std::min( zone_start->y, zone_end->y ),
-                              zone_end->z );
-        const tripoint end( std::max( zone_start->x, zone_end->x ),
-                            std::max( zone_start->y, zone_end->y ),
-                            zone_end->z );
-        draw_zones( start, end, offset );
     }
-
-    if( trail_start && trail_end ) {
-        draw_trail( trail_start.value(), trail_end.value(), trail_end_x );
-    }
-
     wrefresh( w_terrain );
 
     draw_panels( true );
@@ -6328,6 +6390,14 @@ void game::zones_manager()
         wrefresh( w_zones_options );
     };
 
+    cata::optional<tripoint> zone_start;
+    cata::optional<tripoint> zone_end;
+    bool zone_blink = false;
+    bool zone_cursor = false;
+    shared_ptr_fast<draw_callback_t> zone_cb = create_zone_callback(
+                zone_start, zone_end, zone_blink, zone_cursor );
+    add_draw_callback( zone_cb );
+
     auto query_position =
     [&]() -> cata::optional<std::pair<tripoint, tripoint>> {
         on_out_of_scope invalidate_current_ui( [&]()
@@ -6335,7 +6405,11 @@ void game::zones_manager()
             ui.mark_resize();
         } );
         restore_on_out_of_scope<bool> show_prev( show );
+        restore_on_out_of_scope<cata::optional<tripoint>> zone_start_prev( zone_start );
+        restore_on_out_of_scope<cata::optional<tripoint>> zone_end_prev( zone_end );
         show = false;
+        zone_start = cata::nullopt;
+        zone_end = cata::nullopt;
         ui.mark_resize();
 
         static_popup popup;
@@ -6767,8 +6841,15 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
         } );
     }
 
+    cata::optional<tripoint> zone_start;
+    cata::optional<tripoint> zone_end;
+    bool zone_blink = false;
+    bool zone_cursor = true;
+    shared_ptr_fast<draw_callback_t> zone_cb = create_zone_callback( zone_start, zone_end, zone_blink,
+            zone_cursor );
+    add_draw_callback( zone_cb );
+
     is_looking = true;
-    zone_cursor = true;
     const tripoint prev_offset = u.view_offset;
     do {
         u.view_offset = center - u.pos();
@@ -7462,6 +7543,13 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
         }
     } );
 
+    cata::optional<tripoint> trail_start;
+    cata::optional<tripoint> trail_end;
+    bool trail_end_x = false;
+    shared_ptr_fast<draw_callback_t> trail_cb = create_trail_callback( trail_start, trail_end,
+            trail_end_x );
+    add_draw_callback( trail_cb );
+
     do {
         if( action == "COMPARE" && activeItem ) {
             game_menus::inv::compare( u, active_pos );
@@ -7914,6 +8002,13 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
             wrefresh( w_monster_info );
         }
     } );
+
+    cata::optional<tripoint> trail_start;
+    cata::optional<tripoint> trail_end;
+    bool trail_end_x;
+    shared_ptr_fast<draw_callback_t> trail_cb = create_trail_callback( trail_start, trail_end,
+            trail_end_x );
+    add_draw_callback( trail_cb );
 
     do {
         if( action == "UP" ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6674,6 +6674,9 @@ void game::zones_manager()
             ctxt.reset_timeout();
         }
 
+        // Actually accessed from the terrain overlay callback `zone_cb` in the
+        // call to `ui_manager::redraw`.
+        //NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
         zone_blink = blink;
         invalidate_main_ui_adaptor();
 
@@ -6684,9 +6687,7 @@ void game::zones_manager()
     } while( action != "QUIT" );
     zones_manager_open = false;
     ctxt.reset_timeout();
-    zone_start = zone_end = cata::nullopt;
-    zone_blink = false;
-    invalidate_main_ui_adaptor();
+    zone_cb = nullptr;
 
     if( stuff_changed ) {
         auto &zones = zone_manager::get_manager();
@@ -6864,10 +6865,16 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
                 zone_start = lp;
                 zone_end = cata::nullopt;
             }
+            // Actually accessed from the terrain overlay callback `zone_cb` in the
+            // call to `ui_manager::redraw`.
+            //NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
             zone_blink = blink;
         } else {
             zone_start = lp;
             zone_end = cata::nullopt;
+            // Actually accessed from the terrain overlay callback `zone_cb` in the
+            // call to `ui_manager::redraw`.
+            //NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
             zone_blink = false;
         }
         invalidate_main_ui_adaptor();
@@ -7013,11 +7020,8 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
 
     ctxt.reset_timeout();
     u.view_offset = prev_offset;
-    zone_start = zone_end = cata::nullopt;
-    zone_blink = false;
-    zone_cursor = false;
+    zone_cb = nullptr;
     is_looking = false;
-    invalidate_main_ui_adaptor();
 
     reenter_fullscreen();
     bVMonsterLookFire = true;
@@ -7723,8 +7727,6 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             iScrollPos++;
         } else if( action == "NEXT_TAB" || action == "PREV_TAB" ) {
             u.view_offset = stored_view_offset;
-            trail_start = trail_end = cata::nullopt;
-            invalidate_main_ui_adaptor();
             return game::vmenu_ret::CHANGE_TAB;
         }
 
@@ -7748,6 +7750,9 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             centerlistview( active_pos, width );
             trail_start = u.pos();
             trail_end = u.pos() + active_pos;
+            // Actually accessed from the terrain overlay callback `trail_cb` in the
+            // call to `ui_manager::redraw`.
+            //NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
             trail_end_x = true;
         } else {
             u.view_offset = stored_view_offset;
@@ -7761,8 +7766,6 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
     } while( action != "QUIT" );
 
     u.view_offset = stored_view_offset;
-    trail_start = trail_end = cata::nullopt;
-    invalidate_main_ui_adaptor();
     return game::vmenu_ret::QUIT;
 }
 
@@ -8030,8 +8033,6 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
             }
         } else if( action == "NEXT_TAB" || action == "PREV_TAB" ) {
             u.view_offset = stored_view_offset;
-            trail_start = trail_end = cata::nullopt;
-            invalidate_main_ui_adaptor();
             return game::vmenu_ret::CHANGE_TAB;
         } else if( action == "SAFEMODE_BLACKLIST_REMOVE" ) {
             const auto m = dynamic_cast<monster *>( cCurMon );
@@ -8058,8 +8059,6 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
             if( cCurMon != nullptr && rl_dist( u.pos(), cCurMon->pos() ) <= max_gun_range ) {
                 u.last_target = shared_from( *cCurMon );
                 u.view_offset = stored_view_offset;
-                trail_start = trail_end = cata::nullopt;
-                invalidate_main_ui_adaptor();
                 return game::vmenu_ret::FIRE;
             }
         }
@@ -8070,6 +8069,9 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
             centerlistview( iActivePos, width );
             trail_start = u.pos();
             trail_end = cCurMon->pos();
+            // Actually accessed from the terrain overlay callback `trail_cb` in the
+            // call to `ui_manager::redraw`.
+            //NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
             trail_end_x = false;
         } else {
             cCurMon = nullptr;
@@ -8085,8 +8087,6 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
     } while( action != "QUIT" );
 
     u.view_offset = stored_view_offset;
-    trail_start = trail_end = cata::nullopt;
-    invalidate_main_ui_adaptor();
 
     return game::vmenu_ret::QUIT;
 }

--- a/src/game.h
+++ b/src/game.h
@@ -601,8 +601,14 @@ class game
             RIGHT_OF_INFO,
             LEFT_TERMINAL_EDGE,
         };
-        int inventory_item_menu( item_location locThisItem, int startx = 0, int width = 50,
-                                 inventory_item_menu_positon position = RIGHT_OF_INFO );
+        int inventory_item_menu( item_location locThisItem,
+        const std::function<int()> &startx = []() {
+            return 0;
+        },
+        const std::function<int()> &width = []() {
+            return 50;
+        },
+        inventory_item_menu_positon position = RIGHT_OF_INFO );
 
         /** Custom-filtered menu for inventory and nearby items and those that within specified radius */
         item_location inv_map_splice( item_filter filter, const std::string &title, int radius = 0,

--- a/src/game.h
+++ b/src/game.h
@@ -229,15 +229,29 @@ class game
         void draw();
         void draw_ter( bool draw_sounds = true );
         void draw_ter( const tripoint &center, bool looking = false, bool draw_sounds = true );
+
+        class draw_callback_t
+        {
+            public:
+                draw_callback_t( const std::function<void()> &cb );
+                ~draw_callback_t();
+                void operator()();
+                friend class game;
+            private:
+                std::function<void()> cb;
+                bool added = false;
+        };
+        /* Add callback that would be called in `game::draw`. This can be used to
+         * implement map overlays in game menus. If parameters of the callback changes
+         * during its lifetime, `invaliate_main_ui_adaptor` has to be called for
+         * the changes to take effect immediately on the next call to `ui_manager::redraw`.
+         * Otherwise the callback may not take effect until the main ui is invalidated
+         * due to resizing or other menus closing. The callback is disabled once all
+         * shared pointers to the callback are deconstructed, and is removed afterwards. */
+        void add_draw_callback( shared_ptr_fast<draw_callback_t> cb );
     private:
-        cata::optional<tripoint> zone_start;
-        cata::optional<tripoint> zone_end;
-        bool zone_blink = false;
-        bool zone_cursor = false;
         bool is_looking = false;
-        cata::optional<tripoint> trail_start;
-        cata::optional<tripoint> trail_end;
-        bool trail_end_x = false;
+        std::vector<weak_ptr_fast<draw_callback_t>> draw_callbacks;
 
     public:
         // when force_redraw is true, redraw all panel instead of just animated panels

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -869,7 +869,19 @@ void defense_game::caravan()
 
     signed total_price = 0;
 
-    catacurses::window w = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH, point_zero );
+    background_pane bg_pane;
+
+    catacurses::window w;
+    ui_adaptor ui;
+    ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+        const int width = FULL_SCREEN_WIDTH;
+        const int height = FULL_SCREEN_HEIGHT;
+        const int offsetx = std::max( 0, TERMX - FULL_SCREEN_WIDTH ) / 2;
+        const int offsety = std::max( 0, TERMY - FULL_SCREEN_HEIGHT ) / 2;
+        w = catacurses::newwin( height, width, point( offsetx, offsety ) );
+        ui.position_from_window( w );
+    } );
+    ui.mark_resize();
 
     int offset = 0;
     int item_selected = 0;
@@ -877,8 +889,12 @@ void defense_game::caravan()
 
     int current_window = 0;
 
-    draw_caravan_borders( w, current_window );
-    draw_caravan_categories( w, category_selected, total_price, g->u.cash );
+    ui.on_redraw( [&]( const ui_adaptor & ) {
+        draw_caravan_categories( w, category_selected, total_price, g->u.cash );
+        draw_caravan_items( w, &( items[category_selected] ),
+                            &( item_count[category_selected] ), offset, item_selected );
+        draw_caravan_borders( w, current_window );
+    } );
 
     input_context ctxt( "CARAVAN" );
     ctxt.register_cardinal();
@@ -888,12 +904,10 @@ void defense_game::caravan()
     ctxt.register_action( "HELP" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
-
     bool done = false;
     bool cancel = false;
     while( !done ) {
+        ui_manager::redraw();
         const std::string action = ctxt.handle_input();
         if( action == "HELP" ) {
             popup_top( _( "CARAVAN:\n"
@@ -905,23 +919,14 @@ void defense_game::caravan()
                        ctxt.get_desc( "CONFIRM" ),
                        ctxt.get_desc( "QUIT" )
                      );
-            draw_caravan_categories( w, category_selected, total_price, g->u.cash );
-            draw_caravan_items( w, &( items[category_selected] ),
-                                &( item_count[category_selected] ), offset, item_selected );
-            draw_caravan_borders( w, current_window );
         } else if( action == "DOWN" ) {
             if( current_window == 0 ) { // Categories
                 category_selected++;
                 if( category_selected == NUM_CARAVAN_CATEGORIES ) {
                     category_selected = CARAVAN_CART;
                 }
-                draw_caravan_categories( w, category_selected, total_price, g->u.cash );
                 offset = 0;
                 item_selected = 0;
-                draw_caravan_items( w, &( items[category_selected] ),
-                                    &( item_count[category_selected] ), offset,
-                                    item_selected );
-                draw_caravan_borders( w, current_window );
             } else if( !items[category_selected].empty() ) { // Items
                 if( item_selected < static_cast<int>( items[category_selected].size() ) - 1 ) {
                     item_selected++;
@@ -932,10 +937,6 @@ void defense_game::caravan()
                 if( item_selected > offset + 12 ) {
                     offset++;
                 }
-                draw_caravan_items( w, &( items[category_selected] ),
-                                    &( item_count[category_selected] ), offset,
-                                    item_selected );
-                draw_caravan_borders( w, current_window );
             }
         } else if( action == "UP" ) {
             if( current_window == 0 ) { // Categories
@@ -947,13 +948,8 @@ void defense_game::caravan()
                 if( category_selected == NUM_CARAVAN_CATEGORIES ) {
                     category_selected = CARAVAN_CART;
                 }
-                draw_caravan_categories( w, category_selected, total_price, g->u.cash );
                 offset = 0;
                 item_selected = 0;
-                draw_caravan_items( w, &( items[category_selected] ),
-                                    &( item_count[category_selected] ), offset,
-                                    item_selected );
-                draw_caravan_borders( w, current_window );
             } else if( !items[category_selected].empty() ) { // Items
                 if( item_selected > 0 ) {
                     item_selected--;
@@ -967,10 +963,6 @@ void defense_game::caravan()
                 if( item_selected < offset ) {
                     offset--;
                 }
-                draw_caravan_items( w, &( items[category_selected] ),
-                                    &( item_count[category_selected] ), offset,
-                                    item_selected );
-                draw_caravan_borders( w, current_window );
             }
         } else if( action == "RIGHT" ) {
             if( current_window == 1 && !items[category_selected].empty() ) {
@@ -998,10 +990,6 @@ void defense_game::caravan()
                         item_count[0].push_back( 1 );
                     }
                 }
-                draw_caravan_categories( w, category_selected, total_price, g->u.cash );
-                draw_caravan_items( w, &( items[category_selected] ),
-                                    &( item_count[category_selected] ), offset, item_selected );
-                draw_caravan_borders( w, current_window );
             }
         } else if( action == "LEFT" ) {
             if( current_window == 1 && !items[category_selected].empty() &&
@@ -1030,23 +1018,13 @@ void defense_game::caravan()
                         }
                     }
                 }
-                draw_caravan_categories( w, category_selected, total_price, g->u.cash );
-                draw_caravan_items( w, &( items[category_selected] ),
-                                    &( item_count[category_selected] ), offset, item_selected );
-                draw_caravan_borders( w, current_window );
             }
         } else if( action == "NEXT_TAB" ) {
             current_window = ( current_window + 1 ) % 2;
-            draw_caravan_borders( w, current_window );
         } else if( action == "QUIT" ) {
             if( query_yn( _( "Really buy nothing?" ) ) ) {
                 cancel = true;
                 done = true;
-            } else {
-                draw_caravan_categories( w, category_selected, total_price, g->u.cash );
-                draw_caravan_items( w, &( items[category_selected] ),
-                                    &( item_count[category_selected] ), offset, item_selected );
-                draw_caravan_borders( w, current_window );
             }
         } else if( action == "CONFIRM" ) {
             if( total_price > g->u.cash ) {
@@ -1059,12 +1037,6 @@ void defense_game::caravan()
                                    items[0].size(),
                                    format_money( static_cast<int>( g->u.cash ) - static_cast<int>( total_price ) ) ) ) ) {
                 done = true;
-            }
-            if( !done ) { // We canceled, so redraw everything
-                draw_caravan_categories( w, category_selected, total_price, g->u.cash );
-                draw_caravan_items( w, &( items[category_selected] ),
-                                    &( item_count[category_selected] ), offset, item_selected );
-                draw_caravan_borders( w, current_window );
             }
         } // "switch" on (action)
 

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -459,12 +459,25 @@ void defense_game::init_to_style( defense_style new_style )
 
 void defense_game::setup()
 {
-    catacurses::window w = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                           point( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                                  TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 ) );
+    background_pane bg_pane;
+
+    catacurses::window w;
+
+    ui_adaptor ui;
+    ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+        w = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
+                                point( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                                       TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 ) );
+        ui.position_from_window( w );
+    } );
+    ui.mark_resize();
+
     int selection = 1;
     int selection_max = 20;
-    refresh_setup( w, selection );
+
+    ui.on_redraw( [&]( const ui_adaptor & ) {
+        refresh_setup( w, selection );
+    } );
 
     input_context ctxt( "DEFENSE_SETUP" );
     ctxt.register_action( "UP", to_translation( "Previous option" ) );
@@ -477,16 +490,13 @@ void defense_game::setup()
     ctxt.register_action( "START" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
-
     while( true ) {
+        ui_manager::redraw();
         const std::string action = ctxt.handle_input();
 
         if( action == "START" ) {
             if( !zombies && !specials && !spiders && !triffids && !robots && !subspace ) {
                 popup( _( "You must choose at least one monster group!" ) );
-                refresh_setup( w, selection );
             } else {
                 return;
             }
@@ -496,14 +506,12 @@ void defense_game::setup()
             } else {
                 selection++;
             }
-            refresh_setup( w, selection );
         } else if( action == "UP" ) {
             if( selection == 1 ) {
                 selection = selection_max;
             } else {
                 selection--;
             }
-            refresh_setup( w, selection );
         } else {
             switch( selection ) {
                 case 1:
@@ -541,10 +549,6 @@ void defense_game::setup()
                             location = static_cast<defense_location>( location - 1 );
                         }
                     }
-                    mvwprintz( w, point( 2, 5 ), c_black,
-                               " xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" );
-                    mvwprintz( w, point( 2, 5 ), c_yellow, defense_location_name( location ) );
-                    mvwprintz( w, point( 28, 5 ), c_light_gray, defense_location_description( location ) );
                     break;
 
                 case 3:
@@ -555,9 +559,6 @@ void defense_game::setup()
                     if( action == "RIGHT" && initial_difficulty < 995 ) {
                         initial_difficulty += 5;
                     }
-                    mvwprintz( w, point( 22, 7 ), c_black, "xxx" );
-                    mvwprintz( w, point( NUMALIGN( initial_difficulty ), 7 ), c_yellow, "%d",
-                               initial_difficulty );
                     break;
 
                 case 4:
@@ -568,9 +569,6 @@ void defense_game::setup()
                     if( action == "RIGHT" && wave_difficulty < 995 ) {
                         wave_difficulty += 5;
                     }
-                    mvwprintz( w, point( 22, 8 ), c_black, "xxx" );
-                    mvwprintz( w, point( NUMALIGN( wave_difficulty ), 8 ), c_yellow, "%d",
-                               wave_difficulty );
                     break;
 
                 case 5:
@@ -580,9 +578,6 @@ void defense_game::setup()
                     if( action == "RIGHT" && time_between_waves < 995_minutes ) {
                         time_between_waves += 5_minutes;
                     }
-                    mvwprintz( w, point( 22, 10 ), c_black, "xxx" );
-                    mvwprintz( w, point( NUMALIGN( to_minutes<int>( time_between_waves ) ), 10 ),
-                               c_yellow, "%d", to_minutes<int>( time_between_waves ) );
                     break;
 
                 case 6:
@@ -592,9 +587,6 @@ void defense_game::setup()
                     if( action == "RIGHT" && waves_between_caravans < 50 ) {
                         waves_between_caravans += 1;
                     }
-                    mvwprintz( w, point( 22, 11 ), c_black, "xxx" );
-                    mvwprintz( w, point( NUMALIGN( waves_between_caravans ), 11 ), c_yellow, "%d",
-                               waves_between_caravans );
                     break;
 
                 case 7:
@@ -604,9 +596,6 @@ void defense_game::setup()
                     if( action == "RIGHT" && initial_cash < 1000000 ) {
                         initial_cash += 100;
                     }
-                    mvwprintz( w, point( 20, 13 ), c_black, "xxxxx" );
-                    mvwprintz( w, point( NUMALIGN( initial_cash ), 13 ), c_yellow, "%d",
-                               initial_cash / 100 );
                     break;
 
                 case 8:
@@ -616,9 +605,6 @@ void defense_game::setup()
                     if( action == "RIGHT" && cash_per_wave < 1000000 ) {
                         cash_per_wave += 100;
                     }
-                    mvwprintz( w, point( 21, 14 ), c_black, "xxxx" );
-                    mvwprintz( w, point( NUMALIGN( cash_per_wave ), 14 ), c_yellow, "%d",
-                               cash_per_wave / 100 );
                     break;
 
                 case 9:
@@ -628,9 +614,6 @@ void defense_game::setup()
                     if( action == "RIGHT" && cash_increase < 1000000 ) {
                         cash_increase += 50;
                     }
-                    mvwprintz( w, point( 21, 15 ), c_black, "xxxx" );
-                    mvwprintz( w, point( NUMALIGN( cash_increase ), 15 ), c_yellow, "%d",
-                               cash_increase / 100 );
                     break;
 
                 case 10:
@@ -647,75 +630,63 @@ void defense_game::setup()
                         specials = !specials;
                         zombies = false;
                     }
-                    mvwprintz( w, point( 2, 18 ), c_yellow, _( "Zombies" ) );
-                    mvwprintz( w, point( 14, 18 ), ( specials ? c_light_green : c_yellow ), _( "Special Zombies" ) );
                     break;
 
                 case 12:
                     if( action == "CONFIRM" ) {
                         spiders = !spiders;
                     }
-                    mvwprintz( w, point( 34, 18 ), ( spiders ? c_light_green : c_yellow ), _( "Spiders" ) );
                     break;
 
                 case 13:
                     if( action == "CONFIRM" ) {
                         triffids = !triffids;
                     }
-                    mvwprintz( w, point( 46, 18 ), ( triffids ? c_light_green : c_yellow ), _( "Triffids" ) );
                     break;
 
                 case 14:
                     if( action == "CONFIRM" ) {
                         robots = !robots;
                     }
-                    mvwprintz( w, point( 59, 18 ), ( robots ? c_light_green : c_yellow ), _( "Robots" ) );
                     break;
 
                 case 15:
                     if( action == "CONFIRM" ) {
                         subspace = !subspace;
                     }
-                    mvwprintz( w, point( 70, 18 ), ( subspace ? c_light_green : c_yellow ), _( "Subspace" ) );
                     break;
 
                 case 16:
                     if( action == "CONFIRM" ) {
                         hunger = !hunger;
                     }
-                    mvwprintz( w, point( 2, 21 ), ( hunger ? c_light_green : c_yellow ), _( "Food" ) );
                     break;
 
                 case 17:
                     if( action == "CONFIRM" ) {
                         thirst = !thirst;
                     }
-                    mvwprintz( w, point( 14, 21 ), ( thirst ? c_light_green : c_yellow ), _( "Water" ) );
                     break;
 
                 case 18:
                     if( action == "CONFIRM" ) {
                         sleep = !sleep;
                     }
-                    mvwprintz( w, point( 34, 21 ), ( sleep ? c_light_green : c_yellow ), _( "Sleep" ) );
                     break;
 
                 case 19:
                     if( action == "CONFIRM" ) {
                         mercenaries = !mercenaries;
                     }
-                    mvwprintz( w, point( 46, 21 ), ( mercenaries ? c_light_green : c_yellow ), _( "Mercenaries" ) );
                     break;
 
                 case 20:
                     if( action == "CONFIRM" ) {
                         allow_save = !allow_save;
                     }
-                    mvwprintz( w, point( 59, 21 ), ( allow_save ? c_light_green : c_yellow ), _( "Allow save" ) );
                     break;
             }
         }
-        refresh_setup( w, selection );
     }
 }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1028,7 +1028,7 @@ void iexamine::intercom( player &p, const tripoint &examp )
     if( intercom_npcs.empty() ) {
         p.add_msg_if_player( m_info, _( "No one responds." ) );
     } else {
-        intercom_npcs.front()->talk_to_u( false, false );
+        intercom_npcs.front()->talk_to_u( false );
     }
 }
 

--- a/src/iuse_software.cpp
+++ b/src/iuse_software.cpp
@@ -24,13 +24,7 @@ bool play_videogame( const std::string &function_name,
         return true; // generic game
     }
     if( function_name == "robot_finds_kitten" ) {
-        catacurses::window bkatwin = catacurses::newwin( 22, 62, point( ( TERMX - 62 ) / 2,
-                                     ( TERMY - 22 ) / 2 ) );
-        draw_border( bkatwin );
-        wrefresh( bkatwin );
-        catacurses::window katwin = catacurses::newwin( 20, 60, point( ( TERMX - 60 ) / 2,
-                                    ( TERMY - 20 ) / 2 ) );
-        robot_finds_kitten findkitten( katwin );
+        robot_finds_kitten findkitten;
         bool foundkitten = findkitten.ret;
         if( foundkitten ) {
             game_data["end_message"] = _( "You found kitten!" );

--- a/src/iuse_software_kitten.h
+++ b/src/iuse_software_kitten.h
@@ -5,12 +5,10 @@
 #include <string>
 
 #include "color.h"
+#include "cursesdef.h"
 #include "point.h"
 
-namespace catacurses
-{
-class window;
-} // namespace catacurses
+class ui_adaptor;
 
 struct kobject {
     point pos;
@@ -24,21 +22,40 @@ class robot_finds_kitten
 {
     public:
         bool ret;
-        std::string getmessage( int idx );
-        robot_finds_kitten( const catacurses::window &w );
-        void instructions( const catacurses::window &w );
-        void draw_robot( const catacurses::window &w );
-        void draw_kitten( const catacurses::window &w );
-        void process_input( int input, const catacurses::window &w );
+        robot_finds_kitten();
+    private:
+        std::string getmessage( int idx ) const;
+        void draw_robot() const;
+        void draw_kitten() const;
+        void show() const;
+        void process_input();
+        catacurses::window bkatwin;
+        catacurses::window w;
         kobject robot;
         kobject kitten;
         kobject empty;
+        static constexpr int numbogus = 20;
         kobject bogus[MAXMESSAGES];
         static constexpr int rfkLINES = 20;
         static constexpr int rfkCOLS = 60;
         int rfkscreen[rfkCOLS][rfkLINES];
         int nummessages;
         int bogus_messages[MAXMESSAGES];
+
+        enum class ui_state {
+            instructions,
+            main,
+            invalid_input,
+            bogus_message,
+            end_animation,
+            exit,
+        };
+        ui_state current_ui_state = ui_state::instructions;
+
+        int bogus_message_idx = 0;
+        int end_animation_frame = 0;
+        static constexpr int num_end_animation_frames = 6;
+        bool end_animation_last_input_left_or_up = false;
 };
 
 #endif // CATA_SRC_IUSE_SOFTWARE_KITTEN_H

--- a/src/iuse_software_lightson.cpp
+++ b/src/iuse_software_lightson.cpp
@@ -43,9 +43,6 @@ void lightson_game::reset_level()
     } );
 
     position = point_zero;
-
-    werase( w );
-    draw_border( w );
 }
 
 bool lightson_game::get_value_at( const point &pt )
@@ -65,6 +62,8 @@ void lightson_game::toggle_value_at( const point &pt )
 
 void lightson_game::draw_level()
 {
+    werase( w );
+    draw_border( w );
     for( int i = 0; i < level_size.y; i++ ) {
         for( int j = 0; j < level_size.x; j++ ) {
             point current = point( j, i );
@@ -131,11 +130,16 @@ void lightson_game::toggle_lights_at( const point &pt )
 int lightson_game::start_game()
 {
     const int w_height = 15;
-    const int iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-    const int iOffsetY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
-    w_border = catacurses::newwin( w_height, FULL_SCREEN_WIDTH, point( iOffsetX, iOffsetY ) );
-    w = catacurses::newwin( w_height - 6, FULL_SCREEN_WIDTH - 2, point( iOffsetX + 1, iOffsetY + 1 ) );
-    draw_border( w_border );
+
+    ui_adaptor ui;
+    ui.on_screen_resize( [this]( ui_adaptor & ui ) {
+        const int iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
+        const int iOffsetY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
+        w_border = catacurses::newwin( w_height, FULL_SCREEN_WIDTH, point( iOffsetX, iOffsetY ) );
+        w = catacurses::newwin( w_height - 6, FULL_SCREEN_WIDTH - 2, point( iOffsetX + 1, iOffsetY + 1 ) );
+        ui.position_from_window( w_border );
+    } );
+    ui.mark_resize();
 
     input_context ctxt( "LIGHTSON" );
     ctxt.register_directions();
@@ -143,45 +147,49 @@ int lightson_game::start_game()
     ctxt.register_action( "TOGGLE_5" );
     ctxt.register_action( "RESET" );
     ctxt.register_action( "QUIT" );
+    ctxt.register_action( "HELP_KEYBINDINGS" );
 
-    std::vector<std::string> shortcuts;
-    shortcuts.push_back( _( "<spacebar or 5> toggle lights" ) );
-    shortcuts.push_back( _( "<r>eset" ) );
-    shortcuts.push_back( _( "<q>uit" ) );
+    ui.on_redraw( [this]( const ui_adaptor & ) {
+        std::vector<std::string> shortcuts;
+        shortcuts.push_back( _( "<spacebar or 5> toggle lights" ) );
+        shortcuts.push_back( _( "<r>eset" ) );
+        shortcuts.push_back( _( "<q>uit" ) );
 
-    int iWidth = 0;
-    for( auto &shortcut : shortcuts ) {
-        if( iWidth > 0 ) {
-            iWidth += 1;
+        int iWidth = 0;
+        for( auto &shortcut : shortcuts ) {
+            if( iWidth > 0 ) {
+                iWidth += 1;
+            }
+            iWidth += utf8_width( shortcut );
         }
-        iWidth += utf8_width( shortcut );
-    }
 
-    int iPos = FULL_SCREEN_WIDTH - iWidth - 1;
-    for( auto &shortcut : shortcuts ) {
-        shortcut_print( w_border, point( iPos, 0 ), c_white, c_light_green, shortcut );
-        iPos += utf8_width( shortcut ) + 1;
-    }
+        werase( w_border );
+        draw_border( w_border );
+        int iPos = FULL_SCREEN_WIDTH - iWidth - 1;
+        for( auto &shortcut : shortcuts ) {
+            shortcut_print( w_border, point( iPos, 0 ), c_white, c_light_green, shortcut );
+            iPos += utf8_width( shortcut ) + 1;
+        }
 
-    mvwputch( w_border, point( 2, 0 ), hilite( c_white ), _( "Lights on!" ) );
-    fold_and_print( w_border, point( 2, w_height - 5 ), FULL_SCREEN_WIDTH - 4, c_light_gray,
-                    "%s\n%s\n%s", _( "<color_white>Game goal:</color> Switch all the lights on." ),
-                    _( "<color_white>Legend: #</color> on, <color_dark_gray>-</color> off." ),
-                    _( "Toggle lights switches selected light and 4 its neighbors." ) );
+        mvwputch( w_border, point( 2, 0 ), hilite( c_white ), _( "Lights on!" ) );
+        fold_and_print( w_border, point( 2, w_height - 5 ), FULL_SCREEN_WIDTH - 4, c_light_gray,
+                        "%s\n%s\n%s", _( "<color_white>Game goal:</color> Switch all the lights on." ),
+                        _( "<color_white>Legend: #</color> on, <color_dark_gray>-</color> off." ),
+                        _( "Toggle lights switches selected light and 4 its neighbors." ) );
 
-    wrefresh( w_border );
+        wrefresh( w_border );
+
+        draw_level();
+    } );
 
     win = true;
     int hasWon = 0;
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
-
     do {
         if( win ) {
             new_level();
-            draw_level();
         }
+        ui_manager::redraw();
         std::string action = ctxt.handle_input();
         if( const cata::optional<tripoint> vec = ctxt.get_direction( action ) ) {
             position.y = clamp( position.y + vec->y, 0, level_size.y - 1 );
@@ -190,7 +198,7 @@ int lightson_game::start_game()
             toggle_lights();
             win = check_win();
             if( win ) {
-                draw_level();
+                ui.invalidate_ui();
                 popup_top( _( "Congratulations, you won!" ) );
                 hasWon++;
             }
@@ -199,7 +207,6 @@ int lightson_game::start_game()
         } else if( action == "QUIT" ) {
             break;
         }
-        draw_level();
     } while( true );
 
     return hasWon;

--- a/src/iuse_software_lightson.cpp
+++ b/src/iuse_software_lightson.cpp
@@ -132,7 +132,7 @@ int lightson_game::start_game()
     const int w_height = 15;
 
     ui_adaptor ui;
-    ui.on_screen_resize( [this]( ui_adaptor & ui ) {
+    ui.on_screen_resize( [&]( ui_adaptor & ui ) {
         const int iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
         const int iOffsetY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
         w_border = catacurses::newwin( w_height, FULL_SCREEN_WIDTH, point( iOffsetX, iOffsetY ) );
@@ -149,7 +149,7 @@ int lightson_game::start_game()
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
 
-    ui.on_redraw( [this]( const ui_adaptor & ) {
+    ui.on_redraw( [&]( const ui_adaptor & ) {
         std::vector<std::string> shortcuts;
         shortcuts.push_back( _( "<spacebar or 5> toggle lights" ) );
         shortcuts.push_back( _( "<r>eset" ) );

--- a/src/iuse_software_minesweeper.h
+++ b/src/iuse_software_minesweeper.h
@@ -15,7 +15,7 @@ class minesweeper_game
 {
     private:
         bool check_win();
-        void new_level( const catacurses::window &w_minesweeper );
+        void new_level();
         point max;
         point min;
         point level;
@@ -23,9 +23,9 @@ class minesweeper_game
         int iBombs = 0;
 
         std::map<int, std::map<int, int> > mLevel;
+        static constexpr int bomb = -1;
 
         enum reveal {
-            bomb = -1,
             unknown,
             flag,
             seen

--- a/src/iuse_software_sokoban.h
+++ b/src/iuse_software_sokoban.h
@@ -51,7 +51,6 @@ class sokoban_game
         bool check_win();
         int get_wall_connection( const point & );
         void draw_level( const catacurses::window &w_sokoban );
-        void clear_level( const catacurses::window &w_sokoban );
         void print_score( const catacurses::window &w_sokoban, int iScore, int iMoves );
     public:
         int start_game();

--- a/src/live_view.cpp
+++ b/src/live_view.cpp
@@ -8,8 +8,11 @@
 #include "cursesport.h"
 #include "game.h"
 #include "map.h"
+#include "options.h"
 #include "output.h"
+#include "panels.h"
 #include "translations.h"
+#include "ui_manager.h"
 
 namespace
 {
@@ -19,61 +22,57 @@ constexpr int MIN_BOX_HEIGHT = 3;
 
 } //namespace
 
+live_view::live_view() = default;
+live_view::~live_view() = default;
+
 void live_view::init()
 {
     hide();
 }
 
-int live_view::draw( const catacurses::window &win, const int max_height )
-{
-    if( !enabled ) {
-        return 0;
-    }
-
-    // -1 for border. -1 because getmaxy() actually returns height, not y position.
-    const int line_limit = max_height - 2;
-    const visibility_variables &cache = g->m.get_visibility_variables_cache();
-    int line_out = START_LINE;
-    g->pre_print_all_tile_info( mouse_position, win, line_out, line_limit, cache );
-
-    const int live_view_box_height = std::min( max_height, std::max( line_out + 2, MIN_BOX_HEIGHT ) );
-
-#if defined(TILES) || defined(_WIN32)
-    // HACK: Because of the way the status UI is done, the live view window must
-    // be tall enough to clear the entire height of the viewport below the
-    // status bar. This hack allows the border around the live view box to
-    // be drawn only as big as it needs to be, while still leaving the
-    // window tall enough. Won't work for ncurses in Linux, but that doesn't
-    // currently support the mouse. If and when it does, there will need to
-    // be a different code path here that works for ncurses.
-    const int original_height = win.get<cata_cursesport::WINDOW>()->height;
-    win.get<cata_cursesport::WINDOW>()->height = live_view_box_height;
-    g->draw_panels();
-#endif
-
-    draw_border( win );
-    center_print( win, 0, c_white, _( "< <color_green>Mouse View</color> >" ) );
-    wrefresh( win );
-
-#if defined(TILES) || defined(_WIN32)
-    win.get<cata_cursesport::WINDOW>()->height = original_height;
-#endif
-
-    return live_view_box_height;
-}
-
 void live_view::hide()
 {
-    enabled = false;
+    ui = nullptr;
 }
 
 void live_view::show( const tripoint &p )
 {
-    enabled = true;
     mouse_position = p;
+    if( !ui ) {
+        ui = std::make_unique<ui_adaptor>();
+        ui->on_screen_resize( [this]( ui_adaptor & ui ) {
+            auto &mgr = panel_manager::get_manager();
+            const bool sidebar_right = get_option<std::string>( "SIDEBAR_POSITION" ) == "right";
+            const int width = sidebar_right ? mgr.get_width_right() : mgr.get_width_left();
+
+            const int max_height = TERMY / 2;
+            const int line_limit = max_height - 2;
+            const visibility_variables &cache = g->m.get_visibility_variables_cache();
+            int line_out = START_LINE;
+            // HACK: using dummy window to get the window height without refreshing.
+            win = catacurses::newwin( 1, width, point_zero );
+            g->pre_print_all_tile_info( mouse_position, win, line_out, line_limit, cache );
+            const int live_view_box_height = std::min( max_height, std::max( line_out + 2, MIN_BOX_HEIGHT ) );
+
+            win = catacurses::newwin( live_view_box_height, width,
+                                      point( sidebar_right ? TERMX - width : 0, 0 ) );
+            ui.position_from_window( win );
+        } );
+        ui->on_redraw( [this]( const ui_adaptor & ) {
+            werase( win );
+            const visibility_variables &cache = g->m.get_visibility_variables_cache();
+            int line_out = START_LINE;
+            g->pre_print_all_tile_info( mouse_position, win, line_out, getmaxy( win ) - 2, cache );
+            draw_border( win );
+            center_print( win, 0, c_white, _( "< <color_green>Mouse View</color> >" ) );
+            wrefresh( win );
+        } );
+    }
+    // Always mark ui for resize as the required box height may have changed.
+    ui->mark_resize();
 }
 
 bool live_view::is_enabled()
 {
-    return enabled;
+    return ui != nullptr;
 }

--- a/src/live_view.h
+++ b/src/live_view.h
@@ -2,20 +2,20 @@
 #ifndef CATA_SRC_LIVE_VIEW_H
 #define CATA_SRC_LIVE_VIEW_H
 
+#include <memory>
+
+#include "cursesdef.h"
 #include "point.h"
 
-namespace catacurses
-{
-class window;
-} // namespace catacurses
+class ui_adaptor;
 
 class live_view
 {
     public:
-        live_view() = default;
+        live_view();
+        ~live_view();
 
         void init();
-        int draw( const catacurses::window &win, int max_height );
         void show( const tripoint &p );
         bool is_enabled();
         void hide();
@@ -23,7 +23,8 @@ class live_view
     private:
         tripoint mouse_position;
 
-        bool enabled = false;
+        catacurses::window win;
+        std::unique_ptr<ui_adaptor> ui;
 };
 
 #endif // CATA_SRC_LIVE_VIEW_H

--- a/src/npc.h
+++ b/src/npc.h
@@ -926,7 +926,7 @@ class npc : public player
         int follow_distance() const;
 
         // Dialogue and bartering--see npctalk.cpp
-        void talk_to_u( bool text_only = false, bool radio_contact = false );
+        void talk_to_u( bool radio_contact = false );
         // Re-roll the inventory of a shopkeeper
         void shop_restock();
         // Use and assessment of items

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -865,8 +865,7 @@ void npc::talk_to_u( bool text_only, bool radio_contact )
                 chatbin.mission_selected = d.missions_assigned.front();
             }
         }
-        d_win.print_header( name );
-        const talk_topic next = d.opt( d_win, d.topic_stack.back() );
+        const talk_topic next = d.opt( d_win, name, d.topic_stack.back() );
         if( next.id == "TALK_NONE" ) {
             int cat = topic_category( d.topic_stack.back() );
             do {
@@ -1733,7 +1732,8 @@ const talk_topic &special_talk( char ch )
     return no_topic;
 }
 
-talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
+talk_topic dialogue::opt( dialogue_window &d_win, const std::string &npc_name,
+                          const talk_topic &topic )
 {
     bool text_only = d_win.text_only;
     std::string challenge = dynamic_line( topic );
@@ -1771,29 +1771,49 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
         response_lines.push_back( responses[i].create_option_line( *this, 'a' + i ) );
     }
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+#if defined(__ANDROID__)
+    input_context ctxt( "DIALOGUE_CHOOSE_RESPONSE" );
+    for( size_t i = 0; i < responses.size(); i++ ) {
+        ctxt.register_manual_key( 'a' + i );
+    }
+    ctxt.register_manual_key( 'L', "Look at" );
+    ctxt.register_manual_key( 'S', "Size up stats" );
+    ctxt.register_manual_key( 'Y', "Yell" );
+    ctxt.register_manual_key( 'O', "Check opinion" );
+#endif
+
+    ui_adaptor ui;
+    ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+        d_win.resize_dialogue( ui );
+    } );
+    ui.mark_resize();
+
+    ui.on_redraw( [&]( const ui_adaptor & ) {
+        d_win.print_header( npc_name );
+        d_win.display_responses( hilight_lines, response_lines );
+    } );
 
     int ch = text_only ? 'a' + responses.size() - 1 : ' ';
     bool okay;
     do {
         d_win.refresh_response_display();
         do {
-            d_win.display_responses( hilight_lines, response_lines, ch );
+            ui_manager::redraw();
             if( !text_only ) {
                 ch = inp_mngr.get_input_event().get_first_input();
             }
+            d_win.handle_scrolling( ch );
             auto st = special_talk( ch );
             if( st.id != "TALK_NONE" ) {
                 return st;
             }
             switch( ch ) {
-                // send scroll control keys back to the display window
                 case KEY_DOWN:
                 case KEY_NPAGE:
                 case KEY_UP:
                 case KEY_PPAGE:
-                    continue;
+                    ch = -1;
+                    break;
                 default:
                     ch -= 'a';
                     break;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1666,13 +1666,13 @@ talk_data talk_response::create_option_line( const dialogue &d, const char lette
     // dialogue w/ a % chance to work
     if( trial.type == TALK_TRIAL_NONE || trial.type == TALK_TRIAL_CONDITION ) {
         // regular dialogue
-        //~ %1$c is an option letter and shouldn't be translated, %2$s is translated response text
-        ftext = string_format( pgettext( "talk option", "%1$c: %2$s" ), letter, text );
+        //~ %1$s is translated response text
+        ftext = string_format( pgettext( "talk option", "%1$s" ), text );
     } else {
         // dialogue w/ a % chance to work
-        //~ %1$c is an option letter and shouldn't be translated, %2$s is translated trial type, %3$d is a number, and %4$s is the translated response text
-        ftext = string_format( pgettext( "talk option", "%1$c: [%2$s %3$d%%] %4$s" ), letter,
-                               trial.name(), trial.calc_chance( d ), text );
+        //~ %1$s is translated trial type, %2$d is a number, and %3$s is the translated response text
+        ftext = string_format( pgettext( "talk option", "[%1$s %2$d%%] %3$s" ), trial.name(),
+                               trial.calc_chance( d ), text );
     }
     parse_tags( ftext, *d.alpha, *d.beta, success.next_topic.item_type );
 
@@ -1687,10 +1687,7 @@ talk_data talk_response::create_option_line( const dialogue &d, const char lette
     } else {
         color = c_white;
     }
-    talk_data results;
-    results.first = color;
-    results.second = ftext;
-    return results;
+    return {letter, color, ftext};
 }
 
 std::set<dialogue_consequence> talk_response::get_consequences( const dialogue &d ) const
@@ -1827,7 +1824,7 @@ talk_topic dialogue::opt( dialogue_window &d_win, const std::string &npc_name,
 
     talk_response chosen = responses[ch];
     std::string response_printed = string_format( pgettext( "you say something", "You: %s" ),
-                                   response_lines[ch].second.substr( 3 ) );
+                                   response_lines[ch].text );
     d_win.add_to_history( response_printed );
 
     if( chosen.mission_selected != nullptr ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -731,7 +731,7 @@ void npc_chatbin::check_missions()
     ma.erase( last, ma.end() );
 }
 
-void npc::talk_to_u( bool text_only, bool radio_contact )
+void npc::talk_to_u( bool radio_contact )
 {
     if( g->u.is_dead_state() ) {
         set_attitude( NPCATT_NULL );
@@ -848,7 +848,6 @@ void npc::talk_to_u( bool text_only, bool radio_contact )
     decide_needs();
 
     dialogue_window d_win;
-    d_win.open_dialogue( text_only );
     // Main dialogue loop
     do {
         if( chatbin.mission_selected != nullptr ) {
@@ -1732,7 +1731,6 @@ const talk_topic &special_talk( char ch )
 talk_topic dialogue::opt( dialogue_window &d_win, const std::string &npc_name,
                           const talk_topic &topic )
 {
-    bool text_only = d_win.text_only;
     std::string challenge = dynamic_line( topic );
     gen_responses( topic );
     // Put quotes around challenge (unless it's an action)
@@ -1787,15 +1785,13 @@ talk_topic dialogue::opt( dialogue_window &d_win, const std::string &npc_name,
         d_win.display_responses( response_lines );
     } );
 
-    int ch = text_only ? 'a' + responses.size() - 1 : ' ';
+    int ch;
     bool okay;
     do {
         d_win.refresh_response_display();
         do {
             ui_manager::redraw();
-            if( !text_only ) {
-                ch = inp_mngr.get_input_event().get_first_input();
-            }
+            ch = inp_mngr.get_input_event().get_first_input();
             d_win.handle_scrolling( ch );
             auto st = special_talk( ch );
             if( st.id != "TALK_NONE" ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1759,10 +1759,7 @@ talk_topic dialogue::opt( dialogue_window &d_win, const std::string &npc_name,
                                    challenge );
     }
 
-    d_win.add_history_separator();
-
-    // Number of lines to highlight
-    const size_t hilight_lines = d_win.add_to_history( challenge );
+    d_win.add_to_history( challenge );
 
     apply_speaker_effects( topic );
 
@@ -1790,7 +1787,7 @@ talk_topic dialogue::opt( dialogue_window &d_win, const std::string &npc_name,
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         d_win.print_header( npc_name );
-        d_win.display_responses( hilight_lines, response_lines );
+        d_win.display_responses( response_lines );
     } );
 
     int ch = text_only ? 'a' + responses.size() - 1 : ' ';
@@ -1827,7 +1824,6 @@ talk_topic dialogue::opt( dialogue_window &d_win, const std::string &npc_name,
             okay = query_yn( _( "You'll be helpless!  Proceed?" ) );
         }
     } while( !okay );
-    d_win.add_history_separator();
 
     talk_response chosen = responses[ch];
     std::string response_printed = string_format( pgettext( "you say something", "You: %s" ),

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -608,8 +608,8 @@ void border_helper::border_info::set( const point &pos, const point &size )
 
 border_helper::border_info &border_helper::add_border()
 {
-    border_info_list.emplace_back( border_info( *this ) );
-    return border_info_list.back();
+    border_info_list.emplace_front( border_info( *this ) );
+    return border_info_list.front();
 }
 
 void border_helper::draw_border( const catacurses::window &win )

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -949,7 +949,8 @@ input_event draw_item_info( const std::function<catacurses::window()> &init_wind
     }
 
     std::string action;
-    do {
+    bool exit = false;
+    while( !exit ) {
         ui_manager::redraw();
         action = ctxt.handle_input();
         if( data.handle_scrolling && action == "PAGE_UP" ) {
@@ -961,8 +962,12 @@ input_event draw_item_info( const std::function<catacurses::window()> &init_wind
                 ( height > 0 && static_cast<size_t>( *data.ptr_selected + height ) < folded.size() ) ) {
                 ++*data.ptr_selected;
             }
+        } else if( action == "CONFIRM" || action == "QUIT" ) {
+            exit = true;
+        } else if( data.any_input && action == "ANY_INPUT" && !ctxt.get_raw_input().sequence.empty() ) {
+            exit = true;
         }
-    } while( action != "QUIT" && action != "CONFIRM" && action != "ANY_INPUT" );
+    }
 
     return ctxt.get_raw_input();
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -595,7 +595,7 @@ void draw_border_below_tabs( const catacurses::window &w, nc_color border_color 
 }
 
 border_helper::border_info::border_info( border_helper &helper )
-    : pos( point_zero ), size( point_zero ), helper( helper )
+    : helper( helper )
 {
 }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -594,6 +594,102 @@ void draw_border_below_tabs( const catacurses::window &w, nc_color border_color 
     mvwputch( w, point( width - 1, height - 1 ), border_color, LINE_XOOX ); // _|
 }
 
+border_helper::border_info::border_info( border_helper &helper )
+    : pos( point_zero ), size( point_zero ), helper( helper )
+{
+}
+
+void border_helper::border_info::set( const point &pos, const point &size )
+{
+    this->pos = pos;
+    this->size = size;
+    helper.get().border_connection_map.reset();
+}
+
+border_helper::border_info &border_helper::add_border()
+{
+    border_info_list.emplace_back( border_info( *this ) );
+    return border_info_list.back();
+}
+
+void border_helper::draw_border( const catacurses::window &win )
+{
+    if( !border_connection_map.has_value() ) {
+        border_connection_map.emplace();
+        for( const border_info &info : border_info_list ) {
+            const point beg = info.pos;
+            const point end = info.pos + info.size;
+            for( int x = beg.x; x < end.x; ++x ) {
+                const point ptop( x, beg.y );
+                const point pbottom( x, end.y - 1 );
+                if( x > beg.x ) {
+                    border_connection_map.value()[ptop].left =
+                        border_connection_map.value()[pbottom].left = true;
+                }
+                if( x < end.x - 1 ) {
+                    border_connection_map.value()[ptop].right =
+                        border_connection_map.value()[pbottom].right = true;
+                }
+            }
+            for( int y = beg.y; y < end.y; ++y ) {
+                const point pleft( beg.x, y );
+                const point pright( end.x - 1, y );
+                if( y > beg.y ) {
+                    border_connection_map.value()[pleft].top =
+                        border_connection_map.value()[pright].top = true;
+                }
+                if( y < end.y - 1 ) {
+                    border_connection_map.value()[pleft].bottom =
+                        border_connection_map.value()[pright].bottom = true;
+                }
+            }
+        }
+    }
+    const point win_beg( getbegx( win ), getbegy( win ) );
+    const point win_end = win_beg + point( getmaxx( win ), getmaxy( win ) );
+    for( const std::pair<point, border_connection> &conn : border_connection_map.value() ) {
+        if( conn.first.x >= win_beg.x && conn.first.x < win_end.x &&
+            conn.first.y >= win_beg.y && conn.first.y < win_end.y ) {
+            mvwputch( win, conn.first - win_beg, BORDER_COLOR, conn.second.as_curses_line() );
+        }
+    }
+}
+
+int border_helper::border_connection::as_curses_line() const
+{
+    constexpr int t = 0x8;
+    constexpr int r = 0x4;
+    constexpr int b = 0x2;
+    constexpr int l = 0x1;
+    const int conn = ( top ? t : 0 ) | ( right ? r : 0 ) | ( bottom ? b : 0 ) | ( left ? l : 0 );
+    switch( conn ) {
+        default:
+            return '?';
+        case 0x3:
+            return LINE_OOXX;
+        case 0x5:
+            return LINE_OXOX;
+        case 0x6:
+            return LINE_OXXO;
+        case 0x7:
+            return LINE_OXXX;
+        case 0x9:
+            return LINE_XOOX;
+        case 0xA:
+            return LINE_XOXO;
+        case 0xB:
+            return LINE_XOXX;
+        case 0xC:
+            return LINE_XXOO;
+        case 0xD:
+            return LINE_XXOX;
+        case 0xE:
+            return LINE_XXXO;
+        case 0xF:
+            return LINE_XXXX;
+    }
+}
+
 bool query_yn( const std::string &text )
 {
     const bool force_uc = get_option<bool>( "FORCE_CAPITAL_YN" );

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -647,7 +647,7 @@ void border_helper::draw_border( const catacurses::window &win )
     }
     const point win_beg( getbegx( win ), getbegy( win ) );
     const point win_end = win_beg + point( getmaxx( win ), getmaxy( win ) );
-    for( const std::pair<point, border_connection> &conn : border_connection_map.value() ) {
+    for( const std::pair<const point, border_connection> &conn : border_connection_map.value() ) {
         if( conn.first.x >= win_beg.x && conn.first.x < win_end.x &&
             conn.first.y >= win_beg.y && conn.first.y < win_end.y ) {
             mvwputch( win, conn.first - win_beg, BORDER_COLOR, conn.second.as_curses_line() );

--- a/src/output.h
+++ b/src/output.h
@@ -368,6 +368,41 @@ void draw_border( const catacurses::window &w, nc_color border_color = BORDER_CO
                   const std::string &title = "", nc_color title_color = c_light_red );
 void draw_border_below_tabs( const catacurses::window &w, nc_color border_color = BORDER_COLOR );
 
+class border_helper
+{
+    public:
+        class border_info
+        {
+            public:
+                void set( const point &pos, const point &size );
+
+                friend class border_helper;
+            private:
+                border_info( border_helper &helper );
+
+                point pos;
+                point size;
+                std::reference_wrapper<border_helper> helper;
+        };
+
+        border_info &add_border();
+        void draw_border( const catacurses::window &win );
+
+        friend class border_info;
+    private:
+        struct border_connection {
+            bool top = false;
+            bool right = false;
+            bool bottom = false;
+            bool left = false;
+
+            int as_curses_line() const;
+        };
+        cata::optional<std::map<point, border_connection>> border_connection_map;
+
+        std::vector<border_info> border_info_list;
+};
+
 std::string word_rewrap( const std::string &ins, int width, uint32_t split = ' ' );
 std::vector<size_t> get_tag_positions( const std::string &s );
 std::vector<std::string> split_by_color( const std::string &s );

--- a/src/output.h
+++ b/src/output.h
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <forward_list>
 #include <functional>
 #include <iterator>
 #include <locale>
@@ -376,6 +377,12 @@ class border_helper
             public:
                 void set( const point &pos, const point &size );
 
+                // Prevent accidentally copying the return value from border_helper::add_border
+                border_info( const border_info & ) = delete;
+                border_info( border_info && ) = default;
+                border_info &operator=( const border_info & ) = delete;
+                border_info &operator=( border_info && ) = default;
+
                 friend class border_helper;
             private:
                 border_info( border_helper &helper );
@@ -400,7 +407,7 @@ class border_helper
         };
         cata::optional<std::map<point, border_connection>> border_connection_map;
 
-        std::vector<border_info> border_info_list;
+        std::forward_list<border_info> border_info_list;
 };
 
 std::string word_rewrap( const std::string &ins, int width, uint32_t split = ' ' );

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -456,7 +456,7 @@ void player::process_turn()
     }
 }
 
-int player::kcal_speed_penalty()
+int player::kcal_speed_penalty() const
 {
     static const std::vector<std::pair<float, float>> starv_thresholds = { {
             std::make_pair( 0.0f, -90.0f ),

--- a/src/player.h
+++ b/src/player.h
@@ -514,7 +514,7 @@ class player : public Character
         bool beyond_final_warning( const faction_id &id );
         /** Returns the effect of pain on stats */
         stat_mod get_pain_penalty() const;
-        int kcal_speed_penalty();
+        int kcal_speed_penalty() const;
         /** Returns the penalty to speed from thirst */
         static int thirst_speed_penalty( int thirst );
         /** This handles giving xp for a skill */

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -279,22 +279,99 @@ static bool is_cqb_skill( const skill_id &id )
     return std::find( cqb_skills.begin(), cqb_skills.end(), id ) != cqb_skills.end();
 }
 
-static void draw_stats_tab( const catacurses::window &w_stats, const catacurses::window &w_info,
-                            player &you, unsigned int &line, int &curtab, input_context &ctxt, bool &done,
-                            std::string &action )
+namespace
 {
+enum class player_display_tab {
+    stats,
+    encumbrance,
+    skills,
+    traits,
+    bionics,
+    effects,
+    num_tabs,
+};
+}
 
-    mvwprintz( w_stats, point_zero, h_light_gray, header_spaces );
-    center_print( w_stats, 0, h_light_gray, _( title_STATS ) );
+static player_display_tab next_tab( const player_display_tab tab )
+{
+    if( static_cast<int>( tab ) + 1 < static_cast<int>( player_display_tab::num_tabs ) ) {
+        return static_cast<player_display_tab>( static_cast<int>( tab ) + 1 );
+    } else {
+        return static_cast<player_display_tab>( 0 );
+    }
+}
 
-    // Clear bonus/penalty menu.
-    mvwprintz( w_stats, point( 0, 8 ), c_light_gray, std::string( 26, ' ' ) );
+static player_display_tab prev_tab( const player_display_tab tab )
+{
+    if( static_cast<int>( tab ) > 0 ) {
+        return static_cast<player_display_tab>( static_cast<int>( tab ) - 1 );
+    } else {
+        return static_cast<player_display_tab>( static_cast<int>( player_display_tab::num_tabs ) - 1 );
+    }
+}
+
+static void draw_stats_tab( const catacurses::window &w_stats,
+                            const player &you, const unsigned int line, const player_display_tab curtab )
+{
+    werase( w_stats );
+    const nc_color title_col = curtab == player_display_tab::stats ? h_light_gray : c_light_gray;
+    center_print( w_stats, 0, title_col, _( title_STATS ) );
+
+    const auto line_color = [curtab, line]( const unsigned int line_to_draw ) {
+        if( curtab == player_display_tab::stats && line == line_to_draw ) {
+            return h_light_gray;
+        } else {
+            return c_light_gray;
+        }
+    };
+
+    // Stats
+    const auto display_stat = [&w_stats]( const char *name, int cur, int max, int line_n,
+    const nc_color col ) {
+        nc_color cstatus;
+        if( cur <= 0 ) {
+            cstatus = c_dark_gray;
+        } else if( cur < max / 2 ) {
+            cstatus = c_red;
+        } else if( cur < max ) {
+            cstatus = c_light_red;
+        } else if( cur == max ) {
+            cstatus = c_white;
+        } else if( cur < max * 1.5 ) {
+            cstatus = c_light_green;
+        } else {
+            cstatus = c_green;
+        }
+
+        mvwprintz( w_stats, point( 1, line_n ), col, name );
+        mvwprintz( w_stats, point( 18, line_n ), cstatus, "%2d", cur );
+        mvwprintz( w_stats, point( 21, line_n ), c_light_gray, "(%2d)", max );
+    };
+
+    display_stat( _( "Strength:" ), you.get_str(), you.get_str_base(), 1, line_color( 0 ) );
+    display_stat( _( "Dexterity:" ), you.get_dex(), you.get_dex_base(), 2, line_color( 1 ) );
+    display_stat( _( "Intelligence:" ), you.get_int(), you.get_int_base(), 3, line_color( 2 ) );
+    display_stat( _( "Perception:" ), you.get_per(), you.get_per_base(), 4, line_color( 3 ) );
+    mvwprintz( w_stats, point( 1, 5 ), line_color( 4 ), _( "Weight:" ) );
+    mvwprintz( w_stats, point( 25 - utf8_width( you.get_weight_string() ), 5 ), line_color( 4 ),
+               you.get_weight_string() );
+    mvwprintz( w_stats, point( 1, 6 ), line_color( 5 ), _( "Height:" ) );
+    mvwprintz( w_stats, point( 25 - utf8_width( you.height_string() ), 6 ), line_color( 5 ),
+               you.height_string() );
+    mvwprintz( w_stats, point( 1, 7 ), line_color( 6 ), _( "Age:" ) );
+    mvwprintz( w_stats, point( 25 - utf8_width( you.age_string() ), 7 ), line_color( 6 ),
+               you.age_string() );
+
+    wrefresh( w_stats );
+}
+
+static void draw_stats_info( const catacurses::window &w_info,
+                             const player &you, const unsigned int line )
+{
+    werase( w_info );
     nc_color col_temp = c_light_gray;
 
     if( line == 0 ) {
-        // Display information on player strength in appropriate window
-        // NOLINTNEXTLINE(cata-use-named-point-constants)
-        mvwprintz( w_stats, point( 1, 1 ), h_light_gray, _( "Strength:" ) );
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
                         _( "Strength affects your melee damage, the amount of weight you can carry, your total HP, "
@@ -307,8 +384,6 @@ static void draw_stats_tab( const catacurses::window &w_stats, const catacurses:
         print_colored_text( w_info, point( 1, 5 ), col_temp, c_light_gray,
                             string_format( _( "Melee damage: <color_white>%.1f</color>" ), you.bonus_damage( false ) ) );
     } else if( line == 1 ) {
-        // Display information on player dexterity in appropriate window
-        mvwprintz( w_stats, point( 1, 2 ), h_light_gray, _( "Dexterity:" ) );
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
                         _( "Dexterity affects your chance to hit in melee combat, helps you steady your "
@@ -322,8 +397,6 @@ static void draw_stats_tab( const catacurses::window &w_stats, const catacurses:
                             string_format( _( "Throwing penalty per target's dodge: <color_white>%+d</color>" ),
                                            you.throw_dispersion_per_dodge( false ) ) );
     } else if( line == 2 ) {
-        // Display information on player intelligence in appropriate window
-        mvwprintz( w_stats, point( 1, 3 ), h_light_gray, _( "Intelligence:" ) );
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
                         _( "Intelligence is less important in most situations, but it is vital for more complex tasks like "
@@ -337,8 +410,6 @@ static void draw_stats_tab( const catacurses::window &w_stats, const catacurses:
         print_colored_text( w_info, point( 1, 5 ), col_temp, c_light_gray,
                             string_format( _( "Crafting bonus: <color_white>%d%%</color>" ), you.get_int() ) );
     } else if( line == 3 ) {
-        // Display information on player perception in appropriate window
-        mvwprintz( w_stats, point( 1, 4 ), h_light_gray, _( "Perception:" ) );
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
                         _( "Perception is the most important stat for ranged combat.  It's also used for "
@@ -352,78 +423,40 @@ static void draw_stats_tab( const catacurses::window &w_stats, const catacurses:
     } else if( line == 4 ) {
         // TODO: Get rid of this block
     } else if( line == 5 ) {
-        mvwprintz( w_stats, point( 1, 6 ), h_light_gray, _( "Height:" ) );
-        mvwprintz( w_stats, point( 25 - utf8_width( you.height_string() ), 6 ), h_light_gray,
-                   you.height_string() );
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         const int lines = fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
                                           _( "Your height.  Simply how tall you are." ) );
         fold_and_print( w_info, point( 1, 1 + lines ), FULL_SCREEN_WIDTH - 2, c_light_gray,
                         you.height_string() );
     } else if( line == 6 ) {
-        mvwprintz( w_stats, point( 1, 7 ), h_light_gray, _( "Age:" ) );
-        mvwprintz( w_stats, point( 25 - utf8_width( you.age_string() ), 7 ), h_light_gray,
-                   you.age_string() );
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         const int lines = fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
                                           _( "This is how old you are." ) );
         fold_and_print( w_info, point( 1, 1 + lines ), FULL_SCREEN_WIDTH - 2, c_light_gray,
                         you.age_string() );
     }
-    wrefresh( w_stats );
     wrefresh( w_info );
-
-    action = ctxt.handle_input();
-    if( action == "DOWN" ) {
-        line++;
-        if( line == 7 ) {
-            line = 0;
-        }
-    } else if( action == "UP" ) {
-        if( line == 0 ) {
-            line = 6;
-        } else {
-            line--;
-        }
-    } else if( action == "NEXT_TAB" || action == "PREV_TAB" ) {
-        mvwprintz( w_stats, point_zero, c_light_gray, header_spaces );
-        center_print( w_stats, 0, c_light_gray, _( title_STATS ) );
-        wrefresh( w_stats );
-        line = 0;
-        curtab = action == "NEXT_TAB" ? curtab + 1 : 6;
-    } else if( action == "QUIT" ) {
-        done = true;
-    } else if( action == "CONFIRM" && line < 4 && get_option<bool>( "STATS_THROUGH_KILLS" ) &&
-               you.is_player() ) {
-        g->u.upgrade_stat_prompt( static_cast<Character::stat>( line ) );
-    }
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    mvwprintz( w_stats, point( 1, 1 ), c_light_gray, _( "Strength:" ) );
-    mvwprintz( w_stats, point( 1, 2 ), c_light_gray, _( "Dexterity:" ) );
-    mvwprintz( w_stats, point( 1, 3 ), c_light_gray, _( "Intelligence:" ) );
-    mvwprintz( w_stats, point( 1, 4 ), c_light_gray, _( "Perception:" ) );
-    mvwprintz( w_stats, point( 1, 5 ), c_light_gray, _( "Weight:" ) );
-    mvwprintz( w_stats, point( 25 - utf8_width( you.get_weight_string() ), 5 ), c_light_gray,
-               you.get_weight_string() );
-    mvwprintz( w_stats, point( 1, 6 ), c_light_gray, _( "Height:" ) );
-    mvwprintz( w_stats, point( 25 - utf8_width( you.height_string() ), 6 ), c_light_gray,
-               you.height_string() );
-    mvwprintz( w_stats, point( 1, 7 ), c_light_gray, _( "Age:" ) );
-    mvwprintz( w_stats, point( 25 - utf8_width( you.age_string() ), 7 ), c_light_gray,
-               you.age_string() );
-    wrefresh( w_stats );
 }
 
 static void draw_encumbrance_tab( const catacurses::window &w_encumb,
-                                  const catacurses::window &w_info, player &you, unsigned int &line, int &curtab, input_context &ctxt,
-                                  bool &done, std::string &action )
+                                  const player &you, const unsigned int line, const player_display_tab curtab )
+{
+    werase( w_encumb );
+    const bool is_current_tab = curtab == player_display_tab::encumbrance;
+    const nc_color title_col = is_current_tab ? h_light_gray : c_light_gray;
+    center_print( w_encumb, 0, title_col, _( title_ENCUMB ) );
+    if( is_current_tab ) {
+        you.print_encumbrance( w_encumb, line );
+    } else {
+        you.print_encumbrance( w_encumb );
+    }
+    wrefresh( w_encumb );
+}
+
+static void draw_encumbrance_info( const catacurses::window &w_info,
+                                   const player &you, const unsigned int line )
 {
     const std::vector<std::pair<body_part, bool>> bps = list_and_combine_bps( you, nullptr );
-
-    werase( w_encumb );
-    center_print( w_encumb, 0, h_light_gray, _( title_ENCUMB ) );
-    you.print_encumbrance( w_encumb, line );
-    wrefresh( w_encumb );
 
     werase( w_info );
     body_part bp = num_bp;
@@ -436,51 +469,33 @@ static void draw_encumbrance_tab( const catacurses::window &w_encumb,
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, s );
     wrefresh( w_info );
-
-    action = ctxt.handle_input();
-    if( action == "DOWN" ) {
-        if( line + 1 < bps.size() ) {
-            ++line;
-        }
-    } else if( action == "UP" ) {
-        if( line > 0 ) {
-            --line;
-        }
-    } else if( action == "NEXT_TAB" || action == "PREV_TAB" ) {
-        mvwprintz( w_encumb, point_zero, c_light_gray, header_spaces );
-        center_print( w_encumb, 0, c_light_gray, _( title_ENCUMB ) );
-        wrefresh( w_encumb );
-        line = 0;
-        curtab = action == "NEXT_TAB" ? curtab + 1 : curtab - 1;
-    } else if( action == "QUIT" ) {
-        done = true;
-    }
 }
 
-static void draw_traits_tab( const catacurses::window &w_traits, const catacurses::window &w_info,
-                             unsigned int &line, int &curtab, input_context &ctxt, bool &done,
-                             std::string &action, std::vector<trait_id> &traitslist,
+static void draw_traits_tab( const catacurses::window &w_traits,
+                             const unsigned int line, const player_display_tab curtab,
+                             const std::vector<trait_id> &traitslist,
                              const size_t trait_win_size_y )
 {
     werase( w_traits );
-    mvwprintz( w_traits, point_zero, h_light_gray, header_spaces );
-    center_print( w_traits, 0, h_light_gray, _( title_TRAITS ) );
+    const bool is_current_tab = curtab == player_display_tab::traits;
+    const nc_color title_col = is_current_tab ? h_light_gray : c_light_gray;
+    center_print( w_traits, 0, title_col, _( title_TRAITS ) );
 
     size_t min = 0;
     size_t max = 0;
 
-    if( line <= ( trait_win_size_y - 1 ) / 2 ) {
+    if( !is_current_tab || line <= ( trait_win_size_y - 2 ) / 2 ) {
         min = 0;
-        max = trait_win_size_y;
+        max = trait_win_size_y - 1;
         if( traitslist.size() < max ) {
             max = traitslist.size();
         }
-    } else if( line >= traitslist.size() - ( trait_win_size_y + 1 ) / 2 ) {
-        min = ( traitslist.size() < trait_win_size_y ? 0 : traitslist.size() - trait_win_size_y );
+    } else if( line >= traitslist.size() - trait_win_size_y / 2 ) {
+        min = ( traitslist.size() < trait_win_size_y - 1 ? 0 : traitslist.size() - trait_win_size_y + 1 );
         max = traitslist.size();
     } else {
-        min = line - ( trait_win_size_y - 1 ) / 2;
-        max = line + trait_win_size_y / 2 + 1;
+        min = line - ( trait_win_size_y - 2 ) / 2;
+        max = line + ( trait_win_size_y + 1 ) / 2;
         if( traitslist.size() < max ) {
             max = traitslist.size();
         }
@@ -490,66 +505,45 @@ static void draw_traits_tab( const catacurses::window &w_traits, const catacurse
         const auto &mdata = traitslist[i].obj();
         const auto color = mdata.get_display_color();
         trim_and_print( w_traits, point( 1, static_cast<int>( 1 + i - min ) ), getmaxx( w_traits ) - 1,
-                        i == line ? hilite( color ) : color, mdata.name() );
+                        is_current_tab && i == line ? hilite( color ) : color, mdata.name() );
     }
+    wrefresh( w_traits );
+}
+
+static void draw_traits_info( const catacurses::window &w_info, const unsigned int line,
+                              const std::vector<trait_id> &traitslist )
+{
+    werase( w_info );
     if( line < traitslist.size() ) {
         const auto &mdata = traitslist[line].obj();
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, string_format(
                             "%s: %s", colorize( mdata.name(), mdata.get_display_color() ), traitslist[line]->desc() ) );
     }
-    wrefresh( w_traits );
     wrefresh( w_info );
-
-    action = ctxt.handle_input();
-    if( action == "DOWN" ) {
-        if( line < traitslist.size() - 1 ) {
-            line++;
-        }
-        return;
-    } else if( action == "UP" ) {
-        if( line > 0 ) {
-            line--;
-        }
-    } else if( action == "NEXT_TAB" || action == "PREV_TAB" ) {
-        mvwprintz( w_traits, point_zero, c_light_gray, header_spaces );
-        center_print( w_traits, 0, c_light_gray, _( title_TRAITS ) );
-        for( size_t i = 0; i < traitslist.size() && i < trait_win_size_y; i++ ) {
-            const auto &mdata = traitslist[i].obj();
-            mvwprintz( w_traits, point( 1, static_cast<int>( i + 1 ) ), c_black, "                         " );
-            const auto color = mdata.get_display_color();
-            trim_and_print( w_traits, point( 1, static_cast<int>( i + 1 ) ), getmaxx( w_traits ) - 1,
-                            color, mdata.name() );
-        }
-        wrefresh( w_traits );
-        line = 0;
-        curtab = action == "NEXT_TAB" ? curtab + 1 : curtab - 1;
-    } else if( action == "QUIT" ) {
-        done = true;
-    }
 }
 
-static void draw_bionics_tab( const catacurses::window &w_bionics, const catacurses::window &w_info,
-                              player &you, unsigned int &line, int &curtab, input_context &ctxt, bool &done,
-                              std::string &action, std::vector<bionic> &bionicslist,
-                              const size_t bionics_win_size_y )
+static void draw_bionics_tab( const catacurses::window &w_bionics,
+                              const player &you, const unsigned int line, const player_display_tab curtab,
+                              const std::vector<bionic> &bionicslist, const size_t bionics_win_size_y )
 {
     werase( w_bionics );
-    mvwprintz( w_bionics, point_zero, h_light_gray, header_spaces );
-    center_print( w_bionics, 0, h_light_gray, _( title_BIONICS ) );
+    const bool is_current_tab = curtab == player_display_tab::bionics;
+    const nc_color title_col = is_current_tab ? h_light_gray : c_light_gray;
+    center_print( w_bionics, 0, title_col, _( title_BIONICS ) );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     trim_and_print( w_bionics, point( 1, 1 ), getmaxx( w_bionics ) - 1, c_white,
                     string_format( _( "Bionic Power: <color_light_blue>%1$d</color>"
                                       " / <color_light_blue>%2$d</color>" ),
                                    units::to_kilojoule( you.get_power_level() ), units::to_kilojoule( you.get_max_power_level() ) ) );
 
-    const size_t useful_y = bionics_win_size_y - 1;
+    const size_t useful_y = bionics_win_size_y - 2;
     const size_t half_y = useful_y / 2;
 
     size_t min = 0;
     size_t max = 0;
 
-    if( line <= half_y ) { // near the top
+    if( !is_current_tab || line <= half_y ) { // near the top
         min = 0;
         max = std::min( bionicslist.size(), useful_y );
     } else if( line >= bionicslist.size() - half_y ) { // near the bottom
@@ -562,74 +556,52 @@ static void draw_bionics_tab( const catacurses::window &w_bionics, const catacur
 
     for( size_t i = min; i < max; i++ ) {
         trim_and_print( w_bionics, point( 1, static_cast<int>( 2 + i - min ) ), getmaxx( w_bionics ) - 1,
-                        i == line ? hilite( c_white ) : c_white, "%s", bionicslist[i].info().name );
+                        is_current_tab && i == line ? hilite( c_white ) : c_white, "%s", bionicslist[i].info().name );
     }
+    wrefresh( w_bionics );
+}
+
+static void draw_bionics_info( const catacurses::window &w_info, const unsigned int line,
+                               const std::vector<bionic> &bionicslist )
+{
+    werase( w_info );
     if( line < bionicslist.size() ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, "%s",
                         bionicslist[line].info().description );
     }
-    wrefresh( w_bionics );
     wrefresh( w_info );
-
-    action = ctxt.handle_input();
-    if( action == "DOWN" ) {
-        if( line < bionicslist.size() - 1 ) {
-            line++;
-        }
-        return;
-    } else if( action == "UP" ) {
-        if( line > 0 ) {
-            line--;
-        }
-    } else if( action == "NEXT_TAB" || action == "PREV_TAB" ) {
-        mvwprintz( w_bionics, point_zero, c_light_gray, header_spaces );
-        center_print( w_bionics, 0, c_light_gray, _( title_BIONICS ) );
-        // NOLINTNEXTLINE(cata-use-named-point-constants)
-        trim_and_print( w_bionics, point( 1, 1 ), getmaxx( w_bionics ) - 1, c_white,
-                        string_format( _( "Bionic Power: <color_light_blue>%1$d</color>"
-                                          " / <color_light_blue>%2$d</color>" ),
-                                       units::to_kilojoule( you.get_power_level() ), units::to_kilojoule( you.get_max_power_level() ) ) );
-        for( size_t i = 0; i < bionicslist.size() && i < bionics_win_size_y - 1; i++ ) {
-            mvwprintz( w_bionics, point( 1, static_cast<int>( i + 2 ) ), c_black, "                         " );
-            trim_and_print( w_bionics, point( 1, static_cast<int>( i + 2 ) ), getmaxx( w_bionics ) - 1,
-                            c_white, "%s", bionicslist[i].info().name );
-        }
-        wrefresh( w_bionics );
-        line = 0;
-        curtab = action == "NEXT_TAB" ? curtab + 1 : curtab - 1;
-    } else if( action == "QUIT" ) {
-        done = true;
-    }
 }
 
-static void draw_effects_tab( const catacurses::window &w_effects, const catacurses::window &w_info,
-                              unsigned int &line, int &curtab, input_context &ctxt, bool &done,
-                              std::string &action, std::vector<std::pair<std::string, std::string>> &effect_name_and_text,
+static void draw_effects_tab( const catacurses::window &w_effects,
+                              const unsigned int line, const player_display_tab curtab,
+                              const std::vector<std::pair<std::string, std::string>> &effect_name_and_text,
                               const size_t effect_win_size_y )
 {
-    mvwprintz( w_effects, point_zero, h_light_gray, header_spaces );
-    center_print( w_effects, 0, h_light_gray, _( title_EFFECTS ) );
+    werase( w_effects );
+    const bool is_current_tab = curtab == player_display_tab::effects;
+    const nc_color title_col = is_current_tab ? h_light_gray : c_light_gray;
+    center_print( w_effects, 0, title_col, _( title_EFFECTS ) );
 
-    const size_t half_y = effect_win_size_y / 2;
+    const size_t half_y = ( effect_win_size_y - 1 ) / 2;
 
     size_t min = 0;
     size_t max = 0;
 
     const size_t actual_size = effect_name_and_text.size();
 
-    if( line <= half_y ) {
+    if( !is_current_tab || line <= half_y ) {
         min = 0;
-        max = effect_win_size_y;
+        max = effect_win_size_y - 1;
         if( actual_size < max ) {
             max = actual_size;
         }
     } else if( line >= actual_size - half_y ) {
-        min = ( actual_size < effect_win_size_y ? 0 : actual_size - effect_win_size_y );
+        min = ( actual_size < effect_win_size_y - 1 ? 0 : actual_size - effect_win_size_y + 1 );
         max = actual_size;
     } else {
         min = line - half_y;
-        max = line - half_y + effect_win_size_y;
+        max = line - half_y + effect_win_size_y - 1;
         if( actual_size < max ) {
             max = actual_size;
         }
@@ -637,40 +609,22 @@ static void draw_effects_tab( const catacurses::window &w_effects, const catacur
 
     for( size_t i = min; i < max; i++ ) {
         trim_and_print( w_effects, point( 0, static_cast<int>( 1 + i - min ) ), getmaxx( w_effects ) - 1,
-                        i == line ? h_light_gray : c_light_gray, effect_name_and_text[i].first );
+                        is_current_tab && i == line ? h_light_gray : c_light_gray, effect_name_and_text[i].first );
     }
+    wrefresh( w_effects );
+}
+
+static void draw_effects_info( const catacurses::window &w_info, const unsigned int line,
+                               const std::vector<std::pair<std::string, std::string>> &effect_name_and_text )
+{
+    werase( w_info );
+    const size_t actual_size = effect_name_and_text.size();
     if( line < actual_size ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray,
                         effect_name_and_text[line].second );
     }
-    wrefresh( w_effects );
     wrefresh( w_info );
-
-    action = ctxt.handle_input();
-    if( action == "DOWN" ) {
-        if( line < actual_size - 1 ) {
-            line++;
-        }
-        return;
-    } else if( action == "UP" ) {
-        if( line > 0 ) {
-            line--;
-        }
-    } else if( action == "NEXT_TAB" || action == "PREV_TAB" ) {
-        mvwprintz( w_effects, point_zero, c_light_gray, header_spaces );
-        center_print( w_effects, 0, c_light_gray, _( title_EFFECTS ) );
-        for( size_t i = 0; i < actual_size && i < 7; i++ ) {
-            trim_and_print( w_effects, point( 0, static_cast<int>( i ) + 1 ), getmaxx( w_effects ) - 1,
-                            c_light_gray,
-                            effect_name_and_text[i].first );
-        }
-        wrefresh( w_effects );
-        line = 0;
-        curtab = action == "NEXT_TAB" ? 1 : curtab - 1;
-    } else if( action == "QUIT" ) {
-        done = true;
-    }
 }
 
 struct HeaderSkill {
@@ -680,39 +634,36 @@ struct HeaderSkill {
     }
 };
 
-static const Skill *draw_skills_list( const catacurses::window &w_skills,
-                                      player &you, unsigned int &line,
-                                      std::vector<HeaderSkill> &skillslist,
-                                      const size_t skill_win_size_y )
+static void draw_skills_tab( const catacurses::window &w_skills,
+                             player &you, unsigned int line, const player_display_tab curtab,
+                             std::vector<HeaderSkill> &skillslist,
+                             const size_t skill_win_size_y )
 {
     const int col_width = 25;
     if( line == 0 ) { //can't point to a header;
         line = 1;
     }
 
-    nc_color cstatus = c_light_gray;
-    if( line < 100 ) {
-        mvwprintz( w_skills, point_zero, h_light_gray, header_spaces );
-        cstatus = hilite( cstatus );
-    }
+    werase( w_skills );
+    const bool is_current_tab = curtab == player_display_tab::skills;
+    nc_color cstatus = is_current_tab ? h_light_gray : c_light_gray;
     center_print( w_skills, 0, cstatus, _( title_SKILLS ) );
 
     size_t min = 0;
     size_t max = 0;
 
-    const size_t half_y = skill_win_size_y / 2;
+    const size_t half_y = ( skill_win_size_y - 1 ) / 2;
 
-    if( line <= half_y || line > 100 ) {
+    if( !is_current_tab || line <= half_y ) {
         min = 0;
     } else if( line >= skillslist.size() - half_y ) {
-        min = ( skillslist.size() < skill_win_size_y ? 0 : skillslist.size() -
-                skill_win_size_y );
+        min = ( skillslist.size() < skill_win_size_y - 1 ? 0 : skillslist.size() -
+                skill_win_size_y + 1 );
     } else {
         min = line - half_y;
     }
-    max = std::min( min + skill_win_size_y, skillslist.size() );
+    max = std::min( min + skill_win_size_y - 1, skillslist.size() );
 
-    const Skill *selectedSkill = nullptr;
     int y_pos = 1;
     for( size_t i = min; i < max; i++, y_pos++ ) {
         const Skill *aSkill = skillslist[i].skill;
@@ -735,8 +686,7 @@ static const Skill *draw_skills_list( const catacurses::window &w_skills,
                 exercise = 0;
                 locked = true;
             }
-            if( i == line ) {
-                selectedSkill = aSkill;
+            if( is_current_tab && i == line ) {
                 if( locked ) {
                     cstatus = h_yellow;
                 } else if( !can_train ) {
@@ -773,22 +723,25 @@ static const Skill *draw_skills_list( const catacurses::window &w_skills,
         }
     }
 
-    return selectedSkill;
-}
-
-static void draw_skills_tab( const catacurses::window &w_skills, const catacurses::window &w_info,
-                             player &you, unsigned int &line, int &curtab, input_context &ctxt, bool &done,
-                             std::string &action, std::vector<HeaderSkill> &skillslist,
-                             const size_t skill_win_size_y )
-{
-
-    const Skill *selectedSkill = draw_skills_list( w_skills, you, line, skillslist, skill_win_size_y );
-    int list_size = skillslist.size();
-    if( skillslist.size() > skill_win_size_y ) {
-        draw_scrollbar( w_skills, line, skill_win_size_y, list_size,
-                        point_south );
+    if( is_current_tab && skillslist.size() > skill_win_size_y - 1 ) {
+        draw_scrollbar( w_skills, line - 1, skill_win_size_y - 1, skillslist.size() - 1,
+                        // NOLINTNEXTLINE(cata-use-named-point-constants)
+                        point( 0, 1 ) );
     }
     wrefresh( w_skills );
+}
+
+static void draw_skills_info( const catacurses::window &w_info, unsigned int line,
+                              const std::vector<HeaderSkill> &skillslist )
+{
+    werase( w_info );
+    if( line < 1 ) {
+        line = 1;
+    }
+    const Skill *selectedSkill = nullptr;
+    if( line < skillslist.size() && !skillslist[line].is_header ) {
+        selectedSkill = skillslist[line].skill;
+    }
 
     werase( w_info );
 
@@ -798,136 +751,13 @@ static void draw_skills_tab( const catacurses::window &w_skills, const catacurse
                         selectedSkill->description() );
     }
     wrefresh( w_info );
-
-    action = ctxt.handle_input();
-    if( action == "DOWN" ) {
-        line++;
-        if( static_cast<size_t>( line ) >= skillslist.size() ) {
-            line %= skillslist.size();
-        }
-        if( skillslist[line].is_header ) { //ok not to check for wraparound because header can't be at the end of the list
-            line++;
-        }
-    } else if( action == "UP" ) {
-        //ok not to check for -1 because header is always first in the list
-        line--;
-        if( skillslist[line].is_header ) {
-            if( line > 0 ) {
-                line--;
-            } else {
-                line = skillslist.size() - 1;
-            }
-        }
-    } else if( action == "NEXT_TAB" || action == "PREV_TAB" ) {
-        werase( w_skills );
-        line = 1000;
-        draw_skills_list( w_skills, you, line, skillslist, skill_win_size_y );
-        wrefresh( w_skills );
-        line = 0;
-        curtab = action == "NEXT_TAB" ? curtab + 1 : curtab - 1;
-    } else if( action == "CONFIRM" ) {
-        if( selectedSkill ) {
-            you.get_skill_level_object( selectedSkill->ident() ).toggleTraining();
-        }
-    } else if( action == "QUIT" ) {
-        done = true;
-    }
 }
 
-static void draw_initial_windows( const catacurses::window &w_stats,
-                                  const catacurses::window &w_encumb, const catacurses::window &w_traits,
-                                  const catacurses::window &w_bionics, const catacurses::window &w_effects,
-                                  const catacurses::window &w_skills, const catacurses::window &w_speed, player &you,
-                                  unsigned int &line, std::vector<trait_id> &traitslist, std::vector<bionic> &bionicslist,
-                                  std::vector<std::pair<std::string, std::string>> &effect_name_and_text,
-                                  std::vector<HeaderSkill> &skillslist,
-                                  const size_t bionics_win_size_y, const size_t effect_win_size_y, const size_t trait_win_size_y,
-                                  const size_t skill_win_size_y )
+static void draw_speed_tab( const catacurses::window &w_speed,
+                            const player &you,
+                            const std::map<std::string, int> &speed_effects )
 {
-    // First!  Default STATS screen.
-    center_print( w_stats, 0, c_light_gray, _( title_STATS ) );
-
-    // Stats
-    const auto display_stat = [&w_stats]( const char *name, int cur, int max, int line_n ) {
-        nc_color cstatus;
-        if( cur <= 0 ) {
-            cstatus = c_dark_gray;
-        } else if( cur < max / 2 ) {
-            cstatus = c_red;
-        } else if( cur < max ) {
-            cstatus = c_light_red;
-        } else if( cur == max ) {
-            cstatus = c_white;
-        } else if( cur < max * 1.5 ) {
-            cstatus = c_light_green;
-        } else {
-            cstatus = c_green;
-        }
-
-        mvwprintz( w_stats, point( 1, line_n ), c_light_gray, name );
-        mvwprintz( w_stats, point( 18, line_n ), cstatus, "%2d", cur );
-        mvwprintz( w_stats, point( 21, line_n ), c_light_gray, "(%2d)", max );
-    };
-
-    display_stat( _( "Strength:" ), you.get_str(), you.get_str_base(), 1 );
-    display_stat( _( "Dexterity:" ), you.get_dex(), you.get_dex_base(), 2 );
-    display_stat( _( "Intelligence:" ), you.get_int(), you.get_int_base(), 3 );
-    display_stat( _( "Perception:" ), you.get_per(), you.get_per_base(), 4 );
-    mvwprintz( w_stats, point( 1, 5 ), c_light_gray, _( "Weight:" ) );
-    mvwprintz( w_stats, point( 25 - utf8_width( you.get_weight_string() ), 5 ), c_light_gray,
-               you.get_weight_string() );
-    mvwprintz( w_stats, point( 1, 6 ), c_light_gray, _( "Height:" ) );
-    mvwprintz( w_stats, point( 25 - utf8_width( you.height_string() ), 6 ), c_light_gray,
-               you.height_string() );
-    mvwprintz( w_stats, point( 1, 7 ), c_light_gray, _( "Age:" ) );
-    mvwprintz( w_stats, point( 25 - utf8_width( you.age_string() ), 7 ), c_light_gray,
-               you.age_string() );
-
-    wrefresh( w_stats );
-
-    // Next, draw encumbrance.
-    center_print( w_encumb, 0, c_light_gray, _( title_ENCUMB ) );
-    you.print_encumbrance( w_encumb );
-    wrefresh( w_encumb );
-
-    // Next, draw traits.
-    center_print( w_traits, 0, c_light_gray, _( title_TRAITS ) );
-    std::sort( traitslist.begin(), traitslist.end(), trait_display_sort );
-    for( size_t i = 0; i < traitslist.size() && i < trait_win_size_y; i++ ) {
-        const auto &mdata = traitslist[i].obj();
-        const auto color = mdata.get_display_color();
-        trim_and_print( w_traits, point( 1, static_cast<int>( i ) + 1 ), getmaxx( w_traits ) - 1, color,
-                        mdata.name() );
-    }
-    wrefresh( w_traits );
-
-    // Next, draw bionics
-    center_print( w_bionics, 0, c_light_gray, _( title_BIONICS ) );
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    trim_and_print( w_bionics, point( 1, 1 ), getmaxx( w_bionics ) - 1, c_white,
-                    string_format( _( "Bionic Power: <color_light_blue>%1$d</color>"
-                                      " / <color_light_blue>%2$d</color>" ),
-                                   units::to_kilojoule( you.get_power_level() ), units::to_kilojoule( you.get_max_power_level() ) ) );
-    for( size_t i = 0; i < bionicslist.size() && i < bionics_win_size_y - 1; i++ ) {
-        trim_and_print( w_bionics, point( 1, static_cast<int>( i ) + 2 ), getmaxx( w_bionics ) - 1, c_white,
-                        "%s", bionicslist[i].info().name );
-    }
-    wrefresh( w_bionics );
-
-    // Next, draw effects.
-    center_print( w_effects, 0, c_light_gray, _( title_EFFECTS ) );
-    for( size_t i = 0; i < effect_name_and_text.size() && i < effect_win_size_y; i++ ) {
-        trim_and_print( w_effects, point( 0, static_cast<int>( i ) + 1 ), getmaxx( w_effects ) - 1,
-                        c_light_gray,
-                        effect_name_and_text[i].first );
-    }
-    wrefresh( w_effects );
-
-    // Next, draw skills.
-    line = 1000;
-    draw_skills_list( w_skills, you, line, skillslist, skill_win_size_y );
-    wrefresh( w_skills );
-
+    werase( w_speed );
     // Finally, draw speed.
     center_print( w_speed, 0, c_light_gray, _( title_SPEED ) );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -935,7 +765,7 @@ static void draw_initial_windows( const catacurses::window &w_stats,
     mvwprintz( w_speed, point( 1, 2 ), c_light_gray, _( "Current Speed:" ) );
     int newmoves = you.get_speed();
     int pen = 0;
-    line = 3;
+    unsigned int line = 3;
     if( you.weight_carried() > you.weight_capacity() ) {
         pen = 25 * ( you.weight_carried() - you.weight_capacity() ) / ( you.weight_capacity() );
         mvwprintz( w_speed, point( 1, line ), c_red,
@@ -1003,6 +833,16 @@ static void draw_initial_windows( const catacurses::window &w_stats,
     if( you.has_bionic( bionic_id( "bio_speed" ) ) ) {
         mvwprintz( w_speed, point( 1, line ), c_green,
                    pgettext( "speed bonus", "Bionic Speed        +%2d%%" ), bio_speed_bonus );
+        line++;
+    }
+
+    for( const std::pair<const std::string, int> &speed_effect : speed_effects ) {
+        nc_color col = ( speed_effect.second > 0 ? c_green : c_red );
+        mvwprintz( w_speed, point( 1, line ), col, "%s", speed_effect.first );
+        mvwprintz( w_speed, point( 21, line ), col, ( speed_effect.second > 0 ? "+" : "-" ) );
+        mvwprintz( w_speed, point( std::abs( speed_effect.second ) >= 10 ? 22 : 23, line ), col, "%d%%",
+                   std::abs( speed_effect.second ) );
+        line++;
     }
 
     int runcost = you.run_cost( 100 );
@@ -1015,9 +855,170 @@ static void draw_initial_windows( const catacurses::window &w_stats,
     wrefresh( w_speed );
 }
 
+static void draw_info_window( const catacurses::window &w_info, const player &you,
+                              const unsigned int line, const player_display_tab curtab,
+                              const std::vector<trait_id> &traitslist,
+                              const std::vector<bionic> &bionicslist,
+                              const std::vector<std::pair<std::string, std::string>> &effect_name_and_text,
+                              const std::vector<HeaderSkill> &skillslist )
+{
+    switch( curtab ) {
+        case player_display_tab::stats:
+            draw_stats_info( w_info, you, line );
+            break;
+        case player_display_tab::encumbrance:
+            draw_encumbrance_info( w_info, you, line );
+            break;
+        case player_display_tab::skills:
+            draw_skills_info( w_info, line, skillslist );
+            break;
+        case player_display_tab::traits:
+            draw_traits_info( w_info, line, traitslist );
+            break;
+        case player_display_tab::bionics:
+            draw_bionics_info( w_info, line, bionicslist );
+            break;
+        case player_display_tab::effects:
+            draw_effects_info( w_info, line, effect_name_and_text );
+            break;
+        case player_display_tab::num_tabs:
+            abort();
+    }
+}
+
+static void draw_tip( const catacurses::window &w_tip, const player &you,
+                      const std::string &race, const input_context &ctxt )
+{
+    werase( w_tip );
+
+    // Print name and header
+    if( you.custom_profession.empty() ) {
+        if( you.crossed_threshold() ) {
+            //~ player info window: 1s - name, 2s - gender, 3s - Prof or Mutation name
+            mvwprintz( w_tip, point_zero, c_white, _( " %1$s | %2$s | %3$s" ), you.name,
+                       you.male ? _( "Male" ) : _( "Female" ), race );
+        } else if( you.prof == nullptr || you.prof == profession::generic() ) {
+            // Regular person. Nothing interesting.
+            //~ player info window: 1s - name, 2s - gender '|' - field separator.
+            mvwprintz( w_tip, point_zero, c_white, _( " %1$s | %2$s" ), you.name,
+                       you.male ? _( "Male" ) : _( "Female" ) );
+        } else {
+            mvwprintz( w_tip, point_zero, c_white, _( " %1$s | %2$s | %3$s" ), you.name,
+                       you.male ? _( "Male" ) : _( "Female" ), you.prof->gender_appropriate_name( you.male ) );
+        }
+    } else {
+        mvwprintz( w_tip, point_zero, c_white, _( " %1$s | %2$s | %3$s" ), you.name,
+                   you.male ? _( "Male" ) : _( "Female" ), you.custom_profession );
+    }
+
+    right_print( w_tip, 0, 1, c_white, string_format(
+                     _( "[<color_yellow>%s</color>]" ),
+                     ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
+
+    wrefresh( w_tip );
+}
+
+static bool handle_player_display_action( player &you, unsigned int &line,
+        player_display_tab &curtab, input_context &ctxt,
+        const std::vector<trait_id> &traitslist,
+        const std::vector<bionic> &bionicslist,
+        const std::vector<std::pair<std::string, std::string>> &effect_name_and_text,
+        const std::vector<HeaderSkill> &skillslist )
+{
+    unsigned int line_beg = 0;
+    unsigned int line_end = 0;
+    switch( curtab ) {
+        case player_display_tab::stats:
+            line_end = 7;
+            break;
+        case player_display_tab::encumbrance: {
+            const std::vector<std::pair<body_part, bool>> bps = list_and_combine_bps( you, nullptr );
+            line_end = bps.size();
+            break;
+        }
+        case player_display_tab::traits:
+            line_end = traitslist.size();
+            break;
+        case player_display_tab::bionics:
+            line_end = bionicslist.size();
+            break;
+        case player_display_tab::effects:
+            line_end = effect_name_and_text.size();
+            break;
+        case player_display_tab::skills:
+            line_beg = 1; // skip first header
+            line_end = skillslist.size();
+            break;
+        case player_display_tab::num_tabs:
+            abort();
+    }
+    if( line_beg >= line_end || line < line_beg ) {
+        line = line_beg;
+    } else if( line > line_end - 1 ) {
+        line = line_end - 1;
+    }
+
+    bool done = false;
+    std::string action = ctxt.handle_input();
+
+    if( action == "UP" ) {
+        if( line > line_beg ) {
+            --line;
+        } else {
+            line = line_end - 1;
+        }
+        if( curtab == player_display_tab::skills && skillslist[line].is_header ) {
+            --line;
+        }
+    } else if( action == "DOWN" ) {
+        if( line + 1 < line_end ) {
+            ++line;
+        } else {
+            line = line_beg;
+        }
+        if( curtab == player_display_tab::skills && skillslist[line].is_header ) {
+            ++line;
+        }
+    } else if( action == "NEXT_TAB" || action == "PREV_TAB" ) {
+        line = 0;
+        curtab = action == "NEXT_TAB" ? next_tab( curtab ) : prev_tab( curtab );
+    } else if( action == "QUIT" ) {
+        done = true;
+    } else if( action == "CONFIRM" ) {
+        switch( curtab ) {
+            default:
+                break;
+            case player_display_tab::stats:
+                if( line < 4 && get_option<bool>( "STATS_THROUGH_KILLS" ) && you.is_avatar() ) {
+                    you.as_avatar()->upgrade_stat_prompt( static_cast<Character::stat>( line ) );
+                }
+                break;
+            case player_display_tab::skills: {
+                const Skill *selectedSkill = nullptr;
+                if( line < skillslist.size() && !skillslist[line].is_header ) {
+                    selectedSkill = skillslist[line].skill;
+                }
+                if( selectedSkill ) {
+                    you.get_skill_level_object( selectedSkill->ident() ).toggleTraining();
+                }
+                break;
+            }
+        }
+    } else if( action == "CHANGE_PROFESSION_NAME" ) {
+        string_input_popup popup;
+        popup.title( _( "Profession Name: " ) )
+        .width( 25 )
+        .text( "" )
+        .max_length( 25 )
+        .query();
+
+        you.custom_profession = popup.text();
+    }
+    return done;
+}
+
 void player::disp_info()
 {
-    unsigned int line = 0;
     std::vector<std::pair<std::string, std::string>> effect_name_and_text;
     for( auto &elem : *effects ) {
         for( auto &_effect_it : elem.second ) {
@@ -1099,15 +1100,14 @@ void player::disp_info()
         }
     }
 
-    unsigned int maxy = static_cast<unsigned>( TERMY );
-
     unsigned int effect_win_size_y = 1 + static_cast<unsigned>( effect_name_and_text.size() );
 
     std::vector<trait_id> traitslist = get_mutations( false );
-    unsigned int trait_win_size_y = 1 + static_cast<unsigned>( traitslist.size() );
+    std::sort( traitslist.begin(), traitslist.end(), trait_display_sort );
+    const unsigned int trait_win_size_y_max = 1 + static_cast<unsigned>( traitslist.size() );
 
     std::vector<bionic> bionicslist = *my_bionics;
-    unsigned int bionics_win_size_y = 2 + bionicslist.size();
+    const unsigned int bionics_win_size_y_max = 2 + bionicslist.size();
 
     const std::vector<const Skill *> player_skill = Skill::get_skills_sorted_by(
     [&]( const Skill & a, const Skill & b ) {
@@ -1127,7 +1127,7 @@ void player::disp_info()
         }
         skillslist.emplace_back( s, false );
     }
-    unsigned int skill_win_size_y = 1 + skillslist.size();
+    const unsigned int skill_win_size_y_max = 1 + skillslist.size();
     unsigned int info_win_size_y = 6;
 
     const unsigned int grid_width = 26;
@@ -1136,20 +1136,24 @@ void player::disp_info()
     const unsigned int infooffsetytop = grid_height + 2;
     unsigned int infooffsetybottom = infooffsetytop + 1 + info_win_size_y;
 
-    if( ( bionics_win_size_y + trait_win_size_y + infooffsetybottom ) > maxy ) {
+    unsigned int maxy = static_cast<unsigned>( TERMY );
+    unsigned int trait_win_size_y = trait_win_size_y_max;
+    unsigned int bionics_win_size_y = bionics_win_size_y_max;
+    unsigned int skill_win_size_y = skill_win_size_y_max;
+    if( ( bionics_win_size_y_max + 1 + trait_win_size_y_max + infooffsetybottom ) > maxy ) {
         // maximum space for either window if they're both the same size
-        unsigned max_shared_y = ( maxy - infooffsetybottom ) / 2;
-        // both are larger than the shared size
-        if( std::min( bionics_win_size_y, trait_win_size_y ) > max_shared_y ) {
+        unsigned max_shared_y = ( maxy - infooffsetybottom - 1 ) / 2;
+        if( std::min( bionics_win_size_y_max, trait_win_size_y_max ) > max_shared_y ) {
+            // both are larger than the shared size
             bionics_win_size_y = max_shared_y;
+            trait_win_size_y = maxy - infooffsetybottom - 1 - bionics_win_size_y;
+        } else if( trait_win_size_y_max <= max_shared_y ) {
             // trait window is less than the shared size, so give space to bionics
-        } else if( trait_win_size_y <= max_shared_y ) {
-            bionics_win_size_y = maxy - infooffsetybottom - trait_win_size_y;
+            bionics_win_size_y = maxy - infooffsetybottom - 1 - trait_win_size_y_max;
+        } else {
+            // bionics window is less than the shared size
+            trait_win_size_y = maxy - infooffsetybottom - 1 - bionics_win_size_y;
         }
-        // fall through if bionics is smaller
-        trait_win_size_y = maxy - infooffsetybottom - bionics_win_size_y;
-
-        bionics_win_size_y--;
     }
 
     if( skill_win_size_y + infooffsetybottom > maxy ) {
@@ -1233,27 +1237,11 @@ void player::disp_info()
     borders.add_border().set( point( -1, infooffsetytop - 1 ),
                               point( FULL_SCREEN_WIDTH + 2, info_win_size_y + 2 ) );
 
-    const auto draw_grid_borders = [&]() {
-        for( catacurses::window win : {
-                 w_stats_border, w_traits_border, w_bionics_border, w_encumb_border,
-                 w_effects_border, w_speed_border, w_skills_border, w_info_border
-             } ) {
-            borders.draw_border( win );
-            wrefresh( win );
-        }
-    };
-    draw_grid_borders();
-    //-1 for header
-    trait_win_size_y--;
-    bionics_win_size_y--;
-    skill_win_size_y--;
-    effect_win_size_y--;
-
     // Print name and header
     // Post-humanity trumps your pre-Cataclysm life
     // Unless you have a custom profession.
     std::string race;
-    if( g->u.custom_profession.empty() ) {
+    if( custom_profession.empty() ) {
         if( crossed_threshold() ) {
             for( const trait_id &mut : get_mutations() ) {
                 const mutation_branch &mdata = mut.obj();
@@ -1262,21 +1250,7 @@ void player::disp_info()
                     break;
                 }
             }
-            //~ player info window: 1s - name, 2s - gender, 3s - Prof or Mutation name
-            mvwprintw( w_tip, point_zero, _( " %1$s | %2$s | %3$s" ), name,
-                       male ? _( "Male" ) : _( "Female" ), race );
-        } else if( prof == nullptr || prof == profession::generic() ) {
-            // Regular person. Nothing interesting.
-            //~ player info window: 1s - name, 2s - gender '|' - field separator.
-            mvwprintw( w_tip, point_zero, _( " %1$s | %2$s" ), name,
-                       male ? _( "Male" ) : _( "Female" ) );
-        } else {
-            mvwprintw( w_tip, point_zero, _( " %1$s | %2$s | %3$s" ), name,
-                       male ? _( "Male" ) : _( "Female" ), prof->gender_appropriate_name( male ) );
         }
-    } else {
-        mvwprintw( w_tip, point_zero, _( " %1$s | %2$s | %3$s" ), name,
-                   male ? _( "Male" ) : _( "Female" ), g->u.custom_profession );
     }
 
     input_context ctxt( "PLAYER_INFO" );
@@ -1284,19 +1258,9 @@ void player::disp_info()
     ctxt.register_action( "NEXT_TAB", to_translation( "Cycle to next category" ) );
     ctxt.register_action( "PREV_TAB", to_translation( "Cycle to previous category" ) );
     ctxt.register_action( "QUIT" );
-    ctxt.register_action( "CONFIRM", to_translation( "Toggle skill training" ) );
+    ctxt.register_action( "CONFIRM", to_translation( "Toggle skill training / Upgrade stat" ) );
     ctxt.register_action( "CHANGE_PROFESSION_NAME", to_translation( "Change profession name" ) );
     ctxt.register_action( "HELP_KEYBINDINGS" );
-    std::string action;
-
-    right_print( w_tip, 0, 1, c_white, string_format(
-                     _( "[<color_yellow>%s</color>]" ),
-                     ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
-    wrefresh( w_tip );
-
-    draw_initial_windows( w_stats, w_encumb, w_traits, w_bionics, w_effects, w_skills, w_speed, *this,
-                          line, traitslist, bionicslist, effect_name_and_text, skillslist, bionics_win_size_y,
-                          effect_win_size_y, trait_win_size_y, skill_win_size_y );
 
     std::map<std::string, int> speed_effects;
     for( auto &elem : *effects ) {
@@ -1314,19 +1278,8 @@ void player::disp_info()
         }
     }
 
-    for( std::pair<const std::string, int> &speed_effect : speed_effects ) {
-        nc_color col = ( speed_effect.second > 0 ? c_green : c_red );
-        mvwprintz( w_speed, point( 1, line ), col, "%s", speed_effect.first );
-        mvwprintz( w_speed, point( 21, line ), col, ( speed_effect.second > 0 ? "+" : "-" ) );
-        mvwprintz( w_speed, point( std::abs( speed_effect.second ) >= 10 ? 22 : 23, line ), col, "%d%%",
-                   std::abs( speed_effect.second ) );
-        line++;
-    }
-
-    catacurses::refresh();
-
-    int curtab = 1;
-    line = 0;
+    player_display_tab curtab = player_display_tab::stats;
+    unsigned int line = 0;
     bool done = false;
 
     // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
@@ -1335,89 +1288,29 @@ void player::disp_info()
     // Initial printing is DONE.  Now we give the player a chance to scroll around
     // and "hover" over different items for more info.
     do {
-        werase( w_info );
+        g->refresh_all();
 
-        if( action == "CHANGE_PROFESSION_NAME" ) {
-            string_input_popup popup;
-            popup.title( _( "Profession Name: " ) )
-            .width( 25 )
-            .text( "" )
-            .max_length( 25 )
-            .query();
-
-            g->u.custom_profession = popup.text();
-
-            werase( w_tip );
-
-            g->refresh_all();
-
-            draw_grid_borders();
-
-            // Print name and header
-            if( g->u.custom_profession.empty() ) {
-                if( crossed_threshold() ) {
-                    //~ player info window: 1s - name, 2s - gender, 3s - Prof or Mutation name
-                    mvwprintw( w_tip, point_zero, _( " %1$s | %2$s | %3$s" ), name,
-                               male ? _( "Male" ) : _( "Female" ), race );
-                } else if( prof == nullptr || prof == profession::generic() ) {
-                    // Regular person. Nothing interesting.
-                    //~ player info window: 1s - name, 2s - gender '|' - field separator.
-                    mvwprintw( w_tip, point_zero, _( " %1$s | %2$s" ), name,
-                               male ? _( "Male" ) : _( "Female" ) );
-                } else {
-                    mvwprintw( w_tip, point_zero, _( " %1$s | %2$s | %3$s" ), name,
-                               male ? _( "Male" ) : _( "Female" ), prof->gender_appropriate_name( male ) );
-                }
-            } else {
-                mvwprintw( w_tip, point_zero, _( " %1$s | %2$s | %3$s" ), name,
-                           male ? _( "Male" ) : _( "Female" ), g->u.custom_profession );
-            }
-
-            right_print( w_tip, 0, 1, c_white, string_format(
-                             _( "[<color_yellow>%s</color>]" ),
-                             ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
-
-            wrefresh( w_tip );
-
-            draw_initial_windows( w_stats, w_encumb, w_traits, w_bionics, w_effects, w_skills, w_speed, *this,
-                                  line, traitslist, bionicslist, effect_name_and_text, skillslist, bionics_win_size_y,
-                                  effect_win_size_y, trait_win_size_y, skill_win_size_y );
+        for( catacurses::window win : {
+                 w_stats_border, w_traits_border, w_bionics_border, w_encumb_border,
+                 w_effects_border, w_speed_border, w_skills_border, w_info_border
+             } ) {
+            borders.draw_border( win );
+            wrefresh( win );
         }
 
-        switch( curtab ) {
-            case 1:
-                // Stats tab
-                draw_stats_tab( w_stats, w_info, *this, line, curtab, ctxt, done, action );
-                break;
-            case 2:
-                // Encumbrance tab
-                draw_encumbrance_tab( w_encumb, w_info, *this, line, curtab, ctxt, done, action );
-                break;
+        draw_tip( w_tip, *this, race, ctxt );
+        draw_stats_tab( w_stats, *this, line, curtab );
+        draw_encumbrance_tab( w_encumb, *this, line, curtab );
+        draw_traits_tab( w_traits, line, curtab, traitslist, trait_win_size_y );
+        draw_bionics_tab( w_bionics, *this, line, curtab, bionicslist, bionics_win_size_y );
+        draw_effects_tab( w_effects, line, curtab, effect_name_and_text, effect_win_size_y );
+        draw_skills_tab( w_skills, *this, line, curtab, skillslist, skill_win_size_y );
+        draw_speed_tab( w_speed, *this, speed_effects );
+        draw_info_window( w_info, *this, line, curtab,
+                          traitslist, bionicslist, effect_name_and_text, skillslist );
 
-            case 4:
-                // Traits tab
-                draw_traits_tab( w_traits, w_info, line, curtab, ctxt, done, action,
-                                 traitslist, trait_win_size_y );
-                break;
-
-            case 5:
-                // Bionics tab
-                draw_bionics_tab( w_bionics, w_info, *this, line, curtab, ctxt, done, action,
-                                  bionicslist, bionics_win_size_y );
-                break;
-
-            case 6:
-                // Effects tab
-                draw_effects_tab( w_effects, w_info, line, curtab, ctxt, done, action,
-                                  effect_name_and_text, effect_win_size_y );
-                break;
-
-            case 3:
-                // Skills tab
-                draw_skills_tab( w_skills, w_info, *this, line, curtab, ctxt, done, action,
-                                 skillslist, skill_win_size_y );
-
-        }
+        done = handle_player_display_action( *this, line, curtab, ctxt,
+                                             traitslist, bionicslist, effect_name_and_text, skillslist );
     } while( !done );
 
     g->refresh_all();

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -920,11 +920,40 @@ static void draw_tip( const catacurses::window &w_tip, const player &you,
 
 static bool handle_player_display_action( player &you, unsigned int &line,
         player_display_tab &curtab, input_context &ctxt,
+        const ui_adaptor &ui_tip, const ui_adaptor &ui_info,
+        const ui_adaptor &ui_stats, const ui_adaptor &ui_encumb,
+        const ui_adaptor &ui_traits, const ui_adaptor &ui_bionics,
+        const ui_adaptor &ui_effects, const ui_adaptor &ui_skills,
         const std::vector<trait_id> &traitslist,
         const std::vector<bionic> &bionicslist,
         const std::vector<std::pair<std::string, std::string>> &effect_name_and_text,
         const std::vector<HeaderSkill> &skillslist )
 {
+    const auto invalidate_tab = [&]( const player_display_tab tab ) {
+        switch( tab ) {
+            case player_display_tab::stats:
+                ui_stats.invalidate_ui();
+                break;
+            case player_display_tab::encumbrance:
+                ui_encumb.invalidate_ui();
+                break;
+            case player_display_tab::traits:
+                ui_traits.invalidate_ui();
+                break;
+            case player_display_tab::bionics:
+                ui_bionics.invalidate_ui();
+                break;
+            case player_display_tab::effects:
+                ui_effects.invalidate_ui();
+                break;
+            case player_display_tab::skills:
+                ui_skills.invalidate_ui();
+                break;
+            case player_display_tab::num_tabs:
+                abort();
+        }
+    };
+
     unsigned int line_beg = 0;
     unsigned int line_end = 0;
     switch( curtab ) {
@@ -970,6 +999,8 @@ static bool handle_player_display_action( player &you, unsigned int &line,
         if( curtab == player_display_tab::skills && skillslist[line].is_header ) {
             --line;
         }
+        invalidate_tab( curtab );
+        ui_info.invalidate_ui();
     } else if( action == "DOWN" ) {
         if( line + 1 < line_end ) {
             ++line;
@@ -979,9 +1010,14 @@ static bool handle_player_display_action( player &you, unsigned int &line,
         if( curtab == player_display_tab::skills && skillslist[line].is_header ) {
             ++line;
         }
+        invalidate_tab( curtab );
+        ui_info.invalidate_ui();
     } else if( action == "NEXT_TAB" || action == "PREV_TAB" ) {
         line = 0;
+        invalidate_tab( curtab );
         curtab = action == "NEXT_TAB" ? next_tab( curtab ) : prev_tab( curtab );
+        invalidate_tab( curtab );
+        ui_info.invalidate_ui();
     } else if( action == "QUIT" ) {
         done = true;
     } else if( action == "CONFIRM" ) {
@@ -992,6 +1028,7 @@ static bool handle_player_display_action( player &you, unsigned int &line,
                 if( line < 4 && get_option<bool>( "STATS_THROUGH_KILLS" ) && you.is_avatar() ) {
                     you.as_avatar()->upgrade_stat_prompt( static_cast<Character::stat>( line ) );
                 }
+                invalidate_tab( curtab );
                 break;
             case player_display_tab::skills: {
                 const Skill *selectedSkill = nullptr;
@@ -1001,6 +1038,7 @@ static bool handle_player_display_action( player &you, unsigned int &line,
                 if( selectedSkill ) {
                     you.get_skill_level_object( selectedSkill->ident() ).toggleTraining();
                 }
+                invalidate_tab( curtab );
                 break;
             }
         }
@@ -1013,6 +1051,7 @@ static bool handle_player_display_action( player &you, unsigned int &line,
         .query();
 
         you.custom_profession = popup.text();
+        ui_tip.invalidate_ui();
     }
     return done;
 }
@@ -1100,7 +1139,7 @@ void player::disp_info()
         }
     }
 
-    unsigned int effect_win_size_y = 1 + static_cast<unsigned>( effect_name_and_text.size() );
+    const unsigned int effect_win_size_y = 1 + static_cast<unsigned>( effect_name_and_text.size() );
 
     std::vector<trait_id> traitslist = get_mutations( false );
     std::sort( traitslist.begin(), traitslist.end(), trait_display_sort );
@@ -1128,7 +1167,7 @@ void player::disp_info()
         skillslist.emplace_back( s, false );
     }
     const unsigned int skill_win_size_y_max = 1 + skillslist.size();
-    unsigned int info_win_size_y = 6;
+    const unsigned int info_win_size_y = 6;
 
     const unsigned int grid_width = 26;
     const unsigned int grid_height = 9;
@@ -1136,106 +1175,27 @@ void player::disp_info()
     const unsigned int infooffsetytop = grid_height + 2;
     unsigned int infooffsetybottom = infooffsetytop + 1 + info_win_size_y;
 
-    unsigned int maxy = static_cast<unsigned>( TERMY );
-    unsigned int trait_win_size_y = trait_win_size_y_max;
-    unsigned int bionics_win_size_y = bionics_win_size_y_max;
-    unsigned int skill_win_size_y = skill_win_size_y_max;
-    if( ( bionics_win_size_y_max + 1 + trait_win_size_y_max + infooffsetybottom ) > maxy ) {
-        // maximum space for either window if they're both the same size
-        unsigned max_shared_y = ( maxy - infooffsetybottom - 1 ) / 2;
-        if( std::min( bionics_win_size_y_max, trait_win_size_y_max ) > max_shared_y ) {
-            // both are larger than the shared size
-            bionics_win_size_y = max_shared_y;
-            trait_win_size_y = maxy - infooffsetybottom - 1 - bionics_win_size_y;
-        } else if( trait_win_size_y_max <= max_shared_y ) {
-            // trait window is less than the shared size, so give space to bionics
-            bionics_win_size_y = maxy - infooffsetybottom - 1 - trait_win_size_y_max;
-        } else {
-            // bionics window is less than the shared size
-            trait_win_size_y = maxy - infooffsetybottom - 1 - bionics_win_size_y;
+    const auto calculate_trait_and_bionic_height = [&]() {
+        const unsigned int maxy = static_cast<unsigned>( TERMY );
+        unsigned int trait_win_size_y = trait_win_size_y_max;
+        unsigned int bionics_win_size_y = bionics_win_size_y_max;
+        if( ( bionics_win_size_y_max + 1 + trait_win_size_y_max + infooffsetybottom ) > maxy ) {
+            // maximum space for either window if they're both the same size
+            unsigned max_shared_y = ( maxy - infooffsetybottom - 1 ) / 2;
+            if( std::min( bionics_win_size_y_max, trait_win_size_y_max ) > max_shared_y ) {
+                // both are larger than the shared size
+                bionics_win_size_y = max_shared_y;
+                trait_win_size_y = maxy - infooffsetybottom - 1 - bionics_win_size_y;
+            } else if( trait_win_size_y_max <= max_shared_y ) {
+                // trait window is less than the shared size, so give space to bionics
+                bionics_win_size_y = maxy - infooffsetybottom - 1 - trait_win_size_y_max;
+            } else {
+                // bionics window is less than the shared size
+                trait_win_size_y = maxy - infooffsetybottom - 1 - bionics_win_size_y;
+            }
         }
-    }
-
-    if( skill_win_size_y + infooffsetybottom > maxy ) {
-        skill_win_size_y = maxy - infooffsetybottom;
-    }
-
-    border_helper borders;
-
-    catacurses::window w_tip =
-        catacurses::newwin( 1, FULL_SCREEN_WIDTH + 1, point_zero );
-    catacurses::window w_stats =
-        //NOLINTNEXTLINE(cata-use-named-point-constants)
-        catacurses::newwin( grid_height, grid_width, point( 0, 1 ) );
-    // Every grid draws the bottom and right borders. The top and left borders
-    // are either not displayed or drawn by another grid.
-    catacurses::window w_stats_border =
-        //NOLINTNEXTLINE(cata-use-named-point-constants)
-        catacurses::newwin( grid_height + 1, grid_width + 1, point( 0, 1 ) );
-    // But we need to specify the full border for border_helper to calculate the
-    // border connection.
-    //NOLINTNEXTLINE(cata-use-named-point-constants)
-    borders.add_border().set( point( -1, 0 ), point( grid_width + 2, grid_height + 2 ) );
-
-    catacurses::window w_traits =
-        catacurses::newwin( trait_win_size_y, grid_width,
-                            point( grid_width + 1, infooffsetybottom ) );
-    catacurses::window w_traits_border =
-        catacurses::newwin( trait_win_size_y + 1, grid_width + 1,
-                            point( grid_width + 1, infooffsetybottom ) );
-    borders.add_border().set( point( grid_width, infooffsetybottom - 1 ),
-                              point( grid_width + 2, trait_win_size_y + 2 ) );
-
-    catacurses::window w_bionics =
-        catacurses::newwin( bionics_win_size_y, grid_width,
-                            point( grid_width + 1,
-                                   infooffsetybottom + trait_win_size_y + 1 ) );
-    catacurses::window w_bionics_border =
-        catacurses::newwin( bionics_win_size_y + 1, grid_width + 1,
-                            point( grid_width + 1,
-                                   infooffsetybottom + trait_win_size_y + 1 ) );
-    borders.add_border().set( point( grid_width, infooffsetybottom + trait_win_size_y ),
-                              point( grid_width + 2, bionics_win_size_y + 2 ) );
-
-    catacurses::window w_encumb =
-        catacurses::newwin( grid_height, grid_width, point( grid_width + 1, 1 ) );
-    catacurses::window w_encumb_border =
-        catacurses::newwin( grid_height + 1, grid_width + 1, point( grid_width + 1, 1 ) );
-    borders.add_border().set( point( grid_width, 0 ), point( grid_width + 2, grid_height + 2 ) );
-
-    catacurses::window w_effects =
-        catacurses::newwin( effect_win_size_y, grid_width,
-                            point( grid_width * 2 + 2, infooffsetybottom ) );
-    catacurses::window w_effects_border =
-        catacurses::newwin( effect_win_size_y + 1, grid_width + 1,
-                            point( grid_width * 2 + 2, infooffsetybottom ) );
-    borders.add_border().set( point( grid_width * 2 + 1, infooffsetybottom - 1 ),
-                              point( grid_width + 2, effect_win_size_y + 2 ) );
-
-    catacurses::window w_speed =
-        catacurses::newwin( grid_height, grid_width, point( grid_width * 2 + 2, 1 ) );
-    catacurses::window w_speed_border =
-        catacurses::newwin( grid_height + 1, grid_width + 1, point( grid_width * 2 + 2, 1 ) );
-    borders.add_border().set( point( grid_width * 2 + 1, 0 ),
-                              point( grid_width + 2, grid_height + 2 ) );
-
-    catacurses::window w_skills =
-        catacurses::newwin( skill_win_size_y, grid_width,
-                            point( 0, infooffsetybottom ) );
-    catacurses::window w_skills_border =
-        catacurses::newwin( skill_win_size_y + 1, grid_width + 1,
-                            point( 0, infooffsetybottom ) );
-    borders.add_border().set( point( -1, infooffsetybottom - 1 ),
-                              point( grid_width + 2, skill_win_size_y + 2 ) );
-
-    catacurses::window w_info =
-        catacurses::newwin( info_win_size_y, FULL_SCREEN_WIDTH,
-                            point( 0, infooffsetytop ) );
-    catacurses::window w_info_border =
-        catacurses::newwin( info_win_size_y + 1, FULL_SCREEN_WIDTH + 1,
-                            point( 0, infooffsetytop ) );
-    borders.add_border().set( point( -1, infooffsetytop - 1 ),
-                              point( FULL_SCREEN_WIDTH + 2, info_win_size_y + 2 ) );
+        return std::make_pair( trait_win_size_y, bionics_win_size_y );
+    };
 
     // Print name and header
     // Post-humanity trumps your pre-Cataclysm life
@@ -1278,40 +1238,202 @@ void player::disp_info()
         }
     }
 
+    border_helper borders;
+
     player_display_tab curtab = player_display_tab::stats;
     unsigned int line = 0;
-    bool done = false;
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
-
-    // Initial printing is DONE.  Now we give the player a chance to scroll around
-    // and "hover" over different items for more info.
-    do {
-        g->refresh_all();
-
-        for( catacurses::window win : {
-                 w_stats_border, w_traits_border, w_bionics_border, w_encumb_border,
-                 w_effects_border, w_speed_border, w_skills_border, w_info_border
-             } ) {
-            borders.draw_border( win );
-            wrefresh( win );
-        }
-
+    catacurses::window w_tip;
+    ui_adaptor ui_tip;
+    ui_tip.on_screen_resize( [&]( ui_adaptor & ui_tip ) {
+        w_tip = catacurses::newwin( 1, FULL_SCREEN_WIDTH + 1, point_zero );
+        ui_tip.position_from_window( w_tip );
+    } );
+    ui_tip.mark_resize();
+    ui_tip.on_redraw( [&]( const ui_adaptor & ) {
         draw_tip( w_tip, *this, race, ctxt );
+    } );
+
+    catacurses::window w_stats;
+    catacurses::window w_stats_border;
+    border_helper::border_info &border_stats = borders.add_border();
+    ui_adaptor ui_stats;
+    ui_stats.on_screen_resize( [&]( ui_adaptor & ui_stats ) {
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        w_stats = catacurses::newwin( grid_height, grid_width, point( 0, 1 ) );
+        // Every grid draws the bottom and right borders. The top and left borders
+        // are either not displayed or drawn by another grid.
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        w_stats_border = catacurses::newwin( grid_height + 1, grid_width + 1, point( 0, 1 ) );
+        // But we need to specify the full border for border_helper to calculate the
+        // border connection.
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        border_stats.set( point( -1, 0 ), point( grid_width + 2, grid_height + 2 ) );
+        ui_stats.position_from_window( w_stats_border );
+    } );
+    ui_stats.mark_resize();
+    ui_stats.on_redraw( [&]( const ui_adaptor & ) {
+        borders.draw_border( w_stats_border );
+        wrefresh( w_stats_border );
         draw_stats_tab( w_stats, *this, line, curtab );
-        draw_encumbrance_tab( w_encumb, *this, line, curtab );
+    } );
+
+    unsigned int trait_win_size_y = 0;
+    catacurses::window w_traits;
+    catacurses::window w_traits_border;
+    border_helper::border_info &border_traits = borders.add_border();
+    ui_adaptor ui_traits;
+    ui_traits.on_screen_resize( [&]( ui_adaptor & ui_traits ) {
+        trait_win_size_y = calculate_trait_and_bionic_height().first;
+        w_traits = catacurses::newwin( trait_win_size_y, grid_width,
+                                       point( grid_width + 1, infooffsetybottom ) );
+        w_traits_border = catacurses::newwin( trait_win_size_y + 1, grid_width + 1,
+                                              point( grid_width + 1, infooffsetybottom ) );
+        border_traits.set( point( grid_width, infooffsetybottom - 1 ),
+                           point( grid_width + 2, trait_win_size_y + 2 ) );
+        ui_traits.position_from_window( w_traits_border );
+    } );
+    ui_traits.mark_resize();
+    ui_traits.on_redraw( [&]( const ui_adaptor & ) {
+        borders.draw_border( w_traits_border );
+        wrefresh( w_traits_border );
         draw_traits_tab( w_traits, line, curtab, traitslist, trait_win_size_y );
+    } );
+
+    unsigned int bionics_win_size_y = 0;
+    catacurses::window w_bionics;
+    catacurses::window w_bionics_border;
+    border_helper::border_info &border_bionics = borders.add_border();
+    ui_adaptor ui_bionics;
+    ui_bionics.on_screen_resize( [&]( ui_adaptor & ui_bionics ) {
+        bionics_win_size_y = calculate_trait_and_bionic_height().second;
+        w_bionics = catacurses::newwin( bionics_win_size_y, grid_width,
+                                        point( grid_width + 1,
+                                               infooffsetybottom + trait_win_size_y + 1 ) );
+        w_bionics_border = catacurses::newwin( bionics_win_size_y + 1, grid_width + 1,
+                                               point( grid_width + 1,
+                                                       infooffsetybottom + trait_win_size_y + 1 ) );
+        border_bionics.set( point( grid_width, infooffsetybottom + trait_win_size_y ),
+                            point( grid_width + 2, bionics_win_size_y + 2 ) );
+        ui_bionics.position_from_window( w_bionics_border );
+    } );
+    ui_bionics.mark_resize();
+    ui_bionics.on_redraw( [&]( const ui_adaptor & ) {
+        borders.draw_border( w_bionics_border );
+        wrefresh( w_bionics_border );
         draw_bionics_tab( w_bionics, *this, line, curtab, bionicslist, bionics_win_size_y );
+    } );
+
+    catacurses::window w_encumb;
+    catacurses::window w_encumb_border;
+    border_helper::border_info &border_encumb = borders.add_border();
+    ui_adaptor ui_encumb;
+    ui_encumb.on_screen_resize( [&]( ui_adaptor & ui_encumb ) {
+        w_encumb = catacurses::newwin( grid_height, grid_width, point( grid_width + 1, 1 ) );
+        w_encumb_border = catacurses::newwin( grid_height + 1, grid_width + 1, point( grid_width + 1, 1 ) );
+        border_encumb.set( point( grid_width, 0 ), point( grid_width + 2, grid_height + 2 ) );
+        ui_encumb.position_from_window( w_encumb_border );
+    } );
+    ui_encumb.mark_resize();
+    ui_encumb.on_redraw( [&]( const ui_adaptor & ) {
+        borders.draw_border( w_encumb_border );
+        wrefresh( w_encumb_border );
+        draw_encumbrance_tab( w_encumb, *this, line, curtab );
+    } );
+
+    catacurses::window w_effects;
+    catacurses::window w_effects_border;
+    border_helper::border_info &border_effects = borders.add_border();
+    ui_adaptor ui_effects;
+    ui_effects.on_screen_resize( [&]( ui_adaptor & ui_effects ) {
+        w_effects = catacurses::newwin( effect_win_size_y, grid_width,
+                                        point( grid_width * 2 + 2, infooffsetybottom ) );
+        w_effects_border = catacurses::newwin( effect_win_size_y + 1, grid_width + 1,
+                                               point( grid_width * 2 + 2, infooffsetybottom ) );
+        border_effects.set( point( grid_width * 2 + 1, infooffsetybottom - 1 ),
+                            point( grid_width + 2, effect_win_size_y + 2 ) );
+        ui_effects.position_from_window( w_effects_border );
+    } );
+    ui_effects.mark_resize();
+    ui_effects.on_redraw( [&]( const ui_adaptor & ) {
+        borders.draw_border( w_effects_border );
+        wrefresh( w_effects_border );
         draw_effects_tab( w_effects, line, curtab, effect_name_and_text, effect_win_size_y );
-        draw_skills_tab( w_skills, *this, line, curtab, skillslist, skill_win_size_y );
+    } );
+
+    catacurses::window w_speed;
+    catacurses::window w_speed_border;
+    border_helper::border_info &border_speed = borders.add_border();
+    ui_adaptor ui_speed;
+    ui_speed.on_screen_resize( [&]( ui_adaptor & ui_speed ) {
+        w_speed = catacurses::newwin( grid_height, grid_width, point( grid_width * 2 + 2, 1 ) );
+        w_speed_border = catacurses::newwin( grid_height + 1, grid_width + 1,
+                                             point( grid_width * 2 + 2, 1 ) );
+        border_speed.set( point( grid_width * 2 + 1, 0 ),
+                          point( grid_width + 2, grid_height + 2 ) );
+        ui_speed.position_from_window( w_speed_border );
+    } );
+    ui_speed.mark_resize();
+    ui_speed.on_redraw( [&]( const ui_adaptor & ) {
+        borders.draw_border( w_speed_border );
+        wrefresh( w_speed_border );
         draw_speed_tab( w_speed, *this, speed_effects );
+    } );
+
+    unsigned int skill_win_size_y = 0;
+    catacurses::window w_skills;
+    catacurses::window w_skills_border;
+    border_helper::border_info &border_skills = borders.add_border();
+    ui_adaptor ui_skills;
+    ui_skills.on_screen_resize( [&]( ui_adaptor & ui_skills ) {
+        const unsigned int maxy = static_cast<unsigned>( TERMY );
+        skill_win_size_y = skill_win_size_y_max;
+        if( skill_win_size_y + infooffsetybottom > maxy ) {
+            skill_win_size_y = maxy - infooffsetybottom;
+        }
+        w_skills = catacurses::newwin( skill_win_size_y, grid_width,
+                                       point( 0, infooffsetybottom ) );
+        w_skills_border = catacurses::newwin( skill_win_size_y + 1, grid_width + 1,
+                                              point( 0, infooffsetybottom ) );
+        border_skills.set( point( -1, infooffsetybottom - 1 ),
+                           point( grid_width + 2, skill_win_size_y + 2 ) );
+        ui_skills.position_from_window( w_skills_border );
+    } );
+    ui_skills.mark_resize();
+    ui_skills.on_redraw( [&]( const ui_adaptor & ) {
+        borders.draw_border( w_skills_border );
+        wrefresh( w_skills_border );
+        draw_skills_tab( w_skills, *this, line, curtab, skillslist, skill_win_size_y );
+    } );
+
+    catacurses::window w_info;
+    catacurses::window w_info_border;
+    border_helper::border_info &border_info = borders.add_border();
+    ui_adaptor ui_info;
+    ui_info.on_screen_resize( [&]( ui_adaptor & ui_info ) {
+        w_info = catacurses::newwin( info_win_size_y, FULL_SCREEN_WIDTH,
+                                     point( 0, infooffsetytop ) );
+        w_info_border = catacurses::newwin( info_win_size_y + 1, FULL_SCREEN_WIDTH + 1,
+                                            point( 0, infooffsetytop ) );
+        border_info.set( point( -1, infooffsetytop - 1 ),
+                         point( FULL_SCREEN_WIDTH + 2, info_win_size_y + 2 ) );
+        ui_info.position_from_window( w_info_border );
+    } );
+    ui_info.mark_resize();
+    ui_info.on_redraw( [&]( const ui_adaptor & ) {
+        borders.draw_border( w_info_border );
+        wrefresh( w_info_border );
         draw_info_window( w_info, *this, line, curtab,
                           traitslist, bionicslist, effect_name_and_text, skillslist );
+    } );
 
-        done = handle_player_display_action( *this, line, curtab, ctxt,
+    bool done = false;
+
+    do {
+        ui_manager::redraw_invalidated();
+
+        done = handle_player_display_action( *this, line, curtab, ctxt, ui_tip, ui_info,
+                                             ui_stats, ui_encumb, ui_traits, ui_bionics, ui_effects, ui_skills,
                                              traitslist, bionicslist, effect_name_and_text, skillslist );
     } while( !done );
-
-    g->refresh_all();
 }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -290,7 +290,7 @@ enum class player_display_tab {
     effects,
     num_tabs,
 };
-}
+} // namespace
 
 static player_display_tab next_tab( const player_display_tab tab )
 {

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -834,118 +834,6 @@ static void draw_skills_tab( const catacurses::window &w_skills, const catacurse
     }
 }
 
-static void draw_grid_borders( const catacurses::window &w_grid_top,
-                               const catacurses::window &w_grid_skill, const catacurses::window &w_grid_trait,
-                               const catacurses::window &w_grid_bionics, const catacurses::window &w_grid_effect,
-                               const unsigned int &info_win_size_y, const unsigned int &infooffsetybottom,
-                               const unsigned int &skill_win_size_y, const unsigned int &trait_win_size_y,
-                               const unsigned int &bionics_win_size_y, const unsigned int &effect_win_size_y )
-{
-    unsigned upper_info_border = 10;
-    unsigned lower_info_border = 1 + upper_info_border + info_win_size_y;
-    for( unsigned i = 0; i < static_cast<unsigned>( FULL_SCREEN_WIDTH + 1 ); i++ ) {
-        //Horizontal line top grid
-        mvwputch( w_grid_top, point( i, upper_info_border ), BORDER_COLOR, LINE_OXOX );
-        mvwputch( w_grid_top, point( i, lower_info_border ), BORDER_COLOR, LINE_OXOX );
-
-        //Vertical line top grid
-        if( i <= infooffsetybottom ) {
-            mvwputch( w_grid_top, point( 26, i ), BORDER_COLOR, LINE_XOXO );
-            mvwputch( w_grid_top, point( 53, i ), BORDER_COLOR, LINE_XOXO );
-            mvwputch( w_grid_top, point( FULL_SCREEN_WIDTH, i ), BORDER_COLOR, LINE_XOXO );
-        }
-
-        //Horizontal line skills
-        if( i <= 26 ) {
-            mvwputch( w_grid_skill, point( i, skill_win_size_y ), BORDER_COLOR, LINE_OXOX );
-        }
-
-        //Vertical line skills
-        if( i <= skill_win_size_y ) {
-            mvwputch( w_grid_skill, point( 26, i ), BORDER_COLOR, LINE_XOXO );
-        }
-
-        //Horizontal line traits
-        if( i <= 26 ) {
-            mvwputch( w_grid_trait, point( i, trait_win_size_y ), BORDER_COLOR, LINE_OXOX );
-        }
-
-        //Vertical line traits
-        if( i <= trait_win_size_y ) {
-            mvwputch( w_grid_trait, point( 26, i ), BORDER_COLOR, LINE_XOXO );
-        }
-
-        //Horizontal line bionics
-        if( i <= 26 ) {
-            mvwputch( w_grid_bionics, point( i, bionics_win_size_y ), BORDER_COLOR, LINE_OXOX );
-        }
-
-        //Vertical line bionics
-        if( i <= bionics_win_size_y ) {
-            mvwputch( w_grid_bionics, point( 26, i ), BORDER_COLOR, LINE_XOXO );
-        }
-
-        //Horizontal line effects
-        if( i <= 27 ) {
-            mvwputch( w_grid_effect, point( i, effect_win_size_y ), BORDER_COLOR, LINE_OXOX );
-        }
-
-        //Vertical line effects
-        if( i <= effect_win_size_y ) {
-            mvwputch( w_grid_effect, point( 0, i ), BORDER_COLOR, LINE_XOXO );
-            mvwputch( w_grid_effect, point( 27, i ), BORDER_COLOR, LINE_XOXO );
-        }
-    }
-
-    //Intersections top grid
-    mvwputch( w_grid_top, point( 26, lower_info_border ), BORDER_COLOR, LINE_OXXX ); // T
-    mvwputch( w_grid_top, point( 53, lower_info_border ), BORDER_COLOR, LINE_OXXX ); // T
-    mvwputch( w_grid_top, point( 26, upper_info_border ), BORDER_COLOR, LINE_XXOX ); // _|_
-    mvwputch( w_grid_top, point( 53, upper_info_border ), BORDER_COLOR, LINE_XXOX ); // _|_
-    mvwputch( w_grid_top, point( FULL_SCREEN_WIDTH, upper_info_border ), BORDER_COLOR,
-              LINE_XOXX ); // -|
-    mvwputch( w_grid_top, point( FULL_SCREEN_WIDTH, lower_info_border ), BORDER_COLOR,
-              LINE_XOXX ); // -|
-    wrefresh( w_grid_top );
-
-    mvwputch( w_grid_skill, point( 26, skill_win_size_y ), BORDER_COLOR, LINE_XOOX ); // _|
-
-    if( skill_win_size_y > trait_win_size_y ) {
-        mvwputch( w_grid_skill, point( 26, trait_win_size_y ), BORDER_COLOR, LINE_XXXO );    // |-
-    } else if( skill_win_size_y == trait_win_size_y ) {
-        mvwputch( w_grid_skill, point( 26, trait_win_size_y ), BORDER_COLOR, LINE_XXOX );    // _|_
-    }
-
-    mvwputch( w_grid_trait, point( 26, trait_win_size_y ), BORDER_COLOR, LINE_XOXX ); // -|
-
-    if( trait_win_size_y > effect_win_size_y ) {
-        mvwputch( w_grid_trait, point( 26, effect_win_size_y ), BORDER_COLOR, LINE_XXXO ); // |-
-    } else if( trait_win_size_y == effect_win_size_y ) {
-        mvwputch( w_grid_trait, point( 26, effect_win_size_y ), BORDER_COLOR, LINE_XXOX ); // _|_
-    } else if( trait_win_size_y < effect_win_size_y ) {
-        mvwputch( w_grid_trait, point( 26, trait_win_size_y ), BORDER_COLOR, LINE_XOXX ); // -|
-        mvwputch( w_grid_trait, point( 26, effect_win_size_y ), BORDER_COLOR, LINE_XXOO ); // |_
-    }
-
-    if( ( trait_win_size_y + bionics_win_size_y ) > effect_win_size_y ) {
-        mvwputch( w_grid_bionics, point( 26, bionics_win_size_y ), BORDER_COLOR, LINE_XOOX ); // _|
-    } else if( ( trait_win_size_y + bionics_win_size_y ) == effect_win_size_y ) {
-        mvwputch( w_grid_bionics, point( 26, effect_win_size_y ), BORDER_COLOR, LINE_XXOX ); // _|_
-    } else if( ( trait_win_size_y + bionics_win_size_y ) < effect_win_size_y ) {
-        mvwputch( w_grid_bionics, point( 26, bionics_win_size_y ), BORDER_COLOR, LINE_XOXX ); // -|
-        mvwputch( w_grid_bionics, point( 26, effect_win_size_y ), BORDER_COLOR, LINE_XXOO ); // |_
-    }
-
-    mvwputch( w_grid_effect, point( 0, effect_win_size_y ), BORDER_COLOR, LINE_XXOO ); // |_
-    mvwputch( w_grid_effect, point( 27, effect_win_size_y ), BORDER_COLOR, LINE_XOOX ); // _|
-
-    wrefresh( w_grid_skill );
-    wrefresh( w_grid_effect );
-    wrefresh( w_grid_trait );
-    wrefresh( w_grid_bionics );
-
-}
-
 static void draw_initial_windows( const catacurses::window &w_stats,
                                   const catacurses::window &w_encumb, const catacurses::window &w_traits,
                                   const catacurses::window &w_bionics, const catacurses::window &w_effects,
@@ -1242,7 +1130,10 @@ void player::disp_info()
     unsigned int skill_win_size_y = 1 + skillslist.size();
     unsigned int info_win_size_y = 6;
 
-    unsigned int infooffsetytop = 11;
+    const unsigned int grid_width = 26;
+    const unsigned int grid_height = 9;
+
+    const unsigned int infooffsetytop = grid_height + 2;
     unsigned int infooffsetybottom = infooffsetytop + 1 + info_win_size_y;
 
     if( ( bionics_win_size_y + trait_win_size_y + infooffsetybottom ) > maxy ) {
@@ -1265,51 +1156,93 @@ void player::disp_info()
         skill_win_size_y = maxy - infooffsetybottom;
     }
 
-    catacurses::window w_grid_top =
-        catacurses::newwin( infooffsetybottom, FULL_SCREEN_WIDTH + 1,
-                            point_zero );
-    catacurses::window w_grid_skill =
-        catacurses::newwin( skill_win_size_y + 1, 27,
-                            point( 0, infooffsetybottom ) );
-    catacurses::window w_grid_trait =
-        catacurses::newwin( trait_win_size_y + 1, 27,
-                            point( 27, infooffsetybottom ) );
-    catacurses::window w_grid_bionics =
-        catacurses::newwin( bionics_win_size_y + 1, 27,
-                            point( 27,
-                                   infooffsetybottom + trait_win_size_y + 1 ) );
-    catacurses::window w_grid_effect =
-        catacurses::newwin( effect_win_size_y + 1, 28,
-                            point( 53, infooffsetybottom ) );
+    border_helper borders;
 
     catacurses::window w_tip =
-        catacurses::newwin( 1, FULL_SCREEN_WIDTH, point_zero );
+        catacurses::newwin( 1, FULL_SCREEN_WIDTH + 1, point_zero );
     catacurses::window w_stats =
-        catacurses::newwin( 9, 26, point( 0, 1 ) ); //NOLINT(cata-use-named-point-constants)
+        //NOLINTNEXTLINE(cata-use-named-point-constants)
+        catacurses::newwin( grid_height, grid_width, point( 0, 1 ) );
+    // Every grid draws the bottom and right borders. The top and left borders
+    // are either not displayed or drawn by another grid.
+    catacurses::window w_stats_border =
+        //NOLINTNEXTLINE(cata-use-named-point-constants)
+        catacurses::newwin( grid_height + 1, grid_width + 1, point( 0, 1 ) );
+    // But we need to specify the full border for border_helper to calculate the
+    // border connection.
+    //NOLINTNEXTLINE(cata-use-named-point-constants)
+    borders.add_border().set( point( -1, 0 ), point( grid_width + 2, grid_height + 2 ) );
+
     catacurses::window w_traits =
-        catacurses::newwin( trait_win_size_y, 26,
-                            point( 27, infooffsetybottom ) );
+        catacurses::newwin( trait_win_size_y, grid_width,
+                            point( grid_width + 1, infooffsetybottom ) );
+    catacurses::window w_traits_border =
+        catacurses::newwin( trait_win_size_y + 1, grid_width + 1,
+                            point( grid_width + 1, infooffsetybottom ) );
+    borders.add_border().set( point( grid_width, infooffsetybottom - 1 ),
+                              point( grid_width + 2, trait_win_size_y + 2 ) );
+
     catacurses::window w_bionics =
-        catacurses::newwin( bionics_win_size_y, 26,
-                            point( 27,
+        catacurses::newwin( bionics_win_size_y, grid_width,
+                            point( grid_width + 1,
                                    infooffsetybottom + trait_win_size_y + 1 ) );
+    catacurses::window w_bionics_border =
+        catacurses::newwin( bionics_win_size_y + 1, grid_width + 1,
+                            point( grid_width + 1,
+                                   infooffsetybottom + trait_win_size_y + 1 ) );
+    borders.add_border().set( point( grid_width, infooffsetybottom + trait_win_size_y ),
+                              point( grid_width + 2, bionics_win_size_y + 2 ) );
+
     catacurses::window w_encumb =
-        catacurses::newwin( 9, 26, point( 27, 1 ) );
+        catacurses::newwin( grid_height, grid_width, point( grid_width + 1, 1 ) );
+    catacurses::window w_encumb_border =
+        catacurses::newwin( grid_height + 1, grid_width + 1, point( grid_width + 1, 1 ) );
+    borders.add_border().set( point( grid_width, 0 ), point( grid_width + 2, grid_height + 2 ) );
+
     catacurses::window w_effects =
-        catacurses::newwin( effect_win_size_y, 26,
-                            point( 54, infooffsetybottom ) );
+        catacurses::newwin( effect_win_size_y, grid_width,
+                            point( grid_width * 2 + 2, infooffsetybottom ) );
+    catacurses::window w_effects_border =
+        catacurses::newwin( effect_win_size_y + 1, grid_width + 1,
+                            point( grid_width * 2 + 2, infooffsetybottom ) );
+    borders.add_border().set( point( grid_width * 2 + 1, infooffsetybottom - 1 ),
+                              point( grid_width + 2, effect_win_size_y + 2 ) );
+
     catacurses::window w_speed =
-        catacurses::newwin( 9, 26, point( 54, 1 ) );
+        catacurses::newwin( grid_height, grid_width, point( grid_width * 2 + 2, 1 ) );
+    catacurses::window w_speed_border =
+        catacurses::newwin( grid_height + 1, grid_width + 1, point( grid_width * 2 + 2, 1 ) );
+    borders.add_border().set( point( grid_width * 2 + 1, 0 ),
+                              point( grid_width + 2, grid_height + 2 ) );
+
     catacurses::window w_skills =
-        catacurses::newwin( skill_win_size_y, 26,
+        catacurses::newwin( skill_win_size_y, grid_width,
                             point( 0, infooffsetybottom ) );
+    catacurses::window w_skills_border =
+        catacurses::newwin( skill_win_size_y + 1, grid_width + 1,
+                            point( 0, infooffsetybottom ) );
+    borders.add_border().set( point( -1, infooffsetybottom - 1 ),
+                              point( grid_width + 2, skill_win_size_y + 2 ) );
+
     catacurses::window w_info =
         catacurses::newwin( info_win_size_y, FULL_SCREEN_WIDTH,
                             point( 0, infooffsetytop ) );
+    catacurses::window w_info_border =
+        catacurses::newwin( info_win_size_y + 1, FULL_SCREEN_WIDTH + 1,
+                            point( 0, infooffsetytop ) );
+    borders.add_border().set( point( -1, infooffsetytop - 1 ),
+                              point( FULL_SCREEN_WIDTH + 2, info_win_size_y + 2 ) );
 
-    draw_grid_borders( w_grid_top, w_grid_skill, w_grid_trait, w_grid_bionics, w_grid_effect,
-                       info_win_size_y, infooffsetybottom, skill_win_size_y, trait_win_size_y,
-                       bionics_win_size_y, effect_win_size_y );
+    const auto draw_grid_borders = [&]() {
+        for( catacurses::window win : {
+                 w_stats_border, w_traits_border, w_bionics_border, w_encumb_border,
+                 w_effects_border, w_speed_border, w_skills_border, w_info_border
+             } ) {
+            borders.draw_border( win );
+            wrefresh( win );
+        }
+    };
+    draw_grid_borders();
     //-1 for header
     trait_win_size_y--;
     bionics_win_size_y--;
@@ -1356,7 +1289,7 @@ void player::disp_info()
     ctxt.register_action( "HELP_KEYBINDINGS" );
     std::string action;
 
-    right_print( w_tip, 0, 0, c_white, string_format(
+    right_print( w_tip, 0, 1, c_white, string_format(
                      _( "[<color_yellow>%s</color>]" ),
                      ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
     wrefresh( w_tip );
@@ -1418,9 +1351,7 @@ void player::disp_info()
 
             g->refresh_all();
 
-            draw_grid_borders( w_grid_top, w_grid_skill, w_grid_trait, w_grid_bionics, w_grid_effect,
-                               info_win_size_y, infooffsetybottom, skill_win_size_y + 1, trait_win_size_y + 1,
-                               bionics_win_size_y + 1, effect_win_size_y + 1 );
+            draw_grid_borders();
 
             // Print name and header
             if( g->u.custom_profession.empty() ) {
@@ -1442,7 +1373,7 @@ void player::disp_info()
                            male ? _( "Male" ) : _( "Female" ), g->u.custom_profession );
             }
 
-            right_print( w_tip, 0, 0, c_white, string_format(
+            right_print( w_tip, 0, 1, c_white, string_format(
                              _( "[<color_yellow>%s</color>]" ),
                              ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
 

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -174,6 +174,14 @@ void ui_adaptor::invalidate( const rectangle &rect )
 
 void ui_adaptor::redraw()
 {
+    if( !ui_stack.empty() ) {
+        ui_stack.back().get().invalidated = true;
+    }
+    redraw_invalidated();
+}
+
+void ui_adaptor::redraw_invalidated()
+{
     // apply deferred resizing
     auto first = ui_stack.rbegin();
     for( ; first != ui_stack.rend(); ++first ) {
@@ -195,7 +203,6 @@ void ui_adaptor::redraw()
     // redraw invalidated uis
     // TODO refresh only when all stacked UIs are drawn
     if( !ui_stack.empty() ) {
-        ui_stack.back().get().invalidated = true;
         auto first = ui_stack.crbegin();
         for( ; first != ui_stack.crend(); ++first ) {
             if( first->get().disabling_uis_below ) {
@@ -246,6 +253,11 @@ void invalidate( const rectangle &rect )
 void redraw()
 {
     ui_adaptor::redraw();
+}
+
+void redraw_invalidated()
+{
+    ui_adaptor::redraw_invalidated();
 }
 
 void screen_resized()

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -62,6 +62,7 @@ class ui_adaptor
 
         static void invalidate( const rectangle &rect );
         static void redraw();
+        static void redraw_invalidated();
         static void screen_resized();
     private:
         static void invalidation_consistency_and_optimization();
@@ -94,6 +95,8 @@ namespace ui_manager
 void invalidate( const rectangle &rect );
 // invalidate the top window and redraw all invalidated windows
 void redraw();
+// redraw all invalidated windows without invalidating the top window
+void redraw_invalidated();
 void screen_resized();
 } // namespace ui_manager
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Interface "Migrate some UIs to ui_adaptor (ported from DDA), clean up NPC dialogue UI"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Finish migrating UIs to ui_adaptor
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Cherry-picked, almost without changes, PRs from DDA:

CleverRaven#40553
Advanced inventory menu [`/`], defense game menus.
Advanced inventory had text trimming issue when game window was very narrow (around 80), fixed that.

CleverRaven#40526
CleverRaven#40608
iuse games (accessable through handheld game system)

CleverRaven#40621
Live mouse view & npc dialogue window.
The dialogue window had a bunch of problems:
* Message history was saved as folded chunks of actual messages. That means, there was no way to re-fold messages when window was resized.
* At small game window heights (approx <40), NPC-related keybindings were not visible (a bug: they were printed out of visible area).
* Paging of responses worked weirdly, sometimes cutting responses in half (which it shouldn't do).

So I decided to refactor it a bit to mitigate those issues:
* Messages are now stored whole, and a separate vector stores folded chunks of those messages & separators. When game window is resized / new message is added, that vector is re-generated / updated.
* Previously, all responses were folded & treated as a continuous array of lines, and paging was done by indexing into this array. That led to some responses being split in 2. Now, responses are folded and then separated into pages, with only the current page being displayed.

CleverRaven#40727
Cherry-picked everything except changes to targeting ui (too many conflicts, and that ui needs a refactor anyway).

CleverRaven#40770
Character status screen [`@`].

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested each screen by resizing game window.
Tested NPC dialogue window by browsing various entries, switching pages and resizing window.
Checked that zone manager still works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
