### PR TITLE
Port over spellcasting CBMs and NO_FAIL flag

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -610,6 +610,12 @@
     "//": "This makes the spell's effects permanent."
   },
   {
+    "id": "NO_FAIL",
+    "type": "json_flag",
+    "context": [ "SPELL" ],
+    "//": "Spellcasting never fails for this spell"
+  },
+  {
     "id": "IGNORE_WALLS",
     "type": "json_flag",
     "context": [ "SPELL" ],

--- a/data/mods/Aftershock/player/bionics.json
+++ b/data/mods/Aftershock/player/bionics.json
@@ -68,6 +68,7 @@
     "fake_item": "bio_skullgun_gun",
     "flags": [ "BIONIC_TOGGLED", "BIONIC_WEAPON", "NO_UNWIELD" ],
     "stat_bonus": [ [ "INT", -4 ], [ "PER", -2 ] ],
-    "canceled_mutations": [ "INT_UP", "INT_UP_2", "INT_UP_3", "INT_UP_4", "INT_ALPHA" ]
+    "canceled_mutations": [ "INT_UP", "INT_UP_2", "INT_UP_3", "INT_UP_4", "INT_ALPHA" ],
+    "spell_on_activation": { "id": "skullgun_snapback", "hit_self": true }
   }
 ]

--- a/data/mods/Aftershock/spells/spells.json
+++ b/data/mods/Aftershock/spells/spells.json
@@ -23,5 +23,19 @@
     "base_casting_time": 1,
     "min_duration": 100,
     "max_duration": 100
+  },
+  {
+    "id": "skullgun_snapback",
+    "type": "SPELL",
+    "name": "Skullgun Snapback",
+    "//": "Used for activating skullgun cbm, not castable",
+    "description": "This fake spell occurs on skullgun activation.  May be fatal if done in critical condition.",
+    "effect": "target_attack",
+    "valid_targets": [ "self" ],
+    "flags": [ "SILENT", "NO_LEGS", "NO_HANDS", "NO_FAIL" ],
+    "min_damage": 10,
+    "max_damage": 10,
+    "message": "Your head snaps back from the force of the shot.",
+    "damage_type": "bio"
   }
 ]

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -373,7 +373,6 @@ bool Character::activate_bionic( int b, bool eff_only )
             return false;
         }
 
-
         // We can actually activate now, do activation-y things
         mod_power_level( -bio.info().power_activate );
         if( bio.info().toggled || bio.info().charge_time > 0 ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -368,6 +368,12 @@ bool Character::activate_bionic( int b, bool eff_only )
             }
         }
 
+        if( !bio.activate_spell( *this ) ) {
+            // the spell this bionic uses was unable to be cast
+            return false;
+        }
+
+
         // We can actually activate now, do activation-y things
         mod_power_level( -bio.info().power_activate );
         if( bio.info().toggled || bio.info().charge_time > 0 ) {
@@ -2584,6 +2590,7 @@ void load_bionic( const JsonObject &jsobj )
     new_bionic.weight_capacity_modifier = jsobj.get_float( "weight_capacity_modifier", 1.0 );
 
     assign( jsobj, "enchantments", new_bionic.enchantments );
+    assign( jsobj, "spell_on_activation", new_bionic.spell_on_activate );
 
     assign( jsobj, "weight_capacity_bonus", new_bionic.weight_capacity_bonus, false, 0_gram );
     assign( jsobj, "exothermic_power_gen", new_bionic.exothermic_power_gen );

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -114,7 +114,7 @@ struct bionic_data {
     /** bionic enchantments */
     std::vector<enchantment_id> enchantments;
 
-   cata::value_ptr<fake_spell> spell_on_activate;
+    cata::value_ptr<fake_spell> spell_on_activate;
 
     /**
      * Body part slots used to install this bionic, mapped to the amount of space required.

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -13,10 +13,12 @@
 #include "calendar.h"
 #include "character.h"
 #include "flat_set.h"
+#include "magic.h"
 #include "optional.h"
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
+#include "value_ptr.h"
 
 class JsonIn;
 class JsonObject;
@@ -112,6 +114,8 @@ struct bionic_data {
     /** bionic enchantments */
     std::vector<enchantment_id> enchantments;
 
+   cata::value_ptr<fake_spell> spell_on_activate;
+
     /**
      * Body part slots used to install this bionic, mapped to the amount of space required.
      */
@@ -184,6 +188,8 @@ struct bionic {
         void set_auto_start_thresh( float val );
         float get_auto_start_thresh() const;
         bool is_auto_start_on() const;
+
+        bool activate_spell( Character &caster );
 
         void serialize( JsonOut &json ) const;
         void deserialize( JsonIn &jsin );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1521,7 +1521,7 @@ bool bionic::activate_spell( Character &caster )
         return true;
     }
     spell sp = id->spell_on_activate->get_spell();
-    return assign_spellcasting( *caster.as_avatar(), sp, true );
+    return magic.cast_spell( *p, spell, level_override, no_fail, no_cost );
 }
 
 void game::open_consume_item_menu()

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1421,9 +1421,11 @@ static void open_movement_mode_menu()
     }
 }
 
+static bool assign_spellcasting( avatar &you, spell &sp, bool fake_spell );
+
 static void cast_spell()
 {
-    player &u = g->u;
+    avatar &u = g->u;
 
     std::vector<spell_id> spells = u.magic.spells();
 
@@ -1453,35 +1455,45 @@ static void cast_spell()
 
     spell &sp = *u.magic.get_spells()[spell_index];
 
-    if( u.is_armed() && !sp.has_flag( spell_flag::NO_HANDS ) &&
-        !u.weapon.has_flag( flag_MAGIC_FOCUS ) ) {
+    assign_spellcasting( u, sp, false );
+}
+
+// returns if the spell was assigned
+static bool assign_spellcasting( avatar &you, spell &sp, bool fake_spell )
+{
+    if( you.is_armed() && !sp.has_flag( spell_flag::NO_HANDS ) &&
+        !you.weapon.has_flag( flag_MAGIC_FOCUS ) ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
                  _( "You need your hands free to cast this spell!" ) );
-        return;
+        return false;
     }
 
-    if( !u.magic.has_enough_energy( u, sp ) ) {
+    if( !you.magic.has_enough_energy( you, sp ) ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
                  _( "You don't have enough %s to cast the spell." ),
                  sp.energy_string() );
-        return;
+        return false;
     }
 
-    if( sp.energy_source() == hp_energy && !u.has_quality( qual_CUT ) ) {
+    if( sp.energy_source() == hp_energy && !you.has_quality( qual_CUT ) ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
                  _( "You cannot cast Blood Magic without a cutting implement." ) );
-        return;
+        return false;
     }
 
-    player_activity cast_spell( ACT_SPELLCASTING, sp.casting_time( u ) );
+    player_activity cast_spell( ACT_SPELLCASTING, sp.casting_time( you ) );
     // [0] this is used as a spell level override for items casting spells
-    cast_spell.values.emplace_back( -1 );
+    if( fake_spell ) {
+        cast_spell.values.emplace_back( sp.get_level() );
+    } else {
+        cast_spell.values.emplace_back( -1 );
+    }
     // [1] if this value is 1, the spell never fails
     cast_spell.values.emplace_back( 0 );
     // [2] this value overrides the mana cost if set to 0
     cast_spell.values.emplace_back( 1 );
     cast_spell.name = sp.id().c_str();
-    if( u.magic.casting_ignore ) {
+    if( you.magic.casting_ignore ) {
         const std::vector<distraction_type> ignored_distractions = {
             distraction_type::noise,
             distraction_type::pain,
@@ -1497,7 +1509,19 @@ static void cast_spell()
             cast_spell.ignore_distraction( ignored );
         }
     }
-    u.assign_activity( cast_spell, false );
+    you.assign_activity( cast_spell, false );
+    return true;
+}
+
+// this is here because it shares some things in common with cast_spell
+bool bionic::activate_spell( Character &caster )
+{
+    if( !caster.is_avatar() || !id->spell_on_activate ) {
+        // the return value tells us if the spell fails. if it has no spell it can't fail
+        return true;
+    }
+    spell sp = id->spell_on_activate->get_spell();
+    return assign_spellcasting( *caster.as_avatar(), sp, true );
 }
 
 void game::open_consume_item_menu()

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -114,6 +114,7 @@ std::string enum_to_string<spell_flag>( spell_flag data )
         case spell_flag::RANDOM_TARGET: return "RANDOM_TARGET";
         case spell_flag::MUTATE_TRAIT: return "MUTATE_TRAIT";
         case spell_flag::PAIN_NORESIST: return "PAIN_NORESIST";
+        case spell_flag::NO_FAIL: return "NO_FAIL";
         case spell_flag::WONDER: return "WONDER";
         case spell_flag::LAST: break;
     }
@@ -723,6 +724,9 @@ std::string spell::message() const
 
 float spell::spell_fail( const Character &guy ) const
 {
+    if( has_flag( spell_flag::NO_FAIL ) ) {
+        return 0.0f;
+    }
     // formula is based on the following:
     // exponential curve
     // effective skill of 0 or less is 100% failure

--- a/src/magic.h
+++ b/src/magic.h
@@ -56,6 +56,7 @@ enum spell_flag {
     MUTATE_TRAIT, // overrides the mutate spell_effect to use a specific trait_id instead of a category
     WONDER, // instead of casting each of the extra_spells, it picks N of them and casts them (where N is std::min( damage(), number_of_spells ))
     PAIN_NORESIST, // pain altering spells can't be resisted (like with the deadened trait)
+    NO_FAIL, // this spell cannot fail when you cast it
     LAST
 };
 

--- a/src/magic.h
+++ b/src/magic.h
@@ -495,6 +495,8 @@ class known_magic
         // returns false if invlet is already used
         bool set_invlet( const spell_id &sp, int invlet, const std::set<int> &used_invlets );
         void rem_invlet( const spell_id &sp );
+        // actual results of casting the spell, separated from activity_handlers::spellcasting_finish
+        void cast_spell(Character &guy, const spell_id &spell, int level_override, bool no_fail, bool no_cost);
     private:
         // gets length of longest spell name
         int get_spellname_max_width();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Features "Port over changes allowing bionics to cast spells, and NO_FAIL spell flag."

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Should be the second to last part of my work on adding stuff I'll need when converting mods to Bright Nights, adds the ability for CBMs to cast spells on activation, and the NO_FAIL flag from the same PR (the more useful bit right now, but the former feature would be extremely neat to make use of).

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added changes to bionics.cpp, bionics.h, and handle_activity.cpp to support bionics casting spells when used.
2. Added changes to magic.cpp and magic.h for NO_FAIL flag.
3. Added NO_FAIL flag to flags.json.
4. Re-implemented the skullgun's kickback effect for testing purposes.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

NO_FAIL is not really essential for most cases but is extremely useful for mods that can't use the spellbook system (due to the use of the spellcraft skill being hardcoded in), as this allows one to alter the EXP gain from casting via giving it a spell a much higher difficulty, reducing the tedium of cast-grinding.

The other feature is also pretty much unused aside from the skullgun, but would be very useful in the future.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Started a world in Aftershock.
3. Debugged in and installed the skullgun, plus enough CBM power to use it.
4. Tested repeated activation to ensure it deals damage and doesn't fail.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

PR being ported over: https://github.com/CleverRaven/Cataclysm-DDA/pull/41396

Changes not ported over:
1. The changes to activity_handlers.cpp that added in, far as I can tell, a less clunky way to handle overriding spell levels when casting from items. Reason was, code as written was reporting this error:
```
1>C:\Users\V\Documents\GitHub\Cataclysm-BN\src\activity_handlers.cpp(4640,26): error C2039: 'set_level': is not a member of 'spell'
1>C:\Users\V\Documents\GitHub\Cataclysm-BN\src\ranged.h(16): message : see declaration of 'spell'
```

Side note, the skullgun seems a bit odd, both design-wise and balance-wise, even if it is admittedly a Deus Ex meme. Design-wise, the spell kicks in whenever you deploy the gun itself, which is completely divorced from the act of firing it (presumably what's supposed to causing recoil damage). Balance-wise, the player has to put up with a very heavy price just to install it, and using it is generally impractical. If it was a `BIONIC_GUN` drawing a certain amount of kJ as a basic energy weapon, instead of a manually-loaded BIONIC_WEAPON, that would fix the former and make the latter slightly more tolerable.