### PR TITLE
Potential Inclusion Of Additional Weather From Japanese Variant Of CDDA

### DIFF
--- a/src/weather.h
+++ b/src/weather.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef CATA_SRC_WEATHER_H
-#define CATA_SRC_WEATHER_H
+#ifndef WEATHER_H
+#define WEATHER_H
 
 #include "color.h"
 #include "optional.h"
@@ -45,6 +45,8 @@ enum weather_type : int {
     WEATHER_CLEAR,        //!< No effects
     WEATHER_SUNNY,        //!< Glare if no eye protection
     WEATHER_CLOUDY,       //!< No effects
+    WEATHER_RAINBOW,      //!< gain morale
+    WEATHER_DIAMONDDUST,  //!< more gain morale than rainbow
     WEATHER_LIGHT_DRIZZLE,//!< very Light rain
     WEATHER_DRIZZLE,      //!< Light rain
     WEATHER_RAINY,        //!< Lots of rain, sight penalties
@@ -52,9 +54,12 @@ enum weather_type : int {
     WEATHER_LIGHTNING,    //!< Rare lightning strikes!
     WEATHER_ACID_DRIZZLE, //!< No real effects; warning of acid rain
     WEATHER_ACID_RAIN,    //!< Minor acid damage
+    WEATHER_ACID_STORM,   //!< Massive acid damage
     WEATHER_FLURRIES,     //!< Light snow
     WEATHER_SNOW,         //!< snow glare effects
     WEATHER_SNOWSTORM,    //!< sight penalties
+    WEATHER_ACID_FLURRIES,//!< No real effect
+    WEATHER_ACID_SNOW,    //!< Minor acid damage
     NUM_WEATHER_TYPES     //!< Sentinel value
 };
 
@@ -117,6 +122,9 @@ void thunder();
 void lightning();
 void light_acid();
 void acid();
+void acid_storm();
+void rainbow();
+void diamond_dust();
 //!< Currently flurries have no additional effects.
 void flurry();
 void snow();
@@ -183,9 +191,7 @@ std::string print_temperature( double fahrenheit, int decimals = 0 );
 std::string print_humidity( double humidity, int decimals = 0 );
 std::string print_pressure( double pressure, int decimals = 0 );
 
-// Return windchill offset in degrees F, starting from given temperature, humidity and wind
-int get_local_windchill( double temperature_f, double humidity, double wind_mph );
-
+int get_local_windchill( double temperature, double humidity, double windpower );
 int get_local_humidity( double humidity, weather_type weather, bool sheltered = false );
 double get_local_windpower( double windpower, const oter_id &omter, const tripoint &location,
                             const int &winddirection,
@@ -264,4 +270,4 @@ class weather_manager
         void clear_temp_cache();
 };
 
-#endif // CATA_SRC_WEATHER_H
+#endif

--- a/src/weather_data.cpp
+++ b/src/weather_data.cpp
@@ -18,14 +18,18 @@ weather_animation_t get_weather_animation( weather_type const type )
     static const std::map<weather_type, weather_animation_t> map {
         {WEATHER_ACID_DRIZZLE, weather_animation_t {0.01f, c_light_green, '.'}},
         {WEATHER_ACID_RAIN,    weather_animation_t {0.02f, c_light_green, ','}},
+        {WEATHER_ACID_STORM,   weather_animation_t {0.04f, c_light_green, ','}},
         {WEATHER_LIGHT_DRIZZLE, weather_animation_t{0.01f, c_light_blue, ','}},
         {WEATHER_DRIZZLE,      weather_animation_t {0.01f, c_light_blue,  '.'}},
         {WEATHER_RAINY,        weather_animation_t {0.02f, c_light_blue,  ','}},
         {WEATHER_THUNDER,      weather_animation_t {0.02f, c_light_blue,  '.'}},
         {WEATHER_LIGHTNING,    weather_animation_t {0.04f, c_light_blue,  ','}},
         {WEATHER_FLURRIES,     weather_animation_t {0.01f, c_white,   '.'}},
+        {WEATHER_DIAMONDDUST,  weather_animation_t {0.01f, c_white,   '.'}},
         {WEATHER_SNOW,         weather_animation_t {0.02f, c_white,   ','}},
-        {WEATHER_SNOWSTORM,    weather_animation_t {0.04f, c_white,   '*'}}
+        {WEATHER_SNOWSTORM,    weather_animation_t {0.04f, c_white,   '*'}},
+        {WEATHER_ACID_FLURRIES,weather_animation_t {0.02f, c_light_green,'.'}},
+        {WEATHER_ACID_SNOW,    weather_animation_t {0.02f, c_light_green,   ','}}
     };
 
     const auto it = map.find( type );
@@ -67,6 +71,14 @@ static weather_result weather_data_internal( weather_type const type )
                 PRECIP_NONE, false, false, &weather_effect::none
             },
             weather_datum {
+                translate_marker( "Rainbow" ), c_pink, c_pink_cyan, '=', 0, 1.01f, 0, 0, false,
+                PRECIP_VERY_LIGHT, true, false, &weather_effect::rainbow
+            },
+            weather_datum {
+                translate_marker( "Diamond Dust" ), c_white, c_white_cyan, '.', 2, 1.12f, -15, 2, false,
+                PRECIP_LIGHT, false, false, &weather_effect::diamond_dust
+            },
+            weather_datum {
                 translate_marker( "Light Drizzle" ), c_light_blue, h_light_blue, '.', 0, 1.01f, -10, 0, false,
                 PRECIP_VERY_LIGHT, true, false, &weather_effect::none
             },
@@ -95,6 +107,10 @@ static weather_result weather_data_internal( weather_type const type )
                 PRECIP_HEAVY, true, true, &weather_effect::acid
             },
             weather_datum {
+                translate_marker( "Acid Storm" ), c_green, c_yellow_green, '%', 4, 1.2f, -45, 6, true,
+                PRECIP_HEAVY, true, true, &weather_effect::acid_storm
+            },
+            weather_datum {
                 translate_marker( "Flurries" ), c_white, c_dark_gray_cyan, '.', 2, 1.12f, -15, 2, false,
                 PRECIP_LIGHT, false, false, &weather_effect::flurry
             },
@@ -105,8 +121,16 @@ static weather_result weather_data_internal( weather_type const type )
             weather_datum {
                 translate_marker( "Snowstorm" ), c_white, c_white_cyan, '%', 6, 1.2f, -30, 6, false,
                 PRECIP_HEAVY, false, false, &weather_effect::snowstorm
+            },
+            weather_datum {
+                translate_marker( "Acid Flurries" ), c_light_green, c_yellow_green, '.', 2, 1.12f, -15, 2, true,
+                PRECIP_LIGHT, false, false, &weather_effect::light_acid
+            },
+            weather_datum {
+                translate_marker( "Acid Snow" ), c_light_green, c_yellow_green, '*', 4, 1.13f, -20, 4, true,
+                PRECIP_HEAVY, false, false, &weather_effect::acid
             }
-        }};
+    }};
 
     const size_t i = static_cast<size_t>( type );
     if( i < NUM_WEATHER_TYPES ) {

--- a/src/weather_gen.h
+++ b/src/weather_gen.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef CATA_SRC_WEATHER_GEN_H
-#define CATA_SRC_WEATHER_GEN_H
+#ifndef WEATHER_GEN_H
+#define WEATHER_GEN_H
 
 #include <string>
 
@@ -19,6 +19,7 @@ struct w_point {
     std::string wind_desc;
     int winddirection = 0;
     bool acidic = false;
+    bool acidic_weak = false;
 };
 
 class weather_generator
@@ -57,6 +58,7 @@ class weather_generator
         w_point get_weather( const tripoint &, const time_point &, unsigned ) const;
         weather_type get_weather_conditions( const tripoint &, const time_point &, unsigned seed ) const;
         weather_type get_weather_conditions( const w_point & ) const;
+        weather_type get_variant_modded_weather_conditions( const w_point & ) const;
         int get_wind_direction( season_type ) const;
         int convert_winddir( int ) const;
         int get_water_temperature() const;
@@ -67,4 +69,4 @@ class weather_generator
         static weather_generator load( const JsonObject &jo );
 };
 
-#endif // CATA_SRC_WEATHER_GEN_H
+#endif


### PR DESCRIPTION
SUMMARY: [Features] "Additional Weather Variations For Bright Nights From Japanese CDDA"

Purpose of change:

Alright, did it correctly this time. The Japanese Variant of CDDA has some variant weather that might make a good addition to Bright Nights. They included Acid Flurries, Acid Snow, and two morale boosting weather types (Diamond Dust and Rainbows).

Solution:

The way the weather was implemented was hardcoded, in that a menu option to set % of acid rain from zero to 100 was included. Effects for the Rainbow and Diamond Dust are hardcoded, but defined in intensity via JSON.
 
Alternatives:

Depending on future plans, it's possible that weather may have been JSONized in mainline CDDA. If that's the case, hardcoding might not be the best move. It's possible that this could be included as code, but relegated to a mod to activate in the same way that filthy clothing can be deactivated (basically, a game balance JSON entry).

Testing:

Obviously haven't tested in Bright Nights, but it works very well in the Japanese fork.

Additional context:

As I said before, I don't really know coding. I wouldn't expect a 1:1 implementation even if this was determined to be OK to bring in, but it's more of a "this is possible and might be fun" kind of thing.