### PR TITLE
Port over #41095 from CDDA, adapted to Bright Nights

### DIFF
--- a/data/json/mapgen/shelter.json
+++ b/data/json/mapgen/shelter.json
@@ -65,7 +65,7 @@
         "    |----:--+-:----|4   "
       ],
       "palettes": [ "shelter" ],
-      "place_nested": [ { "chunks": [ [ "shelter_nest_base", 50 ], [ "shelter_nest_used", 50 ] ], "x": 0, "y": 0 } ]
+      "place_nested": [ { "chunks": [ [ "shelter_nest_base", 100 ] ], "x": 0, "y": 0 } ]
     }
   },
   {
@@ -149,7 +149,7 @@
         "    |----:--+-:----|    "
       ],
       "palettes": [ "shelter" ],
-      "place_nested": [ { "chunks": [ [ "shelter_1_nest_base", 50 ], [ "shelter_1_nest_used", 50 ] ], "x": 0, "y": 0 } ]
+      "place_nested": [ { "chunks": [ [ "shelter_nest_base", 100 ] ], "x": 0, "y": 0 } ]
     }
   },
   {
@@ -233,7 +233,7 @@
         "            |-:-+-:-|   "
       ],
       "palettes": [ "shelter" ],
-      "place_nested": [ { "chunks": [ [ "shelter_2_nest_base", 50 ], [ "shelter_2_nest_used", 50 ] ], "x": 0, "y": 0 } ],
+      "place_nested": [ { "chunks": [ [ "shelter_nest_base", 100 ] ], "x": 0, "y": 0 } ],
       "computers": {
         "6": {
           "name": "Evac shelter computer",


### PR DESCRIPTION
SUMMARY: Fixes "Import #41095 to Bright Nights, remove 'used shelter' nested mapgen"


Purpose of change:

Duplicate "move used shelter into the vandalized catagory #41095". Simple change, but it means that those people who want an 'untouched' shelter start can have one. Previously, the setup meant that you had a significant chance of starting in a 'vandalized' shelter anyway.

Solution:

Removes the 'shelter_used' nested mapgen entry from the unvandalized shelters (shelter, shelter_1, shelter_2). 

Alternatives:

Keeping them there. Adjusting 'shelter_used' to be non-vandalized but resource poor (which somewhat defeats the purpose of a Evac Shelter start).

Testing:

Loaded repeatedly, works fine in game.

Additional context:

Can't port over directly, the mapgen for BN shelters is different due to the electrical grid changes such as the battery and charger in the basement. With this, I don't think "shelter_used" is actually used by anything. That nested chunk could be deleted unless there's a good reason to keep it around.
