### PR TITLE
Port over just the NO_FAIL feature

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -610,6 +610,12 @@
     "//": "This makes the spell's effects permanent."
   },
   {
+    "id": "NO_FAIL",
+    "type": "json_flag",
+    "context": [ "SPELL" ],
+    "//": "Spellcasting never fails for this spell"
+  },
+  {
     "id": "IGNORE_WALLS",
     "type": "json_flag",
     "context": [ "SPELL" ],

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -2,7 +2,7 @@
   {
     "id": "pain_damage",
     "type": "SPELL",
-    "name": { "str": "Pain" },
+    "name": { "str": "Debug Pain" },
     "description": "Increases pain",
     "valid_targets": [ "hostile" ],
     "flags": [ "SILENT", "NO_FAIL" ],
@@ -17,10 +17,10 @@
   {
     "id": "stamina_damage",
     "type": "SPELL",
-    "name": { "str": "Tired" },
+    "name": { "str": "Debug Tired" },
     "description": "decreases stamina",
     "valid_targets": [ "hostile" ],
-    "flags": [ "SILENT" ],
+    "flags": [ "SILENT", "NO_FAIL" ],
     "//": "Listed as a recover energy effect with a negative modifier that decreases with each level of the spell, which makes it cause damage instead.",
     "min_damage": -2000,
     "max_damage": -10000,

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -5,7 +5,7 @@
     "name": { "str": "Pain" },
     "description": "Increases pain",
     "valid_targets": [ "hostile" ],
-    "flags": [ "SILENT" ],
+    "flags": [ "SILENT", "NO_FAIL" ],
     "//": "Listed as a recover energy effect with a negative modifier that decreases with each level of the spell, which makes it cause damage instead.",
     "min_damage": -25,
     "max_damage": -225,

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -114,6 +114,7 @@ std::string enum_to_string<spell_flag>( spell_flag data )
         case spell_flag::RANDOM_TARGET: return "RANDOM_TARGET";
         case spell_flag::MUTATE_TRAIT: return "MUTATE_TRAIT";
         case spell_flag::PAIN_NORESIST: return "PAIN_NORESIST";
+        case spell_flag::NO_FAIL: return "NO_FAIL";
         case spell_flag::WONDER: return "WONDER";
         case spell_flag::LAST: break;
     }
@@ -723,6 +724,9 @@ std::string spell::message() const
 
 float spell::spell_fail( const Character &guy ) const
 {
+    if( has_flag( spell_flag::NO_FAIL ) ) {
+        return 0.0f;
+    }
     // formula is based on the following:
     // exponential curve
     // effective skill of 0 or less is 100% failure

--- a/src/magic.h
+++ b/src/magic.h
@@ -56,6 +56,7 @@ enum spell_flag {
     MUTATE_TRAIT, // overrides the mutate spell_effect to use a specific trait_id instead of a category
     WONDER, // instead of casting each of the extra_spells, it picks N of them and casts them (where N is std::min( damage(), number_of_spells ))
     PAIN_NORESIST, // pain altering spells can't be resisted (like with the deadened trait)
+    NO_FAIL, // this spell cannot fail when you cast it
     LAST
 };
 

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -210,7 +210,7 @@ TEST_CASE( "memorials" )
         m, b, "Opened a strange temple." );
 
     check_memorial<event_type::player_levels_spell>(
-        m, b, "Gained a spell level on Pain.", spell_id( "pain_damage" ), 5 );
+        m, b, "Gained a spell level on Debug Pain.", spell_id( "pain_damage" ), 5 );
 
     check_memorial<event_type::releases_subspace_specimens>(
         m, b, "Released subspace specimens." );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Features "Port over NO_FAIL spell flag"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Focusing on just the part from the source PR I needed, due to technical difficulties noted in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/208 that are a bit beyond my reach at present.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added NO_FAIL flag to flags.json.
2. Added changes to magic.cpp and magic.h for NO_FAIL flag.
3. Added NO_FAIL flag to debug-only "Pain" and "Tired" spell for testing, renamed them to differentiate them from the mi-go beam side effect spells of the same names.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

As noted in previous PR, it's mostly just real damn useful for casting EXP balance but isn't vital for mod porting.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Debug-learned all spells in a vanilla world.
3. Opened spellcasting menu to check failure rate of Debug Pain, vs. other spells on the list.
4. Cast it to confirm it works and doesn't fail.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/41396

Changes to skullgun and the spellcasting CBM feature not ported over, due to issues with skullgun not really being a good fit for the feature, and issues with the spellcasting activity being all in one function. Not yet experienced enough with the code to properly handle the latter, and fixing the former is going to require coding a whole new "cast spell when you fire a ranged weapon" feature before the skullgun's recoil effect starts actually making sense.