### PR TITLE
Port changes to sorting & localized sorting

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -496,9 +496,7 @@ struct advanced_inv_sorter {
                             return false;
                         }
                     }
-                    return std::lexicographical_compare( a1.begin(), a1.end(),
-                                                         a2.begin(), a2.end(),
-                                                         sort_case_insensitive_less() );
+                    return localized_compare( a1, a2 );
                 }
             }
             break;
@@ -525,8 +523,7 @@ struct advanced_inv_sorter {
             n1 = &d1.name_without_prefix;
             n2 = &d2.name_without_prefix;
         }
-        return std::lexicographical_compare( n1->begin(), n1->end(),
-                                             n2->begin(), n2->end(), sort_case_insensitive_less() );
+        return localized_compare( *n1, *n2 );
     }
 };
 

--- a/src/advanced_inv.h
+++ b/src/advanced_inv.h
@@ -16,12 +16,6 @@ class input_context;
 class item;
 struct advanced_inv_save_state;
 
-struct sort_case_insensitive_less : public std::binary_function< char, char, bool > {
-    bool operator()( char x, char y ) const {
-        return toupper( static_cast< unsigned char >( x ) ) < toupper( static_cast< unsigned char >( y ) );
-    }
-};
-
 void create_advanced_inv();
 
 /**

--- a/src/cata_variant.h
+++ b/src/cata_variant.h
@@ -325,9 +325,9 @@ class cata_variant
         CATA_VARIANT_OPERATOR( == );
         CATA_VARIANT_OPERATOR( != );
         CATA_VARIANT_OPERATOR( < ); // NOLINT( cata-use-localized-sorting )
-        CATA_VARIANT_OPERATOR( <= );
-        CATA_VARIANT_OPERATOR( > );
-        CATA_VARIANT_OPERATOR( >= );
+        CATA_VARIANT_OPERATOR( <= ); // NOLINT( cata-use-localized-sorting )
+        CATA_VARIANT_OPERATOR( > ); // NOLINT( cata-use-localized-sorting )
+        CATA_VARIANT_OPERATOR( >= ); // NOLINT( cata-use-localized-sorting )
 #undef CATA_VARIANT_OPERATOR
     private:
         explicit cata_variant( cata_variant_type t, std::string &&v )

--- a/src/cata_variant.h
+++ b/src/cata_variant.h
@@ -324,7 +324,7 @@ class cata_variant
     }
         CATA_VARIANT_OPERATOR( == );
         CATA_VARIANT_OPERATOR( != );
-        CATA_VARIANT_OPERATOR( < );
+        CATA_VARIANT_OPERATOR( < ); // NOLINT( cata-use-localized-sorting )
         CATA_VARIANT_OPERATOR( <= );
         CATA_VARIANT_OPERATOR( > );
         CATA_VARIANT_OPERATOR( >= );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -928,6 +928,12 @@ const recipe *select_crafting_recipe( int &batch_size )
 
 std::string peek_related_recipe( const recipe *current, const recipe_subset &available )
 {
+    auto compare_second =
+        []( const std::pair<std::string, std::string> &a,
+    const std::pair<std::string, std::string> &b ) {
+        return localized_compare( a.second, b.second );
+    };
+
     // current recipe components
     std::vector<std::pair<itype_id, std::string>> related_components;
     const requirement_data &req = current->simple_requirements();
@@ -936,6 +942,7 @@ std::string peek_related_recipe( const recipe *current, const recipe_subset &ava
             related_components.push_back( { a.type, item::nname( a.type, 1 ) } );
         }
     }
+    std::sort( related_components.begin(), related_components.end(), compare_second );
     // current recipe result
     std::vector<std::pair<itype_id, std::string>> related_results;
     item tmp = current->create_result();
@@ -951,10 +958,7 @@ std::string peek_related_recipe( const recipe *current, const recipe_subset &ava
             related_results.push_back( { b->result(), b->result_name() } );
         }
     }
-    std::stable_sort( related_results.begin(), related_results.end(),
-    []( const std::pair<std::string, std::string> &a, const std::pair<std::string, std::string> &b ) {
-        return localized_compare( a.second, b.second );
-    } );
+    std::stable_sort( related_results.begin(), related_results.end(), compare_second );
 
     uilist rel_menu;
     int np_last = -1;

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -953,7 +953,7 @@ std::string peek_related_recipe( const recipe *current, const recipe_subset &ava
     }
     std::stable_sort( related_results.begin(), related_results.end(),
     []( const std::pair<std::string, std::string> &a, const std::pair<std::string, std::string> &b ) {
-        return a.second < b.second;
+        return localized_compare( a.second, b.second );
     } );
 
     uilist rel_menu;

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -330,7 +330,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
     if( scol >= 0 ) {
         std::sort( rows.begin(), rows.end(), [&scol]( const std::vector<std::string> &lhs,
         const std::vector<std::string> &rhs ) {
-            return lhs[ scol ] < rhs[ scol ];
+            return localized_compare( lhs[ scol ], rhs[ scol ] );
         } );
     }
 

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -315,7 +315,9 @@ std::vector<std::string> find_file_if_bfs( const std::string &root_path,
 
         // Keep files and directories to recurse ordered consistently
         // by sorting from the old end to the new end.
+        // NOLINTNEXTLINE(cata-use-localized-sorting)
         std::sort( std::begin( directories ) + n_dirs,    std::end( directories ) );
+        // NOLINTNEXTLINE(cata-use-localized-sorting)
         std::sort( std::begin( results )     + n_results, std::end( results ) );
     }
 

--- a/src/flat_set.h
+++ b/src/flat_set.h
@@ -13,7 +13,9 @@ struct transparent_less_than {
 
     template<typename T, typename U>
     constexpr auto operator()( T &&lhs, U &&rhs ) const noexcept
+    // NOLINTNEXTLINE(cata-use-localized-sorting)
     -> decltype( std::forward<T>( lhs ) < std::forward<U>( rhs ) ) {
+        // NOLINTNEXTLINE(cata-use-localized-sorting)
         return std::forward<T>( lhs ) < std::forward<U>( rhs );
     }
 };

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6603,8 +6603,7 @@ bool item::operator<( const item &other ) const
         } else {
             std::string n1 = me->type->nname( 1 );
             std::string n2 = rhs->type->nname( 1 );
-            return std::lexicographical_compare( n1.begin(), n1.end(),
-                                                 n2.begin(), n2.end(), sort_case_insensitive_less() );
+            return localized_compare( n1, n2 );
         }
     }
 }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -471,7 +471,8 @@ void main_menu::load_char_templates()
         path.erase( 0, path.find_last_of( "\\/" ) + 1 );
         templates.push_back( path );
     }
-    std::sort( templates.begin(), templates.end(), std::greater<std::string>() );
+    std::sort( templates.begin(), templates.end(), localized_compare );
+    std::reverse( templates.begin(), templates.end() );
 }
 
 bool main_menu::opening_screen()

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -468,7 +468,7 @@ void main_menu::load_char_templates()
             true ) ) {
         path = native_to_utf8( path );
         path.erase( path.find( ".template" ), std::string::npos );
-        path.erase( 0, path.find_last_of( "\\//" ) + 1 );
+        path.erase( 0, path.find_last_of( "\\/" ) + 1 );
         templates.push_back( path );
     }
     std::sort( templates.begin(), templates.end(), std::greater<std::string>() );

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1466,7 +1466,7 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
             std::transform( ma.weapons.begin(), ma.weapons.end(),
                             std::back_inserter( weapons ), []( const std::string & wid )-> std::string { return item::nname( wid ); } );
             // Sorting alphabetically makes it easier to find a specific weapon
-            std::sort( weapons.begin(), weapons.end() );
+            std::sort( weapons.begin(), weapons.end(), localized_compare );
             // This removes duplicate names (e.g. a real weapon and a replica sharing the same name) from the weapon list.
             auto last = std::unique( weapons.begin(), weapons.end() );
             weapons.erase( last, weapons.end() );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1787,8 +1787,8 @@ tab_direction set_skills( avatar &u, points_left &points )
             std::sort( elem.second.begin(), elem.second.end(),
                        []( const std::pair<std::string, int> &lhs,
             const std::pair<std::string, int> &rhs ) {
-                return lhs.second < rhs.second ||
-                       ( lhs.second == rhs.second && lhs.first < rhs.first );
+                return localized_compare( std::make_pair( lhs.second, lhs.first ),
+                                          std::make_pair( rhs.second, rhs.first ) );
             } );
 
             const std::string rec_temp = enumerate_as_string( elem.second.begin(), elem.second.end(),

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1148,6 +1148,12 @@ std::string trim_punctuation_marks( const std::string &s )
 using char_t = std::string::value_type;
 std::string to_upper_case( const std::string &s )
 {
+    if( std::locale().name() != "en_US.UTF-8" && std::locale().name() != "C" ) {
+        const auto &f = std::use_facet<std::ctype<wchar_t>>( std::locale() );
+        std::wstring wstr = utf8_to_wstr( s );
+        f.toupper( &wstr[0], &wstr[0] + wstr.size() );
+        return wstr_to_utf8( wstr );
+    }
     std::string res;
     std::transform( s.begin(), s.end(), std::back_inserter( res ), []( char_t ch ) {
         return std::use_facet<std::ctype<char_t>>( std::locale() ).toupper( ch );

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -358,7 +358,7 @@ std::string requirement_data::print_all_objs( const std::string &header,
         []( const T & t ) {
             return t.to_string();
         } );
-        std::sort( alternatives.begin(), alternatives.end() );
+        std::sort( alternatives.begin(), alternatives.end(), localized_compare );
         buffer += join( alternatives, _( " or " ) );
     }
     if( buffer.empty() ) {
@@ -616,7 +616,7 @@ std::vector<std::string> requirement_data::get_folded_list( int width,
             }
             buffer_has.push_back( text + color_tag );
         }
-        std::sort( list_as_string.begin(), list_as_string.end() );
+        std::sort( list_as_string.begin(), list_as_string.end(), localized_compare );
 
         const std::string separator = colorize( _( " OR " ), c_white );
         const std::string unfolded = join( list_as_string, separator );

--- a/src/scores_ui.cpp
+++ b/src/scores_ui.cpp
@@ -39,7 +39,7 @@ static std::string get_achievements_text( const achievements_tracker &achievemen
         achievement_completion comp = achievements.is_completed( ach->id );
         return std::make_tuple( comp, ach->name().translated(), ach );
     } );
-    std::sort( sortable_achievements.begin(), sortable_achievements.end() );
+    std::sort( sortable_achievements.begin(), sortable_achievements.end(), localized_compare );
     for( const sortable_achievement &ach : sortable_achievements ) {
         os += achievements.ui_text_for( std::get<const achievement *>( ach ) ) + "\n";
     }

--- a/src/scores_ui.cpp
+++ b/src/scores_ui.cpp
@@ -37,7 +37,7 @@ static std::string get_achievements_text( const achievements_tracker &achievemen
                     std::back_inserter( sortable_achievements ),
     [&]( const achievement * ach ) {
         achievement_completion comp = achievements.is_completed( ach->id );
-        return std::make_tuple( comp, ach->description().translated(), ach );
+        return std::make_tuple( comp, ach->name().translated(), ach );
     } );
     std::sort( sortable_achievements.begin(), sortable_achievements.end() );
     for( const sortable_achievement &ach : sortable_achievements ) {

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -704,7 +704,10 @@ bool localized_comparator::operator()( const std::string &l, const std::string &
                      kCFStringEncodingUTF8, kCFAllocatorNull );
     CFStringRef rr = CFStringCreateWithCStringNoCopy( kCFAllocatorDefault, r.c_str(),
                      kCFStringEncodingUTF8, kCFAllocatorNull );
-    return CFStringCompare( lr, rr, kCFCompareLocalized ) < 0;
+    bool result = CFStringCompare( lr, rr, kCFCompareLocalized ) < 0;
+    CFRelease( lr );
+    CFRelease( rr );
+    return result;
 #endif
     return std::locale()( l, r );
 }

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -699,6 +699,14 @@ std::string operator+( const translation &lhs, const translation &rhs )
 
 bool localized_comparator::operator()( const std::string &l, const std::string &r ) const
 {
+    // We need different implementations on each platform.  MacOS seems to not
+    // support localized comparison of strings via the standard library at all,
+    // so resort to MacOS-specific solution.  Windows cannot be expected to be
+    // using a UTF-8 locale (whereas our strings are always UTF-8) and so we
+    // must convert to wstring for comparison there.  Linux seems to work as
+    // expected on regular strings; no workarounds needed.
+    // See https://github.com/CleverRaven/Cataclysm-DDA/pull/40041 for further
+    // discussion.
 #if defined(MACOSX)
     CFStringRef lr = CFStringCreateWithCStringNoCopy( kCFAllocatorDefault, l.c_str(),
                      kCFStringEncodingUTF8, kCFAllocatorNull );
@@ -708,6 +716,18 @@ bool localized_comparator::operator()( const std::string &l, const std::string &
     CFRelease( lr );
     CFRelease( rr );
     return result;
-#endif
+#elif defined(_WIN32)
+    return ( *this )( utf8_to_wstr( l ), utf8_to_wstr( r ) );
+#else
     return std::locale()( l, r );
+#endif
+}
+
+bool localized_comparator::operator()( const std::wstring &l, const std::wstring &r ) const
+{
+#if defined(MACOSX)
+    return ( *this )( wstr_to_utf8( l ), wstr_to_utf8( r ) );
+#else
+    return std::locale()( l, r );
+#endif
 }

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -699,5 +699,12 @@ std::string operator+( const translation &lhs, const translation &rhs )
 
 bool localized_comparator::operator()( const std::string &l, const std::string &r ) const
 {
+#if defined(MACOSX)
+    CFStringRef lr = CFStringCreateWithCStringNoCopy( kCFAllocatorDefault, l.c_str(),
+                     kCFStringEncodingUTF8, kCFAllocatorNull );
+    CFStringRef rr = CFStringCreateWithCStringNoCopy( kCFAllocatorDefault, r.c_str(),
+                     kCFStringEncodingUTF8, kCFAllocatorNull );
+    return CFStringCompare( lr, rr, kCFCompareLocalized ) < 0;
+#endif
     return std::locale()( l, r );
 }

--- a/src/translations.h
+++ b/src/translations.h
@@ -270,6 +270,7 @@ struct localized_comparator {
     }
 
     bool operator()( const std::string &, const std::string & ) const;
+    bool operator()( const std::wstring &, const std::wstring & ) const;
 };
 
 constexpr localized_comparator localized_compare{};

--- a/src/translations.h
+++ b/src/translations.h
@@ -264,6 +264,19 @@ struct localized_comparator {
         return ( *this )( l.second, r.second );
     }
 
+    template<typename Head, typename... Tail>
+    bool operator()( const std::tuple<Head, Tail...> &l,
+                     const std::tuple<Head, Tail...> &r ) const {
+        if( ( *this )( std::get<0>( l ), std::get<0>( r ) ) ) {
+            return true;
+        }
+        if( ( *this )( std::get<0>( r ), std::get<0>( l ) ) ) {
+            return false;
+        }
+        constexpr std::make_index_sequence<sizeof...( Tail )> Ints{};
+        return ( *this )( tie_tail( l, Ints ), tie_tail( r, Ints ) );
+    }
+
     template<typename T>
     bool operator()( const T &l, const T &r ) const {
         return l < r;
@@ -271,6 +284,11 @@ struct localized_comparator {
 
     bool operator()( const std::string &, const std::string & ) const;
     bool operator()( const std::wstring &, const std::wstring & ) const;
+
+    template<typename Head, typename... Tail, size_t... Ints>
+    auto tie_tail( const std::tuple<Head, Tail...> &t, std::index_sequence<Ints...> ) const {
+        return std::tie( std::get < Ints + 1 > ( t )... );
+    }
 };
 
 constexpr localized_comparator localized_compare{};

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <set>
@@ -522,7 +523,16 @@ void debug_menu::wishitem( player *p, const tripoint &pos )
         debugmsg( "game::wishitem(): invalid parameters" );
         return;
     }
-    const auto opts = item_controller->all();
+    std::vector<std::pair<std::string, const itype *>> opts;
+    for( const itype *i : item_controller->all() ) {
+        opts.emplace_back( item( i, 0 ).tname( 1, false ), i );
+    }
+    std::sort( opts.begin(), opts.end(), localized_compare );
+    std::vector<const itype *> itypes;
+    std::transform( opts.begin(), opts.end(), std::back_inserter( itypes ),
+    []( const auto & pair ) {
+        return pair.second;
+    } );
 
     int prev_amount = 1;
     int amount = 1;
@@ -535,12 +545,12 @@ void debug_menu::wishitem( player *p, const tripoint &pos )
         return std::max( TERMX / 2, TERMX - 50 );
     };
     wmenu.selected = uistate.wishitem_selected;
-    wish_item_callback cb( opts );
+    wish_item_callback cb( itypes );
     wmenu.callback = &cb;
 
     for( size_t i = 0; i < opts.size(); i++ ) {
-        item ity( opts[i], 0 );
-        wmenu.addentry( i, true, 0, ity.tname( 1, false ) );
+        item ity( opts[i].second, 0 );
+        wmenu.addentry( i, true, 0, opts[i].first );
         mvwzstr &entry_extra_text = wmenu.entries[i].extratxt;
         entry_extra_text.txt = ity.symbol();
         entry_extra_text.color = ity.color();
@@ -553,7 +563,7 @@ void debug_menu::wishitem( player *p, const tripoint &pos )
         }
         bool did_amount_prompt = false;
         while( wmenu.ret >= 0 ) {
-            item granted( opts[wmenu.ret] );
+            item granted( opts[wmenu.ret].second );
             if( cb.incontainer ) {
                 granted = granted.in_its_container();
             }

--- a/tests/catacharset_test.cpp
+++ b/tests/catacharset_test.cpp
@@ -1,9 +1,11 @@
 #include <clocale>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 #include "catacharset.h"
 #include "catch/catch.hpp"
+#include "translations.h"
 
 TEST_CASE( "utf8_width", "[catacharset]" )
 {
@@ -50,4 +52,32 @@ TEST_CASE( "wstr_to_utf8", "[catacharset]" )
     std::string dest( u8"Hello, 世界!" );
     CHECK( wstr_to_utf8( src ) == dest );
     setlocale( LC_ALL, "C" );
+}
+
+TEST_CASE( "localized_compare", "[catacharset]" )
+{
+    try {
+        std::locale::global( std::locale( "en_US.UTF-8" ) );
+    } catch( std::runtime_error & ) {
+        // On platforms where we can't set the locale, ignore this test
+        return;
+    }
+    CAPTURE( setlocale( LC_ALL, nullptr ) );
+    CAPTURE( std::locale().name() );
+    std::string a = "a";
+    std::string b = "b";
+    std::string c = "c";
+    std::string A = "A";
+    std::string B = "B";
+    CHECK( !localized_compare( a, a ) );
+    CHECK( localized_compare( a, B ) );
+    CHECK( localized_compare( A, b ) );
+    CHECK( !localized_compare( B, a ) );
+    CHECK( !localized_compare( b, A ) );
+    CHECK( localized_compare( std::make_pair( a, a ), std::make_pair( a, B ) ) );
+    CHECK( localized_compare( std::make_tuple( a ), std::make_tuple( B ) ) );
+    CHECK( localized_compare( std::make_tuple( a, c, c ), std::make_tuple( B, a, a ) ) );
+    CHECK( localized_compare( std::make_tuple( a, a, c ), std::make_tuple( a, B, a ) ) );
+    CHECK( localized_compare( std::make_tuple( a, a, a ), std::make_tuple( a, a, B ) ) );
+    std::locale::global( std::locale::classic() );
 }

--- a/tools/clang-tidy-plugin/UseLocalizedSortingCheck.cpp
+++ b/tools/clang-tidy-plugin/UseLocalizedSortingCheck.cpp
@@ -91,7 +91,12 @@ void UseLocalizedSortingCheck::registerMatchers( MatchFinder *Finder )
                 0,
                 expr( hasType( qualType().bind( "arg0Type" ) ) ).bind( "arg0Expr" )
             ),
-            hasOverloadedOperatorName( "<" )
+            anyOf(
+                hasOverloadedOperatorName( "<" ),
+                hasOverloadedOperatorName( ">" ),
+                hasOverloadedOperatorName( "<=" ),
+                hasOverloadedOperatorName( ">=" )
+            )
         ).bind( "opCall" ),
         this
     );

--- a/tools/clang-tidy-plugin/UsePointArithmeticCheck.cpp
+++ b/tools/clang-tidy-plugin/UsePointArithmeticCheck.cpp
@@ -127,6 +127,7 @@ struct ExpressionComponent {
 
 static bool operator<( const ExpressionComponent &l, const ExpressionComponent &r )
 {
+    // NOLINTNEXTLINE(cata-use-localized-sorting)
     return l.sortKey() < r.sortKey();
 }
 

--- a/tools/clang-tidy-plugin/test/use-localized-sorting.cpp
+++ b/tools/clang-tidy-plugin/test/use-localized-sorting.cpp
@@ -24,6 +24,18 @@ bool operator<( const std::basic_string<CharT, Traits, Alloc> &lhs,
 template<class RandomIt>
 void sort( RandomIt first, RandomIt last );
 
+template<class T1, class T2>
+struct pair;
+
+template< class T1, class T2 >
+bool operator<( const std::pair<T1, T2> &lhs, const std::pair<T1, T2> &rhs );
+
+template< class... Types >
+class tuple;
+
+template<class... TTypes, class... UTypes>
+bool operator<( const tuple<TTypes...> &lhs,
+                const tuple<UTypes...> &rhs );
 }
 
 template<class T>
@@ -46,6 +58,35 @@ bool f0( const std::string &l, const std::string &r )
 bool f1( const NonString &l, const NonString &r )
 {
     return l < r;
+}
+
+bool f2( const std::pair<int, std::string> &l, const std::pair<int, std::string> &r )
+{
+    return l < r;
+    // CHECK-MESSAGES: warning: Raw comparison of 'const std::pair<int, std::string>' (aka 'const pair<int, basic_string<char> >'). For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
+}
+
+bool f3( const std::pair<int, NonString> &l, const std::pair<int, NonString> &r )
+{
+    return l < r;
+}
+
+bool f4( const std::tuple<int, std::string> &l, const std::tuple<int, std::string> &r )
+{
+    return l < r;
+    // CHECK-MESSAGES: warning: Raw comparison of 'const std::tuple<int, std::string>' (aka 'const tuple<int, basic_string<char> >').  For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
+}
+
+bool f5( const std::tuple<int, NonString> &l, const std::tuple<int, NonString> &r )
+{
+    return l < r;
+}
+
+bool f4( const std::tuple<std::tuple<std::string>> &l,
+         const std::tuple<std::tuple<std::string>> &r )
+{
+    return l < r;
+    // CHECK-MESSAGES: warning: Raw comparison of 'const std::tuple<std::tuple<std::string> >' (aka 'const tuple<tuple<basic_string<char> > >'). For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
 }
 
 bool sort0( const std::string *start, const std::string *end )

--- a/tools/clang-tidy-plugin/test/use-localized-sorting.cpp
+++ b/tools/clang-tidy-plugin/test/use-localized-sorting.cpp
@@ -21,7 +21,15 @@ template<class CharT, class Traits, class Alloc>
 bool operator<( const std::basic_string<CharT, Traits, Alloc> &lhs,
                 const std::basic_string<CharT, Traits, Alloc> &rhs ) noexcept;
 
+template<class RandomIt>
+void sort( RandomIt first, RandomIt last );
+
 }
+
+template<class T>
+struct iterator {
+    using value_type = T;
+};
 
 class NonString
 {
@@ -38,4 +46,26 @@ bool f0( const std::string &l, const std::string &r )
 bool f1( const NonString &l, const NonString &r )
 {
     return l < r;
+}
+
+bool sort0( const std::string *start, const std::string *end )
+{
+    std::sort( start, end );
+    // CHECK-MESSAGES: warning: Raw sort of 'const std::string' (aka 'const basic_string<char>').  For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
+}
+
+bool sort1( const NonString *start, const NonString *end )
+{
+    std::sort( start, end );
+}
+
+bool sortit0( iterator<std::string> start, iterator<std::string> end )
+{
+    std::sort( start, end );
+    // CHECK-MESSAGES: warning: Raw sort of 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >'.  For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
+}
+
+bool sortit1( iterator<NonString> start, iterator<NonString> end )
+{
+    std::sort( start, end );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: I18N "Switch lists in some menus to use localized sorting; improve the sorting on Windows and MacOS (ported from DDA)"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Port from DDA PRs that switch various menus to use localized sorting (instead of sorting by id, or by blindly comparing strings).
Also port PRs that fix localized sorting on Windows and MacOS.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Cherry-picked without changes (the single merge conflict was due to different header inclusions, wow) the following PRs from DDA:
CleverRaven#40100
CleverRaven#40131
CleverRaven#44288
CleverRaven#40062
CleverRaven#40041
CleverRaven#40291
CleverRaven#44078
CleverRaven#41104

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Looking for a cross-platform library that can:
1. Convert utf-8 string <-> ascii string <-> wstring
2. Compare 2 utf-8 strings alphabetically
3. Format numbers & dates
4. Do all of the aforementioned without being affected by the current locale / platform.

Right now those are done via locale-dependent standard library or platform-specific crutches, and these solutions are far from reliable. From personal experience:
1. Running test suite from DDA's master on my Linux results in 2 failed number formatting tests.
2. Both BN and DDA, when launched on my Windows 10, cannot work with non-ascii paths (conversion from wstring to utf-8 seems to be broken).

However, integrating such library into the codebase is a big project, with all the problems that entails.

#### Testing
List in "wish for items" is now sorted alphabetically under both Linux and Windows 10 in both English & Russian.
List of character templates is now sorted alphabetically under Linux in both English and Russian, and under Windows 10 in English.
Didn't test the rest of the menus, since the code looks correct.
Didn't test on MacOS or Android, since I don't own the first and can't build for second.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
