### PR TITLE
Finish ui_adaptor migration (part 3)

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -952,17 +952,11 @@ action_id handle_action_menu()
             title += ": " + catgname;
         }
 
-        int width = 0;
-        for( uilist_entry &cur_entry : entries ) {
-            width = std::max( width, utf8_width( cur_entry.txt ) );
-        }
-        //border=2, selectors=3, after=3 for balance.
-        width += 2 + 3 + 3;
-        int ix = TERMX > width ? ( TERMX - width ) / 2 - 1 : 0;
-        int iy = TERMY > static_cast<int>( entries.size() ) + 2 ? ( TERMY - static_cast<int>
-                 ( entries.size() ) - 2 ) / 2 - 1 : 0;
-        int selection = uilist( point( std::max( ix, 0 ), std::max( iy, 0 ) ),
-                                std::min( width, TERMX - 2 ), title, entries );
+        uilist smenu;
+        smenu.settext( title );
+        smenu.entries = entries;
+        smenu.query();
+        const int selection = smenu.ret;
 
         g->draw();
 
@@ -1008,17 +1002,11 @@ action_id handle_main_menu()
     REGISTER_ACTION( ACTION_SAVE );
     REGISTER_ACTION( ACTION_DEBUG );
 
-    int width = 0;
-    for( uilist_entry &entry : entries ) {
-        width = std::max( width, utf8_width( entry.txt ) );
-    }
-    //border=2, selectors=3, after=3 for balance.
-    width += 2 + 3 + 3;
-    const int ix = TERMX > width ? ( TERMX - width ) / 2 - 1 : 0;
-    const int iy = TERMY > static_cast<int>( entries.size() ) + 2 ? ( TERMY - static_cast<int>
-                   ( entries.size() ) - 2 ) / 2 - 1 : 0;
-    int selection = uilist( point( std::max( ix, 0 ), std::max( iy, 0 ) ),
-                            std::min( width, TERMX - 2 ), _( "MAIN MENU" ), entries );
+    uilist smenu;
+    smenu.settext( _( "MAIN MENU" ) );
+    smenu.entries = entries;
+    smenu.query();
+    int selection = smenu.ret;
 
     g->draw();
 

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -18,6 +18,9 @@
 #include "posix_time.h"
 #include "translations.h"
 #include "type_id.h"
+#include "explosion.h"
+#include "point.h"
+#include "ui_manager.h"
 #include "weather.h"
 
 #if defined(TILES)
@@ -477,11 +480,35 @@ void game::draw_bullet( const tripoint &t, const int i, const std::vector<tripoi
 
 namespace
 {
+// short visual animation (player, monster, ...) (hit, dodge, ...)
+// cTile is a UTF-8 strings, and must be a single cell wide!
+void hit_animation( const player &u, const tripoint &center, nc_color cColor,
+                    const std::string &cTile )
+{
+    const tripoint init_pos = relative_view_pos( u, center );
+    // Only show animation if initially visible
+    if( init_pos.z == 0 && is_valid_in_w_terrain( init_pos.xy() ) ) {
+        shared_ptr_fast<game::draw_callback_t> hit_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+            // In case the window is resized during waiting, we always re-calculate the animation position
+            const tripoint pos = relative_view_pos( u, center );
+            if( pos.z == 0 && is_valid_in_w_terrain( pos.xy() ) ) {
+                mvwprintz( g->w_terrain, pos.xy(), cColor, cTile );
+            }
+        } );
+        g->add_draw_callback( hit_cb );
+
+        ui_manager::redraw();
+        inp_mngr.set_timeout( get_option<int>( "ANIMATION_DELAY" ) );
+        // Skip input (if any), because holding down a key with nanosleep can get yourself killed
+        inp_mngr.get_input_event();
+        inp_mngr.reset_timeout();
+    }
+}
+
 void draw_hit_mon_curses( const tripoint &center, const monster &m, const player &u,
                           const bool dead )
 {
-    const tripoint p = relative_view_pos( u, center );
-    hit_animation( p.xy(), red_background( m.type->color ), dead ? "%" : m.symbol() );
+    hit_animation( u, center, red_background( m.type->color ), dead ? "%" : m.symbol() );
 }
 
 } // namespace
@@ -514,12 +541,9 @@ namespace
 {
 void draw_hit_player_curses( const game &g, const Character &p, const int dam )
 {
-    const tripoint q = relative_view_pos( g.u, p.pos() );
-    if( q.z == 0 ) {
-        nc_color const col = !dam ? yellow_background( p.symbol_color() ) : red_background(
-                                 p.symbol_color() );
-        hit_animation( q.xy(), col, p.symbol() );
-    }
+    nc_color const col = !dam ? yellow_background( p.symbol_color() ) : red_background(
+                             p.symbol_color() );
+    hit_animation( g.u, p.pos(), col, p.symbol() );
 }
 } //namespace
 

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -18,8 +18,6 @@
 #include "posix_time.h"
 #include "translations.h"
 #include "type_id.h"
-#include "explosion.h"
-#include "point.h"
 #include "ui_manager.h"
 #include "weather.h"
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -70,6 +70,7 @@
 #include "teleport.h"
 #include "translations.h"
 #include "ui.h"
+#include "ui_manager.h"
 #include "units.h"
 #include "value_ptr.h"
 #include "vehicle.h"
@@ -586,26 +587,48 @@ bool Character::activate_bionic( int b, bool eff_only )
             }
         }
 
-        const size_t win_h = std::min( static_cast<size_t>( TERMY ), bad.size() + good.size() + 2 );
         const int win_w = 46;
-        catacurses::window w = catacurses::newwin( win_h, win_w, point( ( TERMX - win_w ) / 2,
-                               ( TERMY - win_h ) / 2 ) );
-        draw_border( w, c_red, string_format( " %s ", _( "Blood Test Results" ) ) );
-        if( good.empty() && bad.empty() ) {
-            trim_and_print( w, point( 2, 1 ), win_w - 3, c_white, _( "No effects." ) );
-        } else {
-            for( size_t line = 1; line < ( win_h - 1 ) && line <= good.size() + bad.size(); ++line ) {
-                if( line <= bad.size() ) {
-                    trim_and_print( w, point( 2, line ), win_w - 3, c_red, bad[line - 1] );
-                } else {
-                    trim_and_print( w, point( 2, line ), win_w - 3, c_green,
-                                    good[line - 1 - bad.size()] );
+        size_t win_h = 0;
+        catacurses::window w;
+        ui_adaptor ui;
+        ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+            win_h = std::min( static_cast<size_t>( TERMY ),
+                              std::max<size_t>( 1, bad.size() + good.size() ) + 2 );
+            w = catacurses::newwin( win_h, win_w,
+                                    point( ( TERMX - win_w ) / 2, ( TERMY - win_h ) / 2 ) );
+            ui.position_from_window( w );
+        } );
+        ui.mark_resize();
+        ui.on_redraw( [&]( const ui_adaptor & ) {
+            draw_border( w, c_red, string_format( " %s ", _( "Blood Test Results" ) ) );
+            if( good.empty() && bad.empty() ) {
+                trim_and_print( w, point( 2, 1 ), win_w - 3, c_white, _( "No effects." ) );
+            } else {
+                for( size_t line = 1; line < ( win_h - 1 ) && line <= good.size() + bad.size(); ++line ) {
+                    if( line <= bad.size() ) {
+                        trim_and_print( w, point( 2, line ), win_w - 3, c_red, bad[line - 1] );
+                    } else {
+                        trim_and_print( w, point( 2, line ), win_w - 3, c_green,
+                                        good[line - 1 - bad.size()] );
+                    }
                 }
             }
+            wrefresh( w );
+        } );
+        input_context ctxt( "BLOOD_TEST_RESULTS" );
+        ctxt.register_action( "CONFIRM" );
+        ctxt.register_action( "QUIT" );
+        ctxt.register_action( "HELP_KEYBINDINGS" );
+        bool stop = false;
+        // Display new messages
+        g->invalidate_main_ui_adaptor();
+        while( !stop ) {
+            ui_manager::redraw();
+            const std::string action = ctxt.handle_input();
+            if( action == "CONFIRM" || action == "QUIT" ) {
+                stop = true;
+            }
         }
-        wrefresh( w );
-        catacurses::refresh();
-        inp_mngr.wait_for_any_key();
     } else if( bio.id == bio_blood_filter ) {
         add_msg_activate();
         static const std::vector<efftype_id> removable = {{

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -746,6 +746,9 @@ void player::power_bionics()
             if( menu_mode == ACTIVATING ) {
                 if( bio_data.activated ) {
                     int b = tmp - &( *my_bionics )[0];
+                    // Invalidate bionics menu so the remaining power gets redrawn
+                    // if other UIs are opened when activating the bionic.
+                    ui.invalidate_ui();
                     if( tmp->powered ) {
                         deactivate_bionic( b );
                     } else {

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -538,8 +538,12 @@ class restore_on_out_of_scope
         on_out_of_scope impl;
     public:
         // *INDENT-OFF*
-        restore_on_out_of_scope( T &t_in ): t( t_in ), orig_t( t_in ),
-            impl( [this]() { t = orig_t; } ) {
+        restore_on_out_of_scope( T &t_in ) : t( t_in ), orig_t( t_in ),
+            impl( [this]() { t = std::move( orig_t ); } ) {
+        }
+
+        restore_on_out_of_scope( T &&t_in ) : t( t_in ), orig_t( std::move( t_in ) ),
+            impl( [this]() { t = std::move( orig_t ); } ) {
         }
         // *INDENT-ON*
 };

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -762,6 +762,7 @@ construction_id construction_menu( const bool blueprint )
                     if( !player_can_see_to_build( g->u, constructs[select] ) ) {
                         add_msg( m_info, _( "It is too dark to construct right now." ) );
                     } else {
+                        ui.reset();
                         place_construction( constructs[select] );
                         uistate.last_construction = constructs[select];
                     }
@@ -876,7 +877,6 @@ bool can_construct( const construction &con )
 
 void place_construction( const std::string &desc )
 {
-    g->refresh_all();
     const inventory &total_inv = g->u.crafting_inventory();
 
     std::vector<construction *> cons = constructions_by_desc( desc );
@@ -889,12 +889,13 @@ void place_construction( const std::string &desc )
         }
     }
 
-    for( auto &elem : valid ) {
-        g->m.drawsq( g->w_terrain, g->u, elem.first, true, false,
-                     g->u.pos() + g->u.view_offset );
-    }
-    wrefresh( g->w_terrain );
-    g->draw_panels();
+    shared_ptr_fast<game::draw_callback_t> draw_valid = make_shared_fast<game::draw_callback_t>( [&]() {
+        for( auto &elem : valid ) {
+            g->m.drawsq( g->w_terrain, g->u, elem.first, true, false,
+                         g->u.pos() + g->u.view_offset );
+        }
+    } );
+    g->add_draw_callback( draw_valid );
 
     const cata::optional<tripoint> pnt_ = choose_adjacent( _( "Construct where?" ) );
     if( !pnt_ ) {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -85,6 +85,8 @@
 #include "translations.h"
 #include "type_id.h"
 #include "ui.h"
+#include "ui_manager.h"
+#include "units.h"
 #include "vehicle.h"
 #include "veh_type.h"
 #include "vitamin.h"
@@ -1481,19 +1483,22 @@ void debug()
 
         case DEBUG_SHOW_SOUND: {
 #if defined(TILES)
-            const point offset {
-                u.view_offset.xy() + point( POSX - u.posx(), POSY - u.posy() )
-            };
-            g->draw_ter();
-            auto sounds_to_draw = sounds::get_monster_sounds();
-            for( const auto &sound : sounds_to_draw.first ) {
-                mvwputch( g->w_terrain, offset + sound.xy(), c_yellow, '?' );
-            }
-            for( const auto &sound : sounds_to_draw.second ) {
-                mvwputch( g->w_terrain, offset + sound.xy(), c_red, '?' );
-            }
-            wrefresh( g->w_terrain );
-            g->draw_panels();
+            const auto &sounds_to_draw = sounds::get_monster_sounds();
+
+            shared_ptr_fast<game::draw_callback_t> sound_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+                const point offset {
+                    u.view_offset.xy() + point( POSX - u.posx(), POSY - u.posy() )
+                };
+                for( const auto &sound : sounds_to_draw.first ) {
+                    mvwputch( g->w_terrain, offset + sound.xy(), c_yellow, '?' );
+                }
+                for( const auto &sound : sounds_to_draw.second ) {
+                    mvwputch( g->w_terrain, offset + sound.xy(), c_red, '?' );
+                }
+            } );
+            g->add_draw_callback( sound_cb );
+
+            ui_manager::redraw();
             inp_mngr.wait_for_any_key();
 #else
             popup( _( "This binary was not compiled with tiles support." ) );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1252,6 +1252,7 @@ void debug()
             if( get_option<bool>( "STATS_THROUGH_KILLS" ) ) {
                 add_msg( m_info, _( "Kill xp: %d" ), u.kill_xp() );
             }
+            g->invalidate_main_ui_adaptor();
             g->disp_NPCs();
             break;
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11429,10 +11429,12 @@ void game::display_scent()
             add_msg( _( "Never mind." ) );
             return;
         }
-        draw_ter();
-        scent.draw( w_terrain, div * 2, u.pos() + u.view_offset );
-        wrefresh( w_terrain );
-        draw_panels();
+        shared_ptr_fast<game::draw_callback_t> scent_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+            scent.draw( w_terrain, div * 2, u.pos() + u.view_offset );
+        } );
+        g->add_draw_callback( scent_cb );
+
+        ui_manager::redraw();
         inp_mngr.wait_for_any_key();
     }
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -478,89 +478,16 @@ void game::init_ui( const bool resized )
     } else {
         FULL_SCREEN_HEIGHT = 24;
     }
-
 #endif
-    // remove some space for the sidebar, this is the maximal space
-    // (using standard font) that the terrain window can have
-    int sidebar_left = panel_manager::get_manager().get_width_left();
-    int sidebar_right = panel_manager::get_manager().get_width_right();
-
-    TERRAIN_WINDOW_HEIGHT = TERMY;
-    TERRAIN_WINDOW_WIDTH = TERMX - ( sidebar_left + sidebar_right );
-    TERRAIN_WINDOW_TERM_WIDTH = TERRAIN_WINDOW_WIDTH;
-    TERRAIN_WINDOW_TERM_HEIGHT = TERRAIN_WINDOW_HEIGHT;
-
-    /**
-     * In tiles mode w_terrain can have a different font (with a different
-     * tile dimension) or can be drawn by cata_tiles which uses tiles that again
-     * might have a different dimension then the normal font used everywhere else.
-     *
-     * TERRAIN_WINDOW_WIDTH/TERRAIN_WINDOW_HEIGHT defines how many squares can
-     * be displayed in w_terrain (using it's specific tile dimension), not
-     * including partially drawn squares at the right/bottom. You should
-     * use it whenever you want to draw specific squares in that window or to
-     * determine whether a specific square is draw on screen (or outside the screen
-     * and needs scrolling).
-     *
-     * TERRAIN_WINDOW_TERM_WIDTH/TERRAIN_WINDOW_TERM_HEIGHT defines the size of
-     * w_terrain in the standard font dimension (the font that everything else uses).
-     * You usually don't have to use it, expect for positioning of windows,
-     * because the window positions use the standard font dimension.
-     *
-     * The code here calculates size available for w_terrain, caps it at
-     * max_view_size (the maximal view range than any character can have at
-     * any time).
-     * It is stored in TERRAIN_WINDOW_*.
-     */
-    to_map_font_dimension( TERRAIN_WINDOW_WIDTH, TERRAIN_WINDOW_HEIGHT );
-
-    // Position of the player in the terrain window, it is always in the center
-    POSX = TERRAIN_WINDOW_WIDTH / 2;
-    POSY = TERRAIN_WINDOW_HEIGHT / 2;
-
-    w_terrain = w_terrain_ptr = catacurses::newwin( TERRAIN_WINDOW_HEIGHT, TERRAIN_WINDOW_WIDTH,
-                                point( sidebar_left, 0 ) );
-    werase( w_terrain );
-
-    /**
-     * Doing the same thing as above for the overmap
-     */
-    OVERMAP_LEGEND_WIDTH = clamp( TERMX / 5, 28, 55 );
-    OVERMAP_WINDOW_HEIGHT = TERMY;
-    OVERMAP_WINDOW_WIDTH = TERMX - OVERMAP_LEGEND_WIDTH;
-    to_overmap_font_dimension( OVERMAP_WINDOW_WIDTH, OVERMAP_WINDOW_HEIGHT );
-
-    //Bring the framebuffer to the maximum required dimensions
-    //Otherwise it segfaults when the overmap needs a bigger buffer size than it provides
-    reinitialize_framebuffer();
-
-    // minimap is always MINIMAP_WIDTH x MINIMAP_HEIGHT in size
-    int _y = 0;
-    int _x = 0;
-
-    w_minimap = w_minimap_ptr = catacurses::newwin( MINIMAP_HEIGHT, MINIMAP_WIDTH, point( _x, _y ) );
-    werase( w_minimap );
-
-    // need to init in order to avoid crash. gets updated by the panel code.
-    w_pixel_minimap = catacurses::newwin( 1, 1, point_zero );
-    liveview.init();
-
-    // Only refresh if we are in-game, otherwise all resources are not initialized
-    // and this refresh will crash the game.
-    if( resized && u.getID().is_valid() ) {
-        refresh_all();
-    }
 }
 
 void game::toggle_fullscreen()
 {
 #if !defined(TILES)
     fullscreen = !fullscreen;
-    init_ui();
-    refresh_all();
+    mark_main_ui_adaptor_resize();
 #else
     toggle_fullscreen_window();
-    refresh_all();
 #endif
 }
 
@@ -571,8 +498,7 @@ void game::toggle_pixel_minimap()
         clear_window_area( w_pixel_minimap );
     }
     pixel_minimap_option = !pixel_minimap_option;
-    init_ui();
-    refresh_all();
+    mark_main_ui_adaptor_resize();
 #endif // TILES
 }
 
@@ -3257,13 +3183,60 @@ shared_ptr_fast<ui_adaptor> game::create_or_get_main_ui_adaptor()
     shared_ptr_fast<ui_adaptor> ui = main_ui_adaptor.lock();
     if( !ui ) {
         main_ui_adaptor = ui = make_shared_fast<ui_adaptor>();
-        ui->position_from_window( catacurses::stdscr );
         ui->on_redraw( []( const ui_adaptor & ) {
             g->draw();
         } );
-        ui->on_screen_resize( []( ui_adaptor & ui ) {
+        ui->on_screen_resize( [this]( ui_adaptor & ui ) {
+            // remove some space for the sidebar, this is the maximal space
+            // (using standard font) that the terrain window can have
+            const int sidebar_left = panel_manager::get_manager().get_width_left();
+            const int sidebar_right = panel_manager::get_manager().get_width_right();
+
+            TERRAIN_WINDOW_HEIGHT = TERMY;
+            TERRAIN_WINDOW_WIDTH = TERMX - ( sidebar_left + sidebar_right );
+            TERRAIN_WINDOW_TERM_WIDTH = TERRAIN_WINDOW_WIDTH;
+            TERRAIN_WINDOW_TERM_HEIGHT = TERRAIN_WINDOW_HEIGHT;
+
+            /**
+             * In tiles mode w_terrain can have a different font (with a different
+             * tile dimension) or can be drawn by cata_tiles which uses tiles that again
+             * might have a different dimension then the normal font used everywhere else.
+             *
+             * TERRAIN_WINDOW_WIDTH/TERRAIN_WINDOW_HEIGHT defines how many squares can
+             * be displayed in w_terrain (using it's specific tile dimension), not
+             * including partially drawn squares at the right/bottom. You should
+             * use it whenever you want to draw specific squares in that window or to
+             * determine whether a specific square is draw on screen (or outside the screen
+             * and needs scrolling).
+             *
+             * TERRAIN_WINDOW_TERM_WIDTH/TERRAIN_WINDOW_TERM_HEIGHT defines the size of
+             * w_terrain in the standard font dimension (the font that everything else uses).
+             * You usually don't have to use it, expect for positioning of windows,
+             * because the window positions use the standard font dimension.
+             *
+             * The code here calculates size available for w_terrain, caps it at
+             * max_view_size (the maximal view range than any character can have at
+             * any time).
+             * It is stored in TERRAIN_WINDOW_*.
+             */
+            to_map_font_dimension( TERRAIN_WINDOW_WIDTH, TERRAIN_WINDOW_HEIGHT );
+
+            // Position of the player in the terrain window, it is always in the center
+            POSX = TERRAIN_WINDOW_WIDTH / 2;
+            POSY = TERRAIN_WINDOW_HEIGHT / 2;
+
+            w_terrain = w_terrain_ptr = catacurses::newwin( TERRAIN_WINDOW_HEIGHT, TERRAIN_WINDOW_WIDTH,
+                                        point( sidebar_left, 0 ) );
+
+            // minimap is always MINIMAP_WIDTH x MINIMAP_HEIGHT in size
+            w_minimap = w_minimap_ptr = catacurses::newwin( MINIMAP_HEIGHT, MINIMAP_WIDTH, point_zero );
+
+            // need to init in order to avoid crash. gets updated by the panel code.
+            w_pixel_minimap = catacurses::newwin( 1, 1, point_zero );
+
             ui.position_from_window( catacurses::stdscr );
         } );
+        ui->mark_resize();
     }
     return ui;
 }
@@ -3273,6 +3246,14 @@ void game::invalidate_main_ui_adaptor() const
     shared_ptr_fast<ui_adaptor> ui = main_ui_adaptor.lock();
     if( ui ) {
         ui->invalidate_ui();
+    }
+}
+
+void game::mark_main_ui_adaptor_resize() const
+{
+    shared_ptr_fast<ui_adaptor> ui = main_ui_adaptor.lock();
+    if( ui ) {
+        ui->mark_resize();
     }
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3137,32 +3137,53 @@ struct npc_dist_to_player {
 
 void game::disp_NPCs()
 {
-    catacurses::window w = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                           point( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                                  TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 ) );
-
     const tripoint ppos = u.global_omt_location();
     const tripoint &lpos = u.pos();
-    mvwprintz( w, point_zero, c_white, _( "Your overmap position: %d, %d, %d" ), ppos.x, ppos.y,
-               ppos.z );
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    mvwprintz( w, point( 0, 1 ), c_white, _( "Your local position: %d, %d, %d" ), lpos.x, lpos.y,
-               lpos.z );
     std::vector<shared_ptr_fast<npc>> npcs = overmap_buffer.get_npcs_near_player( 100 );
     std::sort( npcs.begin(), npcs.end(), npc_dist_to_player() );
-    size_t i;
-    for( i = 0; i < 20 && i < npcs.size(); i++ ) {
-        const tripoint apos = npcs[i]->global_omt_location();
-        mvwprintz( w, point( 0, i + 3 ), c_white, "%s: %d, %d, %d", npcs[i]->name,
-                   apos.x, apos.y, apos.z );
+
+    catacurses::window w;
+    ui_adaptor ui;
+    ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+        w = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
+                                point( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                                       TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 ) );
+        ui.position_from_window( w );
+    } );
+    ui.mark_resize();
+    ui.on_redraw( [&]( const ui_adaptor & ) {
+        werase( w );
+        mvwprintz( w, point_zero, c_white, _( "Your overmap position: %d, %d, %d" ), ppos.x, ppos.y,
+                   ppos.z );
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        mvwprintz( w, point( 0, 1 ), c_white, _( "Your local position: %d, %d, %d" ), lpos.x, lpos.y,
+                   lpos.z );
+        size_t i;
+        for( i = 0; i < 20 && i < npcs.size(); i++ ) {
+            const tripoint apos = npcs[i]->global_omt_location();
+            mvwprintz( w, point( 0, i + 3 ), c_white, "%s: %d, %d, %d", npcs[i]->name,
+                       apos.x, apos.y, apos.z );
+        }
+        for( const monster &m : all_monsters() ) {
+            mvwprintz( w, point( 0, i + 3 ), c_white, "%s: %d, %d, %d", m.name(),
+                       m.posx(), m.posy(), m.posz() );
+            ++i;
+        }
+        wrefresh( w );
+    } );
+
+    input_context ctxt( "DISP_NPCS" );
+    ctxt.register_action( "CONFIRM" );
+    ctxt.register_action( "QUIT" );
+    ctxt.register_action( "HELP_KEYBINDINGS" );
+    bool stop = false;
+    while( !stop ) {
+        ui_manager::redraw();
+        const std::string action = ctxt.handle_input();
+        if( action == "CONFIRM" || action == "QUIT" ) {
+            stop = true;
+        }
     }
-    for( const monster &m : all_monsters() ) {
-        mvwprintz( w, point( 0, i + 3 ), c_white, "%s: %d, %d, %d", m.name(),
-                   m.posx(), m.posy(), m.posz() );
-        ++i;
-    }
-    wrefresh( w );
-    inp_mngr.wait_for_any_key();
 }
 
 // A little helper to draw footstep glyphs.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7082,10 +7082,7 @@ void draw_trail( const tripoint &start, const tripoint &end, const bool bDrawX )
 
 void game::draw_trail_to_square( const tripoint &t, bool bDrawX )
 {
-    //Reset terrain
-    draw_ter();
     ::draw_trail( u.pos(), u.pos() + t, bDrawX );
-    wrefresh( w_terrain );
 }
 
 static void centerlistview( const tripoint &active_item_position, int ui_width )

--- a/src/game.h
+++ b/src/game.h
@@ -226,6 +226,7 @@ class game
         bool do_turn();
         shared_ptr_fast<ui_adaptor> create_or_get_main_ui_adaptor();
         void invalidate_main_ui_adaptor() const;
+        void mark_main_ui_adaptor_resize() const;
         void draw();
         void draw_ter( bool draw_sounds = true );
         void draw_ter( const tripoint &center, bool looking = false, bool draw_sounds = true );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2333,7 +2333,6 @@ bool game::handle_action()
 
             case ACTION_OPTIONS:
                 get_options().show( true );
-                g->init_ui( true );
                 break;
 
             case ACTION_AUTOPICKUP:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1683,12 +1683,12 @@ void options_manager::add_options_graphics()
     add_empty_line();
 
     add( "TERMINAL_X", "graphics", translate_marker( "Terminal width" ),
-         translate_marker( "Set the size of the terminal along the X axis.  Requires restart." ),
+         translate_marker( "Set the size of the terminal along the X axis." ),
          80, 960, 80, COPT_POSIX_CURSES_HIDE
        );
 
     add( "TERMINAL_Y", "graphics", translate_marker( "Terminal height" ),
-         translate_marker( "Set the size of the terminal along the Y axis.  Requires restart." ),
+         translate_marker( "Set the size of the terminal along the Y axis." ),
          24, 270, 24, COPT_POSIX_CURSES_HIDE
        );
 
@@ -2459,8 +2459,7 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
             use_tiles = false;
         }
     } else if( ingame && g->pixel_minimap_option && pixel_minimap_height_changed ) {
-        g->init_ui();
-        g->refresh_all();
+        g->mark_main_ui_adaptor_resize();
     }
 }
 #else
@@ -2927,7 +2926,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
         get_option( "TERMINAL_Y" ).setValue( std::max( FULL_SCREEN_HEIGHT * scaling_factor, TERMY ) );
         save();
 
-        handle_resize( projected_window_width(), projected_window_height() );
+        resize_term( ::get_option<int>( "TERMINAL_X" ), ::get_option<int>( "TERMINAL_Y" ) );
     }
 #else
     ( void ) terminal_size_changed;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1572,25 +1572,6 @@ void calcStartPos( int &iStartPos, const int iCurrentLine, const int iContentHei
     }
 }
 
-catacurses::window w_hit_animation;
-void hit_animation( const point &p, nc_color cColor, const std::string &cTile )
-{
-    catacurses::window w_hit =
-        catacurses::newwin( 1, 1, p );
-    if( !w_hit ) {
-        return; //we passed in negative values (semi-expected), so let's not segfault
-    }
-    w_hit_animation = w_hit;
-
-    mvwprintz( w_hit, point_zero, cColor, cTile );
-    wrefresh( w_hit );
-
-    inp_mngr.set_timeout( get_option<int>( "ANIMATION_DELAY" ) );
-    // Skip input (if any), because holding down a key with nanosleep can get yourself killed
-    inp_mngr.get_input_event();
-    inp_mngr.reset_timeout();
-}
-
 #if defined(_MSC_VER)
 std::string cata::string_formatter::raw_string_format( const char *const format, ... )
 {

--- a/src/output.h
+++ b/src/output.h
@@ -588,10 +588,6 @@ size_t shortcut_print( const catacurses::window &w, nc_color text_color, nc_colo
                        const std::string &fmt );
 std::string shortcut_text( nc_color shortcut_color, const std::string &fmt );
 
-// short visual animation (player, monster, ...) (hit, dodge, ...)
-// cTile is a UTF-8 strings, and must be a single cell wide!
-void hit_animation( const point &p, nc_color cColor, const std::string &cTile );
-
 /**
  * @return Pair of a string containing the bar, and its color
  * @param cur Current value being formatted

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -28,6 +28,7 @@
 #include "enums.h"
 #include "game.h"
 #include "game_constants.h"
+#include "game_ui.h"
 #include "ime.h"
 #include "input.h"
 #include "int_id.h"
@@ -1404,6 +1405,14 @@ static tripoint display( const tripoint &orig, const draw_data_t &data = draw_da
 {
     ui_adaptor ui;
     ui.on_screen_resize( []( ui_adaptor & ui ) {
+        /**
+         * Handle possibly different overmap font size
+         */
+        OVERMAP_LEGEND_WIDTH = clamp( TERMX / 5, 28, 55 );
+        OVERMAP_WINDOW_HEIGHT = TERMY;
+        OVERMAP_WINDOW_WIDTH = TERMX - OVERMAP_LEGEND_WIDTH;
+        to_overmap_font_dimension( OVERMAP_WINDOW_WIDTH, OVERMAP_WINDOW_HEIGHT );
+
         /* please do not change point( TERMX - OVERMAP_LEGEND_WIDTH, 0 ) to point( OVERMAP_WINDOW_WIDTH, 0 ) */
         /* because overmap legend will be absent */
         g->w_omlegend = catacurses::newwin( TERMY, OVERMAP_LEGEND_WIDTH,

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -2392,8 +2392,7 @@ void panel_manager::show_adm()
             int h; // to_map_font_dimension needs a second input
             to_map_font_dimension( width, h );
             // tell the game that the main screen might have a different size now.
-            g->init_ui( false );
-            g->invalidate_main_ui_adaptor();
+            g->mark_main_ui_adaptor_resize();
             recalc = true;
         } else if( !swapping && ( action == "RIGHT" || action == "LEFT" ) ) {
             // there are only two columns

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1034,16 +1034,22 @@ static void invalidate_framebuffer( std::vector<curseline> &framebuffer )
 
 void reinitialize_framebuffer()
 {
+    static int prev_height = -1;
+    static int prev_width = -1;
     //Re-initialize the framebuffer with new values.
-    const int new_height = std::max( TERMY, std::max( OVERMAP_WINDOW_HEIGHT, TERRAIN_WINDOW_HEIGHT ) );
-    const int new_width = std::max( TERMX, std::max( OVERMAP_WINDOW_WIDTH, TERRAIN_WINDOW_WIDTH ) );
-    oversized_framebuffer.resize( new_height );
-    for( int i = 0; i < new_height; i++ ) {
-        oversized_framebuffer[i].chars.assign( new_width, cursecell( "" ) );
-    }
-    terminal_framebuffer.resize( new_height );
-    for( int i = 0; i < new_height; i++ ) {
-        terminal_framebuffer[i].chars.assign( new_width, cursecell( "" ) );
+    const int new_height = std::max( { TERMY, OVERMAP_WINDOW_HEIGHT, TERRAIN_WINDOW_HEIGHT } );
+    const int new_width = std::max( { TERMX, OVERMAP_WINDOW_WIDTH, TERRAIN_WINDOW_WIDTH } );
+    if( new_height != prev_height || new_width != prev_width ) {
+        prev_height = new_height;
+        prev_width = new_width;
+        oversized_framebuffer.resize( new_height );
+        for( int i = 0; i < new_height; i++ ) {
+            oversized_framebuffer[i].chars.assign( new_width, cursecell( "" ) );
+        }
+        terminal_framebuffer.resize( new_height );
+        for( int i = 0; i < new_height; i++ ) {
+            terminal_framebuffer[i].chars.assign( new_width, cursecell( "" ) );
+        }
     }
 }
 
@@ -1780,6 +1786,15 @@ bool handle_resize( int w, int h )
         return true;
     }
     return false;
+}
+
+void resize_term( const int cell_w, const int cell_h )
+{
+    int w = cell_w * fontwidth * scaling_factor;
+    int h = cell_h * fontheight * scaling_factor;
+    SDL_SetWindowSize( window.get(), w, h );
+    SDL_GetWindowSize( window.get(), &w, &h );
+    handle_resize( w, h );
 }
 
 void toggle_fullscreen_window()
@@ -3718,7 +3733,7 @@ bool gamepad_available()
 void rescale_tileset( int size )
 {
     tilecontext->set_draw_scale( size );
-    game_ui::init_ui();
+    g->mark_main_ui_adaptor_resize();
 }
 
 static window_dimensions get_window_dimensions( const catacurses::window &win,

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -256,7 +256,6 @@ static std::vector<curseline> oversized_framebuffer;
 static std::vector<curseline> terminal_framebuffer;
 static std::weak_ptr<void> winBuffer; //tracking last drawn window to fix the framebuffer
 static int fontScaleBuffer; //tracking zoom levels to fix framebuffer w/tiles
-extern catacurses::window w_hit_animation; //this window overlays w_terrain which can be oversized
 
 //***********************************
 //Non-curses, Window functions      *
@@ -1067,7 +1066,7 @@ static void invalidate_framebuffer_proportion( cata_cursesport::WINDOW *win )
     if( !g || win == nullptr ) {
         return;
     }
-    if( win == g->w_overmap || win == g->w_terrain || win == w_hit_animation ) {
+    if( win == g->w_overmap || win == g->w_terrain ) {
         return;
     }
 
@@ -1243,13 +1242,6 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
     } else if( g && w == g->w_overmap && overmap_font ) {
         // Special font for the terrain window
         update = overmap_font->draw_window( w );
-    } else if( w == w_hit_animation && map_font ) {
-        // The animation window overlays the terrain window,
-        // it uses the same font, but it's only 1 square in size.
-        // The offset must not use the global font, but the map font
-        int offsetx = win->pos.x * map_font->fontwidth;
-        int offsety = win->pos.y * map_font->fontheight;
-        update = map_font->draw_window( w, point( offsetx, offsety ) );
     } else if( g && w == g->w_pixel_minimap && g->pixel_minimap_option ) {
         // ensure the space the minimap covers is "dirtied".
         // this is necessary when it's the only part of the sidebar being drawn
@@ -1305,8 +1297,7 @@ bool Font::draw_window( const catacurses::window &w, const point &offset )
     invalidate_framebuffer_proportion( win );
 
     // use the oversize buffer when dealing with windows that can have a different font than the main text font
-    bool use_oversized_framebuffer = g && ( w == g->w_terrain || w == g->w_overmap ||
-                                            w == w_hit_animation );
+    bool use_oversized_framebuffer = g && ( w == g->w_terrain || w == g->w_overmap );
 
     std::vector<curseline> &framebuffer = use_oversized_framebuffer ? oversized_framebuffer :
                                           terminal_framebuffer;

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -29,6 +29,7 @@ void draw_alt_rect( const SDL_Renderer_Ptr &renderer, const SDL_Rect &rect,
 void load_tileset();
 void rescale_tileset( int size );
 bool save_screenshot( const std::string &file_path );
+void resize_term( int cell_w, int cell_h );
 void toggle_fullscreen_window();
 
 struct window_dimensions {

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -950,38 +950,60 @@ void uilist::settext( const std::string &str )
     text = str;
 }
 
-pointmenu_cb::pointmenu_cb( const std::vector< tripoint > &pts ) : points( pts )
+struct pointmenu_cb::impl_t {
+    const std::vector< tripoint > &points;
+    int last; // to suppress redrawing
+    tripoint last_view; // to reposition the view after selecting
+    shared_ptr_fast<game::draw_callback_t> terrain_draw_cb;
+
+    impl_t( const std::vector<tripoint> &pts );
+    ~impl_t();
+
+    void select( uilist *menu );
+};
+
+pointmenu_cb::impl_t::impl_t( const std::vector<tripoint> &pts ) : points( pts )
 {
     last = INT_MIN;
     last_view = g->u.view_offset;
+    terrain_draw_cb = make_shared_fast<game::draw_callback_t>( [this]() {
+        if( last >= 0 && static_cast<size_t>( last ) < points.size() ) {
+            g->draw_trail_to_square( g->u.view_offset, true );
+        }
+    } );
+    g->add_draw_callback( terrain_draw_cb );
 }
 
-pointmenu_cb::~pointmenu_cb()
+pointmenu_cb::impl_t::~impl_t()
 {
     g->u.view_offset = last_view;
 }
 
-void pointmenu_cb::refresh( uilist *menu )
+void pointmenu_cb::impl_t::select( uilist *const menu )
 {
     if( last == menu->selected ) {
         return;
     }
-    if( menu->selected < 0 || menu->selected >= static_cast<int>( points.size() ) ) {
-        last = menu->selected;
-        g->u.view_offset = tripoint_zero;
-        g->draw_ter();
-        wrefresh( g->w_terrain );
-        g->draw_panels();
-        menu->show();
-        return;
-    }
-
     last = menu->selected;
-    const tripoint &center = points[menu->selected];
-    g->u.view_offset = center - g->u.pos();
-    // TODO: Remove this line when it's safe
-    g->u.view_offset.z = 0;
-    g->draw_trail_to_square( g->u.view_offset, true );
-    menu->show();
+    if( menu->selected < 0 || menu->selected >= static_cast<int>( points.size() ) ) {
+        g->u.view_offset = tripoint_zero;
+    } else {
+        const tripoint &center = points[menu->selected];
+        g->u.view_offset = center - g->u.pos();
+        // TODO: Remove this line when it's safe
+        g->u.view_offset.z = 0;
+    }
+    g->invalidate_main_ui_adaptor();
+}
+
+pointmenu_cb::pointmenu_cb( const std::vector<tripoint> &pts ) : impl( pts )
+{
+}
+
+pointmenu_cb::~pointmenu_cb() = default;
+
+void pointmenu_cb::select( uilist *const menu )
+{
+    impl->select( menu );
 }
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -120,46 +120,6 @@ uilist::uilist( const std::string &msg, std::initializer_list<const char *const>
     query();
 }
 
-uilist::uilist( const point &start, int width, const std::string &msg,
-                const std::vector<uilist_entry> &opts )
-{
-    init();
-    w_x = start.x;
-    w_y = start.y;
-    w_width = width;
-    text = msg;
-    entries = opts;
-    query();
-}
-
-uilist::uilist( const point &start, int width, const std::string &msg,
-                const std::vector<std::string> &opts )
-{
-    init();
-    w_x = start.x;
-    w_y = start.y;
-    w_width = width;
-    text = msg;
-    for( const auto &opt : opts ) {
-        entries.emplace_back( opt );
-    }
-    query();
-}
-
-uilist::uilist( const point &start, int width, const std::string &msg,
-                std::initializer_list<const char *const> opts )
-{
-    init();
-    w_x = start.x;
-    w_y = start.y;
-    w_width = width;
-    text = msg;
-    for( auto opt : opts ) {
-        entries.emplace_back( opt );
-    }
-    query();
-}
-
 uilist::~uilist()
 {
     shared_ptr_fast<ui_adaptor> current_ui = ui.lock();

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -294,24 +294,30 @@ void uilist::filterlist()
 
 void uilist::inputfilter()
 {
+    input_context ctxt( input_category );
+    ctxt.register_updown();
+    ctxt.register_action( "PAGE_UP" );
+    ctxt.register_action( "PAGE_DOWN" );
+    ctxt.register_action( "SCROLL_UP" );
+    ctxt.register_action( "SCROLL_DOWN" );
+    ctxt.register_action( "ANY_INPUT" );
     filter_popup = std::make_unique<string_input_popup>();
-    filter_popup->text( filter )
+    filter_popup->context( ctxt ).text( filter )
     .max_length( 256 )
     .window( window, point( 4, w_height - 1 ), w_width - 4 );
-    input_event event;
     ime_sentry sentry;
     do {
         ui_manager::redraw();
         filter = filter_popup->query_string( false );
-        event = filter_popup->context().get_raw_input();
-        if( event.get_first_input() != KEY_ESCAPE ) {
-            if( !scrollby( scroll_amount_from_key( event.get_first_input() ) ) ) {
+        if( !filter_popup->canceled() ) {
+            const std::string action = ctxt.input_to_action( ctxt.get_raw_input() );
+            if( !scrollby( scroll_amount_from_action( action ) ) ) {
                 filterlist();
             }
         }
-    } while( event.get_first_input() != '\n' && event.get_first_input() != KEY_ESCAPE );
+    } while( !filter_popup->confirmed() && !filter_popup->canceled() );
 
-    if( event.get_first_input() == KEY_ESCAPE ) {
+    if( filter_popup->canceled() ) {
         filterlist();
     }
 
@@ -706,21 +712,6 @@ void uilist::show()
     wrefresh( window );
     if( callback != nullptr ) {
         callback->refresh( this );
-    }
-}
-
-int uilist::scroll_amount_from_key( const int key )
-{
-    if( key == KEY_UP ) {
-        return -1;
-    } else if( key == KEY_PPAGE ) {
-        return ( -vmax + 1 );
-    } else if( key == KEY_DOWN ) {
-        return 1;
-    } else if( key == KEY_NPAGE ) {
-        return vmax - 1;
-    } else {
-        return 0;
     }
 }
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -12,6 +12,7 @@
 #include "color.h"
 #include "cursesdef.h"
 #include "memory_fast.h"
+#include "pimpl.h"
 #include "point.h"
 #include "string_formatter.h"
 
@@ -355,13 +356,12 @@ class uilist // NOLINT(cata-xy)
 class pointmenu_cb : public uilist_callback
 {
     private:
-        const std::vector< tripoint > &points;
-        int last; // to suppress redrawing
-        tripoint last_view; // to reposition the view after selecting
+        struct impl_t;
+        pimpl<impl_t> impl;
     public:
         pointmenu_cb( const std::vector< tripoint > &pts );
         ~pointmenu_cb() override;
-        void refresh( uilist *menu ) override;
+        void select( uilist *menu ) override;
 };
 
 #endif // CATA_SRC_UI_H

--- a/src/ui.h
+++ b/src/ui.h
@@ -193,12 +193,6 @@ class uilist // NOLINT(cata-xy)
         uilist( const std::string &msg, const std::vector<uilist_entry> &opts );
         uilist( const std::string &msg, const std::vector<std::string> &opts );
         uilist( const std::string &msg, std::initializer_list<const char *const> opts );
-        uilist( const point &start, int width, const std::string &msg,
-                const std::vector<uilist_entry> &opts );
-        uilist( const point &start, int width, const std::string &msg,
-                const std::vector<std::string> &opts );
-        uilist( const point &start, int width, const std::string &msg,
-                std::initializer_list<const char *const> opts );
 
         ~uilist();
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -241,7 +241,6 @@ class uilist // NOLINT(cata-xy)
         operator int() const;
 
     private:
-        int scroll_amount_from_key( int key );
         int scroll_amount_from_action( const std::string &action );
         void apply_scrollbar();
         // This function assumes it's being called from `query` and should

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "cursesdef.h"
+#include "game_ui.h"
 #include "point.h"
 #include "sdltiles.h"
 
@@ -199,6 +200,7 @@ void ui_adaptor::redraw_invalidated()
             ui.deferred_resize = false;
         }
     }
+    reinitialize_framebuffer();
 
     // redraw invalidated uis
     // TODO refresh only when all stacked UIs are drawn

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -40,17 +40,21 @@ ui_adaptor::~ui_adaptor()
 
 void ui_adaptor::position_from_window( const catacurses::window &win )
 {
-    const rectangle old_dimensions = dimensions;
-    // ensure position is updated before calling invalidate
+    if( !win ) {
+        position( point_zero, point_zero );
+    } else {
+        const rectangle old_dimensions = dimensions;
+        // ensure position is updated before calling invalidate
 #ifdef TILES
-    const window_dimensions dim = get_window_dimensions( win );
-    dimensions = rectangle( dim.window_pos_pixel, dim.window_pos_pixel + dim.window_size_pixel );
+        const window_dimensions dim = get_window_dimensions( win );
+        dimensions = rectangle( dim.window_pos_pixel, dim.window_pos_pixel + dim.window_size_pixel );
 #else
-    const point origin( getbegx( win ), getbegy( win ) );
-    dimensions = rectangle( origin, origin + point( getmaxx( win ), getmaxy( win ) ) );
+        const point origin( getbegx( win ), getbegy( win ) );
+        dimensions = rectangle( origin, origin + point( getmaxx( win ), getmaxy( win ) ) );
 #endif
-    invalidated = true;
-    ui_manager::invalidate( old_dimensions );
+        invalidated = true;
+        ui_manager::invalidate( old_dimensions );
+    }
 }
 
 void ui_adaptor::position( const point &topleft, const point &size )

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -31,6 +31,7 @@ class ui_adaptor
         ui_adaptor &operator=( const ui_adaptor &rhs ) = delete;
         ui_adaptor &operator=( ui_adaptor &&rhs ) = delete;
 
+        // If win is null, the function has the same effect as position( point_zero, point_zero )
         void position_from_window( const catacurses::window &win );
         // Set the position and size of the ui to that of an imaginary normal
         // catacurses::window, except that size can be zero.

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -22,8 +22,7 @@ class ui_adaptor
 
         ui_adaptor();
         // ui_adaptor constructed this way will block any uis below from being
-        // redrawn or resized until it is deconstructed. It is used for `debug_msg`
-        // and for temporarily disabling redrawing of lower UIs in unmigrated UIs.
+        // redrawn or resized until it is deconstructed. It is used for `debug_msg`.
         ui_adaptor( disable_uis_below );
         ui_adaptor( const ui_adaptor &rhs ) = delete;
         ui_adaptor( ui_adaptor &&rhs ) = delete;

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -160,7 +160,6 @@ player_activity veh_interact::run( vehicle &veh, const point &p )
 {
     veh_interact vehint( veh, p );
     vehint.do_main_loop();
-    g->refresh_all();
     return vehint.serialize_activity();
 }
 
@@ -172,7 +171,6 @@ vehicle_part &veh_interact::select_part( const vehicle &veh, const part_selector
 
     auto act = [&]( const vehicle_part & pt ) {
         res = const_cast<vehicle_part *>( &pt );
-        return false; // avoid redraw
     };
 
     int opts = std::count_if( veh.parts.cbegin(), veh.parts.cend(), sel );
@@ -184,7 +182,6 @@ vehicle_part &veh_interact::select_part( const vehicle &veh, const part_selector
         veh_interact vehint( const_cast<vehicle &>( veh ) );
         vehint.set_title( title.empty() ? _( "Select part" ) : title );
         vehint.overview( sel, act );
-        g->refresh_all();
     }
 
     return *res;
@@ -231,7 +228,8 @@ veh_interact::veh_interact( vehicle &veh, const point &p )
 
     count_durability();
     cache_tool_availability();
-    allocate_windows();
+    // Initialize info of selected parts
+    move_cursor( point_zero );
 }
 
 veh_interact::~veh_interact() = default;
@@ -273,12 +271,6 @@ void veh_interact::allocate_windows()
     w_list  = catacurses::newwin( page_size, pane_w, point( list_x, pane_y ) );
     w_stats = catacurses::newwin( stats_h,   grid_w, point( 1, stats_y ) );
     w_name  = catacurses::newwin( name_h,    grid_w, point( 1, name_y ) );
-
-    display_grid();
-    display_name();
-    display_stats();
-    display_veh();
-    move_cursor( point_zero ); // display w_disp & w_parts
 }
 
 void veh_interact::set_title( const std::string &msg ) const
@@ -328,6 +320,58 @@ bool veh_interact::format_reqs( std::string &msg, const requirement_data &reqs,
     return ok;
 }
 
+shared_ptr_fast<ui_adaptor> veh_interact::create_or_get_ui_adaptor()
+{
+    shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
+    if( !current_ui ) {
+        ui = current_ui = make_shared_fast<ui_adaptor>();
+        current_ui->on_screen_resize( [this]( ui_adaptor & current_ui ) {
+            allocate_windows();
+            current_ui.position_from_window( catacurses::stdscr );
+        } );
+        current_ui->mark_resize();
+        current_ui->on_redraw( [this]( const ui_adaptor & ) {
+            display_grid();
+            display_name();
+            display_stats();
+            display_veh();
+
+            const int hw = getmaxx( w_disp ) / 2;
+            const int hh = getmaxy( w_disp ) / 2;
+            const point vd = -dd;
+            const point q = veh->coord_translate( vd );
+            const tripoint vehp = veh->global_pos3() + q;
+            bool obstruct = g->m.impassable_ter_furn( vehp );
+            const optional_vpart_position ovp = g->m.veh_at( vehp );
+            if( ovp && &ovp->vehicle() != veh ) {
+                obstruct = true;
+            }
+            nc_color col = cpart >= 0 ? veh->part_color( cpart ) : c_black;
+            int sym = cpart >= 0 ? veh->part_sym( cpart ) : ' ';
+            mvwputch( w_disp, point( hw, hh ), obstruct ? red_background( col ) : hilite( col ),
+                      special_symbol( sym ) );
+            wrefresh( w_disp );
+            werase( w_parts );
+            veh->print_part_list( w_parts, 0, getmaxy( w_parts ) - 1, getmaxx( w_parts ), cpart, -1, true );
+            wrefresh( w_parts );
+
+            werase( w_msg );
+            if( !msg.has_value() ) {
+                veh->print_vparts_descs( w_msg, getmaxy( w_msg ), getmaxx( w_msg ), cpart, start_at, start_limit );
+            } else {
+                // NOLINTNEXTLINE(cata-use-named-point-constants)
+                fold_and_print( w_msg, point( 1, 0 ), getmaxx( w_msg ) - 2, c_light_red, msg.value() );
+            }
+            wrefresh( w_msg );
+
+            // Draw overview without querying
+            overview();
+            display_mode();
+        } );
+    }
+    return current_ui;
+}
+
 void veh_interact::do_main_loop()
 {
     bool finish = false;
@@ -339,65 +383,47 @@ void veh_interact::do_main_loop()
         owner_fac = g->faction_manager_ptr->get( faction_id( "no_faction" ) );
     }
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
 
     while( !finish ) {
-        overview();
-        display_mode();
+        ui_manager::redraw();
         const std::string action = main_context.handle_input();
-        werase( w_msg );
-        wrefresh( w_msg );
-        std::string msg;
-        bool redraw = false;
+        msg.reset();
         if( const cata::optional<tripoint> vec = main_context.get_direction( action ) ) {
             move_cursor( vec->xy() );
         } else if( action == "QUIT" ) {
             finish = true;
-        } else if( action == "HELP_KEYBINDINGS" ) {
-            redraw = true;
         } else if( action == "INSTALL" ) {
-            if( !veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
-                redraw = true;
-            } else {
-                redraw = do_install( msg );
+            if( veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
+                do_install();
             }
         } else if( action == "REPAIR" ) {
-            if( !veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
-                redraw = true;
-            } else {
-                redraw = do_repair( msg );
+            if( veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
+                do_repair();
             }
         } else if( action == "MEND" ) {
-            if( !veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
-                redraw = true;
-            } else {
-                redraw = do_mend( msg );
+            if( veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
+                do_mend();
             }
         } else if( action == "REFILL" ) {
-            if( !veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
-                redraw = true;
-            } else {
-                redraw = do_refill( msg );
+            if( veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
+                do_refill();
             }
         } else if( action == "REMOVE" ) {
-            if( !veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
-                redraw = true;
-            } else {
-                redraw = do_remove( msg );
+            if( veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
+                do_remove();
             }
         } else if( action == "RENAME" ) {
             if( owned_by_player ) {
-                redraw = do_rename( msg );
+                do_rename();
             } else {
                 if( owner_fac ) {
                     popup( _( "You cannot rename this vehicle as it is owned by: %s." ), _( owner_fac->name ) );
                 }
-                redraw = true;
             }
         } else if( action == "SIPHON" ) {
             if( veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
-                redraw = do_siphon( msg );
+                do_siphon();
                 // Siphoning may have started a player activity. If so, we should close the
                 // vehicle dialog and continue with the activity.
                 finish = !g->u.activity.is_null();
@@ -405,34 +431,27 @@ void veh_interact::do_main_loop()
                     // it's possible we just invalidated our crafting inventory
                     cache_tool_availability();
                 }
-            } else {
-                redraw = true;
             }
         } else if( action == "UNLOAD" ) {
             if( veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
-                redraw = do_unload( msg );
-                finish = redraw;
-            } else {
-                redraw = true;
+                finish = do_unload();
             }
         } else if( action == "ASSIGN_CREW" ) {
             if( owned_by_player ) {
-                redraw = do_assign_crew( msg );
+                do_assign_crew();
             } else {
                 if( owner_fac ) {
                     popup( _( "You cannot assign crew on this vehicle as it is owned by: %s." ),
                            _( owner_fac->name ) );
                 }
-                redraw = true;
             }
         } else if( action == "RELABEL" ) {
             if( owned_by_player ) {
-                redraw = do_relabel( msg );
+                do_relabel();
             } else {
                 if( owner_fac ) {
                     popup( _( "You cannot relabel this vehicle as it is owned by: %s." ), _( owner_fac->name ) );
                 }
-                redraw = true;
             }
         } else if( action == "FUEL_LIST_DOWN" ) {
             move_fuel_cursor( 1 );
@@ -449,22 +468,6 @@ void veh_interact::do_main_loop()
         }
         if( sel_cmd != ' ' ) {
             finish = true;
-        }
-
-        if( !finish && redraw ) {
-            display_grid();
-            display_name();
-            display_stats();
-            display_veh();
-        }
-
-        if( !msg.empty() ) {
-            werase( w_msg );
-            // NOLINTNEXTLINE(cata-use-named-point-constants)
-            fold_and_print( w_msg, point( 1, 0 ), getmaxx( w_msg ) - 2, c_light_red, msg );
-            wrefresh( w_msg );
-        } else {
-            move_cursor( point_zero );
         }
     }
 }
@@ -834,8 +837,6 @@ void veh_interact::move_fuel_cursor( int delta )
     } else if( fuel_index > max_fuel_indicators - height ) {
         fuel_index = std::max( max_fuel_indicators - height, 0 );
     }
-
-    display_stats();
 }
 
 static void sort_uilist_entries_by_line_drawing( std::vector<uilist_entry> &shape_ui_entries )
@@ -867,13 +868,13 @@ static void sort_uilist_entries_by_line_drawing( std::vector<uilist_entry> &shap
     } );
 }
 
-bool veh_interact::do_install( std::string &msg )
+void veh_interact::do_install()
 {
     task_reason reason = cant_do( 'i' );
 
     if( reason == INVALID_TARGET ) {
         msg = _( "Cannot install any part here." );
-        return false;
+        return;
     }
 
     set_title( _( "Choose new part to install here:" ) );
@@ -1029,7 +1030,6 @@ bool veh_interact::do_install( std::string &msg )
             display_grid();
             display_stats();
             display_veh(); // Fix the (currently) mangled windows
-            move_cursor( point_zero ); // Wake up the vehicle display
         }
         if( action == "REPAIR" ) {
             filter.clear();
@@ -1040,19 +1040,19 @@ bool veh_interact::do_install( std::string &msg )
                 switch( reason ) {
                     case LOW_MORALE:
                         msg = _( "Your morale is too low to construct…" );
-                        return false;
+                        return;
                     case LOW_LIGHT:
                         msg = _( "It's too dark to see what you are doing…" );
-                        return false;
+                        return;
                     case MOVING_VEHICLE:
                         msg = _( "You can't install parts while driving." );
-                        return false;
+                        return;
                     default:
                         break;
                 }
                 if( veh->is_foldable() && !sel_vpart_info->has_flag( "FOLDABLE" ) &&
                     !query_yn( _( "Installing this part will make the vehicle unfoldable.  Continue?" ) ) ) {
-                    return true;
+                    return;
                 }
                 const auto &shapes = vpart_shapes[ sel_vpart_info->name() + sel_vpart_info->item ];
                 int selected_shape = -1;
@@ -1075,7 +1075,7 @@ bool veh_interact::do_install( std::string &msg )
                 if( selected_shape >= 0 && static_cast<size_t>( selected_shape ) < shapes.size() ) {
                     sel_vpart_info = shapes[selected_shape];
                     sel_cmd = 'i';
-                    return true; // force redraw
+                    return;
                 }
             }
         } else if( action == "QUIT" ) {
@@ -1109,8 +1109,6 @@ bool veh_interact::do_install( std::string &msg )
     //restore windows that had been covered by w_details
     display_stats();
     display_name();
-
-    return false;
 }
 
 bool veh_interact::move_in_list( int &pos, const std::string &action, const int size,
@@ -1137,7 +1135,7 @@ bool veh_interact::move_in_list( int &pos, const std::string &action, const int 
     return true;
 }
 
-bool veh_interact::do_repair( std::string &msg )
+void veh_interact::do_repair()
 {
     task_reason reason = cant_do( 'r' );
 
@@ -1145,11 +1143,11 @@ bool veh_interact::do_repair( std::string &msg )
         vehicle_part *most_repairable = get_most_repariable_part();
         if( most_repairable ) {
             move_cursor( ( most_repairable->mount + dd ).rotate( 3 ) );
-            return false;
+            return;
         }
     }
 
-    auto can_repair = [&msg, &reason]() {
+    auto can_repair = [this, &reason]() {
         switch( reason ) {
             case LOW_MORALE:
                 msg = _( "Your morale is too low to repair…" );
@@ -1170,7 +1168,7 @@ bool veh_interact::do_repair( std::string &msg )
     };
 
     if( !can_repair() ) {
-        return false;
+        return;
     }
 
     set_title( _( "Choose a part here to repair:" ) );
@@ -1215,7 +1213,7 @@ bool veh_interact::do_repair( std::string &msg )
         if( ( action == "REPAIR" || action == "CONFIRM" ) && ok ) {
             reason = cant_do( 'r' );
             if( !can_repair() ) {
-                return false;
+                return;
             }
             sel_vehicle_part = &pt;
             sel_vpart_info = &vp;
@@ -1238,25 +1236,23 @@ bool veh_interact::do_repair( std::string &msg )
             move_in_list( pos, action, need_repair.size() );
         }
     }
-
-    return false;
 }
 
-bool veh_interact::do_mend( std::string &msg )
+void veh_interact::do_mend()
 {
     switch( cant_do( 'm' ) ) {
         case LOW_MORALE:
             msg = _( "Your morale is too low to mend…" );
-            return false;
+            return;
         case LOW_LIGHT:
             msg = _( "It's too dark to see what you are doing…" );
-            return false;
+            return;
         case INVALID_TARGET:
             msg = _( "No faulty parts require mending." );
-            return false;
+            return;
         case MOVING_VEHICLE:
             msg = _( "You can't mend stuff while driving." );
-            return false;
+            return;
         default:
             break;
     }
@@ -1275,22 +1271,21 @@ bool veh_interact::do_mend( std::string &msg )
     auto act = [&]( const vehicle_part & pt ) {
         g->u.mend_item( veh->part_base( veh->index_of_part( &pt ) ) );
         sel_cmd = 'q';
-        return true; // force redraw
     };
 
-    return overview( sel, act );
+    overview( sel, act );
 }
 
-bool veh_interact::do_refill( std::string &msg )
+void veh_interact::do_refill()
 {
     switch( cant_do( 'f' ) ) {
         case MOVING_VEHICLE:
             msg = _( "You can't refill a moving vehicle." );
-            return false;
+            return;
 
         case INVALID_TARGET:
             msg = _( "No parts can currently be refilled." );
-            return false;
+            return;
 
         default:
             break;
@@ -1321,15 +1316,13 @@ bool veh_interact::do_refill( std::string &msg )
             sel_vpart_info = &pt.info();
             sel_cmd = 'f';
         }
-
-        return true; // force redraw
     };
 
-    return overview( can_refill, act );
+    overview( can_refill, act );
 }
 
-bool veh_interact::overview( std::function<bool( const vehicle_part &pt )> enable,
-                             std::function<bool( vehicle_part &pt )> action )
+void veh_interact::overview( const std::function<bool( const vehicle_part &pt )> &enable,
+                             const std::function<void( vehicle_part &pt )> &action )
 {
     struct part_option {
         part_option( const std::string &key, vehicle_part *part, char hotkey,
@@ -1580,7 +1573,6 @@ bool veh_interact::overview( std::function<bool( const vehicle_part &pt )> enabl
     // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
     ui_adaptor ui( ui_adaptor::disable_uis_below {} );
 
-    bool redraw = false;
     while( true ) {
         werase( w_list );
         std::string last;
@@ -1634,7 +1626,7 @@ bool veh_interact::overview( std::function<bool( const vehicle_part &pt )> enabl
         if( !std::any_of( opts.begin(), opts.end(), []( const part_option & e ) {
         return e.hotkey;
     } ) ) {
-            return false; // nothing is selectable
+            return; // nothing is selectable
         }
 
         move_cursor( ( opts[pos].part->mount + dd ).rotate( 3 ) );
@@ -1645,7 +1637,7 @@ bool veh_interact::overview( std::function<bool( const vehicle_part &pt )> enabl
 
         const std::string input = main_context.handle_input();
         if( input == "CONFIRM" && opts[pos].hotkey ) {
-            redraw = action( *opts[pos].part );
+            action( *opts[pos].part );
             break;
 
         } else if( input == "QUIT" ) {
@@ -1684,7 +1676,6 @@ bool veh_interact::overview( std::function<bool( const vehicle_part &pt )> enabl
 
     werase( w_list );
     wrefresh( w_list );
-    return redraw;
 }
 
 void veh_interact::move_overview_line( int amount )
@@ -1806,13 +1797,13 @@ bool veh_interact::can_remove_part( int idx, const player &p )
     return ok || g->u.has_trait( trait_DEBUG_HS );
 }
 
-bool veh_interact::do_remove( std::string &msg )
+void veh_interact::do_remove()
 {
     task_reason reason = cant_do( 'o' );
 
     if( reason == INVALID_TARGET ) {
         msg = _( "No parts here." );
-        return false;
+        return;
     }
 
     set_title( _( "Choose a part here to remove:" ) );
@@ -1848,16 +1839,16 @@ bool veh_interact::do_remove( std::string &msg )
             switch( reason ) {
                 case LOW_MORALE:
                     msg = _( "Your morale is too low to construct…" );
-                    return false;
+                    return;
                 case LOW_LIGHT:
                     msg = _( "It's too dark to see what you are doing…" );
-                    return false;
+                    return;
                 case NOT_FREE:
                     msg = _( "You cannot remove that part while something is attached to it." );
-                    return false;
+                    return;
                 case MOVING_VEHICLE:
                     msg = _( "Better not remove something while driving." );
-                    return false;
+                    return;
                 default:
                     break;
             }
@@ -1878,24 +1869,22 @@ bool veh_interact::do_remove( std::string &msg )
             move_in_list( pos, action, parts_here.size() );
         }
     }
-
-    return false;
 }
 
-bool veh_interact::do_siphon( std::string &msg )
+void veh_interact::do_siphon()
 {
     switch( cant_do( 's' ) ) {
         case INVALID_TARGET:
             msg = _( "The vehicle has no liquid fuel left to siphon." );
-            return false;
+            return;
 
         case LACK_TOOLS:
             msg = _( "You need a <color_red>hose</color> to siphon liquid fuel." );
-            return false;
+            return;
 
         case MOVING_VEHICLE:
             msg = _( "You can't siphon from a moving vehicle." );
-            return false;
+            return;
 
         default:
             break;
@@ -1915,13 +1904,12 @@ bool veh_interact::do_siphon( std::string &msg )
         if( liquid_handler::handle_liquid( liquid, nullptr, 1, nullptr, veh, idx ) ) {
             veh->drain( idx, liq_charges - liquid.charges );
         }
-        return true;
     };
 
-    return overview( sel, act );
+    overview( sel, act );
 }
 
-bool veh_interact::do_unload( std::string &msg )
+bool veh_interact::do_unload()
 {
     switch( cant_do( 'd' ) ) {
         case INVALID_TARGET:
@@ -1937,15 +1925,14 @@ bool veh_interact::do_unload( std::string &msg )
     }
 
     act_vehicle_unload_fuel( veh );
-    // force redraw
     return true;
 }
 
-bool veh_interact::do_assign_crew( std::string &msg )
+void veh_interact::do_assign_crew()
 {
     if( cant_do( 'w' ) != CAN_DO ) {
         msg = _( "Need at least one seat and an ally to assign crew members." );
-        return false;
+        return;
     }
 
     set_title( _( "Assign crew positions:" ) );
@@ -1973,15 +1960,12 @@ bool veh_interact::do_assign_crew( std::string &msg )
             const auto &who = *g->critter_by_id<npc>( character_id( menu.ret ) );
             veh->assign_seat( pt, who );
         }
-
-        // force redraw
-        return true;
     };
 
-    return overview( sel, act );
+    overview( sel, act );
 }
 
-bool veh_interact::do_rename( std::string & )
+void veh_interact::do_rename()
 {
     std::string name = string_input_popup()
                        .title( _( "Enter new vehicle name:" ) )
@@ -1995,15 +1979,13 @@ bool veh_interact::do_rename( std::string & )
             overmap_buffer.add_vehicle( veh );
         }
     }
-
-    return true;
 }
 
-bool veh_interact::do_relabel( std::string &msg )
+void veh_interact::do_relabel()
 {
     if( cant_do( 'a' ) == INVALID_TARGET ) {
         msg = _( "There are no parts here to label." );
-        return false;
+        return;
     }
 
     const vpart_position vp( *veh, cpart );
@@ -2014,10 +1996,6 @@ bool veh_interact::do_relabel( std::string &msg )
                        .query_string();
     // empty input removes the label
     vp.set_label( text );
-    // refresh w_disp & w_part windows:
-    move_cursor( point_zero );
-
-    return false;
 }
 
 /**
@@ -2049,9 +2027,6 @@ bool veh_interact::can_potentially_install( const vpart_info &vpart )
  */
 void veh_interact::move_cursor( const point &d, int dstart_at )
 {
-    const int hw = getmaxx( w_disp ) / 2;
-    const int hh = getmaxy( w_disp ) / 2;
-
     dd += d.rotate( 3 );
     if( d != point_zero ) {
         start_limit = 0;
@@ -2059,7 +2034,6 @@ void veh_interact::move_cursor( const point &d, int dstart_at )
         start_at += dstart_at;
     }
 
-    display_veh();
     // Update the current active component index to the new position.
     cpart = part_at( point_zero );
     const point vd = -dd;
@@ -2071,18 +2045,6 @@ void veh_interact::move_cursor( const point &d, int dstart_at )
     if( ovp && &ovp->vehicle() != veh ) {
         obstruct = true;
     }
-    nc_color col = cpart >= 0 ? veh->part_color( cpart ) : c_black;
-    int sym = cpart >= 0 ? veh->part_sym( cpart ) : ' ';
-    mvwputch( w_disp, point( hw, hh ), obstruct ? red_background( col ) : hilite( col ),
-              special_symbol( sym ) );
-    wrefresh( w_disp );
-    werase( w_parts );
-    veh->print_part_list( w_parts, 0, getmaxy( w_parts ) - 1, getmaxx( w_parts ), cpart, -1, true );
-    wrefresh( w_parts );
-
-    werase( w_msg );
-    veh->print_vparts_descs( w_msg, getmaxy( w_msg ), getmaxx( w_msg ), cpart, start_at, start_limit );
-    wrefresh( w_msg );
 
     can_mount.clear();
     if( !obstruct ) {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -238,40 +238,49 @@ veh_interact::~veh_interact() = default;
 void veh_interact::allocate_windows()
 {
     // grid window
+    const int grid_x = 1;
+    const int grid_y = 1;
     const int grid_w = TERMX - 2; // exterior borders take 2
     const int grid_h = TERMY - 2; // exterior borders take 2
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    w_grid = catacurses::newwin( grid_h, grid_w, point( 1, 1 ) );
+    w_grid = catacurses::newwin( grid_h, grid_w, point( grid_x, grid_y ) );
 
-    int mode_h  = 1;
-    int name_h  = 1;
+    const int mode_h  = 1;
+    const int name_h  = 1;
 
     page_size = grid_h - ( mode_h + stats_h + name_h ) - 2;
 
-    int pane_y = 1 + mode_h + 1;
+    const int pane_y = grid_y + mode_h + 1;
 
-    int pane_w = ( grid_w / 3 ) - 1;
+    const int pane_w = ( grid_w / 3 ) - 1;
 
-    int disp_w = grid_w - ( pane_w * 2 ) - 2;
-    int disp_h = page_size * 0.45;
-    int parts_h = page_size - disp_h;
-    int parts_y = pane_y + disp_h;
+    const int disp_w = grid_w - ( pane_w * 2 ) - 2;
+    const int disp_h = page_size * 0.45;
+    const int parts_h = page_size - disp_h;
+    const int parts_y = pane_y + disp_h;
 
-    int name_y = pane_y + page_size + 1;
-    int stats_y = name_y + name_h;
+    const int name_y = pane_y + page_size + 1;
+    const int stats_y = name_y + name_h;
 
-    int list_x = 1 + disp_w + 1;
-    int msg_x  = list_x + pane_w + 1;
+    const int list_x = grid_x + disp_w + 1;
+    const int msg_x  = list_x + pane_w + 1;
+
+    // covers right part of w_name and w_stats in vertical/hybrid
+    const int details_y = name_y;
+    const int details_x = list_x;
+
+    const int details_h = 7;
+    const int details_w = grid_x + grid_w - details_x;
 
     // make the windows
     // NOLINTNEXTLINE(cata-use-named-point-constants)
-    w_mode  = catacurses::newwin( mode_h,    grid_w, point( 1, 1 ) );
+    w_mode  = catacurses::newwin( mode_h,    grid_w, point( grid_x, grid_y ) );
     w_msg   = catacurses::newwin( page_size, pane_w, point( msg_x, pane_y ) );
-    w_disp  = catacurses::newwin( disp_h,    disp_w, point( 1, pane_y ) );
-    w_parts = catacurses::newwin( parts_h,   disp_w, point( 1, parts_y ) );
+    w_disp  = catacurses::newwin( disp_h,    disp_w, point( grid_x, pane_y ) );
+    w_parts = catacurses::newwin( parts_h,   disp_w, point( grid_x, parts_y ) );
     w_list  = catacurses::newwin( page_size, pane_w, point( list_x, pane_y ) );
-    w_stats = catacurses::newwin( stats_h,   grid_w, point( 1, stats_y ) );
-    w_name  = catacurses::newwin( name_h,    grid_w, point( 1, name_y ) );
+    w_stats = catacurses::newwin( stats_h,   grid_w, point( grid_x, stats_y ) );
+    w_name  = catacurses::newwin( name_h,    grid_w, point( grid_x, name_y ) );
+    w_details = catacurses::newwin( details_h, details_w, point( details_x, details_y ) );
 }
 
 bool veh_interact::format_reqs( std::string &msg, const requirement_data &reqs,
@@ -365,6 +374,10 @@ shared_ptr_fast<ui_adaptor> veh_interact::create_or_get_ui_adaptor()
                 wrefresh( w_mode );
             } else {
                 display_mode();
+            }
+
+            if( submenu_redraw ) {
+                submenu_redraw();
             }
         } );
     }
@@ -641,13 +654,9 @@ bool veh_interact::is_drive_conflict()
     bool has_conflict = veh->has_engine_conflict( sel_vpart_info, conflict_type );
 
     if( has_conflict ) {
-        werase( w_msg );
-        // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_msg, point( 1, 0 ), getmaxx( w_msg ) - 2, c_light_red,
-                        //~ %1$s is fuel_type
-                        string_format( _( "Only one %1$s powered engine can be installed." ),
-                                       conflict_type ) );
-        wrefresh( w_msg );
+        //~ %1$s is fuel_type
+        msg = string_format( _( "Only one %1$s powered engine can be installed." ),
+                             conflict_type );
     }
     return has_conflict;
 }
@@ -664,20 +673,9 @@ bool veh_interact::can_self_jack()
     return false;
 }
 
-static void print_message_to( catacurses::window &w_msg, const nc_color col,
-                              const std::string &msg )
-{
-    werase( w_msg );
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    fold_and_print( w_msg, point( 1, 0 ), getmaxx( w_msg ) - 2, col, msg );
-    wrefresh( w_msg );
-}
-
 bool veh_interact::can_install_part()
 {
     if( sel_vpart_info == nullptr ) {
-        werase( w_msg );
-        wrefresh( w_msg );
         return false;
     }
 
@@ -688,7 +686,7 @@ bool veh_interact::can_install_part()
         if( std::none_of( parts_here.begin(), parts_here.end(), [&]( const int e ) {
         return veh->parts[e].is_tank();
         } ) ) {
-            print_message_to( w_msg, c_light_red, _( "Funnels need to be installed over a tank." ) );
+            msg = _( "Funnels need to be installed over a tank." );
             return false;
         }
     }
@@ -697,7 +695,7 @@ bool veh_interact::can_install_part()
         if( std::any_of( parts_here.begin(), parts_here.end(), [&]( const int e ) {
         return veh->parts[e].is_turret();
         } ) ) {
-            print_message_to( w_msg, c_light_red, _( "Can't install turret on another turret." ) );
+            msg = _( "Can't install turret on another turret." );
             return false;
         }
     }
@@ -734,8 +732,8 @@ bool veh_interact::can_install_part()
 
     const auto reqs = sel_vpart_info->install_requirements();
 
-    std::string msg;
-    bool ok = format_reqs( msg, reqs, sel_vpart_info->install_skills,
+    std::string nmsg;
+    bool ok = format_reqs( nmsg, reqs, sel_vpart_info->install_skills,
                            sel_vpart_info->install_time( g->u ) );
 
     std::string additional_requirements;
@@ -811,13 +809,13 @@ bool veh_interact::can_install_part()
                                    colorize( str_string, str_color ) ) + "\n";
     }
     if( !additional_requirements.empty() ) {
-        msg += _( "<color_white>Additional requirements:</color>\n" );
-        msg += additional_requirements;
+        nmsg += _( "<color_white>Additional requirements:</color>\n" );
+        nmsg += additional_requirements;
     }
 
-    sel_vpart_info->format_description( msg, c_light_gray, getmaxx( w_msg ) - 4 );
+    sel_vpart_info->format_description( nmsg, c_light_gray, getmaxx( w_msg ) - 4 );
 
-    print_message_to( w_msg, c_light_gray, msg );
+    msg = colorize( nmsg, c_light_gray );
     return ok || g->u.has_trait( trait_DEBUG_HS );
 }
 
@@ -994,12 +992,13 @@ void veh_interact::do_install()
     // full list of mountable parts, to be filtered according to tab
     std::vector<const vpart_info *> tab_vparts = can_mount;
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
 
     int pos = 0;
     size_t tab = 0;
-    while( true ) {
+
+    restore_on_out_of_scope<std::function<void()>> prev_submenu_redraw( submenu_redraw );
+    submenu_redraw = [&]() {
         display_list( pos, tab_vparts, 2 );
 
         // draw tab menu
@@ -1013,13 +1012,18 @@ void veh_interact::do_install()
         }
         wrefresh( w_list );
 
-        sel_vpart_info = tab_vparts.empty() ? nullptr : tab_vparts[pos]; // filtered list can be empty
-
         display_details( sel_vpart_info );
+    };
+
+    while( true ) {
+        sel_vpart_info = tab_vparts.empty() ? nullptr : tab_vparts[pos]; // filtered list can be empty
 
         bool can_install = can_install_part();
 
+        ui_manager::redraw();
+
         const std::string action = main_context.handle_input();
+        msg.reset();
         if( action == "FILTER" ) {
             string_input_popup()
             .title( _( "Search for part" ) )
@@ -1028,9 +1032,6 @@ void veh_interact::do_install()
             .max_length( 100 )
             .edit( filter );
             tab = 7; // Move to the user filter tab.
-            display_grid();
-            display_stats();
-            display_veh(); // Fix the (currently) mangled windows
         }
         if( action == "REPAIR" ) {
             filter.clear();
@@ -1081,10 +1082,6 @@ void veh_interact::do_install()
             }
         } else if( action == "QUIT" ) {
             sel_vpart_info = nullptr;
-            werase( w_list );
-            wrefresh( w_list );
-            werase( w_msg );
-            wrefresh( w_msg );
             break;
         } else if( action == "PREV_TAB" || action == "NEXT_TAB" || action == "FILTER" ||
                    action == "REPAIR" ) {
@@ -1102,14 +1099,6 @@ void veh_interact::do_install()
             move_in_list( pos, action, tab_vparts.size(), 2 );
         }
     }
-
-    //destroy w_details
-    werase( w_details );
-    w_details = catacurses::window();
-
-    //restore windows that had been covered by w_details
-    display_stats();
-    display_name();
 }
 
 bool veh_interact::move_in_list( int &pos, const std::string &action, const int size,
@@ -1721,21 +1710,21 @@ bool veh_interact::can_remove_part( int idx, const player &p )
 {
     sel_vehicle_part = &veh->parts[idx];
     sel_vpart_info = &sel_vehicle_part->info();
-    std::string msg;
+    std::string nmsg;
 
     if( sel_vehicle_part->is_broken() ) {
-        msg += string_format(
-                   _( "<color_white>Removing the broken %1$s may yield some fragments.</color>\n" ),
-                   sel_vehicle_part->name() );
+        nmsg += string_format(
+                    _( "<color_white>Removing the broken %1$s may yield some fragments.</color>\n" ),
+                    sel_vehicle_part->name() );
     } else {
         item result_of_removal = sel_vehicle_part->properties_to_item();
-        msg += string_format(
-                   _( "<color_white>Removing the %1$s will yield:</color>\n> %2$s\n" ),
-                   sel_vehicle_part->name(), result_of_removal.display_name() );
+        nmsg += string_format(
+                    _( "<color_white>Removing the %1$s will yield:</color>\n> %2$s\n" ),
+                    sel_vehicle_part->name(), result_of_removal.display_name() );
     }
 
     const auto reqs = sel_vpart_info->removal_requirements();
-    bool ok = format_reqs( msg, reqs, sel_vpart_info->removal_skills,
+    bool ok = format_reqs( nmsg, reqs, sel_vpart_info->removal_skills,
                            sel_vpart_info->removal_time( p ) );
     std::string additional_requirements;
     bool lifting_or_jacking_required = false;
@@ -1796,13 +1785,13 @@ bool veh_interact::can_remove_part( int idx, const player &p )
 
     }
     if( !additional_requirements.empty() ) {
-        msg += _( "<color_white>Additional requirements:</color>\n" );
-        msg += additional_requirements;
+        nmsg += _( "<color_white>Additional requirements:</color>\n" );
+        nmsg += additional_requirements;
     }
     const nc_color desc_color = sel_vehicle_part->is_broken() ? c_dark_gray : c_light_gray;
-    sel_vehicle_part->info().format_description( msg, desc_color, getmaxx( w_msg ) - 4 );
+    sel_vehicle_part->info().format_description( nmsg, desc_color, getmaxx( w_msg ) - 4 );
 
-    print_message_to( w_msg, c_light_gray, msg );
+    msg = colorize( nmsg, c_light_gray );
     return ok || g->u.has_trait( trait_DEBUG_HS );
 }
 
@@ -2580,31 +2569,17 @@ void veh_interact::display_list( size_t pos, const std::vector<const vpart_info 
  */
 void veh_interact::display_details( const vpart_info *part )
 {
-
-    // create details window first if required
-    if( !w_details ) {
-
-        // covers right part of w_name and w_stats in vertical/hybrid
-        const int details_y = getbegy( w_name );
-        const int details_x = getbegx( w_list );
-
-        const int details_h = 7;
-        const int details_w = getbegx( w_grid ) + getmaxx( w_grid ) - details_x;
-
-        // clear rightmost blocks of w_stats to avoid overlap
-        int stats_col_2 = 33;
-        int stats_col_3 = 65 + ( ( TERMX - FULL_SCREEN_WIDTH ) / 4 );
-        int clear_x = getmaxx( w_stats ) - details_w + 1 >= stats_col_3 ? stats_col_3 : stats_col_2;
-        for( int i = 0; i < getmaxy( w_stats ); i++ ) {
-            mvwhline( w_stats, point( clear_x, i ), ' ', getmaxx( w_stats ) - clear_x );
-        }
-
-        wrefresh( w_stats );
-
-        w_details = catacurses::newwin( details_h, details_w, point( details_x, details_y ) );
-    } else {
-        werase( w_details );
+    const int details_w = getmaxx( w_details );
+    // clear rightmost blocks of w_stats to avoid overlap
+    int stats_col_2 = 33;
+    int stats_col_3 = 65 + ( ( TERMX - FULL_SCREEN_WIDTH ) / 4 );
+    int clear_x = getmaxx( w_stats ) - details_w + 1 >= stats_col_3 ? stats_col_3 : stats_col_2;
+    for( int i = 0; i < getmaxy( w_stats ); i++ ) {
+        mvwhline( w_stats, point( clear_x, i ), ' ', getmaxx( w_stats ) - clear_x );
     }
+    wrefresh( w_stats );
+
+    werase( w_details );
 
     wborder( w_details, LINE_XOXO, LINE_XOXO, LINE_OXOX, LINE_OXOX, LINE_OXXO, LINE_OOXX, LINE_XXOO,
              LINE_XOOX );
@@ -2613,7 +2588,6 @@ void veh_interact::display_details( const vpart_info *part )
         wrefresh( w_details );
         return;
     }
-    int details_w = getmaxx( w_details );
     // displays data in two columns
     int column_width = details_w / 2;
     int col_1 = 2;

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1164,10 +1164,18 @@ void veh_interact::do_repair()
     restore_on_out_of_scope<cata::optional<std::string>> prev_title( title );
     title = _( "Choose a part here to repair:" );
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
 
     int pos = 0;
+
+    restore_on_out_of_scope<std::function<void()>> prev_submenu_redraw( submenu_redraw );
+    submenu_redraw = [&]() {
+        werase( w_parts );
+        veh->print_part_list( w_parts, 0, getmaxy( w_parts ) - 1, getmaxx( w_parts ), cpart,
+                              need_repair[pos], true );
+        wrefresh( w_parts );
+    };
+
     while( true ) {
         vehicle_part &pt = veh->parts[parts_here[need_repair[pos]]];
         const vpart_info &vp = pt.info();
@@ -1190,17 +1198,12 @@ void veh_interact::do_repair()
         const nc_color desc_color = pt.is_broken() ? c_dark_gray : c_light_gray;
         vp.format_description( nmsg, desc_color, getmaxx( w_msg ) - 4 );
 
-        werase( w_msg );
-        // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_msg, point( 1, 0 ), getmaxx( w_msg ) - 2, c_light_gray, nmsg );
-        wrefresh( w_msg );
+        msg = colorize( nmsg, c_light_gray );
 
-        werase( w_parts );
-        veh->print_part_list( w_parts, 0, getmaxy( w_parts ) - 1, getmaxx( w_parts ), cpart,
-                              need_repair[pos], true );
-        wrefresh( w_parts );
+        ui_manager::redraw();
 
         const std::string action = main_context.handle_input();
+        msg.reset();
         if( ( action == "REPAIR" || action == "CONFIRM" ) && ok ) {
             reason = cant_do( 'r' );
             if( !can_repair() ) {
@@ -1216,11 +1219,6 @@ void veh_interact::do_repair()
             break;
 
         } else if( action == "QUIT" ) {
-            werase( w_parts );
-            veh->print_part_list( w_parts, 0, getmaxy( w_parts ) - 1, getmaxx( w_parts ), cpart, -1, true );
-            wrefresh( w_parts );
-            werase( w_msg );
-            wrefresh( w_msg );
             break;
 
         } else {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -180,7 +180,7 @@ vehicle_part &veh_interact::select_part( const vehicle &veh, const part_selector
 
     } else if( opts != 0 ) {
         veh_interact vehint( const_cast<vehicle &>( veh ) );
-        vehint.set_title( title.empty() ? _( "Select part" ) : title );
+        vehint.title = title.empty() ? _( "Select part" ) : title;
         vehint.overview( sel, act );
     }
 
@@ -225,6 +225,7 @@ veh_interact::veh_interact( vehicle &veh, const point &p )
     main_context.register_action( "CONFIRM" );
     main_context.register_action( "HELP_KEYBINDINGS" );
     main_context.register_action( "FILTER" );
+    main_context.register_action( "ANY_INPUT" );
 
     count_durability();
     cache_tool_availability();
@@ -271,15 +272,6 @@ void veh_interact::allocate_windows()
     w_list  = catacurses::newwin( page_size, pane_w, point( list_x, pane_y ) );
     w_stats = catacurses::newwin( stats_h,   grid_w, point( 1, stats_y ) );
     w_name  = catacurses::newwin( name_h,    grid_w, point( 1, name_y ) );
-}
-
-void veh_interact::set_title( const std::string &msg ) const
-{
-    werase( w_mode );
-    nc_color col = c_light_gray;
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    print_colored_text( w_mode, point( 1, 0 ), col, col, msg );
-    wrefresh( w_mode );
 }
 
 bool veh_interact::format_reqs( std::string &msg, const requirement_data &reqs,
@@ -364,9 +356,16 @@ shared_ptr_fast<ui_adaptor> veh_interact::create_or_get_ui_adaptor()
             }
             wrefresh( w_msg );
 
-            // Draw overview without querying
-            overview();
-            display_mode();
+            display_overview();
+            if( title.has_value() ) {
+                werase( w_mode );
+                nc_color title_col = c_light_gray;
+                // NOLINTNEXTLINE(cata-use-named-point-constants)
+                print_colored_text( w_mode, point( 1, 0 ), title_col, title_col, title.value() );
+                wrefresh( w_mode );
+            } else {
+                display_mode();
+            }
         } );
     }
     return current_ui;
@@ -386,6 +385,7 @@ void veh_interact::do_main_loop()
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
 
     while( !finish ) {
+        calc_overview();
         ui_manager::redraw();
         const std::string action = main_context.handle_input();
         msg.reset();
@@ -541,9 +541,9 @@ task_reason veh_interact::cant_do( char mode )
             valid_target = std::any_of( veh->parts.begin(),
             veh->parts.end(), [toggling]( const vehicle_part & pt ) {
                 if( toggling ) {
-                    return !pt.faults_potential().empty();
+                    return pt.is_available() && !pt.faults_potential().empty();
                 } else {
-                    return !pt.faults().empty();
+                    return pt.is_available() && !pt.faults().empty();
                 }
             } );
             enough_light = g->u.fine_detail_vision_mod() <= 4;
@@ -877,7 +877,8 @@ void veh_interact::do_install()
         return;
     }
 
-    set_title( _( "Choose new part to install here:" ) );
+    restore_on_out_of_scope<cata::optional<std::string>> prev_title( title );
+    title = _( "Choose new part to install here:" );
 
     std::array<std::string, 8> tab_list = { {
             pgettext( "Vehicle Parts|", "All" ),
@@ -1171,7 +1172,8 @@ void veh_interact::do_repair()
         return;
     }
 
-    set_title( _( "Choose a part here to repair:" ) );
+    restore_on_out_of_scope<cata::optional<std::string>> prev_title( title );
+    title = _( "Choose a part here to repair:" );
 
     // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
     ui_adaptor ui( ui_adaptor::disable_uis_below {} );
@@ -1257,7 +1259,8 @@ void veh_interact::do_mend()
             break;
     }
 
-    set_title( _( "Choose a part here to mend:" ) );
+    restore_on_out_of_scope<cata::optional<std::string>> prev_title( title );
+    title = _( "Choose a part here to mend:" );
 
     const bool toggling = g->u.has_trait( trait_DEBUG_HS );
     auto sel = [toggling]( const vehicle_part & pt ) {
@@ -1291,7 +1294,8 @@ void veh_interact::do_refill()
             break;
     }
 
-    set_title( _( "Select part to refill:" ) );
+    restore_on_out_of_scope<cata::optional<std::string>> prev_title( title );
+    title = _( "Select part to refill:" );
 
     auto act = [&]( const vehicle_part & pt ) {
         auto validate = [&]( const item & obj ) {
@@ -1321,63 +1325,59 @@ void veh_interact::do_refill()
     overview( can_refill, act );
 }
 
-void veh_interact::overview( const std::function<bool( const vehicle_part &pt )> &enable,
-                             const std::function<void( vehicle_part &pt )> &action )
+void veh_interact::calc_overview()
 {
-    struct part_option {
-        part_option( const std::string &key, vehicle_part *part, char hotkey,
-                     std::function<void( const vehicle_part &pt, const catacurses::window &w, int y )> details ) :
-            key( key ), part( part ), hotkey( hotkey ), details( details ) {}
-
-        part_option( const std::string &key, vehicle_part *part, char hotkey,
-                     std::function<void( const vehicle_part &pt, const catacurses::window &w, int y )> details,
-                     std::function<void( const vehicle_part &pt )> message ) :
-            key( key ), part( part ), hotkey( hotkey ), details( details ), message( message ) {}
-
-        std::string key;
-        vehicle_part *part;
-
-        /** Can @param action be run for this entry? */
-        char hotkey;
-
-        /** Writes any extra details for this entry */
-        std::function<void( const vehicle_part &pt, const catacurses::window &w, int y )> details;
-
-        /** Writes to message window when part is selected */
-        std::function<void( const vehicle_part &pt )> message;
+    const auto next_hotkey = [&]( const vehicle_part & pt, char &hotkey ) {
+        if( overview_action && overview_enable && overview_enable( pt ) ) {
+            const char ret = hotkey;
+            // Calculate next hotkey
+            ++hotkey;
+            bool finish = false;
+            while( !finish ) {
+                switch( hotkey ) {
+                    default:
+                        finish = true;
+                        break;
+                    case '{':
+                        hotkey = 'A';
+                        break;
+                    case 'c':
+                    case 'g':
+                    case 'j':
+                    case 'k':
+                    case 'l':
+                    case 'p':
+                    case 'q':
+                    case 't':
+                    case 'v':
+                    case 'x':
+                    case 'z':
+                        ++hotkey;
+                        break;
+                }
+            }
+            return ret;
+        } else {
+            return '\0';
+        }
     };
 
-    const auto next_hotkey = [&]( char &hotkey ) {
-        hotkey += 1;
-        if( hotkey == '{' ) {
-            hotkey = 'A';
-        }
-
-        while( hotkey == 'c' || hotkey == 'g' || hotkey == 'j' || hotkey == 'k' || hotkey == 'l' ||
-               hotkey == 'p' || hotkey == 'q' || hotkey == 't' || hotkey == 'v' || hotkey == 'x' ||
-               hotkey == 'z' ) {
-            hotkey += 1;
-        }
-        return hotkey;
-    };
-
-    std::vector<part_option> opts;
-
-    std::map<std::string, std::function<void( const catacurses::window &, int )>> headers;
+    overview_opts.clear();
+    overview_headers.clear();
 
     int epower_w = veh->net_battery_charge_rate_w();
-    headers["ENGINE"] = [this]( const catacurses::window & w, int y ) {
+    overview_headers["ENGINE"] = [this]( const catacurses::window & w, int y ) {
         trim_and_print( w, point( 1, y ), getmaxx( w ) - 2, c_light_gray,
                         string_format( _( "Engines: %sSafe %4d kW</color> %sMax %4d kW</color>" ),
                                        health_color( true ), veh->total_power_w( true, true ) / 1000,
                                        health_color( false ), veh->total_power_w() / 1000 ) );
         right_print( w, y, 1, c_light_gray, _( "Fuel     Use" ) );
     };
-    headers["TANK"] = []( const catacurses::window & w, int y ) {
+    overview_headers["TANK"] = []( const catacurses::window & w, int y ) {
         trim_and_print( w, point( 1, y ), getmaxx( w ) - 2, c_light_gray, _( "Tanks" ) );
         right_print( w, y, 1, c_light_gray, _( "Contents     Qty" ) );
     };
-    headers["BATTERY"] = [epower_w]( const catacurses::window & w, int y ) {
+    overview_headers["BATTERY"] = [epower_w]( const catacurses::window & w, int y ) {
         std::string batt;
         if( std::abs( epower_w ) < 10000 ) {
             batt = string_format( _( "Batteries: %s%+4d W</color>" ),
@@ -1389,7 +1389,7 @@ void veh_interact::overview( const std::function<bool( const vehicle_part &pt )>
         trim_and_print( w, point( 1, y ), getmaxx( w ) - 2, c_light_gray, batt );
         right_print( w, y, 1, c_light_gray, _( "Capacity  Status" ) );
     };
-    headers["REACTOR"] = [this, epower_w]( const catacurses::window & w, int y ) {
+    overview_headers["REACTOR"] = [this, epower_w]( const catacurses::window & w, int y ) {
         int reactor_epower_w = veh->max_reactor_epower_w();
         if( reactor_epower_w > 0 && epower_w < 0 ) {
             reactor_epower_w += epower_w;
@@ -1407,11 +1407,11 @@ void veh_interact::overview( const std::function<bool( const vehicle_part &pt )>
         trim_and_print( w, point( 1, y ), getmaxx( w ) - 2, c_light_gray, reactor );
         right_print( w, y, 1, c_light_gray, _( "Contents     Qty" ) );
     };
-    headers["TURRET"] = []( const catacurses::window & w, int y ) {
+    overview_headers["TURRET"] = []( const catacurses::window & w, int y ) {
         trim_and_print( w, point( 1, y ), getmaxx( w ) - 2, c_light_gray, _( "Turrets" ) );
         right_print( w, y, 1, c_light_gray, _( "Ammo     Qty" ) );
     };
-    headers["SEAT"] = []( const catacurses::window & w, int y ) {
+    overview_headers["SEAT"] = []( const catacurses::window & w, int y ) {
         trim_and_print( w, point( 1, y ), getmaxx( w ) - 2, c_light_gray, _( "Seats" ) );
         right_print( w, y, 1, c_light_gray, _( "Who" ) );
     };
@@ -1430,20 +1430,14 @@ void veh_interact::overview( const std::function<bool( const vehicle_part &pt )>
             };
 
             // display engine faults (if any)
-            auto msg = [&]( const vehicle_part & pt ) {
-                werase( w_msg );
-                int y = 0;
+            auto msg_cb = [&]( const vehicle_part & pt ) {
+                msg = std::string();
                 for( const auto &e : pt.faults() ) {
-                    y += fold_and_print( w_msg, point( 1, y ), getmaxx( w_msg ) - 2, c_red,
-                                         "%s", e.obj().name() );
-                    y += fold_and_print( w_msg, point( 3, y ), getmaxx( w_msg ) - 4, c_light_gray,
-                                         "%s", e.obj().description() );
-                    y++;
+                    msg = msg.value() + string_format( "%s\n  %s\n\n", colorize( e->name(), c_red ),
+                                                       colorize( e->description(), c_light_gray ) );
                 }
-                wrefresh( w_msg );
             };
-            opts.emplace_back( "ENGINE", &pt, action && enable &&
-                               enable( pt ) ? next_hotkey( hotkey ) : '\0', details, msg );
+            overview_opts.emplace_back( "ENGINE", &pt, next_hotkey( pt, hotkey ), details, msg_cb );
         }
     }
 
@@ -1478,8 +1472,7 @@ void veh_interact::overview( const std::function<bool( const vehicle_part &pt )>
                     }
                 }
             };
-            opts.emplace_back( "TANK", &pt, action && enable &&
-                               enable( pt ) ? next_hotkey( hotkey ) : '\0', details );
+            overview_opts.emplace_back( "TANK", &pt, next_hotkey( pt, hotkey ), details );
         } else if( pt.is_fuel_store() && !( pt.is_battery() || pt.is_reactor() ) && !pt.is_broken() ) {
             auto details = []( const vehicle_part & pt, const catacurses::window & w, int y ) {
                 if( pt.ammo_current() != "null" ) {
@@ -1496,8 +1489,7 @@ void veh_interact::overview( const std::function<bool( const vehicle_part &pt )>
                                                 round_up( to_liter( pt.ammo_remaining() * stack ), 1 ) ) );
                 }
             };
-            opts.emplace_back( "TANK", &pt, action && enable &&
-                               enable( pt ) ? next_hotkey( hotkey ) : '\0', details );
+            overview_opts.emplace_back( "TANK", &pt, next_hotkey( pt, hotkey ), details );
         }
     }
 
@@ -1515,8 +1507,7 @@ void veh_interact::overview( const std::function<bool( const vehicle_part &pt )>
                 right_print( w, y, offset, item::find_type( pt.ammo_current() )->color,
                              string_format( fmtstring, pt.ammo_capacity(), pct ) );
             };
-            opts.emplace_back( "BATTERY", &pt, action && enable &&
-                               enable( pt ) ? next_hotkey( hotkey ) : '\0', details );
+            overview_opts.emplace_back( "BATTERY", &pt, next_hotkey( pt, hotkey ), details );
         }
     }
 
@@ -1535,15 +1526,13 @@ void veh_interact::overview( const std::function<bool( const vehicle_part &pt )>
 
     for( auto &pt : veh->parts ) {
         if( pt.is_reactor() && pt.is_available() ) {
-            opts.emplace_back( "REACTOR", &pt, action && enable &&
-                               enable( pt ) ? next_hotkey( hotkey ) : '\0', details_ammo );
+            overview_opts.emplace_back( "REACTOR", &pt, next_hotkey( pt, hotkey ), details_ammo );
         }
     }
 
     for( auto &pt : veh->parts ) {
         if( pt.is_turret() && pt.is_available() ) {
-            opts.emplace_back( "TURRET", &pt, action && enable &&
-                               enable( pt ) ? next_hotkey( hotkey ) : '\0', details_ammo );
+            overview_opts.emplace_back( "TURRET", &pt, next_hotkey( pt, hotkey ), details_ammo );
         }
     }
 
@@ -1555,89 +1544,113 @@ void veh_interact::overview( const std::function<bool( const vehicle_part &pt )>
             }
         };
         if( pt.is_seat() && pt.is_available() ) {
-            opts.emplace_back( "SEAT", &pt, action && enable &&
-                               enable( pt ) ? next_hotkey( hotkey ) : '\0', details );
+            overview_opts.emplace_back( "SEAT", &pt, next_hotkey( pt, hotkey ), details );
+        }
+    }
+}
+
+void veh_interact::display_overview()
+{
+    werase( w_list );
+    std::string last;
+    int y = 0;
+    if( overview_offset ) {
+        trim_and_print( w_list, point( 1, y ), getmaxx( w_list ) - 1,
+                        c_yellow, _( "'{' to scroll up" ) );
+        y++;
+    }
+    for( int idx = overview_offset; idx != static_cast<int>( overview_opts.size() ); ++idx ) {
+        const auto &pt = *overview_opts[idx].part;
+
+        // if this is a new section print a header row
+        if( last != overview_opts[idx].key ) {
+            y += last.empty() ? 0 : 1;
+            overview_headers[overview_opts[idx].key]( w_list, y );
+            y += 2;
+            last = overview_opts[idx].key;
+        }
+
+        bool highlighted = false;
+        // No action means no selecting, just highlight relevant ones
+        if( overview_pos < 0 && overview_enable && !overview_action ) {
+            highlighted = overview_enable( pt );
+        } else if( overview_pos == idx ) {
+            highlighted = true;
+        }
+
+        // print part name
+        nc_color col = overview_opts[idx].hotkey ? c_white : c_dark_gray;
+        trim_and_print( w_list, point( 1, y ), getmaxx( w_list ) - 1,
+                        highlighted ? hilite( col ) : col,
+                        "<color_dark_gray>%c </color>%s",
+                        overview_opts[idx].hotkey ? overview_opts[idx].hotkey : ' ', pt.name() );
+
+        // print extra columns (if any)
+        overview_opts[idx].details( pt, w_list, y );
+        y++;
+        if( y < ( getmaxy( w_list ) - 1 ) ) {
+            overview_limit = overview_offset;
+        } else {
+            overview_limit = idx;
+            trim_and_print( w_list, point( 1, y ), getmaxx( w_list ) - 1,
+                            c_yellow, _( "'}' to scroll down" ) );
+            break;
         }
     }
 
-    int pos = -1;
-    if( enable && action ) {
-        do {
-            if( ++pos >= static_cast<int>( opts.size() ) ) {
-                pos = -1;
-                break; // nothing could be selected
-            }
-        } while( !opts[pos].hotkey );
-    }
+    wrefresh( w_list );
+}
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+void veh_interact::overview( const overview_enable_t &enable,
+                             const overview_action_t &action )
+{
+    restore_on_out_of_scope<overview_enable_t> prev_overview_enable( overview_enable );
+    restore_on_out_of_scope<overview_action_t> prev_overview_action( overview_action );
+    overview_enable = enable;
+    overview_action = action;
+
+    restore_on_out_of_scope<int> prev_overview_pos( overview_pos );
+
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
 
     while( true ) {
-        werase( w_list );
-        std::string last;
-        int y = 0;
-        if( overview_offset ) {
-            trim_and_print( w_list, point( 1, y ), getmaxx( w_list ) - 1,
-                            c_yellow, _( "'{' to scroll up" ) );
-            y++;
-        }
-        for( int idx = overview_offset; idx != static_cast<int>( opts.size() ); ++idx ) {
-            const auto &pt = *opts[idx].part;
+        calc_overview();
 
-            // if this is a new section print a header row
-            if( last != opts[idx].key ) {
-                y += last.empty() ? 0 : 1;
-                headers[opts[idx].key]( w_list, y );
-                y += 2;
-                last = opts[idx].key;
-            }
-
-            bool highlighted = false;
-            // No action means no selecting, just highlight relevant ones
-            if( pos < 0 && enable && !action ) {
-                highlighted = enable( pt );
-            } else if( pos == idx ) {
-                highlighted = true;
-            }
-
-            // print part name
-            nc_color col = opts[idx].hotkey ? c_white : c_dark_gray;
-            trim_and_print( w_list, point( 1, y ), getmaxx( w_list ) - 1,
-                            highlighted ? hilite( col ) : col,
-                            "<color_dark_gray>%c </color>%s",
-                            opts[idx].hotkey ? opts[idx].hotkey : ' ', pt.name() );
-
-            // print extra columns (if any)
-            opts[idx].details( pt, w_list, y );
-            y++;
-            if( y < ( getmaxy( w_list ) - 1 ) ) {
-                overview_limit = overview_offset;
-            } else {
-                overview_limit = idx;
-                trim_and_print( w_list, point( 1, y ), getmaxx( w_list ) - 1,
-                                c_yellow, _( "'}' to scroll down" ) );
-                break;
-            }
+        if( overview_pos < 0 || static_cast<size_t>( overview_pos ) >= overview_opts.size() ) {
+            overview_pos = -1;
+            do {
+                if( ++overview_pos >= static_cast<int>( overview_opts.size() ) ) {
+                    overview_pos = -1;
+                    break; // nothing could be selected
+                }
+            } while( !overview_opts[overview_pos].hotkey );
         }
 
-        wrefresh( w_list );
-
-        if( !std::any_of( opts.begin(), opts.end(), []( const part_option & e ) {
-        return e.hotkey;
-    } ) ) {
+        const bool has_any_hotkey = std::any_of( overview_opts.begin(), overview_opts.end(),
+        []( const part_option & e ) {
+            return e.hotkey;
+        } );
+        if( !has_any_hotkey ) {
             return; // nothing is selectable
         }
 
-        move_cursor( ( opts[pos].part->mount + dd ).rotate( 3 ) );
-
-        if( opts[pos].message ) {
-            opts[pos].message( *opts[pos].part );
+        if( overview_pos >= 0 && static_cast<size_t>( overview_pos ) < overview_opts.size() ) {
+            move_cursor( ( overview_opts[overview_pos].part->mount + dd ).rotate( 3 ) );
         }
 
+        if( overview_pos >= 0 && static_cast<size_t>( overview_pos ) < overview_opts.size() &&
+            overview_opts[overview_pos].message ) {
+            overview_opts[overview_pos].message( *overview_opts[overview_pos].part );
+        } else {
+            msg.reset();
+        }
+
+        ui_manager::redraw();
+
         const std::string input = main_context.handle_input();
-        if( input == "CONFIRM" && opts[pos].hotkey ) {
-            action( *opts[pos].part );
+        msg.reset();
+        if( input == "CONFIRM" && overview_opts[overview_pos].hotkey && overview_action ) {
+            overview_action( *overview_opts[overview_pos].part );
             break;
 
         } else if( input == "QUIT" ) {
@@ -1646,36 +1659,32 @@ void veh_interact::overview( const std::function<bool( const vehicle_part &pt )>
         } else if( input == "UP" ) {
             do {
                 move_overview_line( -1 );
-                if( --pos < 0 ) {
-                    pos = opts.size() - 1;
+                if( --overview_pos < 0 ) {
+                    overview_pos = overview_opts.size() - 1;
                 }
-            } while( !opts[pos].hotkey );
-
+            } while( !overview_opts[overview_pos].hotkey );
         } else if( input == "DOWN" ) {
             do {
                 move_overview_line( 1 );
-                if( ++pos >= static_cast<int>( opts.size() ) ) {
-                    pos = 0;
+                if( ++overview_pos >= static_cast<int>( overview_opts.size() ) ) {
+                    overview_pos = 0;
                 }
-            } while( !opts[pos].hotkey );
-
+            } while( !overview_opts[overview_pos].hotkey );
         } else {
             // did we try and activate a hotkey option?
             char hotkey = main_context.get_raw_input().get_first_input();
-            if( hotkey ) {
-                auto iter = std::find_if( opts.begin(), opts.end(), [&hotkey]( const part_option & e ) {
+            if( hotkey && overview_action ) {
+                auto iter = std::find_if( overview_opts.begin(),
+                overview_opts.end(), [&hotkey]( const part_option & e ) {
                     return e.hotkey == hotkey;
                 } );
-                if( iter != opts.end() ) {
-                    action( *iter->part );
+                if( iter != overview_opts.end() ) {
+                    overview_action( *iter->part );
                     break;
                 }
             }
         }
     }
-
-    werase( w_list );
-    wrefresh( w_list );
 }
 
 void veh_interact::move_overview_line( int amount )
@@ -1806,7 +1815,8 @@ void veh_interact::do_remove()
         return;
     }
 
-    set_title( _( "Choose a part here to remove:" ) );
+    restore_on_out_of_scope<cata::optional<std::string>> prev_title( title );
+    title = _( "Choose a part here to remove:" );
 
     int pos = 0;
     for( size_t i = 0; i < parts_here.size(); i++ ) {
@@ -1819,6 +1829,8 @@ void veh_interact::do_remove()
     // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
     ui_adaptor ui( ui_adaptor::disable_uis_below {} );
 
+    restore_on_out_of_scope<overview_enable_t> prev_overview_enable( overview_enable );
+
     while( true ) {
         //redraw list of parts
         werase( w_parts );
@@ -1828,10 +1840,12 @@ void veh_interact::do_remove()
 
         bool can_remove = can_remove_part( part, g->u );
 
-        auto sel = [&]( const vehicle_part & pt ) {
+        overview_enable = [this, part]( const vehicle_part & pt ) {
             return &pt == &veh->parts[part];
         };
-        overview( sel );
+
+        calc_overview();
+        display_overview();
 
         //read input
         const std::string action = main_context.handle_input();
@@ -1890,7 +1904,8 @@ void veh_interact::do_siphon()
             break;
     }
 
-    set_title( _( "Select part to siphon:" ) );
+    restore_on_out_of_scope<cata::optional<std::string>> prev_title( title );
+    title = _( "Select part to siphon:" );
 
     auto sel = [&]( const vehicle_part & pt ) {
         return( pt.is_tank() && pt.base.contents_made_of( LIQUID ) );
@@ -1935,7 +1950,8 @@ void veh_interact::do_assign_crew()
         return;
     }
 
-    set_title( _( "Assign crew positions:" ) );
+    restore_on_out_of_scope<cata::optional<std::string>> prev_title( title );
+    title = _( "Assign crew positions:" );
 
     auto sel = []( const vehicle_part & pt ) {
         return pt.is_seat();

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -242,7 +242,6 @@ void veh_interact::allocate_windows()
     const int grid_y = 1;
     const int grid_w = TERMX - 2; // exterior borders take 2
     const int grid_h = TERMY - 2; // exterior borders take 2
-    w_grid = catacurses::newwin( grid_h, grid_w, point( grid_x, grid_y ) );
 
     const int mode_h  = 1;
     const int name_h  = 1;
@@ -272,7 +271,7 @@ void veh_interact::allocate_windows()
     const int details_w = grid_x + grid_w - details_x;
 
     // make the windows
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    w_border = catacurses::newwin( TERMY, TERMX, point_zero );
     w_mode  = catacurses::newwin( mode_h,    grid_w, point( grid_x, grid_y ) );
     w_msg   = catacurses::newwin( page_size, pane_w, point( msg_x, pane_y ) );
     w_disp  = catacurses::newwin( disp_h,    disp_w, point( grid_x, pane_y ) );
@@ -321,6 +320,14 @@ bool veh_interact::format_reqs( std::string &msg, const requirement_data &reqs,
     return ok;
 }
 
+struct veh_interact::install_info_t {
+    int pos;
+    size_t tab;
+    std::vector<const vpart_info *> tab_vparts;
+    std::array<std::string, 8> tab_list;
+    std::array<std::string, 8> tab_list_short;
+};
+
 shared_ptr_fast<ui_adaptor> veh_interact::create_or_get_ui_adaptor()
 {
     shared_ptr_fast<ui_adaptor> current_ui = ui.lock();
@@ -337,23 +344,9 @@ shared_ptr_fast<ui_adaptor> veh_interact::create_or_get_ui_adaptor()
             display_stats();
             display_veh();
 
-            const int hw = getmaxx( w_disp ) / 2;
-            const int hh = getmaxy( w_disp ) / 2;
-            const point vd = -dd;
-            const point q = veh->coord_translate( vd );
-            const tripoint vehp = veh->global_pos3() + q;
-            bool obstruct = g->m.impassable_ter_furn( vehp );
-            const optional_vpart_position ovp = g->m.veh_at( vehp );
-            if( ovp && &ovp->vehicle() != veh ) {
-                obstruct = true;
-            }
-            nc_color col = cpart >= 0 ? veh->part_color( cpart ) : c_black;
-            int sym = cpart >= 0 ? veh->part_sym( cpart ) : ' ';
-            mvwputch( w_disp, point( hw, hh ), obstruct ? red_background( col ) : hilite( col ),
-                      special_symbol( sym ) );
-            wrefresh( w_disp );
             werase( w_parts );
-            veh->print_part_list( w_parts, 0, getmaxy( w_parts ) - 1, getmaxx( w_parts ), cpart, -1, true );
+            veh->print_part_list( w_parts, 0, getmaxy( w_parts ) - 1, getmaxx( w_parts ), cpart, highlight_part,
+                                  true );
             wrefresh( w_parts );
 
             werase( w_msg );
@@ -365,20 +358,13 @@ shared_ptr_fast<ui_adaptor> veh_interact::create_or_get_ui_adaptor()
             }
             wrefresh( w_msg );
 
-            display_overview();
-            if( title.has_value() ) {
-                werase( w_mode );
-                nc_color title_col = c_light_gray;
-                // NOLINTNEXTLINE(cata-use-named-point-constants)
-                print_colored_text( w_mode, point( 1, 0 ), title_col, title_col, title.value() );
-                wrefresh( w_mode );
+            if( install_info ) {
+                display_list( install_info->pos, install_info->tab_vparts, 2 );
+                display_details( sel_vpart_info );
             } else {
-                display_mode();
+                display_overview();
             }
-
-            if( submenu_redraw ) {
-                submenu_redraw();
-            }
+            display_mode();
         } );
     }
     return current_ui;
@@ -878,7 +864,11 @@ void veh_interact::do_install()
     restore_on_out_of_scope<cata::optional<std::string>> prev_title( title );
     title = _( "Choose new part to install here:" );
 
-    std::array<std::string, 8> tab_list = { {
+    restore_on_out_of_scope<std::unique_ptr<install_info_t>> prev_install_info( std::move(
+                install_info ) );
+    install_info = std::make_unique<install_info_t>();
+
+    std::array<std::string, 8> &tab_list = install_info->tab_list = { {
             pgettext( "Vehicle Parts|", "All" ),
             pgettext( "Vehicle Parts|", "Cargo" ),
             pgettext( "Vehicle Parts|", "Light" ),
@@ -890,7 +880,7 @@ void veh_interact::do_install()
         }
     };
 
-    std::array<std::string, 8> tab_list_short = { {
+    install_info->tab_list_short = { {
             pgettext( "Vehicle Parts|", "A" ),
             pgettext( "Vehicle Parts|", "C" ),
             pgettext( "Vehicle Parts|", "L" ),
@@ -990,30 +980,12 @@ void veh_interact::do_install()
     };
 
     // full list of mountable parts, to be filtered according to tab
-    std::vector<const vpart_info *> tab_vparts = can_mount;
+    std::vector<const vpart_info *> &tab_vparts = install_info->tab_vparts = can_mount;
 
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
 
-    int pos = 0;
-    size_t tab = 0;
-
-    restore_on_out_of_scope<std::function<void()>> prev_submenu_redraw( submenu_redraw );
-    submenu_redraw = [&]() {
-        display_list( pos, tab_vparts, 2 );
-
-        // draw tab menu
-        int tab_x = 0;
-        for( size_t i = 0; i < tab_list.size(); i++ ) {
-            std::string tab_name = ( tab == i ) ? tab_list[i] : tab_list_short[i]; // full name for selected tab
-            tab_x += ( tab == i ); // add a space before selected tab
-            draw_subtab( w_list, tab_x, tab_name, tab == i, false );
-            tab_x += ( 1 + utf8_width( tab_name ) + ( tab ==
-                       i ) ); // one space padding and add a space after selected tab
-        }
-        wrefresh( w_list );
-
-        display_details( sel_vpart_info );
-    };
+    int &pos = install_info->pos = 0;
+    size_t &tab = install_info->tab = 0;
 
     while( true ) {
         sel_vpart_info = tab_vparts.empty() ? nullptr : tab_vparts[pos]; // filtered list can be empty
@@ -1168,13 +1140,7 @@ void veh_interact::do_repair()
 
     int pos = 0;
 
-    restore_on_out_of_scope<std::function<void()>> prev_submenu_redraw( submenu_redraw );
-    submenu_redraw = [&]() {
-        werase( w_parts );
-        veh->print_part_list( w_parts, 0, getmaxy( w_parts ) - 1, getmaxx( w_parts ), cpart,
-                              need_repair[pos], true );
-        wrefresh( w_parts );
-    };
+    restore_on_out_of_scope<int> prev_hilight_part( highlight_part );
 
     while( true ) {
         vehicle_part &pt = veh->parts[parts_here[need_repair[pos]]];
@@ -1199,6 +1165,8 @@ void veh_interact::do_repair()
         vp.format_description( nmsg, desc_color, getmaxx( w_msg ) - 4 );
 
         msg = colorize( nmsg, c_light_gray );
+
+        highlight_part = need_repair[pos];
 
         ui_manager::redraw();
 
@@ -1818,13 +1786,7 @@ void veh_interact::do_remove()
 
     restore_on_out_of_scope<overview_enable_t> prev_overview_enable( overview_enable );
 
-    restore_on_out_of_scope<std::function<void()>> prev_submenu_redraw( submenu_redraw );
-    submenu_redraw = [&]() {
-        //redraw list of parts
-        werase( w_parts );
-        veh->print_part_list( w_parts, 0, getmaxy( w_parts ) - 1, getmaxx( w_parts ), cpart, pos, true );
-        wrefresh( w_parts );
-    };
+    restore_on_out_of_scope<int> prev_hilight_part( highlight_part );
 
     while( true ) {
         int part = parts_here[ pos ];
@@ -1834,6 +1796,8 @@ void veh_interact::do_remove()
         overview_enable = [this, part]( const vehicle_part & pt ) {
             return &pt == &veh->parts[part];
         };
+
+        highlight_part = pos;
 
         calc_overview();
         ui_manager::redraw();
@@ -2095,7 +2059,6 @@ void veh_interact::move_cursor( const point &d, int dstart_at )
 void veh_interact::display_grid()
 {
     // border window
-    catacurses::window w_border = catacurses::newwin( TERMY, TERMX, point_zero );
     draw_border( w_border );
 
     // match grid lines
@@ -2109,39 +2072,38 @@ void veh_interact::display_grid()
     mvwputch( w_border, point( 0, y_list ), BORDER_COLOR, LINE_XXXO );
     // -|
     mvwputch( w_border, point( TERMX - 1, y_list ), BORDER_COLOR, LINE_XOXX );
-    wrefresh( w_border );
-    // TODO: move code using w_border into a separate scope
-    w_border = catacurses::window();
 
-    const int grid_w = getmaxx( w_grid );
+    const int grid_w = getmaxx( w_border ) - 2;
 
     // Two lines dividing the three middle sections.
     for( int i = 1 + getmaxy( w_mode ); i < ( 1 + getmaxy( w_mode ) + page_size ); ++i ) {
         // |
-        mvwputch( w_grid, point( getmaxx( w_disp ), i ), BORDER_COLOR, LINE_XOXO );
+        mvwputch( w_border, point( getmaxx( w_disp ) + 1, i + 1 ), BORDER_COLOR, LINE_XOXO );
         // |
-        mvwputch( w_grid, point( getmaxx( w_disp ) + 1 + getmaxx( w_list ), i ), BORDER_COLOR, LINE_XOXO );
+        mvwputch( w_border, point( getmaxx( w_disp ) + 2 + getmaxx( w_list ), i + 1 ), BORDER_COLOR,
+                  LINE_XOXO );
     }
     // Two lines dividing the vertical menu sections.
     for( int i = 0; i < grid_w; ++i ) {
         // -
-        mvwputch( w_grid, point( i, getmaxy( w_mode ) ), BORDER_COLOR, LINE_OXOX );
+        mvwputch( w_border, point( i + 1, getmaxy( w_mode ) + 1 ), BORDER_COLOR, LINE_OXOX );
         // -
-        mvwputch( w_grid, point( i, getmaxy( w_mode ) + 1 + page_size ), BORDER_COLOR, LINE_OXOX );
+        mvwputch( w_border, point( i + 1, getmaxy( w_mode ) + 2 + page_size ), BORDER_COLOR, LINE_OXOX );
     }
     // Fix up the line intersections.
-    mvwputch( w_grid, point( getmaxx( w_disp ), getmaxy( w_mode ) ), BORDER_COLOR, LINE_OXXX );
+    mvwputch( w_border, point( getmaxx( w_disp ) + 1, getmaxy( w_mode ) + 1 ), BORDER_COLOR,
+              LINE_OXXX );
     // _|_
-    mvwputch( w_grid, point( getmaxx( w_disp ), getmaxy( w_mode ) + 1 + page_size ), BORDER_COLOR,
+    mvwputch( w_border, point( getmaxx( w_disp ) + 1, getmaxy( w_mode ) + 2 + page_size ), BORDER_COLOR,
               LINE_XXOX );
-    mvwputch( w_grid, point( getmaxx( w_disp ) + 1 + getmaxx( w_list ), getmaxy( w_mode ) ),
+    mvwputch( w_border, point( getmaxx( w_disp ) + 2 + getmaxx( w_list ), getmaxy( w_mode ) + 1 ),
               BORDER_COLOR, LINE_OXXX );
     // _|_
-    mvwputch( w_grid, point( getmaxx( w_disp ) + 1 + getmaxx( w_list ),
-                             getmaxy( w_mode ) + 1 + page_size ),
+    mvwputch( w_border, point( getmaxx( w_disp ) + 2 + getmaxx( w_list ),
+                               getmaxy( w_mode ) + 2 + page_size ),
               BORDER_COLOR, LINE_XXOX );
 
-    wrefresh( w_grid );
+    wrefresh( w_border );
 }
 
 /**
@@ -2210,6 +2172,21 @@ void veh_interact::display_veh()
         }
         mvwputch( w_disp, h_size + q, col, special_symbol( sym ) );
     }
+
+    const int hw = getmaxx( w_disp ) / 2;
+    const int hh = getmaxy( w_disp ) / 2;
+    const point vd = -dd;
+    const point q = veh->coord_translate( vd );
+    const tripoint vehp = veh->global_pos3() + q;
+    bool obstruct = g->m.impassable_ter_furn( vehp );
+    const optional_vpart_position ovp = g->m.veh_at( vehp );
+    if( ovp && &ovp->vehicle() != veh ) {
+        obstruct = true;
+    }
+    nc_color col = cpart >= 0 ? veh->part_color( cpart ) : c_black;
+    int sym = cpart >= 0 ? veh->part_sym( cpart ) : ' ';
+    mvwputch( w_disp, point( hw, hh ), obstruct ? red_background( col ) : hilite( col ),
+              special_symbol( sym ) );
     wrefresh( w_disp );
 }
 
@@ -2457,6 +2434,17 @@ void veh_interact::display_stats() const
                                 ( x[ i ] + 10 < getmaxx( w_stats ) ),
                                 ( x[ i ] + 10 < getmaxx( w_stats ) ) );
 
+    if( install_info ) {
+        const int details_w = getmaxx( w_details );
+        // clear rightmost blocks of w_stats to avoid overlap
+        int stats_col_2 = 33;
+        int stats_col_3 = 65 + ( ( TERMX - FULL_SCREEN_WIDTH ) / 4 );
+        int clear_x = getmaxx( w_stats ) - details_w + 1 >= stats_col_3 ? stats_col_3 : stats_col_2;
+        for( int i = 0; i < getmaxy( w_stats ); i++ ) {
+            mvwhline( w_stats, point( clear_x, i ), ' ', getmaxx( w_stats ) - clear_x );
+        }
+    }
+
     wrefresh( w_stats );
 }
 
@@ -2479,51 +2467,56 @@ void veh_interact::display_mode()
 {
     werase( w_mode );
 
-    size_t esc_pos = display_esc( w_mode );
+    if( title.has_value() ) {
+        nc_color title_col = c_light_gray;
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        print_colored_text( w_mode, point( 1, 0 ), title_col, title_col, title.value() );
+    } else {
+        size_t esc_pos = display_esc( w_mode );
 
-    // broken indentation preserved to avoid breaking git history for large number of lines
-    const std::array<std::string, 10> actions = { {
-            { _( "<i>nstall" ) },
-            { _( "<r>epair" ) },
-            { _( "<m>end" ) },
-            { _( "re<f>ill" ) },
-            { _( "rem<o>ve" ) },
-            { _( "<s>iphon" ) },
-            { _( "unloa<d>" ) },
-            { _( "cre<w>" ) },
-            { _( "r<e>name" ) },
-            { _( "l<a>bel" ) },
+        // broken indentation preserved to avoid breaking git history for large number of lines
+        const std::array<std::string, 10> actions = { {
+                { _( "<i>nstall" ) },
+                { _( "<r>epair" ) },
+                { _( "<m>end" ) },
+                { _( "re<f>ill" ) },
+                { _( "rem<o>ve" ) },
+                { _( "<s>iphon" ) },
+                { _( "unloa<d>" ) },
+                { _( "cre<w>" ) },
+                { _( "r<e>name" ) },
+                { _( "l<a>bel" ) },
+            }
+        };
+
+        const std::array<bool, std::tuple_size<decltype( actions )>::value> enabled = { {
+                !cant_do( 'i' ),
+                !cant_do( 'r' ),
+                !cant_do( 'm' ),
+                !cant_do( 'f' ),
+                !cant_do( 'o' ),
+                !cant_do( 's' ),
+                !cant_do( 'd' ),
+                !cant_do( 'w' ),
+                true,          // 'rename' is always available
+                !cant_do( 'a' ),
+            }
+        };
+
+        int pos[std::tuple_size<decltype( actions )>::value + 1];
+        pos[0] = 1;
+        for( size_t i = 0; i < actions.size(); i++ ) {
+            pos[i + 1] = pos[i] + utf8_width( actions[i] ) - 2;
         }
-    };
-
-    const std::array<bool, std::tuple_size<decltype( actions )>::value> enabled = { {
-            !cant_do( 'i' ),
-            !cant_do( 'r' ),
-            !cant_do( 'm' ),
-            !cant_do( 'f' ),
-            !cant_do( 'o' ),
-            !cant_do( 's' ),
-            !cant_do( 'd' ),
-            !cant_do( 'w' ),
-            true,          // 'rename' is always available
-            !cant_do( 'a' ),
+        int spacing = static_cast<int>( ( esc_pos - 1 - pos[actions.size()] ) / actions.size() );
+        int shift = static_cast<int>( ( esc_pos - pos[actions.size()] - spacing *
+                                        ( actions.size() - 1 ) ) / 2 ) - 1;
+        for( size_t i = 0; i < actions.size(); i++ ) {
+            shortcut_print( w_mode, point( pos[i] + spacing * i + shift, 0 ),
+                            enabled[i] ? c_light_gray : c_dark_gray, enabled[i] ? c_light_green : c_green,
+                            actions[i] );
         }
-    };
-
-    int pos[std::tuple_size<decltype( actions )>::value + 1];
-    pos[0] = 1;
-    for( size_t i = 0; i < actions.size(); i++ ) {
-        pos[i + 1] = pos[i] + utf8_width( actions[i] ) - 2;
     }
-    int spacing = static_cast<int>( ( esc_pos - 1 - pos[actions.size()] ) / actions.size() );
-    int shift = static_cast<int>( ( esc_pos - pos[actions.size()] - spacing *
-                                    ( actions.size() - 1 ) ) / 2 ) - 1;
-    for( size_t i = 0; i < actions.size(); i++ ) {
-        shortcut_print( w_mode, point( pos[i] + spacing * i + shift, 0 ),
-                        enabled[i] ? c_light_gray : c_dark_gray, enabled[i] ? c_light_green : c_green,
-                        actions[i] );
-    }
-
     wrefresh( w_mode );
 }
 
@@ -2533,7 +2526,6 @@ size_t veh_interact::display_esc( const catacurses::window &win )
     // right text align
     size_t pos = getmaxx( win ) - utf8_width( backstr ) + 2;
     shortcut_print( win, point( pos, 0 ), c_light_gray, c_light_green, backstr );
-    wrefresh( win );
     return pos;
 }
 
@@ -2558,6 +2550,21 @@ void veh_interact::display_list( size_t pos, const std::vector<const vpart_info 
         trim_and_print( w_list, point( 3, y ), getmaxx( w_list ) - 3, pos == i ? hilite( col ) : col,
                         info.name() );
     }
+
+    if( install_info ) {
+        auto &tab_list = install_info->tab_list;
+        auto &tab_list_short = install_info->tab_list_short;
+        auto &tab = install_info->tab;
+        // draw tab menu
+        int tab_x = 0;
+        for( size_t i = 0; i < tab_list.size(); i++ ) {
+            std::string tab_name = ( tab == i ) ? tab_list[i] : tab_list_short[i]; // full name for selected tab
+            tab_x += ( tab == i ); // add a space before selected tab
+            draw_subtab( w_list, tab_x, tab_name, tab == i, false );
+            tab_x += ( 1 + utf8_width( tab_name ) + ( tab ==
+                       i ) ); // one space padding and add a space after selected tab
+        }
+    }
     wrefresh( w_list );
 }
 
@@ -2568,14 +2575,6 @@ void veh_interact::display_list( size_t pos, const std::vector<const vpart_info 
 void veh_interact::display_details( const vpart_info *part )
 {
     const int details_w = getmaxx( w_details );
-    // clear rightmost blocks of w_stats to avoid overlap
-    int stats_col_2 = 33;
-    int stats_col_3 = 65 + ( ( TERMX - FULL_SCREEN_WIDTH ) / 4 );
-    int clear_x = getmaxx( w_stats ) - details_w + 1 >= stats_col_3 ? stats_col_3 : stats_col_2;
-    for( int i = 0; i < getmaxy( w_stats ); i++ ) {
-        mvwhline( w_stats, point( clear_x, i ), ' ', getmaxx( w_stats ) - clear_x );
-    }
-    wrefresh( w_stats );
 
     werase( w_details );
 

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -659,7 +659,7 @@ bool veh_interact::can_self_jack()
     return false;
 }
 
-bool veh_interact::can_install_part()
+bool veh_interact::update_part_requirements()
 {
     if( sel_vpart_info == nullptr ) {
         return false;
@@ -990,7 +990,7 @@ void veh_interact::do_install()
     while( true ) {
         sel_vpart_info = tab_vparts.empty() ? nullptr : tab_vparts[pos]; // filtered list can be empty
 
-        bool can_install = can_install_part();
+        bool can_install = update_part_requirements();
 
         ui_manager::redraw();
 

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -661,6 +661,15 @@ bool veh_interact::can_self_jack()
     return false;
 }
 
+static void print_message_to( catacurses::window &w_msg, const nc_color col,
+                              const std::string &msg )
+{
+    werase( w_msg );
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    fold_and_print( w_msg, point( 1, 0 ), getmaxx( w_msg ) - 2, col, msg );
+    wrefresh( w_msg );
+}
+
 bool veh_interact::can_install_part()
 {
     if( sel_vpart_info == nullptr ) {
@@ -676,11 +685,7 @@ bool veh_interact::can_install_part()
         if( std::none_of( parts_here.begin(), parts_here.end(), [&]( const int e ) {
         return veh->parts[e].is_tank();
         } ) ) {
-            werase( w_msg );
-            // NOLINTNEXTLINE(cata-use-named-point-constants)
-            fold_and_print( w_msg, point( 1, 0 ), getmaxx( w_msg ) - 2, c_light_red,
-                            _( "Funnels need to be installed over a tank." ) );
-            wrefresh( w_msg );
+            print_message_to( w_msg, c_light_red, _( "Funnels need to be installed over a tank." ) );
             return false;
         }
     }
@@ -689,11 +694,7 @@ bool veh_interact::can_install_part()
         if( std::any_of( parts_here.begin(), parts_here.end(), [&]( const int e ) {
         return veh->parts[e].is_turret();
         } ) ) {
-            werase( w_msg );
-            // NOLINTNEXTLINE(cata-use-named-point-constants)
-            fold_and_print( w_msg, point( 1, 0 ), getmaxx( w_msg ) - 2, c_light_red,
-                            _( "Can't install turret on another turret." ) );
-            wrefresh( w_msg );
+            print_message_to( w_msg, c_light_red, _( "Can't install turret on another turret." ) );
             return false;
         }
     }
@@ -813,10 +814,7 @@ bool veh_interact::can_install_part()
 
     sel_vpart_info->format_description( msg, c_light_gray, getmaxx( w_msg ) - 4 );
 
-    werase( w_msg );
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    fold_and_print( w_msg, point( 1, 0 ), getmaxx( w_msg ) - 2, c_light_gray, msg );
-    wrefresh( w_msg );
+    print_message_to( w_msg, c_light_gray, msg );
     return ok || g->u.has_trait( trait_DEBUG_HS );
 }
 
@@ -1804,10 +1802,7 @@ bool veh_interact::can_remove_part( int idx, const player &p )
     const nc_color desc_color = sel_vehicle_part->is_broken() ? c_dark_gray : c_light_gray;
     sel_vehicle_part->info().format_description( msg, desc_color, getmaxx( w_msg ) - 4 );
 
-    werase( w_msg );
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    fold_and_print( w_msg, point( 1, 0 ), getmaxx( w_msg ) - 2, c_light_gray, msg );
-    wrefresh( w_msg );
+    print_message_to( w_msg, c_light_gray, msg );
     return ok || g->u.has_trait( trait_DEBUG_HS );
 }
 

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1040,9 +1040,20 @@ void veh_interact::do_install()
                         shape_ui_entries.push_back( entry );
                     }
                     sort_uilist_entries_by_line_drawing( shape_ui_entries );
-                    selected_shape = uilist(
-                                         point( getbegx( w_list ), getbegy( w_list ) ), getmaxx( w_list ),
-                                         _( "Choose shape:" ), shape_ui_entries );
+                    uilist smenu;
+                    smenu.settext( _( "Choose shape:" ) );
+                    smenu.entries = shape_ui_entries;
+                    smenu.w_width_setup = [this]() {
+                        return getmaxx( w_list );
+                    };
+                    smenu.w_x_setup = [this]( const int ) {
+                        return getbegx( w_list );
+                    };
+                    smenu.w_y_setup = [this]( const int ) {
+                        return getbegy( w_list );
+                    };
+                    smenu.query();
+                    selected_shape = smenu.ret;
                 } else { // only one shape available, default to first one
                     selected_shape = 0;
                 }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1812,17 +1812,21 @@ void veh_interact::do_remove()
             break;
         }
     }
+    msg.reset();
 
-    // FIXME: temporarily disable redrawing of lower UIs before this UI is migrated to `ui_adaptor`
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
 
     restore_on_out_of_scope<overview_enable_t> prev_overview_enable( overview_enable );
 
-    while( true ) {
+    restore_on_out_of_scope<std::function<void()>> prev_submenu_redraw( submenu_redraw );
+    submenu_redraw = [&]() {
         //redraw list of parts
         werase( w_parts );
         veh->print_part_list( w_parts, 0, getmaxy( w_parts ) - 1, getmaxx( w_parts ), cpart, pos, true );
         wrefresh( w_parts );
+    };
+
+    while( true ) {
         int part = parts_here[ pos ];
 
         bool can_remove = can_remove_part( part, g->u );
@@ -1832,10 +1836,11 @@ void veh_interact::do_remove()
         };
 
         calc_overview();
-        display_overview();
+        ui_manager::redraw();
 
         //read input
         const std::string action = main_context.handle_input();
+        msg.reset();
         if( can_remove && ( action == "REMOVE" || action == "CONFIRM" ) ) {
             switch( reason ) {
                 case LOW_MORALE:
@@ -1860,11 +1865,6 @@ void veh_interact::do_remove()
             sel_cmd = 'o';
             break;
         } else if( action == "QUIT" ) {
-            werase( w_parts );
-            veh->print_part_list( w_parts, 0, getmaxy( w_parts ) - 1, getmaxx( w_parts ), cpart, -1, true );
-            wrefresh( w_parts );
-            werase( w_msg );
-            wrefresh( w_msg );
             break;
         } else {
             move_in_list( pos, action, parts_here.size() );

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -93,6 +93,8 @@ class veh_interact
 
         weak_ptr_fast<ui_adaptor> ui;
 
+        std::function<void()> submenu_redraw;
+
         cata::optional<std::string> title;
         cata::optional<std::string> msg;
 

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -80,7 +80,7 @@ class veh_interact
         int fuel_index = 0; /** Starting index of where to start printing fuels from */
         // height of the stats window
         const int stats_h = 8;
-        catacurses::window w_grid;
+        catacurses::window w_border;
         catacurses::window w_mode;
         catacurses::window w_msg;
         catacurses::window w_disp;
@@ -89,14 +89,16 @@ class veh_interact
         catacurses::window w_list;
         catacurses::window w_details;
         catacurses::window w_name;
-        catacurses::window w_owner;
 
         weak_ptr_fast<ui_adaptor> ui;
 
-        std::function<void()> submenu_redraw;
-
         cata::optional<std::string> title;
         cata::optional<std::string> msg;
+
+        int highlight_part = -1;
+
+        struct install_info_t;
+        std::unique_ptr<install_info_t> install_info;
 
         vehicle *veh;
         inventory crafting_inv;

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -13,6 +13,7 @@
 #include "input.h"
 #include "inventory.h"
 #include "item_location.h"
+#include "memory_fast.h"
 #include "player_activity.h"
 #include "point.h"
 #include "type_id.h"
@@ -34,6 +35,7 @@ enum task_reason {
     LOW_LIGHT // Player cannot see enough to work (for operations that require it)
 };
 
+class ui_adaptor;
 class vehicle;
 struct vehicle_part;
 
@@ -89,6 +91,10 @@ class veh_interact
         catacurses::window w_name;
         catacurses::window w_owner;
 
+        weak_ptr_fast<ui_adaptor> ui;
+
+        cata::optional<std::string> msg;
+
         vehicle *veh;
         inventory crafting_inv;
         input_context main_context;
@@ -97,6 +103,8 @@ class veh_interact
         int max_lift;
         // maximum level of available jacking equipment (if any)
         int max_jack;
+
+        shared_ptr_fast<ui_adaptor> create_or_get_ui_adaptor();
 
         player_activity serialize_activity();
 
@@ -128,19 +136,19 @@ class veh_interact
          * One function for each specific task
          * @warning presently functions may mutate local state
          * @param msg failure message to display (if any)
-         * @return whether a redraw is required (typically necessary if task opened subwindows)
          */
         /*@{*/
-        bool do_install( std::string &msg );
-        bool do_repair( std::string &msg );
-        bool do_mend( std::string &msg );
-        bool do_refill( std::string &msg );
-        bool do_remove( std::string &msg );
-        bool do_rename( std::string &msg );
-        bool do_siphon( std::string &msg );
-        bool do_unload( std::string &msg );
-        bool do_assign_crew( std::string &msg );
-        bool do_relabel( std::string &msg );
+        void do_install();
+        void do_repair();
+        void do_mend();
+        void do_refill();
+        void do_remove();
+        void do_rename();
+        void do_siphon();
+        // Returns true if exiting the screen
+        bool do_unload();
+        void do_assign_crew();
+        void do_relabel();
         /*@}*/
 
         void display_grid();
@@ -158,11 +166,10 @@ class veh_interact
          * @param enable used to determine parts of interest. If \p action also present, these
                          parts are the ones that can be selected. Otherwise, these are the parts
                          that will be highlighted
-         * @param action callback when part is selected, should return true if redraw required.
-         * @return whether redraw is required (always false if no action was run)
+         * @param action callback when part is selected.
          */
-        bool overview( std::function<bool( const vehicle_part &pt )> enable = {},
-                       std::function<bool( vehicle_part &pt )> action = {} );
+        void overview( const std::function<bool( const vehicle_part &pt )> &enable = {},
+                       const std::function<void( vehicle_part &pt )> &action = {} );
         void move_overview_line( int );
 
         void count_durability();

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -223,7 +223,7 @@ class veh_interact
         //do_remove supporting operation, writes requirements to ui
         bool can_remove_part( int idx, const player &p );
         //do install support, writes requirements to ui
-        bool can_install_part();
+        bool update_part_requirements();
         //true if trying to install foot crank with electric engines for example
         //writes failure to ui
         bool is_drive_conflict();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: None
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Finish migrating UIs to ui_adaptor
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Cherry-picked from DDA:

Commit CleverRaven@6892e81d751d9f908bebc838bddc251790a555c3 and PR CleverRaven#40985
Vehicle interaction menu. There were a bunch of merge conflicts, mainly because DDA uses some convoluted logic when it comes to how helicopters can be modified and whether they would fly after that (BN allows helicopter modifications with no penalties or restrictions, I believe).

PR CleverRaven#41050
Various small changes, including actions menu [`Return`] and main menu (not to be confused with title screen) [`Esc`].

PR CleverRaven#41069
5 miscellaneous menus

The last commit is me renaming a function since confusion around its purpose led to a bug in DDA.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Vehicle menu:
* Opened various sub-menus (part selection for installation/removal/mending/repair), played a bit with various window sizes.
* The original PR reports some flickering on curses, but from my tests it's absent on tiles (and was fixed on curses in one of the following PRs).
* Part installation tab does not re-fold text when game window is resized until another part is selected - a small issue, but I don't see a simple solution for it.
* The menu is overall somewhat ugly at low game window width (approx. <140) and partially unusable at tiny game window sizes (around 80x25). There were(are) some PRs in DDA that tried to help with it, but nothing big.

The rest of the changes are mostly trivial - briefly went over affected menus in-game to see if they work.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
Part 4 should be the last one.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
