### PR TITLE
Fix attempting to read non-books from inventory screen causing segfault

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -658,6 +658,9 @@ object_type avatar::get_grab_type() const
 
 static void skim_book_msg( const item &book, avatar &u )
 {
+    if( !book.type->book ) {
+        return;
+    }
     const auto &reading = book.type->book;
     const skill_id &skill = reading->skill;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->


SUMMARY: Bugfixes "Fix segfaults from attempting to read non-book items in inventory examine screen"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Simple bugfix using code change proposal posted in relevant issue, thanks to @ anothersimulacrum for posting it.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Added the suggested fix from the issue to avatar.cpp, to prevent the player from attempting to read non-books from the inventory menu.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

N/A

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Started up a game.
3. Examined various items from inventory screen to confirm that trying to read them failed without a crash.
4. Examined items from AIM to likewise ensure that wouldn't crash on attempting to read.
5. Spawned in a book to skim and read it, to confirm books still work. Reading an unread book skims it, brings up skillbook menu if valid skill book, brings up martial art learning options if a martial arts book.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Closes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/227

Secondary suggestion of converting `const auto &reading = book.type->book;` was not attempted just yet, as I was not very confident in my ability to get the syntax right.

Assuming I figure out whatever changes allow spellbooks to be readable in DDA, the apparent cause of both that issue and https://github.com/cataclysmbnteam/Cataclysm-BN/issues/40 does give me the idea of maybe adding a skill entry to spellbooks. Since right now they're hardcoded to train spellcraft while reading, this may be a useful feature for modding anyway.