### PR TITLE
Port over minor QoL changes from MST Extra, 3 PRs

### DIFF
--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -323,7 +323,7 @@
     "time": "1 m 30 s",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "fur", 9 ] ] ],
+    "components": [ [ [ "fur", 9 ], [ "cured_pelt", 9 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -335,7 +335,7 @@
     "time": "1 m 30 s",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "leather", 9 ] ] ],
+    "components": [ [ [ "leather", 9 ], [ "cured_hide", 9 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -324,7 +324,7 @@
     "time": "1 m 30 s",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "fur", 6 ] ] ],
+    "components": [ [ [ "fur", 6 ], [ "cured_pelt", 6 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -336,7 +336,7 @@
     "time": "1 m 30 s",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "leather", 6 ] ] ],
+    "components": [ [ [ "leather", 6 ], [ "cured_hide", 6 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -324,7 +324,8 @@
     "time": "1 m",
     "autolearn": true,
     "tools": [  ],
-    "components": [ [ [ "fur", 2 ] ] ]
+    "components": [ [ [ "fur", 2 ], [ "cured_pelt", 2 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "loincloth_leather",
@@ -334,8 +335,9 @@
     "skill_used": "tailor",
     "time": "3 m",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 12 ] ],
-    "components": [ [ [ "leather", 2 ] ] ]
+    "tools": [  ],
+    "components": [ [ [ "leather", 2 ], [ "cured_hide", 2 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   },
   {
     "result": "loincloth_wool",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -121,7 +121,7 @@
     "time": "1 m 30 s",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "fur", 12 ] ] ],
+    "components": [ [ [ "fur", 12 ], [ "cured_pelt", 12 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -133,7 +133,7 @@
     "time": "1 m 30 s",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "leather", 12 ] ] ],
+    "components": [ [ [ "leather", 12 ], [ "cured_hide", 12 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {

--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -19,11 +19,12 @@
     "type": "recipe",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MEDICAL",
-    "skill_used": "tailor",
+    "skill_used": "firstaid",
     "time": "9 s",
     "autolearn": true,
     "charges": 1,
-    "components": [ [ [ "rag", 1 ] ] ]
+    "components": [ [ [ "rag", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "bandages_makeshift_bleached",

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -57,8 +57,9 @@
     "skill_used": "cooking",
     "time": "9 s",
     "autolearn": true,
-    "tools": [ [ [ "water_purifier", 1 ] ] ],
-    "components": [ [ [ "water", 1 ] ] ]
+    "tools": [ [ [ "water_purifier", 1 ], [ "pur_tablets", 1 ], [ "char_purifier", 1 ] ] ],
+    "components": [ [ [ "water", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -2283,7 +2283,7 @@
     "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
     "qualities": [ { "id": "CHISEL", "level": 3 } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "plastic_chunk", 1 ], [ "scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_chunk", 1 ], [ "stick", 1 ], [ "2x4", 1 ], [ "scrap", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -3659,7 +3659,7 @@
     "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
     "components": [
       [ [ "water_clean", 2 ], [ "water", 2 ] ],
-      [ [ "tanbark", 1 ], [ "acorns", 2 ], [ "hops", 2 ], [ "pine_bough", 6 ] ],
+      [ [ "tanbark", 1 ], [ "acorns", 2 ], [ "hops", 2 ], [ "pine_bough", 6 ], [ "brain", 3 ] ],
       [ [ "salt_water", 2 ], [ "saline", 10 ], [ "salt", 10 ] ],
       [ [ "edible_tallow_lard", 1, "LIST" ], [ "tallow_tainted", 1 ] ],
       [ [ "cured_hide", 6 ] ]
@@ -3701,7 +3701,7 @@
     "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
     "components": [
       [ [ "water_clean", 2 ], [ "water", 2 ] ],
-      [ [ "tanbark", 1 ], [ "acorns", 2 ], [ "hops", 2 ], [ "pine_bough", 6 ] ],
+      [ [ "tanbark", 1 ], [ "acorns", 2 ], [ "hops", 2 ], [ "pine_bough", 6 ], [ "brain", 3 ] ],
       [ [ "salt_water", 2 ], [ "saline", 10 ], [ "salt", 10 ] ],
       [ [ "edible_tallow_lard", 1, "LIST" ], [ "tallow_tainted", 1 ] ],
       [ [ "cured_pelt", 6 ] ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Port over QoL recipe changes from MST Extra and three DDA PRs, makeshift bandages change"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

While preparing a Bright Nights compatible version of my MST Extra mod, I took note of some recipe overrides made for QoL purposes, and decided to port them over. Additionally, reviewing the JSON for those versions reminded me of three PRs made to DDA that would be desirable to port over to here.

Finally, discussion in modder discord convinced me that changing the craft skill for makeshift bandages (also affected by one minor PR being ported over) would be an improvement.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Ported over recipe overrides from MST Extra, allowing cured hides/pelts to be used in leather wraps and loincloths, due to these being crude reversible items. Also made leather loincloth consistent with fur loincloth in not using sewing, added BLIND_HARD for consistency with the other non-sewing primitive clothing items.
2. Ported over recipe override from MST Extra, permitting the recipe version of water purification to be used in the dark, for consistency with using the items directly.
3. Ported over recipe overrides from MST Extra to forged pliers, allowing for the use of wooden handles as an alternative to plastic.
3. Ported over the change allowing other water purification items to be used in the recipe.
4. Ported over the change permitting brains to be used as a lecithin source for tanning. Added it to pelts as well, seems strange to only have it viable for tanning hides.
5. Ported over the change allowing makeshift bandages to be craftable in darkness.
6. Also went with the proposed idea of changing makeshift bandages to use first aid as their crafting skill.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Retaining the MST Extra changes to vanilla content in the mod.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Load-tested JSON changes.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

PRs being ported over:
1. Water purification tool expansion: https://github.com/CleverRaven/Cataclysm-DDA/pull/44116
2. Brain tanning: https://github.com/CleverRaven/Cataclysm-DDA/pull/41415
3. Makeshift bandages dark-crafting: https://github.com/CleverRaven/Cataclysm-DDA/pull/42175

Note on BLIND_HARD, it still seems to disallow crafting outright at a certain light threshold. Could make the primitive non-sewn clothes use BLIND_EASY if desired.

Could also make cloth and wool loincloths use the same absence of sewing. Realistically, two long enough pieces of material could be made into a loincloth at minimum (one tied around the waist as a sash, one serving as the actual loincloth, essentially a breechclout). This is presumably how the fur loincloth is interpreted, for it to not rely on sewing.