### PR TITLE
Finish ui_adaptor migration (part 4)

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1078,31 +1078,33 @@ cata::optional<tripoint> choose_adjacent_highlight( const std::string &message,
         const std::string &failure_message, const std::function<bool ( const tripoint & )> &allowed,
         const bool allow_vertical )
 {
-    // Highlight nearby terrain according to the highlight function
-    if( allowed != nullptr ) {
-        cata::optional<tripoint> single;
-        bool highlighted = false;
+    std::vector<tripoint> valid;
+    if( allowed ) {
         for( const tripoint &pos : g->m.points_in_radius( g->u.pos(), 1 ) ) {
             if( allowed( pos ) ) {
-                if( !highlighted ) {
-                    single = pos;
-                    highlighted = true;
-                } else {
-                    single = cata::nullopt;
-                }
+                valid.emplace_back( pos );
+            }
+        }
+    }
+
+    const bool auto_select = get_option<bool>( "AUTOSELECT_SINGLE_VALID_TARGET" );
+    if( valid.empty() && auto_select ) {
+        add_msg( failure_message );
+        return cata::nullopt;
+    } else if( valid.size() == 1 && auto_select ) {
+        return valid.back();
+    }
+
+    shared_ptr_fast<game::draw_callback_t> hilite_cb;
+    if( !valid.empty() ) {
+        hilite_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+            for( const tripoint &pos : valid ) {
                 g->m.drawsq( g->w_terrain, g->u, pos,
                              true, true, g->u.pos() + g->u.view_offset );
             }
-        }
-        if( highlighted ) {
-            wrefresh( g->w_terrain );
-        } else if( get_option<bool>( "AUTOSELECT_SINGLE_VALID_TARGET" ) ) {
-            add_msg( failure_message );
-            return cata::nullopt;
-        }
-        if( get_option<bool>( "AUTOSELECT_SINGLE_VALID_TARGET" ) && single ) {
-            return single;
-        }
+        } );
+        g->add_draw_callback( hilite_cb );
     }
+
     return choose_adjacent( message, allow_vertical );
 }

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -958,8 +958,6 @@ action_id handle_action_menu()
         smenu.query();
         const int selection = smenu.ret;
 
-        g->draw();
-
         if( selection < 0 || selection == NUM_ACTIONS ) {
             return ACTION_NULL;
         } else if( selection == 2 * NUM_ACTIONS ) {
@@ -1007,8 +1005,6 @@ action_id handle_main_menu()
     smenu.entries = entries;
     smenu.query();
     int selection = smenu.ret;
-
-    g->draw();
 
     if( selection < 0 || selection >= NUM_ACTIONS ) {
         return ACTION_NULL;

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2794,7 +2794,6 @@ void activity_handlers::repair_item_finish( player_activity *act, player *p )
 
     // target selection and validation.
     while( act->targets.size() < 2 ) {
-        g->draw();
         item_location item_loc = game_menus::inv::repair( *p, actor, &main_tool );
 
         if( item_loc == item_location::nowhere ) {
@@ -2840,7 +2839,6 @@ void activity_handlers::repair_item_finish( player_activity *act, player *p )
             act->values.resize( 1 );
         }
         do {
-            g->draw();
             repeat = repeat_menu( title, repeat );
 
             if( repeat == REPEAT_CANCEL ) {
@@ -3092,7 +3090,6 @@ void activity_handlers::travel_do_turn( player_activity *act, player *p )
         p->omt_path.pop_back();
         if( p->omt_path.empty() ) {
             p->add_msg_if_player( m_info, _( "You have reached your destination." ) );
-            g->draw();
             act->set_to_null();
             return;
         }
@@ -3119,7 +3116,6 @@ void activity_handlers::travel_do_turn( player_activity *act, player *p )
     } else {
         p->add_msg_if_player( m_info, _( "You have reached your destination." ) );
     }
-    g->draw();
     act->set_to_null();
 }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2335,7 +2335,6 @@ void activity_handlers::vehicle_finish( player_activity *act, player *p )
         } else {
             if( vp ) {
                 g->m.invalidate_map_cache( g->get_levz() );
-                g->refresh_all();
                 // TODO: Z (and also where the activity is queued)
                 // Or not, because the vehicle coordinates are dropped anyway
                 if( !resume_for_multi_activities( *p ) ) {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -118,12 +118,6 @@ advanced_inventory::~advanced_inventory()
     }
     // Only refresh if we exited manually, otherwise we're going to be right back
     if( exit ) {
-        werase( head );
-        werase( minimap );
-        werase( mm_border );
-        werase( panes[left].window );
-        werase( panes[right].window );
-        g->refresh_all();
         g->u.check_item_encumbrance_flag();
     }
 }
@@ -1654,12 +1648,7 @@ bool advanced_inventory::query_destination( aim_location &def )
     }
     // Selected keyed to uilist.entries, which starts at 0.
     menu.selected = save_state->last_popup_dest - AIM_SOUTHWEST;
-    // generate and show window.
-    menu.show();
-    // query, but don't loop
-    while( menu.ret == UILIST_WAIT_INPUT ) {
-        menu.query( false );
-    }
+    menu.query();
     if( menu.ret >= AIM_SOUTHWEST && menu.ret <= AIM_NORTHEAST ) {
         assert( squares[menu.ret].canputitems() );
         def = static_cast<aim_location>( menu.ret );

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -695,7 +695,7 @@ void advanced_inventory::redraw_pane( side p )
         mvwprintz( w, point( getmaxx( w ) - utf8_width( fsuffix ) - 2, getmaxy( w ) - 1 ), c_white, "%s",
                    fsuffix );
     }
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 // be explicit with the values
@@ -1059,7 +1059,7 @@ void advanced_inventory::redraw_sidebar()
             const std::string time = to_string_time_of_day( calendar::turn );
             mvwprintz( head, point( 2, 0 ), c_white, time );
         }
-        wrefresh( head );
+        wnoutrefresh( head );
         refresh_minimap();
     }
 }
@@ -1606,7 +1606,7 @@ void query_destination_callback::draw_squares( const uilist *menu )
         wprintz( menu->window, kcolor, "%s", key );
         wprintz( menu->window, bcolor, "%c", bracket[1] );
     }
-    wrefresh( menu->window );
+    wnoutrefresh( menu->window );
 }
 
 bool advanced_inventory::query_destination( aim_location &def )
@@ -1824,8 +1824,8 @@ void advanced_inventory::refresh_minimap()
         mvwprintz( mm_border, point( 1, 0 ), c_light_gray, utf8_truncate( _( "All" ), minimap_width ) );
     }
     // refresh border, then minimap
-    wrefresh( mm_border );
-    wrefresh( minimap );
+    wnoutrefresh( mm_border );
+    wnoutrefresh( minimap );
 }
 
 void advanced_inventory::draw_minimap()

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -46,15 +46,13 @@ class basic_animation
         }
 
         void draw() const {
-            wrefresh( g->w_terrain );
-            g->draw_panels();
-
-            query_popup()
+            static_popup popup;
+            popup
             .wait_message( "%s", _( "Hang on a bit…" ) )
-            .on_top( true )
-            .show();
+            .on_top( true );
 
-            catacurses::refresh();
+            g->invalidate_main_ui_adaptor();
+            ui_manager::redraw_invalidated();
             refresh_display();
         }
 
@@ -120,7 +118,7 @@ tripoint relative_view_pos( const game &g, const tripoint &p ) noexcept
     return p - g.ter_view_p + point( POSX, POSY );
 }
 
-void draw_explosion_curses( const game &g, const tripoint &center, const int r,
+void draw_explosion_curses( game &g, const tripoint &center, const int r,
                             const nc_color &col )
 {
     if( !is_radius_visible( center, r ) ) {
@@ -129,33 +127,39 @@ void draw_explosion_curses( const game &g, const tripoint &center, const int r,
     // TODO: Make it look different from above/below
     const tripoint p = relative_view_pos( g.u, center );
 
-    // TODO: why not always print '*'?
-    if( r == 0 ) {
-        mvwputch( g.w_terrain, point( p.y, p.x ), col, '*' );
-    }
-
     explosion_animation anim;
 
-    for( int i = 1; i <= r; ++i ) {
-        // corner: top left
-        mvwputch( g.w_terrain, p.xy() + point( -i, -i ), col, '/' );
-        // corner: top right
-        mvwputch( g.w_terrain, p.xy() + point( i, -i ), col, '\\' );
-        // corner: bottom left
-        mvwputch( g.w_terrain, p.xy() + point( -i, i ), col, '\\' );
-        // corner: bottom right
-        mvwputch( g.w_terrain, p.xy() + point( i, i ), col, '/' );
-        for( int j = 1 - i; j < 0 + i; j++ ) {
-            // edge: top
-            mvwputch( g.w_terrain, p.xy() + point( j, -i ), col, '-' );
-            // edge: bottom
-            mvwputch( g.w_terrain, p.xy() + point( j, i ), col, '-' );
-            // edge: left
-            mvwputch( g.w_terrain, p.xy() + point( -i, j ), col, '|' );
-            // edge: right
-            mvwputch( g.w_terrain, p.xy() + point( i, j ), col, '|' );
+    int frame = 0;
+    shared_ptr_fast<game::draw_callback_t> explosion_cb =
+    make_shared_fast<game::draw_callback_t>( [&]() {
+        if( r == 0 ) {
+            mvwputch( g.w_terrain, point( p.y, p.x ), col, '*' );
         }
 
+        for( int i = 1; i <= frame; ++i ) {
+            // corner: top left
+            mvwputch( g.w_terrain, p.xy() + point( -i, -i ), col, '/' );
+            // corner: top right
+            mvwputch( g.w_terrain, p.xy() + point( i, -i ), col, '\\' );
+            // corner: bottom left
+            mvwputch( g.w_terrain, p.xy() + point( -i, i ), col, '\\' );
+            // corner: bottom right
+            mvwputch( g.w_terrain, p.xy() + point( i, i ), col, '/' );
+            for( int j = 1 - i; j < 0 + i; j++ ) {
+                // edge: top
+                mvwputch( g.w_terrain, p.xy() + point( j, -i ), col, '-' );
+                // edge: bottom
+                mvwputch( g.w_terrain, p.xy() + point( j, i ), col, '-' );
+                // edge: left
+                mvwputch( g.w_terrain, p.xy() + point( -i, j ), col, '|' );
+                // edge: right
+                mvwputch( g.w_terrain, p.xy() + point( i, j ), col, '|' );
+            }
+        }
+    } );
+    g.add_draw_callback( explosion_cb );
+
+    for( frame = 1; frame <= r; ++frame ) {
         anim.progress();
     }
 }
@@ -170,7 +174,7 @@ constexpr explosion_neighbors operator ^ ( explosion_neighbors lhs, explosion_ne
     return static_cast<explosion_neighbors>( static_cast< int >( lhs ) ^ static_cast< int >( rhs ) );
 }
 
-void draw_custom_explosion_curses( const game &g,
+void draw_custom_explosion_curses( game &g,
                                    const std::list< std::map<tripoint, explosion_tile> > &layers )
 {
     // calculate screen offset relative to player + view offset position
@@ -180,57 +184,64 @@ void draw_custom_explosion_curses( const game &g,
 
     explosion_animation anim;
 
-    for( const auto &layer : layers ) {
-        for( const auto &pr : layer ) {
-            // update tripoint in relation to top left corner of curses window
-            // mvwputch already filters out of bounds coordinates
-            const tripoint p = pr.first - topleft;
-            const explosion_neighbors ngh = pr.second.neighborhood;
-            const nc_color col = pr.second.color;
+    auto last_layer_it = layers.begin();
+    shared_ptr_fast<game::draw_callback_t> explosion_cb =
+    make_shared_fast<game::draw_callback_t>( [&]() {
+        for( auto it = layers.begin(); it != std::next( last_layer_it ); ++it ) {
+            for( const auto &pr : *it ) {
+                // update tripoint in relation to top left corner of curses window
+                // mvwputch already filters out of bounds coordinates
+                const tripoint p = pr.first - topleft;
+                const explosion_neighbors ngh = pr.second.neighborhood;
+                const nc_color col = pr.second.color;
 
-            switch( ngh ) {
-                // '^', 'v', '<', '>'
-                case N_NORTH:
-                    mvwputch( g.w_terrain, p.xy(), col, '^' );
-                    break;
-                case N_SOUTH:
-                    mvwputch( g.w_terrain, p.xy(), col, 'v' );
-                    break;
-                case N_WEST:
-                    mvwputch( g.w_terrain, p.xy(), col, '<' );
-                    break;
-                case N_EAST:
-                    mvwputch( g.w_terrain, p.xy(), col, '>' );
-                    break;
-                // '|' and '-'
-                case N_NORTH | N_SOUTH:
-                case N_NORTH | N_SOUTH | N_WEST:
-                case N_NORTH | N_SOUTH | N_EAST:
-                    mvwputch( g.w_terrain, p.xy(), col, '|' );
-                    break;
-                case N_WEST | N_EAST:
-                case N_WEST | N_EAST | N_NORTH:
-                case N_WEST | N_EAST | N_SOUTH:
-                    mvwputch( g.w_terrain, p.xy(), col, '-' );
-                    break;
-                // '/' and '\'
-                case N_NORTH | N_WEST:
-                case N_SOUTH | N_EAST:
-                    mvwputch( g.w_terrain, p.xy(), col, '/' );
-                    break;
-                case N_SOUTH | N_WEST:
-                case N_NORTH | N_EAST:
-                    mvwputch( g.w_terrain, p.xy(), col, '\\' );
-                    break;
-                case N_NO_NEIGHBORS:
-                    mvwputch( g.w_terrain, p.xy(), col, '*' );
-                    break;
-                case N_WEST | N_EAST | N_NORTH | N_SOUTH:
-                    break;
+                switch( ngh ) {
+                    // '^', 'v', '<', '>'
+                    case N_NORTH:
+                        mvwputch( g.w_terrain, p.xy(), col, '^' );
+                        break;
+                    case N_SOUTH:
+                        mvwputch( g.w_terrain, p.xy(), col, 'v' );
+                        break;
+                    case N_WEST:
+                        mvwputch( g.w_terrain, p.xy(), col, '<' );
+                        break;
+                    case N_EAST:
+                        mvwputch( g.w_terrain, p.xy(), col, '>' );
+                        break;
+                    // '|' and '-'
+                    case N_NORTH | N_SOUTH:
+                    case N_NORTH | N_SOUTH | N_WEST:
+                    case N_NORTH | N_SOUTH | N_EAST:
+                        mvwputch( g.w_terrain, p.xy(), col, '|' );
+                        break;
+                    case N_WEST | N_EAST:
+                    case N_WEST | N_EAST | N_NORTH:
+                    case N_WEST | N_EAST | N_SOUTH:
+                        mvwputch( g.w_terrain, p.xy(), col, '-' );
+                        break;
+                    // '/' and '\'
+                    case N_NORTH | N_WEST:
+                    case N_SOUTH | N_EAST:
+                        mvwputch( g.w_terrain, p.xy(), col, '/' );
+                        break;
+                    case N_SOUTH | N_WEST:
+                    case N_NORTH | N_EAST:
+                        mvwputch( g.w_terrain, p.xy(), col, '\\' );
+                        break;
+                    case N_NO_NEIGHBORS:
+                        mvwputch( g.w_terrain, p.xy(), col, '*' );
+                        break;
+                    case N_WEST | N_EAST | N_NORTH | N_SOUTH:
+                        break;
+                }
             }
         }
+    } );
+    g.add_draw_callback( explosion_cb );
 
-        if( is_layer_visible( layer ) ) {
+    for( last_layer_it = layers.begin(); last_layer_it != layers.end(); ++last_layer_it ) {
+        if( is_layer_visible( *last_layer_it ) ) {
             anim.progress();
         }
     }
@@ -256,10 +267,16 @@ void explosion_handler::draw_explosion( const tripoint &p, const int r, const nc
 
     explosion_animation anim;
 
-    const bool visible = is_radius_visible( p, r );
-    for( int i = 1; i <= r; i++ ) {
+    int i = 1;
+    shared_ptr_fast<game::draw_callback_t> explosion_cb =
+    make_shared_fast<game::draw_callback_t>( [&]() {
         // TODO: not xpos ypos?
         tilecontext->init_explosion( p, i );
+    } );
+    g->add_draw_callback( explosion_cb );
+
+    const bool visible = is_radius_visible( p, r );
+    for( i = 1; i <= r; i++ ) {
         if( visible ) {
             anim.progress();
         }
@@ -399,9 +416,15 @@ void explosion_handler::draw_custom_explosion( const tripoint &,
     explosion_animation anim;
     // We need to draw all explosions up to now
     std::map<tripoint, explosion_tile> combined_layer;
+
+    shared_ptr_fast<game::draw_callback_t> explosion_cb =
+    make_shared_fast<game::draw_callback_t>( [&]() {
+        tilecontext->init_custom_explosion_layer( combined_layer );
+    } );
+    g->add_draw_callback( explosion_cb );
+
     for( const auto &layer : layers ) {
         combined_layer.insert( layer.begin(), layer.end() );
-        tilecontext->init_custom_explosion_layer( combined_layer );
         if( is_layer_visible( layer ) ) {
             anim.progress();
         }
@@ -424,15 +447,17 @@ void draw_bullet_curses( map &m, const tripoint &t, const char bullet, const tri
 
     const tripoint vp = g->u.pos() + g->u.view_offset;
 
-    if( p != nullptr && p->z == vp.z ) {
-        m.drawsq( g->w_terrain, g->u, *p, false, true, vp );
-    }
-
     if( vp.z != t.z ) {
         return;
     }
 
-    mvwputch( g->w_terrain, t.xy() - vp.xy() + point( POSX, POSY ), c_red, bullet );
+    shared_ptr_fast<game::draw_callback_t> bullet_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+        if( p != nullptr && p->z == vp.z ) {
+            m.drawsq( g->w_terrain, g->u, *p, false, true, vp );
+        }
+        mvwputch( g->w_terrain, t.xy() - vp.xy() + point( POSX, POSY ), c_red, bullet );
+    } );
+    g->add_draw_callback( bullet_cb );
     bullet_animation().progress();
 }
 
@@ -464,7 +489,11 @@ void game::draw_bullet( const tripoint &t, const int /*i*/,
         : bullet == '`' ? bullet_shrapnel
         : bullet_unknown;
 
-    tilecontext->init_draw_bullet( t, bullet_type );
+    shared_ptr_fast<draw_callback_t> bullet_cb = make_shared_fast<draw_callback_t>( [&]() {
+        tilecontext->init_draw_bullet( t, bullet_type );
+    } );
+    add_draw_callback( bullet_cb );
+
     bullet_animation().progress();
     tilecontext->void_bullet();
 }
@@ -524,7 +553,10 @@ void game::draw_hit_mon( const tripoint &p, const monster &m, const bool dead )
         return;
     }
 
-    tilecontext->init_draw_hit( p, m.type->id.str() );
+    shared_ptr_fast<draw_callback_t> hit_cb = make_shared_fast<draw_callback_t>( [&]() {
+        tilecontext->init_draw_hit( p, m.type->id.str() );
+    } );
+    add_draw_callback( hit_cb );
 
     bullet_animation().progress();
 }
@@ -565,7 +597,12 @@ void game::draw_hit_player( const Character &p, const int dam )
 
     const std::string &type = p.is_player() ? ( p.male ? player_male : player_female )
                               : p.male ? npc_male : npc_female;
-    tilecontext->init_draw_hit( p.pos(), type );
+
+    shared_ptr_fast<draw_callback_t> hit_cb = make_shared_fast<draw_callback_t>( [&]() {
+        tilecontext->init_draw_hit( p.pos(), type );
+    } );
+    add_draw_callback( hit_cb );
+
     bullet_animation().progress();
 }
 #else

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -424,7 +424,7 @@ static void draw_grid( const catacurses::window &w, int left_pane_w, int mid_pan
     mvwputch( w, point( left_pane_w + mid_pane_w + 2, 2 ), BORDER_COLOR, LINE_OXXX );
     mvwputch( w, point( left_pane_w + mid_pane_w + 2, win_h - 1 ), BORDER_COLOR, LINE_XXOX );
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 void player::sort_armor()
@@ -681,11 +681,11 @@ void player::sort_armor()
                        _( "<more>" ) );
         }
         // F5
-        wrefresh( w_sort_cat );
-        wrefresh( w_sort_left );
-        wrefresh( w_sort_middle );
-        wrefresh( w_sort_right );
-        wrefresh( w_encumb );
+        wnoutrefresh( w_sort_cat );
+        wnoutrefresh( w_sort_left );
+        wnoutrefresh( w_sort_middle );
+        wnoutrefresh( w_sort_right );
+        wnoutrefresh( w_encumb );
     } );
 
     bool exit = false;

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -229,7 +229,7 @@ void auto_note_manager_gui::show()
         mvwputch( w_border, point( 0, 2 ), c_light_gray, LINE_XXXO );
         mvwputch( w_border, point( 79, 2 ), c_light_gray, LINE_XOXX );
         mvwputch( w_border, point( 61, FULL_SCREEN_HEIGHT - 1 ), c_light_gray, LINE_XXOX );
-        wrefresh( w_border );
+        wnoutrefresh( w_border );
 
         // == Draw header
         int tmpx = 0;
@@ -251,7 +251,7 @@ void auto_note_manager_gui::show()
         mvwprintz( w_header, point( 53, 2 ), c_white, _( "Symbol" ) );
         mvwprintz( w_header, point( 62, 2 ), c_white, _( "Enabled" ) );
 
-        wrefresh( w_header );
+        wnoutrefresh( w_header );
 
         mvwprintz( w_header, point( 39, 0 ), c_white, _( "Auto notes enabled:" ) );
 
@@ -314,9 +314,9 @@ void auto_note_manager_gui::show()
             }
         }
 
-        wrefresh( w_header );
-        wrefresh( w_border );
-        wrefresh( w );
+        wnoutrefresh( w_header );
+        wnoutrefresh( w_border );
+        wnoutrefresh( w );
     } );
 
     while( true ) {

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -89,7 +89,7 @@ void user_interface::show()
         mvwputch( w_border, point( 5, FULL_SCREEN_HEIGHT - 1 ), c_light_gray, LINE_XXOX );
         mvwputch( w_border, point( 51, FULL_SCREEN_HEIGHT - 1 ), c_light_gray, LINE_XXOX );
         mvwputch( w_border, point( 61, FULL_SCREEN_HEIGHT - 1 ), c_light_gray, LINE_XXOX );
-        wrefresh( w_border );
+        wnoutrefresh( w_border );
 
         // Redraw the header
         int tmpx = 0;
@@ -138,7 +138,7 @@ void user_interface::show()
         locx += shortcut_print( w_header, point( locx, 1 ), c_white, c_light_green, _( "<S>witch" ) );
         shortcut_print( w_header, point( locx, 1 ), c_white, c_light_green, "  " );
 
-        wrefresh( w_header );
+        wnoutrefresh( w_header );
 
         // Clear the lines
         for( int i = 0; i < iContentHeight; i++ ) {
@@ -152,7 +152,7 @@ void user_interface::show()
         }
 
         draw_scrollbar( w_border, iLine, iContentHeight, cur_rules.size(), point( 0, 5 ) );
-        wrefresh( w_border );
+        wnoutrefresh( w_border );
 
         calcStartPos( iStartPos, iLine, iContentHeight, cur_rules.size() );
 
@@ -181,7 +181,7 @@ void user_interface::show()
             }
         }
 
-        wrefresh( w );
+        wnoutrefresh( w );
     } );
 
     bStuffChanged = false;
@@ -312,7 +312,7 @@ void user_interface::show()
                                   );
 
                     draw_border( w_help );
-                    wrefresh( w_help );
+                    wnoutrefresh( w_help );
                 } );
                 const std::string r = string_input_popup()
                                       .title( _( "Pickup Rule:" ) )
@@ -471,7 +471,7 @@ void rule::test_pattern() const
         draw_border( w_test_rule_border, BORDER_COLOR, buf, hilite( c_white ) );
         center_print( w_test_rule_border, iContentHeight + 1, red_background( c_white ),
                       _( "Won't display content or suffix matches" ) );
-        wrefresh( w_test_rule_border );
+        wnoutrefresh( w_test_rule_border );
 
         // Clear the lines
         for( int i = 0; i < iContentHeight; i++ ) {
@@ -502,7 +502,7 @@ void rule::test_pattern() const
             }
         }
 
-        wrefresh( w_test_rule_content );
+        wnoutrefresh( w_test_rule_content );
     } );
 
     while( true ) {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1595,8 +1595,6 @@ bool avatar::invoke_item( item *used, const tripoint &pt )
 
     const std::string &method = std::next( use_methods.begin(), choice )->first;
 
-    g->refresh_all();
-
     return invoke_item( used, method, pt );
 }
 

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1171,11 +1171,9 @@ void avatar_action::plthrow( avatar &you, item_location loc,
     const tripoint original_player_position = you.pos();
     if( blind_throw_from_pos ) {
         you.setpos( *blind_throw_from_pos );
-        g->draw_ter();
     }
 
     g->temp_exit_fullscreen();
-    g->m.draw( g->w_terrain, you.pos() );
 
     const target_mode throwing_target_mode = blind_throw_from_pos ? TARGET_MODE_THROW_BLIND :
             TARGET_MODE_THROW;

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -879,8 +879,6 @@ void avatar_action::aim_do_turn( avatar &you, map &m )
             // At low stamina levels, firing starts getting slow.
             int sta_percent = ( 100 * you.get_stamina() ) / you.get_stamina_max();
             reload_time += ( sta_percent < 25 ) ? ( ( 25 - sta_percent ) * 2 ) : 0;
-
-            g->refresh_all();
         }
     }
 
@@ -888,7 +886,6 @@ void avatar_action::aim_do_turn( avatar &you, map &m )
     const itype *ammo = gun->ammo_data();
 
     g->temp_exit_fullscreen();
-    m.draw( g->w_terrain, you.pos() );
     std::vector<tripoint> trajectory = target_handler().target_ui( you, TARGET_MODE_FIRE, weapon, range,
                                        ammo );
 
@@ -908,10 +905,6 @@ void avatar_action::aim_do_turn( avatar &you, map &m )
         g->reenter_fullscreen();
         return;
     }
-    // Recenter our view
-    g->draw_ter();
-    wrefresh( g->w_terrain );
-    g->draw_panels();
 
     you.moves -= reload_time;
 
@@ -969,7 +962,6 @@ void avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret
     item *turret_base = &*turret.base();
 
     g->temp_exit_fullscreen();
-    g->m.draw( g->w_terrain, you.pos() );
     std::vector<tripoint> trajectory = target_handler().target_ui(
                                            you,
                                            TARGET_MODE_TURRET_MANUAL,
@@ -980,11 +972,6 @@ void avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret
                                        );
 
     if( !trajectory.empty() ) {
-        // Recenter our view
-        g->draw_ter();
-        wrefresh( g->w_terrain );
-        g->draw_panels();
-
         turret.fire( you, trajectory.back() );
     }
     g->reenter_fullscreen();
@@ -1108,7 +1095,6 @@ void avatar_action::plthrow( avatar &you, item_location loc,
     if( !loc ) {
         loc = game_menus::inv::titled_menu( you,  _( "Throw item" ),
                                             _( "You don't have any items to throw." ) );
-        g->refresh_all();
     }
 
     if( !loc ) {
@@ -1266,8 +1252,6 @@ void avatar_action::use_item( avatar &you, item_location &loc )
             you.mod_moves( obtain_cost );
         }
     }
-
-    g->refresh_all();
 
     if( use_in_place ) {
         update_lum( loc, false );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -611,7 +611,7 @@ bool Character::activate_bionic( int b, bool eff_only )
                     }
                 }
             }
-            wrefresh( w );
+            wnoutrefresh( w );
         } );
         input_context ctxt( "BLOOD_TEST_RESULTS" );
         ctxt.register_action( "CONFIRM" );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -400,7 +400,6 @@ bool Character::activate_bionic( int b, bool eff_only )
     if( bio.info().gun_bionic ) {
         add_msg_activate();
         refund_power(); // Power usage calculated later, in avatar_action::fire
-        g->refresh_all();
         avatar_action::fire_ranged_bionic( g->u, g->m, item( bio.info().fake_item ),
                                            bio.info().power_activate );
     } else if( bio.info().weapon_bionic ) {
@@ -426,7 +425,6 @@ bool Character::activate_bionic( int b, bool eff_only )
         if( bio.ammo_count > 0 ) {
             weapon.ammo_set( bio.ammo_loaded, bio.ammo_count );
             avatar_action::fire_wielded_weapon( g->u, g->m );
-            g->refresh_all();
         }
     } else if( bio.id == bio_ears && has_active_bionic( bio_earplugs ) ) {
         add_msg_activate();
@@ -658,7 +656,6 @@ bool Character::activate_bionic( int b, bool eff_only )
         add_msg_activate();
         add_msg_if_player( m_info, _( "You can now run faster, assisted by joint servomotors." ) );
     } else if( bio.id == bio_lighter ) {
-        g->refresh_all();
         const cata::optional<tripoint> pnt = choose_adjacent( _( "Start a fire where?" ) );
         if( pnt && g->m.is_flammable( *pnt ) ) {
             add_msg_activate();
@@ -690,7 +687,6 @@ bool Character::activate_bionic( int b, bool eff_only )
             add_effect( effect_adrenaline, 20_minutes );
         }
     } else if( bio.id == bio_emp ) {
-        g->refresh_all();
         if( const cata::optional<tripoint> pnt = choose_adjacent( _( "Create an EMP where?" ) ) ) {
             add_msg_activate();
             explosion_handler::emp_blast( *pnt );
@@ -758,7 +754,6 @@ bool Character::activate_bionic( int b, bool eff_only )
             }
         }
 
-        g->refresh_all();
         for( const std::pair<item, tripoint> &pr : affected ) {
             projectile proj;
             proj.speed  = 50;
@@ -774,7 +769,6 @@ bool Character::activate_bionic( int b, bool eff_only )
 
         mod_moves( -100 );
     } else if( bio.id == bio_lockpick ) {
-        g->refresh_all();
         bool used = false;
         bool tried_lockpick = false;
         const cata::optional<tripoint> pnt = choose_adjacent( _( "Use your lockpick where?" ) );
@@ -2009,7 +2003,6 @@ void Character::perform_uninstall( bionic_id bid, int difficulty, int success,
 
     }
     g->m.invalidate_map_cache( g->get_levz() );
-    g->refresh_all();
 }
 
 bool Character::uninstall_bionic( const bionic &target_cbm, monster &installer, player &patient,
@@ -2083,7 +2076,6 @@ bool Character::uninstall_bionic( const bionic &target_cbm, monster &installer, 
     } else {
         bionics_uninstall_failure( installer, patient, difficulty, success, adjusted_skill );
     }
-    g->refresh_all();
 
     return false;
 }
@@ -2280,7 +2272,6 @@ void Character::perform_install( bionic_id bid, bionic_id upbid, int difficulty,
         bionics_install_failure( bid, installer_name, difficulty, success, adjusted_skill, patient_pos );
     }
     g->m.invalidate_map_cache( g->get_levz() );
-    g->refresh_all();
 }
 
 void Character::bionics_install_failure( const bionic_id &bid, const std::string &installer,

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -436,8 +436,13 @@ void player::power_bionics()
     catacurses::window w_title;
     catacurses::window w_tabs;
 
+    bool hide = false;
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+        if( hide ) {
+            ui.position( point_zero, point_zero );
+            return;
+        }
         // Main window
         /** Total required height is:
          * top frame line:                                         + 1
@@ -508,6 +513,10 @@ void player::power_bionics()
     ctxt.register_action( "TOGGLE_AUTO_START" );
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
+        if( hide ) {
+            return;
+        }
+
         std::vector<bionic *> *current_bionic_list = ( tab_mode == TAB_ACTIVE ? &active : &passive );
 
         werase( wBio );
@@ -745,9 +754,8 @@ void player::power_bionics()
             if( menu_mode == ACTIVATING ) {
                 if( bio_data.activated ) {
                     int b = tmp - &( *my_bionics )[0];
-                    // Invalidate bionics menu so the remaining power gets redrawn
-                    // if other UIs are opened when activating the bionic.
-                    ui.invalidate_ui();
+                    hide = true;
+                    ui.mark_resize();
                     if( tmp->powered ) {
                         deactivate_bionic( b );
                     } else {
@@ -757,6 +765,8 @@ void player::power_bionics()
                             break;
                         }
                     }
+                    hide = false;
+                    ui.mark_resize();
                     g->invalidate_main_ui_adaptor();
                     if( moves < 0 ) {
                         return;

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -163,7 +163,7 @@ static void draw_bionics_titlebar( const catacurses::window &window, player *p,
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     int lines_count = fold_and_print( window, point( 1, 1 ), pwr_str_pos - 2, c_white, desc );
     fold_and_print( window, point( 1, ++lines_count ), pwr_str_pos - 2, c_white, fuel_string );
-    wrefresh( window );
+    wnoutrefresh( window );
 }
 
 //builds the power usage string of a given bionic
@@ -242,7 +242,7 @@ static void draw_bionics_tabs( const catacurses::window &win, const size_t activ
     // -|
     mvwputch( win, point( width - 1, height - 1 ), BORDER_COLOR, LINE_XOXX );
 
-    wrefresh( win );
+    wnoutrefresh( win );
 }
 
 static void draw_description( const catacurses::window &win, const bionic &bio )
@@ -263,7 +263,7 @@ static void draw_description( const catacurses::window &win, const bionic &bio )
         fold_and_print( win, point( 0, ypos ), width, c_light_gray, list_occupied_bps( bio.id,
                         _( "This bionic occupies the following body parts:" ), each_bp_on_new_line ) );
     }
-    wrefresh( win );
+    wnoutrefresh( win );
 }
 
 static void draw_connectors( const catacurses::window &win, const int start_y, const int start_x,
@@ -581,7 +581,7 @@ void player::power_bionics()
 
         draw_scrollbar( wBio, cursor, LIST_HEIGHT, current_bionic_list->size(), point( 0, list_start_y ) );
 
-        wrefresh( wBio );
+        wnoutrefresh( wBio );
         draw_bionics_tabs( w_tabs, active.size(), passive.size(), tab_mode );
 
         draw_bionics_titlebar( w_title, this, menu_mode );

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -646,7 +646,6 @@ void player::power_bionics()
             }
             const int newch = popup_getkey( _( "%s; enter new letter.  Space to clear.  Esc to cancel." ),
                                             tmp->id->name );
-            wrefresh( wBio );
             if( newch == ch || newch == KEY_ESCAPE ) {
                 continue;
             }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1242,7 +1242,6 @@ void Character::dismount()
         mounted_creature = nullptr;
         critter->mounted_player = nullptr;
         setpos( *pnt );
-        g->refresh_all();
         mod_moves( -100 );
         set_movement_mode( CMM_WALK );
     }

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -713,7 +713,7 @@ static void draw_header( const catacurses::window &w )
     mvwprintz( w, point( 21, 3 ), c_white, _( "Normal" ) );
     mvwprintz( w, point( 52, 3 ), c_white, _( "Invert" ) );
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 void color_manager::show_gui()
@@ -789,7 +789,7 @@ void color_manager::show_gui()
                 mvwputch( w_colors_header, point( iCol, 3 ), BORDER_COLOR, LINE_XOXO );
             }
         }
-        wrefresh( w_colors_border );
+        wnoutrefresh( w_colors_border );
 
         draw_header( w_colors_header );
 
@@ -809,7 +809,7 @@ void color_manager::show_gui()
         calcStartPos( iStartPos, iCurrentLine, iContentHeight, iMaxColors );
 
         draw_scrollbar( w_colors_border, iCurrentLine, iContentHeight, iMaxColors, point( 0, 5 ) );
-        wrefresh( w_colors_border );
+        wnoutrefresh( w_colors_border );
 
         auto iter = name_color_map.begin();
         std::advance( iter, iStartPos );
@@ -842,7 +842,7 @@ void color_manager::show_gui()
             }
         }
 
-        wrefresh( w_colors );
+        wnoutrefresh( w_colors );
     } );
 
     while( true ) {

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -1476,9 +1476,6 @@ computer_session::ynq computer_session::query_ynq( const std::string &text, Args
                 return ynq::quit;
             }
         }
-        if( action == "HELP_KEYBINDINGS" ) {
-            refresh();
-        }
     } while( true );
 }
 

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -1488,7 +1488,7 @@ void computer_session::refresh()
         print_colored_text( win, point( left + lines[i].first, top + static_cast<int>( i ) ),
                             dummy, dummy, lines[i].second );
     }
-    wrefresh( win );
+    wnoutrefresh( win );
 }
 
 template<typename ...Args>

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -225,7 +225,7 @@ static void draw_grid( const catacurses::window &w, const int list_width )
     mvwputch( w, point( 0, 2 ), c_light_gray, LINE_XXXO );
     mvwputch( w, point( list_width, 2 ), c_light_gray, LINE_XOXX );
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static nc_color construction_color( const std::string &con_name, bool highlight )
@@ -605,13 +605,13 @@ construction_id construction_menu( const bool blueprint )
         }
 
         draw_scrollbar( w_con, select, w_list_height, constructs.size(), point( 0, 3 ) );
-        wrefresh( w_con );
+        wnoutrefresh( w_con );
 
         // place the cursor at the selected construction name as expected by screen readers
         if( cursor_pos ) {
             wmove( w_list, cursor_pos.value() );
         }
-        wrefresh( w_list );
+        wnoutrefresh( w_list );
     } );
 
     do {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -435,7 +435,7 @@ const recipe *select_crafting_recipe( int &batch_size )
             const auto &req = current[line]->simple_requirements();
 
             draw_can_craft_indicator( w_head, *current[line] );
-            wrefresh( w_head );
+            wnoutrefresh( w_head );
 
             int ypos = 0;
 
@@ -561,7 +561,7 @@ const recipe *select_crafting_recipe( int &batch_size )
         }
 
         draw_scrollbar( w_data, line, dataLines, recmax, point_zero );
-        wrefresh( w_data );
+        wnoutrefresh( w_data );
 
         if( isWide && !current.empty() ) {
             item_info_data data = item_info_data_from_recipe( current[line], count, item_info_scroll );
@@ -575,7 +575,7 @@ const recipe *select_crafting_recipe( int &batch_size )
         if( cursor_pos ) {
             // place the cursor at the selected item name as expected by screen readers
             wmove( w_data, cursor_pos.value() );
-            wrefresh( w_data );
+            wnoutrefresh( w_data );
         }
     } );
 
@@ -1102,7 +1102,7 @@ static void draw_recipe_tabs( const catacurses::window &w, const std::string &ta
             break;
     }
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_recipe_subtabs( const catacurses::window &w, const std::string &tab,
@@ -1149,7 +1149,7 @@ static void draw_recipe_subtabs( const catacurses::window &w, const std::string 
             break;
     }
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 template<typename T>

--- a/src/cursesdef.h
+++ b/src/cursesdef.h
@@ -96,8 +96,10 @@ void wborder( const window &win, chtype ls, chtype rs, chtype ts, chtype bs, cht
               chtype bl, chtype br );
 void mvwhline( const window &win, const point &p, chtype ch, int n );
 void mvwvline( const window &win, const point &p, chtype ch, int n );
+void wnoutrefresh( const window &win );
 void wrefresh( const window &win );
 void refresh();
+void doupdate();
 void wredrawln( const window &win, int beg_line, int num_lines );
 void mvwprintw( const window &win, const point &p, const std::string &text );
 template<typename ...Args>

--- a/src/cursesport.cpp
+++ b/src/cursesport.cpp
@@ -392,7 +392,6 @@ void catacurses::werase( const window &win_ )
     }
     win->draw = true;
     wmove( win_, point_zero );
-    //    wrefresh(win);
     handle_additional_window_clear( win );
 }
 

--- a/src/cursesport.cpp
+++ b/src/cursesport.cpp
@@ -181,8 +181,7 @@ void catacurses::mvwvline( const window &win, const point &p, chtype ch, int n )
     wattroff( win, BORDER_COLOR );
 }
 
-//Refreshes a window, causing it to redraw on top.
-void catacurses::wrefresh( const window &win_ )
+void catacurses::wnoutrefresh( const window &win_ )
 {
     cata_cursesport::WINDOW *const win = win_.get<cata_cursesport::WINDOW>();
     // TODO: log win == nullptr
@@ -191,10 +190,22 @@ void catacurses::wrefresh( const window &win_ )
     }
 }
 
+//Refreshes a window, causing it to redraw on top.
+void catacurses::wrefresh( const window &win )
+{
+    wnoutrefresh( win );
+    doupdate();
+}
+
 //Refreshes the main window, causing it to redraw on top.
 void catacurses::refresh()
 {
     return wrefresh( stdscr );
+}
+
+void catacurses::doupdate()
+{
+    refresh_display();
 }
 
 void catacurses::wredrawln( const window &/*win*/, int /*beg_line*/, int /*num_lines*/ )

--- a/src/cursesport.h
+++ b/src/cursesport.h
@@ -84,6 +84,7 @@ void clear_window_area( const catacurses::window &win );
 int projected_window_width();
 int projected_window_height();
 bool handle_resize( int w, int h );
+void resize_term( int cell_w, int cell_h );
 int get_scaling_factor();
 
 #endif

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -74,6 +74,7 @@
 #include "player.h"
 #include "pldata.h"
 #include "point.h"
+#include "popup.h"
 #include "recipe_dictionary.h"
 #include "rng.h"
 #include "sounds.h"
@@ -1156,13 +1157,19 @@ void draw_benchmark( const int max_difference )
     auto end_tick = std::chrono::steady_clock::now();
     int64_t difference = 0;
     int draw_counter = 0;
+
+    static_popup popup;
+    popup.on_top( true ).message( "%s", _( "Benchmark in progress…" ) );
+
     while( true ) {
         end_tick = std::chrono::steady_clock::now();
         difference = std::chrono::duration_cast<std::chrono::milliseconds>( end_tick - start_tick ).count();
         if( difference >= max_difference ) {
             break;
         }
-        g->draw();
+        g->invalidate_main_ui_adaptor();
+        ui_manager::redraw_invalidated();
+        refresh_display();
         draw_counter++;
     }
 
@@ -1894,9 +1901,7 @@ void debug()
             MapExtras::debug_spawn_test();
             break;
     }
-    catacurses::erase();
     m.invalidate_map_cache( g->get_levz() );
-    g->refresh_all();
 }
 
 } // namespace debug_menu

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -461,7 +461,6 @@ void spawn_nested_mapgen()
         target_map.save();
         g->load_npcs();
         g->m.invalidate_map_cache( g->get_levz() );
-        g->refresh_all();
     }
 }
 
@@ -1194,7 +1193,6 @@ void debug()
 {
     bool debug_menu_has_hotkey = hotkey_for_action( ACTION_DEBUG, false ) != -1;
     int action = debug_menu_uilist( debug_menu_has_hotkey );
-    g->refresh_all();
     avatar &u = g->u;
     map &m = g->m;
     switch( action ) {
@@ -1716,7 +1714,6 @@ void debug()
                     MapExtras::apply_function( mx_str[mx_choice], mx_map, where_sm );
                     g->load_npcs();
                     g->m.invalidate_map_cache( g->get_levz() );
-                    g->refresh_all();
                 }
             }
             break;

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -89,7 +89,7 @@ void game::extended_description( const tripoint &p )
             mvwputch( w_head, point( i, top - 1 ), c_white, LINE_OXOX );
         }
 
-        wrefresh( w_head );
+        wnoutrefresh( w_head );
 
         std::string desc;
         // Allow looking at invisible tiles - player may want to examine hallucinations etc.
@@ -130,7 +130,7 @@ void game::extended_description( const tripoint &p )
 
         werase( w_main );
         fold_and_print_from( w_main, point_zero, width, 0, c_light_gray, desc );
-        wrefresh( w_main );
+        wnoutrefresh( w_main );
     } );
 
     do {

--- a/src/dialogue_win.cpp
+++ b/src/dialogue_win.cpp
@@ -204,6 +204,5 @@ void dialogue_window::display_responses( const std::vector<talk_data> &responses
     if( can_scroll_down ) {
         mvwprintz( d_win, point( FULL_SCREEN_WIDTH - 2 - 2, win_maxy - 2 ), c_green, "vv" );
     }
-
-    wrefresh( d_win );
+    wnoutrefresh( d_win );
 }

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -822,7 +822,7 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
         nc_color dummy = c_light_gray;
         print_colored_text( w_info, point( 1, line ), dummy, c_light_gray, *it );
     }
-    wrefresh( w_info );
+    wnoutrefresh( w_info );
 }
 
 static ter_id get_alt_ter( bool isvert, ter_id sel_ter )

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -810,7 +810,7 @@ void faction_manager::display() const
             default:
                 break;
         }
-        wrefresh( w_missions );
+        wnoutrefresh( w_missions );
     } );
 
     while( true ) {

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1541,10 +1541,6 @@ bool basecamp::handle_mission( const std::string &miss_id,
         emergency_recall();
     }
 
-    g->draw_ter();
-    wrefresh( g->w_terrain );
-    g->draw_panels( true );
-
     return true;
 
 }
@@ -3556,9 +3552,6 @@ std::vector<item *> basecamp::give_equipment( std::vector<item *> equipment,
 {
     std::vector<item *> equipment_lost;
     do {
-        g->draw_ter();
-        wrefresh( g->w_terrain );
-
         std::vector<std::string> names;
         names.reserve( equipment.size() );
         for( auto &i : equipment ) {

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1689,7 +1689,7 @@ void basecamp::worker_assignment_ui()
         }
         mvwprintz( w_followers, point( 1, FULL_SCREEN_HEIGHT - 1 ), c_light_gray,
                    _( "Press %s to assign this follower to this camp." ), ctxt.get_desc( "CONFIRM" ) );
-        wrefresh( w_followers );
+        wnoutrefresh( w_followers );
     } );
 
     while( true ) {
@@ -1802,7 +1802,7 @@ void basecamp::job_assignment_ui()
         }
         mvwprintz( w_jobs, point( 1, FULL_SCREEN_HEIGHT - 1 ), c_light_gray,
                    _( "Press %s to change this workers job priorities." ), ctxt.get_desc( "CONFIRM" ) );
-        wrefresh( w_jobs );
+        wnoutrefresh( w_jobs );
     } );
 
     while( true ) {
@@ -3004,7 +3004,7 @@ void talk_function::draw_camp_tabs( const catacurses::window &win,
         tab_space += tab_step + utf8_width( t );
         tab_x++;
     }
-    wrefresh( win );
+    wnoutrefresh( win );
 }
 
 std::string talk_function::name_mission_tabs( const tripoint &omt_pos, const std::string &role_id,

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1913,7 +1913,6 @@ void basecamp::start_cut_logs()
                        chop_time, travel_time, dist, 2, time_to_food( work_time ) ) ) ) {
             return;
         }
-        g->draw_ter();
 
         npc_ptr comp = start_mission( "_faction_camp_cut_log", work_time, true,
                                       _( "departs to cut logs…" ), false, {},
@@ -1959,7 +1958,6 @@ void basecamp::start_clearcut()
                        chop_time, travel_time, dist, 2, time_to_food( work_time ) ) ) ) {
             return;
         }
-        g->draw_ter();
 
         npc_ptr comp = start_mission( "_faction_camp_clearcut", work_time,
                                       true, _( "departs to clear a forest…" ), false, {},

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5841,37 +5841,57 @@ cata::optional<tripoint> game::look_debug()
 }
 ////////////////////////////////////////////////////////////////////////////////////////////
 
-void game::draw_terrain_indicator( const tripoint &lp, const visibility_variables &cache ) const
+void game::draw_look_around_cursor( const tripoint &lp, const visibility_variables &cache )
 {
-    visibility_type visibility = VIS_HIDDEN;
-    const bool inbounds = m.inbounds( lp );
-    if( inbounds ) {
-        visibility = m.get_visibility( m.apparent_light_at( lp, cache ), cache );
-    }
-    const Creature *creature = critter_at( lp, true );
-    switch( visibility ) {
-        case VIS_CLEAR:
+    if( !liveview.is_enabled() ) {
 #if defined( TILES )
-            if( !is_draw_tiles_mode() && !liveview.is_enabled() )
+        if( is_draw_tiles_mode() ) {
+            draw_cursor( lp );
+            return;
+        }
 #endif
-            {
-                if( creature != nullptr && u.sees( *creature ) ) {
-                    creature->draw( w_terrain, lp, true );
-                } else {
-                    m.drawsq( w_terrain, u, lp, true, true, lp );
-                }
+        const tripoint view_center = u.pos() + u.view_offset;
+        visibility_type visibility = VIS_HIDDEN;
+        const bool inbounds = m.inbounds( lp );
+        if( inbounds ) {
+            visibility = m.get_visibility( m.apparent_light_at( lp, cache ), cache );
+        }
+        if( visibility == VIS_CLEAR ) {
+            const Creature *const creature = critter_at( lp, true );
+            if( creature != nullptr && u.sees( *creature ) ) {
+                creature->draw( w_terrain, view_center, true );
+            } else {
+                m.drawsq( w_terrain, u, lp, true, true, view_center );
             }
-            break;
-        case VIS_HIDDEN:
-#if defined( TILES )
-            if( !is_draw_tiles_mode() && !liveview.is_enabled() )
-#endif
-            {
-                print_visibility_indicator( visibility );
+        } else {
+            std::string visibility_indicator;
+            nc_color visibility_indicator_color = c_white;
+            switch( visibility ) {
+                case VIS_CLEAR:
+                    // Already handled by the outer if statement
+                    break;
+                case VIS_BOOMER:
+                case VIS_BOOMER_DARK:
+                    visibility_indicator = '#';
+                    visibility_indicator_color = c_pink;
+                    break;
+                case VIS_DARK:
+                    visibility_indicator = '#';
+                    visibility_indicator_color = c_dark_gray;
+                    break;
+                case VIS_LIT:
+                    visibility_indicator = '#';
+                    visibility_indicator_color = c_light_gray;
+                    break;
+                case VIS_HIDDEN:
+                    visibility_indicator = 'x';
+                    visibility_indicator_color = c_white;
+                    break;
             }
-            break;
-        default:
-            break;
+
+            const tripoint screen_pos = point( POSX, POSY ) + lp - view_center;
+            mvwputch( w_terrain, screen_pos.xy(), visibility_indicator_color, visibility_indicator );
+        }
     }
 }
 
@@ -6103,36 +6123,6 @@ void game::print_vehicle_info( const vehicle *veh, int veh_part, const catacurse
         mvwprintw( w_look, point( column, ++line ), _( "There is a %s there.  Parts:" ), veh->name );
         line = veh->print_part_list( w_look, ++line, last_line, getmaxx( w_look ), veh_part );
     }
-}
-
-void game::print_visibility_indicator( visibility_type visibility ) const
-{
-    std::string visibility_indicator;
-    nc_color visibility_indicator_color = c_white;
-    switch( visibility ) {
-        case VIS_CLEAR:
-            // Nothing printed when visibility is clear
-            return;
-        case VIS_BOOMER:
-        case VIS_BOOMER_DARK:
-            visibility_indicator = '#';
-            visibility_indicator_color = c_pink;
-            break;
-        case VIS_DARK:
-            visibility_indicator = '#';
-            visibility_indicator_color = c_dark_gray;
-            break;
-        case VIS_LIT:
-            visibility_indicator = '#';
-            visibility_indicator_color = c_light_gray;
-            break;
-        case VIS_HIDDEN:
-            visibility_indicator = 'x';
-            visibility_indicator_color = c_white;
-            break;
-    }
-
-    mvwputch( w_terrain, point( POSX, POSY ), visibility_indicator_color, visibility_indicator );
 }
 
 void game::print_items_info( const tripoint &lp, const catacurses::window &w_look, const int column,
@@ -6835,7 +6825,7 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
             wrefresh( w_info );
         } );
         ter_indicator_cb = make_shared_fast<draw_callback_t>( [&]() {
-            draw_terrain_indicator( lp, cache );
+            draw_look_around_cursor( lp, cache );
         } );
         add_draw_callback( ter_indicator_cb );
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3080,30 +3080,33 @@ void game::write_memorial_file( std::string sLastWords )
 
 void game::disp_NPC_epilogues()
 {
-    catacurses::window w = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                           point( std::max( 0, ( TERMX - FULL_SCREEN_WIDTH ) / 2 ), std::max( 0,
-                                   ( TERMY - FULL_SCREEN_HEIGHT ) / 2 ) ) );
     // TODO: This search needs to be expanded to all NPCs
     for( auto elem : follower_ids ) {
         shared_ptr_fast<npc> guy = overmap_buffer.find_npc( elem );
         if( !guy ) {
             continue;
         }
-        scrollable_text( w, guy->disp_name(), guy->get_epilogue() );
+        const auto new_win = []() {
+            return catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
+                                       point( std::max( 0, ( TERMX - FULL_SCREEN_WIDTH ) / 2 ),
+                                              std::max( 0, ( TERMY - FULL_SCREEN_HEIGHT ) / 2 ) ) );
+        };
+        scrollable_text( new_win, guy->disp_name(), guy->get_epilogue() );
     }
 }
 
 void game::display_faction_epilogues()
 {
-    catacurses::window w = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                           point( std::max( 0, ( TERMX - FULL_SCREEN_WIDTH ) / 2 ),
-                                  std::max( 0, ( TERMY - FULL_SCREEN_HEIGHT ) / 2 ) ) );
-
     for( const auto &elem : faction_manager_ptr->all() ) {
         if( elem.second.known_by_u ) {
             const std::vector<std::string> epilogue = elem.second.epilogue();
             if( !epilogue.empty() ) {
-                scrollable_text( w, elem.second.name,
+                const auto new_win = []() {
+                    return catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
+                                               point( std::max( 0, ( TERMX - FULL_SCREEN_WIDTH ) / 2 ),
+                                                      std::max( 0, ( TERMY - FULL_SCREEN_HEIGHT ) / 2 ) ) );
+                };
+                scrollable_text( new_win, elem.second.name,
                                  std::accumulate( epilogue.begin() + 1, epilogue.end(), epilogue.front(),
                 []( const std::string & lhs, const std::string & rhs ) -> std::string {
                     return lhs + "\n" + rhs;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -287,7 +287,7 @@ game::game() :
     seed( 0 ),
     last_mouse_edge_scroll( std::chrono::steady_clock::now() )
 {
-    player_was_sleeping = false;
+    first_redraw_since_waiting_started = true;
     reset_light_level();
     events().subscribe( &*stats_tracker_ptr );
     events().subscribe( &*kill_tracker_ptr );
@@ -1549,38 +1549,39 @@ bool game::do_turn()
     }
 
     const bool player_is_sleeping = u.has_effect( effect_sleep );
-
+    bool wait_redraw = false;
+    std::string wait_message;
+    time_duration wait_refresh_rate;
     if( player_is_sleeping ) {
-        if( calendar::once_every( 30_minutes ) || !player_was_sleeping ) {
-            ui_manager::redraw();
-            //Putting this in here to save on checking
-            if( calendar::once_every( 1_hours ) ) {
-                add_artifact_dreams( );
-            }
+        wait_redraw = true;
+        wait_message = _( "Wait till you wake up…" );
+        wait_refresh_rate = 30_minutes;
+        if( calendar::once_every( 1_hours ) ) {
+            add_artifact_dreams();
         }
-
-        if( calendar::once_every( 1_minutes ) ) {
-            query_popup()
-            .wait_message( "%s", _( "Wait till you wake up…" ) )
-            .on_top( true )
-            .show();
-
-            catacurses::refresh();
-            refresh_display();
-        }
-    } else if( calendar::once_every( 1_minutes ) ) {
-        if( const cata::optional<std::string> progress = u.activity.get_progress_message( u ) ) {
-            query_popup()
-            .wait_message( "%s", *progress )
-            .on_top( true )
-            .show();
-
-            catacurses::refresh();
-            refresh_display();
-        }
+    } else if( const cata::optional<std::string> progress = u.activity.get_progress_message( u ) ) {
+        wait_redraw = true;
+        wait_message = *progress;
+        wait_refresh_rate = 5_minutes;
     }
+    if( wait_redraw ) {
+        if( first_redraw_since_waiting_started || calendar::once_every( 1_minutes ) ) {
+            if( first_redraw_since_waiting_started || calendar::once_every( wait_refresh_rate ) ) {
+                ui_manager::redraw();
+            }
 
-    player_was_sleeping = player_is_sleeping;
+            // Avoid redrawing the main UI every time due to invalidation
+            ui_adaptor dummy( ui_adaptor::disable_uis_below {} );
+            static_popup popup;
+            popup.on_top( true ).wait_message( "%s", wait_message );
+            ui_manager::redraw();
+            refresh_display();
+            first_redraw_since_waiting_started = false;
+        }
+    } else {
+        // Nothing to wait for now
+        first_redraw_since_waiting_started = true;
+    }
 
     u.update_bodytemp();
     u.update_body_wetness( *weather.weather_precise );
@@ -1624,11 +1625,6 @@ void game::process_activity()
 {
     if( !u.activity ) {
         return;
-    }
-
-    if( calendar::once_every( 5_minutes ) ) {
-        ui_manager::redraw();
-        refresh_display();
     }
 
     while( u.moves > 0 && u.activity ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5854,10 +5854,44 @@ cata::optional<tripoint> game::look_debug()
 }
 ////////////////////////////////////////////////////////////////////////////////////////////
 
+void game::draw_terrain_indicator( const tripoint &lp, const visibility_variables &cache ) const
+{
+    visibility_type visibility = VIS_HIDDEN;
+    const bool inbounds = m.inbounds( lp );
+    if( inbounds ) {
+        visibility = m.get_visibility( m.apparent_light_at( lp, cache ), cache );
+    }
+    const Creature *creature = critter_at( lp, true );
+    switch( visibility ) {
+        case VIS_CLEAR:
+#if defined( TILES )
+            if( !is_draw_tiles_mode() && !liveview.is_enabled() )
+#endif
+            {
+                if( creature != nullptr && u.sees( *creature ) ) {
+                    creature->draw( w_terrain, lp, true );
+                } else {
+                    m.drawsq( w_terrain, u, lp, true, true, lp );
+                }
+            }
+            break;
+        case VIS_HIDDEN:
+#if defined( TILES )
+            if( !is_draw_tiles_mode() && !liveview.is_enabled() )
+#endif
+            {
+                print_visibility_indicator( visibility );
+            }
+            break;
+        default:
+            break;
+    }
+}
+
 void game::print_all_tile_info( const tripoint &lp, const catacurses::window &w_look,
                                 const std::string &area_name, int column,
                                 int &line,
-                                const int last_line, bool draw_terrain_indicators,
+                                const int last_line,
                                 const visibility_variables &cache )
 {
     visibility_type visibility = VIS_HIDDEN;
@@ -5877,14 +5911,6 @@ void game::print_all_tile_info( const tripoint &lp, const catacurses::window &w_
                                 last_line );
             print_items_info( lp, w_look, column, line, last_line );
             print_graffiti_info( lp, w_look, column, line, last_line );
-
-            if( draw_terrain_indicators && !liveview.is_enabled() ) {
-                if( creature != nullptr && u.sees( *creature ) ) {
-                    creature->draw( w_terrain, lp, true );
-                } else {
-                    m.drawsq( w_terrain, u, lp, true, true, lp );
-                }
-            }
         }
         break;
         case VIS_BOOMER:
@@ -5920,10 +5946,6 @@ void game::print_all_tile_info( const tripoint &lp, const catacurses::window &w_
                 } else if( u.sees_with_specials( *creature ) ) {
                     mvwprintw( w_look, point( 1, ++line ), _( "You sense a creature here." ) );
                 }
-            }
-
-            if( draw_terrain_indicators && !liveview.is_enabled() ) {
-                print_visibility_indicator( visibility );
             }
             break;
     }
@@ -6096,7 +6118,7 @@ void game::print_vehicle_info( const vehicle *veh, int veh_part, const catacurse
     }
 }
 
-void game::print_visibility_indicator( visibility_type visibility )
+void game::print_visibility_indicator( visibility_type visibility ) const
 {
     std::string visibility_indicator;
     nc_color visibility_indicator_color = c_white;
@@ -6692,8 +6714,7 @@ void game::pre_print_all_tile_info( const tripoint &lp, const catacurses::window
     const oter_id &cur_ter_m = overmap_buffer.ter( ms_to_omt_copy( g->m.getabs( lp ) ) );
     // we only need the area name and then pass it to print_all_tile_info() function below
     const std::string area_name = cur_ter_m->get_name();
-    print_all_tile_info( lp, w_info, area_name, 1, first_line, last_line, !is_draw_tiles_mode(),
-                         cache );
+    print_all_tile_info( lp, w_info, area_name, 1, first_line, last_line, cache );
 }
 
 cata::optional<tripoint> game::look_around()
@@ -6800,6 +6821,8 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
     bool blink = true;
     look_around_result result;
 
+    shared_ptr_fast<draw_callback_t> ter_indicator_cb;
+
     if( show_window && ui ) {
         ui->on_redraw( [&]( const ui_adaptor & ) {
             werase( w_info );
@@ -6824,6 +6847,10 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
 
             wrefresh( w_info );
         } );
+        ter_indicator_cb = make_shared_fast<draw_callback_t>( [&]() {
+            draw_terrain_indicator( lp, cache );
+        } );
+        add_draw_callback( ter_indicator_cb );
     }
 
     cata::optional<tripoint> zone_start;
@@ -6850,13 +6877,6 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
             // call to `ui_manager::redraw`.
             //NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
             zone_blink = blink;
-        } else {
-            zone_start = lp;
-            zone_end = cata::nullopt;
-            // Actually accessed from the terrain overlay callback `zone_cb` in the
-            // call to `ui_manager::redraw`.
-            //NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-            zone_blink = false;
         }
         invalidate_main_ui_adaptor();
         ui_manager::redraw();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -513,7 +513,6 @@ void game::reload_tileset()
         popup( _( "Loading the tileset failed: %s" ), err.what() );
     }
     g->reset_zoom();
-    g->refresh_all();
 #endif // TILES
 }
 
@@ -3092,8 +3091,6 @@ void game::disp_NPC_epilogues()
         }
         scrollable_text( w, guy->disp_name(), guy->get_epilogue() );
     }
-
-    refresh_all();
 }
 
 void game::display_faction_epilogues()
@@ -3114,8 +3111,6 @@ void game::display_faction_epilogues()
             }
         }
     }
-
-    refresh_all();
 }
 
 struct npc_dist_to_player {
@@ -3557,17 +3552,6 @@ void game::draw_veh_dir_indicator( bool next )
         auto col = next ? c_white : c_dark_gray;
         mvwputch( w_terrain, indicator_offset->xy() - u.view_offset.xy() + point( POSX, POSY ), col, 'X' );
     }
-}
-
-void game::refresh_all()
-{
-    const int minz = m.has_zlevels() ? -OVERMAP_DEPTH : get_levz();
-    const int maxz = m.has_zlevels() ? OVERMAP_HEIGHT : get_levz();
-    for( int z = minz; z <= maxz; z++ ) {
-        m.reset_vehicle_cache( z );
-    }
-
-    draw();
 }
 
 void game::draw_minimap()
@@ -8097,7 +8081,6 @@ void game::drop()
 void game::drop_in_direction()
 {
     if( const cata::optional<tripoint> pnt = choose_adjacent( _( "Drop where?" ) ) ) {
-        refresh_all();
         u.drop( game_menus::inv::multidrop( u ), *pnt );
     }
 }
@@ -8697,8 +8680,6 @@ void game::reload( item_location &loc, bool prompt, bool empty )
         }
         u.activity.targets.push_back( std::move( opt.ammo ) );
     }
-
-    refresh_all();
 }
 
 // Reload something.
@@ -10657,7 +10638,6 @@ void game::vertical_move( int movez, bool force, bool peeking )
     }
 
     m.invalidate_map_cache( g->get_levz() );
-    refresh_all();
     // Upon force movement, traps can not be avoided.
     m.creature_on_trap( u, !force );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3568,7 +3568,6 @@ void game::refresh_all()
     }
 
     draw();
-    catacurses::refresh();
 }
 
 void game::draw_minimap()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1438,6 +1438,7 @@ bool game::do_turn()
                 }
                 sounds::process_sound_markers( &u );
                 if( !u.activity && !u.has_distant_destination() && uquit != QUIT_WATCH ) {
+                    wait_popup.reset();
                     ui_manager::redraw();
                 }
 
@@ -1571,14 +1572,15 @@ bool game::do_turn()
 
             // Avoid redrawing the main UI every time due to invalidation
             ui_adaptor dummy( ui_adaptor::disable_uis_below {} );
-            static_popup popup;
-            popup.on_top( true ).wait_message( "%s", wait_message );
+            wait_popup = std::make_unique<static_popup>();
+            wait_popup->on_top( true ).wait_message( "%s", wait_message );
             ui_manager::redraw();
             refresh_display();
             first_redraw_since_waiting_started = false;
         }
     } else {
         // Nothing to wait for now
+        wait_popup.reset();
         first_redraw_since_waiting_started = true;
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10169,7 +10169,9 @@ void game::fling_creature( Creature *c, const int &dir, float flvel, bool contro
         range--;
         steps++;
         if( animate && ( seen || u.sees( *c ) ) ) {
-            draw();
+            invalidate_main_ui_adaptor();
+            ui_manager::redraw_invalidated();
+            refresh_display();
         }
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5585,10 +5585,6 @@ void game::examine()
         return;
     }
     u.manual_examine = true;
-    // redraw terrain to erase 'examine' window
-    draw_ter();
-    wrefresh( w_terrain );
-    draw_panels( true );
     examine( *examp_ );
     u.manual_examine = false;
 }
@@ -5744,9 +5740,6 @@ void game::examine( const tripoint &examp )
 
     if( !m.tr_at( examp ).is_null() && !u.is_mounted() ) {
         iexamine::trap( u, examp );
-        draw_ter();
-        wrefresh( w_terrain );
-        draw_panels();
     } else if( !m.tr_at( examp ).is_null() && u.is_mounted() ) {
         add_msg( m_warning, _( "You cannot do that while mounted." ) );
     }
@@ -5796,17 +5789,16 @@ void game::pickup()
     if( !examp_ ) {
         return;
     }
-    // redraw terrain to erase 'pickup' window
-    draw_ter();
-    // wrefresh is called in pickup( const tripoint & )
     pickup( *examp_ );
 }
 
 void game::pickup( const tripoint &p )
 {
     // Highlight target
-    g->m.drawsq( w_terrain, u, p, true, true, u.pos() + u.view_offset );
-    wrefresh( w_terrain );
+    shared_ptr_fast<game::draw_callback_t> hilite_cb = make_shared_fast<game::draw_callback_t>( [&]() {
+        m.drawsq( w_terrain, u, p, true, true, u.pos() + u.view_offset );
+    } );
+    add_draw_callback( hilite_cb );
 
     Pickup::pick_up( p, 0 );
 }
@@ -5822,7 +5814,6 @@ void game::peek()
 {
     const cata::optional<tripoint> p = choose_direction( _( "Peek where?" ), true );
     if( !p ) {
-        refresh_all();
         return;
     }
 
@@ -5833,10 +5824,7 @@ void game::peek()
         if( old_pos != u.pos() ) {
             look_around();
             vertical_move( p->z * -1, false, true );
-            draw_ter();
         }
-        wrefresh( w_terrain );
-        draw_panels();
         return;
     }
 
@@ -5862,10 +5850,6 @@ void game::peek( const tripoint &p )
         avatar_action::plthrow( u, loc, p );
     }
     m.invalidate_map_cache( p.z );
-
-    draw_ter();
-    wrefresh( w_terrain );
-    draw_panels();
 }
 ////////////////////////////////////////////////////////////////////////////////////////////
 cata::optional<tripoint> game::look_debug()
@@ -8586,9 +8570,6 @@ void game::butcher()
             break;
         case BUTCHER_CORPSE: {
             butcher_submenu( corpses, indexer_index );
-            draw_ter();
-            wrefresh( w_terrain );
-            draw_panels( true );
             u.activity.targets.emplace_back( map_cursor( u.pos() ), &*corpses[indexer_index] );
         }
         break;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3163,7 +3163,7 @@ void game::disp_NPCs()
                        m.posx(), m.posy(), m.posz() );
             ++i;
         }
-        wrefresh( w );
+        wnoutrefresh( w );
     } );
 
     input_context ctxt( "DISP_NPCS" );
@@ -3385,7 +3385,7 @@ void game::draw()
             it = draw_callbacks.erase( it );
         }
     }
-    wrefresh( w_terrain );
+    wnoutrefresh( w_terrain );
 
     draw_panels( true );
 }
@@ -3426,7 +3426,7 @@ void game::draw_panels( bool force_draw )
                                                      TERMX - panel.get_width() - panel_name_width - 1 : panel.get_width() + 1, y ) );
                     werase( label );
                     mvwprintz( label, point_zero, c_light_red, panel_name );
-                    wrefresh( label );
+                    wnoutrefresh( label );
                     label = catacurses::newwin( h, 1,
                                                 point( sidebar_right ? TERMX - panel.get_width() - 1 : panel.get_width(), y ) );
                     werase( label );
@@ -3439,7 +3439,7 @@ void game::draw_panels( bool force_draw )
                         }
                         mvwputch( label, point( 0, h - 1 ), c_light_red, sidebar_right ? LINE_XXOO : LINE_XOOX );
                     }
-                    wrefresh( label );
+                    wnoutrefresh( label );
                 }
                 y += h;
             }
@@ -3765,7 +3765,7 @@ void game::draw_minimap()
         }
     }
 
-    wrefresh( w_minimap );
+    wnoutrefresh( w_minimap );
 }
 
 float game::natural_light_level( const int zlev ) const
@@ -6213,7 +6213,7 @@ static void zones_manager_shortcuts( const catacurses::window &w_info )
                             _( "<S>how all / hide distant" ) ) + 2;
     shortcut_print( w_info, point( tmpx, 3 ), c_white, c_light_green, _( "<M>ap" ) );
 
-    wrefresh( w_info );
+    wnoutrefresh( w_info );
 }
 
 static void zones_manager_draw_borders( const catacurses::window &w_border,
@@ -6242,7 +6242,7 @@ static void zones_manager_draw_borders( const catacurses::window &w_border,
               LINE_XOXX ); // -|
 
     mvwprintz( w_border, point( 2, 0 ), c_white, _( "Zones manager" ) );
-    wrefresh( w_border );
+    wnoutrefresh( w_border );
 
     for( int j = 0; j < iInfoHeight - 1; ++j ) {
         mvwputch( w_info_border, point( 0, j ), c_light_gray, LINE_XOXO );
@@ -6255,7 +6255,7 @@ static void zones_manager_draw_borders( const catacurses::window &w_border,
 
     mvwputch( w_info_border, point( 0, iInfoHeight - 1 ), c_light_gray, LINE_XXOO );
     mvwputch( w_info_border, point( width - 1, iInfoHeight - 1 ), c_light_gray, LINE_XOOX );
-    wrefresh( w_info_border );
+    wnoutrefresh( w_info_border );
 }
 
 void game::zones_manager()
@@ -6370,7 +6370,7 @@ void game::zones_manager()
             }
         }
 
-        wrefresh( w_zones_options );
+        wnoutrefresh( w_zones_options );
     };
 
     cata::optional<tripoint> zone_start;
@@ -6444,7 +6444,7 @@ void game::zones_manager()
             calcStartPos( start_index, active_index, max_rows, zone_cnt );
 
             draw_scrollbar( w_zones_border, active_index, max_rows, zone_cnt, point_south );
-            wrefresh( w_zones_border );
+            wnoutrefresh( w_zones_border );
 
             int iNum = 0;
 
@@ -6490,7 +6490,7 @@ void game::zones_manager()
             zones_manager_options();
         }
 
-        wrefresh( w_zones );
+        wnoutrefresh( w_zones );
     } );
 
     zones_manager_open = true;
@@ -6822,7 +6822,7 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
             const int last_line = getmaxy( w_info ) - 2;
             pre_print_all_tile_info( lp, w_info, first_line, last_line, cache );
 
-            wrefresh( w_info );
+            wnoutrefresh( w_info );
         } );
         ter_indicator_cb = make_shared_fast<draw_callback_t>( [&]() {
             draw_look_around_cursor( lp, cache );
@@ -7408,7 +7408,7 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
         reset_item_list_state( w_items_border, iInfoHeight, sort_radius );
 
         if( ground_items.empty() ) {
-            wrefresh( w_items_border );
+            wnoutrefresh( w_items_border );
             mvwprintz( w_items, point( 2, 10 ), c_white, _( "You don't see any items around you!" ) );
         } else {
             int iStartPos = 0;
@@ -7503,7 +7503,7 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
                 draw_item_info( w_item_info, dummy );
             }
             draw_scrollbar( w_items_border, iActive, iMaxRows, iItemNum, point_south );
-            wrefresh( w_items_border );
+            wnoutrefresh( w_items_border );
         }
 
         const bool bDrawLeft = ground_items.empty() || filtered_items.empty() || !activeItem || filter_type;
@@ -7517,8 +7517,8 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             wprintw( w_item_info, " >" );
         }
 
-        wrefresh( w_items );
-        wrefresh( w_item_info );
+        wnoutrefresh( w_items );
+        wnoutrefresh( w_item_info );
 
         if( filter_type ) {
             draw_item_filter_rules( w_item_info, 0, iInfoHeight - 1, filter_type.value() );
@@ -7977,10 +7977,10 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
                                 point_south );
             }
 
-            wrefresh( w_monsters_border );
-            wrefresh( w_monster_info_border );
-            wrefresh( w_monsters );
-            wrefresh( w_monster_info );
+            wnoutrefresh( w_monsters_border );
+            wnoutrefresh( w_monster_info_border );
+            wnoutrefresh( w_monsters );
+            wnoutrefresh( w_monster_info );
         }
     } );
 

--- a/src/game.h
+++ b/src/game.h
@@ -589,7 +589,9 @@ class game
         // Shared method to print "look around" info
         void print_all_tile_info( const tripoint &lp, const catacurses::window &w_look,
                                   const std::string &area_name, int column,
-                                  int &line, int last_line, bool draw_terrain_indicators, const visibility_variables &cache );
+                                  int &line, int last_line, const visibility_variables &cache );
+
+        void draw_terrain_indicator( const tripoint &lp, const visibility_variables &cache ) const;
 
         /** Long description of (visible) things at tile. */
         void extended_description( const tripoint &p );
@@ -854,7 +856,7 @@ class game
                                  int column, int &line, int last_line );
         void print_visibility_info( const catacurses::window &w_look, int column, int &line,
                                     visibility_type visibility );
-        void print_visibility_indicator( visibility_type visibility );
+        void print_visibility_indicator( visibility_type visibility ) const;
         void print_items_info( const tripoint &lp, const catacurses::window &w_look, int column, int &line,
                                int last_line );
         void print_graffiti_info( const tripoint &lp, const catacurses::window &w_look, int column,

--- a/src/game.h
+++ b/src/game.h
@@ -119,6 +119,7 @@ class live_view;
 class loading_ui;
 class overmap;
 class scent_map;
+class static_popup;
 class timed_event_manager;
 class ui_adaptor;
 struct visibility_variables;
@@ -1102,6 +1103,8 @@ class game
                 const tripoint &last, bool iso );
 
         weak_ptr_fast<ui_adaptor> main_ui_adaptor;
+
+        std::unique_ptr<static_popup> wait_popup;
     public:
         /** Used to implement mouse "edge scrolling". Returns a
          *  tripoint which is a vector of the resulting "move", i.e.

--- a/src/game.h
+++ b/src/game.h
@@ -590,7 +590,7 @@ class game
                                   const std::string &area_name, int column,
                                   int &line, int last_line, const visibility_variables &cache );
 
-        void draw_terrain_indicator( const tripoint &lp, const visibility_variables &cache ) const;
+        void draw_look_around_cursor( const tripoint &lp, const visibility_variables &cache );
 
         /** Long description of (visible) things at tile. */
         void extended_description( const tripoint &p );
@@ -855,7 +855,6 @@ class game
                                  int column, int &line, int last_line );
         void print_visibility_info( const catacurses::window &w_look, int column, int &line,
                                     visibility_type visibility );
-        void print_visibility_indicator( visibility_type visibility ) const;
         void print_items_info( const tripoint &lp, const catacurses::window &w_look, int column, int &line,
                                int last_line );
         void print_graffiti_info( const tripoint &lp, const catacurses::window &w_look, int column,

--- a/src/game.h
+++ b/src/game.h
@@ -556,7 +556,6 @@ class game
         character_id assign_npc_id();
         Creature *is_hostile_nearby();
         Creature *is_hostile_very_close();
-        void refresh_all();
         // Handles shifting coordinates transparently when moving between submaps.
         // Helper to make calling with a player pointer less verbose.
         point update_map( player &p );

--- a/src/game.h
+++ b/src/game.h
@@ -1077,8 +1077,8 @@ class game
         bool npcs_dirty = false;
         /** Has anything died in this turn and needs to be cleaned up? */
         bool critter_died = false;
-        /** Was the player sleeping during this turn. */
-        bool player_was_sleeping = false;
+        /** Is this the first redraw since waiting (sleeping or activity) started */
+        bool first_redraw_since_waiting_started = true;
         /** Is Zone manager open or not - changes graphics of some zone tiles */
         bool zones_manager_open = false;
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -244,10 +244,7 @@ void game_menus::inv::common( avatar &you )
             }
         }
 
-        g->refresh_all();
         res = g->inventory_item_menu( location );
-        g->refresh_all();
-
     } while( loop_options.count( res ) != 0 );
 }
 
@@ -1543,7 +1540,6 @@ void game_menus::inv::swap_letters( player &p )
         }
 
         reassign_letter( p, *loc );
-        g->refresh_all();
     }
 }
 

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -743,7 +743,7 @@ void defense_game::refresh_setup( const catacurses::window &w, int selection )
     mvwprintz( w, point( 34, 21 ), TOGCOL( 18, sleep ), _( "Sleep" ) );
     mvwprintz( w, point( 46, 21 ), TOGCOL( 19, mercenaries ), _( "Mercenaries" ) );
     mvwprintz( w, point( 59, 21 ), TOGCOL( 20, allow_save ), _( "Allow save" ) );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 std::string defense_style_name( defense_style style )
@@ -1201,7 +1201,7 @@ void draw_caravan_borders( const catacurses::window &w, int current_window )
     // Quick reminded about help.
     // NOLINTNEXTLINE(cata-text-style): literal question mark
     mvwprintz( w, point( 2, FULL_SCREEN_HEIGHT - 1 ), c_red, _( "Press ? for help." ) );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 void draw_caravan_categories( const catacurses::window &w, int category_selected,
@@ -1221,7 +1221,7 @@ void draw_caravan_categories( const catacurses::window &w, int category_selected
         mvwprintz( w, point( 1, i + 3 ), ( i == category_selected ? h_white : c_white ),
                    caravan_category_name( static_cast<caravan_category>( i ) ) );
     }
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 void draw_caravan_items( const catacurses::window &w, std::vector<itype_id> *items,
@@ -1255,7 +1255,7 @@ void draw_caravan_items( const catacurses::window &w, std::vector<itype_id> *ite
             wprintz( w, ( price > g->u.cash ? c_red : c_green ), " (%s)", format_money( price ) );
         }
     }
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 int caravan_price( player &u, int price )

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -323,7 +323,7 @@ void tutorial_game::add_message( tut_lesson lesson )
         return;
     }
     tutorials_seen[lesson] = true;
+    g->invalidate_main_ui_adaptor();
     popup( SNIPPET.get_snippet_by_id( snippet_id( io::enum_to_string<tut_lesson>( lesson ) ) ).value_or(
                translation() ).translated(), PF_ON_TOP );
-    g->refresh_all();
 }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -68,6 +68,7 @@
 #include "string_input_popup.h"
 #include "translations.h"
 #include "ui.h"
+#include "ui_manager.h"
 #include "units.h"
 #include "veh_type.h"
 #include "vehicle.h"
@@ -243,7 +244,17 @@ input_context game::get_player_input( std::string &action )
         wPrint.vdrops.clear();
 
         ctxt.set_timeout( 125 );
-        bool initial_draw = true;
+
+        shared_ptr_fast<game::draw_callback_t> animation_cb =
+        make_shared_fast<game::draw_callback_t>( [&]() {
+            draw_weather( wPrint );
+
+            if( uquit != QUIT_WATCH ) {
+                draw_sct();
+            }
+        } );
+        add_draw_callback( animation_cb );
+
         do {
             if( bWeatherEffect && get_option<bool>( "ANIMATION_RAIN" ) ) {
                 /*
@@ -253,24 +264,8 @@ input_context game::get_player_input( std::string &action )
                 WEATHER_DRIZZLE | WEATHER_LIGHT_DRIZZLE | WEATHER_RAINY | WEATHER_THUNDER | WEATHER_LIGHTNING = "weather_rain_drop"
                 WEATHER_FLURRIES | WEATHER_SNOW | WEATHER_SNOWSTORM = "weather_snowflake"
                 */
+                invalidate_main_ui_adaptor();
 
-#if defined(TILES)
-                if( !use_tiles ) {
-#endif //TILES
-                    //If not using tiles, erase previous drops from w_terrain
-                    for( auto &elem : wPrint.vdrops ) {
-                        const tripoint location( elem.first + offset_x, elem.second + offset_y, get_levz() );
-                        const lit_level lighting = visibility_cache[location.x][location.y];
-                        wmove( w_terrain, location.xy() + point( -offset_x, -offset_y ) );
-                        if( !m.apply_vision_effects( w_terrain, m.get_visibility( lighting, cache ) ) ) {
-                            m.drawsq( w_terrain, u, location, false, true,
-                                      u.pos() + u.view_offset,
-                                      lighting == LL_LOW, lighting == LL_BRIGHT );
-                        }
-                    }
-#if defined(TILES)
-                }
-#endif //TILES
                 wPrint.vdrops.clear();
 
                 for( int i = 0; i < dropCount; i++ ) {
@@ -292,28 +287,7 @@ input_context game::get_player_input( std::string &action )
             }
             // don't bother calculating SCT if we won't show it
             if( uquit != QUIT_WATCH && get_option<bool>( "ANIMATION_SCT" ) ) {
-#if defined(TILES)
-                if( !use_tiles ) {
-#endif
-                    for( auto &elem : SCT.vSCT ) {
-                        //Erase previous text from w_terrain
-                        if( elem.getStep() > 0 ) {
-                            const int width = utf8_width( elem.getText() );
-                            for( int i = 0; i < width; ++i ) {
-                                const tripoint location( elem.getPosX() + i, elem.getPosY(), get_levz() );
-                                const lit_level lighting = visibility_cache[location.x][location.y];
-                                wmove( w_terrain, location.xy() + point( -offset_x, -offset_y ) );
-                                if( !m.apply_vision_effects( w_terrain, m.get_visibility( lighting, cache ) ) ) {
-                                    m.drawsq( w_terrain, u, location, false, true,
-                                              u.pos() + u.view_offset,
-                                              lighting == LL_LOW, lighting == LL_BRIGHT );
-                                }
-                            }
-                        }
-                    }
-#if defined(TILES)
-                }
-#endif
+                invalidate_main_ui_adaptor();
 
                 SCT.advanceAllSteps();
 
@@ -344,27 +318,15 @@ input_context game::get_player_input( std::string &action )
                 }
             }
 
-            if( initial_draw ) {
-                werase( w_terrain );
-
-                draw_ter();
-                initial_draw = false;
-            }
-            draw_weather( wPrint );
-
-            if( uquit != QUIT_WATCH ) {
-                draw_sct();
-            }
-
-            wrefresh( w_terrain );
-            g->draw_panels();
-
+            std::unique_ptr<static_popup> deathcam_msg_popup;
             if( uquit == QUIT_WATCH ) {
-                query_popup()
-                .wait_message( c_red, _( "Press %s to accept your fate…" ), ctxt.get_desc( "QUIT" ) )
-                .on_top( true )
-                .show();
+                deathcam_msg_popup = std::make_unique<static_popup>();
+                deathcam_msg_popup
+                ->wait_message( c_red, _( "Press %s to accept your fate…" ), ctxt.get_desc( "QUIT" ) )
+                .on_top( true );
             }
+
+            ui_manager::redraw_invalidated();
         } while( handle_mouseview( ctxt, action ) && uquit != QUIT_WATCH
                  && ( action != "TIMEOUT" || !current_turn.has_timeout_elapsed() ) );
         ctxt.reset_timeout();
@@ -1275,15 +1237,11 @@ static void read()
 static void reach_attack( int range, player &u )
 {
     g->temp_exit_fullscreen();
-    g->m.draw( g->w_terrain, u.pos() );
     std::vector<tripoint> trajectory = target_handler().target_ui( u, TARGET_MODE_REACH, &u.weapon,
                                        range );
     if( !trajectory.empty() ) {
         u.reach_attack( trajectory.back() );
     }
-    g->draw_ter();
-    wrefresh( g->w_terrain );
-    g->draw_panels();
     g->reenter_fullscreen();
 }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1495,7 +1495,6 @@ bool game::handle_action()
 
         if( act == ACTION_KEYBINDINGS ) {
             // already handled by input context
-            refresh_all();
             return false;
         }
 
@@ -2039,16 +2038,13 @@ bool game::handle_action()
                 break;
             case ACTION_BIONICS:
                 u.power_bionics();
-                refresh_all();
                 break;
             case ACTION_MUTATIONS:
                 u.power_mutations();
-                refresh_all();
                 break;
 
             case ACTION_SORT_ARMOR:
                 u.sort_armor();
-                refresh_all();
                 break;
 
             case ACTION_WAIT:
@@ -2092,7 +2088,6 @@ bool game::handle_action()
                     add_msg( m_info, _( "You can't disassemble items while you're riding." ) );
                 } else {
                     u.disassemble();
-                    refresh_all();
                 }
                 break;
 
@@ -2198,7 +2193,6 @@ bool game::handle_action()
                         uquit = QUIT_SUICIDE;
                     }
                 }
-                refresh_all();
                 break;
 
             case ACTION_SAVE:
@@ -2208,7 +2202,6 @@ bool game::handle_action()
                         uquit = QUIT_SAVED;
                     }
                 }
-                refresh_all();
                 break;
 
             case ACTION_QUICKSAVE:
@@ -2249,17 +2242,14 @@ bool game::handle_action()
 
             case ACTION_MORALE:
                 u.disp_morale();
-                refresh_all();
                 break;
 
             case ACTION_MESSAGES:
                 Messages::display_messages();
-                refresh_all();
                 break;
 
             case ACTION_HELP:
                 get_help().display_help();
-                refresh_all();
                 break;
 
             case ACTION_OPTIONS:
@@ -2268,27 +2258,22 @@ bool game::handle_action()
 
             case ACTION_AUTOPICKUP:
                 get_auto_pickup().show();
-                refresh_all();
                 break;
 
             case ACTION_AUTONOTES:
                 get_auto_notes_settings().show_gui();
-                refresh_all();
                 break;
 
             case ACTION_SAFEMODE:
                 get_safemode().show();
-                refresh_all();
                 break;
 
             case ACTION_COLOR:
                 all_colors.show_gui();
-                refresh_all();
                 break;
 
             case ACTION_WORLD_MODS:
                 world_generator->show_active_world_mods( world_generator->active_world->active_mod_order );
-                refresh_all();
                 break;
 
             case ACTION_DEBUG:

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2224,13 +2224,11 @@ bool game::handle_action()
                 break;
 
             case ACTION_MAP:
-                werase( w_terrain );
                 ui::omap::display();
                 break;
 
             case ACTION_SKY:
                 if( m.is_outside( u.pos() ) ) {
-                    werase( w_terrain );
                     ui::omap::display_visible_weather();
                 } else {
                     add_msg( m_info, _( "You can't see the sky from here." ) );

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -263,7 +263,6 @@ static bool get_liquid_target( item &liquid, item *const source, const int radiu
 
         const std::string liqstr = string_format( _( "Pour %s where?" ), liquid_name );
 
-        g->refresh_all();
         const cata::optional<tripoint> target_pos_ = choose_adjacent( liqstr );
         if( !target_pos_ ) {
             return;
@@ -291,7 +290,6 @@ static bool get_liquid_target( item &liquid, item *const source, const int radiu
     }
 
     menu.query();
-    g->refresh_all();
     if( menu.ret < 0 || static_cast<size_t>( menu.ret ) >= actions.size() ) {
         add_msg( _( "Never mind." ) );
         // Explicitly canceled all options (container, drink, pour).

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -117,7 +117,7 @@ void help::draw_menu( const catacurses::window &win )
                         c_white, c_light_blue, cat_name );
     }
 
-    wrefresh( win );
+    wnoutrefresh( win );
 }
 
 std::string help::get_note_colors()
@@ -160,7 +160,7 @@ void help::display_help()
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         draw_border( w_help_border, BORDER_COLOR, _( " HELP " ), c_black_white );
-        wrefresh( w_help_border );
+        wnoutrefresh( w_help_border );
         draw_menu( w_help );
     } );
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -713,7 +713,7 @@ void iexamine::vending( player &p, const tripoint &examp )
         }
 
         draw_scrollbar( w, cur_pos, list_lines, num_items, point( 0, first_item_offset ) );
-        wrefresh( w );
+        wnoutrefresh( w );
 
         // Item info
         auto &cur_items = item_list[static_cast<size_t>( cur_pos )]->second;
@@ -731,7 +731,7 @@ void iexamine::vending( player &p, const tripoint &examp )
         const std::string name = utf8_truncate( cur_item->display_name(),
                                                 static_cast<size_t>( w_info_w - 4 ) );
         mvwprintw( w_item_info, point_east, "<%s>", name );
-        wrefresh( w_item_info );
+        wnoutrefresh( w_item_info );
     } );
 
     for( ;; ) {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -383,7 +383,6 @@ class atm_menu
                 if( !u.activity.is_null() ) {
                     break;
                 }
-                g->draw();
             }
         }
     private:

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -719,6 +719,4 @@ void DynamicDataLoader::check_consistency( loading_ui &ui )
         e.second();
         ui.proceed();
     }
-    catacurses::erase();
-    catacurses::refresh();
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1287,8 +1287,6 @@ action_id input_context::display_menu( const bool permit_execute_action )
     } else if( changed ) {
         inp_mngr.action_contexts.swap( old_action_contexts );
     }
-    werase( w_help );
-    wrefresh( w_help );
 
     return action_to_execute;
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1124,7 +1124,7 @@ action_id input_context::display_menu( const bool permit_execute_action )
             mvwprintz( w_help, point( 52, i + 10 ), col, "%s", get_desc( action_id ) );
         }
 
-        // spopup.query_string() will call wrefresh( w_help )
+        // spopup.query_string() will call wnoutrefresh( w_help )
         spopup.text( filter_phrase );
         spopup.query_string( false, true );
     };

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1533,7 +1533,7 @@ void inventory_selector::refresh_window() const
     draw_columns( w_inv );
     draw_footer( w_inv );
 
-    wrefresh( w_inv );
+    wnoutrefresh( w_inv );
 }
 
 void inventory_selector::set_filter()

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -324,10 +324,6 @@ void game::item_action_menu()
         return;
     }
 
-    draw_ter();
-    wrefresh( w_terrain );
-    draw_panels( true );
-
     const item_action_id action = std::get<0>( menu_items[kmenu.ret] );
     item *it = iactions[action];
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1900,7 +1900,6 @@ int iuse::extinguisher( player *p, item *it, bool, const tripoint & )
     if( !it->ammo_sufficient() ) {
         return 0;
     }
-    g->draw();
     // If anyone other than the player wants to use one of these,
     // they're going to need to figure out how to aim it.
     const cata::optional<tripoint> dest_ = choose_adjacent( _( "Spray where?" ) );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1431,7 +1431,7 @@ int iuse::mycus( player *p, item *it, bool t, const tripoint &pos )
         p->fall_asleep( 5_hours - p->int_cur * 1_minutes );
         p->unset_mutation( trait_THRESH_MARLOSS );
         p->set_mutation( trait_THRESH_MYCUS );
-        g->refresh_all();
+        g->invalidate_main_ui_adaptor();
         //~ The Mycus does not use the term (or encourage the concept of) "you".  The PC is a local/native organism, but is now the Mycus.
         //~ It still understands the concept, but uninitelligent fungaloids and mind-bent symbiotes should not need it.
         //~ We are the Mycus.
@@ -1439,22 +1439,22 @@ int iuse::mycus( player *p, item *it, bool t, const tripoint &pos )
         p->add_msg_if_player( " " );
         p->add_msg_if_player( m_good,
                               _( "A sea of white caps, waving gently.  A haze of spores wafting silently over a forest." ) );
-        g->refresh_all();
+        g->invalidate_main_ui_adaptor();
         popup( _( "The natives have a saying: \"E Pluribus Unum.\"  Out of many, one." ) );
         p->add_msg_if_player( " " );
         p->add_msg_if_player( m_good,
                               _( "The blazing pink redness of the berry.  The juices spreading across your tongue, the warmth draping over us like a lover's embrace." ) );
-        g->refresh_all();
+        g->invalidate_main_ui_adaptor();
         popup( _( "We welcome the union of our lines in our local guide.  We will prosper, and unite this world.  Even now, our fruits adapt to better serve local physiology." ) );
         p->add_msg_if_player( " " );
         p->add_msg_if_player( m_good,
                               _( "The sky-blue of the seed.  The nutty, creamy flavors intermingling with the berry, a memory that will never leave us." ) );
-        g->refresh_all();
+        g->invalidate_main_ui_adaptor();
         popup( _( "As, in time, shall we adapt to better welcome those who have not received us." ) );
         p->add_msg_if_player( " " );
         p->add_msg_if_player( m_good,
                               _( "The amber-yellow of the sap.  Feel it flowing through our veins, taking the place of the strange, thin red gruel called \"blood.\"" ) );
-        g->refresh_all();
+        g->invalidate_main_ui_adaptor();
         popup( _( "We are the Mycus." ) );
         /*p->add_msg_if_player( m_good,
                               _( "We welcome into us.  We have endured long in this forbidding world." ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1288,7 +1288,6 @@ bool firestarter_actor::prep_firestarter_use( const player &p, tripoint &pos )
         if( const cata::optional<tripoint> pnt_ = choose_adjacent( _( "Light where?" ) ) ) {
             pos = *pnt_;
         } else {
-            g->refresh_all();
             return false;
         }
     }

--- a/src/iuse_software_kitten.cpp
+++ b/src/iuse_software_kitten.cpp
@@ -328,7 +328,7 @@ void robot_finds_kitten::show() const
     input_context ctxt( "IUSE_SOFTWARE_KITTEN" );
 
     draw_border( bkatwin );
-    wrefresh( bkatwin );
+    wnoutrefresh( bkatwin );
 
     werase( w );
     if( current_ui_state != ui_state::instructions ) {
@@ -411,7 +411,7 @@ void robot_finds_kitten::show() const
         case ui_state::exit:
             break;
     }
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 void robot_finds_kitten::process_input()

--- a/src/iuse_software_lightson.cpp
+++ b/src/iuse_software_lightson.cpp
@@ -74,7 +74,7 @@ void lightson_game::draw_level()
             mvwputch( w, current + point_south_east, selected ? hilite( c_white ) : fg, symbol );
         }
     }
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 void lightson_game::generate_change_coords( int changes )
@@ -177,7 +177,7 @@ int lightson_game::start_game()
                         _( "<color_white>Legend: #</color> on, <color_dark_gray>-</color> off." ),
                         _( "Toggle lights switches selected light and 4 its neighbors." ) );
 
-        wrefresh( w_border );
+        wnoutrefresh( w_border );
 
         draw_level();
     } );

--- a/src/iuse_software_minesweeper.cpp
+++ b/src/iuse_software_minesweeper.cpp
@@ -203,7 +203,7 @@ int minesweeper_game::start_game()
 
         mvwputch( w_minesweeper_border, point( 2, 0 ), hilite( c_white ), _( "Minesweeper" ) );
 
-        wrefresh( w_minesweeper_border );
+        wnoutrefresh( w_minesweeper_border );
 
         if( !started ) {
             return;
@@ -256,7 +256,7 @@ int minesweeper_game::start_game()
                 mvwputch( w_minesweeper, offset + point( x, y ), col, ch );
             }
         }
-        wrefresh( w_minesweeper );
+        wnoutrefresh( w_minesweeper );
     } );
 
     std::function<void ( int, int )> rec_reveal = [&]( const int y, const int x ) {

--- a/src/iuse_software_snake.cpp
+++ b/src/iuse_software_snake.cpp
@@ -81,7 +81,7 @@ void snake_game::snake_over( const catacurses::window &w_snake, int iScore )
     center_print( w_snake, 17, c_yellow, string_format( _( "TOTAL SCORE: %d" ), iScore ) );
     // TODO: print actual bound keys
     center_print( w_snake, 21, c_white, _( "Press 'q' or ESC to exit." ) );
-    wrefresh( w_snake );
+    wnoutrefresh( w_snake );
 }
 
 int snake_game::start_game()
@@ -138,7 +138,7 @@ int snake_game::start_game()
             mvwputch( w_snake, point( iFruitPosX, iFruitPosY ), c_light_red, '*' );
         }
         print_score( w_snake, iScore );
-        wrefresh( w_snake );
+        wnoutrefresh( w_snake );
     } );
 
     do {

--- a/src/iuse_software_sokoban.cpp
+++ b/src/iuse_software_sokoban.cpp
@@ -266,7 +266,7 @@ int sokoban_game::start_game()
         print_score( w_sokoban, iScore, iMoves );
 
         draw_level( w_sokoban );
-        wrefresh( w_sokoban );
+        wnoutrefresh( w_sokoban );
     } );
 
     int iPlayerY = 0;

--- a/src/live_view.cpp
+++ b/src/live_view.cpp
@@ -65,7 +65,7 @@ void live_view::show( const tripoint &p )
             g->pre_print_all_tile_info( mouse_position, win, line_out, getmaxy( win ) - 2, cache );
             draw_border( win );
             center_print( win, 0, c_white, _( "< <color_green>Mouse View</color> >" ) );
-            wrefresh( win );
+            wnoutrefresh( win );
         } );
     }
     // Always mark ui for resize as the required box height may have changed.

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1538,7 +1538,7 @@ class spellcasting_callback : public uilist_callback
             if( menu->selected >= 0 && static_cast<size_t>( menu->selected ) < known_spells.size() ) {
                 draw_spell_info( *known_spells[menu->selected], menu );
             }
-            wrefresh( menu->window );
+            wnoutrefresh( menu->window );
         }
 };
 
@@ -1978,7 +1978,7 @@ void spellbook_callback::refresh( uilist *menu )
     if( menu->selected >= 0 && static_cast<size_t>( menu->selected ) < spells.size() ) {
         draw_spellbook_info( spells[menu->selected], menu );
     }
-    wrefresh( menu->window );
+    wnoutrefresh( menu->window );
 }
 
 void fake_spell::load( const JsonObject &jo )

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -178,7 +178,7 @@ class teleporter_callback : public uilist_callback
                                           rl_dist( ms_to_omt_copy( g->m.getabs( g->u.pos() ) ), index_pairs[entnum] ),
                                           index_pairs[entnum].x, index_pairs[entnum].y ) );
             }
-            wrefresh( menu->window );
+            wnoutrefresh( menu->window );
         }
 };
 

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -185,7 +185,6 @@ class teleporter_callback : public uilist_callback
 cata::optional<tripoint> teleporter_list::choose_teleport_location()
 {
     cata::optional<tripoint> ret = cata::nullopt;
-    g->refresh_all();
 
     uilist teleport_selector;
     teleport_selector.w_height_setup = 24;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -755,8 +755,6 @@ void exit_handler( int s )
     const int old_timeout = inp_mngr.get_timeout();
     inp_mngr.reset_timeout();
     if( s != 2 || query_yn( _( "Really Quit?  All unsaved changes will be lost." ) ) ) {
-        catacurses::erase(); // Clear screen
-
         deinitDebug();
 
         int exit_status = 0;

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -218,7 +218,7 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
 
     print_menu_items( w_open, vMenuItems, iSel, point( final_offset, offset.y ), spacing );
 
-    wrefresh( w_open );
+    wnoutrefresh( w_open );
 }
 
 std::vector<std::string> main_menu::load_file( const std::string &path,
@@ -453,8 +453,8 @@ void main_menu::display_text( const std::string &text, const std::string &title,
     fold_and_print_from( w_text, point_zero, width, selected, c_light_gray, text );
 
     draw_scrollbar( w_border, selected, height, iLines, point_south, BORDER_COLOR, true );
-    wrefresh( w_border );
-    wrefresh( w_text );
+    wnoutrefresh( w_border );
+    wnoutrefresh( w_text );
 }
 
 void main_menu::load_char_templates()
@@ -562,7 +562,7 @@ bool main_menu::opening_screen()
                 point offset( menu_offset + point( -( xlen / 4 ) + 32 + extra_w / 2, -2 ) );
                 print_menu_items( w_open, special_names, sel2, offset );
 
-                wrefresh( w_open );
+                wnoutrefresh( w_open );
             } else if( sel1 == 5 ) {  // Settings Menu
                 int settings_subs_to_display = vSettingsSubItems.size();
                 std::vector<std::string> settings_subs;
@@ -578,7 +578,7 @@ bool main_menu::opening_screen()
                     offset.x -= 6;
                 }
                 print_menu_items( w_open, settings_subs, sel2, offset );
-                wrefresh( w_open );
+                wnoutrefresh( w_open );
             }
         }
     } );
@@ -813,7 +813,7 @@ bool main_menu::new_character_tab()
             center_print( w_open, getmaxy( w_open ) - 7, c_yellow, hints[sel2] );
 
             print_menu_items( w_open, vSubItems, sel2, menu_offset + point( 0, -2 ) );
-            wrefresh( w_open );
+            wnoutrefresh( w_open );
         } else if( layer == 3 && sel1 == 1 ) {
             // Then view presets
             if( templates.empty() ) {
@@ -829,7 +829,7 @@ bool main_menu::new_character_tab()
                                templates[i] );
                 }
             }
-            wrefresh( w_open );
+            wnoutrefresh( w_open );
         }
     } );
     ui.on_screen_resize( [this]( ui_adaptor & ui ) {
@@ -1068,7 +1068,7 @@ bool main_menu::load_character_tab( bool transfer )
                                world_name, savegames_count );
                 }
             }
-            wrefresh( w_open );
+            wnoutrefresh( w_open );
         } else if( layer == 3 && sel1 == 2 ) {
             savegames = world_generator->get_world( all_worldnames[sel2] )->world_saves;
 
@@ -1090,7 +1090,7 @@ bool main_menu::load_character_tab( bool transfer )
                                "%s", savename.player_name() );
                 }
             }
-            wrefresh( w_open );
+            wnoutrefresh( w_open );
         }
     } );
     ui.on_screen_resize( [this]( ui_adaptor & ui ) {
@@ -1231,7 +1231,7 @@ void main_menu::world_tab()
                     wprintz( w_open, c_light_gray, "]" );
                 }
 
-                wrefresh( w_open );
+                wnoutrefresh( w_open );
             } else if( layer == 2 ) { // Show world names
                 mvwprintz( w_open, menu_offset + point( 25 + extra_w / 2, -2 ),
                            ( sel2 == 0 ? h_white : c_white ), "%s", _( "Create World" ) );
@@ -1253,7 +1253,7 @@ void main_menu::world_tab()
                                ( sel2 == i ? color2 : color1 ), "%s (%d)", ( *it ).c_str(), savegames_count );
                 }
 
-                wrefresh( w_open );
+                wnoutrefresh( w_open );
             }
         }
     } );

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -774,10 +774,6 @@ bool main_menu::opening_screen()
             }
         }
     }
-    if( start ) {
-        g->refresh_all();
-        g->draw();
-    }
     return start;
 }
 

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -218,9 +218,7 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
 
     print_menu_items( w_open, vMenuItems, iSel, point( final_offset, offset.y ), spacing );
 
-    catacurses::refresh();
     wrefresh( w_open );
-    catacurses::refresh();
 }
 
 std::vector<std::string> main_menu::load_file( const std::string &path,
@@ -457,7 +455,6 @@ void main_menu::display_text( const std::string &text, const std::string &title,
     draw_scrollbar( w_border, selected, height, iLines, point_south, BORDER_COLOR, true );
     wrefresh( w_border );
     wrefresh( w_text );
-    catacurses::refresh();
 }
 
 void main_menu::load_char_templates()
@@ -487,9 +484,7 @@ bool main_menu::opening_screen()
     world_generator->init();
 
     get_help().load();
-    init_windows();
     init_strings();
-    print_menu( w_open, 0, menu_offset );
 
     if( !assure_dir_exist( PATH_INFO::config_dir() ) ) {
         popup( _( "Unable to make config directory.  Check permissions." ) );
@@ -591,7 +586,7 @@ bool main_menu::opening_screen()
         init_windows();
         ui.position_from_window( w_open );
     } );
-    ui.position_from_window( w_open );
+    ui.mark_resize();
 
     while( !start ) {
         ui_manager::redraw();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -84,6 +84,7 @@
 #include "timed_event.h"
 #include "translations.h"
 #include "trap.h"
+#include "ui_manager.h"
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
@@ -678,7 +679,8 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
     // Redraw scene
     // But only if the vehicle was seen before or after the move
     if( seen || sees_veh( g->u, veh, true ) ) {
-        g->draw();
+        g->invalidate_main_ui_adaptor();
+        ui_manager::redraw_invalidated();
         refresh_display();
     }
     return new_vehicle;

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1536,7 +1536,7 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
             fold_and_print_from( w, point( 2, 1 ), width, selected, c_light_gray, text );
             draw_border( w, BORDER_COLOR, string_format( _( " Style: %s " ), ma.name ) );
             draw_scrollbar( w, selected, height, iLines, point_south, BORDER_COLOR, true );
-            wrefresh( w );
+            wnoutrefresh( w );
         } );
 
         do {

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -619,7 +619,7 @@ void Messages::dialog::show()
     }
 
     if( filtering ) {
-        wrefresh( w );
+        wnoutrefresh( w );
         // Print the help text
         werase( w_filter_help );
         draw_border( w_filter_help, border_color );
@@ -631,7 +631,7 @@ void Messages::dialog::show()
         mvwprintz( w_filter_help, point( border_width, w_fh_height - 1 ), border_color, "< " );
         mvwprintz( w_filter_help, point( w_fh_width - border_width - 2, w_fh_height - 1 ), border_color,
                    " >" );
-        wrefresh( w_filter_help );
+        wnoutrefresh( w_filter_help );
 
         // This line is preventing this method from being const
         filter.query( false, true ); // Draw only
@@ -644,7 +644,7 @@ void Messages::dialog::show()
             mvwprintz( w, point( border_width, w_height - 1 ), border_color, "< %s >", filter_str );
             mvwprintz( w, point( border_width + 2, w_height - 1 ), filter_color, "%s", filter_str );
         }
-        wrefresh( w );
+        wnoutrefresh( w );
     }
 }
 

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -669,10 +669,6 @@ bool talk_function::handle_outpost_mission( const mission_entry &cur_key, npc &p
         forage_return( p );
     }
 
-    g->draw_ter();
-    wrefresh( g->w_terrain );
-    g->draw_panels( true );
-
     return true;
 }
 

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -507,7 +507,7 @@ bool talk_function::display_and_choose_opts( mission_data &mission_key, const tr
             .viewport_size( info_height + 1 )
             .apply( w_list );
         }
-        wrefresh( w_list );
+        wnoutrefresh( w_list );
         werase( w_info );
 
         // Fold mission text, store it for scrolling
@@ -534,12 +534,12 @@ bool talk_function::display_and_choose_opts( mission_data &mission_key, const tr
                                 mission_text[start_line + info_offset] );
         }
 
-        wrefresh( w_info );
+        wnoutrefresh( w_info );
 
         if( role_id == "FACTION_CAMP" ) {
             werase( w_tabs );
             draw_camp_tabs( w_tabs, tab_mode, mission_key.entries );
-            wrefresh( w_tabs );
+            wnoutrefresh( w_tabs );
         }
     } );
 

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -155,7 +155,7 @@ void game::list_missions()
             mvwprintz( w_missions, point( 31, 4 ), c_light_red, _( nope.at( tab ) ) );
         }
 
-        wrefresh( w_missions );
+        wnoutrefresh( w_missions );
     } );
 
     while( true ) {

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -73,6 +73,7 @@
 #include "translations.h"
 #include "type_id.h"
 #include "ui.h"
+#include "ui_manager.h"
 #include "units.h"
 #include "value_ptr.h"
 #include "weighted_list.h"
@@ -2596,7 +2597,9 @@ bool mattack::ranged_pull( monster *z )
         target->setpos( pt );
         range--;
         if( target->is_player() && seen ) {
-            g->draw();
+            g->invalidate_main_ui_adaptor();
+            ui_manager::redraw_invalidated();
+            refresh_display();
         }
     }
     // The monster might drag a target that's not on it's z level

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -757,7 +757,7 @@ void player_morale::display( int focus_eq, int pain_penalty, int fatigue_penalty
         draw_scrollbar( w, offset, rows_visible, rows_total,
                         point( 0, top_lines.size() ), c_white, true );
 
-        wrefresh( w );
+        wnoutrefresh( w );
     } );
 
     input_context ctxt( "MORALE" );

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -645,7 +645,6 @@ void Character::activate_mutation( const trait_id &mut )
         return;
     } else if( !mdata.ranged_mutation.empty() ) {
         add_msg_if_player( mdata.ranged_mutation_message() );
-        g->refresh_all();
         avatar_action::fire_ranged_mutation( g->u, g->m, item( mdata.ranged_mutation ) );
         tdata.powered = false;
         return;

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -65,7 +65,7 @@ static void show_mutations_titlebar( const catacurses::window &window,
     desc += shortcut_desc( _( "%s to change keybindings." ), ctxt.get_desc( "HELP_KEYBINDINGS" ) );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     fold_and_print( window, point( 1, 0 ), getmaxx( window ) - 1, c_white, desc );
-    wrefresh( window );
+    wnoutrefresh( window );
 }
 
 void player::power_mutations()
@@ -260,13 +260,13 @@ void player::power_mutations()
 
         draw_scrollbar( wBio, scroll_position, list_height, mutations_count,
                         point( 0, list_start_y ), c_white, true );
-        wrefresh( wBio );
+        wnoutrefresh( wBio );
         show_mutations_titlebar( w_title, menu_mode, ctxt );
 
         if( menu_mode == mutation_menu_mode::examining && examine_id.has_value() ) {
             werase( w_description );
             fold_and_print( w_description, point_zero, WIDTH - 2, c_light_blue, examine_id.value()->desc() );
-            wrefresh( w_description );
+            wnoutrefresh( w_description );
         }
     } );
 

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -39,6 +39,11 @@ catacurses::window catacurses::newwin( const int nlines, const int ncols, const 
     } );
 }
 
+void catacurses::wnoutrefresh( const window &win )
+{
+    return curses_check_result( ::wnoutrefresh( win.get<::WINDOW>() ), OK, "wnoutrefresh" );
+}
+
 void catacurses::wrefresh( const window &win )
 {
     return curses_check_result( ::wrefresh( win.get<::WINDOW>() ), OK, "wrefresh" );
@@ -109,6 +114,16 @@ void catacurses::wprintw( const window &win, const std::string &text )
 void catacurses::refresh()
 {
     return curses_check_result( ::refresh(), OK, "refresh" );
+}
+
+void refresh_display()
+{
+    catacurses::doupdate();
+}
+
+void catacurses::doupdate()
+{
+    return curses_check_result( ::doupdate(), OK, "doupdate" );
 }
 
 void catacurses::clear()
@@ -238,6 +253,8 @@ input_event input_manager::get_input_event()
     input_event rval;
     do {
         previously_pressed_key = 0;
+        // flush any output
+        catacurses::doupdate();
         key = getch();
         if( key != ERR ) {
             int newch;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -728,8 +728,8 @@ tab_direction set_points( avatar &, points_left &points )
         fold_and_print( w_description, point_zero, getmaxx( w_description ),
                         COL_SKILL_USED, std::get<2>( cur_opt ) );
 
-        wrefresh( w );
-        wrefresh( w_description );
+        wnoutrefresh( w );
+        wnoutrefresh( w_description );
     } );
 
     do {
@@ -907,8 +907,8 @@ tab_direction set_stats( avatar &u, points_left &points )
                 break;
         }
 
-        wrefresh( w );
-        wrefresh( w_description );
+        wnoutrefresh( w );
+        wnoutrefresh( w_description );
     } );
 
     do {
@@ -1184,8 +1184,8 @@ tab_direction set_traits( avatar &u, points_left &points )
                             point( page_width * iCurrentPage, 5 ) );
         }
 
-        wrefresh( w );
-        wrefresh( w_description );
+        wnoutrefresh( w );
+        wnoutrefresh( w_description );
     } );
 
     do {
@@ -1569,11 +1569,11 @@ tab_direction set_profession( avatar &u, points_left &points,
 
         draw_scrollbar( w, cur_id, iContentHeight, profs_length, point( 0, 5 ) );
 
-        wrefresh( w );
-        wrefresh( w_description );
-        wrefresh( w_items );
-        wrefresh( w_genderswap );
-        wrefresh( w_sorting );
+        wnoutrefresh( w );
+        wnoutrefresh( w_description );
+        wnoutrefresh( w_items );
+        wnoutrefresh( w_genderswap );
+        wnoutrefresh( w_sorting );
     } );
 
     do {
@@ -1849,8 +1849,8 @@ tab_direction set_skills( avatar &u, points_left &points )
 
         draw_scrollbar( w, cur_pos, iContentHeight, num_skills, point( 0, 5 ) );
 
-        wrefresh( w );
-        wrefresh( w_description );
+        wnoutrefresh( w );
+        wnoutrefresh( w_description );
     } );
 
     do {
@@ -2161,13 +2161,13 @@ tab_direction set_scenario( avatar &u, points_left &points,
         }
 
         draw_scrollbar( w, cur_id, iContentHeight, scens_length, point( 0, 5 ) );
-        wrefresh( w );
-        wrefresh( w_description );
-        wrefresh( w_sorting );
-        wrefresh( w_profession );
-        wrefresh( w_location );
-        wrefresh( w_vehicle );
-        wrefresh( w_flags );
+        wnoutrefresh( w );
+        wnoutrefresh( w_description );
+        wnoutrefresh( w_sorting );
+        wnoutrefresh( w_profession );
+        wnoutrefresh( w_location );
+        wnoutrefresh( w_vehicle );
+        wnoutrefresh( w_flags );
     } );
 
     do {
@@ -2274,7 +2274,7 @@ static void draw_height( const catacurses::window &w_height, const avatar &you,
     unsigned height_pos = 1 + utf8_width( _( "Height:" ) );
     mvwprintz( w_height, point( height_pos, 0 ), c_white, string_format( "%d cm",
                you.base_height() ) );
-    wrefresh( w_height );
+    wnoutrefresh( w_height );
 }
 
 static void draw_age( const catacurses::window &w_age, const avatar &you, const bool highlight )
@@ -2283,7 +2283,7 @@ static void draw_age( const catacurses::window &w_age, const avatar &you, const 
     mvwprintz( w_age, point_zero, highlight ? h_light_gray : c_light_gray, _( "Age:" ) );
     unsigned age_pos = 1 + utf8_width( _( "Age:" ) );
     mvwprintz( w_age, point( age_pos, 0 ), c_white, string_format( "%d", you.base_age() ) );
-    wrefresh( w_age );
+    wnoutrefresh( w_age );
 }
 } // namespace char_creation
 
@@ -2396,7 +2396,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
                 wputch( w, BORDER_COLOR, LINE_OXOX );
             }
         }
-        wrefresh( w );
+        wnoutrefresh( w );
 
         wclear( w_stats );
         wclear( w_traits );
@@ -2419,7 +2419,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
         mvwprintz( w_stats, point( pos + 1, 2 ), c_light_gray, "%2d", you.dex_max );
         mvwprintz( w_stats, point( pos + 1, 3 ), c_light_gray, "%2d", you.int_max );
         mvwprintz( w_stats, point( pos + 1, 4 ), c_light_gray, "%2d", you.per_max );
-        wrefresh( w_stats );
+        wnoutrefresh( w_stats );
 
         mvwprintz( w_traits, point_zero, COL_HEADER, _( "Traits: " ) );
         std::vector<trait_id> current_traits = points.limit == points_left::TRANSFER ? you.get_mutations() :
@@ -2434,7 +2434,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
                                 current_trait->get_display_color(), current_trait->name() );
             }
         }
-        wrefresh( w_traits );
+        wnoutrefresh( w_traits );
 
         mvwprintz( w_skills, point_zero, COL_HEADER, _( "Skills:" ) );
 
@@ -2473,7 +2473,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
         if( !has_skills ) {
             mvwprintz( w_skills, point( utf8_width( _( "Skills:" ) ) + 1, 0 ), c_light_red, _( "None!" ) );
         }
-        wrefresh( w_skills );
+        wnoutrefresh( w_skills );
 
 
         fold_and_print( w_guide, point( 0, getmaxy( w_guide ) - 4 ), ( TERMX / 2 ), c_light_gray,
@@ -2508,7 +2508,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
                             _( "Press <color_light_green>%s</color> to save a template of this character." ),
                             ctxt.get_desc( "SAVE_TEMPLATE" ) );
         }
-        wrefresh( w_guide );
+        wnoutrefresh( w_guide );
 
         wclear( w_name );
         mvwprintz( w_name, point_zero,
@@ -2527,7 +2527,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
                             _( "Press <color_light_green>%s</color> to edit.\nPress <color_light_green>%s</color> to randomize description." ),
                             ctxt.get_desc( "CONFIRM" ), ctxt.get_desc( "RANDOMIZE_CHAR_DESCRIPTION" ) );
         }
-        wrefresh( w_name );
+        wnoutrefresh( w_name );
 
         mvwprintz( w_gender, point_zero, c_light_gray, _( "Gender:" ) );
         mvwprintz( w_gender, point( male_pos, 0 ), ( you.male ? c_light_cyan : c_light_gray ),
@@ -2538,7 +2538,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
         fold_and_print( w_gender, point( 0, 1 ), ( TERMX / 2 ), c_light_gray,
                         _( "Press <color_light_green>%s</color> to switch gender" ),
                         ctxt.get_desc( "CHANGE_GENDER" ) );
-        wrefresh( w_gender );
+        wnoutrefresh( w_gender );
 
         char_creation::draw_age( w_age, you, current_selector == char_creation::AGE );
         char_creation::draw_height( w_height, you, current_selector == char_creation::HEIGHT );
@@ -2558,7 +2558,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
                    string_format( remove_color_tags( START_LOC_TEXT_TEMPLATE ),
                                   you.start_location.obj().name(),
                                   you.start_location.obj().targets_count() ) );
-        wrefresh( w_location );
+        wnoutrefresh( w_location );
 
         werase( w_vehicle );
         mvwprintz( w_vehicle, point_zero, c_light_gray, _( "Starting Vehicle: " ) );
@@ -2569,17 +2569,17 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
         } else if( prof_veh ) {
             wprintz( w_vehicle, c_light_green, prof_veh->name );
         }
-        wrefresh( w_vehicle );
+        wnoutrefresh( w_vehicle );
 
         werase( w_scenario );
         mvwprintz( w_scenario, point_zero, COL_HEADER, _( "Scenario: " ) );
         wprintz( w_scenario, c_light_gray, g->scen->gender_appropriate_name( you.male ) );
-        wrefresh( w_scenario );
+        wnoutrefresh( w_scenario );
 
         werase( w_profession );
         mvwprintz( w_profession, point_zero, COL_HEADER, _( "Profession: " ) );
         wprintz( w_profession, c_light_gray, you.prof->gender_appropriate_name( you.male ) );
-        wrefresh( w_profession );
+        wnoutrefresh( w_profession );
     } );
 
     // do not switch IME mode now, but restore previous mode on return

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -279,7 +279,6 @@ static void npc_temp_orders_menu( const std::vector<npc *> &npc_list )
             output_string += std::string( "\n" ) +
                              _( "Other followers might have different temporary orders." );
         }
-        g->refresh_all();
         nmenu.reset();
         nmenu.text = _( "Issue what temporary order?" );
         nmenu.desc_enabled = true;
@@ -623,7 +622,6 @@ void game::chat()
     }
 
     u.moves -= 100;
-    refresh_all();
 }
 
 void npc::handle_sound( const sounds::sound_t spriority, const std::string &description,
@@ -878,7 +876,6 @@ void npc::talk_to_u( bool radio_contact )
             d.add_topic( next );
         }
     } while( !d.done );
-    g->refresh_all();
 
     if( g->u.activity.id() == ACT_AIM && !g->u.has_weapon() ) {
         g->u.cancel_activity();

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -398,9 +398,9 @@ void trading_window::update_win( npc &np, const std::string &deal )
             mvwprintw( w_whose, point( 9, entries_per_page + 2 ), _( "More >" ) );
         }
     }
-    wrefresh( w_head );
-    wrefresh( w_them );
-    wrefresh( w_you );
+    wnoutrefresh( w_head );
+    wnoutrefresh( w_them );
+    wnoutrefresh( w_you );
 }
 
 void trading_window::show_item_data( size_t offset,
@@ -421,7 +421,7 @@ void trading_window::show_item_data( size_t offset,
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         mvwprintz( w_tmp, point( 1, 1 ), c_red, _( "Examine which item?" ) );
         draw_border( w_tmp );
-        wrefresh( w_tmp );
+        wnoutrefresh( w_tmp );
     } );
 
     input_context ctxt( "NPC_TRADE" );

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -715,7 +715,6 @@ bool npc_trading::trade( npc &np, int cost, const std::string &deal )
             g->u.practice( skill_barter, practice / 10000 );
         }
     }
-    g->refresh_all();
     return traded;
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2480,7 +2480,7 @@ static void draw_borders_external(
             mvwputch( w, point( mapLine.first + 1, getmaxy( w ) - 1 ), BORDER_COLOR, LINE_XXOX ); // _|_
         }
     }
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_borders_internal( const catacurses::window &w, std::map<int, bool> &mapLines )
@@ -2494,7 +2494,7 @@ static void draw_borders_internal( const catacurses::window &w, std::map<int, bo
             mvwputch( w, point( i, 0 ), BORDER_COLOR, LINE_OXOX );
         }
     }
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 std::string options_manager::show( bool ingame, const bool world_options_only,
@@ -2664,7 +2664,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
 
         draw_scrollbar( w_options_border, iCurrentLine, iContentHeight,
                         page_items.size(), point( 0, iTooltipHeight + 2 + iWorldOffset ), BORDER_COLOR );
-        wrefresh( w_options_border );
+        wnoutrefresh( w_options_border );
 
         //Draw Tabs
         if( !world_options_only ) {
@@ -2683,7 +2683,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
             }
         }
 
-        wrefresh( w_options_header );
+        wnoutrefresh( w_options_header );
 
         const std::string &opt_name = *page_items[iCurrentLine];
         cOpt &current_opt = cOPTIONS[opt_name];
@@ -2732,9 +2732,9 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
             wprintz( w_options_tooltip, c_white, "%s",
                      _( "Some of these options may produce unexpected results if changed." ) );
         }
-        wrefresh( w_options_tooltip );
+        wnoutrefresh( w_options_tooltip );
 
-        wrefresh( w_options );
+        wnoutrefresh( w_options );
     } );
 
     while( true ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2450,9 +2450,6 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
             tilecontext->load_tileset( get_option<std::string>( "TILES" ) );
             //g->init_ui is called when zoom is changed
             g->reset_zoom();
-            if( ingame ) {
-                g->refresh_all();
-            }
             tilecontext->do_tile_loading_report();
         } catch( const std::exception &err ) {
             popup( _( "Loading the tileset failed: %s" ), err.what() );

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -336,14 +336,6 @@ int fold_and_print_from( const catacurses::window &w, const point &begin, int wi
     return textformatted.size();
 }
 
-void scrollable_text( const catacurses::window &w, const std::string &title,
-                      const std::string &text )
-{
-    scrollable_text( [&w]() {
-        return w;
-    }, title, text );
-}
-
 void scrollable_text( const std::function<catacurses::window()> &init_window,
                       const std::string &title, const std::string &text )
 {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -386,7 +386,7 @@ void scrollable_text( const std::function<catacurses::window()> &init_window,
         }
         scrollbar().offset_x( width - 1 ).offset_y( text_y ).content_size( lines.size() )
         .viewport_pos( std::min( beg_line, max_beg_line ) ).viewport_size( text_h ).apply( w );
-        wrefresh( w );
+        wnoutrefresh( w );
     } );
 
     std::string action;
@@ -773,7 +773,7 @@ input_event draw_item_info( const int iLeft, const int iWidth, const int iTop, c
     clear_window_area( win );
 #endif // TILES
     wclear( win );
-    wrefresh( win );
+    wnoutrefresh( win );
 
     const input_event result = draw_item_info( win, data );
     return result;
@@ -861,7 +861,7 @@ void draw_item_filter_rules( const catacurses::window &win, int starty, int heig
     fold_and_print( win, point( 1, starty ), len, c_white,
                     //~ An example of how to filter items based on category or material.
                     _( "Examples: c:food,m:iron,q:hammering,n:toolshelf,d:pipe" ) );
-    wrefresh( win );
+    wnoutrefresh( win );
 }
 
 std::string format_item_info( const std::vector<iteminfo> &vItemDisplay,
@@ -1005,7 +1005,7 @@ input_event draw_item_info( const std::function<catacurses::window()> &init_wind
         if( !data.without_border ) {
             draw_custom_border( win, buffer.empty() );
         }
-        wrefresh( win );
+        wnoutrefresh( win );
     };
 
     if( data.without_getch ) {
@@ -1525,7 +1525,7 @@ void scrolling_text_view::draw( const nc_color &base_color )
                             text_[line_num + offset_] );
     }
 
-    wrefresh( w_ );
+    wnoutrefresh( w_ );
 }
 
 int scrolling_text_view::text_width()

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2330,10 +2330,6 @@ bool is_draw_tiles_mode()
 {
     return false;
 }
-
-void refresh_display()
-{
-}
 #endif
 
 void mvwprintz( const catacurses::window &w, const point &p, const nc_color &FG,

--- a/src/output.h
+++ b/src/output.h
@@ -324,8 +324,6 @@ void center_print( const catacurses::window &w, int y, const nc_color &FG,
                    const std::string &text );
 int right_print( const catacurses::window &w, int line, int right_indent,
                  const nc_color &FG, const std::string &text );
-void scrollable_text( const catacurses::window &w, const std::string &title,
-                      const std::string &text );
 void scrollable_text( const std::function<catacurses::window()> &init_window,
                       const std::string &title, const std::string &text );
 std::string name_and_value( const std::string &name, int value, int field_width );

--- a/src/output.h
+++ b/src/output.h
@@ -839,7 +839,7 @@ class scrollbar
 // Update the text with set_text (it will be wrapped for you).
 // scroll_up and scroll_down are expected to be called from handlers for the
 // keys used for that purpose.
-// Call draw when drawing related UI stuff.  draw calls werase/wrefresh for its
+// Call draw when drawing related UI stuff.  draw calls werase/wnoutrefresh for its
 // window internally.
 class scrolling_text_view
 {

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -168,7 +168,7 @@ static void update_note_preview( const std::string &note,
     draw_border( *w_preview );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( *w_preview, point( 1, 1 ), c_white, _( "Note preview" ) );
-    wrefresh( *w_preview );
+    wnoutrefresh( *w_preview );
 
     werase( *w_preview_title );
     nc_color default_color = c_unset;
@@ -179,7 +179,7 @@ static void update_note_preview( const std::string &note,
         mvwputch( *w_preview_title, point( i, 1 ), c_white, LINE_OXOX );
     }
     mvwputch( *w_preview_title, point( note_text_width, 1 ), c_white, LINE_XOOX );
-    wrefresh( *w_preview_title );
+    wnoutrefresh( *w_preview_title );
 
     const int npm_offset_x = 1;
     const int npm_offset_y = 1;
@@ -193,7 +193,7 @@ static void update_note_preview( const std::string &note,
     }
     mvwputch( *w_preview_map, point( npm_width / 2 + npm_offset_x, npm_height / 2 + npm_offset_y ),
               note_color, symbol );
-    wrefresh( *w_preview_map );
+    wnoutrefresh( *w_preview_map );
 }
 
 static weather_type get_weather_at_point( const tripoint &pos )
@@ -1059,9 +1059,9 @@ void draw( const catacurses::window &w, const catacurses::window &wbar, const tr
         mvwputch( w, point( om_half_width + 1, om_half_height + 1 ), c_light_gray, LINE_XOOX );
     }
     // Done with all drawing!
-    wrefresh( wbar );
+    wnoutrefresh( wbar );
     wmove( w, point( om_half_width, om_half_height ) );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 void create_note( const tripoint &curs )
@@ -1255,7 +1255,7 @@ static bool search( const ui_adaptor &om_ui, tripoint &curs, const tripoint &ori
         fold_and_print( w_search, point( 1, 11 ), search_width, c_white,
                         _( "Press [<color_yellow>%s</color>] to quit." ), ctxt.get_desc( "QUIT" ) );
         draw_border( w_search );
-        wrefresh( w_search );
+        wnoutrefresh( w_search );
     } );
 
     std::string action;
@@ -1381,7 +1381,7 @@ static void place_ter_or_special( const ui_adaptor &om_ui, tripoint &curs,
             mvwprintz( w_editor, point( 1, 12 ), c_white, _( "[%s] Apply" ),
                        ctxt.get_desc( "CONFIRM" ) );
             mvwprintz( w_editor, point( 1, 13 ), c_white, _( "[ESCAPE/Q] Cancel" ) );
-            wrefresh( w_editor );
+            wnoutrefresh( w_editor );
         } );
 
         std::string action;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1424,6 +1424,8 @@ static void place_ter_or_special( const ui_adaptor &om_ui, tripoint &curs,
 
 static tripoint display( const tripoint &orig, const draw_data_t &data = draw_data_t() )
 {
+    background_pane bg_pane;
+
     ui_adaptor ui;
     ui.on_screen_resize( []( ui_adaptor & ui ) {
         /**

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -957,7 +957,7 @@ static void draw_limb2( avatar &u, const catacurses::window &w )
     const auto pwr = power_stat( u );
     mvwprintz( w, point( 31 - utf8_width( pwr.second ), 1 ), pwr.first, pwr.second );
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_stats( avatar &u, const catacurses::window &w )
@@ -983,7 +983,7 @@ static void draw_stats( avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 25, 0 ), c_light_gray, _( "PER" ) );
     mvwprintz( w, point( stat < 10 ? 30 : 29, 0 ), stat_clr,
                stat < 100 ? to_string( stat ) : "99+" );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static nc_color move_mode_color( avatar &u )
@@ -1024,7 +1024,7 @@ static void draw_stealth( avatar &u, const catacurses::window &w )
         mvwprintz( w, point( 30 - utf8_width( snd ), 0 ), u.volume != 0 ? c_yellow : c_light_gray, snd );
     }
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_time_graphic( const catacurses::window &w )
@@ -1093,7 +1093,7 @@ static void draw_time( const avatar &u, const catacurses::window &w )
     nc_color clr = c_white;
     print_colored_text( w, point( 27, 0 ), clr, c_white, get_moon_graphic() );
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_needs_compact( const avatar &u, const catacurses::window &w )
@@ -1118,7 +1118,7 @@ static void draw_needs_compact( const avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 17, 2 ), c_light_gray, _( "Focus" ) );
     mvwprintz( w, point( 24, 2 ), focus_color( u.focus_pool ), to_string( u.focus_pool ) );
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_limb_narrow( avatar &u, const catacurses::window &w )
@@ -1161,7 +1161,7 @@ static void draw_limb_narrow( avatar &u, const catacurses::window &w )
         str = left_justify( str, 5 );
         wprintz( w, u.limb_color( part[i], true, true, true ), str + ":" );
     }
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_limb_wide( avatar &u, const catacurses::window &w )
@@ -1185,7 +1185,7 @@ static void draw_limb_wide( avatar &u, const catacurses::window &w )
         print_colored_text( w, point( nx, ny ), part_color, c_white, str );
         draw_limb_health( u, w, parts[i].second );
     }
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_char_narrow( avatar &u, const catacurses::window &w )
@@ -1226,7 +1226,7 @@ static void draw_char_narrow( avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 26, 0 ), morale_pair.first, "%s", smiley );
     mvwprintz( w, point( 26, 1 ), focus_color( u.get_speed() ), "%s", u.get_speed() );
     mvwprintz( w, point( 26, 2 ), move_color, "%s", movecost );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_char_wide( avatar &u, const catacurses::window &w )
@@ -1263,7 +1263,7 @@ static void draw_char_wide( avatar &u, const catacurses::window &w )
 
     mvwprintz( w, point( 23, 1 ), focus_color( u.get_speed() ), "%s", u.get_speed() );
     mvwprintz( w, point( 38, 1 ), move_color, "%s", movecost );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_stat_narrow( avatar &u, const catacurses::window &w )
@@ -1291,7 +1291,7 @@ static void draw_stat_narrow( avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 19, 2 ), c_light_gray, _( "Safe :" ) );
     mvwprintz( w, point( 8, 2 ), pwr_pair.first, "%s", pwr_pair.second );
     mvwprintz( w, point( 26, 2 ), safe_color(), g->safe_mode ? _( "On" ) : _( "Off" ) );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_stat_wide( avatar &u, const catacurses::window &w )
@@ -1317,7 +1317,7 @@ static void draw_stat_wide( avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 31, 1 ), c_light_gray, _( "Safe :" ) );
     mvwprintz( w, point( 38, 0 ), pwr_pair.first, "%s", pwr_pair.second );
     mvwprintz( w, point( 38, 1 ), safe_color(), g->safe_mode ? _( "On" ) : _( "Off" ) );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_loc_labels( const avatar &u, const catacurses::window &w, bool minimap )
@@ -1363,7 +1363,7 @@ static void draw_loc_labels( const avatar &u, const catacurses::window &w, bool 
         const tripoint curs = u.global_omt_location();
         overmap_ui::draw_overmap_chunk( w, u, curs, point( offset, -1 ), 5, 5 );
     }
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_loc_narrow( const avatar &u, const catacurses::window &w )
@@ -1388,7 +1388,7 @@ static void draw_moon_narrow( const avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Moon : %s" ), get_moon() );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 1 ), c_light_gray, _( "Temp : %s" ), get_temp( u ) );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_moon_wide( const avatar &u, const catacurses::window &w )
@@ -1397,7 +1397,7 @@ static void draw_moon_wide( const avatar &u, const catacurses::window &w )
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Moon : %s" ), get_moon() );
     mvwprintz( w, point( 23, 0 ), c_light_gray, _( "Temp : %s" ), get_temp( u ) );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_weapon_labels( const avatar &u, const catacurses::window &w )
@@ -1409,7 +1409,7 @@ static void draw_weapon_labels( const avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 1, 1 ), c_light_gray, _( "Style:" ) );
     trim_and_print( w, point( 8, 0 ), getmaxx( w ) - 8, c_light_gray, u.weapname() );
     mvwprintz( w, point( 8, 1 ), c_light_gray, "%s", u.martial_arts_data.selected_style_name( u ) );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_needs_narrow( const avatar &u, const catacurses::window &w )
@@ -1432,7 +1432,7 @@ static void draw_needs_narrow( const avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 8, 2 ), rest_pair.second, rest_pair.first );
     mvwprintz( w, point( 8, 3 ), pain_pair.second, pain_pair.first );
     mvwprintz( w, point( 8, 4 ), temp_pair.first, temp_pair.second );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_needs_labels( const avatar &u, const catacurses::window &w )
@@ -1456,7 +1456,7 @@ static void draw_needs_labels( const avatar &u, const catacurses::window &w )
     mvwprintz( w, point( 30, 1 ), hunger_pair.second, hunger_pair.first );
     mvwprintz( w, point( 1, 2 ), c_light_gray, _( "Heat :" ) );
     mvwprintz( w, point( 8, 2 ), temp_pair.first, temp_pair.second );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_sound_labels( const avatar &u, const catacurses::window &w )
@@ -1469,7 +1469,7 @@ static void draw_sound_labels( const avatar &u, const catacurses::window &w )
     } else {
         mvwprintz( w, point( 8, 0 ), c_red, _( "Deaf!" ) );
     }
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_sound_narrow( const avatar &u, const catacurses::window &w )
@@ -1482,7 +1482,7 @@ static void draw_sound_narrow( const avatar &u, const catacurses::window &w )
     } else {
         mvwprintz( w, point( 8, 0 ), c_red, _( "Deaf!" ) );
     }
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_env_compact( avatar &u, const catacurses::window &w )
@@ -1519,7 +1519,7 @@ static void draw_env_compact( avatar &u, const catacurses::window &w )
         mvwprintz( w, point( 31 - utf8_width( temp ), 5 ), c_light_gray, temp );
     }
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void render_wind( avatar &u, const catacurses::window &w, const std::string &formatstr )
@@ -1533,7 +1533,7 @@ static void render_wind( avatar &u, const catacurses::window &w, const std::stri
                                             u.pos(), g->weather.winddirection, g->is_sheltered( u.pos() ) );
     mvwprintz( w, point( 8, 0 ), get_wind_color( windpower ),
                get_wind_desc( windpower ) + " " + get_wind_arrow( g->weather.winddirection ) );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_wind( avatar &u, const catacurses::window &w )
@@ -1658,7 +1658,7 @@ static void draw_health_classic( avatar &u, const catacurses::window &w )
         }
     }
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_armor_padding( const avatar &u, const catacurses::window &w )
@@ -1679,7 +1679,7 @@ static void draw_armor_padding( const avatar &u, const catacurses::window &w )
     print_colored_text( w, point( 8, 2 ), color, color, get_armor( u, bp_arm_r, max_length ) );
     print_colored_text( w, point( 8, 3 ), color, color, get_armor( u, bp_leg_r, max_length ) );
     print_colored_text( w, point( 8, 4 ), color, color, get_armor( u, bp_foot_r, max_length ) );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_armor( const avatar &u, const catacurses::window &w )
@@ -1699,7 +1699,7 @@ static void draw_armor( const avatar &u, const catacurses::window &w )
     print_colored_text( w, point( 7, 2 ), color, color, get_armor( u, bp_arm_r, max_length ) );
     print_colored_text( w, point( 7, 3 ), color, color, get_armor( u, bp_leg_r, max_length ) );
     print_colored_text( w, point( 7, 4 ), color, color, get_armor( u, bp_foot_r, max_length ) );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_messages( avatar &, const catacurses::window &w )
@@ -1708,7 +1708,7 @@ static void draw_messages( avatar &, const catacurses::window &w )
     int line = getmaxy( w ) - 2;
     int maxlength = getmaxx( w );
     Messages::display_messages( w, 1, 0 /*topline*/, maxlength - 1, line );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_messages_classic( avatar &, const catacurses::window &w )
@@ -1717,7 +1717,7 @@ static void draw_messages_classic( avatar &, const catacurses::window &w )
     int line = getmaxy( w ) - 2;
     int maxlength = getmaxx( w );
     Messages::display_messages( w, 0, 0 /*topline*/, maxlength, line );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 #if defined(TILES)
@@ -1725,7 +1725,7 @@ static void draw_mminimap( avatar &, const catacurses::window &w )
 {
     werase( w );
     g->draw_pixel_minimap( w );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 #endif
 
@@ -1733,14 +1733,14 @@ static void draw_compass( avatar &, const catacurses::window &w )
 {
     werase( w );
     g->mon_info( w );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_compass_padding( avatar &, const catacurses::window &w )
 {
     werase( w );
     g->mon_info( w, 1 );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_veh_compact( const avatar &u, const catacurses::window &w )
@@ -1772,7 +1772,7 @@ static void draw_veh_compact( const avatar &u, const catacurses::window &w )
         }
     }
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_veh_padding( const avatar &u, const catacurses::window &w )
@@ -1804,7 +1804,7 @@ static void draw_veh_padding( const avatar &u, const catacurses::window &w )
         }
     }
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_ai_goal( const avatar &u, const catacurses::window &w )
@@ -1816,7 +1816,7 @@ static void draw_ai_goal( const avatar &u, const catacurses::window &w )
     std::string current_need = needs.tick( &player_oracle );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 0 ), c_light_gray, _( "Goal: %s" ), current_need );
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_location_classic( const avatar &u, const catacurses::window &w )
@@ -1827,7 +1827,7 @@ static void draw_location_classic( const avatar &u, const catacurses::window &w 
     mvwprintz( w, point( 10, 0 ), c_white, utf8_truncate( overmap_buffer.ter(
                    u.global_omt_location() )->get_name(), getmaxx( w ) - 13 ) );
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_weather_classic( avatar &, const catacurses::window &w )
@@ -1845,7 +1845,7 @@ static void draw_weather_classic( avatar &, const catacurses::window &w )
     nc_color clr = c_white;
     print_colored_text( w, point( 38, 0 ), clr, c_white, get_moon_graphic() );
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_lighting_classic( const avatar &u, const catacurses::window &w )
@@ -1863,7 +1863,7 @@ static void draw_lighting_classic( const avatar &u, const catacurses::window &w 
         mvwprintz( w, point( 31, 0 ), c_red, _( "Deaf!" ) );
     }
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_weapon_classic( const avatar &u, const catacurses::window &w )
@@ -1881,7 +1881,7 @@ static void draw_weapon_classic( const avatar &u, const catacurses::window &w )
         mvwprintz( w, point( 31, 0 ), style_color, style );
     }
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_time_classic( const avatar &u, const catacurses::window &w )
@@ -1909,7 +1909,7 @@ static void draw_time_classic( const avatar &u, const catacurses::window &w )
         mvwprintz( w, point( 31, 0 ), c_light_gray, _( "Temp : " ) + temp );
     }
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_hint( const avatar &, const catacurses::window &w )
@@ -1920,7 +1920,7 @@ static void draw_hint( const avatar &, const catacurses::window &w )
     mvwprintz( w, point( 1, 0 ), c_light_green, press );
     mvwprintz( w, point( 2 + utf8_width( press ), 0 ), c_white, _( "to open sidebar options" ) );
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void print_mana( const player &u, const catacurses::window &w, const std::string &fmt_string,
@@ -1939,7 +1939,7 @@ static void print_mana( const player &u, const catacurses::window &w, const std:
     nc_color gray = c_light_gray;
     print_colored_text( w, point_zero, gray, gray, mana_string );
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 static void draw_mana_classic( const player &u, const catacurses::window &w )
@@ -2328,7 +2328,7 @@ void panel_manager::show_adm()
                    col_width ) + ":" );
         mvwprintz( w, point( col_offset, 6 ), c_white, _( "Exit" ) );
 
-        wrefresh( w );
+        wnoutrefresh( w );
     } );
 
     while( !exit ) {

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -648,7 +648,7 @@ void Pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                 draw_item_info( w_item_info, dummy );
             } else {
                 werase( w_item_info );
-                wrefresh( w_item_info );
+                wnoutrefresh( w_item_info );
             }
             draw_custom_border( w_item_info, 0 );
 
@@ -657,7 +657,7 @@ void Pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
             trim_and_print( w_item_info, point( 4, 0 ), pickupW - 8, selected_item.color_in_inventory(),
                             selected_item.display_name() );
             wprintw( w_item_info, " >" );
-            wrefresh( w_item_info );
+            wnoutrefresh( w_item_info );
 
             const std::string pickup_chars = ctxt.get_available_single_char_hotkeys( all_pickup_chars );
 
@@ -770,7 +770,7 @@ void Pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
                                            fmted_weight_predict, fmted_weight_capacity,
                                            fmted_volume_predict, fmted_volume_capacity ) );
 
-            wrefresh( w_pickup );
+            wnoutrefresh( w_pickup );
         } );
 
         // Now print the two lists; those on the ground and about to be added to inv

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -362,7 +362,7 @@ static void draw_stats_tab( const catacurses::window &w_stats,
     mvwprintz( w_stats, point( 25 - utf8_width( you.age_string() ), 7 ), line_color( 6 ),
                you.age_string() );
 
-    wrefresh( w_stats );
+    wnoutrefresh( w_stats );
 }
 
 static void draw_stats_info( const catacurses::window &w_info,
@@ -435,7 +435,7 @@ static void draw_stats_info( const catacurses::window &w_info,
         fold_and_print( w_info, point( 1, 1 + lines ), FULL_SCREEN_WIDTH - 2, c_light_gray,
                         you.age_string() );
     }
-    wrefresh( w_info );
+    wnoutrefresh( w_info );
 }
 
 static void draw_encumbrance_tab( const catacurses::window &w_encumb,
@@ -450,7 +450,7 @@ static void draw_encumbrance_tab( const catacurses::window &w_encumb,
     } else {
         you.print_encumbrance( w_encumb );
     }
-    wrefresh( w_encumb );
+    wnoutrefresh( w_encumb );
 }
 
 static void draw_encumbrance_info( const catacurses::window &w_info,
@@ -468,7 +468,7 @@ static void draw_encumbrance_info( const catacurses::window &w_info,
     const std::string s = get_encumbrance_description( you, bp, combined_here );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, s );
-    wrefresh( w_info );
+    wnoutrefresh( w_info );
 }
 
 static void draw_traits_tab( const catacurses::window &w_traits,
@@ -507,7 +507,7 @@ static void draw_traits_tab( const catacurses::window &w_traits,
         trim_and_print( w_traits, point( 1, static_cast<int>( 1 + i - min ) ), getmaxx( w_traits ) - 1,
                         is_current_tab && i == line ? hilite( color ) : color, mdata.name() );
     }
-    wrefresh( w_traits );
+    wnoutrefresh( w_traits );
 }
 
 static void draw_traits_info( const catacurses::window &w_info, const unsigned int line,
@@ -520,7 +520,7 @@ static void draw_traits_info( const catacurses::window &w_info, const unsigned i
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, string_format(
                             "%s: %s", colorize( mdata.name(), mdata.get_display_color() ), traitslist[line]->desc() ) );
     }
-    wrefresh( w_info );
+    wnoutrefresh( w_info );
 }
 
 static void draw_bionics_tab( const catacurses::window &w_bionics,
@@ -558,7 +558,7 @@ static void draw_bionics_tab( const catacurses::window &w_bionics,
         trim_and_print( w_bionics, point( 1, static_cast<int>( 2 + i - min ) ), getmaxx( w_bionics ) - 1,
                         is_current_tab && i == line ? hilite( c_white ) : c_white, "%s", bionicslist[i].info().name );
     }
-    wrefresh( w_bionics );
+    wnoutrefresh( w_bionics );
 }
 
 static void draw_bionics_info( const catacurses::window &w_info, const unsigned int line,
@@ -570,7 +570,7 @@ static void draw_bionics_info( const catacurses::window &w_info, const unsigned 
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, "%s",
                         bionicslist[line].info().description );
     }
-    wrefresh( w_info );
+    wnoutrefresh( w_info );
 }
 
 static void draw_effects_tab( const catacurses::window &w_effects,
@@ -611,7 +611,7 @@ static void draw_effects_tab( const catacurses::window &w_effects,
         trim_and_print( w_effects, point( 0, static_cast<int>( 1 + i - min ) ), getmaxx( w_effects ) - 1,
                         is_current_tab && i == line ? h_light_gray : c_light_gray, effect_name_and_text[i].first );
     }
-    wrefresh( w_effects );
+    wnoutrefresh( w_effects );
 }
 
 static void draw_effects_info( const catacurses::window &w_info, const unsigned int line,
@@ -624,7 +624,7 @@ static void draw_effects_info( const catacurses::window &w_info, const unsigned 
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray,
                         effect_name_and_text[line].second );
     }
-    wrefresh( w_info );
+    wnoutrefresh( w_info );
 }
 
 struct HeaderSkill {
@@ -728,7 +728,7 @@ static void draw_skills_tab( const catacurses::window &w_skills,
                         // NOLINTNEXTLINE(cata-use-named-point-constants)
                         point( 0, 1 ) );
     }
-    wrefresh( w_skills );
+    wnoutrefresh( w_skills );
 }
 
 static void draw_skills_info( const catacurses::window &w_info, unsigned int line,
@@ -750,7 +750,7 @@ static void draw_skills_info( const catacurses::window &w_info, unsigned int lin
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray,
                         selectedSkill->description() );
     }
-    wrefresh( w_info );
+    wnoutrefresh( w_info );
 }
 
 static void draw_speed_tab( const catacurses::window &w_speed,
@@ -852,7 +852,7 @@ static void draw_speed_tab( const catacurses::window &w_speed,
     col = ( newmoves >= 100 ? c_green : c_red );
     mvwprintz( w_speed, point( 21 + ( newmoves >= 100 ? 0 : ( newmoves < 10 ? 2 : 1 ) ), 2 ), col,
                "%d", newmoves );
-    wrefresh( w_speed );
+    wnoutrefresh( w_speed );
 }
 
 static void draw_info_window( const catacurses::window &w_info, const player &you,
@@ -915,7 +915,7 @@ static void draw_tip( const catacurses::window &w_tip, const player &you,
                      _( "[<color_yellow>%s</color>]" ),
                      ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
 
-    wrefresh( w_tip );
+    wnoutrefresh( w_tip );
 }
 
 static bool handle_player_display_action( player &you, unsigned int &line,
@@ -1274,7 +1274,7 @@ void player::disp_info()
     ui_stats.mark_resize();
     ui_stats.on_redraw( [&]( const ui_adaptor & ) {
         borders.draw_border( w_stats_border );
-        wrefresh( w_stats_border );
+        wnoutrefresh( w_stats_border );
         draw_stats_tab( w_stats, *this, line, curtab );
     } );
 
@@ -1296,7 +1296,7 @@ void player::disp_info()
     ui_traits.mark_resize();
     ui_traits.on_redraw( [&]( const ui_adaptor & ) {
         borders.draw_border( w_traits_border );
-        wrefresh( w_traits_border );
+        wnoutrefresh( w_traits_border );
         draw_traits_tab( w_traits, line, curtab, traitslist, trait_win_size_y );
     } );
 
@@ -1320,7 +1320,7 @@ void player::disp_info()
     ui_bionics.mark_resize();
     ui_bionics.on_redraw( [&]( const ui_adaptor & ) {
         borders.draw_border( w_bionics_border );
-        wrefresh( w_bionics_border );
+        wnoutrefresh( w_bionics_border );
         draw_bionics_tab( w_bionics, *this, line, curtab, bionicslist, bionics_win_size_y );
     } );
 
@@ -1337,7 +1337,7 @@ void player::disp_info()
     ui_encumb.mark_resize();
     ui_encumb.on_redraw( [&]( const ui_adaptor & ) {
         borders.draw_border( w_encumb_border );
-        wrefresh( w_encumb_border );
+        wnoutrefresh( w_encumb_border );
         draw_encumbrance_tab( w_encumb, *this, line, curtab );
     } );
 
@@ -1357,7 +1357,7 @@ void player::disp_info()
     ui_effects.mark_resize();
     ui_effects.on_redraw( [&]( const ui_adaptor & ) {
         borders.draw_border( w_effects_border );
-        wrefresh( w_effects_border );
+        wnoutrefresh( w_effects_border );
         draw_effects_tab( w_effects, line, curtab, effect_name_and_text, effect_win_size_y );
     } );
 
@@ -1376,7 +1376,7 @@ void player::disp_info()
     ui_speed.mark_resize();
     ui_speed.on_redraw( [&]( const ui_adaptor & ) {
         borders.draw_border( w_speed_border );
-        wrefresh( w_speed_border );
+        wnoutrefresh( w_speed_border );
         draw_speed_tab( w_speed, *this, speed_effects );
     } );
 
@@ -1402,7 +1402,7 @@ void player::disp_info()
     ui_skills.mark_resize();
     ui_skills.on_redraw( [&]( const ui_adaptor & ) {
         borders.draw_border( w_skills_border );
-        wrefresh( w_skills_border );
+        wnoutrefresh( w_skills_border );
         draw_skills_tab( w_skills, *this, line, curtab, skillslist, skill_win_size_y );
     } );
 
@@ -1422,7 +1422,7 @@ void player::disp_info()
     ui_info.mark_resize();
     ui_info.on_redraw( [&]( const ui_adaptor & ) {
         borders.draw_border( w_info_border );
-        wrefresh( w_info_border );
+        wnoutrefresh( w_info_border );
         draw_info_window( w_info, *this, line, curtab,
                           traitslist, bionicslist, effect_name_and_text, skillslist );
     } );

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -236,7 +236,7 @@ void query_popup::show() const
                             col, col, btn.text );
     }
 
-    wrefresh( win );
+    wnoutrefresh( win );
 }
 
 std::shared_ptr<ui_adaptor> query_popup::create_or_get_adaptor()

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -350,11 +350,6 @@ query_popup::result query_popup::query()
     do {
         res = query_once();
     } while( res.wait_input );
-    // Erase the window so there's feedback during consecutive popups
-    werase( win );
-    wrefresh( win );
-    catacurses::refresh();
-    refresh_display();
     return res;
 }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1789,7 +1789,6 @@ std::vector<tripoint> target_handler::target_ui( player &pc, target_mode mode,
             // We need to do a bunch of redrawing and cache updates since we're
             // looking at a different z-level.
             g->m.invalidate_map_cache( dst.z );
-            g->refresh_all();
         }
 
         /* More drawing to terrain */
@@ -2313,7 +2312,7 @@ std::vector<tripoint> target_handler::target_ui( spell &casting, const bool no_f
 
             // We need to do a bunch of redrawing and cache updates since we're
             // looking at a different z-level.
-            g->refresh_all();
+            g->m.invalidate_map_cache( dst.z );
         }
 
         /* More drawing to terrain */

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -132,7 +132,7 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
             mvwputch( w_border, point( column.second + 1, FULL_SCREEN_HEIGHT - 1 ), c_light_gray, LINE_XXOX );
         }
 
-        wrefresh( w_border );
+        wnoutrefresh( w_border );
 
         static const std::vector<std::string> hotkeys = {{
                 translate_marker( "<A>dd" ), translate_marker( "<R>emove" ),
@@ -186,7 +186,7 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
         locx += shortcut_print( w_header, point( locx, 1 ), c_white, c_light_green, _( "<S>witch" ) );
         shortcut_print( w_header, point( locx, 1 ), c_white, c_light_green, "  " );
 
-        wrefresh( w_header );
+        wnoutrefresh( w_header );
 
         // Clear the lines
         for( int i = 0; i < content_height; i++ ) {
@@ -211,7 +211,7 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
         }
 
         draw_scrollbar( w_border, line, content_height, current_tab.size(), point( 0, 5 ) );
-        wrefresh( w_border );
+        wnoutrefresh( w_border );
 
         calcStartPos( start_pos, line, content_height, current_tab.size() );
 
@@ -245,7 +245,7 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
             }
         }
 
-        wrefresh( w );
+        wnoutrefresh( w );
     } );
 
     while( true ) {
@@ -370,7 +370,7 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
                             break;
                     }
                     draw_border( w_help );
-                    wrefresh( w_help );
+                    wnoutrefresh( w_help );
                 } );
 
                 current_tab[line].rule = wildcard_trim_rule( string_input_popup()
@@ -544,7 +544,7 @@ void safemode::test_pattern( const int tab_in, const int row_in )
         center_print( w_test_rule_border, content_height + 1, red_background( c_white ),
                       _( "Lists monsters regardless of their attitude." ) );
 
-        wrefresh( w_test_rule_border );
+        wnoutrefresh( w_test_rule_border );
 
         // Clear the lines
         for( int i = 0; i < content_height; i++ ) {
@@ -571,7 +571,7 @@ void safemode::test_pattern( const int tab_in, const int row_in )
             }
         }
 
-        wrefresh( w_test_rule_content );
+        wnoutrefresh( w_test_rule_content );
     } );
 
     while( true ) {

--- a/src/scores_ui.cpp
+++ b/src/scores_ui.cpp
@@ -114,7 +114,7 @@ void show_scores_ui( const achievements_tracker &achievements, stats_tracker &st
         werase( w );
         draw_tabs( w, tabs, tab );
         draw_border_below_tabs( w );
-        wrefresh( w );
+        wnoutrefresh( w );
 
         view.draw( c_white );
     } );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2894,9 +2894,11 @@ static void CheckMessages()
                         }
 #endif
                         break;
-                    case SDL_WINDOWEVENT_RESIZED:
+                    case SDL_WINDOWEVENT_RESIZED: {
+                        restore_on_out_of_scope<input_event> prev_last_input( last_input );
                         needupdate = handle_resize( ev.window.data1, ev.window.data2 );
                         break;
+                    }
                     default:
                         break;
                 }
@@ -3230,6 +3232,7 @@ static void CheckMessages()
         }
     }
     if( need_redraw ) {
+        restore_on_out_of_scope<input_event> prev_last_input( last_input );
         // FIXME: SDL_RENDER_TARGETS_RESET only seems to be fired after the first redraw
         // when restoring the window after system sleep, rather than immediately
         // on focus gain. This seems to mess up the first redraw and

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1771,6 +1771,7 @@ bool handle_resize( int w, int h )
         WindowHeight = h;
         TERMINAL_WIDTH = WindowWidth / fontwidth / scaling_factor;
         TERMINAL_HEIGHT = WindowHeight / fontheight / scaling_factor;
+        catacurses::stdscr = catacurses::newwin( TERMINAL_HEIGHT, TERMINAL_WIDTH, point_zero );
         SetupRenderTarget();
         game_ui::init_ui();
         ui_manager::screen_resized();

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3239,7 +3239,7 @@ static void CheckMessages()
         // causes black screen that lasts ~0.5 seconds before the screen
         // contents are redrawn in the following code.
         window_dimensions dim = get_window_dimensions( catacurses::stdscr );
-        ui_manager::invalidate( rectangle( point_zero, dim.window_size_pixel ) );
+        ui_manager::invalidate( rectangle( point_zero, dim.window_size_pixel ), false );
         ui_manager::redraw();
     }
     if( needupdate ) {

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -29,7 +29,6 @@ void draw_alt_rect( const SDL_Renderer_Ptr &renderer, const SDL_Rect &rect,
 void load_tileset();
 void rescale_tileset( int size );
 bool save_screenshot( const std::string &file_path );
-void resize_term( int cell_w, int cell_h );
 void toggle_fullscreen_window();
 
 struct window_dimensions {

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -271,7 +271,7 @@ void string_input_popup::draw( const utf8_wrapper &ret, const utf8_wrapper &edit
         mvwprintz( w, point( start_x_edit, _starty ), _cursor_color, "%s", edit.c_str() );
     }
 
-    wrefresh( w );
+    wnoutrefresh( w );
 }
 
 void string_input_popup::query( const bool loop, const bool draw_only )

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -146,8 +146,6 @@ void string_input_popup::show_history( utf8_wrapper &ret )
                 finished = true;
             }
         } while( !finished );
-        werase( hmenu.window );
-        wrefresh( hmenu.window );
     }
 }
 

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -163,8 +163,6 @@ void select_language()
         return lang.first.empty() || lang.second.empty();
     } ), languages.end() );
 
-    wrefresh( catacurses::stdscr );
-
     uilist sm;
     sm.allow_cancel = false;
     sm.text = _( "Select your language" );

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -669,7 +669,7 @@ void uilist::show()
     }
     apply_scrollbar();
 
-    wrefresh( window );
+    wnoutrefresh( window );
     if( callback != nullptr ) {
         callback->refresh( this );
     }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -222,7 +222,7 @@ void uilist::filterlist()
             fentries.push_back( i );
             if( i == selected && ( hilight_disabled || entries[i].enabled ) ) {
                 fselected = f;
-            } else if( i > selected && fselected == -1 ) {
+            } else if( i > selected && fselected == -1 && ( hilight_disabled || entries[i].enabled ) ) {
                 // Past the previously selected entry, which has been filtered out,
                 // choose another nearby entry instead.
                 fselected = f;

--- a/src/ui.h
+++ b/src/ui.h
@@ -106,7 +106,7 @@ struct uilist_entry {
  *   void refresh( uilist *menu ) {
  *       if( menu->selected >= 0 && static_cast<size_t>( menu->selected ) < game_z.size() ) {
  *           mvwprintz( menu->window, 0, 0, c_red, "( %s )",game_z[menu->selected]->name() );
- *           wrefresh( menu->window );
+ *           wnoutrefresh( menu->window );
  *       }
  *   }
  * }

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -244,7 +244,7 @@ background_pane::background_pane()
     ui.position_from_window( catacurses::stdscr );
     ui.on_redraw( []( const ui_adaptor & ) {
         catacurses::erase();
-        catacurses::refresh();
+        wnoutrefresh( catacurses::stdscr );
     } );
 }
 

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -187,15 +187,16 @@ void ui_adaptor::redraw()
 
 void ui_adaptor::redraw_invalidated()
 {
+    ui_stack_t ui_stack_copy = ui_stack;
     // apply deferred resizing
-    auto first = ui_stack.rbegin();
-    for( ; first != ui_stack.rend(); ++first ) {
+    auto first = ui_stack_copy.rbegin();
+    for( ; first != ui_stack_copy.rend(); ++first ) {
         if( first->get().disabling_uis_below ) {
             break;
         }
     }
-    for( auto it = first == ui_stack.rend() ? ui_stack.begin() : std::prev( first.base() );
-         it != ui_stack.end(); ++it ) {
+    for( auto it = first == ui_stack_copy.rend() ? ui_stack_copy.begin() : std::prev( first.base() );
+         it != ui_stack_copy.end(); ++it ) {
         ui_adaptor &ui = *it;
         if( ui.deferred_resize ) {
             if( ui.screen_resized_cb ) {
@@ -208,15 +209,15 @@ void ui_adaptor::redraw_invalidated()
 
     // redraw invalidated uis
     // TODO refresh only when all stacked UIs are drawn
-    if( !ui_stack.empty() ) {
-        auto first = ui_stack.crbegin();
-        for( ; first != ui_stack.crend(); ++first ) {
+    if( !ui_stack_copy.empty() ) {
+        auto first = ui_stack_copy.crbegin();
+        for( ; first != ui_stack_copy.crend(); ++first ) {
             if( first->get().disabling_uis_below ) {
                 break;
             }
         }
-        for( auto it = first == ui_stack.crend() ? ui_stack.cbegin() : std::prev( first.base() );
-             it != ui_stack.cend(); ++it ) {
+        for( auto it = first == ui_stack_copy.crend() ? ui_stack_copy.cbegin() : std::prev( first.base() );
+             it != ui_stack_copy.cend(); ++it ) {
             const ui_adaptor &ui = *it;
             if( ui.invalidated ) {
                 if( ui.redraw_cb ) {

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -32,7 +32,7 @@ ui_adaptor::~ui_adaptor()
         if( &it->get() == this ) {
             ui_stack.erase( std::prev( it.base() ) );
             // TODO avoid invalidating portions that do not need to be redrawn
-            ui_manager::invalidate( dimensions );
+            ui_manager::invalidate( dimensions, disabling_uis_below );
             break;
         }
     }
@@ -53,7 +53,7 @@ void ui_adaptor::position_from_window( const catacurses::window &win )
         dimensions = rectangle( origin, origin + point( getmaxx( win ), getmaxy( win ) ) );
 #endif
         invalidated = true;
-        ui_manager::invalidate( old_dimensions );
+        ui_manager::invalidate( old_dimensions, false );
     }
 }
 
@@ -68,7 +68,7 @@ void ui_adaptor::position( const point &topleft, const point &size )
     dimensions = rectangle( topleft, topleft + size );
 #endif
     invalidated = true;
-    ui_manager::invalidate( old_dimensions );
+    ui_manager::invalidate( old_dimensions, false );
 }
 
 void ui_adaptor::on_redraw( const redraw_callback_t &fun )
@@ -107,9 +107,21 @@ static bool overlap( const rectangle &lhs, const rectangle &rhs )
 // be redrawn, but all UIs that need to be redrawn are guaranteed be invalidated.
 void ui_adaptor::invalidation_consistency_and_optimization()
 {
-    for( auto it_upper = ui_stack.cbegin(); it_upper < ui_stack.cend(); ++it_upper ) {
+    // Only ensure consistency and optimize for UIs not disabled by another UI
+    // with `disable_uis_below`, since if a UI is disabled, it does not get
+    // resized or redrawn, so the invalidation flag is not cleared, and including
+    // the disabled UI in the following calculation would unnecessarily
+    // invalidate any upper intersecting UIs.
+    auto rfirst = ui_stack.crbegin();
+    for( ; rfirst != ui_stack.crend(); ++rfirst ) {
+        if( rfirst->get().disabling_uis_below ) {
+            break;
+        }
+    }
+    const auto first = rfirst == ui_stack.crend() ? ui_stack.cbegin() : std::prev( rfirst.base() );
+    for( auto it_upper = first; it_upper < ui_stack.cend(); ++it_upper ) {
         const ui_adaptor &ui_upper = it_upper->get();
-        for( auto it_lower = ui_stack.cbegin(); it_lower < it_upper; ++it_lower ) {
+        for( auto it_lower = first; it_lower < it_upper; ++it_lower ) {
             const ui_adaptor &ui_lower = it_lower->get();
             if( !ui_upper.invalidated && ui_lower.invalidated &&
                 overlap( ui_upper.dimensions, ui_lower.dimensions ) ) {
@@ -151,6 +163,9 @@ void ui_adaptor::invalidate_ui() const
             return;
         }
     }
+    // Always mark this UI for redraw even if it is below another UI with
+    // `disable_uis_below`, so when the UI with `disable_uis_below` is removed,
+    // this UI is correctly marked for redraw.
     invalidated = true;
     invalidation_consistency_and_optimization();
 }
@@ -162,11 +177,17 @@ void ui_adaptor::reset()
     position( point_zero, point_zero );
 }
 
-void ui_adaptor::invalidate( const rectangle &rect )
+void ui_adaptor::invalidate( const rectangle &rect, const bool reenable_uis_below )
 {
     if( rect.p_min.x >= rect.p_max.x || rect.p_min.y >= rect.p_max.y ) {
+        if( reenable_uis_below ) {
+            invalidation_consistency_and_optimization();
+        }
         return;
     }
+    // Always invalidate every UI, even if it is below another UI with
+    // `disable_uis_below`, so when the UI with `disable_uis_below` is removed,
+    // UIs below are correctly marked for redraw.
     for( auto it_upper = ui_stack.cbegin(); it_upper < ui_stack.cend(); ++it_upper ) {
         const ui_adaptor &ui_upper = it_upper->get();
         if( !ui_upper.invalidated && overlap( ui_upper.dimensions, rect ) ) {
@@ -208,7 +229,6 @@ void ui_adaptor::redraw_invalidated()
     reinitialize_framebuffer();
 
     // redraw invalidated uis
-    // TODO refresh only when all stacked UIs are drawn
     if( !ui_stack_copy.empty() ) {
         auto first = ui_stack_copy.crbegin();
         for( ; first != ui_stack_copy.crend(); ++first ) {
@@ -231,6 +251,9 @@ void ui_adaptor::redraw_invalidated()
 
 void ui_adaptor::screen_resized()
 {
+    // Always mark every UI for resize even if it is below another UI with
+    // `disable_uis_below`, so when the UI with `disable_uis_below` is removed,
+    // UIs below are correctly marked for resize.
     for( ui_adaptor &ui : ui_stack ) {
         ui.deferred_resize = true;
     }
@@ -252,9 +275,9 @@ background_pane::background_pane()
 namespace ui_manager
 {
 
-void invalidate( const rectangle &rect )
+void invalidate( const rectangle &rect, const bool reenable_uis_below )
 {
-    ui_adaptor::invalidate( rect );
+    ui_adaptor::invalidate( rect, reenable_uis_below );
 }
 
 void redraw()

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -38,9 +38,13 @@ class ui_adaptor
         // Note that `topleft` and `size` are in console cells on both tiles
         // and curses build.
         void position( const point &topleft, const point &size );
-        // Set redraw and resizing callbacks. These callbacks should NOT call
-        // `debugmsg`, construct new `ui_adaptor` instances, deconstruct old
+        // Set redraw and resizing callbacks. These callbacks should NOT
+        // construct new `ui_adaptor` instances, deconstruct old
         // `ui_adaptor` instances, call `redraw`, or call `screen_resized`.
+        //
+        // As a special case, calling `debugmsg` inside the callbacks is (semi-)
+        // supported, but may cause display glitches after the debug message is
+        // closed.
         //
         // The redraw callback should also not call `position_from_window`,
         // otherwise it may cause UI glitch if the window position changes.

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -64,7 +64,7 @@ class ui_adaptor
         // Reset all callbacks and dimensions
         void reset();
 
-        static void invalidate( const rectangle &rect );
+        static void invalidate( const rectangle &rect, bool reenable_uis_below );
         static void redraw();
         static void redraw_invalidated();
         static void screen_resized();
@@ -96,7 +96,7 @@ class background_pane
 namespace ui_manager
 {
 // rect is the pixel dimensions in tiles or console cell dimensions in curses
-void invalidate( const rectangle &rect );
+void invalidate( const rectangle &rect, bool reenable_uis_below );
 // invalidate the top window and redraw all invalidated windows
 void redraw();
 // redraw all invalidated windows without invalidating the top window

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -347,7 +347,7 @@ shared_ptr_fast<ui_adaptor> veh_interact::create_or_get_ui_adaptor()
             werase( w_parts );
             veh->print_part_list( w_parts, 0, getmaxy( w_parts ) - 1, getmaxx( w_parts ), cpart, highlight_part,
                                   true );
-            wrefresh( w_parts );
+            wnoutrefresh( w_parts );
 
             werase( w_msg );
             if( !msg.has_value() ) {
@@ -356,7 +356,7 @@ shared_ptr_fast<ui_adaptor> veh_interact::create_or_get_ui_adaptor()
                 // NOLINTNEXTLINE(cata-use-named-point-constants)
                 fold_and_print( w_msg, point( 1, 0 ), getmaxx( w_msg ) - 2, c_light_red, msg.value() );
             }
-            wrefresh( w_msg );
+            wnoutrefresh( w_msg );
 
             if( install_info ) {
                 display_list( install_info->pos, install_info->tab_vparts, 2 );
@@ -1564,7 +1564,7 @@ void veh_interact::display_overview()
         }
     }
 
-    wrefresh( w_list );
+    wnoutrefresh( w_list );
 }
 
 void veh_interact::overview( const overview_enable_t &enable,
@@ -2114,7 +2114,7 @@ void veh_interact::display_grid()
                                getmaxy( w_mode ) + 2 + page_size ),
               BORDER_COLOR, LINE_XXOX );
 
-    wrefresh( w_border );
+    wnoutrefresh( w_border );
 }
 
 /**
@@ -2198,7 +2198,7 @@ void veh_interact::display_veh()
     int sym = cpart >= 0 ? veh->part_sym( cpart ) : ' ';
     mvwputch( w_disp, point( hw, hh ), obstruct ? red_background( col ) : hilite( col ),
               special_symbol( sym ) );
-    wrefresh( w_disp );
+    wnoutrefresh( w_disp );
 }
 
 static std::string wheel_state_description( const vehicle &veh )
@@ -2456,7 +2456,7 @@ void veh_interact::display_stats() const
         }
     }
 
-    wrefresh( w_stats );
+    wnoutrefresh( w_stats );
 }
 
 void veh_interact::display_name()
@@ -2468,7 +2468,7 @@ void veh_interact::display_name()
     mvwprintz( w_name, point( 1 + utf8_width( _( "Name: " ) ), 0 ),
                !veh->is_owned_by( g->u, true ) ? c_light_red : c_light_green,
                string_format( _( "%s (%s)" ), veh->name, veh->get_owner_name() ) );
-    wrefresh( w_name );
+    wnoutrefresh( w_name );
 }
 
 /**
@@ -2528,7 +2528,7 @@ void veh_interact::display_mode()
                             actions[i] );
         }
     }
-    wrefresh( w_mode );
+    wnoutrefresh( w_mode );
 }
 
 size_t veh_interact::display_esc( const catacurses::window &win )
@@ -2576,7 +2576,7 @@ void veh_interact::display_list( size_t pos, const std::vector<const vpart_info 
                        i ) ); // one space padding and add a space after selected tab
         }
     }
-    wrefresh( w_list );
+    wnoutrefresh( w_list );
 }
 
 /**
@@ -2593,7 +2593,7 @@ void veh_interact::display_details( const vpart_info *part )
              LINE_XOOX );
 
     if( part == nullptr ) {
-        wrefresh( w_details );
+        wnoutrefresh( w_details );
         return;
     }
     // displays data in two columns
@@ -2727,7 +2727,7 @@ void veh_interact::display_details( const vpart_info *part )
         }
     }
 
-    wrefresh( w_details );
+    wnoutrefresh( w_details );
 }
 
 void veh_interact::count_durability()

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -294,7 +294,7 @@ void vehicle::print_vparts_descs( const catacurses::window &win, int max_y, int 
     // -2 for left & right padding
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     fold_and_print( win, point( 1, 0 ), width - 2, c_light_gray, msg );
-    wrefresh( win );
+    wnoutrefresh( win );
 }
 
 /**

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1885,7 +1885,6 @@ void vehicle::use_bike_rack( int part )
     }
     if( success ) {
         g->m.invalidate_map_cache( g->get_levz() );
-        g->refresh_all();
     }
 }
 

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -188,7 +188,6 @@ bool handle_resize( int, int )
         if( SetDIBColorTable( backbuffer, 0, windowsPalette.size(), windowsPalette.data() ) == 0 ) {
             throw std::runtime_error( "SetDIBColorTable failed" );
         }
-        catacurses::refresh();
         ui_manager::screen_resized();
     }
 

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -440,17 +440,9 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
     int drawx = 0;
     int drawy = 0;
     wchar_t tmp;
-    RECT update = {win->pos.x * fontwidth, -1,
-                   ( win->pos.x + win->width ) *fontwidth, -1
-                  };
 
     for( j = 0; j < win->height; j++ ) {
         if( win->line[j].touched ) {
-            update.bottom = ( win->pos.y + j + 1 ) * fontheight;
-            if( update.top == -1 ) {
-                update.top = update.bottom - fontheight;
-            }
-
             win->line[j].touched = false;
 
             for( i = 0; i < win->width; i++ ) {
@@ -555,9 +547,6 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
     }// for (j=0;j<win->height;j++)
     // We drew the window, mark it as so
     win->draw = false;
-    if( update.top != -1 ) {
-        RedrawWindow( WindowHandle, &update, nullptr, RDW_INVALIDATE | RDW_UPDATENOW );
-    }
 }
 
 // Check for any window messages (keypress, paint, mousemove, etc)
@@ -570,6 +559,7 @@ static void CheckMessages()
     }
     if( needs_resize ) {
         handle_resize( 0, 0 );
+        refresh_display();
     }
 }
 
@@ -782,6 +772,11 @@ int get_scaling_factor()
 HWND getWindowHandle()
 {
     return WindowHandle;
+}
+
+void refresh_display()
+{
+    RedrawWindow( WindowHandle, nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW );
 }
 
 #endif

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -558,6 +558,7 @@ static void CheckMessages()
         DispatchMessage( &msg );
     }
     if( needs_resize ) {
+        restore_on_out_of_scope<input_event> prev_lastchar( lastchar );
         handle_resize( 0, 0 );
         refresh_display();
     }

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -202,7 +202,7 @@ class wish_mutate_callback: public uilist_callback
                        _( "[%s] find, [%s] quit, [t] toggle base trait" ),
                        ctxt.get_desc( "FILTER" ), ctxt.get_desc( "QUIT" ) );
 
-            wrefresh( menu->window );
+            wnoutrefresh( menu->window );
         }
 
         ~wish_mutate_callback() override = default;
@@ -371,7 +371,7 @@ class wish_monster_callback: public uilist_callback
                        _( "[%s] find, [f]riendly, [h]allucination, [i]ncrease group, [d]ecrease group, [%s] quit" ),
                        ctxt.get_desc( "FILTER" ), ctxt.get_desc( "QUIT" ) );
 
-            wrefresh( w_info );
+            wnoutrefresh( w_info );
         }
 
         ~wish_monster_callback() override = default;
@@ -508,7 +508,7 @@ class wish_item_callback: public uilist_callback
             mvwprintw( menu->window, point( startx, menu->w_height - 2 ),
                        _( "[%s] find, [f] container, [F] flag, [E] everything, [%s] quit" ),
                        ctxt.get_desc( "FILTER" ), ctxt.get_desc( "QUIT" ) );
-            wrefresh( menu->window );
+            wnoutrefresh( menu->window );
         }
 };
 

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -683,9 +683,6 @@ void debug_menu::wishskill( player *p )
                 sksetmenu.addentry( i, true, i + 48, "%d%s", i, skcur == i ? _( " (current)" ) : "" );
             }
             sksetmenu.query();
-            g->draw_ter();
-            wrefresh( g->w_terrain );
-            g->draw_panels( true );
             skset = sksetmenu.ret;
         }
 

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -157,7 +157,7 @@ WORLDPTR worldfactory::make_new_world( bool show_prompt, const std::string &worl
 
         ui.on_redraw( [&]( const ui_adaptor & ) {
             draw_worldgen_tabs( wf_win, static_cast<size_t>( curtab ) );
-            wrefresh( wf_win );
+            wnoutrefresh( wf_win );
         } );
 
         const size_t numtabs = tabs.size();
@@ -435,7 +435,7 @@ WORLDPTR worldfactory::pick_world( bool show_prompt )
             }
         }
 
-        wrefresh( w_worlds_border );
+        wnoutrefresh( w_worlds_border );
 
         for( int i = 0; i < getmaxx( w_worlds_border ); i++ ) {
             if( mapLines[i] ) {
@@ -445,7 +445,7 @@ WORLDPTR worldfactory::pick_world( bool show_prompt )
             }
         }
 
-        wrefresh( w_worlds_header );
+        wnoutrefresh( w_worlds_header );
 
         //Clear the lines
         for( int i = 0; i < iContentHeight; i++ ) {
@@ -493,12 +493,12 @@ WORLDPTR worldfactory::pick_world( bool show_prompt )
             }
         }
 
-        wrefresh( w_worlds_header );
+        wnoutrefresh( w_worlds_header );
 
         fold_and_print( w_worlds_tooltip, point_zero, 78, c_white, _( "Pick a world to enter game" ) );
-        wrefresh( w_worlds_tooltip );
+        wnoutrefresh( w_worlds_tooltip );
 
-        wrefresh( w_worlds );
+        wnoutrefresh( w_worlds );
     } );
 
     input_context ctxt( "PICK_WORLD_DIALOG" );
@@ -746,8 +746,8 @@ void worldfactory::draw_mod_list( const catacurses::window &w, int &start, size_
         draw_scrollbar( w, static_cast<int>( iActive ), iMaxRows, static_cast<int>( iModNum ), point_zero );
     }
 
-    wrefresh( w );
-    wrefresh( w_shift );
+    wnoutrefresh( w );
+    wnoutrefresh( w_shift );
 }
 
 void worldfactory::show_active_world_mods( const std::vector<mod_id> &world_mods )
@@ -782,11 +782,11 @@ void worldfactory::show_active_world_mods( const std::vector<mod_id> &world_mods
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         draw_border( w_border, BORDER_COLOR, _( " ACTIVE WORLD MODS " ) );
-        wrefresh( w_border );
+        wnoutrefresh( w_border );
 
         draw_mod_list( w_mods, start, static_cast<size_t>( cursor ), world_mods,
                        true, _( "--NO ACTIVE MODS--" ), catacurses::window() );
-        wrefresh( w_mods );
+        wnoutrefresh( w_mods );
     } );
 
     while( true ) {
@@ -926,7 +926,7 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
                 mvwputch( header_windows[i], point( header_x + utf8_width( headers[i] ) + 2, 0 ),
                           c_red, '>' );
             }
-            wrefresh( header_windows[i] );
+            wnoutrefresh( header_windows[i] );
         }
 
         // Redraw description
@@ -960,8 +960,8 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
             wputch( win, BORDER_COLOR, LINE_OXOX );
         }
 
-        wrefresh( w_description );
-        wrefresh( win );
+        wnoutrefresh( w_description );
+        wnoutrefresh( win );
 
         // Redraw list
         draw_mod_list( w_list, startsel[0], cursel[0], current_tab_mods, active_header == 0,
@@ -1176,8 +1176,8 @@ int worldfactory::show_worldgen_tab_confirm( const catacurses::window &win, WORL
             }
         }
 
-        wrefresh( win );
-        wrefresh( w_confirmation );
+        wnoutrefresh( win );
+        wnoutrefresh( w_confirmation );
     } );
 
     do {
@@ -1305,7 +1305,7 @@ void worldfactory::draw_modselection_borders( const catacurses::window &win,
                     ctxtp.get_desc( "NEXT_CATEGORY_TAB" ),
                     ctxtp.get_desc( "HELP_KEYBINDINGS" )
                   );
-    wrefresh( win );
+    wnoutrefresh( win );
 }
 
 void worldfactory::draw_worldgen_tabs( const catacurses::window &w, size_t current )

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1306,7 +1306,6 @@ void worldfactory::draw_modselection_borders( const catacurses::window &win,
                     ctxtp.get_desc( "HELP_KEYBINDINGS" )
                   );
     wrefresh( win );
-    catacurses::refresh();
 }
 
 void worldfactory::draw_worldgen_tabs( const catacurses::window &w, size_t current )

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -192,7 +192,6 @@ TEST_CASE( "Vehicle charging station", "[vehicle][power]" )
         REQUIRE( veh_ptr != nullptr );
         REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) > 1000 );
         veh_ptr->update_time( calendar::turn_zero );
-        g->refresh_all();
 
         auto cargo_part_index = veh_ptr->part_with_feature( {0, 0}, "CARGO", true );
         REQUIRE( cargo_part_index >= 0 );

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -42,7 +42,6 @@ TEST_CASE( "vehicle power with reactor and solar panels", "[vehicle][power]" )
         const tripoint reactor_origin = tripoint( 10, 10, 0 );
         vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "reactor_test" ), reactor_origin, 0, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        g->refresh_all();
 
         REQUIRE( !veh_ptr->reactors.empty() );
         vehicle_part &reactor = veh_ptr->parts[ veh_ptr->reactors.front() ];
@@ -71,7 +70,6 @@ TEST_CASE( "vehicle power with reactor and solar panels", "[vehicle][power]" )
         const tripoint solar_origin = tripoint( 5, 5, 0 );
         vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "solar_panel_test" ), solar_origin, 0, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        g->refresh_all();
 
         GIVEN( "it is 3 hours after sunrise, with sunny weather" ) {
             calendar::turn = calendar::turn_zero + calendar::season_length() + 1_days;
@@ -136,7 +134,6 @@ TEST_CASE( "maximum reverse velocity", "[vehicle][power][reverse]" )
         const tripoint origin = tripoint( 10, 0, 0 );
         vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "scooter_test" ), origin, 0, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        g->refresh_all();
         veh_ptr->charge_battery( 500 );
         REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 500 );
 
@@ -162,7 +159,6 @@ TEST_CASE( "maximum reverse velocity", "[vehicle][power][reverse]" )
         const tripoint origin = tripoint( 15, 0, 0 );
         vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "scooter_electric_test" ), origin, 0, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        g->refresh_all();
         veh_ptr->charge_battery( 5000 );
         REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 5000 );
 

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -23,7 +23,6 @@ TEST_CASE( "vehicle_split_section" )
             veh_ptr = vehs_v.v;
             g->m.destroy_vehicle( veh_ptr );
         }
-        g->refresh_all();
         REQUIRE( g->m.get_vehicles().empty() );
         veh_ptr = g->m.add_vehicle( vproto_id( "cross_split_test" ), vehicle_origin, dir, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
@@ -65,7 +64,6 @@ TEST_CASE( "vehicle_split_section" )
             g->m.destroy_vehicle( vehs[ 1 ].v );
             g->m.destroy_vehicle( vehs[ 0 ].v );
         }
-        g->refresh_all();
         REQUIRE( g->m.get_vehicles().empty() );
         vehicle_origin = tripoint( 20, 20, 0 );
         veh_ptr = g->m.add_vehicle( vproto_id( "circle_split_test" ), vehicle_origin, dir, 0, 0 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: None
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Finish migrating UIs to ui_adaptor
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Cherry-picked from DDA:

CleverRaven#41112
CleverRaven#41170
CleverRaven#41140
CleverRaven#41584
CleverRaven#42952

#### Testing
Briefly tested a few animations, highlight from 'choose adjacent' / 'picking up', cursor for 'Look around' on both tiles & curses.
The only UI with significant merge conflicts - the not-yet-migrated target selection ui - has some flickering both on tiles & curses, but otherwise works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
