### PR TITLE
Port over some DDA relic effects to BN

### DIFF
--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -189,8 +189,9 @@
         {
           "has": "HELD",
           "condition": "ALWAYS",
+          "values": [ { "value": "REGEN_HP", "add": 99 } ],
           "mutations": [ "CARNIVORE" ],
-          "intermittent_activation": { "effects": [ { "frequency": "5 minutes", "spell_effects": [ { "id": "AEA_HEAL" } ] } ] }
+          "intermittent_activation": { "effects": [ { "frequency": "60 minutes", "spell_effects": [ { "id": "AEA_HEAL" } ] } ] }
         },
         {
           "has": "HELD",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4733,7 +4733,7 @@ needs_rates Character::calc_needs_rates() const
         rates.thirst *= 0.25f;
     }
 
-    rates.fatigue = calculate_by_enchantment( rates.fatigue, enchantment::mod::FATIGUE, true );
+    rates.fatigue = calculate_by_enchantment( rates.fatigue, enchantment::mod::FATIGUE );
 
     return rates;
 }
@@ -6550,7 +6550,7 @@ float Character::healing_rate( float at_rest_quality ) const
         final_rate *= 1.0f + primary_hp_mod;
     }
 
-    final_rate = calculate_by_enchantment( final_rate, enchantment::mod::REGEN_HP, true );
+    final_rate = calculate_by_enchantment( final_rate, enchantment::mod::REGEN_HP );
 
     return final_rate;
 }
@@ -6955,8 +6955,7 @@ void Character::update_stamina( int turns )
     // But mouth encumbrance interferes, even with mutated stamina.
     stamina_recovery += stamina_multiplier * std::max( 1.0f,
                         base_regen_rate - ( encumb( bp_mouth ) / 5.0f ) );
-    stamina_recovery = calculate_by_enchantment( stamina_recovery, enchantment::mod::REGEN_STAMINA,
-                       true );
+    stamina_recovery = calculate_by_enchantment( stamina_recovery, enchantment::mod::REGEN_STAMINA );
     // TODO: recovering stamina causes hunger/thirst/fatigue.
     // TODO: Tiredness slowing recovery
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6521,6 +6521,7 @@ float Character::healing_rate( float at_rest_quality ) const
     }
     float awake_rate = heal_rate * mutation_value( "healing_awake" );
     float final_rate = 0.0f;
+    final_rate = calculate_by_enchantment( final_rate, enchantment::mod::REGEN_HP );
     if( awake_rate > 0.0f ) {
         final_rate += awake_rate;
     } else if( at_rest_quality < 1.0f ) {
@@ -6549,7 +6550,7 @@ float Character::healing_rate( float at_rest_quality ) const
         final_rate *= 1.0f + primary_hp_mod;
     }
 
-    return calculate_by_enchantment( final_rate, enchantment::mod::REGEN_HP );
+    return final_rate;
 }
 
 float Character::healing_rate_medicine( float at_rest_quality, const body_part bp ) const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1592,6 +1592,7 @@ void Character::recalc_hp()
         /** @EFFECT_STR_MAX increases base hp */
         elem = 60 + str_max * 3 + hp_adjustment;
         elem *= hp_mod;
+        elem = calculate_by_enchantment( elem, enchantment::mod::MAX_HP, true );
     }
     if( has_trait( trait_GLASSJAW ) ) {
         new_max_hp[hp_head] *= 0.8;
@@ -4732,6 +4733,8 @@ needs_rates Character::calc_needs_rates() const
         rates.thirst *= 0.25f;
     }
 
+    rates.fatigue = calculate_by_enchantment( rates.fatigue, enchantment::mod::FATIGUE, true );
+
     return rates;
 }
 
@@ -6547,6 +6550,8 @@ float Character::healing_rate( float at_rest_quality ) const
         final_rate *= 1.0f + primary_hp_mod;
     }
 
+    final_rate = calculate_by_enchantment( final_rate, enchantment::mod::REGEN_HP, true );
+
     return final_rate;
 }
 
@@ -6950,6 +6955,7 @@ void Character::update_stamina( int turns )
     // But mouth encumbrance interferes, even with mutated stamina.
     stamina_recovery += stamina_multiplier * std::max( 1.0f,
                         base_regen_rate - ( encumb( bp_mouth ) / 5.0f ) );
+    stamina_recovery = calculate_by_enchantment( stamina_recovery, enchantment::mod::REGEN_STAMINA, true );
     // TODO: recovering stamina causes hunger/thirst/fatigue.
     // TODO: Tiredness slowing recovery
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1592,7 +1592,6 @@ void Character::recalc_hp()
         /** @EFFECT_STR_MAX increases base hp */
         elem = 60 + str_max * 3 + hp_adjustment;
         elem *= hp_mod;
-        elem = calculate_by_enchantment( elem, enchantment::mod::MAX_HP, true );
     }
     if( has_trait( trait_GLASSJAW ) ) {
         new_max_hp[hp_head] *= 0.8;
@@ -6550,9 +6549,7 @@ float Character::healing_rate( float at_rest_quality ) const
         final_rate *= 1.0f + primary_hp_mod;
     }
 
-    final_rate = calculate_by_enchantment( final_rate, enchantment::mod::REGEN_HP );
-
-    return final_rate;
+    return calculate_by_enchantment( final_rate, enchantment::mod::REGEN_HP );
 }
 
 float Character::healing_rate_medicine( float at_rest_quality, const body_part bp ) const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6955,7 +6955,8 @@ void Character::update_stamina( int turns )
     // But mouth encumbrance interferes, even with mutated stamina.
     stamina_recovery += stamina_multiplier * std::max( 1.0f,
                         base_regen_rate - ( encumb( bp_mouth ) / 5.0f ) );
-    stamina_recovery = calculate_by_enchantment( stamina_recovery, enchantment::mod::REGEN_STAMINA, true );
+    stamina_recovery = calculate_by_enchantment( stamina_recovery, enchantment::mod::REGEN_STAMINA,
+                       true );
     // TODO: recovering stamina causes hunger/thirst/fatigue.
     // TODO: Tiredness slowing recovery
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->


SUMMARY: Features "Port over a few more relic effects from DDA"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some basic enchantment values to port over. Took a bit of looking it over as the code as-is was affected by several prerequisite PRs. Evidently if I were to port over https://github.com/CleverRaven/Cataclysm-DDA/pull/41242 that would improve build speed but it looks significantly more involved. On top of that, I'd have had to implement MAX_HP different no matter what since the source PR's handling of it is rooted in the unhardcoded bodypart stuff.

Not actually all of them just yet, the second source PR contains a high volume of changes broken up into single commits. I decided I'd only port over the values specifically being used by Arcana mod at present. I'll port over the rest in a follow-up PR, if I can. The individual commits themselves are all easily ported over, basic one-line changes for the most part (aside from changing enchant_vals::mod back to enchantment::mod).

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changes to character.cpp adding code that looks for REGEN_HP enchantments. MAX_HP is going in the "when I understand the code better" pile due to some issues with current code not pinging recalc_hp on grabbing an enchantment.
2. Change to character.cpp implementing the REGEN_STAMINA value.
3. Change to character.cpp implementing the FATIGUE value.
4. Added a REGEN_HP modifier to the cube of shame.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Mutations from enchantments would be great for this (HP modifiers, healing rate, stamina regen modifer, fatigue modifier, etc) but 90% of mutation properties still don't seem to work when called by an enchantment, even in the DDA version. Pretty much only hardcoded effects, mutation flags, and a handful of obscure things like `ignored_by`.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Set HP to 1.
3. Spawned in a cube of shame, confirmed it now works after resolving previous inconsistencies (see below).
4. Temporarily dumped the BN version of Arcana in for testing.
5. Observed that Life Sign Suppression's current multiplier of -1.0 appeared to slow, but not halt, healing while the CBM was active.
6. Observed that debug mode reported an increase in stamina regen with the Temporal Stimulation CBM active.
7. Observed a fatigue gain of 3 every 5 minutes instead of 1 every 5 minutes, while Temporal Stimulation is on.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

PRs being ported over:
1. Part of https://github.com/CleverRaven/Cataclysm-DDA/pull/42030
2. Part of https://github.com/CleverRaven/Cataclysm-DDA/pull/42090

Properties that will be a priority for my to port over next PR:
1. MAX_HP turned out to be harder to get working than I'd hoped.
2. METABOLISM and THIRST, since I ported over FATIGUE. Since BN doesn't have the metabolic rate stuff, from what I can tell I'll need to put the implementation in Consumption.cpp instead for METABOLISM to work. We'll see.
3. MAX_STAMINA, since I ported over REGEN_STAMINA.

Side note, I was trying to find SOCIAL_PERSUADE since it's also one Arcana uses, but checked on https://github.com/CleverRaven/Cataclysm-DDA/issues/33837 and realized it actually hasn't been implemented yet. Not important to me, Arcana's use of it is basically just a flavor effect, I'll just have to remember to remove it from my mod JSON so I don't get confused in the future.

So, important note on REGEN_HP, I have observed some major issues with how it handles as of the source PR' s version of it:
1. Health regen modifier only did anything if you had a fast-healing trait, otherwise it had no visible effect on healing, with or without medical items applied.
2. Trying to disable healing with a -1.0 multiplier did not appear to properly disable healing outright.
3. An absurdly large negative multiplier, like -99 for example, did absolutely nothing without any healing traits, but would kils you dead as hell if if you do.
4. `add` had the same wacky behavior as `multiply`, i.e. only taking effect if you have a fast-healing trait, in both DDA and BN.

This was found to be present up to DDA build 11218, and mimicking the source PR's way HP regen was done produced the exact same inconsistencies. I've since been able to get it working as expected (though minimum healing appears to be enforced such that trying to outright disable healing with an enchantment won't work).

As for more current DDA handling, testing with 11246 found that the enchantment now just outright doesn't work at all in DDA, Fast Healer or no. Would recommend someone report an issue over there to inform them that the feature is broken.