### PR TITLE
Fix tile memory behavior after quicksave

### DIFF
--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -335,10 +335,10 @@ bool map_memory::save( const tripoint &pos )
             const bool res = write_to_file( path, writer, descr.c_str() );
             result = result & res;
         }
-        point regp_sm = mmr_to_sm_copy( regp ).xy();
-        rectangle rect_reg( regp_sm, regp_sm + point( MM_REG_SIZE, MM_REG_SIZE ) );
+        tripoint regp_sm = mmr_to_sm_copy( regp );
+        rectangle rect_reg( regp_sm.xy(), regp_sm.xy() + point( MM_REG_SIZE, MM_REG_SIZE ) );
         if( rect_reg.overlaps_half_open( rect_keep ) ) {
-            dbg( D_INFO ) << "Keeping mm_region " << regp << " [" << mmr_to_sm_copy( regp ) << "]";
+            dbg( D_INFO ) << "Keeping mm_region " << regp << " [" << regp_sm << "]";
             // Put submaps back
             for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
                 for( size_t x = 0; x < MM_REG_SIZE; x++ ) {
@@ -348,7 +348,7 @@ bool map_memory::save( const tripoint &pos )
                 }
             }
         } else {
-            dbg( D_INFO ) << "Dropping mm_region " << regp << " [" << mmr_to_sm_copy( regp ) << "]";
+            dbg( D_INFO ) << "Dropping mm_region " << regp << " [" << regp_sm << "]";
         }
     }
 


### PR DESCRIPTION
#### Summary
SUMMARY:  None

#### Purpose of change
Fix tile memory showing wrong tiles at z == 0 after a quicksave if the player had tile memory loaded for submaps with z != 0.

#### Describe the solution
Don't discard z

#### Describe alternatives you've considered
Getting tile memory to work properly on the first try would've been nice.

#### Testing
Teleported to a house roof, saved the game, loaded it, quicksaved, then scrolled the view down to z = 0.

#### Additional context
I'm not sure how it compiled in the first place given `point` does not implement `operator+(const tripoint&)`