### PR TITLE
Fix highlight in "wish mutation" menu

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -592,17 +592,27 @@ void uilist::show()
     for( int fei = vshift, si = 0; si < vmax; fei++, si++ ) {
         if( fei < static_cast<int>( fentries.size() ) ) {
             int ei = fentries [ fei ];
-            nc_color co = ( ei == selected ?
-                            hilight_color :
-                            ( entries[ ei ].enabled || entries[ei].force_color ?
-                              entries[ ei ].text_color :
-                              disabled_color )
-                          );
+            nc_color co;
+            nc_color hk_co;
+            if( ei == selected ) {
+                if( entries[ei].override_hilite_color ) {
+                    co = entries[ei].hilite_color;
+                } else {
+                    co = hilight_color;
+                }
+                hk_co = co;
+            } else {
+                if( entries[ei].enabled || entries[ei].force_color ) {
+                    co = entries[ ei ].text_color;
+                } else {
+                    co = disabled_color;
+                }
+                hk_co = entries[ei].enabled ? hotkey_color : co;
+            }
 
             mvwprintz( window, point( pad_left + 1, estart + si ), co, padspaces );
             if( entries[ ei ].hotkey >= 33 && entries[ ei ].hotkey < 126 ) {
-                const nc_color hotkey_co = ei == selected ? hilight_color : hotkey_color;
-                mvwprintz( window, point( pad_left + 2, estart + si ), entries[ ei ].enabled ? hotkey_co : co,
+                mvwprintz( window, point( pad_left + 2, estart + si ), hk_co,
                            "%c", entries[ ei ].hotkey );
             }
             if( pad_size > 3 ) {

--- a/src/ui.h
+++ b/src/ui.h
@@ -62,8 +62,10 @@ struct uilist_entry {
     nc_color hotkey_color;
     nc_color text_color;
     mvwzstr extratxt;
+    // Use 'hilite_color' when selected instead of uilist's 'hilight_color'
+    bool override_hilite_color = false;
+    nc_color hilite_color;
 
-    //std::string filtertxt; // possibly useful
     uilist_entry( std::string T ) : retval( -1 ), enabled( true ), hotkey( -1 ), txt( T ) {
         text_color = c_red_red;
     }

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -67,8 +67,15 @@ class wish_mutate_callback: public uilist_callback
                     p->set_mutation( vTraits[ entnum ] );
                     p->toggle_trait( vTraits[ entnum ] );
                 }
-                menu->entries[ entnum ].text_color = p->has_trait( vTraits[ entnum ] ) ? c_green : menu->text_color;
-                menu->entries[ entnum ].extratxt.txt = p->has_base_trait( vTraits[ entnum ] ) ? "T" : "";
+                uilist_entry &entry = menu->entries[entnum];
+                if( p->has_trait( vTraits[ entnum ] ) ) {
+                    entry.text_color = c_green;
+                    entry.override_hilite_color = true;
+                } else {
+                    entry.text_color = menu->text_color;
+                    entry.override_hilite_color = false;
+                }
+                entry.extratxt.txt = p->has_base_trait( vTraits[ entnum ] ) ? "T" : "";
                 return true;
             }
             return false;
@@ -218,8 +225,10 @@ void debug_menu::wishmutate( player *p )
         wmenu.entries[ c ].extratxt.left = 1;
         wmenu.entries[ c ].extratxt.txt.clear();
         wmenu.entries[ c ].extratxt.color = c_light_green;
+        wmenu.entries[ c ].hilite_color = h_light_green;
         if( p->has_trait( traits_iter.id ) ) {
             wmenu.entries[ c ].text_color = c_green;
+            wmenu.entries[ c ].override_hilite_color = true;
             if( p->has_base_trait( traits_iter.id ) ) {
                 wmenu.entries[ c ].extratxt.txt = "T";
             }
@@ -277,12 +286,14 @@ void debug_menu::wishmutate( player *p )
                     entry.extratxt.txt.clear();
                     if( p->has_trait( cb.vTraits[ i ] ) ) {
                         entry.text_color = c_green;
+                        entry.override_hilite_color = true;
                         cb.pTraits[ cb.vTraits[ i ] ] = true;
                         if( p->has_base_trait( cb.vTraits[ i ] ) ) {
                             entry.extratxt.txt = "T";
                         }
                     } else {
                         entry.text_color = wmenu.text_color;
+                        entry.override_hilite_color = false;
                         cb.pTraits[ cb.vTraits[ i ] ] = false;
                     }
                 }


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Fix highlight in "Player->Mutate" debug menu (see screenshots)

#### Describe the solution
Allow `uilist_entry` to override highlight color specified for `uilist`.

#### Testing
Opened debug mutate ui, played a bit with mutations.

#### Additional context
Before: it's unclear whether avatar has "Deaf"
![Screenshot_20201208_232048](https://user-images.githubusercontent.com/60584843/101537324-52b9d280-39ac-11eb-8a0a-4308871e0c84.png)
After: "Deaf" switches between `h_white` and `h_light_green`
![Screenshot_20201208_232254](https://user-images.githubusercontent.com/60584843/101537325-53eaff80-39ac-11eb-9621-93d8177caff9.png)
