### PR TITLE
Fix Draw benchmark behavior, add FPS benchmark

### DIFF
--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -14,6 +14,10 @@ class player;
 
 namespace debug_menu
 {
+enum bench_kind {
+    DRAW,
+    FPS
+};
 
 void teleport_short();
 void teleport_long();
@@ -27,7 +31,7 @@ void wishmonster( const cata::optional<tripoint> &p );
 void wishmutate( player *p );
 void wishskill( player *p );
 void mutation_wish();
-void draw_benchmark( int max_difference );
+void benchmark( const int max_difference, bench_kind kind );
 
 void debug();
 


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Added separate benchmark for 'Draws per second' as opposed to existing 'Frames per second'"

#### Purpose of change
This came up in #251.

After migration to `ui_adaptor`, "Draw benchmark (X seconds)" went from measuring number of redraws (`g->draw()`) per second to number of redraws + window refreshes (`g->draw()` + `refresh_window()`) per second. Window refresh is a blocking operation, with block time depending on the OS, and therefore may skew with the benchmark results.

This PR reverts the behavior of the "Draw benchmark" back to how it worked before the migration, and adds "FPS benchmark" that retains the current behavior.

#### Describe the solution
Changed the code to call `refresh_window()` only when measuring FPS.
Also, moved popup creation out of measuring code (!!!), and made the game actually display it during draw benchmark.

#### Describe alternatives you've considered
Just removing `refresh_window()` call, but then I realized that FPS benchmark may be useful too.

#### Testing
With `opengl` renderer, my Kubuntu 20.04 caps FPS benchmark at 60 (due to synchronization), but Draw benchmark shows 140.