### PR TITLE
Proper cleanup when closing game window

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -1,0 +1,8 @@
+#pragma once
+#ifndef CATA_SRC_MAIN_H
+#define CATA_SRC_MAIN_H
+
+[[ noreturn ]]
+void exit_handler( int status );
+
+#endif // CATA_SRC_MAIN_H

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -45,6 +45,7 @@
 #include "get_version.h"
 #include "hash_utils.h"
 #include "input.h"
+#include "main.h"
 #include "json.h"
 #include "optional.h"
 #include "options.h"
@@ -2794,8 +2795,7 @@ static void CheckMessages()
         try_sdl_update();
     }
     if( quit ) {
-        catacurses::endwin();
-        exit( 0 );
+        exit_handler( 0 );
     }
 }
 

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -16,6 +16,7 @@
 #include "get_version.h"
 #include "init.h"
 #include "input.h"
+#include "main.h"
 #include "path_info.h"
 #include "filesystem.h"
 #include "debug.h"
@@ -398,9 +399,8 @@ LRESULT CALLBACK ProcessMessages( HWND__ *hWnd, unsigned int Msg,
             ValidateRect( WindowHandle, nullptr );
             return 0;
 
-        case WM_DESTROY:
-            // A messy exit, but easy way to escape game loop
-            exit( 0 );
+        case WM_CLOSE:
+            exit_handler( 0 );
     }
 
     return DefWindowProcW( hWnd, Msg, wParam, lParam );


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed segfault when closing game window via Alt+F4"

#### Purpose of change
1. Fix segfault (see 'Additional context') when closing game window via Alt+F4.
2. Untangle signal handling code, make TILES version terminate immediately on SIGINT

#### Describe the solution
1. Use `exit_handler` that destroys the `game` instance before calling `exit()` instead of calling `exit()` and trusting compiler to run destructors in correct order. As a bonus, it now properly closes debug log.
2. Show "Really quit?" query only on CURSES.

#### Testing
Tried windows tiles, linux tiles and linux curses. Segfault is gone, Ctrl+C terminates the game on tiles and queries for exit on curses.

#### Additional context
```
Thread 1 "cataclysm-tiles" received signal SIGSEGV, Segmentation fault.
ui_adaptor::invalidate (rect=..., reenable_uis_below=<optimized out>) at src/ui_manager.cpp:193
193             if( !ui_upper.invalidated && overlap( ui_upper.dimensions, rect ) ) {
(gdb) bt
#0  ui_adaptor::invalidate (rect=..., reenable_uis_below=<optimized out>) at src/ui_manager.cpp:193
#1  0x0000000002845bd6 in ui_manager::invalidate (rect=..., reenable_uis_below=8) at src/ui_manager.cpp:280
#2  0x0000000002845b82 in ui_adaptor::~ui_adaptor (this=0x56ea730) at src/ui_manager.cpp:35
#3  0x0000000001a3b841 in std::default_delete<ui_adaptor>::operator() (this=<optimized out>, __ptr=0x56ea730) at /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:81
#4  0x0000000001a29e13 in std::unique_ptr<ui_adaptor, std::default_delete<ui_adaptor> >::~unique_ptr (this=<optimized out>) at /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:292
#5  0x0000000002168a2d in live_view::~live_view (this=0x44b00d0) at src/live_view.cpp:26
#6  0x0000000001e7f6c1 in std::default_delete<live_view>::operator() (this=<optimized out>, __ptr=0x44b00d0) at /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:81
#7  0x0000000001e77283 in std::unique_ptr<live_view, std::default_delete<live_view> >::~unique_ptr (this=<optimized out>) at /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:292
#8  0x0000000001e1fbe9 in game::~game (this=0x3768ed0) at src/game.cpp:302
#9  0x0000000001e86c11 in std::default_delete<game>::operator() (this=<optimized out>, __ptr=0x3768ed0) at /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:81
#10 0x0000000001e76423 in std::unique_ptr<game, std::default_delete<game> >::~unique_ptr (this=<optimized out>) at /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:292
#11 0x00007ffff792ca27 in __run_exit_handlers (status=0, listp=0x7ffff7ace718 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at exit.c:108
#12 0x00007ffff792cbe0 in __GI_exit (status=<optimized out>) at exit.c:139
#13 0x00000000027bff37 in CheckMessages () at src/sdltiles.cpp:3250
#14 0x00000000027bf765 in input_manager::get_input_event (this=0x34a84d0 <inp_mngr>) at src/sdltiles.cpp:3691
#15 0x0000000001f5e930 in input_context::handle_input[abi:cxx11](int) (this=0x7fffffffd228, timeout=125) at src/input.cpp:863
#16 0x0000000001f5e89c in input_context::handle_input[abi:cxx11]() (this=0x3a5a960) at src/input.cpp:851
#17 0x0000000001e334ba in game::handle_mouseview (this=0x3768ed0, ctxt=..., Python Exception <class 'gdb.error'> There is no member named _M_dataplus.: 
action=) at src/game.cpp:2191
#18 0x0000000001edf8fc in game::get_player_input (this=<optimized out>, Python Exception <class 'gdb.error'> There is no member named _M_dataplus.: 
action=) at src/handle_action.cpp:330
#19 0x0000000001ee01c3 in game::handle_action (this=0x3768ed0) at src/handle_action.cpp:1477
#20 0x0000000001e27888 in game::do_turn (this=<optimized out>) at src/game.cpp:1445
#21 0x00000000021c46d2 in main (argc=<optimized out>, argv=0x7fffffffdeb0) at src/main.cpp:698
```
To reproduce, load a save, move the cursor to make "Mouse look" window show up, then press Alt+F4.
This crash is absent in DDA for some reason. C++ header inclusion order magic? The relevant code seems identical.
