### PR TITLE
Warn at startup if user directory is not writable

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -425,3 +425,29 @@ std::string ensure_valid_file_name( const std::string &file_name )
 
     return new_file_name;
 }
+
+// This string is 'CataclysmBrightNights' encoded as base64
+const char *CBN = "Q2F0YWNseXNtQnJpZ2h0TmlnaHRz";
+
+bool can_write_to_dir( const std::string &dir_path )
+{
+    // TODO: remove this hack once c++17 is a thing
+
+    std::string dummy_file = dir_path + CBN;
+    if( file_exist( dummy_file ) ) {
+        if( !remove_file( dummy_file ) ) {
+            return false;
+        }
+    }
+
+    const auto writer = []( std::ostream & s ) {
+        // Write at least something to check if there is free space on disk
+        s << CBN << std::endl;
+    };
+
+    if( !write_to_file( dummy_file, writer, nullptr ) ) {
+        return false;
+    }
+
+    return remove_file( dummy_file );
+}

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -14,6 +14,8 @@ bool remove_file( const std::string &path );
 bool remove_directory( const std::string &path );
 // Rename a file, overriding the target!
 bool rename_file( const std::string &old_path, const std::string &new_path );
+// Check if can write to the given directory
+bool can_write_to_dir( const std::string &dir_path );
 
 namespace cata_files
 {


### PR DESCRIPTION
#### Summary
SUMMARY: Interface "The game now warns if user directory is not writable on startup."

#### Purpose of change
Solves #254
Also, fixes debug log file not being created for the first game session.

#### Describe the solution
This PR adds a check to determine whether directory is writable, and makes the game run this check for `user` and `config` dirs on startup.

If the check fails, the code produces a "fatal error" that is displayed in a user friendly way:
On curses: writes to `stderr`
On tiles: shows SDL's cross-platform message box

#### Describe alternatives you've considered
1. Bump required C++ version to C++17 and implement the check via [Filesystem library](https://en.cppreference.com/w/cpp/filesystem), but this solution works too and does not require dropping support for older compilers.
2. Add error codes in these messages. The game can't use translations at that stage, but numerical error codes may help people who don't understand English.
3. Add this check for other directories (save, template, fonts, gfx, etc.) created in `main_menu.cpp`, but they seem to be covered by `user_dir` check anyway.

#### Testing
Running the game from a system directory produces:

Linux curses
```
Cataclysm BN: Fatal error
Can't write to "./"
Please ensure you have write permission and free storage space.
```

Linux tiles
![image](https://user-images.githubusercontent.com/60584843/101938924-44122c00-3bf5-11eb-969d-526f08777477.png)

Windows tiles
![BN-fatal](https://user-images.githubusercontent.com/60584843/101938889-32c91f80-3bf5-11eb-8d40-ea0ff64399b4.png)
