### PR TITLE
Fix the 'losing book during reading - book in car' test

### DIFF
--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -414,7 +414,7 @@ TEST_CASE( "Losing book during reading", "[reading][book]" )
     }
 
     SECTION( "Book in car" ) {
-        vehicle *veh = g->m.add_vehicle( vproto_id( "car" ), u.pos(), 0 );
+        vehicle *veh = g->m.add_vehicle( vproto_id( "car" ), u.pos(), 0, 0, 0 );
         REQUIRE( veh != nullptr );
         int part = veh->part_with_feature( point_zero, "CARGO", true );
         REQUIRE( part >= 0 );


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Fix failing test:
```
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cata_test is a Catch v2.12.0 host application.
Run with -? for options                                                                                                                                                                                                                                                        

Randomness seeded to: 1607345790                                                                                                                                                                                                                                               

-------------------------------------------------------------------------------
Losing book during reading
  Book in car
-------------------------------------------------------------------------------
reading_test.cpp:416
...............................................................................                                                                                                                                                                                                

reading_test.cpp:420: FAILED:
  REQUIRE( part >= 0 )
with expansion:
  -1 >= 0

```

#### Describe the solution
Spawn vehicle in mint condition so that the required `CARGO` part is not broken.

#### Testing
The test passes