### PR TITLE
Ammunition Rebalance Part 2: .32 and .380 ACP

### DIFF
--- a/data/json/items/ammo/22.json
+++ b/data/json/items/ammo/22.json
@@ -28,7 +28,7 @@
     "ammo_type": "22",
     "casing": "22_casing",
     "range": 13,
-    "//": "Base muzzle energy of ~144 joules, balance increase of one-third.",
+    "//": "Base damage of 12, balance increase of one-third.",
     "damage": { "damage_type": "stab", "amount": 16, "armor_penetration": 7 },
     "dispersion": 60,
     "recoil": 150,

--- a/data/json/items/ammo/32.json
+++ b/data/json/items/ammo/32.json
@@ -17,7 +17,8 @@
     "ammo_type": "32",
     "casing": "32_casing",
     "range": 12,
-    "damage": { "damage_type": "stab", "amount": 16 },
+    "//": "Base muzzle energy of ~256 joules, balance increase of one-third.",
+    "damage": { "damage_type": "stab", "amount": 21, "armor_penetration": 7 },
     "dispersion": 70,
     "recoil": 150,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/32.json
+++ b/data/json/items/ammo/32.json
@@ -17,7 +17,7 @@
     "ammo_type": "32",
     "casing": "32_casing",
     "range": 12,
-    "//": "Base muzzle energy of ~256 joules, balance increase of one-third.",
+    "//": "Base damage of 16, balance increase of one-third.",
     "damage": { "damage_type": "stab", "amount": 21, "armor_penetration": 7 },
     "dispersion": 70,
     "recoil": 150,

--- a/data/json/items/ammo/380.json
+++ b/data/json/items/ammo/380.json
@@ -17,7 +17,7 @@
     "ammo_type": "380",
     "casing": "380_casing",
     "range": 13,
-    "//": "Base muzzle energy of ~256 joules, balance increase of one-third.",
+    "//": "Base damage of 16, balance increase of one-third.",
     "damage": { "damage_type": "stab", "amount": 21, "armor_penetration": 8 },
     "dispersion": 60,
     "recoil": 300,
@@ -42,9 +42,9 @@
     "price_postapoc": 1500,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "count": 25,
-    "damage": { "damage_type": "stab", "amount": 24, "armor_penetration": 4 },
+    "damage": { "damage_type": "stab", "amount": 30, "armor_penetration": 0 },
     "relative": { "dispersion": -15 },
-    "proportional": { "recoil": 1.1 }
+    "proportional": { "recoil": 2.0 }
   },
   {
     "id": "bp_380_FMJ",

--- a/data/json/items/ammo/380.json
+++ b/data/json/items/ammo/380.json
@@ -17,7 +17,8 @@
     "ammo_type": "380",
     "casing": "380_casing",
     "range": 13,
-    "damage": { "damage_type": "stab", "amount": 16, "armor_penetration": 2 },
+    "//": "Base muzzle energy of ~256 joules, balance increase of one-third.",
+    "damage": { "damage_type": "stab", "amount": 21, "armor_penetration": 8 },
     "dispersion": 60,
     "recoil": 300,
     "effects": [ "COOKOFF" ]
@@ -28,7 +29,8 @@
     "type": "AMMO",
     "name": { "str": ".380 ACP JHP" },
     "description": ".380 ACP ammunition with a 95gr jacketed hollow point bullet.  It is a popular round for small concealable backup pistols, and often the weakest recommended defensive caliber.  One should be careful not to chamber it in 9x18mm Makarov or 9x19mm firearms.",
-    "relative": { "damage": { "damage_type": "stab", "amount": 2, "armor_penetration": -2 } }
+    "//": "Hollowpoint damage increase of 25%",
+    "damage": { "damage_type": "stab", "amount": 26, "armor_penetration": 0 }
   },
   {
     "id": "380_p",
@@ -40,7 +42,8 @@
     "price_postapoc": 1500,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "count": 25,
-    "relative": { "damage": { "damage_type": "stab", "amount": 4, "armor_penetration": 2 }, "dispersion": -15 },
+    "damage": { "damage_type": "stab", "amount": 24, "armor_penetration": 4 },
+    "relative": { "dispersion": -15 },
     "proportional": { "recoil": 1.1 }
   },
   {

--- a/doc/GAME_BALANCE.md
+++ b/doc/GAME_BALANCE.md
@@ -206,8 +206,10 @@ Everywhere else   | Predominately 9mm and 223. Always with standard magazine  | 
 Bow damage is based on the momentum achieved in the projectile.  Since arrows and bolts have sharp cutting surfaces, the penetration and therefore damage achieved is based on the projectile's capacity for slicing through tissues.  The arrow has a modifier based on construction, material and design, most critically centered around the effectiveness of the head.  Base damage is calculated from momentum by taking momentum in Slug-foot-seconds, multiplying by 150 and subtracting 32. This was arrived at by taking well-regarded bowhunting guidelines and determining the damage numbers necessary for a kill of various game on a critical hit, see tests/archery_damage_test.cpp for details.
 
 ## Ammo stats
-The damage (**Dmg**) of firearm ammunition is the square root of a round's muzzle energy in joules (**Energy, J**) rounded to the nearest integer with an arbitrary increase or decrease to account for terminal ballistics. Damage of handloaded ammo is set to 92% (rounded down) of their factory counterparts. A similar system for calculating recoil is planned but not currently being worked on. The figures used to calculate stats and any other relevant information are presented in table below.
+### Base Damage
+The damage (**Dmg**) of firearm ammunition starts with the square root of a round's muzzle energy in joules (**Energy, J**) rounded to the nearest integer with an arbitrary increase or decrease to account for terminal ballistics. These numbers are modified depending on certain criteria (see Adjustment Criteria, below). Damage of handloaded ammo is set to 92% (rounded down) of their factory counterparts. A similar system for calculating recoil is planned but not currently being worked on. The figures used to calculate stats and any other relevant information are presented in table below.
 
+### Base Barrel Length
 Each cartridge also has a Base Barrel Length (**Base Brl**) listed; this determines the damage for the connected guns. A firearm has its damage modifier determined by it's real life barrel length; for every three inches between it and the listed baseline here, the gun takes a 1 point bonus or penalty, rounding to the nearest modifier. For example, a .45 ACP gun with a 7 inch barrel would get a +1 bonus (against a baseline of 5 inches).
 
 Ammo ID            | Description                 | Energy, J | Dmg | Base Brl | Applied Modifiers / Comments |
@@ -264,6 +266,15 @@ Ammo ID            | Description                 | Energy, J | Dmg | Base Brl | 
 .50 BMG M33 Ball   | 706.7gr bullet              | 18013     | 134 | 45in     |                              |
 .50 BMG M903 SLAP  | 355gr tungsten AP bullet    | 17083     | 131 | 45in     |  Can't be used with M107A1   |
 .410 000 shot      | 5 000 pellets               | 1530      | 39  | 18in     |                              |
+
+###Adjustment Criteria
+If the resulting base damage is below specific thresholds, apply one of three multipliers. If the base damage is less than 20, the multiplier is 1.333. Else, if the base damage less than 30, the multiplier is 1.222. Else, if the base damage is less than 40, the multiplier is 1.111. Ammunition with damage of 40 or higher will generally have no arbitrary multiplier given to its basic variant.
+
+As for terminal ballistics, hollowpoints variant should be at least 25% more effective against a completely unarmored target, in order for the difference to be considered relevant. Conversely, the base FMJ variation should ideally be at least 25% more effective against a reasonable level of armor for that ammunition to encounter. This recommendation will inform how much armor penetration the two variants should have.
+
+For ammunition that would not be expected to defeat soft body armor (i.e. kevlar), test the difference in damage against both 8 and 16 armor. For reference, 16 is the current cut protection a kevlar vest offers. In at least one of these contexts, preferably both, the standard FMJ should have 25% or higher damage than the hollowpoint version.
+
+For ammunition expected to defeat soft body armor but not hard body armor (i.e. ballistic vest with ceramic plates), perform the same tests against armor values of 23 and 45. For reference, the latter number is the current cut protection of a ceramic-plated MBR vest, and the latter is half that (rounded up). Again, at least one of those scenarios, preferably both, should involve a high enough difference in armor penetration for the FMJ variant to perform at least 25% better than the JHP variant.
 
 # LIQUIDS:
 Multi-charge items are weighed by the charge/use.  If you have an item that contains 40 uses, it'll weigh 40x as much (when found in-game) as you entered in the JSON. Liquids are priced by the 250mL unit, but handled in containers.  This can cause problems if you create something that comes in (say) a gallon jug (15 charges) and price it at the cost of a jug's worth: it'll be 15x as expensive as intended.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Establish documentation of rebalancing plans, apply to two more calibers."

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Part two in my rebalancing of low-tier ammunition, applying the balancing scheme to two more ammo types: .32 ACP and .380 ACP. Moreover, I've also established a rough outline of how the plan is expected to work, and what goals it seeks to accompish, in GAME_BALANCE.md.

This explicitly takes the "use real-world numbers for determining how much damage to deal" concept already defined in the documentation, and uses it as a starting point. Then it outlines under what contexts to adjust those numbers, a recommendation for how much, and additionally outlines the how armor penetration should be utilized to make the different variations of ammunition better for different situations.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Applied the rebalancing multiplier of 33% to .32 ACP, and same armor piercing as .22 LR, to make it compare appropriately against the newly-buffed .22 LR. As it has no hollowpoint variant, this one was relatively simpler.
2. Applied the rebalancing multiplier of 33% to .380 ACP, and likewise altered armor piercing. This is at the point where testing the two main variants against both 8 armor and 16 armor may be desirable, as it's now becoming harder to get that "FMJ is 25% better against light armor" mark.
3. Altered the balance of the +P variation. It's a JHP bullet but also overpressure, which makes balancing it a bit more tricky. The reasonable approach to me seemed to be to allow it to retain its original armor penetration so that it's in between standard JHP and FMJ, and give it a 12.5% hollowpoint bonus instead of the 25% standard JHP has. This is somewhat justifiable by its stated bullet weight being lower than the normal JHP, but moreover that makes it statistically in between the two standard variants.
4. Documented the current process in GAME_BALANCE.md, and outlined the recommended numbers of armor ammunition should be tested against.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Testing non-AP pistol rounds exclusively against 16 armor instead of 8, and adjusting arpen with that criteria as the only important one. This would lead to a reduction in armor penetration for at least some of these, and a revisit of how much armor penetration .22 LR needs to meet the desired criteria (since its comparison was exclusively balanced against 8 armor, not 16).
2. Capping how high the hollowpoint bonus should be. I.E. defining the bonus as "25% or X, whichever result is lower" instead. This will be relevant once we reach the latter half of the rebalancing PR, as eventually it'll cause JHP pistol rounds to be able to compete with shotgun slugs if the bonus isn't capped. What number to cap the bonus at, I'm not yet certain.
3. Conversely, it may also be desirable to also place a cap on how big a difference we want out of FMJ/AP rounds when tested against armor. Same issue as above, except in this case the arpen needed to enable a 25% difference may lead to the higher-end, non-AP pistol rounds receiving AP levels of piercing to meet this criteria, again encouraging this criteria to be capped at a currently-undetermined maximum.
4. Adjusting .380 ACP +P ammunition in some other way to give it a more distinct niche, or obsoleting it if doing so seems impossible.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Imported JSON changes to build 1044 and load-tested them.
2. Ran numbers for how the different ammunition performs in certain contexts. In particular, .380 ACP FMJ is only 16.667% more effective than JHP against 8 armor, but 30% more effective against 16 armor. This is what prompted me to suggest that testing them against 16 armor might be a sensible second test to do, and also what led to posing the question over whether the 8-armor test should be retained at all.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

The next PR, assuming we're able to hash out which tests are best to do for each ammotype, whether to, will likely be easier still and will likely allow me to cover all ballistic ammunition that's in the first two tiers (below 20 and below 30).

That said, the +P issue does outline that nonstandard variants will be harder for me to figure out the best practice for balancing.