### PR TITLE
Fix compilation (for real this time)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@
 #include "game_ui.h"
 #include "input.h"
 #include "loading_ui.h"
-#include "main.h"
+#include "runtime_handlers.h"
 #include "main_menu.h"
 #include "mapsharing.h"
 #include "options.h"
@@ -819,12 +819,3 @@ void printHelpMessage( const arg_handler *first_pass_arguments,
     }
 }
 }  // namespace
-
-[[ noreturn ]]
-void exit_handler( int status )
-{
-    deinitDebug();
-    g.reset();
-    catacurses::endwin();
-    exit( status );
-}

--- a/src/main.h
+++ b/src/main.h
@@ -1,8 +1,0 @@
-#pragma once
-#ifndef CATA_SRC_MAIN_H
-#define CATA_SRC_MAIN_H
-
-[[ noreturn ]]
-void exit_handler( int status );
-
-#endif // CATA_SRC_MAIN_H

--- a/src/runtime_handlers.cpp
+++ b/src/runtime_handlers.cpp
@@ -1,0 +1,12 @@
+#include "cursesdef.h"
+#include "debug.h"
+#include "game.h"
+
+[[ noreturn ]]
+void exit_handler( int status )
+{
+    deinitDebug();
+    g.reset();
+    catacurses::endwin();
+    exit( status );
+}

--- a/src/runtime_handlers.h
+++ b/src/runtime_handlers.h
@@ -1,0 +1,8 @@
+#pragma once
+#ifndef CATA_SRC_RUNTIME_HANDLERS_H
+#define CATA_SRC_RUNTIME_HANDLERS_H
+
+[[ noreturn ]]
+void exit_handler( int status );
+
+#endif // CATA_SRC_RUNTIME_HANDLERS_H

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -45,7 +45,7 @@
 #include "get_version.h"
 #include "hash_utils.h"
 #include "input.h"
-#include "main.h"
+#include "runtime_handlers.h"
 #include "json.h"
 #include "optional.h"
 #include "options.h"

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -16,7 +16,7 @@
 #include "get_version.h"
 #include "init.h"
 #include "input.h"
-#include "main.h"
+#include "runtime_handlers.h"
 #include "path_info.h"
 #include "filesystem.h"
 #include "debug.h"


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Fix compilation for _real_ real

#### Describe the solution
Make sure `exit_handler(int)` is included into `cataclysm.a` when linking `cata_test`

#### Describe alternatives you've considered
Move it into an existing `.cpp` file instead? None of them looked suitable

#### Testing
The tiles version compiles on linux under `clang10`, and all the tests compile too.