### PR TITLE
Fix compilation for gcc and mingw

### DIFF
--- a/src/runtime_handlers.cpp
+++ b/src/runtime_handlers.cpp
@@ -1,3 +1,4 @@
+#include "runtime_handlers.h"
 #include "cursesdef.h"
 #include "debug.h"
 #include "game.h"


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Fix compilation. Hopefully, for the last time.

#### Describe the solution
Add missing include to satisfy gcc and mingw

#### Describe alternatives you've considered
Giving up programming

#### Testing
gcc gives no errors when it compiles `runtime_handlers.cpp`

#### Additional context
Sorry for the mess -_-