### PR TITLE
A bit stricter test assumption for damage block

### DIFF
--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -113,7 +113,7 @@ TEST_CASE( "effective damage per second", "[effective][dps]" )
 
     SECTION( "against an agile target" ) {
         monster smoker( mtype_id( "mon_zombie_smoker" ) );
-        REQUIRE( smoker.get_dodge() >= 4 );
+        REQUIRE( smoker.get_dodge() == 4 );
 
         CHECK( clumsy_sword.effective_dps( dummy, smoker ) == Approx( 11.0f ).epsilon( 0.15f ) );
         CHECK( good_sword.effective_dps( dummy, smoker ) == Approx( 25.0f ).epsilon( 0.15f ) );

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -144,6 +144,8 @@ TEST_CASE( "weapon attack ratings and moves", "[item][iteminfo][weapon]" )
     clear_avatar();
     REQUIRE( g->u.get_str() == 8 );
     REQUIRE( g->u.get_dex() == 8 );
+    REQUIRE( g->u.get_int() == 8 );
+    REQUIRE( g->u.get_per() == 8 );
     iteminfo_query q = q_vec( { iteminfo_parts::BASE_DAMAGE, iteminfo_parts::BASE_TOHIT,
                                 iteminfo_parts::BASE_MOVES
                               } );


### PR DESCRIPTION
This is an attempt to catch the non-deterministic test failure, where the player has higher than expected damage, as displayed by item info.