### PR TITLE
Port DDA's fix for crash when DebugLog is called before logging is initialized

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -183,6 +183,12 @@ void limitDebugClass( int );
  */
 bool debug_has_error_been_observed();
 
+/**
+ * Should be called after catacurses::stdscr is initialized.
+ * If catacurses::stdscr is available, shows all buffered debugmsg prompts.
+ */
+void replay_buffered_debugmsg_prompts();
+
 // Debug Only                                                       {{{1
 // ---------------------------------------------------------------------
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -749,6 +749,7 @@ int main( int argc, char *argv[] )
         set_language();
     }
 #endif
+    replay_buffered_debugmsg_prompts();
 
     while( true ) {
         if( !world.empty() ) {


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Fix crash when DebugLog is called before logging is initialized.
Example case is crash on startup if there are multiple tilesets with the same id https://github.com/DoctorGoat/BN_Update/issues/7

#### Describe the solution
Port CleverRaven#44498

#### Testing
![image](https://user-images.githubusercontent.com/60584843/102653614-3c67ff80-4180-11eb-80cd-28e36a0e72ab.png)
