### PR TITLE
Fix martial arts providing bonuses from effects markes as 'removed'

### DIFF
--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1053,8 +1053,12 @@ static void accumulate_ma_buff_effects( const C &container, F f )
 {
     for( auto &elem : container ) {
         for( auto &eff : elem.second ) {
-            if( auto buff = ma_buff::from_effect( eff.second ) ) {
-                f( *buff, eff.second );
+            const effect &e = eff.second;
+            if( e.is_removed() ) {
+                continue;
+            }
+            if( auto buff = ma_buff::from_effect( e ) ) {
+                f( *buff, e );
             }
         }
     }
@@ -1065,8 +1069,12 @@ static bool search_ma_buff_effect( const C &container, F f )
 {
     for( auto &elem : container ) {
         for( auto &eff : elem.second ) {
-            if( auto buff = ma_buff::from_effect( eff.second ) ) {
-                if( f( *buff, eff.second ) ) {
+            const effect &e = eff.second;
+            if( e.is_removed() ) {
+                continue;
+            }
+            if( auto buff = ma_buff::from_effect( e ) ) {
+                if( f( *buff, e ) ) {
                     return true;
                 }
             }

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -90,7 +90,8 @@ void clear_character( player &dummy, bool debug_storage )
     dummy.set_movement_mode( CMM_WALK );
 
     // Make sure we don't carry around weird effects.
-    dummy.clear_effects();
+    dummy.clear_effects(); // mark effects for removal
+    dummy.process_effects(); // actually remove them
 
     // Make stats nominal.
     dummy.str_max = 8;


### PR DESCRIPTION
#### Purpose of change
Fix a bug and order-dependent dps test failure.

#### Describe the solution
See commits

#### Describe alternatives you've considered
Add a test for complete effect removal?

#### Testing
DPS tests are fixed by either commit, as expected.
