### PR TITLE
Port over fix to effects-from-enchantments

### DIFF
--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -195,7 +195,7 @@
         {
           "has": "HELD",
           "condition": "ACTIVE",
-          "values": [ { "value": "INTELLIGENCE", "add": -4 }, { "value": "PERCEPTION", "add": -4 } ],
+          "values": [ { "value": "INTELLIGENCE", "add": -2 }, { "value": "PERCEPTION", "add": -2 } ],
           "ench_effects": [ { "effect": "debug_clairvoyance", "intensity": 1 } ]
         }
       ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7624,15 +7624,6 @@ void Character::recalculate_enchantment_cache()
     // start by resetting the cache to all inventory items
     enchantment_cache = inv.get_active_enchantment_cache( *this );
 
-    visit_items( [&]( const item * it ) {
-        for( const enchantment &ench : it->get_enchantments() ) {
-            if( ench.is_active( *this, *it ) ) {
-                enchantment_cache.force_add( ench );
-            }
-        }
-        return VisitResponse::NEXT;
-    } );
-
     // get from traits/ mutations
     for( const std::pair<const trait_id, trait_data> &mut_map : my_mutations ) {
         const mutation_branch &mut = mut_map.first.obj();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7621,8 +7621,17 @@ std::string Character::get_highest_category() const
 
 void Character::recalculate_enchantment_cache()
 {
-    // start by resetting the cache to all inventory items
-    enchantment_cache = inv.get_active_enchantment_cache( *this );
+    // start by resetting the cache
+    enchantment_cache = enchantment();
+
+    visit_items( [&]( const item * it ) {
+        for( const enchantment &ench : it->get_enchantments() ) {
+            if( ench.is_active( *this, *it ) ) {
+                enchantment_cache.force_add( ench );
+            }
+        }
+        return VisitResponse::NEXT;
+    } );
 
     // get from traits/ mutations
     for( const std::pair<const trait_id, trait_data> &mut_map : my_mutations ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8547,16 +8547,6 @@ void item::process_relic( Character *carrier )
             active_enchantments.emplace_back( ench );
         }
     }
-
-    for( const enchantment &ench : active_enchantments ) {
-        ench.activate_passive( *carrier );
-    }
-
-    // Recalculate, as it might have changed (by mod_*_bonus above)
-    carrier->str_cur = carrier->get_str();
-    carrier->int_cur = carrier->get_int();
-    carrier->dex_cur = carrier->get_dex();
-    carrier->per_cur = carrier->get_per();
 }
 
 bool item::process_corpse( player *carrier, const tripoint &pos )

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3429,8 +3429,8 @@ void player::use( item_location loc )
     } else {
         add_msg( m_info, _( "You can't do anything interesting with your %s." ),
                  used.tname() );
-        recalculate_enchantment_cache();
     }
+    recalculate_enchantment_cache();
 }
 
 void player::reassign_item( item &it, int invlet )

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3429,7 +3429,7 @@ void player::use( item_location loc )
     } else {
         add_msg( m_info, _( "You can't do anything interesting with your %s." ),
                  used.tname() );
-    recalculate_enchantment_cache();
+        recalculate_enchantment_cache();
     }
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3429,6 +3429,7 @@ void player::use( item_location loc )
     } else {
         add_msg( m_info, _( "You can't do anything interesting with your %s." ),
                  used.tname() );
+    recalculate_enchantment_cache();
     }
 }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1458,6 +1458,8 @@ void Character::suffer()
 
     suffer_without_sleep( sleep_deprivation );
     suffer_from_pain();
+    //Suffer from enchantments
+    enchantment_cache.activate_passive( *this );
 
     if( calendar::once_every( 1_hours ) ) {
         add_effect( effect_accumulated_mutagen, 1_hours, num_bp, true );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Port over fix for applying effects from passive enchantments"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

An important fix to enchantment code that I forgot about. Needed for effects-from-enchantments to function again, especially if from mutations.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Ported over changes to item.cpp and suffer.cpp, for less broken processing of passive relic/enchantment effects. This had to be done as `enchantment_cache.activate_passive` instead of `enchantment_cache->activate_passive` but this causes a problem, see below.
2. Altered the stat adjustment of the cube of shame to test an issue that came up while working on initial commit.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Continue to slowly go insane.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Spawned in and activated the cube of shame.
3. Tested the Cloaking System CBM to confirm invisibility effect appears on activation.
4. Ported the BN version of Arcana over temporaily to test Draconic Wings, effect shows up on character screen and fall damage negated.
5. Also waited a while with the currently WIP version of the Life Sign Supression CBM active, confirming healthiness stats went down.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/43101

Changes to TEST_DATA content not ported over, as that would require me to also port over transforming mutations. Something that'd be useful to port over in the future, but not a vital fix like this is. It will be needed if I want to port over https://github.com/CleverRaven/Cataclysm-DDA/pull/45687 however, which I would like to eventually.

Had an issue with the double-stat bug recurring for reasons I could've figure out, at first. Fix is entirely thanks to Coolthulhu finding the cause after discussion on the modder's discord, I was 100% stumped here and the cause turned out to be in a file I hadn't even thought to scrutinize.