### PR TITLE
Display effects of perception and eye encumbrance on night vision in menus

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -1618,16 +1618,17 @@ See also VEHICLE_JSON.md
 ],
 "explode_in_fire": true,                     // Should the item explode if set on fire
 "explosion": {                               // Physical explosion data
-    "power": 10,                             // Measure of explosion power in grams of TNT equivalent explosive, affects damage and range.
-    "distance_factor": 0.9,                  // How much power is retained per traveled tile of explosion. Must be lower than 1 and higher than 0.
-    "fire": true,                            // Should the explosion leave fire
-    "shrapnel": 200,                         // Total mass of casing, rest of fragmentation variables set to reasonable defaults.
-    "shrapnel": {
-        "casing_mass": 200,                  // Total mass of casing, casing/power ratio determines fragment velocity.
-        "fragment_mass": 0.05,               // Mass of each fragment in grams. Large fragments hit harder, small fragments hit more often.
-        "recovery": 10,                      // Percentage chance to drop an item at landing point.
-        "drop": "nail"                       // Which item to drop at landing point.
+  "damage": 10,                              // Damage the explosion deals to player at epicenter. Damage is halved above 50% radius.
+  "radius": 8,                               // Radius of the explosion. 0 means only the epicenter is affected.
+  "fire": true,                              // Should the explosion leave fire
+  "fragment": {                              // Projectile data of "shrapnel". This projectile will hit every target in its range and field of view exactly once.
+    "damage": {                              // Damage data of the shrapnel projectile.
+      "damage_type": "acid",                 // Type of damage dealt.
+      "amount": 10                           // Amount of damage dealt.
+      "armor_penetration": 4                 // Amount of armor ignored. Applied per armor piece, not in total.
+      "armor_multiplier": 2.5                // Multiplier on effective armor value. Applied after armor penetration.
     }
+  }
 },
 ```
 

--- a/src/character.h
+++ b/src/character.h
@@ -2309,4 +2309,18 @@ struct enum_traits<Character::stat> {
 };
 /**Get translated name of a stat*/
 std::string get_stat_name( Character::stat Stat );
+
+// TODO: Move to its own file (it's not Character-specific)
+namespace vision
+{
+/**
+ * Returns the light level that darkness will have at this range from player.
+ * Assumes pure air transparency.
+ */
+float threshold_for_nv_range( float range );
+
+float nv_range_from_per( int per );
+float nv_range_from_eye_encumbrance( int enc );
+} // namespace vision
+
 #endif // CATA_SRC_CHARACTER_H

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -902,7 +902,9 @@ tab_direction set_stats( avatar &u, points_left &points )
                     mvwprintz( w_description, point_zero, COL_STAT_PENALTY, _( "Aiming penalty: -%d" ),
                                u.ranged_per_mod() );
                 }
-                fold_and_print( w_description, point( 0, 2 ), getmaxx( w_description ) - 1, COL_STAT_NEUTRAL,
+                mvwprintz( w_description, point( 0, 2 ), COL_STAT_BONUS, _( "Night vision bonus: -%.1f" ),
+                           vision::nv_range_from_per( u.per_max ) );
+                fold_and_print( w_description, point( 0, 4 ), getmaxx( w_description ) - 1, COL_STAT_NEUTRAL,
                                 _( "Perception is also used for detecting traps and other things of interest." ) );
                 break;
         }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -224,9 +224,11 @@ static std::string get_encumbrance_description( const player &p, body_part bp, b
         case bp_eyes:
             s += string_format(
                      _( "Perception when checking traps or firing ranged weapons: <color_white>%+d</color>\n"
-                        "Dispersion when throwing items: <color_white>%+d</color>" ),
+                        "Dispersion when throwing items: <color_white>%+d</color>\n"
+                        "Night vision range: <color_white>%+.1f</color>" ),
                      -( eff_encumbrance / 10 ),
-                     eff_encumbrance * 10 );
+                     eff_encumbrance * 10,
+                     vision::nv_range_from_eye_encumbrance( eff_encumbrance ) );
             break;
         case bp_mouth:
             s += _( "<color_magenta>Covering your mouth will make it more difficult to breathe and catch your breath.</color>\n" );
@@ -414,6 +416,9 @@ static void draw_stats_info( const catacurses::window &w_info,
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
                         _( "Perception is the most important stat for ranged combat.  It's also used for "
                            "detecting traps and other things of interest." ) );
+        print_colored_text( w_info, point( 1, 3 ), col_temp, c_light_gray,
+                            string_format( _( "Base night vision range: <color_white>%.1f</color>" ),
+                                           vision::nv_range_from_per( you.get_per() ) ) );
         print_colored_text( w_info, point( 1, 4 ), col_temp, c_light_gray,
                             string_format( _( "Trap detection level: <color_white>%d</color>" ), you.get_per() ) );
         if( you.ranged_per_mod() > 0 ) {

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -536,3 +536,14 @@ TEST_CASE( "vision_see_wall_in_moonlight", "[shadowcasting][vision][.]" )
 
     t.test_all();
 }
+
+TEST_CASE( "nv_range_math_correct", "[vision]" )
+{
+    for( int i = 0; i < 80; i++ ) {
+        float threshold = vision::threshold_for_nv_range( i );
+        // minus, because LIGHT_RANGE is for luminosity at a distance
+        // tl;dr: exp/log math, luminosity * exp( -range ) = threshold
+        int range = -LIGHT_RANGE( threshold );
+        CHECK( range == i );
+    }
+}


### PR DESCRIPTION
As in title. Closes #184
UI now whows that perception grants 1/3 of a tile of night vision per point and that eye encumbrance takes 0.1 tile per point of encumbrance.

I'm not satisfied with how the math currently rounds things up, but subtracts 1 internally.
This moves breakpoints: you gain the extra vision tile at 7, 10, 13. Should be at 3, 6, 9, 12.
Due to how the vision math works, there are no gains outside the breakpoints (except cancelling out eye encumbrance), not even in circular distance mode. There is no way to get a "more filled out LOS circle" or a half-visible tile.

It will probably require a hard `floor` to get it where I want it.