### PR TITLE
Make bio scalpel not activated

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1003,7 +1003,7 @@
     "description": "A system of surgical grade scalpels is implanted on your fingers.  They allow you to make automated precise cuts and can also be used as a high-quality butchering tool.",
     "occupied_bodyparts": [ [ "ARM_R", 1 ], [ "ARM_L", 1 ] ],
     "fake_item": "bio_scalpel",
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_WEAPON" ]
+    "flags": [ "BIONIC_NPC_USABLE" ]
   },
   {
     "id": "bio_sunglasses",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -62,7 +62,7 @@
     "to_hit": 2,
     "cutting": 8,
     "techniques": "PRECISE",
-    "flags": [ "TRADER_AVOID", "NO_UNWIELD", "UNBREAKABLE_MELEE", "SPEAR" ],
+    "flags": [ "TRADER_AVOID", "NO_DROP", "UNBREAKABLE_MELEE", "SPEAR" ],
     "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 5 ], [ "BUTCHER", 50 ] ]
   },
   {


### PR DESCRIPTION
Closes #168 

Will leave wielded scalpels if you have a save with them pulled out. It's a minor bug, so I'll let it slide.
Making them not-toggled makes them work at all times.