### PR TITLE
Changes & fixes for item washing

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -674,14 +674,14 @@ void activity_on_turn_wear( player_activity &act, player &p )
 
 void activity_handlers::washing_finish( player_activity *act, player *p )
 {
-    std::list<act_item> items = reorder_for_dropping( *p, convert_to_locations( *act ) );
+    drop_locations items = convert_to_locations( *act );
 
     // Check again that we have enough water and soap incase the amount in our inventory changed somehow
     // Consume the water and soap
     units::volume total_volume = 0_ml;
 
-    for( const act_item &filthy_item : items ) {
-        total_volume += filthy_item.loc->volume();
+    for( const auto &it : items ) {
+        total_volume += it.first->volume();
     }
     washing_requirements required = washing_requirements_for_volume( total_volume );
 
@@ -704,10 +704,10 @@ void activity_handlers::washing_finish( player_activity *act, player *p )
         return;
     }
 
-    for( const auto &ait : items ) {
-        item *filthy_item = const_cast<item *>( &*ait.loc );
-        filthy_item->item_tags.erase( "FILTHY" );
-        p->on_worn_item_washed( *filthy_item );
+    for( auto &it : items ) {
+        item &filthy_item = *it.first;
+        filthy_item.item_tags.erase( "FILTHY" );
+        p->on_worn_item_washed( filthy_item );
     }
 
     std::vector<item_comp> comps;

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -676,6 +676,12 @@ class inventory_compare_selector : public inventory_multiselector
 
 // This and inventory_drop_selectors should probably both inherit from a higher-abstraction "action selector".
 // Should accept a function to calculate dummy values.
+
+struct iuse_location {
+    item_location loc;
+    size_t count;
+};
+
 class inventory_iuse_selector : public inventory_multiselector
 {
     public:
@@ -684,7 +690,7 @@ class inventory_iuse_selector : public inventory_multiselector
                                  const std::string &selector_title,
                                  const inventory_selector_preset &preset = default_preset,
                                  const GetStats & = {} );
-        drop_locations execute();
+        std::list<iuse_location> execute();
 
     protected:
         stats get_raw_stats() const override;
@@ -692,8 +698,8 @@ class inventory_iuse_selector : public inventory_multiselector
 
     private:
         GetStats get_stats;
-        std::map<const item *, int> to_use;
-        size_t max_chosen_count;
+        std::map<const item *, std::vector<iuse_location>> to_use;
+        const size_t max_chosen_count = std::numeric_limits<size_t>::max();
 };
 
 class inventory_drop_selector : public inventory_multiselector

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9474,9 +9474,9 @@ int iuse::wash_items( player *p, bool soft_items, bool hard_items )
                 display_stat( _( "Cleanser" ), required.cleanser, available_cleanser, to_string )
             }};
     };
-    // TODO: this should also search surrounding area, not just player inventory.
     inventory_iuse_selector inv_s( *p, _( "ITEMS TO CLEAN" ), preset, make_raw_stats );
     inv_s.add_character_items( *p );
+    inv_s.add_nearby_items( PICKUP_RANGE );
     inv_s.set_title( _( "Multiclean" ) );
     inv_s.set_hint( _( "To clean x items, type a number before selecting." ) );
     if( inv_s.empty() ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9483,20 +9483,20 @@ int iuse::wash_items( player *p, bool soft_items, bool hard_items )
         popup( std::string( _( "You have nothing to clean." ) ), PF_GET_KEY );
         return 0;
     }
-    const drop_locations to_clean = inv_s.execute();
+    const std::list<iuse_location> to_clean = inv_s.execute();
     if( to_clean.empty() ) {
         return 0;
     }
 
     // Determine if we have enough water and cleanser for all the items.
     units::volume total_volume = 0_ml;
-    for( drop_location pair : to_clean ) {
-        if( !pair.first ) {
+    for( iuse_location iloc : to_clean ) {
+        if( !iloc.loc ) {
             p->add_msg_if_player( m_info, _( "Never mind." ) );
             return 0;
         }
-        item &i = *pair.first;
-        total_volume += i.volume() * pair.second / ( i.count_by_charges() ? i.charges : 1 );
+        item &i = *iloc.loc;
+        total_volume += i.volume() * iloc.count / ( i.count_by_charges() ? i.charges : 1 );
     }
 
     washing_requirements required = washing_requirements_for_volume( total_volume );
@@ -9522,9 +9522,9 @@ int iuse::wash_items( player *p, bool soft_items, bool hard_items )
     // Assign the activity values.
     p->assign_activity( ACT_WASH, required.time );
 
-    for( drop_location pair : to_clean ) {
-        p->activity.targets.push_back( pair.first );
-        p->activity.values.push_back( pair.second );
+    for( iuse_location iloc : to_clean ) {
+        p->activity.targets.push_back( iloc.loc );
+        p->activity.values.push_back( iloc.count );
     }
 
     return 0;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9457,8 +9457,7 @@ int iuse::wash_items( player *p, bool soft_items, bool hard_items )
     ) {
         units::volume total_volume = 0_ml;
         for( const auto &p : items ) {
-            total_volume += p.first->volume() * p.second /
-                            ( p.first->count_by_charges() ? p.first->charges : 1 );
+            total_volume += p.first->volume() * p.second / p.first->count();
         }
         washing_requirements required = washing_requirements_for_volume( total_volume );
         auto to_string = []( int val ) -> std::string {
@@ -9496,7 +9495,7 @@ int iuse::wash_items( player *p, bool soft_items, bool hard_items )
             return 0;
         }
         item &i = *iloc.loc;
-        total_volume += i.volume() * iloc.count / ( i.count_by_charges() ? i.charges : 1 );
+        total_volume += i.volume() * iloc.count / i.count();
     }
 
     washing_requirements required = washing_requirements_for_volume( total_volume );


### PR DESCRIPTION
#### Purpose of change
Closes #147
Fixes washing for count-by-charges items (CleverRaven#41884)

#### Describe the solution
In the same order as commits:
1. Change `inventory_iuse_selector` to correctly handle items not on character. Since it is a copy-pasted version of `inventory_drop_selector`, it assumed all items are on character, and so did some questionable casting between `item_location` and `item*`, producing invalid `item_location`s as a result.
2. Stopped activity handler for item washing from trying to reorder received items. It is a) unnecessary here b) breaks with items the character doesn't have.
3. Added items within `PICKUP_RANGE` (like when crafting) to the list of items to wash - that's pretty much CleverRaven#45348
4. Fixed handling of partial stacks of count-by-charges items: split off some charges into a separate item and remove the `FILTHY` flag for it.

#### Describe alternatives you've considered
Regarding washing partial stacks of count-by-charges items: the game needs to create a copy of the original item (without `FILTHY` flag, and with specified number of charges) and place it somewhere. Right now that 'somewhere' is the avatar's pos, but an alternative would be the tripoint of the original item. I've decided to stop on the former since it feels more robust (and does not require much code for what is essentially an edge case).

#### Testing
Tried washing
* worn items
* wielded items 
* stashed items
* items lying nearby
* partial and full stacks of rubber chunks

#### Additional context
NPC companions do not reduce washing time due to a bug with how the time modifier is calculated:
```
const int helpersize = g->u.get_num_crafting_helpers( 3 );
required.time = required.time * ( 1 - ( helpersize / 10 ) );
```
All variables are integers, so naturally `helpersize / 10` always equals 0. That's not the only place where it happens, so I'll make a separate PR.