### PR TITLE
Show an animated 'Please wait' popup while looking for mission target

### DIFF
--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -1383,6 +1383,8 @@ void computer_session::action_emerg_ref_center()
 {
     reset_terminal();
     print_line( _( "SEARCHING FOR NEAREST REFUGEE CENTER, PLEASE WAIT…" ) );
+    ui_manager::redraw();
+    refresh_display();
 
     const mission_type_id &mission_type = mission_type_id( "MISSION_REACH_REFUGEE_CENTER" );
     tripoint mission_target;

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -23,6 +23,7 @@
 #include "optional.h"
 #include "overmap.h"
 #include "overmapbuffer.h"
+#include "popup.h"
 #include "rng.h"
 #include "string_formatter.h"
 #include "translations.h"
@@ -613,7 +614,12 @@ void mission_start::reveal_refugee_center( mission *miss )
                                  3, false );
     const tripoint dest_road = overmap_buffer.find_closest( *target_pos, "road", 3, false );
 
-    if( overmap_buffer.reveal_route( source_road, dest_road, 1, true ) ) {
+    omt_route_params params;
+    params.radius = 1;
+    params.road_only = true;
+    params.popup = make_shared_fast<throbber_popup>( _( "Please wait…" ) );
+
+    if( overmap_buffer.reveal_route( source_road, dest_road, params ) ) {
         add_msg( _( "You mark the refugee center and the road that leads to it…" ) );
     } else {
         add_msg( _( "You mark the refugee center, but you have no idea how to get there by road…" ) );

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -25,6 +25,7 @@
 #include "overmap.h"
 #include "overmapbuffer.h"
 #include "point.h"
+#include "popup.h"
 #include "rng.h"
 #include "translations.h"
 #include "type_id.h"
@@ -180,6 +181,7 @@ static cata::optional<tripoint> find_or_create_om_terrain( const tripoint &origi
     find_params.must_see = params.must_see;
     find_params.cant_see = params.cant_see;
     find_params.existing_only = true;
+    find_params.popup = make_shared_fast<throbber_popup>( _( "Please wait…" ) );
 
     auto get_target_position = [&]() {
         // Either find a random or closest match, based on the criteria.

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -127,6 +127,20 @@ struct omt_find_params {
     shared_ptr_fast<throbber_popup> popup = nullptr;
 };
 
+/**
+ * Standard arguments for finding overmap route
+ * @param radius Radius of revealed terrain around the route
+ * @param road_only If set, restricts route to only use roads
+ * @param popup If set, the popup will be periodically updated to indicate ongoing pathfinding.
+ */
+struct omt_route_params {
+    ~omt_route_params();
+
+    int radius = 0;
+    bool road_only = false;
+    shared_ptr_fast<throbber_popup> popup = nullptr;
+};
+
 class overmapbuffer
 {
     public:
@@ -319,8 +333,7 @@ class overmapbuffer
                      const std::function<bool( const oter_id & )> &filter );
         std::vector<tripoint> get_npc_path( const tripoint &src, const tripoint &dest );
         std::vector<tripoint> get_npc_path( const tripoint &src, const tripoint &dest, path_type &ptype );
-        bool reveal_route( const tripoint &source, const tripoint &dest, int radius = 0,
-                           bool road_only = false );
+        bool reveal_route( const tripoint &source, const tripoint &dest, const omt_route_params &params );
         /**
          * Returns the closest point of terrain type.
          * @param origin Location of search

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -27,6 +27,7 @@ class monster;
 class npc;
 class overmap;
 class overmap_special_batch;
+class throbber_popup;
 class vehicle;
 struct mongroup;
 struct om_vehicle;
@@ -99,7 +100,7 @@ struct overmap_with_local_coords {
     }
 };
 
-/*
+/**
  * Standard arguments for finding overmap terrain
  * @param origin Location of search
  * @param types vector of Terrain type/matching rule to use to find the type
@@ -111,8 +112,11 @@ struct overmap_with_local_coords {
  * is particularly useful if we want to attempt to add a missing overmap special to an existing
  * overmap rather than creating many overmaps in an attempt to find it.
  * @param om_special If set, the terrain must be part of the specified overmap special.
+ * @param popup If set, the popup will be periodically updated to indicate ongoing search.
 */
 struct omt_find_params {
+    ~omt_find_params();
+
     std::vector<std::pair<std::string, ot_match_type>> types;
     int search_range = 0;
     int min_distance = 0;
@@ -120,6 +124,7 @@ struct omt_find_params {
     bool cant_see = false;
     bool existing_only = false;
     cata::optional<overmap_special_id> om_special = cata::nullopt;
+    shared_ptr_fast<throbber_popup> popup = nullptr;
 };
 
 class overmapbuffer

--- a/src/simple_pathfinding.h
+++ b/src/simple_pathfinding.h
@@ -42,14 +42,16 @@ struct path {
  * @param estimator BinaryPredicate( node &previous, node *current ) returns
  * integer estimation (smaller - better) for the current node or a negative value
  * if the node is unsuitable.
+ * @param reporter void ProgressReporter() called on each step of the algorithm.
  */
-template<class Offsets, class BinaryPredicate>
+template<class Offsets, class BinaryPredicate, class ProgressReporter>
 path find_path( const point &source,
                 const point &dest,
                 const int max_x,
                 const int max_y,
                 Offsets offsets,
-                BinaryPredicate estimator )
+                BinaryPredicate estimator,
+                ProgressReporter reporter )
 {
     const auto inbounds = [ max_x, max_y ]( const point & p ) {
         return p.x >= 0 && p.x < max_x && p.y >= 0 && p.y < max_y;
@@ -87,6 +89,8 @@ path find_path( const point &source,
 
     // use A* to find the shortest path from (x1,y1) to (x2,y2)
     while( !nodes.empty() ) {
+        reporter();
+
         const node mn( nodes.top() ); // get the best-looking node
 
         nodes.pop();
@@ -147,7 +151,18 @@ path find_path_4dir( const point &source,
                      const int max_y,
                      BinaryPredicate estimator )
 {
-    return find_path( source, dest, max_x, max_y, four_adjacent_offsets, estimator );
+    return find_path( source, dest, max_x, max_y, four_adjacent_offsets, estimator, []() {} );
+}
+
+template<class BinaryPredicate, class ProgressReporter>
+path find_path_4dir( const point &source,
+                     const point &dest,
+                     const int max_x,
+                     const int max_y,
+                     BinaryPredicate estimator,
+                     ProgressReporter reporter )
+{
+    return find_path( source, dest, max_x, max_y, four_adjacent_offsets, estimator, reporter );
 }
 
 template<class BinaryPredicate>
@@ -157,7 +172,7 @@ path find_path_8dir( const point &source,
                      const int max_y,
                      BinaryPredicate estimator )
 {
-    return find_path( source, dest, max_x, max_y, eight_adjacent_offsets, estimator );
+    return find_path( source, dest, max_x, max_y, eight_adjacent_offsets, estimator, []() {} );
 }
 
 inline path straight_path( const point &source,

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -22,7 +22,8 @@ class ui_adaptor
 
         ui_adaptor();
         // ui_adaptor constructed this way will block any uis below from being
-        // redrawn or resized until it is deconstructed. It is used for `debug_msg`.
+        // redrawn or resized until it is deconstructed.
+        // It is used for `debug_msg` and `throbber_popup`.
         ui_adaptor( disable_uis_below );
         ui_adaptor( const ui_adaptor &rhs ) = delete;
         ui_adaptor( ui_adaptor &&rhs ) = delete;


### PR DESCRIPTION
#### Purpose of change
Starting shelter console gives a player their first mission - to reach a refugee center.
To do this, the game first must find (or generate) that center, and then find a path to it. The whole process normally takes a second or five, but depending on worldgen can take up to a minute.

A whole minute of being unresponsive is perhaps not the best first impression the game should leave on new players.

This PR adds a small animated 'Please wait' popup that acts as a [throbber](https://en.wikipedia.org/wiki/Throbber) - indicates that the game is busy generating terrain / finding path. 

#### Describe the solution
Implement a new popup called `throbber_popup` and show it while searching for/generating mission target and finding path to it.
To minimize the overhead, the popup employs some tricks:
* It freezes all underlying UIs since redrawing everything is pretty expensive
* It caps game window refresh rate at 2 times per second since this, too, may be expensive depending on the OS

#### Describe alternatives you've considered
* It would be cool to have the popup "embedded" in the console, since the console already prints a 'Please wait' message, but that wouldn't work with other kinds of mission assignment (like from NPCs).
* It could show search/pathfinding progress, but that seems an overkill to me (would also require more code...)
* Try optimizing worldgen?

#### Testing
1. The popup shows up after selecting "Contact Us" entry or accepting "Analyze Zombie Blood" quest from the doctor in the refugee center 
2. The popup does not interfere with errors during pathfinding/target search/generation (e.g. when trying to find a refugee center with 'Dark Days of the Dead' mod enabled)
3. Redrawing overhead is pretty much negligible:
![throbber_efficiency_find](https://user-images.githubusercontent.com/60584843/103217393-893e9980-4929-11eb-9898-98ea8f6acd18.png)
Can't reliably measure overhead from window refreshes, but I'll assume average time spent refreshing with 60 FPS sync would be ((1/60)/2)*2 = 1.66%

#### Additional context
![contact-us-wait](https://user-images.githubusercontent.com/60584843/103224034-38826d00-4938-11eb-8aca-e6fd35c76271.gif)
