### PR TITLE
Fix multiple issues with NPC assistance

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -818,7 +818,7 @@ int butcher_time_to_cut( const inventory &inv, const item &corpse_item, const bu
     if( corpse_item.has_flag( flag_QUARTERED ) ) {
         time_to_cut /= 4;
     }
-    time_to_cut = time_to_cut * ( 1 - ( g->u.get_num_crafting_helpers( 3 ) / 10 ) );
+    time_to_cut = time_to_cut * ( 10 - g->u.get_crafting_helpers( 3 ).size() ) / 10;
     return time_to_cut;
 }
 
@@ -1985,7 +1985,7 @@ void activity_handlers::pickaxe_finish( player_activity *act, player *p )
     // Invalidate the activity early to prevent a query from mod_pain()
     act->set_to_null();
     if( p->is_avatar() ) {
-        const int helpersize = g->u.get_num_crafting_helpers( 3 );
+        const int helpersize = g->u.get_crafting_helpers( 3 ).size();
         if( g->m.is_bashable( pos ) && g->m.has_flag( flag_SUPPORTS_ROOF, pos ) &&
             g->m.ter( pos ) != t_tree ) {
             // Tunneling through solid rock is hungry, sweaty, tiring, backbreaking work
@@ -4074,7 +4074,7 @@ void activity_handlers::chop_tree_finish( player_activity *act, player *p )
     }
 
     g->m.ter_set( pos, t_stump );
-    const int helpersize = p->get_num_crafting_helpers( 3 );
+    const int helpersize = p->get_crafting_helpers( 3 ).size();
     p->mod_stored_nutr( 5 - helpersize );
     p->mod_thirst( 5 - helpersize );
     p->mod_fatigue( 10 - ( helpersize * 2 ) );
@@ -4121,7 +4121,7 @@ void activity_handlers::chop_logs_finish( player_activity *act, player *p )
         g->m.add_item_or_charges( pos, obj );
     }
     g->m.ter_set( pos, t_dirt );
-    const int helpersize = p->get_num_crafting_helpers( 3 );
+    const int helpersize = p->get_crafting_helpers( 3 ).size();
     p->mod_stored_nutr( 5 - helpersize );
     p->mod_thirst( 5 - helpersize );
     p->mod_fatigue( 10 - ( helpersize * 2 ) );
@@ -4173,7 +4173,7 @@ void activity_handlers::jackhammer_finish( player_activity *act, player *p )
     g->m.destroy( pos, true );
 
     if( p->is_avatar() ) {
-        const int helpersize = g->u.get_num_crafting_helpers( 3 );
+        const int helpersize = g->u.get_crafting_helpers( 3 ).size();
         p->mod_stored_nutr( 5 - helpersize );
         p->mod_thirst( 5 - helpersize );
         p->mod_fatigue( 10 - ( helpersize * 2 ) );
@@ -4251,7 +4251,7 @@ void activity_handlers::dig_finish( player_activity *act, player *p )
         g->m.spawn_items( dump_loc, item_group::items_from( byproducts_item_group, calendar::turn ) );
     }
 
-    const int helpersize = g->u.get_num_crafting_helpers( 3 );
+    const int helpersize = g->u.get_crafting_helpers( 3 ).size();
     p->mod_stored_nutr( 5 - helpersize );
     p->mod_thirst( 5 - helpersize );
     p->mod_fatigue( 10 - ( helpersize * 2 ) );
@@ -4308,7 +4308,7 @@ void activity_handlers::fill_pit_finish( player_activity *act, player *p )
     } else {
         g->m.ter_set( pos, t_dirt );
     }
-    const int helpersize = g->u.get_num_crafting_helpers( 3 );
+    const int helpersize = g->u.get_crafting_helpers( 3 ).size();
     p->mod_stored_nutr( 5 - helpersize );
     p->mod_thirst( 5 - helpersize );
     p->mod_fatigue( 10 - ( helpersize * 2 ) );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2277,20 +2277,6 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
     p.activity.set_to_null();
 }
 
-static int chop_moves( player &p, item *it )
-{
-    // quality of tool
-    const int quality = it->get_quality( qual_AXE );
-
-    // attribute; regular tools - based on STR, powered tools - based on DEX
-    const int attr = it->has_flag( flag_POWERED ) ? p.dex_cur : p.str_cur;
-
-    int moves = to_moves<int>( time_duration::from_minutes( 60 - attr ) / std::pow( 2, quality - 1 ) );
-    const int helpersize = p.get_num_crafting_helpers( 3 );
-    moves = moves * ( 1 - ( helpersize / 10 ) );
-    return moves;
-}
-
 static bool mine_activity( player &p, const tripoint &src_loc )
 {
     std::vector<item *> mining_inv = p.items_with( []( const item & itm ) {
@@ -2343,7 +2329,7 @@ static bool chop_tree_activity( player &p, const tripoint &src_loc )
     if( !best_qual ) {
         return false;
     }
-    int moves = chop_moves( p, best_qual );
+    int moves = iuse::chop_moves( p, *best_qual );
     if( best_qual->type->can_have_charges() ) {
         p.consume_charges( *best_qual, best_qual->type->charges_to_use() );
     }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2253,13 +2253,21 @@ void remove_ammo( item &dis_item, player &p )
     }
 }
 
-std::vector<npc *> player::get_crafting_helpers() const
+std::vector<npc *> player::get_crafting_helpers( size_t max ) const
 {
-    return g->get_npcs_if( [this]( const npc & guy ) {
+    size_t n = 0;
+    return g->get_npcs_if( [ &n, max, this]( const npc & guy ) {
         // NPCs can help craft if awake, taking orders, within pickup range and have clear path
-        return !guy.in_sleep_state() && guy.is_obeying( *this ) &&
-               rl_dist( guy.pos(), pos() ) < PICKUP_RANGE &&
-               g->m.clear_path( pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
+        if( max != 0 && n >= max ) {
+            return false;
+        }
+        bool ok = !guy.in_sleep_state() && guy.is_obeying( *this ) &&
+                  rl_dist( guy.pos(), pos() ) < PICKUP_RANGE &&
+                  g->m.clear_path( pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
+        if( ok ) {
+            n += 1;
+        }
+        return ok;
     } );
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8527,10 +8527,9 @@ void game::butcher()
         }
         return;
     }
-    const auto helpers = u.get_crafting_helpers();
+    const auto helpers = u.get_crafting_helpers( 3 );
     for( const npc *np : helpers ) {
         add_msg( m_info, _( "%s helps with this task…" ), np->name );
-        break;
     }
     switch( butcher_select ) {
         case BUTCHER_OTHER:

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -234,6 +234,9 @@ class iuse
         static int handle_ground_graffiti( player &p, item *it, const std::string &prefix,
                                            const tripoint &where );
 
+        // Helper for wood chopping
+        static int chop_moves( Character &ch, item &tool );
+
         // LEGACY
         int cauterize_hotplate( player *, item *, bool, const tripoint & );
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1093,12 +1093,6 @@ int player::get_lift_assist() const
     return result;
 }
 
-int player::get_num_crafting_helpers( int max ) const
-{
-    std::vector<npc *> helpers = get_crafting_helpers();
-    return std::min( max, static_cast<int>( helpers.size() ) );
-}
-
 bool player::immune_to( body_part bp, damage_unit dam ) const
 {
     if( has_trait( trait_DEBUG_NODMG ) || is_immune_damage( dam.type ) ) {

--- a/src/player.h
+++ b/src/player.h
@@ -637,9 +637,11 @@ class player : public Character
          * @return if the craft can be continued
          */
         bool can_continue_craft( item &craft );
-        /** Returns nearby NPCs ready and willing to help with crafting. */
-        std::vector<npc *> get_crafting_helpers() const;
-        int get_num_crafting_helpers( int max ) const;
+        /**
+         * Returns nearby NPCs ready and willing to help with crafting or some other manual task.
+         * @param max If set, limits number of helpers to that value
+         */
+        std::vector<npc *> get_crafting_helpers( size_t max = 0 ) const;
         /**
          * Handle skill gain for player and followers during crafting
          * @param craft the currently in progress craft

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1190,7 +1190,7 @@ void veh_interact::do_repair()
             }
             sel_vehicle_part = &pt;
             sel_vpart_info = &vp;
-            const std::vector<npc *> helpers = g->u.get_crafting_helpers();
+            const std::vector<npc *> helpers = g->u.get_crafting_helpers( 3 );
             for( const npc *np : helpers ) {
                 add_msg( m_info, _( "%s helps with this task…" ), np->name );
             }
@@ -1833,7 +1833,7 @@ void veh_interact::do_remove()
                 default:
                     break;
             }
-            const std::vector<npc *> helpers = g->u.get_crafting_helpers();
+            const std::vector<npc *> helpers = g->u.get_crafting_helpers( 3 );
             for( const npc *np : helpers ) {
                 add_msg( m_info, _( "%s helps with this task…" ), np->name );
             }

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -796,10 +796,8 @@ static int scale_time( const std::map<skill_id, int> &sk, int mv, const player &
     } );
     // 10% per excess level (reduced proportionally if >1 skill required) with max 50% reduction
     // 10% reduction per assisting NPC
-    const std::vector<npc *> helpers = p.get_crafting_helpers();
-    const int helpersize = p.get_num_crafting_helpers( 3 );
-    return mv * ( 1.0 - std::min( static_cast<double>( lvl ) / sk.size() / 10.0,
-                                  0.5 ) ) * ( 1 - ( helpersize / 10.0 ) );
+    return mv * ( 1.0 - std::min( static_cast<double>( lvl ) / sk.size() / 10.0, 0.5 ) )
+           * ( 10 - p.get_crafting_helpers( 3 ).size() ) / 10;
 }
 
 int vpart_info::install_time( const player &p ) const


### PR DESCRIPTION
#### Purpose of change
1. Fixes assisting NPCs not actually providing speed bonuses (CleverRaven#35610)
2. Print names of _all_ NPCs that assist with activity
3. Don't print names of NPCs that don't assist with activity

#### Describe the solution
1. Fix integer math
2. Fix loops
3. Fix more loops

#### Describe alternatives you've considered
Rewriting the whole thing to be incorporated into activity code, so that multiple characters can work on a single task, leave/join at any time and provide bonuses proportional to their abilities instead of the current magical -10%/-20%/-30% reduction to activity time from 1/2/3 NPCs for simply being nearby when activity is started.
Or just moving half of affected activities into construction/crafting recipies.

#### Testing
Tried digging a pit with 4 NPCs nearby, 3 of them are recognized as 'helpers' and provide move reduction for the activity (120'000 -> 84'000)

#### Additional context
I ain't Ketchum, but I think I've got them all.

Also, DDA has recently had CleverRaven#46077 and CleverRaven#46078 which essentially do the same things as this PR.