### PR TITLE
(Android) Port DDA's fixes for stuck joystick and game restarting when plugging in usb keyboard

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -43,7 +43,7 @@
                   android:launchMode="singleInstance"
                   android:keepScreenOn="true"
                   android:screenOrientation="userLandscape"
-                  android:configChanges="keyboardHidden|keyboard|orientation|screenSize"
+                  android:configChanges="keyboardHidden|keyboard|orientation|screenSize|navigation"
                   >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -55,7 +55,7 @@
                   android:launchMode="singleInstance"
                   android:keepScreenOn="true"
                   android:screenOrientation="userLandscape"
-                  android:configChanges="keyboardHidden|keyboard|orientation|screenSize"
+                  android:configChanges="keyboardHidden|keyboard|orientation|screenSize|navigation"
                   >
         </activity>
     </application>

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2368,6 +2368,18 @@ static void CheckMessages()
             if( ticks - finger_repeat_time > finger_repeat_delay ) {
                 handle_finger_input( ticks );
                 finger_repeat_time = ticks;
+                // Prevent repeating inputs on the next call to this function if there is a fingerup event
+                while( SDL_PollEvent( &ev ) ) {
+                    if( ev.type == SDL_FINGERUP ) {
+                        second_finger_down_x = second_finger_curr_x = finger_down_x = finger_curr_x = -1.0f;
+                        second_finger_down_y = second_finger_curr_y = finger_down_y = finger_curr_y = -1.0f;
+                        is_two_finger_touch = false;
+                        finger_down_time = 0;
+                        finger_repeat_time = 0;
+                        // let the next call decide if needupdate should be true
+                        break;
+                    }
+                }
                 return;
             }
         }


### PR DESCRIPTION
#### Purpose of change
Apparently there were some users who experienced the joystick issue in BN (inherited form DDA, CleverRaven#33936).
This PR ports DDA's fix for it and another fix for game restarting when usb keyboard is plugged in.

#### Describe the solution
Cherry-picked CleverRaven#42982 and CleverRaven#45506

#### Testing
None, since I can't build it myself (and don't own usb keyboard).
I can't find any bugreports in DDA repo related to these changes, and there were no conflicts, so I'm pretty sure everything will work as is.