### PR TITLE
Prevent crashes for guns that can't be loaded

### DIFF
--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -63,6 +63,7 @@ item_location titled_filter_menu( item_filter filter, avatar &you,
 
 void common( avatar &you );
 void compare( player &p, const cata::optional<tripoint> &offset );
+void compare( const item &left, const item &right );
 void reassign_letter( player &p, item &it );
 void swap_letters( player &p );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1855,6 +1855,12 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     if( mod->ammo_required() && !mod->ammo_remaining() ) {
         tmp = *mod;
         tmp.ammo_set( mod->magazine_current() ? tmp.common_ammo_default() : tmp.ammo_default() );
+        if( tmp.ammo_data() == nullptr ) {
+            insert_separation_line( info );
+            info.emplace_back( "GUN",
+                               _( "Weapon <bad>can't be loaded in its current state</bad>." ) );
+            return;
+        }
         loaded_mod = &tmp;
         if( parts->test( iteminfo_parts::GUN_DEFAULT_AMMO ) ) {
             insert_separation_line( info );
@@ -7262,7 +7268,7 @@ ret_val<bool> item::is_gunmod_compatible( const item &mod ) const
     } else if( mod.typeId() == "brass_catcher" && has_flag( flag_RELOAD_EJECT ) ) {
         return ret_val<bool>::make_failure( _( "cannot have a brass catcher" ) );
 
-    } else if( ( mod.type->mod->ammo_modifier.empty() || !mod.type->mod->magazine_adaptor.empty() )
+    } else if( ( !mod.type->mod->ammo_modifier.empty() || !mod.type->mod->magazine_adaptor.empty() )
                && ( ammo_remaining() > 0 || magazine_current() ) ) {
         return ret_val<bool>::make_failure( _( "must be unloaded before installing this mod" ) );
     }

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -8,6 +8,7 @@
 #include "player.h"
 #include "ret_val.h"
 #include "translations.h"
+#include "skill.h"
 
 struct tripoint;
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -568,6 +568,7 @@ class gun_type_type
         }
 
         friend struct std::hash<gun_type_type>;
+        friend class Item_factory;
 };
 
 namespace std

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -29,6 +29,7 @@
 #include "fault.h"
 #include "field_type.h"
 #include "game.h"
+#include "game_inventory.h"
 #include "gun_mode.h"
 #include "handle_liquid.h"
 #include "input.h"
@@ -3568,24 +3569,30 @@ void player::gunmod_add( item &gun, item &mod )
 
     std::string tool;
     int qty = 0;
+    bool requery = false;
 
-    if( mod.is_irremovable() ) {
-        if( !query_yn( _( "Permanently install your %1$s in your %2$s?" ),
-                       colorize( mod.tname(), mod.color_in_inventory() ),
-                       colorize( gun.tname(), gun.color_in_inventory() ) ) ) {
-            add_msg_if_player( _( "Never mind." ) );
-            return; // player canceled installation
-        }
+    item modded = gun;
+    modded.put_in( mod );
+    bool no_magazines = modded.common_ammo_default() == "NULL";
+
+    std::string query_msg = mod.is_irremovable()
+                            ? _( "<color_yellow>Permanently</color> install your %1$s in your %2$s?" )
+                            : _( "Attach your %1$s to your %2$s?" );
+    if( no_magazines ) {
+        query_msg += "\n";
+        query_msg += colorize(
+                         _( "Warning: after installing this mod, a magazine adapter mod will be required to load it!" ),
+                         c_red );
     }
 
-    // if chance of success <100% prompt user to continue
+    uilist prompt;
+    prompt.text = string_format( query_msg,
+                                 colorize( mod.tname(), mod.color_in_inventory() ),
+                                 colorize( gun.tname(), gun.color_in_inventory() ) );
+
+    std::vector<std::function<void()>> actions;
+
     if( roll < 100 ) {
-        uilist prompt;
-        prompt.text = string_format( _( "Attach your %1$s to your %2$s?" ), mod.tname(),
-                                     gun.tname() );
-
-        std::vector<std::function<void()>> actions;
-
         prompt.addentry( -1, true, 'w',
                          string_format( _( "Try without tools (%i%%) risking damage (%i%%)" ), roll, risk ) );
         actions.emplace_back( [&] {} );
@@ -3609,14 +3616,26 @@ void player::gunmod_add( item &gun, item &mod )
             roll *= 3; // gunsmith repair kit improves success markedly...
             risk = 0;  // ...and entirely prevents damage upon failure
         } );
+    } else {
+        prompt.addentry( -1, true, 'w', _( "Install without tools" ) );
+        actions.emplace_back( [&] {} );
+    }
 
+    prompt.addentry( -1, true, 'c', _( "Compare before/after installation" ) );
+    actions.emplace_back( [&] {
+        requery = true;
+        game_menus::inv::compare( gun, modded );
+    } );
+
+    do {
+        requery = false;
         prompt.query();
         if( prompt.ret < 0 ) {
             add_msg_if_player( _( "Never mind." ) );
             return; // player canceled installation
         }
         actions[ prompt.ret ]();
-    }
+    } while( requery );
 
     const int moves = !has_trait( trait_DEBUG_HS ) ? mod.type->gunmod->install_time : 0;
 


### PR DESCRIPTION
Closes #303

Guns that can't be loaded will not have a "this weapon can't be loaded in current state" line instead of causing a crash.

Additionally:
* If a gunmod can be applied to specific gun types, but will make them unable to be loaded, debugmsg on game load. This might be undesirable if a mod has separate ammo and magazine mods, though.
* Gunmod installation always asks you exactly once if you want to do it, using the same menu query, instead of possibly asking you twice if the mod is unremovable, or zero times if it's guaranteed. If installation is guaranteed, it just doesn't offer to use tools.
* If a gunmod would cause a gun to become un-loadable, warn about it. This isn't covered in the on-load debugmsg, because you can specify whole classes of guns.
* The gunmod installation query offers to compare the gun pre/post installation.
* I may have swapped panes for "compare items" action. The one selected first will go on the left, because that's how things generally go in the western world.