### PR TITLE
Fix mess kit again

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4971,26 +4971,41 @@ int item::get_quality( const quality_id &id ) const
      * EXCEPTION: Items with quality BOIL only count as such if they are empty,
      * excluding items of their ammo type if they are tools.
      */
-    auto boil_filter = [this]( const item & itm ) {
+    auto not_boil_filter = [this]( const item & itm ) {
         if( itm.is_ammo() ) {
-            return ammo_types().count( itm.ammo_type() ) != 0;
+            return ammo_types().count( itm.ammo_type() ) == 0;
         } else if( itm.is_magazine() ) {
             for( const ammotype &at : ammo_types() ) {
                 for( const ammotype &mag_at : itm.ammo_types() ) {
-                    if( at == mag_at ) {
+                    if( at != mag_at ) {
                         return true;
                     }
                 }
             }
             return false;
         } else if( itm.is_toolmod() ) {
-            return true;
+            return false;
         }
         return false;
     };
+    /*
     if( id == quality_id( "BOIL" ) && ( !contents.empty() ||
                                         ( is_tool() && !has_item_with( boil_filter ) ) ) ) {
         return INT_MIN;
+    }
+    */
+    if( id == quality_id( "BOIL" ) ) {
+        if( contents.empty() ) {
+            // Nothing
+        } else {
+            if( is_tool() ) {
+                if( has_item_with( not_boil_filter ) ) {
+                    return INT_MIN;
+                }
+            } else {
+                return INT_MIN;
+            }
+        }
     }
 
     for( const std::pair<const quality_id, int> &quality : type->qualities ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4971,25 +4971,27 @@ int item::get_quality( const quality_id &id ) const
      * EXCEPTION: Items with quality BOIL only count as such if they are empty,
      * excluding items of their ammo type if they are tools.
      */
-    auto not_boil_filter = [this]( const item & itm ) {
+    auto block_boil_filter = [this]( const item & itm ) {
         if( itm.is_ammo() ) {
             return ammo_types().count( itm.ammo_type() ) == 0;
         } else if( itm.is_magazine() ) {
+            // we want to return "fine for boiling" if any of the ammo types match and "blocks boiling" if none match.
             for( const ammotype &at : ammo_types() ) {
                 for( const ammotype &mag_at : itm.ammo_types() ) {
-                    if( at != mag_at ) {
-                        return true;
+                    if( at == mag_at ) {
+                        return false;
                     }
                 }
             }
-            return false;
+            return true;
         } else if( itm.is_toolmod() ) {
             return false;
         }
         return false;
     };
+    //if it's empty, it's good to go. If it's not empty and it's not a tool (it's probably a container), it's out. If it's a tool, it gets an extra chance: if it's only contents are mods or batteries, it's still good.
     if( id == quality_id( "BOIL" ) && !contents.empty() &&
-        ( !is_tool() || has_item_with( not_boil_filter ) ) ) {
+        ( !is_tool() || has_item_with( block_boil_filter ) ) ) {
         return INT_MIN;
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4988,12 +4988,6 @@ int item::get_quality( const quality_id &id ) const
         }
         return false;
     };
-    /*
-    if( id == quality_id( "BOIL" ) && ( !contents.empty() ||
-                                        ( is_tool() && !has_item_with( boil_filter ) ) ) ) {
-        return INT_MIN;
-    }
-    */
     if( id == quality_id( "BOIL" ) ) {
         if( contents.empty() ) {
             // Nothing

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4989,7 +4989,8 @@ int item::get_quality( const quality_id &id ) const
         }
         return false;
     };
-    //if it's empty, it's good to go. If it's not empty and it's not a tool (it's probably a container), it's out. If it's a tool, it gets an extra chance: if it's only contents are mods or batteries, it's still good.
+    // if it's empty, it's good to go. If it's not empty and it's not a tool (it's probably a container), it's out. If it's a tool, it gets an extra chance: if it's only contents are mods or batteries, it's still good.
+    // Also  we are using inverted filter, since we don't care about items that the filter likes, we only care if it find something it doesn't like.
     if( id == quality_id( "BOIL" ) && !contents.empty() &&
         ( !is_tool() || has_item_with( block_boil_filter ) ) ) {
         return INT_MIN;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4974,7 +4974,7 @@ int item::get_quality( const quality_id &id ) const
     auto block_boil_filter = [this]( const item & itm ) {
         // We want to skip (do not block) only those : correct ammo, correct magazine, correct toolmod.Everything else should block.
         if( &itm == this ) {
-            // Do not block if checking itself - we are checking only item contents not item itself. 
+            // Do not block if checking itself - we are checking only item contents not item itself.
             return false;
         } else if( itm.is_ammo() ) {
             return ammo_types().count( itm.ammo_type() ) == 0;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4972,12 +4972,11 @@ int item::get_quality( const quality_id &id ) const
      * excluding items of their ammo type if they are tools.
      */
     auto block_boil_filter = [this]( const item & itm ) {
+        // We want to skip (do not block) only those : correct ammo, correct magazine, correct toolmod.Everything else should block.
         if( &itm == this ) {
-            // Do not block if checking itself - we are checking only contents
+            // Do not block if checking itself - we are checking only item contents not item itself. 
             return false;
-        }
-
-        if( itm.is_ammo() ) {
+        } else if( itm.is_ammo() ) {
             return ammo_types().count( itm.ammo_type() ) == 0;
         } else if( itm.is_magazine() ) {
             // we want to return "fine for boiling" if any of the ammo types match and "blocks boiling" if none match.
@@ -4994,7 +4993,7 @@ int item::get_quality( const quality_id &id ) const
         }
         return true;
     };
-    // if it's has bpil quality and it's empty, it's good to boil. If it's not empty and it's not a tool (it's probably a container), it's not good to boil. If it's a tool, it gets an extra chance: if it's only contents are mods or batteries, it's still good.
+    // if it's has boil quality and it's empty, it's good to boil. If it's not empty and it's not a tool (it's probably a container), it's not good to boil. If it's a tool, it gets an extra chance: if it's only contents are mods or batteries, it's still good.
     // Also  we are using inverted filter, since we don't care about items that the filter likes, we only care if it find something it doesn't like.
     if( id == quality_id( "BOIL" ) && !contents.empty() &&
         ( !is_tool() || has_item_with( block_boil_filter ) ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4989,7 +4989,7 @@ int item::get_quality( const quality_id &id ) const
         }
         return false;
     };
-    // if it's empty, it's good to go. If it's not empty and it's not a tool (it's probably a container), it's out. If it's a tool, it gets an extra chance: if it's only contents are mods or batteries, it's still good.
+    // if it's has biol quality and it's empty, it's good to boil. If it's not empty and it's not a tool (it's probably a container), it's not good to boil. If it's a tool, it gets an extra chance: if it's only contents are mods or batteries, it's still good.
     // Also  we are using inverted filter, since we don't care about items that the filter likes, we only care if it find something it doesn't like.
     if( id == quality_id( "BOIL" ) && !contents.empty() &&
         ( !is_tool() || has_item_with( block_boil_filter ) ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4971,25 +4971,25 @@ int item::get_quality( const quality_id &id ) const
      * EXCEPTION: Items with quality BOIL only count as such if they are empty,
      * excluding items of their ammo type if they are tools.
      */
-    auto not_boil_filter = [this]( const item & itm ) {
+    auto boil_filter = [this]( const item & itm ) {
         if( itm.is_ammo() ) {
-            return ammo_types().count( itm.ammo_type() ) == 0;
+            return ammo_types().count( itm.ammo_type() ) != 0;
         } else if( itm.is_magazine() ) {
             for( const ammotype &at : ammo_types() ) {
                 for( const ammotype &mag_at : itm.ammo_types() ) {
-                    if( at != mag_at ) {
+                    if( at == mag_at ) {
                         return true;
                     }
                 }
             }
             return false;
         } else if( itm.is_toolmod() ) {
-            return false;
+            return true;
         }
         return false;
     };
     if( id == quality_id( "BOIL" ) && !contents.empty() &&
-        ( !is_tool() || has_item_with( not_boil_filter ) ) ) {
+        ( !is_tool() || !has_item_with( boil_filter ) ) ) {
         return INT_MIN;
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4971,25 +4971,25 @@ int item::get_quality( const quality_id &id ) const
      * EXCEPTION: Items with quality BOIL only count as such if they are empty,
      * excluding items of their ammo type if they are tools.
      */
-    auto boil_filter = [this]( const item & itm ) {
+    auto not_boil_filter = [this]( const item & itm ) {
         if( itm.is_ammo() ) {
-            return ammo_types().count( itm.ammo_type() ) != 0;
+            return ammo_types().count( itm.ammo_type() ) == 0;
         } else if( itm.is_magazine() ) {
             for( const ammotype &at : ammo_types() ) {
                 for( const ammotype &mag_at : itm.ammo_types() ) {
-                    if( at == mag_at ) {
+                    if( at != mag_at ) {
                         return true;
                     }
                 }
             }
             return false;
         } else if( itm.is_toolmod() ) {
-            return true;
+            return false;
         }
         return false;
     };
     if( id == quality_id( "BOIL" ) && !contents.empty() &&
-        ( !is_tool() || !has_item_with( boil_filter ) ) ) {
+        ( !is_tool() || has_item_with( not_boil_filter ) ) ) {
         return INT_MIN;
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4972,6 +4972,11 @@ int item::get_quality( const quality_id &id ) const
      * excluding items of their ammo type if they are tools.
      */
     auto block_boil_filter = [this]( const item & itm ) {
+        if( &itm == this ) {
+            // Do not block if checking itself - we are checking only contents
+            return false;
+        }
+
         if( itm.is_ammo() ) {
             return ammo_types().count( itm.ammo_type() ) == 0;
         } else if( itm.is_magazine() ) {
@@ -4987,9 +4992,9 @@ int item::get_quality( const quality_id &id ) const
         } else if( itm.is_toolmod() ) {
             return false;
         }
-        return false;
+        return true;
     };
-    // if it's has biol quality and it's empty, it's good to boil. If it's not empty and it's not a tool (it's probably a container), it's not good to boil. If it's a tool, it gets an extra chance: if it's only contents are mods or batteries, it's still good.
+    // if it's has bpil quality and it's empty, it's good to boil. If it's not empty and it's not a tool (it's probably a container), it's not good to boil. If it's a tool, it gets an extra chance: if it's only contents are mods or batteries, it's still good.
     // Also  we are using inverted filter, since we don't care about items that the filter likes, we only care if it find something it doesn't like.
     if( id == quality_id( "BOIL" ) && !contents.empty() &&
         ( !is_tool() || has_item_with( block_boil_filter ) ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4988,12 +4988,9 @@ int item::get_quality( const quality_id &id ) const
         }
         return false;
     };
-    if( id == quality_id( "BOIL" ) ) {
-        if( contents.empty() ) {
-            // Nothing
-        } else if( is_tool() && has_item_with( not_boil_filter ) ) {
-            return INT_MIN;
-        }
+    if( id == quality_id( "BOIL" ) && !contents.empty() &&
+        ( !is_tool() || has_item_with( not_boil_filter ) ) ) {
+        return INT_MIN;
     }
 
     for( const std::pair<const quality_id, int> &quality : type->qualities ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4991,14 +4991,8 @@ int item::get_quality( const quality_id &id ) const
     if( id == quality_id( "BOIL" ) ) {
         if( contents.empty() ) {
             // Nothing
-        } else {
-            if( is_tool() ) {
-                if( has_item_with( not_boil_filter ) ) {
-                    return INT_MIN;
-                }
-            } else {
-                return INT_MIN;
-            }
+        } else if( is_tool() && has_item_with( not_boil_filter ) ) {
+            return INT_MIN;
         }
     }
 


### PR DESCRIPTION
Fix mess kit again

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->
SUMMARY: Bugfixes "Fix mess kit again"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->
Fix: https://github.com/cataclysmbnteam/Cataclysm-BN/issues/292
#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->
https://github.com/cataclysmbnteam/Cataclysm-BN/issues/292#issuecomment-751388918

> 
> 
> Now that I'm reading the new logic, it also seems wrong:
> If the item is loaded, it has contents. Meaning the second part of the check (the one for tools) only triggers for UNloaded items.
> 
> I must have tested it wrong. I probably spawned a container with boiling quality, like a glass bottle.
> 
> The correct logic would probably be
> 
> ```
> if( id == quality_id( "BOIL" ) && !contents.empty() &&
>     ( !is_tool() || has_item_with( boil_filter ) ) ) {
> ```
> 
> Except for one caveat (at the bottom of my post).
> This way: if it's empty, it's good to go. If it's not empty and it's not a tool (it's probably a container), it's out. If it's a tool, it gets an extra chance: if it's only contents are mods or batteries, it's still good.
> Or, expressed more explicitly:
> 
> ```
> if( id == quality_id( "BOIL" ) ) {
>   if( contents.empty() ) {
>     // Nothing
>   } else {
>     if( is_tool() ) {
>       if( has_item_with( NOT( boil_filter ) ) ) {
>         return INT_MIN;
>       }
>     } else {
>       return INT_MIN;
>     }
>   }
> ```
> 
> Note that `NOT` - we'll need to invert the filter, since we don't care about items that the filter likes, we only care if it find something it doesn't like.




#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Just drop is tool and ammo check
Drop all checks completely, pretending player getting rid of wrong contents during the crafting.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->
1) Emtpy inventroy
2) Spawn mess kit
3) Move to water source (for example- toliet)
4) Pass manual tests

- Empty open tin can provides boil
- Open tin can filled with something doesn't provide boil
- Mess kit loaded with batteries provides boil
- Empty mess kit provides boil
- Survivor mess kit - the one that uses oil - provides boil both filled and empty
- Mess kit modded to use vehicle batteries and loaded with charged one provides boil
- Mess kit modded to use vehicle batteries and loaded with an empty battery provides boil (that "empty" part is important) 

#### Additional context
**Save for tests are provided:**
[messkit.zip](https://github.com/cataclysmbnteam/Cataclysm-BN/files/5796867/messkit.zip)

**You will find all neccesary items right next tile from your left. Toilets- from your right.**

I am slightly worry about correctness of inverted filter.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
