### PR TITLE
Some RAM optimizations for tile memory

### DIFF
--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -5,8 +5,8 @@
 #include "line.h"
 #include "cata_utility.h"
 
-static const memorized_terrain_tile default_tile{ "", 0, 0 };
-static const int default_symbol = 0;
+const memorized_terrain_tile mm_submap::default_tile{ "", 0, 0 };
+const int mm_submap::default_symbol = 0;
 
 #define MM_SIZE (MAPSIZE * 2)
 
@@ -40,8 +40,7 @@ struct reg_coord_pair {
     }
 };
 
-mm_submap::mm_submap() : empty( true ),
-    tiles{{ default_tile }}, symbols{{ default_symbol }} {}
+mm_submap::mm_submap() {}
 
 mm_region::mm_region() : submaps {{ nullptr }} {}
 
@@ -49,7 +48,7 @@ bool mm_region::is_empty() const
 {
     for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
         for( size_t x  = 0; x < MM_REG_SIZE; x++ ) {
-            if( !submaps[x][y]->empty ) {
+            if( !submaps[x][y]->is_empty() ) {
                 return false;
             }
         }
@@ -71,7 +70,7 @@ const memorized_terrain_tile &map_memory::get_tile( const tripoint &pos ) const
 {
     coord_pair p( pos );
     const mm_submap &sm = get_submap( p.sm );
-    return sm.tiles[p.loc.x][p.loc.y];
+    return sm.tile( p.loc );
 }
 
 void map_memory::memorize_tile( const tripoint &pos, const std::string &ter,
@@ -79,31 +78,29 @@ void map_memory::memorize_tile( const tripoint &pos, const std::string &ter,
 {
     coord_pair p( pos );
     mm_submap &sm = get_submap( p.sm );
-    sm.empty = false;
-    sm.tiles[p.loc.x][p.loc.y] = memorized_terrain_tile{ ter, subtile, rotation };
+    sm.set_tile( p.loc, memorized_terrain_tile{ ter, subtile, rotation } );
 }
 
 int map_memory::get_symbol( const tripoint &pos ) const
 {
     coord_pair p( pos );
     const mm_submap &sm = get_submap( p.sm );
-    return sm.symbols[p.loc.x][p.loc.y];
+    return sm.symbol( p.loc );
 }
 
 void map_memory::memorize_symbol( const tripoint &pos, const int symbol )
 {
     coord_pair p( pos );
     mm_submap &sm = get_submap( p.sm );
-    sm.empty = false;
-    sm.symbols[p.loc.x][p.loc.y] = symbol;
+    sm.set_symbol( p.loc, symbol );
 }
 
 void map_memory::clear_memorized_tile( const tripoint &pos )
 {
     coord_pair p( pos );
     mm_submap &sm = get_submap( p.sm );
-    sm.symbols[p.loc.x][p.loc.y] = default_symbol;
-    sm.tiles[p.loc.x][p.loc.y] = default_tile;
+    sm.set_symbol( p.loc, mm_submap::default_symbol );
+    sm.set_tile( p.loc, mm_submap::default_tile );
 }
 
 bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -15,20 +15,69 @@ struct memorized_terrain_tile {
     std::string tile;
     int subtile;
     int rotation;
+
+    inline bool operator==( const memorized_terrain_tile &rhs ) const {
+        return ( rotation == rhs.rotation ) && ( subtile == rhs.subtile ) && ( tile == rhs.tile );
+    }
+
+    inline bool operator!=( const memorized_terrain_tile &rhs ) const {
+        return !( *this == rhs );
+    }
 };
 
 /** Represent a submap-sized chunk of tile memory. */
 struct mm_submap {
-    /** Whether this mm_submap is empty. Empty submaps are skipped during saving. */
-    bool empty;
+    public:
+        static const memorized_terrain_tile default_tile;
+        static const int default_symbol;
 
-    memorized_terrain_tile tiles[SEEX][SEEY];
-    int symbols[SEEX][SEEY];
+        mm_submap();
 
-    mm_submap();
+        /** Whether this mm_submap is empty. Empty submaps are skipped during saving. */
+        bool is_empty() const {
+            return tiles.empty() && symbols.empty();
+        }
 
-    void serialize( JsonOut &jsout ) const;
-    void deserialize( JsonIn &jsin );
+        inline const memorized_terrain_tile &tile( const point &p ) const {
+            if( tiles.empty() ) {
+                return default_tile;
+            } else {
+                return tiles[p.y * SEEX + p.x];
+            }
+        }
+
+        inline void set_tile( const point &p, const memorized_terrain_tile &value ) {
+            if( tiles.empty() ) {
+                // call 'reserve' first to force allocation of exact size
+                tiles.reserve( SEEX * SEEY );
+                tiles.resize( SEEX * SEEY, default_tile );
+            }
+            tiles[p.y * SEEX + p.x] = value;
+        }
+
+        inline int symbol( const point &p ) const {
+            if( symbols.empty() ) {
+                return default_symbol;
+            } else {
+                return symbols[p.y * SEEX + p.x];
+            }
+        }
+
+        inline void set_symbol( const point &p, int value ) {
+            if( symbols.empty() ) {
+                // call 'reserve' first to force allocation of exact size
+                symbols.reserve( SEEX * SEEY );
+                symbols.resize( SEEX * SEEY, default_symbol );
+            }
+            symbols[p.y * SEEX + p.x] = value;
+        }
+
+        void serialize( JsonOut &jsout ) const;
+        void deserialize( JsonIn &jsin );
+
+    private:
+        std::vector<memorized_terrain_tile> tiles; // holds either 0 or SEEX*SEEY elements
+        std::vector<int> symbols; // holds either 0 or SEEX*SEEY elements
 };
 
 /**

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3082,9 +3082,8 @@ struct mm_elem {
     memorized_terrain_tile tile;
     int symbol;
 
-    bool operator==( const mm_elem &rhs ) {
-        return symbol == rhs.symbol && tile.subtile == rhs.tile.subtile &&
-               tile.rotation == rhs.tile.rotation && tile.tile == rhs.tile.tile;
+    bool operator==( const mm_elem &rhs ) const {
+        return symbol == rhs.symbol && tile == rhs.tile;
     }
 };
 
@@ -3111,7 +3110,8 @@ void mm_submap::serialize( JsonOut &jsout ) const
 
     for( size_t y = 0; y < SEEY; y++ ) {
         for( size_t x = 0; x < SEEX; x++ ) {
-            const mm_elem elem = { tiles[x][y], symbols[x][y] };
+            point p( x, y );
+            const mm_elem elem = { tile( p ), symbol( p ) };
             if( x == 0 && y == 0 ) {
                 last = elem;
                 continue;
@@ -3154,8 +3154,14 @@ void mm_submap::deserialize( JsonIn &jsin )
                 }
                 jsin.end_array();
             }
-            tiles[x][y] = elem.tile;
-            symbols[x][y] = elem.symbol;
+            point p( x, y );
+            // Try to avoid assigning to save up on memory
+            if( elem.tile != mm_submap::default_tile ) {
+                set_tile( p, elem.tile );
+            }
+            if( elem.symbol != mm_submap::default_symbol ) {
+                set_symbol( p, elem.symbol );
+            }
         }
     }
     jsin.end_array();
@@ -3167,7 +3173,7 @@ void mm_region::serialize( JsonOut &jsout ) const
     for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
         for( size_t x = 0; x < MM_REG_SIZE; x++ ) {
             const shared_ptr_fast<mm_submap> &sm = submaps[x][y];
-            if( sm->empty ) {
+            if( sm->is_empty() ) {
                 jsout.write_null();
             } else {
                 sm->serialize( jsout );
@@ -3187,7 +3193,6 @@ void mm_region::deserialize( JsonIn &jsin )
             if( jsin.test_null() ) {
                 jsin.skip_null();
             } else {
-                sm->empty = false;
                 sm->deserialize( jsin );
             }
         }
@@ -3235,9 +3240,12 @@ void map_memory::load_legacy( JsonIn &jsin )
         if( !sm ) {
             sm = allocate_submap( cp.sm );
         }
-        sm->empty = false;
-        sm->tiles[cp.loc.x][cp.loc.y] = elem.second.tile;
-        sm->symbols[cp.loc.x][cp.loc.y] = elem.second.symbol;
+        if( elem.second.tile != mm_submap::default_tile ) {
+            sm->set_tile( cp.loc, elem.second.tile );
+        }
+        if( elem.second.symbol != mm_submap::default_symbol ) {
+            sm->set_symbol( cp.loc, elem.second.symbol );
+        }
     }
 }
 


### PR DESCRIPTION
#### Purpose of change
Lowers RAM usage for 2 cases:
1. When there are no graphical tiles memorized, only symbols
2. When zooming out or scrolling up/down in 'Look around' window

#### Describe the solution
Rewrite `mm_submap` in such way that it allocates buffer for memorized tiles/symbols only on first write operation (as opposed to always allocating on init).

#### Testing
Loaded existing save, walked around a bit. Didn't notice any problems.

Loaded a save where avatar is in a clear field, noted RAM usage. Zoomed out (with tiles only), pressed `x` and moved the cursor up/down 3 z levels, noted RAM usage again.

Tiles:
Memory usage | base, MB | increased to, MB | delta, MB
-|-|-|-
without patch | 326 | 367 | +41
with patch | 322 | 327 | +5

ASCII (SDL build with tiles disabled):
Memory usage | base, MB | increased to, MB | delta, MB
-|-|-|-
without patch | 314 | 334 | +20
with patch | 310 | 311 | +1
