### PR TITLE
Misc bugfixes from DDA 4

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -474,6 +474,7 @@
     "symbol": ";",
     "color": "light_gray",
     "ammo": "battery",
+    "charges_per_use": 1,
     "use_action": "PORTABLE_GAME",
     "magazines": [
       [

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -316,6 +316,7 @@
     "coverage": 15,
     "symbol": "[",
     "ammo": "battery",
+    "charges_per_use": 1,
     "use_action": "PORTABLE_GAME",
     "magazines": [ [ "battery", [ "light_minus_battery_cell", "light_minus_atomic_battery_cell", "light_minus_disposable_cell" ] ] ]
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1074,7 +1074,7 @@
     "id": "JITTERY",
     "name": { "str": "Jittery" },
     "points": -3,
-    "description": "During moments of great stress or under the effects of stimulants, you may find your hands shaking uncontrollably, severely reducing your Dexterity.",
+    "description": "When very hungry or under the effects of stimulants, you may find your hands shaking uncontrollably, severely reducing your Dexterity.",
     "starting_trait": true,
     "valid": false,
     "category": [ "MEDICAL", "MOUSE" ]

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -686,7 +686,8 @@ butchery_setup consider_butchery( const item &corpse_item, player &u, butcher_ty
             not_this_one( _( "This is already quartered." ), butcherable_rating::already_quartered );
         }
         if( !( corpse_item.has_flag( flag_FIELD_DRESS ) ||
-               corpse_item.has_flag( flag_FIELD_DRESS_FAILED ) ) ) {
+               corpse_item.has_flag( flag_FIELD_DRESS_FAILED ) ) &&
+            corpse_item.get_mtype()->harvest->has_entry_type( "offal" ) ) {
             not_this_one( _( "You need to perform field dressing before quartering." ),
                           butcherable_rating::needs_dressing );
         }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -892,7 +892,7 @@ static void butchery_drops_harvest( item *corpse_item, const mtype &mt, player &
     int monster_weight = to_gram( mt.weight );
     monster_weight += std::round( monster_weight * rng_float( -0.1, 0.1 ) );
     if( corpse_item->has_flag( flag_QUARTERED ) ) {
-        monster_weight /= 4;
+        monster_weight *= 0.95;
     }
     if( corpse_item->has_flag( flag_GIBBED ) ) {
         monster_weight = std::round( 0.85 * monster_weight );

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1138,7 +1138,7 @@ void avatar::reset_stats()
         add_miss_reason( _( "Your chitin gets in the way." ), 1 );
     }
     if( has_trait( trait_COMPOUND_EYES ) && !wearing_something_on( bp_eyes ) ) {
-        mod_per_bonus( 1 );
+        mod_per_bonus( 2 );
     }
     if( has_trait( trait_INSECT_ARMS ) ) {
         add_miss_reason( _( "Your insect limbs get in the way." ), 2 );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -909,7 +909,7 @@ bool Character::activate_bionic( int b, bool eff_only )
                     add_msg_if_player( m_info,
                                        _( "You have a cable plugged to a portable power source, but you need to plug it in to the CBM." ) );
                 }
-                if( state == "pay_oyt_cable" ) {
+                if( state == "pay_out_cable" ) {
                     add_msg_if_player( m_info,
                                        _( "You have a cable plugged to a vehicle, but you need to plug it in to the CBM." ) );
                 }

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -585,7 +585,7 @@ void zone_manager::cache_vzones()
         }
 
         const std::string &type_hash = elem->get_type_hash();
-        auto &cache = area_cache[type_hash];
+        auto &cache = vzone_cache[type_hash];
 
         // TODO: looks very similar to the above cache_data - maybe merge it?
 
@@ -1175,6 +1175,7 @@ void zone_manager::load_zones()
     removed_vzones.clear();
 
     cache_data();
+    cache_vzones();
 }
 
 void zone_manager::zone_edited( zone_data &zone )

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -55,6 +55,16 @@ bool harvest_list::is_null() const
     return id_ == harvest_id::NULL_ID();
 }
 
+bool harvest_list::has_entry_type( std::string type ) const
+{
+    for( const harvest_entry &entry : entries() ) {
+        if( entry.type == type ) {
+            return true;
+        }
+    }
+    return false;
+}
+
 harvest_entry harvest_entry::load( const JsonObject &jo, const std::string &src )
 {
     const bool strict = src == "dda";

--- a/src/harvest.h
+++ b/src/harvest.h
@@ -52,6 +52,8 @@ class harvest_list
             return entries().empty();
         }
 
+        bool has_entry_type( std::string type ) const;
+
         /**
          * Returns a set of cached, translated names of the items this harvest entry could produce.
          * Filled in at finalization and not valid before that stage.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -124,7 +124,6 @@ static const std::string trait_flag_CANNIBAL( "CANNIBAL" );
 static const bionic_id bio_digestion( "bio_digestion" );
 
 static const trait_id trait_CARNIVORE( "CARNIVORE" );
-static const trait_id trait_JITTERY( "JITTERY" );
 static const trait_id trait_LIGHTWEIGHT( "LIGHTWEIGHT" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
 static const trait_id trait_SMALL_OK( "SMALL_OK" );
@@ -8661,8 +8660,7 @@ bool item::process_litcig( player *carrier, const tripoint &pos )
         }
         carrier->moves -= 15;
 
-        if( ( carrier->has_effect( effect_shakes ) && one_in( 10 ) ) ||
-            ( carrier->has_trait( trait_JITTERY ) && one_in( 200 ) ) ) {
+        if( ( carrier->has_effect( effect_shakes ) && one_in( 10 ) ) ) {
             carrier->add_msg_if_player( m_bad, _( "Your shaking hand causes you to drop your %s." ),
                                         tname() );
             g->m.add_item_or_charges( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), *this );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4329,7 +4329,7 @@ int iuse::portable_game( player *p, item *it, bool t, const tripoint & )
     if( p->has_trait( trait_ILLITERATE ) ) {
         p->add_msg_if_player( m_info, _( "You're illiterate!" ) );
         return 0;
-    } else if( it->ammo_remaining() < 15 ) {
+    } else if( it->units_remaining( *p ) < it->ammo_required() ) {
         p->add_msg_if_player( m_info, _( "The %s's batteries are dead." ), it->tname() );
         return 0;
     } else {
@@ -4376,7 +4376,7 @@ int iuse::portable_game( player *p, item *it, bool t, const tripoint & )
         if( loaded_software == "null" ) {
             p->assign_activity( ACT_GENERIC_GAME, to_moves<int>( 1_hours ), -1,
                                 p->get_item_position( it ), "gaming" );
-            return it->type->charges_to_use();
+            return 0;
         }
         p->assign_activity( ACT_GAME, moves, -1, 0, "gaming" );
         p->activity.targets.push_back( item_location( *p, it ) );
@@ -4402,7 +4402,7 @@ int iuse::portable_game( player *p, item *it, bool t, const tripoint & )
         }
 
     }
-    return it->type->charges_to_use();
+    return 0;
 }
 
 int iuse::hand_crank( player *p, item *it, bool, const tripoint & )

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -485,6 +485,7 @@ bool mutation_type_exists( const std::string &id );
 std::vector<trait_id> get_mutations_in_types( const std::set<std::string> &ids );
 std::vector<trait_id> get_mutations_in_type( const std::string &id );
 bool trait_display_sort( const trait_id &a, const trait_id &b ) noexcept;
+bool trait_display_nocolor_sort( const trait_id &a, const trait_id &b ) noexcept;
 
 bool are_conflicting_traits( const trait_id &trait_a, const trait_id &trait_b );
 bool b_is_lower_trait_of_a( const trait_id &trait_a, const trait_id &trait_b );

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -652,6 +652,11 @@ bool trait_display_sort( const trait_id &a, const trait_id &b ) noexcept
     return localized_compare( a->name(), b->name() );
 }
 
+bool trait_display_nocolor_sort( const trait_id &a, const trait_id &b ) noexcept
+{
+    return localized_compare( a->name(), b->name() );
+}
+
 void mutation_branch::load_trait_blacklist( const JsonObject &jsobj )
 {
     for( const std::string line : jsobj.get_array( "traits" ) ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1041,7 +1041,7 @@ tab_direction set_traits( avatar &u, points_left &points )
     for( auto &vStartingTrait : vStartingTraits ) {
         std::sort( vStartingTrait.begin(), vStartingTrait.end(), []( const trait_entry & a,
         const trait_entry & b ) {
-            return trait_display_sort( a.id, b.id );
+            return trait_display_nocolor_sort( a.id, b.id );
         } );
     }
 

--- a/src/translations.h
+++ b/src/translations.h
@@ -128,13 +128,6 @@ static inline local_translation_cache<std::string> get_local_translation_cache(
     return local_translation_cache<std::string>();
 }
 
-// this function is used as a marker for clang-tidy check (see TranslatorCommentsCheck.cpp)
-template <typename T>
-static inline auto translation_macro_marker_func( T &&arg )
-{
-    return std::forward<T>( arg );
-}
-
 } // namespace detail
 
 // Note: in case of std::string argument, the result is copied, this is intended (for safety)
@@ -142,7 +135,7 @@ static inline auto translation_macro_marker_func( T &&arg )
     ( ( []( const auto & arg ) { \
         static auto cache = detail::get_local_translation_cache( arg ); \
         return cache( arg ); \
-    } )( detail::translation_macro_marker_func( msg ) ) )
+    } )( msg ) )
 
 // ngettext overload taking an unsigned long long so that people don't need
 // to cast at call sites.  This is particularly relevant on 64-bit Windows where

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -181,7 +181,7 @@ void vehicle::thrust( int thd, int z )
     //find power ratio used of engines max
     int load;
     // Keep exact cruise control speed
-    if( cruise_on ) {
+    if( cruise_on && accel != 0 ) {
         int effective_cruise = std::min( cruise_velocity, max_vel );
         if( thd > 0 ) {
             vel_inc = std::min( vel_inc, effective_cruise - velocity );

--- a/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp
+++ b/tools/clang-tidy-plugin/TranslatorCommentsCheck.cpp
@@ -150,10 +150,16 @@ class TranslatorCommentsCheck::TranslationMacroCallback : public PPCallbacks
 
             StringRef MacroName = MacroNameTok.getIdentifierInfo()->getName();
 
+            bool is_marker;
             unsigned int RawStringInd;
-            if( MacroName == "translate_marker" ) {
+            if( MacroName == "_" ) {
+                is_marker = false;
+                RawStringInd = 0;
+            } else if( MacroName == "translate_marker" ) {
+                is_marker = true;
                 RawStringInd = 0;
             } else if( MacroName == "translate_marker_context" ) {
+                is_marker = true;
                 RawStringInd = 1;
             } else {
                 return;
@@ -173,7 +179,9 @@ class TranslatorCommentsCheck::TranslationMacroCallback : public PPCallbacks
                 }
                 for( ; Tok->isNot( tok::eof ); ++Tok ) {
                     if( !tok::isStringLiteral( Tok->getKind() ) ) {
-                        Check.diag( Tok->getLocation(), "Translation marker macros only accepts string literal arguments" );
+                        if( is_marker ) {
+                            Check.diag( Tok->getLocation(), "Translation marker macros only accepts string literal arguments" );
+                        }
                         return;
                     }
                 }
@@ -220,7 +228,7 @@ void TranslatorCommentsCheck::registerMatchers( MatchFinder *Finder )
         );
     Finder->addMatcher(
         callExpr(
-            callee( functionDecl( hasAnyName( "_", "gettext", "translation_macro_marker_func" ) ) ),
+            callee( functionDecl( hasAnyName( "_", "gettext" ) ) ),
             hasImmediateArgument( 0, stringLiteralArgumentBound )
         ),
         this

--- a/tools/clang-tidy-plugin/test/translator-comments.cpp
+++ b/tools/clang-tidy-plugin/test/translator-comments.cpp
@@ -18,8 +18,12 @@ using string = basic_string<char>;
 // check_clang_tidy uses -nostdinc++, so we add dummy translation interface here instead of including translations.h
 #define translate_marker( s ) ( s )
 #define translate_marker_context( c, s ) ( s )
+// mimic how it's declared in translation.h
+#define _( msg ) \
+    ( ( []( const auto & arg ) { \
+        return arg; \
+    } )( msg ) )
 
-const char *_( const char * );
 const char *gettext( const char * );
 const char *pgettext( const char *, const char * );
 const char *ngettext( const char *, const char *, int );


### PR DESCRIPTION
#### Purpose of change
Deporting bugs by porting fixes

#### Describe the solution
Cherry-picked from DDA:
CleverRaven#45165
CleverRaven#44938 (squashed with CleverRaven#46442)
CleverRaven#45234 (not a bugfix, but a must-have nonetheless)
CleverRaven#45250 (also removed a check for Jittery so that behavior completely matches description)
CleverRaven#45250 (in case clang-tidy will be part of CI some day)
CleverRaven#45281
CleverRaven#45451
CleverRaven#45609
CleverRaven#45685
CleverRaven#45963
CleverRaven#45626

#### Testing
Couldn't reproduce that vehicle SIGFPE crash and didn't check clang-tidy, but the rest of the fixes work.
