### PR TITLE
Fix uilist filtering with non-ascii chars on Windows

### DIFF
--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -97,7 +97,7 @@ T divide_round_up( units::quantity<T, U> num, units::quantity<T, U> den )
 bool isBetween( int test, int down, int up );
 
 /**
- * Perform case sensitive search for a query string inside a subject string.
+ * Perform case insensitive search for a query string inside a subject string.
  *
  * Searches for string given by qry inside a subject string given by str.
  *

--- a/src/ui.h
+++ b/src/ui.h
@@ -282,7 +282,7 @@ class uilist // NOLINT(cata-xy)
         bool desc_enabled;
 
         bool filtering;
-        bool filtering_nocase;
+        bool filtering_igncase;
 
         // return on selecting disabled entry, default false
         bool allow_disabled = false;


### PR DESCRIPTION
#### Purpose of change
It's doesn't show any results when I try to use the filter with Russian interface.

#### Describe the solution
Get rid of `tolower()` call. On Linux it apparently skips UTF-8 chars, but on Windows it mangles them. Must be something with locales... The `lcmatch()` function that performs case-insensitive comparison already converts input to lower case, and does it right, so the problematic `tolower()` is unnecessary here.
Also, renamed a few variables for readability and fixed docs for `lcmatch()`.

#### Testing
Switched to Russian, entered `я` in debug wish item uilist filter.
Before the fix: no entries found.
After: many entries found, all of the contain either `я` or `Я`.
Works on both Win and Linux.