### PR TITLE
Fix 'Wait for...' query when player doesn't have a watch.

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -809,13 +809,13 @@ static void wait()
 
     const bool has_watch = u.has_watch() || setting_alarm;
 
-    const auto add_menu_item = [ &as_m, &durations, has_watch ]
+    const auto add_menu_item = [ &as_m, &durations ]
                                ( int retval, int hotkey, const std::string &caption = "",
     const time_duration &duration = time_duration::from_turns( calendar::INDEFINITELY_LONG ) ) {
 
         std::string text( caption );
 
-        if( has_watch && duration != time_duration::from_turns( calendar::INDEFINITELY_LONG ) ) {
+        if( duration != time_duration::from_turns( calendar::INDEFINITELY_LONG ) ) {
             const std::string dur_str( to_string( duration ) );
             text += ( text.empty() ? dur_str : string_format( " (%s)", dur_str ) );
         }


### PR DESCRIPTION
#### Purpose of change
![image](https://user-images.githubusercontent.com/60584843/105408324-dc152380-5c3f-11eb-98bd-09d759e1962c.png)

#### Describe the solution
Removed a leftover check

#### Testing
![image](https://user-images.githubusercontent.com/60584843/105408790-7a08ee00-5c40-11eb-8886-c005d5df95ae.png)