### PR TITLE
Fancy fixes for filesystem functions

### DIFF
--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -361,6 +361,214 @@ float multi_lerp( const std::vector<std::pair<float, float>> &points, float x )
     return ( t * points[i].second ) + ( ( 1 - t ) * points[i - 1].second );
 }
 
+#if defined (_WIN32) && !defined (_MSC_VER)
+// On Linux/MacOS, UTF-8 paths work out of the box, and we pass the string as is.
+// On Windows, narrow API does not recognize paths encoded with UTF-8,
+// so we have to jump through hoops to use wide API:
+// * with Visual Studio, there's a non-standard fstream constructor that
+//   accepts wstring for path; we just need to convert UTF-8 to UTF-16.
+// * when cross-compiling with mingw64, there's a non-standard __gnu_cxx::stdio_filebuf
+//   that allows creating fstream from FILE, and _wfopen that allows opening FILE
+//   using wide string for path.
+// Although Windows 10 insider build 17035 (November 2017) enables narrow API to use UTF-8
+// paths, we can't rely on it here for backwards compatibility.
+
+cata_ofstream &cata_ofstream::operator=( cata_ofstream &&x )
+{
+    _stream = std::move( x._stream );
+    _buffer = std::move( x._buffer );
+    _file = x._file;
+    x._file = nullptr;
+    _binary = x._binary;
+    _append = x._append;
+    return *this;
+}
+
+cata_ofstream &cata_ofstream::open( const std::string &path )
+{
+    std::wstring mode;
+    if( _append ) {
+        mode = L"a";
+    } else {
+        mode = L"w";
+    }
+    if( _binary ) {
+        mode += L"b";
+    }
+
+    _file = _wfopen( utf8_to_wstr( path ).c_str(), mode.c_str() );
+    if( !_file ) {
+        // failed
+        return *this;
+    }
+
+    std::ios_base::openmode smode = std::ios_base::out;
+    if( _binary ) {
+        smode |= std::ios_base::binary;
+    }
+    if( _append ) {
+        smode |= std::ios_base::app;
+    }
+
+    _buffer = std::make_unique<__gnu_cxx::stdio_filebuf<char>>( _file, smode );
+    _stream = std::make_unique<std::ostream>( &*_buffer );
+
+    return *this;
+}
+
+bool cata_ofstream::is_open()
+{
+    return _file;
+}
+
+void cata_ofstream::close()
+{
+    if( _stream ) {
+        _stream->flush();
+        _stream.reset();
+    }
+    _buffer.reset();
+    if( _file ) {
+        fclose( _file );
+        _file = nullptr;
+    }
+}
+
+#else // defined (_WIN32) && !defined (_MSC_VER)
+
+cata_ofstream &cata_ofstream::operator=( cata_ofstream &&x )
+{
+    _stream = std::move( x._stream );
+    _binary = x._binary;
+    _append = x._append;
+    return *this;
+}
+
+cata_ofstream &cata_ofstream::open( const std::string &path )
+{
+    std::ios_base::openmode mode = std::ios_base::out;
+    if( _binary ) {
+        mode |= std::ios_base::binary;
+    }
+    if( _append ) {
+        mode |= std::ios_base::app;
+    }
+
+#if defined (_MSC_VER)
+    _stream = std::make_unique<std::ofstream>( utf8_to_wstr( path ), mode );
+#else
+    _stream = std::make_unique<std::ofstream>( path, mode );
+#endif
+    return *this;
+}
+
+bool cata_ofstream::is_open()
+{
+    return _stream && _stream->is_open();
+}
+
+void cata_ofstream::close()
+{
+    if( _stream ) {
+        _stream->close();
+        _stream.reset();
+    }
+}
+
+#endif // defined (_WIN32) && !defined (_MSC_VER)
+
+#if defined (_WIN32) && !defined (_MSC_VER)
+
+cata_ifstream &cata_ifstream::operator=( cata_ifstream &&x )
+{
+    _stream = std::move( x._stream );
+    _buffer = std::move( x._buffer );
+    _file = x._file;
+    x._file = nullptr;
+    _binary = x._binary;
+    return *this;
+}
+
+cata_ifstream &cata_ifstream::open( const std::string &path )
+{
+    std::wstring mode = L"r";
+    if( _binary ) {
+        mode += L"b";
+    }
+
+    _file = _wfopen( utf8_to_wstr( path ).c_str(), mode.c_str() );
+    if( !_file ) {
+        // failed
+        return *this;
+    }
+
+    std::ios_base::openmode smode = std::ios_base::in;
+    if( _binary ) {
+        smode |= std::ios_base::binary;
+    }
+
+    _buffer = std::make_unique<__gnu_cxx::stdio_filebuf<char>>( _file, smode );
+    _stream = std::make_unique<std::istream>( &*_buffer );
+
+    return *this;
+}
+
+bool cata_ifstream::is_open()
+{
+    return _file;
+}
+
+void cata_ifstream::close()
+{
+    if( _stream ) {
+        _stream.reset();
+    }
+    _buffer.reset();
+    if( _file ) {
+        fclose( _file );
+        _file = nullptr;
+    }
+}
+
+#else // defined (_WIN32) && !defined (_MSC_VER)
+
+cata_ifstream &cata_ifstream::operator=( cata_ifstream &&x )
+{
+    _stream = std::move( x._stream );
+    _binary = x._binary;
+    return *this;
+}
+
+cata_ifstream &cata_ifstream::open( const std::string &path )
+{
+    std::ios_base::openmode mode = std::ios_base::in;
+    if( _binary ) {
+        mode |= std::ios_base::binary;
+    }
+
+#if defined (_MSC_VER)
+    _stream = std::make_unique<std::ifstream>( utf8_to_wstr( path ), mode );
+#else
+    _stream = std::make_unique<std::ifstream>( path, mode );
+#endif
+    return *this;
+}
+
+bool cata_ifstream::is_open()
+{
+    return _stream && _stream->is_open();
+}
+
+void cata_ifstream::close()
+{
+    if( _stream ) {
+        _stream->close();
+        _stream.reset();
+    }
+}
+
+#endif // defined (_WIN32) && !defined (_MSC_VER)
+
 void write_to_file( const std::string &path, const std::function<void( std::ostream & )> &writer )
 {
     // Any of the below may throw. ofstream_wrapper will clean up the temporary path on its own.
@@ -430,11 +638,11 @@ std::istream &safe_getline( std::istream &ins, std::string &str )
 bool read_from_file( const std::string &path, const std::function<void( std::istream & )> &reader )
 {
     try {
-        std::ifstream fin( path, std::ios::binary );
-        if( !fin ) {
+        cata_ifstream fin = std::move( cata_ifstream().binary( true ).open( path ) );
+        if( !fin.is_open() ) {
             throw std::runtime_error( "opening file failed" );
         }
-        reader( fin );
+        reader( *fin );
         if( fin.bad() ) {
             throw std::runtime_error( "reading file failed" );
         }
@@ -501,7 +709,8 @@ void ofstream_wrapper::open( const std::ios::openmode mode )
         remove_file( temp_path );
     }
 
-    file_stream.open( temp_path, mode );
+    file_stream = std::move( cata_ofstream().binary( mode & std::ios_base::binary ).append(
+                                 mode & std::ios_base::app ).open( temp_path ) );
     if( !file_stream.is_open() ) {
         throw std::runtime_error( "opening file failed" );
     }

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -86,6 +86,11 @@ bool lcmatch( const translation &str, const std::string &qry )
     return lcmatch( str.translated(), qry );
 }
 
+bool lcequal( const std::string &str1, const std::string &str2 )
+{
+    return to_lower_case( str1 ) == to_lower_case( str2 );
+}
+
 bool match_include_exclude( const std::string &text, std::string filter )
 {
     size_t iPos;

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -488,6 +488,10 @@ bool read_from_file_optional( const std::string &path, JsonDeserializer &reader 
 
 void ofstream_wrapper::open( const std::ios::openmode mode )
 {
+    if( dir_exist( path ) ) {
+        throw std::runtime_error( "target path is a directory" );
+    }
+
     // Create a *unique* temporary path. No other running program should
     // use this path. If the file exists, it must be of a *former* program
     // instance and can savely be deleted.

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -10,6 +10,10 @@
 #include <algorithm>
 #include <type_traits>
 
+#if defined (_WIN32) && !defined (_MSC_VER)
+#include <ext/stdio_filebuf.h>
+#endif
+
 #include "units.h"
 
 class JsonIn;
@@ -356,6 +360,107 @@ class list_circularizer
 };
 
 /**
+ * Wrapper around std::ofstream that provides cross-platform support for UTF-8 paths.
+ */
+struct cata_ofstream {
+    public:
+        cata_ofstream() {};
+        cata_ofstream( cata_ofstream &&x ) {
+            *this = std::move( x );
+        };
+        ~cata_ofstream() {
+            close();
+        }
+        cata_ofstream &operator=( cata_ofstream && );
+
+        inline cata_ofstream &binary( bool value ) {
+            _binary = value;
+            return *this;
+        }
+        inline cata_ofstream &append( bool value ) {
+            _append = value;
+            return *this;
+        }
+        cata_ofstream &open( const std::string &path );
+        bool is_open();
+        bool fail() {
+            return !_stream || _stream->fail();
+        }
+        bool bad() {
+            return !_stream || _stream->bad();
+        }
+        void flush() {
+            _stream->flush();
+        }
+        void close();
+
+        std::ostream &operator*() {
+            return *_stream;
+        }
+        std::ostream *operator->() {
+            return &*_stream;
+        }
+
+    private:
+        bool _binary = false;
+        bool _append = false;
+#if defined (_WIN32) && !defined (_MSC_VER)
+        std::unique_ptr<std::ostream> _stream;
+        std::unique_ptr<__gnu_cxx::stdio_filebuf<char>> _buffer;
+        FILE *_file = nullptr;
+#else
+        std::unique_ptr<std::ofstream> _stream;
+#endif
+};
+
+/**
+ * Wrapper around std::ifstream that provides cross-platform support for UTF-8 paths.
+ */
+struct cata_ifstream {
+    public:
+        cata_ifstream() {};
+        cata_ifstream( cata_ifstream &&x ) {
+            *this = std::move( x );
+        };
+        ~cata_ifstream() {
+            close();
+        }
+
+        cata_ifstream &operator=( cata_ifstream && );
+
+        inline cata_ifstream &binary( bool value ) {
+            _binary = value;
+            return *this;
+        }
+        cata_ifstream &open( const std::string &path );
+        bool is_open();
+        bool fail() {
+            return !_stream || _stream->fail();
+        }
+        bool bad() {
+            return !_stream || _stream->bad();
+        }
+        void close();
+
+        std::istream &operator*() {
+            return *_stream;
+        }
+        std::istream *operator->() {
+            return &*_stream;
+        }
+
+    private:
+        bool _binary = false;
+#if defined (_WIN32) && !defined (_MSC_VER)
+        std::unique_ptr<std::istream> _stream;
+        std::unique_ptr<__gnu_cxx::stdio_filebuf<char>> _buffer;
+        FILE *_file = nullptr;
+#else
+        std::unique_ptr<std::ifstream> _stream;
+#endif
+};
+
+/**
  * Open a file for writing, calls the writer on that stream.
  *
  * If the writer throws, or if the file could not be opened or if any I/O error
@@ -422,7 +527,7 @@ bool read_from_file_optional( const std::string &path, JsonDeserializer &reader 
 class ofstream_wrapper
 {
     private:
-        std::ofstream file_stream;
+        cata_ofstream file_stream;
         std::string path;
         std::string temp_path;
 
@@ -433,10 +538,10 @@ class ofstream_wrapper
         ~ofstream_wrapper();
 
         std::ostream &stream() {
-            return file_stream;
+            return *file_stream;
         }
         operator std::ostream &() {
-            return file_stream;
+            return *file_stream;
         }
 
         void close();

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -110,6 +110,9 @@ bool isBetween( int test, int down, int up );
 bool lcmatch( const std::string &str, const std::string &qry );
 bool lcmatch( const translation &str, const std::string &qry );
 
+/** Perform case insensitive comparison of 2 strings. */
+bool lcequal( const std::string &str1, const std::string &str2 );
+
 /**
  * Matches text case insensitive with the include/exclude rules of the filter
  *

--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -414,48 +414,6 @@ std::string wstr_to_utf8( const std::wstring &wstr )
 #endif
 }
 
-std::string native_to_utf8( const std::string &str )
-{
-    if( get_options().has_option( "ENCODING_CONV" ) && !get_option<bool>( "ENCODING_CONV" ) ) {
-        return str;
-    }
-#if defined(_WIN32)
-    // native encoded string --> Unicode sequence --> UTF-8 string
-    int unicode_size = MultiByteToWideChar( CP_ACP, 0, str.c_str(), -1, nullptr, 0 ) + 1;
-    std::wstring unicode( unicode_size, '\0' );
-    MultiByteToWideChar( CP_ACP, 0, str.c_str(), -1, &unicode[0], unicode_size );
-    int utf8_size = WideCharToMultiByte( CP_UTF8, 0, &unicode[0], -1, nullptr, 0, nullptr,
-                                         nullptr ) + 1;
-    std::string result( utf8_size, '\0' );
-    WideCharToMultiByte( CP_UTF8, 0, &unicode[0], -1, &result[0], utf8_size, nullptr, nullptr );
-    strip_trailing_nulls( result );
-    return result;
-#else
-    return str;
-#endif
-}
-
-std::string utf8_to_native( const std::string &str )
-{
-    if( get_options().has_option( "ENCODING_CONV" ) && !get_option<bool>( "ENCODING_CONV" ) ) {
-        return str;
-    }
-#if defined(_WIN32)
-    // UTF-8 string --> Unicode sequence --> native encoded string
-    int unicode_size = MultiByteToWideChar( CP_UTF8, 0, str.c_str(), -1, nullptr, 0 ) + 1;
-    std::wstring unicode( unicode_size, '\0' );
-    MultiByteToWideChar( CP_UTF8, 0, str.c_str(), -1, &unicode[0], unicode_size );
-    int native_size = WideCharToMultiByte( CP_ACP, 0, &unicode[0], -1, nullptr, 0, nullptr,
-                                           nullptr ) + 1;
-    std::string result( native_size, '\0' );
-    WideCharToMultiByte( CP_ACP, 0, &unicode[0], -1, &result[0], native_size, nullptr, nullptr );
-    strip_trailing_nulls( result );
-    return result;
-#else
-    return str;
-#endif
-}
-
 std::string utf32_to_utf8( const std::u32string &str )
 {
     std::string ret;

--- a/src/catacharset.h
+++ b/src/catacharset.h
@@ -51,9 +51,6 @@ std::string base64_decode( const std::string &str );
 std::wstring utf8_to_wstr( const std::string &str );
 std::string wstr_to_utf8( const std::wstring &wstr );
 
-std::string native_to_utf8( const std::string &str );
-std::string utf8_to_native( const std::string &str );
-
 std::string utf32_to_utf8( const std::u32string &str );
 std::u32string utf8_to_utf32( const std::string &str );
 

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -463,3 +463,12 @@ bool can_write_to_dir( const std::string &dir_path )
 
     return remove_file( dummy_file );
 }
+
+std::string get_pid_string()
+{
+#if defined _WIN32
+    return to_string( GetCurrentProcessId() );
+#else
+    return to_string( getpid() );
+#endif
+}

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -413,13 +413,14 @@ std::vector<std::string> get_directories_with( const std::vector<std::string> &p
 
 bool copy_file( const std::string &source_path, const std::string &dest_path )
 {
-    std::ifstream source_stream( source_path.c_str(), std::ifstream::in | std::ifstream::binary );
-    if( !source_stream ) {
+    cata_ifstream source_stream = std::move( cata_ifstream().binary( true ).open( source_path ) );
+    if( !source_stream.is_open() ) {
         return false;
     }
-    return write_to_file( dest_path, [&]( std::ostream & dest_stream ) {
-        dest_stream << source_stream.rdbuf();
-    }, nullptr ) &&source_stream;
+    bool res = write_to_file( dest_path, [&]( std::ostream & dest_stream ) {
+        dest_stream << source_stream->rdbuf();
+    }, nullptr );
+    return res && !source_stream.fail();
 }
 
 std::string ensure_valid_file_name( const std::string &file_name )

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -439,9 +439,13 @@ const char *CBN = "Q2F0YWNseXNtQnJpZ2h0TmlnaHRz";
 
 bool can_write_to_dir( const std::string &dir_path )
 {
-    // TODO: remove this hack once c++17 is a thing
+    std::string dummy_file;
+    if( string_ends_with( dir_path, "/" ) ) {
+        dummy_file = dir_path + CBN;
+    } else {
+        dummy_file = dir_path + "/" + CBN;
+    }
 
-    std::string dummy_file = dir_path + CBN;
     if( file_exist( dummy_file ) ) {
         if( !remove_file( dummy_file ) ) {
             return false;

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -19,8 +19,12 @@
 #include "catacharset.h"
 
 #if defined(_WIN32)
-#   include "wdirent.h"
 #   include "platform_win.h"
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#   include "wdirent.h"
+#   pragma GCC diagnostic pop
+#   include <direct.h>
 #else
 #   include <dirent.h>
 #   include <unistd.h>

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -69,7 +69,8 @@ bool dir_exist( const std::string &path )
 bool file_exist( const std::string &path )
 {
     struct stat buffer;
-    return ( stat( path.c_str(), &buffer ) == 0 );
+    bool success = stat( path.c_str(), &buffer ) == 0;
+    return success && S_ISREG( buffer.st_mode );
 }
 
 #if defined(_WIN32)

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -277,7 +277,14 @@ std::vector<std::string> find_file_if_bfs( const std::string &root_path,
         const bool recursive_search,
         Predicate predicate )
 {
-    std::deque<std::string>  directories {!root_path.empty() ? root_path : "."};
+    std::deque<std::string>  directories;
+    if( root_path.empty() ) {
+        directories.emplace_back( "./" );
+    } else if( string_ends_with( root_path, "/" ) ) {
+        directories.emplace_back( root_path );
+    } else {
+        directories.emplace_back( root_path + "/" );
+    }
     std::vector<std::string> results;
 
     while( !directories.empty() ) {
@@ -293,7 +300,7 @@ std::vector<std::string> find_file_if_bfs( const std::string &root_path,
                 return;
             }
 
-            const auto full_path = path + "/" + entry.d_name;
+            const auto full_path = path + entry.d_name;
 
             // don't add files ending in '~'.
             if( full_path.back() == '~' ) {
@@ -303,7 +310,7 @@ std::vector<std::string> find_file_if_bfs( const std::string &root_path,
             // add sub directories to recursive_search if requested
             const auto is_dir = is_directory( entry, full_path );
             if( recursive_search && is_dir ) {
-                directories.emplace_back( full_path );
+                directories.emplace_back( full_path + "/" );
             }
 
             // check the file

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -184,8 +184,14 @@ bool is_directory_stat( const std::string &full_path )
         return false;
     }
 
+#if defined(_WIN32)
+    struct _stat result;
+    int stat_ret = _wstat( utf8_to_wstr( full_path ).c_str(), &result );
+#else
     struct stat result;
-    if( stat( full_path.c_str(), &result ) != 0 ) {
+    int stat_ret = stat( full_path.c_str(), &result );
+#endif
+    if( stat_ret != 0 ) {
         const auto e_str = strerror( errno );
         DebugLog( D_WARNING, D_MAIN ) << "stat [" << full_path << "] failed with \"" << e_str << "\".";
         return false;

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -16,6 +16,8 @@ bool remove_directory( const std::string &path );
 bool rename_file( const std::string &old_path, const std::string &new_path );
 // Check if can write to the given directory
 bool can_write_to_dir( const std::string &dir_path );
+/** Get process id string. Used for temporary file paths. */
+std::string get_pid_string();
 
 namespace cata_files
 {

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -5,17 +5,46 @@
 #include <string>
 #include <vector>
 
+/**
+ * Create directory if it does not exist.
+ * @return true if directory exists or was successfully created.
+ */
 bool assure_dir_exist( const std::string &path );
+/**
+ * Check if directory exists.
+ * @return false if directory does not exist or if unable to check.
+ */
 bool dir_exist( const std::string &path );
+/**
+ * Check if file exists.
+ * @return false if file does not exist or if unable to check.
+ */
 bool file_exist( const std::string &path );
-// Remove a file, does not remove folders,
-// returns true on success
+/**
+ * Remove a file. Does not remove directories.
+ * @return true on success.
+ */
 bool remove_file( const std::string &path );
+/**
+ * Remove an empty directory.
+ * @return true on success, false on failure (e.g. directory is not empty).
+ */
 bool remove_directory( const std::string &path );
-// Rename a file, overriding the target!
+/**
+ * Rename a file, overwriting the target. Does not overwrite directories.
+ * @return true on success, false on failure.
+ */
 bool rename_file( const std::string &old_path, const std::string &new_path );
-// Check if can write to the given directory
+/**
+ * Check if can write to the given directory (write permission, disk space).
+ * @return false if cannot write or if unable to check.
+ */
 bool can_write_to_dir( const std::string &dir_path );
+/**
+ * Copy file, overwriting the target. Does not overwrite directories.
+ * @return true on success, false on failure.
+ */
+bool copy_file( const std::string &source_path, const std::string &dest_path );
 /** Get process id string. Used for temporary file paths. */
 std::string get_pid_string();
 
@@ -53,8 +82,6 @@ std::vector<std::string> get_directories_with( const std::vector<std::string> &p
 
 std::vector<std::string> get_directories_with( const std::string &pattern,
         const std::string &root_path = "", bool recursive_search = false );
-
-bool copy_file( const std::string &source_path, const std::string &dest_path );
 
 /**
  *  Replace invalid characters in a string with a default character; can be used to ensure that a file name is compliant with most file systems.

--- a/src/font_loader.h
+++ b/src/font_loader.h
@@ -42,8 +42,8 @@ class font_loader
     private:
         void load_throws( const std::string &path ) {
             try {
-                std::ifstream stream( path.c_str(), std::ifstream::binary );
-                JsonIn json( stream );
+                cata_ifstream stream = std::move( cata_ifstream().binary( true ).open( path ) );
+                JsonIn json( *stream );
                 JsonObject config = json.get_object();
                 if( config.has_string( "typeface" ) ) {
                     typeface.emplace_back( config.get_string( "typeface" ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3009,8 +3009,8 @@ std::vector<std::string> game::list_active_characters()
 void game::write_memorial_file( std::string sLastWords )
 {
     const std::string &memorial_dir = PATH_INFO::memorialdir();
-    const std::string &memorial_active_world_dir = memorial_dir + utf8_to_native(
-                world_generator->active_world->world_name ) + "/";
+    const std::string &memorial_active_world_dir = memorial_dir +
+            world_generator->active_world->world_name + "/";
 
     //Check if both dirs exist. Nested assure_dir_exist fails if the first dir of the nested dir does not exist.
     if( !assure_dir_exist( memorial_dir ) ) {
@@ -3038,17 +3038,7 @@ void game::write_memorial_file( std::string sLastWords )
     std::ostringstream memorial_file_path;
     memorial_file_path << memorial_active_world_dir;
 
-    if( get_options().has_option( "ENCODING_CONV" ) && !get_option<bool>( "ENCODING_CONV" ) ) {
-        // Use the default locale to replace non-printable characters with _ in the player name.
-        std::locale locale {"C"};
-        std::replace_copy_if( std::begin( u.name ), std::begin( u.name ) + truncated_name_len,
-                              std::ostream_iterator<char>( memorial_file_path ),
-        [&]( const char c ) {
-            return !std::isgraph( c, locale );
-        }, '_' );
-    } else {
-        memorial_file_path << utf8_to_native( u.name );
-    }
+    memorial_file_path << ensure_valid_file_name( u.name );
 
     // Add a ~ if the player name was actually truncated.
     memorial_file_path << ( ( truncated_name_len != name_len ) ? "~-" : "-" );

--- a/src/ime.cpp
+++ b/src/ime.cpp
@@ -33,7 +33,7 @@ class imm_wrapper
     public:
         imm_wrapper() {
             // Check if East Asian support is available
-            hImm = LoadLibrary( "imm32.dll" );
+            hImm = LoadLibraryW( L"imm32.dll" );
             if( hImm ) {
                 pImmGetContext = fun_ptr_cast<pImmGetContext_t>(
                                      GetProcAddress( hImm, "ImmGetContext" ) );

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -428,11 +428,11 @@ void DynamicDataLoader::load_data_from_path( const std::string &path, const std:
     for( auto &files_i : files ) {
         const std::string &file = files_i;
         // open the file as a stream
-        std::ifstream infile( file.c_str(), std::ifstream::in | std::ifstream::binary );
+        cata_ifstream infile = std::move( cata_ifstream().binary( true ).open( file ) );
         // and stuff it into ram
         std::istringstream iss(
             std::string(
-                ( std::istreambuf_iterator<char>( infile ) ),
+                ( std::istreambuf_iterator<char>( *infile ) ),
                 std::istreambuf_iterator<char>()
             )
         );

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -433,7 +433,6 @@ void main_menu::load_char_templates()
 
     for( std::string path : get_files_from_path( ".template", PATH_INFO::templatedir(), false,
             true ) ) {
-        path = native_to_utf8( path );
         path.erase( path.find( ".template" ), std::string::npos );
         path.erase( 0, path.find_last_of( "\\/" ) + 1 );
         templates.push_back( path );
@@ -927,8 +926,8 @@ bool main_menu::new_character_tab()
             } else if( !templates.empty() && action == "DELETE_TEMPLATE" ) {
                 if( query_yn( _( "Are you sure you want to delete %s?" ),
                               templates[sel3].c_str() ) ) {
-                    const auto path = PATH_INFO::templatedir() + utf8_to_native( templates[sel3] ) + ".template";
-                    if( std::remove( path.c_str() ) != 0 ) {
+                    const auto path = PATH_INFO::templatedir() + templates[sel3] + ".template";
+                    if( !remove_file( path ) ) {
                         popup( _( "Sorry, something went wrong." ) );
                     } else {
                         templates.erase( templates.begin() + sel3 );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -24,6 +24,7 @@
 #include "character_martial_arts.h"
 #include "color.h"
 #include "cursesdef.h"
+#include "filesystem.h"
 #include "game.h"
 #include "game_constants.h"
 #include "ime.h"
@@ -2904,20 +2905,8 @@ cata::optional<std::string> query_for_template_name()
 
 void avatar::save_template( const std::string &name, const points_left &points )
 {
-    std::string native = utf8_to_native( name );
-#if defined(_WIN32)
-    if( native.find_first_of( "\"*/:<>?\\|"
-                              "\x01\x02\x03\x04\x05\x06\x07\x08\x09" // NOLINT(cata-text-style)
-                              "\x0A\x0B\x0C\x0D\x0E\x0F\x10\x11\x12" // NOLINT(cata-text-style)
-                              "\x13\x14\x15\x16\x17\x18\x19\x1A\x1B"
-                              "\x1C\x1D\x1E\x1F"
-                            ) != std::string::npos ) {
-        popup( _( "Conversion of your filename to your native character set resulted in some unsafe characters, please try an alphanumeric filename instead" ) );
-        return;
-    }
-#endif
-
-    write_to_file( PATH_INFO::templatedir() + native + ".template", [&]( std::ostream & fout ) {
+    std::string name_san = ensure_valid_file_name( name );
+    write_to_file( PATH_INFO::templatedir() + name_san + ".template", [&]( std::ostream & fout ) {
         JsonOut jsout( fout, true );
 
         jsout.start_array();
@@ -2941,7 +2930,7 @@ void avatar::save_template( const std::string &name, const points_left &points )
 
 bool avatar::load_template( const std::string &template_name, points_left &points )
 {
-    return read_from_file_json( PATH_INFO::templatedir() + utf8_to_native( template_name ) +
+    return read_from_file_json( PATH_INFO::templatedir() + template_name +
     ".template", [&]( JsonIn & jsin ) {
 
         if( jsin.test_array() ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1991,11 +1991,6 @@ void options_manager::add_options_debug()
 
     get_option( "FOV_3D_Z_RANGE" ).setPrerequisite( "FOV_3D" );
 
-    add( "ENCODING_CONV", "debug", translate_marker( "Experimental path name encoding conversion" ),
-         translate_marker( "If true, file path names are going to be transcoded from system encoding to UTF-8 when reading and will be transcoded back when writing.  Mainly for CJK Windows users." ),
-         true
-       );
-
     add( "ENABLE_EVENTS", "debug", translate_marker( "Event bus system" ),
          translate_marker( "If false, achievements and some Magiclysm functionality won't work, but performance will be better." ),
          true

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1151,6 +1151,21 @@ std::string to_upper_case( const std::string &s )
     return res;
 }
 
+std::string to_lower_case( const std::string &s )
+{
+    if( std::locale().name() != "en_US.UTF-8" && std::locale().name() != "C" ) {
+        const auto &f = std::use_facet<std::ctype<wchar_t>>( std::locale() );
+        std::wstring wstr = utf8_to_wstr( s );
+        f.tolower( &wstr[0], &wstr[0] + wstr.size() );
+        return wstr_to_utf8( wstr );
+    }
+    std::string res;
+    std::transform( s.begin(), s.end(), std::back_inserter( res ), []( char_t ch ) {
+        return std::use_facet<std::ctype<char_t>>( std::locale() ).tolower( ch );
+    } );
+    return res;
+}
+
 // find the position of each non-printing tag in a string
 std::vector<size_t> get_tag_positions( const std::string &s )
 {

--- a/src/output.h
+++ b/src/output.h
@@ -566,6 +566,8 @@ std::string trim( const std::string &s );
 std::string trim_punctuation_marks( const std::string &s );
 // Converts the string to upper case.
 std::string to_upper_case( const std::string &s );
+// Converts the string to lower case.
+std::string to_lower_case( const std::string &s );
 
 // TODO: move these elsewhere
 // string manipulations.

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -1,18 +1,7 @@
 #if defined(TILES)
 #include "sdl_font.h"
 #include "output.h"
-
-#if defined(_WIN32)
-#   if 1 // HACK: Hack to prevent reordering of #include "platform_win.h" by IWYU
-#       include "platform_win.h"
-#   endif
-#   include <shlwapi.h>
-#   if !defined(strcasecmp)
-#       define strcasecmp StrCmpI
-#   endif
-#else
-#   include <strings.h> // for strcasecmp
-#endif
+#include "platform_win.h"
 
 #define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
 
@@ -30,7 +19,7 @@ static int test_face_size( const std::string &f, int size, int faceIndex )
                 char *ts = nullptr;
                 if( tf ) {
                     if( nullptr != ( ts = TTF_FontFaceStyleName( tf.get() ) ) ) {
-                        if( 0 == strcasecmp( ts, style ) && TTF_FontHeight( tf.get() ) <= size ) {
+                        if( lcequal( ts, style ) && TTF_FontHeight( tf.get() ) <= size ) {
                             return i;
                         }
                     }
@@ -268,8 +257,7 @@ CachedTTFFont::CachedTTFFont(
         fontsize = height - 1;
     }
     // SDL_ttf handles bitmap fonts size incorrectly
-    if( typeface.length() > 4 &&
-        strcasecmp( typeface.substr( typeface.length() - 4 ).c_str(), ".fon" ) == 0 ) {
+    if( typeface.length() > 4 && lcequal( typeface.substr( typeface.length() - 4 ), ".fon" ) ) {
         faceIndex = test_face_size( typeface, fontsize, faceIndex );
     }
     font.reset( TTF_OpenFontIndex( typeface.c_str(), fontsize, faceIndex ) );

--- a/src/wdirent.h
+++ b/src/wdirent.h
@@ -1,117 +1,72 @@
 #pragma once
 /*
- * dirent.h - dirent API for Microsoft Visual Studio
+ * dirent.h - Dirent interface for Microsoft Visual Studio
  *
- * Copyright (C) 2006-2012 Toni Ronkko
+ * This file is part of dirent.  Dirent may be freely distributed
+ * under the MIT license.  For all details and documentation, see
+ * https://github.com/tronkko/dirent
  *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * ``Software''), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
+ * The MIT License (MIT)
  *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
+ * Copyright (c) 1998-2021 Toni Ronkko
  *
- * THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL TONI RONKKO BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
- * Version 1.13, Dec 12 2012, Toni Ronkko
- * Use traditional 8+3 file name if the name cannot be represented in the
- * default ANSI code page.  Now compiles again with MSVC 6.0.  Thanks to
- * Konstantin Khomoutov for testing.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
- * Version 1.12.1, Oct 1 2012, Toni Ronkko
- * Bug fix: renamed wide-character DIR structure _wDIR to _WDIR (with
- * capital W) in order to maintain compatibility with MingW.
- *
- * Version 1.12, Sep 30 2012, Toni Ronkko
- * Define PATH_MAX and NAME_MAX.  Added wide-character variants _wDIR,
- * _wdirent, _wopendir(), _wreaddir(), _wclosedir() and _wrewinddir().
- * Thanks to Edgar Buerkle and Jan Nijtmans for ideas and code.
- *
- * Do not include windows.h.  This allows dirent.h to be integrated more
- * easily into programs using winsock.  Thanks to Fernando Azaldegui.
- *
- * Version 1.11, Mar 15, 2011, Toni Ronkko
- * Defined FILE_ATTRIBUTE_DEVICE for MSVC 6.0.
- *
- * Version 1.10, Aug 11, 2010, Toni Ronkko
- * Added d_type and d_namlen fields to dirent structure.  The former is
- * especially useful for determining whether directory entry represents a
- * file or a directory.  For more information, see
- * http://www.delorie.com/gnu/docs/glibc/libc_270.html
- *
- * Improved conformance to the standards.  For example, errno is now set
- * properly on failure and assert() is never used.  Thanks to Peter Brockam
- * for suggestions.
- *
- * Fixed a bug in rewinddir(): when using relative directory names, change
- * of working directory no longer causes rewinddir() to fail.
- *
- * Version 1.9, Dec 15, 2009, John Cunningham
- * Added rewinddir member function
- *
- * Version 1.8, Jan 18, 2008, Toni Ronkko
- * Using FindFirstFileA and WIN32_FIND_DATAA to avoid converting string
- * between multi-byte and unicode representations.  This makes the
- * code simpler and also allows the code to be compiled under MingW.  Thanks
- * to Azriel Fasten for the suggestion.
- *
- * Mar 4, 2007, Toni Ronkko
- * Bug fix: due to the strncpy_s() function this file only compiled in
- * Visual Studio 2005.  Using the new string functions only when the
- * compiler version allows.
- *
- * Nov  2, 2006, Toni Ronkko
- * Major update: removed support for Watcom C, MS-DOS and Turbo C to
- * simplify the file, updated the code to compile cleanly on Visual
- * Studio 2005 with both unicode and multi-byte character strings,
- * removed rewinddir() as it had a bug.
- *
- * Aug 20, 2006, Toni Ronkko
- * Removed all remarks about MSVC 1.0, which is antiqued now.  Simplified
- * comments by removing SGML tags.
- *
- * May 14 2002, Toni Ronkko
- * Embedded the function definitions directly to the header so that no
- * source modules need to be included in the Visual Studio project.  Removed
- * all the dependencies to other projects so that this header file can be
- * used independently.
- *
- * May 28 1998, Toni Ronkko
- * First version.
- *****************************************************************************/
+ * Modifications for Cataclysm BN:
+ * 1. Some functions were removed as dead code.
+ * 2. dirent_mbstowcs_s and dirent_wcstombs_s were rewritten to
+ *    use MultiByteToWideChar and WideCharToMultiByte
+ *    to make it work under mingw64.
+ * 3. dirent_mbstowcs_s and dirent_wcstombs_s are always used
+ *    instead of mbstowcs_s and wcstombs_s on MSC.
+ */
 #ifndef DIRENT_H
 #define DIRENT_H
 
-#if !defined(_68K_) && !defined(_MPPC_) && !defined(_X86_) && !defined(_IA64_) && !defined(_AMD64_) && defined(_M_IX86)
-#   define _X86_
+/* Hide warnings about unreferenced local functions */
+#if defined(__clang__)
+#   pragma clang diagnostic ignored "-Wunused-function"
+#elif defined(_MSC_VER)
+#   pragma warning(disable:4505)
+#elif defined(__GNUC__)
+#   pragma GCC diagnostic ignored "-Wunused-function"
 #endif
-#include <windef.h>
-#include <WinBase.h>
+
+/*
+ * Include windows.h without Windows Sockets 1.1 to prevent conflicts with
+ * Windows Sockets 2.0.
+ */
+#ifndef WIN32_LEAN_AND_MEAN
+#   define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <wchar.h>
+#include <string.h>
+#include <stdlib.h>
 #include <malloc.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <cstdio>
-#include <cstdarg>
-#include <cwchar>
-#include <cstring>
-#include <cstdlib>
-#include <cerrno>
-
-#if defined(_WIN32)
-// needed by MultiByteToWideChar
-#include <Windows.h>
-#endif
+#include <errno.h>
+#include <ctype.h>
 
 /* Indicates that d_type field is available in dirent structure */
 #define _DIRENT_HAVE_D_TYPE
@@ -124,54 +79,109 @@
 #   define FILE_ATTRIBUTE_DEVICE 0x40
 #endif
 
-/* File type and permission flags for stat() */
+/* File type and permission flags for stat(), general mask */
 #if !defined(S_IFMT)
-#   define S_IFMT   _S_IFMT                     /* File type mask */
-#endif
-#if !defined(S_IFDIR)
-#   define S_IFDIR  _S_IFDIR                    /* Directory */
-#endif
-#if !defined(S_IFCHR)
-#   define S_IFCHR  _S_IFCHR                    /* Character device */
-#endif
-#if !defined(S_IFFIFO)
-#   define S_IFFIFO _S_IFFIFO                   /* Pipe */
-#endif
-#if !defined(S_IFREG)
-#   define S_IFREG  _S_IFREG                    /* Regular file */
-#endif
-#if !defined(S_IREAD)
-#   define S_IREAD  _S_IREAD                    /* Read permission */
-#endif
-#if !defined(S_IWRITE)
-#   define S_IWRITE _S_IWRITE                   /* Write permission */
-#endif
-#if !defined(S_IEXEC)
-#   define S_IEXEC  _S_IEXEC                    /* Execute permission */
-#endif
-#if !defined(S_IFIFO)
-#   define S_IFIFO _S_IFIFO                     /* Pipe */
-#endif
-#if !defined(S_IFBLK)
-#   define S_IFBLK   0                          /* Block device */
-#endif
-#if !defined(S_IFLNK)
-#   define S_IFLNK   0                          /* Link */
-#endif
-#if !defined(S_IFSOCK)
-#   define S_IFSOCK  0                          /* Socket */
+#   define S_IFMT _S_IFMT
 #endif
 
-#if defined(_MSC_VER)
-#   define S_IRUSR  S_IREAD                     /* Read user */
-#   define S_IWUSR  S_IWRITE                    /* Write user */
-#   define S_IXUSR  0                           /* Execute user */
-#   define S_IRGRP  0                           /* Read group */
-#   define S_IWGRP  0                           /* Write group */
-#   define S_IXGRP  0                           /* Execute group */
-#   define S_IROTH  0                           /* Read others */
-#   define S_IWOTH  0                           /* Write others */
-#   define S_IXOTH  0                           /* Execute others */
+/* Directory bit */
+#if !defined(S_IFDIR)
+#   define S_IFDIR _S_IFDIR
+#endif
+
+/* Character device bit */
+#if !defined(S_IFCHR)
+#   define S_IFCHR _S_IFCHR
+#endif
+
+/* Pipe bit */
+#if !defined(S_IFFIFO)
+#   define S_IFFIFO _S_IFFIFO
+#endif
+
+/* Regular file bit */
+#if !defined(S_IFREG)
+#   define S_IFREG _S_IFREG
+#endif
+
+/* Read permission */
+#if !defined(S_IREAD)
+#   define S_IREAD _S_IREAD
+#endif
+
+/* Write permission */
+#if !defined(S_IWRITE)
+#   define S_IWRITE _S_IWRITE
+#endif
+
+/* Execute permission */
+#if !defined(S_IEXEC)
+#   define S_IEXEC _S_IEXEC
+#endif
+
+/* Pipe */
+#if !defined(S_IFIFO)
+#   define S_IFIFO _S_IFIFO
+#endif
+
+/* Block device */
+#if !defined(S_IFBLK)
+#   define S_IFBLK 0
+#endif
+
+/* Link */
+#if !defined(S_IFLNK)
+#   define S_IFLNK 0
+#endif
+
+/* Socket */
+#if !defined(S_IFSOCK)
+#   define S_IFSOCK 0
+#endif
+
+/* Read user permission */
+#if !defined(S_IRUSR)
+#   define S_IRUSR S_IREAD
+#endif
+
+/* Write user permission */
+#if !defined(S_IWUSR)
+#   define S_IWUSR S_IWRITE
+#endif
+
+/* Execute user permission */
+#if !defined(S_IXUSR)
+#   define S_IXUSR 0
+#endif
+
+/* Read group permission */
+#if !defined(S_IRGRP)
+#   define S_IRGRP 0
+#endif
+
+/* Write group permission */
+#if !defined(S_IWGRP)
+#   define S_IWGRP 0
+#endif
+
+/* Execute group permission */
+#if !defined(S_IXGRP)
+#   define S_IXGRP 0
+#endif
+
+/* Read others permission */
+#if !defined(S_IROTH)
+#   define S_IROTH 0
+#endif
+
+/* Write others permission */
+#if !defined(S_IWOTH)
+#   define S_IWOTH 0
+#endif
+
+/* Execute others permission */
+#if !defined(S_IXOTH)
+#   define S_IXOTH 0
 #endif
 
 /* Maximum length of file name */
@@ -186,13 +196,14 @@
 #endif
 
 /* File type flags for d_type */
-#define DT_UNKNOWN  0
-#define DT_REG      S_IFREG
-#define DT_DIR      S_IFDIR
-#define DT_FIFO     S_IFIFO
-#define DT_SOCK     S_IFSOCK
-#define DT_CHR      S_IFCHR
-#define DT_BLK      S_IFBLK
+#define DT_UNKNOWN 0
+#define DT_REG S_IFREG
+#define DT_DIR S_IFDIR
+#define DT_FIFO S_IFIFO
+#define DT_SOCK S_IFSOCK
+#define DT_CHR S_IFCHR
+#define DT_BLK S_IFBLK
+#define DT_LNK S_IFLNK
 
 /* Macros for converting between st_mode and d_type */
 #define IFTODT(mode) ((mode) & S_IFMT)
@@ -204,243 +215,245 @@
  * only defined for compatibility.  These macros should always return false
  * on Windows.
  */
-#define S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
-#define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
-#define S_ISREG(mode)  (((mode) & S_IFMT) == S_IFREG)
-#define S_ISLNK(mode)  (((mode) & S_IFMT) == S_IFLNK)
-#define S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
-#define S_ISCHR(mode)  (((mode) & S_IFMT) == S_IFCHR)
-#define S_ISBLK(mode)  (((mode) & S_IFMT) == S_IFBLK)
+#if !defined(S_ISFIFO)
+#   define S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
+#endif
+#if !defined(S_ISDIR)
+#   define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#endif
+#if !defined(S_ISREG)
+#   define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#endif
+#if !defined(S_ISLNK)
+#   define S_ISLNK(mode) (((mode) & S_IFMT) == S_IFLNK)
+#endif
+#if !defined(S_ISSOCK)
+#   define S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
+#endif
+#if !defined(S_ISCHR)
+#   define S_ISCHR(mode) (((mode) & S_IFMT) == S_IFCHR)
+#endif
+#if !defined(S_ISBLK)
+#   define S_ISBLK(mode) (((mode) & S_IFMT) == S_IFBLK)
+#endif
 
-/* Return the exact length of d_namlen without zero terminator */
+/* Return the exact length of the file name without zero terminator */
 #define _D_EXACT_NAMLEN(p) ((p)->d_namlen)
 
-/* Return number of bytes needed to store d_namlen */
-#define _D_ALLOC_NAMLEN(p) (PATH_MAX + 1)
+/* Return the maximum size of a file name */
+#define _D_ALLOC_NAMLEN(p) ((PATH_MAX)+1)
 
-#if defined(__cplusplus)
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
+
 /* Wide-character version */
 struct _wdirent {
-    long d_ino;                                 /* Always zero */
-    unsigned short d_reclen;                    /* Structure size */
-    size_t d_namlen;                            /* Length of name without \0 */
-    int d_type;                                 /* File type */
-    wchar_t d_name[PATH_MAX + 1];               /* File name */
+    /* Always zero */
+    long d_ino;
+
+    /* File position within stream */
+    long d_off;
+
+    /* Structure size */
+    unsigned short d_reclen;
+
+    /* Length of name without \0 */
+    size_t d_namlen;
+
+    /* File type */
+    int d_type;
+
+    /* File name */
+    wchar_t d_name[PATH_MAX + 1];
 };
+typedef struct _wdirent _wdirent;
 
 struct _WDIR {
-    struct _wdirent ent;                        /* Current directory entry */
-    WIN32_FIND_DATAW data;                      /* Private file data */
-    int cached;                                 /* True if data is valid */
-    HANDLE handle;                              /* Win32 search handle */
-    wchar_t *patt;                              /* Initial directory name */
-};
+    /* Current directory entry */
+    struct _wdirent ent;
 
+    /* Private file data */
+    WIN32_FIND_DATAW data;
+
+    /* True if data is valid */
+    int cached;
+
+    /* Win32 search handle */
+    HANDLE handle;
+
+    /* Initial directory name */
+    wchar_t *patt;
+};
+typedef struct _WDIR _WDIR;
+
+/* Multi-byte character version */
+struct dirent {
+    /* Always zero */
+    long d_ino;
+
+    /* File position within stream */
+    long d_off;
+
+    /* Structure size */
+    unsigned short d_reclen;
+
+    /* Length of name without \0 */
+    size_t d_namlen;
+
+    /* File type */
+    int d_type;
+
+    /* File name */
+    char d_name[PATH_MAX + 1];
+};
+typedef struct dirent dirent;
+
+struct DIR {
+    struct dirent ent;
+    struct _WDIR *wdirp;
+};
+typedef struct DIR DIR;
+
+
+/* Dirent functions */
+static DIR *opendir( const char *dirname );
 static _WDIR *_wopendir( const wchar_t *dirname );
-static struct _wdirent *_wreaddir( _WDIR *dirp );
+
+static struct dirent *readdir( DIR *dirp );
+
+static int readdir_r(
+    DIR *dirp, struct dirent *entry, struct dirent **result );
+
+static int closedir( DIR *dirp );
 static int _wclosedir( _WDIR *dirp );
-static void _wrewinddir( _WDIR *dirp );
 
 /* For compatibility with Symbian */
 #define wdirent _wdirent
 #define WDIR _WDIR
 #define wopendir _wopendir
 #define wreaddir _wreaddir
-#define wclosedir _wclosedir
-#define wrewinddir _wrewinddir
 
-/* Multi-byte character versions */
-struct dirent {
-    long d_ino;                                 /* Always zero */
-    unsigned short d_reclen;                    /* Structure size */
-    size_t d_namlen;                            /* Length of name without \0 */
-    int d_type;                                 /* File type */
-    char d_name[PATH_MAX + 1];                  /* File name */
-};
+/* Optimize dirent_set_errno() away on modern Microsoft compilers */
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+#   define dirent_set_errno _set_errno
+#endif
 
-struct DIR {
-    struct dirent ent;
-    struct _WDIR *wdirp;
-};
-
-static DIR *opendir( const char *dirname );
-static struct dirent *readdir( DIR *dirp );
-static int closedir( DIR *dirp );
-static void rewinddir( DIR *dirp );
 
 /* Internal utility functions */
 static WIN32_FIND_DATAW *dirent_first( _WDIR *dirp );
 static WIN32_FIND_DATAW *dirent_next( _WDIR *dirp );
 
 static int dirent_mbstowcs_s(
-    size_t *pReturnValue,
-    wchar_t *wcstr,
-    size_t sizeInWords,
-    const char *mbstr,
-    size_t count );
+    size_t *pReturnValue, wchar_t *wcstr, size_t sizeInWords,
+    const char *mbstr, size_t count );
 
 static int dirent_wcstombs_s(
-    size_t *pReturnValue,
-    char *mbstr,
-    size_t sizeInBytes,
-    const wchar_t *wcstr,
-    size_t count );
+    size_t *pReturnValue, char *mbstr, size_t sizeInBytes,
+    const wchar_t *wcstr, size_t count );
 
+#if !defined(_MSC_VER) || _MSC_VER < 1400
 static void dirent_set_errno( int error );
+#endif
+
 
 /*
  * Open directory stream DIRNAME for read and return a pointer to the
  * internal working area that is used to retrieve individual directory
  * entries.
  */
-static _WDIR *
-_wopendir(
-    const wchar_t *dirname )
+static _WDIR *_wopendir( const wchar_t *dirname )
 {
-    _WDIR *dirp = NULL;
-    int error;
+    wchar_t *p;
 
     /* Must have directory name */
-    if( dirname == NULL  ||  dirname[0] == '\0' ) {
+    if( dirname == NULL || dirname[0] == '\0' ) {
         dirent_set_errno( ENOENT );
         return NULL;
     }
 
     /* Allocate new _WDIR structure */
-    dirp = static_cast<_WDIR *>( malloc( sizeof( struct _WDIR ) ) );
-    if( dirp != NULL ) {
-        /* Reset _WDIR structure */
-        dirp->handle = INVALID_HANDLE_VALUE;
-        dirp->patt = NULL;
-        dirp->cached = 0;
-
-        /* Compute the length of full path plus zero terminator */
-        DWORD n = GetFullPathNameW( dirname, 0, NULL, NULL );
-
-        /* Allocate room for absolute directory name and search pattern */
-        dirp->patt = static_cast<wchar_t *>( malloc( sizeof( wchar_t ) * n + 16 ) );
-        if( dirp->patt ) {
-
-            /*
-             * Convert relative directory name to an absolute one.  This
-             * allows rewinddir() to function correctly even when current
-             * working directory is changed between opendir() and rewinddir().
-             */
-            n = GetFullPathNameW( dirname, n, dirp->patt, NULL );
-            if( n > 0 ) {
-                /* Append search pattern \* to the directory name */
-                wchar_t *p = dirp->patt + n;
-                if( dirp->patt < p ) {
-                    switch( p[-1] ) {
-                        case '\\':
-                        case '/':
-                        case ':':
-                            /* Directory ends in path separator, e.g. c:\temp\ */
-                            /*NOP*/
-                            ;
-                            break;
-
-                        default:
-                            /* Directory name doesn't end in path separator */
-                            *p++ = '\\';
-                    }
-                }
-                *p++ = '*';
-                *p = '\0';
-
-                /* Open directory stream and retrieve the first entry */
-                if( dirent_first( dirp ) ) {
-                    /* Directory stream opened successfully */
-                    error = 0;
-                } else {
-                    /* Cannot retrieve first entry */
-                    error = 1;
-                    dirent_set_errno( ENOENT );
-                }
-
-            } else {
-                /* Cannot retrieve full path name */
-                dirent_set_errno( ENOENT );
-                error = 1;
-            }
-
-        } else {
-            /* Cannot allocate memory for search pattern */
-            error = 1;
-        }
-
-    } else {
-        /* Cannot allocate _WDIR structure */
-        error = 1;
+    _WDIR *dirp = ( _WDIR * ) malloc( sizeof( struct _WDIR ) );
+    if( !dirp ) {
+        return NULL;
     }
 
-    /* Clean up in case of error */
-    if( error  &&  dirp ) {
-        _wclosedir( dirp );
-        dirp = NULL;
+    /* Reset _WDIR structure */
+    dirp->handle = INVALID_HANDLE_VALUE;
+    dirp->patt = NULL;
+    dirp->cached = 0;
+
+    /*
+     * Compute the length of full path plus zero terminator
+     *
+     * Note that on WinRT there's no way to convert relative paths
+     * into absolute paths, so just assume it is an absolute path.
+     */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+    /* Desktop */
+    DWORD n = GetFullPathNameW( dirname, 0, NULL, NULL );
+#else
+    /* WinRT */
+    size_t n = wcslen( dirname );
+#endif
+
+    /* Allocate room for absolute directory name and search pattern */
+    dirp->patt = ( wchar_t * ) malloc( sizeof( wchar_t ) * n + 16 );
+    if( dirp->patt == NULL ) {
+        goto exit_closedir;
     }
 
+    /*
+     * Convert relative directory name to an absolute one.  This
+     * allows rewinddir() to function correctly even when current
+     * working directory is changed between opendir() and rewinddir().
+     *
+     * Note that on WinRT there's no way to convert relative paths
+     * into absolute paths, so just assume it is an absolute path.
+     */
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+    /* Desktop */
+    n = GetFullPathNameW( dirname, n, dirp->patt, NULL );
+    if( n <= 0 ) {
+        goto exit_closedir;
+    }
+#else
+    /* WinRT */
+    wcsncpy_s( dirp->patt, n + 1, dirname, n );
+#endif
+
+    /* Append search pattern \* to the directory name */
+    p = dirp->patt + n;
+    switch( p[-1] ) {
+        case '\\':
+        case '/':
+        case ':':
+            /* Directory ends in path separator, e.g. c:\temp\ */
+            /*NOP*/
+            ;
+            break;
+
+        default:
+            /* Directory name doesn't end in path separator */
+            *p++ = '\\';
+    }
+    *p++ = '*';
+    *p = '\0';
+
+    /* Open directory stream and retrieve the first entry */
+    if( !dirent_first( dirp ) ) {
+        goto exit_closedir;
+    }
+
+    /* Success */
     return dirp;
-}
 
-/*
- * Read next directory entry.  The directory entry is returned in dirent
- * structure in the d_name field.  Individual directory entries returned by
- * this function include regular files, sub-directories, pseudo-directories
- * "." and ".." as well as volume labels, hidden files and system files.
- */
-static struct _wdirent *
-_wreaddir(
-    _WDIR *dirp )
-{
-    struct _wdirent *entp;
-
-    /* Read next directory entry */
-    WIN32_FIND_DATAW *datap = dirent_next( dirp );
-    if( datap ) {
-        /* Pointer to directory entry to return */
-        entp = &dirp->ent;
-
-        /*
-         * Copy file name as wide-character string.  If the file name is too
-         * long to fit in to the destination buffer, then truncate file name
-         * to PATH_MAX characters and zero-terminate the buffer.
-         */
-        size_t n = 0;
-        while( n < PATH_MAX  &&  datap->cFileName[n] != 0 ) {
-            entp->d_name[n] = datap->cFileName[n];
-            n++;
-        }
-        dirp->ent.d_name[n] = 0;
-
-        /* Length of file name excluding zero terminator */
-        entp->d_namlen = n;
-
-        /* File type */
-        DWORD attr = datap->dwFileAttributes;
-        if( ( attr & FILE_ATTRIBUTE_DEVICE ) != 0 ) {
-            entp->d_type = DT_CHR;
-        } else if( ( attr & FILE_ATTRIBUTE_DIRECTORY ) != 0 ) {
-            entp->d_type = DT_DIR;
-        } else {
-            entp->d_type = DT_REG;
-        }
-
-        /* Reset dummy fields */
-        entp->d_ino = 0;
-        entp->d_reclen = sizeof( struct _wdirent );
-
-    } else {
-
-        /* Last directory entry read */
-        entp = NULL;
-
-    }
-
-    return entp;
+    /* Failure */
+exit_closedir:
+    _wclosedir( dirp );
+    return NULL;
 }
 
 /*
@@ -448,317 +461,259 @@ _wreaddir(
  * DIR structure as well as any directory entry read previously by
  * _wreaddir().
  */
-static int
-_wclosedir(
-    _WDIR *dirp )
+static int _wclosedir( _WDIR *dirp )
 {
-    int ok;
-    if( dirp ) {
-
-        /* Release search handle */
-        if( dirp->handle != INVALID_HANDLE_VALUE ) {
-            FindClose( dirp->handle );
-            dirp->handle = INVALID_HANDLE_VALUE;
-        }
-
-        /* Release search pattern */
-        if( dirp->patt ) {
-            free( dirp->patt );
-            dirp->patt = NULL;
-        }
-
-        /* Release directory structure */
-        free( dirp );
-        ok = /*success*/0;
-
-    } else {
-        /* Invalid directory stream */
+    if( !dirp ) {
         dirent_set_errno( EBADF );
-        ok = /*failure*/ -1;
+        return /*failure*/ -1;
     }
-    return ok;
+
+    /* Release search handle */
+    if( dirp->handle != INVALID_HANDLE_VALUE ) {
+        FindClose( dirp->handle );
+    }
+
+    /* Release search pattern */
+    free( dirp->patt );
+
+    /* Release directory structure */
+    free( dirp );
+    return /*success*/0;
 }
 
-/*
- * Rewind directory stream such that _wreaddir() returns the very first
- * file name again.
- */
-static void
-_wrewinddir(
-    _WDIR *dirp )
+/* Get first directory entry */
+static WIN32_FIND_DATAW *dirent_first( _WDIR *dirp )
 {
-    if( dirp ) {
-        /* Release existing search handle */
-        if( dirp->handle != INVALID_HANDLE_VALUE ) {
-            FindClose( dirp->handle );
-        }
-
-        /* Open new search handle */
-        dirent_first( dirp );
+    if( !dirp ) {
+        return NULL;
     }
-}
-
-/* Get first directory entry (internal) */
-static WIN32_FIND_DATAW *
-dirent_first(
-    _WDIR *dirp )
-{
-    WIN32_FIND_DATAW *datap;
 
     /* Open directory and retrieve the first entry */
-    dirp->handle = FindFirstFileW( dirp->patt, &dirp->data );
-    if( dirp->handle != INVALID_HANDLE_VALUE ) {
-
-        /* a directory entry is now waiting in memory */
-        datap = &dirp->data;
-        dirp->cached = 1;
-
-    } else {
-
-        /* Failed to re-open directory: no directory entry in memory */
-        dirp->cached = 0;
-        datap = NULL;
-
-    }
-    return datap;
-}
-
-/* Get next directory entry (internal) */
-static WIN32_FIND_DATAW *
-dirent_next(
-    _WDIR *dirp )
-{
-    WIN32_FIND_DATAW *p;
-
-    /* Get next directory entry */
-    if( dirp->cached != 0 ) {
-
-        /* A valid directory entry already in memory */
-        p = &dirp->data;
-        dirp->cached = 0;
-
-    } else if( dirp->handle != INVALID_HANDLE_VALUE ) {
-
-        /* Get the next directory entry from stream */
-        if( FindNextFileW( dirp->handle, &dirp->data ) != FALSE ) {
-            /* Got a file */
-            p = &dirp->data;
-        } else {
-            /* The very last entry has been processed or an error occurred */
-            FindClose( dirp->handle );
-            dirp->handle = INVALID_HANDLE_VALUE;
-            p = NULL;
-        }
-
-    } else {
-
-        /* End of directory stream reached */
-        p = NULL;
-
+    dirp->handle = FindFirstFileExW(
+                       dirp->patt, FindExInfoStandard, &dirp->data,
+                       FindExSearchNameMatch, NULL, 0 );
+    if( dirp->handle == INVALID_HANDLE_VALUE ) {
+        goto error;
     }
 
-    return p;
+    /* A directory entry is now waiting in memory */
+    dirp->cached = 1;
+    return &dirp->data;
+
+error:
+    /* Failed to open directory: no directory entry in memory */
+    dirp->cached = 0;
+
+    /* Set error code */
+    DWORD errorcode = GetLastError();
+    switch( errorcode ) {
+        case ERROR_ACCESS_DENIED:
+            /* No read access to directory */
+            dirent_set_errno( EACCES );
+            break;
+
+        case ERROR_DIRECTORY:
+            /* Directory name is invalid */
+            dirent_set_errno( ENOTDIR );
+            break;
+
+        case ERROR_PATH_NOT_FOUND:
+        default:
+            /* Cannot find the file */
+            dirent_set_errno( ENOENT );
+    }
+    return NULL;
 }
 
-/*
- * Open directory stream using plain old C-string.
- */
-static DIR *
-opendir(
-    const char *dirname )
+/* Get next directory entry */
+static WIN32_FIND_DATAW *dirent_next( _WDIR *dirp )
 {
-    int error;
+    /* Is the next directory entry already in cache? */
+    if( dirp->cached ) {
+        /* Yes, a valid directory entry found in memory */
+        dirp->cached = 0;
+        return &dirp->data;
+    }
 
+    /* No directory entry in cache */
+    if( dirp->handle == INVALID_HANDLE_VALUE ) {
+        return NULL;
+    }
+
+    /* Read the next directory entry from stream */
+    if( FindNextFileW( dirp->handle, &dirp->data ) == FALSE ) {
+        goto exit_close;
+    }
+
+    /* Success */
+    return &dirp->data;
+
+    /* Failure */
+exit_close:
+    FindClose( dirp->handle );
+    dirp->handle = INVALID_HANDLE_VALUE;
+    return NULL;
+}
+
+/* Open directory stream using plain old C-string */
+static DIR *opendir( const char *dirname )
+{
     /* Must have directory name */
-    if( dirname == NULL  ||  dirname[0] == '\0' ) {
+    if( dirname == NULL || dirname[0] == '\0' ) {
         dirent_set_errno( ENOENT );
         return NULL;
     }
 
     /* Allocate memory for DIR structure */
-    struct DIR *dirp = static_cast<DIR *>( malloc( sizeof( struct DIR ) ) );
-    if( dirp ) {
-        wchar_t wname[PATH_MAX + 1];
-        size_t n;
-
-        /* Convert directory name to wide-character string */
-        error = dirent_mbstowcs_s(
-                    &n, wname, PATH_MAX + 1, dirname, PATH_MAX );
-        if( !error ) {
-
-            /* Open directory stream using wide-character name */
-            dirp->wdirp = _wopendir( wname );
-            if( dirp->wdirp ) {
-                /* Directory stream opened */
-                error = 0;
-            } else {
-                /* Failed to open directory stream */
-                error = 1;
-            }
-
-        } else {
-            /*
-             * Cannot convert file name to wide-character string.  This
-             * occurs if the string contains invalid multi-byte sequences or
-             * the output buffer is too small to contain the resulting
-             * string.
-             */
-            error = 1;
-        }
-
-    } else {
-        /* Cannot allocate DIR structure */
-        error = 1;
+    struct DIR *dirp = ( DIR * ) malloc( sizeof( struct DIR ) );
+    if( !dirp ) {
+        return NULL;
     }
 
-    /* Clean up in case of error */
-    if( error  &&  dirp ) {
-        free( dirp );
-        dirp = NULL;
+    /* Convert directory name to wide-character string */
+    wchar_t wname[PATH_MAX + 1];
+    size_t n;
+    int error = dirent_mbstowcs_s( &n, wname, PATH_MAX + 1, dirname, PATH_MAX + 1 );
+    if( error ) {
+        goto exit_failure;
     }
 
+    /* Open directory stream using wide-character name */
+    dirp->wdirp = _wopendir( wname );
+    if( !dirp->wdirp ) {
+        goto exit_failure;
+    }
+
+    /* Success */
     return dirp;
+
+    /* Failure */
+exit_failure:
+    free( dirp );
+    return NULL;
+}
+
+/* Read next directory entry */
+static struct dirent *readdir( DIR *dirp )
+{
+    /*
+     * Read directory entry to buffer.  We can safely ignore the return
+     * value as entry will be set to NULL in case of error.
+     */
+    struct dirent *entry;
+    ( void ) readdir_r( dirp, &dirp->ent, &entry );
+
+    /* Return pointer to statically allocated directory entry */
+    return entry;
 }
 
 /*
- * Read next directory entry.
+ * Read next directory entry into called-allocated buffer.
  *
- * When working with text consoles, please note that file names returned by
- * readdir() are represented in the default ANSI code page while any output to
- * console is typically formatted on another code page.  Thus, non-ASCII
- * characters in file names will not usually display correctly on console.  The
- * problem can be fixed in two ways: (1) change the character set of console
- * to 1252 using chcp utility and use Lucida Console font, or (2) use
- * _cprintf function when writing to console.  The _cprinf() will re-encode
- * ANSI strings to the console code page so many non-ASCII characters will
- * display correctly.
+ * Returns zero on success.  If the end of directory stream is reached, then
+ * sets result to NULL and returns zero.
  */
-static struct dirent *
-readdir(
-    DIR *dirp )
+static int readdir_r(
+    DIR *dirp, struct dirent *entry, struct dirent **result )
 {
-    struct dirent *entp;
-
     /* Read next directory entry */
     WIN32_FIND_DATAW *datap = dirent_next( dirp->wdirp );
-    if( datap ) {
-        size_t n;
-
-        /* Attempt to convert file name to multi-byte string */
-        int error = dirent_wcstombs_s(
-                        &n, dirp->ent.d_name, MAX_PATH + 1, datap->cFileName, MAX_PATH );
-
-        /*
-         * If the file name cannot be represented by a multi-byte string,
-         * then attempt to use old 8+3 file name.  This allows traditional
-         * Unix-code to access some file names despite of Unicode
-         * characters, although file names may seem unfamiliar to the user.
-         *
-         * Be ware that the code below cannot come up with a short file
-         * name unless the file system provides one.  At least
-         * VirtualBox shared folders fail to do this.
-         */
-        if( error  &&  datap->cAlternateFileName[0] != '\0' ) {
-            error = dirent_wcstombs_s(
-                        &n, dirp->ent.d_name, MAX_PATH + 1, datap->cAlternateFileName,
-                        sizeof( datap->cAlternateFileName ) /
-                        sizeof( datap->cAlternateFileName[0] ) );
-        }
-
-        if( !error ) {
-            /* Initialize directory entry for return */
-            entp = &dirp->ent;
-
-            /* Length of file name excluding zero terminator */
-            entp->d_namlen = n - 1;
-
-            /* File attributes */
-            DWORD attr = datap->dwFileAttributes;
-            if( ( attr & FILE_ATTRIBUTE_DEVICE ) != 0 ) {
-                entp->d_type = DT_CHR;
-            } else if( ( attr & FILE_ATTRIBUTE_DIRECTORY ) != 0 ) {
-                entp->d_type = DT_DIR;
-            } else {
-                entp->d_type = DT_REG;
-            }
-
-            /* Reset dummy fields */
-            entp->d_ino = 0;
-            entp->d_reclen = sizeof( struct dirent );
-
-        } else {
-            /*
-             * Cannot convert file name to multi-byte string so construct
-             * an erroneous directory entry and return that.  Note that
-             * we cannot return NULL as that would stop the processing
-             * of directory entries completely.
-             */
-            entp = &dirp->ent;
-            entp->d_name[0] = '?';
-            entp->d_name[1] = '\0';
-            entp->d_namlen = 1;
-            entp->d_type = DT_UNKNOWN;
-            entp->d_ino = 0;
-            entp->d_reclen = 0;
-        }
-
-    } else {
+    if( !datap ) {
         /* No more directory entries */
-        entp = NULL;
+        *result = NULL;
+        return /*OK*/0;
     }
 
-    return entp;
+    /* Attempt to convert file name to multi-byte string */
+    size_t n;
+    int error = dirent_wcstombs_s(
+                    &n, entry->d_name, PATH_MAX + 1,
+                    datap->cFileName, PATH_MAX + 1 );
+
+    /*
+     * If the file name cannot be represented by a multi-byte string, then
+     * attempt to use old 8+3 file name.  This allows the program to
+     * access files although file names may seem unfamiliar to the user.
+     *
+     * Be ware that the code below cannot come up with a short file name
+     * unless the file system provides one.  At least VirtualBox shared
+     * folders fail to do this.
+     */
+    if( error && datap->cAlternateFileName[0] != '\0' ) {
+        error = dirent_wcstombs_s(
+                    &n, entry->d_name, PATH_MAX + 1,
+                    datap->cAlternateFileName, PATH_MAX + 1 );
+    }
+
+    if( !error ) {
+        /* Length of file name excluding zero terminator */
+        entry->d_namlen = n - 1;
+
+        /* File attributes */
+        DWORD attr = datap->dwFileAttributes;
+        if( ( attr & FILE_ATTRIBUTE_DEVICE ) != 0 ) {
+            entry->d_type = DT_CHR;
+        } else if( ( attr & FILE_ATTRIBUTE_DIRECTORY ) != 0 ) {
+            entry->d_type = DT_DIR;
+        } else {
+            entry->d_type = DT_REG;
+        }
+
+        /* Reset dummy fields */
+        entry->d_ino = 0;
+        entry->d_off = 0;
+        entry->d_reclen = sizeof( struct dirent );
+    } else {
+        /*
+         * Cannot convert file name to multi-byte string so construct
+         * an erroneous directory entry and return that.  Note that
+         * we cannot return NULL as that would stop the processing
+         * of directory entries completely.
+         */
+        entry->d_name[0] = '?';
+        entry->d_name[1] = '\0';
+        entry->d_namlen = 1;
+        entry->d_type = DT_UNKNOWN;
+        entry->d_ino = 0;
+        entry->d_off = -1;
+        entry->d_reclen = 0;
+    }
+
+    /* Return pointer to directory entry */
+    *result = entry;
+    return /*OK*/0;
 }
 
-/*
- * Close directory stream.
- */
-static int
-closedir(
-    DIR *dirp )
+/* Close directory stream */
+static int closedir( DIR *dirp )
 {
     int ok;
-    if( dirp ) {
 
-        /* Close wide-character directory stream */
-        ok = _wclosedir( dirp->wdirp );
-        dirp->wdirp = NULL;
-
-        /* Release multi-byte character version */
-        free( dirp );
-
-    } else {
-
-        /* Invalid directory stream */
-        dirent_set_errno( EBADF );
-        ok = /*failure*/ -1;
-
+    if( !dirp ) {
+        goto exit_failure;
     }
-    return ok;
-}
 
-/*
- * Rewind directory stream to beginning.
- */
-static void
-rewinddir(
-    DIR *dirp )
-{
-    /* Rewind wide-character string directory stream */
-    _wrewinddir( dirp->wdirp );
+    /* Close wide-character directory stream */
+    ok = _wclosedir( dirp->wdirp );
+    dirp->wdirp = NULL;
+
+    /* Release multi-byte character version */
+    free( dirp );
+    return ok;
+
+exit_failure:
+    /* Invalid directory stream */
+    dirent_set_errno( EBADF );
+    return /*failure*/ -1;
 }
 
 /* Convert multi-byte string to wide character string */
-static int
-dirent_mbstowcs_s(
-    size_t *pReturnValue,
-    wchar_t *wcstr,
-    size_t sizeInWords,
-    const char *mbstr,
-    size_t count )
+static int dirent_mbstowcs_s(
+    size_t *pReturnValue, wchar_t *wcstr,
+    size_t sizeInWords, const char *mbstr, size_t /*count*/ )
 {
-    const int required_size = MultiByteToWideChar( CP_UTF8, 0, mbstr, -1, NULL, NULL ) + 1;
-    if( required_size > sizeInWords ) {
+    const int required_size = MultiByteToWideChar( CP_UTF8, 0, mbstr, -1, NULL, 0 ) + 1;
+    if( required_size > static_cast<int>( sizeInWords ) ) {
         return 1;
     }
     const int n = MultiByteToWideChar( CP_UTF8, 0, mbstr, -1, wcstr, required_size );
@@ -773,19 +728,15 @@ dirent_mbstowcs_s(
 }
 
 /* Convert wide-character string to multi-byte string */
-static int
-dirent_wcstombs_s(
-    size_t *pReturnValue,
-    char *mbstr,
-    size_t sizeInBytes,
-    const wchar_t *wcstr,
-    size_t count )
+static int dirent_wcstombs_s(
+    size_t *pReturnValue, char *mbstr,
+    size_t sizeInBytes, const wchar_t *wcstr, size_t /*count*/ )
 {
-    const int required_size = WideCharToMultiByte( CP_UTF8, 0, wcstr, -1, NULL, 0, NULL, NULL ) + 1;
-    if( required_size > sizeInBytes ) {
+    const int required_size = WideCharToMultiByte( CP_UTF8, 0, wcstr, -1, NULL, 0, NULL, 0 ) + 1;
+    if( required_size > static_cast<int>( sizeInBytes ) ) {
         return 1;
     }
-    const int n = WideCharToMultiByte( CP_UTF8, 0, wcstr, -1, mbstr, required_size, NULL, NULL );
+    const int n = WideCharToMultiByte( CP_UTF8, 0, wcstr, -1, mbstr, required_size, NULL, 0 );
     if( n == 0 ) {
         debugmsg( "WideCharToMultiByte failed!" );
         return 1;
@@ -797,25 +748,15 @@ dirent_wcstombs_s(
 }
 
 /* Set errno variable */
-static void
-dirent_set_errno(
-    int error )
+#if !defined(_MSC_VER) || _MSC_VER < 1400
+static void dirent_set_errno( int error )
 {
-#if defined(_MSC_VER)
-
-    /* Microsoft Visual Studio */
-    _set_errno( error );
-
-#else
-
-    /* Non-Microsoft compiler */
+    /* Non-Microsoft compiler or older Microsoft compiler */
     errno = error;
-
-#endif
 }
+#endif
 
-#if defined(__cplusplus)
+#ifdef __cplusplus
 }
 #endif
 #endif /*DIRENT_H*/
-

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -570,12 +570,12 @@ void worldfactory::remove_world( const std::string &worldname )
 
 void worldfactory::load_last_world_info()
 {
-    std::ifstream file = utf8_ifstream( PATH_INFO::lastworld(), std::ios::in | std::ios::binary );
-    if( !file.good() ) {
+    cata_ifstream file = std::move( cata_ifstream().binary( true ).open( PATH_INFO::lastworld() ) );
+    if( !file.is_open() ) {
         return;
     }
 
-    JsonIn jsin( file );
+    JsonIn jsin( *file );
     JsonObject data = jsin.get_object();
     last_world_name = data.get_string( "world_name" );
     last_character_name = data.get_string( "character_name" );

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -88,7 +88,7 @@ void WORLD::COPY_WORLD( const WORLD *world_to_copy )
 
 std::string WORLD::folder_path() const
 {
-    return PATH_INFO::savedir() + utf8_to_native( world_name );
+    return PATH_INFO::savedir() + world_name;
 }
 
 bool WORLD::save_exists( const save_t &name ) const
@@ -283,7 +283,7 @@ void worldfactory::init()
         // the directory name is the name of the world
         std::string worldname;
         size_t name_index = world_dir.find_last_of( "/\\" );
-        worldname = native_to_utf8( world_dir.substr( name_index + 1 ) );
+        worldname = world_dir.substr( name_index + 1 );
 
         // create and store the world
         all_worlds[worldname] = std::make_unique<WORLD>();
@@ -570,7 +570,7 @@ void worldfactory::remove_world( const std::string &worldname )
 
 void worldfactory::load_last_world_info()
 {
-    std::ifstream file( PATH_INFO::lastworld(), std::ifstream::in | std::ifstream::binary );
+    std::ifstream file = utf8_ifstream( PATH_INFO::lastworld(), std::ios::in | std::ios::binary );
     if( !file.good() ) {
         return;
     }

--- a/tests/filesystem_test.cpp
+++ b/tests/filesystem_test.cpp
@@ -5,18 +5,9 @@
 #include "string_formatter.h"
 #include "path_info.h"
 #include "game.h"
-#include "rng.h"
 #include "cata_utility.h"
 
-#if defined(__linux__)
-#include <unistd.h>
-#endif // __linux__
-
-#if defined(_WIN32)
-#include "platform_win.h"
-#endif
-
-std::string str_to_hex( const std::string &s )
+static std::string str_to_hex( const std::string &s )
 {
     std::stringstream ss;
     for( char c : s ) {
@@ -26,21 +17,8 @@ std::string str_to_hex( const std::string &s )
     return ss.str();
 }
 
-std::string pid_string()
-{
-#ifdef _WIN32
-    return std::to_string( GetCurrentProcessId() );
-#else
-#ifdef __linux__
-    return std::to_string( getpid() );
-#else
-    return std::to_string( rng( 1, 10000 ) );
-#endif // __linux__
-#endif // _WIN32
-}
-
-void filesystem_test_group( int serial, const std::string &s1, const std::string &s2,
-                            const std::string &s3 )
+static void filesystem_test_group( int serial, const std::string &s1, const std::string &s2,
+                                   const std::string &s3 )
 {
     CAPTURE( serial );
     CAPTURE( s1 );
@@ -52,7 +30,7 @@ void filesystem_test_group( int serial, const std::string &s1, const std::string
 
     // Make sure there's no interference from e.g. uncleaned old runs
     std::string base = g->get_world_base_save_path() + "/fs_test_" +
-                       pid_string() + "_" + to_string( serial ) + "/";
+                       get_pid_string() + "_" + to_string( serial ) + "/";
     REQUIRE( !dir_exist( base ) );
     REQUIRE( assure_dir_exist( base ) );
     REQUIRE( can_write_to_dir( base ) );

--- a/tests/filesystem_test.cpp
+++ b/tests/filesystem_test.cpp
@@ -151,14 +151,29 @@ TEST_CASE( "filesystem_ascii", "[filesystem]" )
 
 TEST_CASE( "filesystem_utf8", "[filesystem]" )
 {
-    // French
-    filesystem_test_group( 2, u8R"(crème brûlée)", u8R"(rèm)", u8R"(rûlé)" );
     // Russian
-    filesystem_test_group( 3, u8R"(МамаМылаРаму)", u8R"(амаМ)", u8R"(ылаР)" );
+    filesystem_test_group( 2, u8R"(МамаМылаРаму)", u8R"(амаМ)", u8R"(ылаР)" );
     // Chinese
-    filesystem_test_group( 4, u8R"(你好)", u8R"(你)", u8R"(好)" );
-    // Hindi (with diacritics)
-    filesystem_test_group( 5, u8R"(नमस्ते)", u8R"(स्ते)", u8R"(मस्)" );
-    // Let's spice it up a bit
+    filesystem_test_group( 3, u8R"(你好)", u8R"(你)", u8R"(好)" );
+}
+
+// Older Macs with HFS+ filesystem apply NFD unicode normalization to file names.
+// This is done to avoid having composite chars be treated differently from decomposed
+// (e.g. "è" vs "e\u0300"), but it also means that paths written with composed chars
+// will have them decomposed when read back from the filesystem.
+// Hence, the 'mayfail' flag.
+TEST_CASE( "filesystem_utf8_comp", "[filesystem][!mayfail]" )
+{
+    // Hindi (should be unaffected)
+    filesystem_test_group( 4, u8R"(नमस्ते)", u8R"(स्ते)", u8R"(मस्)" );
+    // French (should not decompose into char + combining char)
+    filesystem_test_group( 5, u8R"(crème brûlée)", u8R"(rèm)", u8R"(rûlé)" );
+    // Spice it up a bit
     filesystem_test_group( 6, u8R"(Dw你ы)", u8R"(лаस्तेlé)", u8R"(मябस्or好)" );
+}
+
+TEST_CASE( "filesystem_utf8_decomp", "[filesystem]" )
+{
+    // French (should stay decomposed)
+    filesystem_test_group( 7, "cre\u0300me bru\u0302le\u0301e", "re\u0300m", "ru\u0302le\u0301" );
 }

--- a/tests/filesystem_test.cpp
+++ b/tests/filesystem_test.cpp
@@ -1,0 +1,186 @@
+#include <sstream>
+
+#include "catch/catch.hpp"
+#include "filesystem.h"
+#include "string_formatter.h"
+#include "path_info.h"
+#include "game.h"
+#include "rng.h"
+#include "cata_utility.h"
+
+#if defined(__linux__)
+#include <unistd.h>
+#endif // __linux__
+
+#if defined(_WIN32)
+#include "platform_win.h"
+#endif
+
+std::string str_to_hex( const std::string &s )
+{
+    std::stringstream ss;
+    for( char c : s ) {
+        ss << std::hex << std::uppercase <<
+           static_cast<int>( static_cast<unsigned char>( c ) ) << " ";
+    }
+    return ss.str();
+}
+
+std::string pid_string()
+{
+#ifdef _WIN32
+    return std::to_string( GetCurrentProcessId() );
+#else
+#ifdef __linux__
+    return std::to_string( getpid() );
+#else
+    return std::to_string( rng( 1, 10000 ) );
+#endif // __linux__
+#endif // _WIN32
+}
+
+void filesystem_test_group( int serial, const std::string &s1, const std::string &s2,
+                            const std::string &s3 )
+{
+    CAPTURE( serial );
+    CAPTURE( s1 );
+    CAPTURE( str_to_hex( s1 ) );
+    CAPTURE( s2 );
+    CAPTURE( str_to_hex( s2 ) );
+    CAPTURE( s3 );
+    CAPTURE( str_to_hex( s3 ) );
+
+    // Make sure there's no interference from e.g. uncleaned old runs
+    std::string base = g->get_world_base_save_path() + "/fs_test_" +
+                       pid_string() + "_" + to_string( serial ) + "/";
+    REQUIRE( !dir_exist( base ) );
+    REQUIRE( assure_dir_exist( base ) );
+    REQUIRE( can_write_to_dir( base ) );
+
+    std::string dir1 = base + s1 + "/";
+    std::string file1_1 = dir1 + s2 + ".json";
+    std::string file1_2 = dir1 + s3 + ".json";
+    std::string dir2 = dir1 + s3 + "/";
+    std::string file2_1 = dir2 + s2 + ".json";
+
+    std::string writebuf = s3;
+    std::string writebuf2 = s2;
+    std::string readbuf;
+    const auto reader = [&readbuf]( std::istream & s ) {
+        s >> readbuf;
+    };
+    const auto writer = [&writebuf]( std::ostream & s ) {
+        s << writebuf;
+    };
+    const auto writer2 = [&writebuf2]( std::ostream & s ) {
+        s << writebuf2;
+    };
+
+    // Creating/removing directory; not confusing it with a file
+    REQUIRE( !dir_exist( dir1 ) );
+    REQUIRE( !file_exist( dir1 ) );
+    REQUIRE( assure_dir_exist( dir1 ) );
+    REQUIRE( dir_exist( dir1 ) );
+    REQUIRE( !file_exist( dir1 ) );
+    REQUIRE( remove_directory( dir1 ) );
+    REQUIRE( !remove_directory( dir1 ) );
+    REQUIRE( !dir_exist( dir1 ) );
+
+    // Creating/reading file, renaming it, removing, not confusing with a directory
+    REQUIRE( assure_dir_exist( dir1 ) );
+    REQUIRE( !file_exist( file1_1 ) );
+    REQUIRE( write_to_file( file1_1, writer, nullptr ) );
+    REQUIRE( file_exist( file1_1 ) );
+    REQUIRE( read_from_file( file1_1, reader ) );
+    CHECK( readbuf == writebuf );
+    REQUIRE( rename_file( file1_1, file1_2 ) );
+    REQUIRE( !rename_file( file1_1, file1_2 ) );
+    REQUIRE( file_exist( file1_2 ) );
+    REQUIRE( !rename_file( file1_2, dir1 ) );
+    REQUIRE( file_exist( file1_2 ) );
+    REQUIRE( !dir_exist( file1_2 ) );
+    REQUIRE( remove_file( file1_2 ) );
+    REQUIRE( !remove_file( file1_2 ) );
+
+    // Copying file
+    REQUIRE( write_to_file( file1_1, writer, nullptr ) );
+    REQUIRE( copy_file( file1_1, file1_2 ) );
+    REQUIRE( file_exist( file1_2 ) );
+    REQUIRE( copy_file( file1_1, file1_2 ) );
+    REQUIRE( remove_file( file1_2 ) );
+    REQUIRE( write_to_file( file1_2, writer2, nullptr ) );
+    REQUIRE( copy_file( file1_2, file1_1 ) );
+    REQUIRE( remove_file( file1_2 ) );
+    REQUIRE( read_from_file( file1_1, reader ) );
+    CHECK( readbuf == writebuf2 );
+    REQUIRE( assure_dir_exist( dir2 ) );
+    REQUIRE( !copy_file( file1_2, file1_1 ) );
+    REQUIRE( !copy_file( file1_1, dir2 ) );
+    REQUIRE( !copy_file( dir2, file1_2 ) );
+    REQUIRE( remove_file( file1_1 ) );
+    REQUIRE( remove_directory( dir2 ) );
+    REQUIRE( !copy_file( file1_1, file1_2 ) );
+
+    // Checking if can write to dir
+    REQUIRE( can_write_to_dir( dir1 ) );
+    REQUIRE( remove_directory( dir1 ) );
+    REQUIRE( !can_write_to_dir( dir1 ) );
+
+    // Listing files from dir; paths should stay valid utf-8 strings
+    REQUIRE( assure_dir_exist( dir1 ) );
+    REQUIRE( write_to_file( file1_1, writer, nullptr ) );
+    REQUIRE( write_to_file( file1_2, writer, nullptr ) );
+    REQUIRE( assure_dir_exist( dir2 ) );
+    REQUIRE( write_to_file( file2_1, writer, nullptr ) );
+    {
+        std::vector<std::string> got = get_files_from_path(
+                                           ".json",
+                                           base,
+                                           true,
+                                           true
+                                       );
+        std::vector<std::string> exp = {
+            file1_1,
+            file1_2,
+            file2_1,
+        };
+        const auto comparator = []( const std::string & a, const std::string & b ) {
+            // We don't care about lexicographic order here, just the data order
+            return a > b;
+        };
+        std::sort( exp.begin(), exp.end(), comparator );
+        std::sort( got.begin(), got.end(), comparator );
+        CHECK( got == exp );
+    }
+
+    // Can't delete directory with files
+    REQUIRE( !remove_directory( dir1 ) );
+
+    // Clean up
+    REQUIRE( remove_file( file1_1 ) );
+    REQUIRE( remove_file( file1_2 ) );
+    REQUIRE( remove_file( file2_1 ) );
+    REQUIRE( remove_directory( dir2 ) );
+    REQUIRE( remove_directory( dir1 ) );
+    REQUIRE( remove_directory( base ) );
+}
+
+TEST_CASE( "filesystem_ascii", "[filesystem]" )
+{
+    // English
+    filesystem_test_group( 1, u8R"(DwarfFort)", u8R"(warf)", u8R"(fFor)" );
+}
+
+TEST_CASE( "filesystem_utf8", "[filesystem]" )
+{
+    // French
+    filesystem_test_group( 2, u8R"(crème brûlée)", u8R"(rèm)", u8R"(rûlé)" );
+    // Russian
+    filesystem_test_group( 3, u8R"(МамаМылаРаму)", u8R"(амаМ)", u8R"(ылаР)" );
+    // Chinese
+    filesystem_test_group( 4, u8R"(你好)", u8R"(你)", u8R"(好)" );
+    // Hindi (with diacritics)
+    filesystem_test_group( 5, u8R"(नमस्ते)", u8R"(स्ते)", u8R"(मस्)" );
+    // Let's spice it up a bit
+    filesystem_test_group( 6, u8R"(Dw你ы)", u8R"(лаस्तेlé)", u8R"(मябस्or好)" );
+}


### PR DESCRIPTION
#### Purpose of change
Fixes miscellaneous issues with filesystem access, most notable is reading/writing non-English paths on Windows.

#### Describe the solution
1. Add tests for filesystem operations, with both ASCII and UTF-8 paths
2. Fix misc bugs detected by the tests
3. Rewrite all filesystem functions to accept paths as UTF-8 encoded strings, and:
   * on Linux, use these UTF-8 encoded paths for system calls;
   * on Windows, convert them to `wstring` and pass them to wide Windows API (as per https://utf8everywhere.org/#windows ).
   Newer Windows 10 builds have optional support for UTF-8, but I'm not sure if it's mature enough to warrant full switch.
4. As part of №3, remove the optional Chinese/Japanese/Korean path encoding conversion hack. Because it
   * is enabled by default, and breaks file paths when working with some other non-English languages (e.g. Russian);
   * is no longer required.

Upd: Turns out `*fstream` constructor with `wstring` path is a Microsoft extension, so I had to write a wrapper that constructs a stream from FILE. I've left some low-level `std::*fstream`s usages (like `debug.log`) without changes (and UTF-8 path support) in case the wrapper breaks for some reason on some platforms.

#### Describe alternatives you've considered
`std::filesystem` from c++17?

#### Testing
The tests pass on 
1. Ubuntu 20 (both clang and gcc)
2. Windows 10 (Visual Studio, MSYS2 and Cygwin)
3. Windows 7 Simplified Chinese edition (in VM; both mxe version from linux and Visual Studio version from Win10)
4. MacOS HighSierra 10.13 (in VM)

Also, tried creating character template with Russian file name / new world with Russian name, and it worked fine.
Didn't test much under cygwin, since the game refuses to change language for some reason.

#### Additional context
I was looking into how the game treats different languages for that mod localization thing, and noticed that the filesystem code is a bit of a broken mess.
