### PR TITLE
Move cached options to separate file, make PICKUP_RANGE configurable

### DIFF
--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -11,3 +11,4 @@ bool fov_3d;
 int fov_3d_z_range;
 bool tile_iso;
 bool pixel_minimap_option = false;
+int PICKUP_RANGE;

--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -1,0 +1,13 @@
+#include "cached_options.h"
+
+bool test_mode = false;
+bool debug_mode = false;
+bool use_tiles;
+bool log_from_top;
+int message_ttl;
+int message_cooldown;
+bool trigdist;
+bool fov_3d;
+int fov_3d_z_range;
+bool tile_iso;
+bool pixel_minimap_option = false;

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -52,4 +52,10 @@ extern bool tile_iso;
  */
 extern bool pixel_minimap_option;
 
+/**
+ * Items on the map with at most this distance to the player are considered
+ * available for crafting, see inventory::form_from_map
+*/
+extern int PICKUP_RANGE;
+
 #endif // CATA_SRC_CACHED_OPTIONS_H

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -1,0 +1,55 @@
+#pragma once
+#ifndef CATA_SRC_CACHED_OPTIONS_H
+#define CATA_SRC_CACHED_OPTIONS_H
+
+// A collection of options which are accessed frequently enough that we don't
+// want to pay the overhead of a string lookup each time one is tested.
+// They should be updated when the corresponding option is changed (in options.cpp).
+
+/**
+ * Set to true when running unit tests.
+ * Not a game option, but it's frequently used in the anyway.
+ */
+extern bool test_mode;
+
+/**
+ * Extended debugging mode, can be toggled during game.
+ * If enabled some debug messages in the normal player message log are shown,
+ * and other windows might have verbose display (e.g. vehicle window).
+ */
+extern bool debug_mode;
+
+/**
+ * Use tiles for display. Always false for ncurses build,
+ * but can be toggled in sdl build.
+ */
+extern bool use_tiles;
+
+/** Flow direction for the message log in the sidebar. */
+extern bool log_from_top;
+extern int message_ttl;
+extern int message_cooldown;
+
+/**
+ * Circular distances.
+ * If true, calculate distance in a realistic way [sqrt(dX^2 + dY^2)].
+ * If false, use roguelike distance [maximum of dX and dY].
+ */
+extern bool trigdist;
+
+/** 3D FoV enabled/disabled. */
+extern bool fov_3d;
+
+/** 3D FoV range, in Z levels, in both directions. */
+extern int fov_3d_z_range;
+
+/** Using isometric tileset. */
+extern bool tile_iso;
+
+/**
+ * Whether to show the pixel minimap. Always false for ncurses build,
+ * but can be toggled during game in sdl build.
+ */
+extern bool pixel_minimap_option;
+
+#endif // CATA_SRC_CACHED_OPTIONS_H

--- a/src/creature.h
+++ b/src/creature.h
@@ -17,7 +17,7 @@
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
-#include "debug.h"
+#include "cached_options.h"
 #include "enums.h"
 
 enum game_message_type : int;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "cata_utility.h"
+#include "cached_options.h"
 #include "color.h"
 #include "cursesdef.h"
 #include "filesystem.h"
@@ -86,8 +87,6 @@ static int debugLevel = D_ERROR;
 static int debugClass = D_MAIN;
 #endif
 
-extern bool test_mode;
-
 /** True during game startup, when debugmsgs cannot be displayed yet. */
 static bool buffering_debugmsgs = true;
 
@@ -98,8 +97,6 @@ bool debug_has_error_been_observed()
 {
     return error_observed;
 }
-
-bool debug_mode = false;
 
 struct buffered_prompt_info {
     std::string filename;

--- a/src/debug.h
+++ b/src/debug.h
@@ -195,13 +195,6 @@ void replay_buffered_debugmsg_prompts();
 // See documentation at the top.
 std::ostream &DebugLog( DebugLevel, DebugClass );
 
-/**
- * Extended debugging mode, can be toggled during game.
- * If enabled some debug message in the normal player message log are shown,
- * and other windows might have verbose display (e.g. vehicle window).
- */
-extern bool debug_mode;
-
 #if defined(BACKTRACE)
 /**
  * Write a stack backtrace to the given ostream

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -180,9 +180,6 @@ class computer;
 const int core_version = 6;
 static constexpr int DANGEROUS_PROXIMITY = 5;
 
-/** Will be set to true when running unit tests */
-bool test_mode = false;
-
 static const mtype_id mon_manhack( "mon_manhack" );
 
 static const skill_id skill_melee( "melee" );
@@ -274,7 +271,6 @@ game::game() :
     uquit( QUIT_NO ),
     new_game( false ),
     safe_mode( SAFE_MODE_ON ),
-    pixel_minimap_option( 0 ),
     mostseen( 0 ),
     u_shared_ptr( &u, null_deleter{} ),
     safe_mode_warning_logged( false ),
@@ -435,7 +431,7 @@ void check_encoding();
 void ensure_term_size();
 #endif
 
-void game::init_ui( const bool resized )
+void game_ui::init_ui()
 {
     // clear the screen
     static bool first_init = true;
@@ -459,13 +455,10 @@ void game::init_ui( const bool resized )
     TERMX = get_terminal_width();
     TERMY = get_terminal_height();
 
-    if( resized ) {
-        get_options().get_option( "TERMINAL_X" ).setValue( TERMX * get_scaling_factor() );
-        get_options().get_option( "TERMINAL_Y" ).setValue( TERMY * get_scaling_factor() );
-        get_options().save();
-    }
+    get_options().get_option( "TERMINAL_X" ).setValue( TERMX * get_scaling_factor() );
+    get_options().get_option( "TERMINAL_Y" ).setValue( TERMY * get_scaling_factor() );
+    get_options().save();
 #else
-    ( void ) resized;
     ensure_term_size();
 
     TERMY = getmaxy( catacurses::stdscr );

--- a/src/game.h
+++ b/src/game.h
@@ -46,17 +46,10 @@ static const std::string SAVE_EXTENSION_LOG( ".log" );
 static const std::string SAVE_EXTENSION_WEATHER( ".weather" );
 static const std::string SAVE_EXTENSION_SHORTCUTS( ".shortcuts" );
 
-extern bool test_mode;
-
 // The reference to the one and only game instance.
 class game;
 
 extern std::unique_ptr<game> g;
-
-extern bool use_tiles;
-extern bool fov_3d;
-extern int fov_3d_z_range;
-extern bool tile_iso;
 
 extern const int core_version;
 
@@ -203,8 +196,6 @@ class game
         /** Loads dynamic data from the given directory. May throw. */
         void load_data_from_dir( const std::string &path, const std::string &src, loading_ui &ui );
     public:
-        /** Initializes the UI. */
-        void init_ui( bool resized = false );
         void setup();
         /** Saving and loading functions. */
         void serialize( std::ostream &fout ); // for save
@@ -1043,9 +1034,6 @@ class game
         bool was_fullscreen = false;
         bool auto_travel_mode = false;
         safe_mode_type safe_mode;
-
-        //pixel minimap management
-        int pixel_minimap_option = 0;
         int turnssincelastmon = 0; // needed for auto run mode
 
         weather_manager weather;

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -57,12 +57,6 @@
 // Size of a square unit of tile memory saved in a single file, in mm_submaps.
 #define MM_REG_SIZE 8
 
-/**
- * Items on the map with at most this distance to the player are considered available for crafting,
- * see inventory::form_from_map
-*/
-#define PICKUP_RANGE 6
-
 // Number of z-levels below 0 (not including 0).
 #define OVERMAP_DEPTH 10
 // Number of z-levels above 0 (not including 0).

--- a/src/game_ui.cpp
+++ b/src/game_ui.cpp
@@ -1,14 +1,5 @@
 #include "game_ui.h"
 
-#include <memory>
-
-#include "game.h"
-
-void game_ui::init_ui()
-{
-    g->init_ui( true );
-}
-
 #if !defined(TILES)
 
 void reinitialize_framebuffer()

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -18,10 +18,9 @@
 #include <vector>
 
 #include "cata_utility.h"
+#include "cached_options.h"
 #include "debug.h"
 #include "string_formatter.h"
-
-extern bool test_mode;
 
 // JSON parsing and serialization tools for Cataclysm-DDA.
 // For documentation, see the included header, json.h.

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -14,8 +14,6 @@
 #include "output.h"
 #include "enums.h"
 
-bool trigdist;
-
 void bresenham( const point &p1, const point &p2, int t,
                 const std::function<bool( const point & )> &interact )
 {

--- a/src/line.h
+++ b/src/line.h
@@ -10,8 +10,7 @@
 
 #include "math_defines.h"
 #include "point.h"
-
-extern bool trigdist;
+#include "cached_options.h"
 
 /** Converts degrees to radians */
 constexpr double DEGREES( double v )

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "cached_options.h"
 #include "color.h"
 #include "output.h"
 #include "translations.h"
@@ -16,8 +17,6 @@
 #       include <SDL.h>
 #   endif
 #endif // TILES
-
-extern bool test_mode;
 
 loading_ui::loading_ui( bool display )
 {

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -29,12 +29,6 @@
 #include <deque>
 #include <iterator>
 #include <memory>
-
-// sidebar messages flow direction
-extern bool log_from_top;
-extern int message_ttl;
-extern int message_cooldown;
-
 namespace
 {
 

--- a/src/messages.h
+++ b/src/messages.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "cached_options.h"
 #include "string_formatter.h"
 #include "enums.h"
 #include "debug.h"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -49,14 +49,6 @@
 #include <sstream>
 #include <string>
 
-bool use_tiles;
-bool log_from_top;
-int message_ttl;
-int message_cooldown;
-bool fov_3d;
-int fov_3d_z_range;
-bool tile_iso;
-
 std::map<std::string, std::string> TILESETS; // All found tilesets: <name, tileset_dir>
 std::map<std::string, std::string> SOUNDPACKS; // All found soundpacks: <name, soundpack_dir>
 
@@ -2442,14 +2434,14 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
         try {
             tilecontext->reinit();
             tilecontext->load_tileset( get_option<std::string>( "TILES" ) );
-            //g->init_ui is called when zoom is changed
+            //game_ui::init_ui is called when zoom is changed
             g->reset_zoom();
             tilecontext->do_tile_loading_report();
         } catch( const std::exception &err ) {
             popup( _( "Loading the tileset failed: %s" ), err.what() );
             use_tiles = false;
         }
-    } else if( ingame && g->pixel_minimap_option && pixel_minimap_height_changed ) {
+    } else if( ingame && pixel_minimap_option && pixel_minimap_height_changed ) {
         g->mark_main_ui_adaptor_resize();
     }
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2982,11 +2982,8 @@ std::string options_manager::migrateOptionValue( const std::string &name,
     return iter_val != iter->second.second.end() ? iter_val->second : val;
 }
 
-bool options_manager::save()
+void options_manager::cache_to_globals()
 {
-    const auto savefile = PATH_INFO::options();
-
-    // cache to global due to heavy usage.
     trigdist = ::get_option<bool>( "CIRCLEDIST" );
     use_tiles = ::get_option<bool>( "USE_TILES" );
     log_from_top = ::get_option<std::string>( "LOG_FLOW" ) == "new_top";
@@ -2994,7 +2991,15 @@ bool options_manager::save()
     message_cooldown = ::get_option<int>( "MESSAGE_COOLDOWN" );
     fov_3d = ::get_option<bool>( "FOV_3D" );
     fov_3d_z_range = ::get_option<int>( "FOV_3D_Z_RANGE" );
+#if defined(SDL_SOUND)
+    sounds::sound_enabled = ::get_option<bool>( "SOUND_ENABLED" );
+#endif
+}
 
+bool options_manager::save()
+{
+    const auto savefile = PATH_INFO::options();
+    cache_to_globals();
     update_music_volume();
 
     return write_to_file( savefile, [&]( std::ostream & fout ) {
@@ -3018,18 +3023,7 @@ void options_manager::load()
     }
 
     update_global_locale();
-
-    // cache to global due to heavy usage.
-    trigdist = ::get_option<bool>( "CIRCLEDIST" );
-    use_tiles = ::get_option<bool>( "USE_TILES" );
-    log_from_top = ::get_option<std::string>( "LOG_FLOW" ) == "new_top";
-    message_ttl = ::get_option<int>( "MESSAGE_TTL" );
-    message_cooldown = ::get_option<int>( "MESSAGE_COOLDOWN" );
-    fov_3d = ::get_option<bool>( "FOV_3D" );
-    fov_3d_z_range = ::get_option<int>( "FOV_3D_Z_RANGE" );
-#if defined(SDL_SOUND)
-    sounds::sound_enabled = ::get_option<bool>( "SOUND_ENABLED" );
-#endif
+    cache_to_globals();
 }
 
 bool options_manager::load_legacy()

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1972,6 +1972,13 @@ void options_manager::add_options_debug()
 
     add_empty_line();
 
+    add( "PICKUP_RANGE", "debug", translate_marker( "Crafting range" ),
+         translate_marker( "Maximum distance at which items are considered available for crafting (or some other actions)." ),
+         1, 30, 6
+       );
+
+    add_empty_line();
+
     add( "FOV_3D", "debug", translate_marker( "Experimental 3D field of vision" ),
          translate_marker( "If false, vision is limited to current z-level.  If true and the world is in z-level mode, the vision will extend beyond current z-level.  Currently very bugged!" ),
          false
@@ -2991,6 +2998,7 @@ void options_manager::cache_to_globals()
     message_cooldown = ::get_option<int>( "MESSAGE_COOLDOWN" );
     fov_3d = ::get_option<bool>( "FOV_3D" );
     fov_3d_z_range = ::get_option<int>( "FOV_3D_Z_RANGE" );
+    PICKUP_RANGE = ::get_option<int>( "PICKUP_RANGE" );
 #if defined(SDL_SOUND)
     sounds::sound_enabled = ::get_option<bool>( "SOUND_ENABLED" );
 #endif

--- a/src/options.h
+++ b/src/options.h
@@ -53,6 +53,7 @@ class options_manager
         options_manager();
 
         void addOptionToPage( const std::string &name, const std::string &page );
+        void cache_to_globals(); // cache some options to globals due to heavy usage
 
     public:
         enum copt_hide_t {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -18,6 +18,7 @@
 #include <type_traits>
 #include <cmath>
 
+#include "cached_options.h"
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "color.h"
@@ -61,10 +62,6 @@ int OVERMAP_LEGEND_WIDTH;
 static std::string rm_prefix( std::string str, char c1 = '<', char c2 = '>' );
 
 scrollingcombattext SCT;
-extern bool tile_iso;
-extern bool use_tiles;
-
-extern bool test_mode;
 
 // utf8 version
 std::vector<std::string> foldstring( const std::string &str, int width, const char split )

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -15,6 +15,7 @@
 #include "avatar.h"
 #include "behavior.h"
 #include "bodypart.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "catacharset.h"
@@ -186,7 +187,7 @@ static nc_color focus_color( int focus )
 int window_panel::get_height() const
 {
     if( height == -1 ) {
-        if( g->pixel_minimap_option ) {
+        if( pixel_minimap_option ) {
             return  get_option<int>( "PIXEL_MINIMAP_HEIGHT" ) > 0 ?
                     get_option<int>( "PIXEL_MINIMAP_HEIGHT" ) :
                     width / 2;

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <memory>
 
+#include "cached_options.h"
 #include "catacharset.h"
 #include "ime.h"
 #include "input.h"
@@ -17,8 +18,6 @@
 #       include <SDL.h>
 #   endif
 #endif // TILES
-
-extern bool test_mode;
 
 query_popup::query_popup()
     : cur( 0 ), default_text_color( c_white ), anykey( false ), cancel( false ), ontop( false ),

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 
 #include "assign.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character.h"
@@ -30,8 +31,6 @@
 #include "uistate.h"
 #include "units.h"
 #include "value_ptr.h"
-
-extern bool test_mode;
 
 static const std::string flag_FIT( "FIT" );
 static const std::string flag_VARSIZE( "VARSIZE" );

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -236,8 +236,6 @@ void stop_music()
 
 void update_music_volume()
 {
-    sounds::sound_enabled = ::get_option<bool>( "SOUND_ENABLED" );
-
     if( !sounds::sound_enabled ) {
         stop_music();
         return;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -969,7 +969,7 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
     } else if( g && w == g->w_overmap && overmap_font ) {
         // Special font for the terrain window
         update = draw_window( overmap_font, w );
-    } else if( g && w == g->w_pixel_minimap && g->pixel_minimap_option ) {
+    } else if( g && w == g->w_pixel_minimap && pixel_minimap_option ) {
         // ensure the space the minimap covers is "dirtied".
         // this is necessary when it's the only part of the sidebar being drawn
         // TODO: Figure out how to properly make the minimap code do whatever it is this does

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "cached_options.h"
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "cursesdef.h"
@@ -31,8 +32,6 @@
 #include "path_info.h"
 #include "rng.h"
 #include "text_style_check.h"
-
-extern bool test_mode;
 
 // Names depend on the language settings. They are loaded from different files
 // based on the currently used language. If that changes, we have to reload the


### PR DESCRIPTION
#### Purpose of change
1. Move cached options to a separate lightweight header. This might allow to get rid of some heavier #includes on the next IWYU run, and overall is a bit cleaner than spreading them over the codebase.
2. Make PICKUP_RANGE configurable through debug options tab. The purpose of that is to make it possible to craft with items that are e.g. in a different room of the player's base. Might also come in useful for actual debugging.

#### Describe the solution
See commits. Partially uses code from https://github.com/CleverRaven/Cataclysm-DDA/pull/43983/commits/ebfe558c2a96bf9f5edb036e92f8c4f7e12625cd and https://github.com/CleverRaven/Cataclysm-DDA/commit/bf604e5625860758773c66bcdd19be0fc585b023 (the crash and black screen issues referenced in that commit should have been fixed in #321).

#### Describe alternatives you've considered
While looking into history of PICKUP_RANGE, I've noticed existence of CleverRaven#4904. With electric networks and potential shift from vehicles to base building, would it make sense to resurrect it in some way?

#### Testing
Changing PICKUP_RANGE changes which items are available for crafting.