### PR TITLE
Ammo Rebalance Project: Part 3

### DIFF
--- a/data/json/items/ammo/357mag.json
+++ b/data/json/items/ammo/357mag.json
@@ -17,7 +17,8 @@
     "ammo_type": "357mag",
     "casing": "357mag_casing",
     "range": 16,
-    "damage": { "damage_type": "stab", "amount": 28, "armor_penetration": 4 },
+    "//": "Base damage of 28, balance increase of two-nineths.",
+    "damage": { "damage_type": "stab", "amount": 34, "armor_penetration": 14 },
     "dispersion": 30,
     "recoil": 700,
     "effects": [ "COOKOFF" ]
@@ -28,7 +29,7 @@
     "type": "AMMO",
     "name": { "str": ".357 magnum JHP" },
     "description": "Jacketed hollow point .357 magnum ammunition.  The .357 magnum round is derived from the earlier .38 special, with a marginally longer case and generating greater pressure.",
-    "relative": { "damage": { "damage_type": "stab", "amount": 4, "armor_penetration": -2 } }
+    "damage": { "damage_type": "stab", "amount": 42, "armor_penetration": 0 }
   },
   {
     "id": "bp_357mag_fmj",

--- a/data/json/items/ammo/357sig.json
+++ b/data/json/items/ammo/357sig.json
@@ -17,7 +17,8 @@
     "ammo_type": "357sig",
     "casing": "357sig_casing",
     "range": 16,
-    "damage": { "damage_type": "stab", "amount": 28, "armor_penetration": 4 },
+    "//": "Base damage of 28, balance increase of two-nineths.",
+    "damage": { "damage_type": "stab", "amount": 34, "armor_penetration": 14 },
     "dispersion": 30,
     "recoil": 600,
     "effects": [ "COOKOFF" ]
@@ -28,7 +29,7 @@
     "type": "AMMO",
     "name": { "str": ".357 SIG JHP" },
     "description": "Jacketed hollow point .357 SIG ammunition.  The .357 SIG round is a high velocity pistol cartridge, giving it a flatter trajectory than many handgun rounds.",
-    "relative": { "damage": { "damage_type": "stab", "amount": 4, "armor_penetration": -2 } }
+    "damage": { "damage_type": "stab", "amount": 42, "armor_penetration": 0 }
   },
   {
     "id": "reloaded_357sig_fmj",

--- a/data/json/items/ammo/38.json
+++ b/data/json/items/ammo/38.json
@@ -5,7 +5,8 @@
     "type": "AMMO",
     "name": { "str": ".38 FMJ" },
     "description": ".38 Special ammunition with brass jacketed 130gr bullets.  The .38 Special round has been known from its inception for its accuracy and low recoil.",
-    "relative": { "damage": { "damage_type": "stab", "amount": -2, "armor_penetration": 4 } }
+    "//": "Base damage of 20, balance increase of two-nineths.",
+    "relative": { "damage": { "damage_type": "stab", "amount": -6, "armor_penetration": 9 } }
   },
   {
     "id": "38_special",
@@ -25,23 +26,11 @@
     "ammo_type": "38",
     "casing": "38_casing",
     "range": 14,
-    "damage": { "damage_type": "stab", "amount": 22 },
+    "//": "Hollowpoint damage bonus of 25%.",
+    "damage": { "damage_type": "stab", "amount": 30 },
     "dispersion": 30,
     "recoil": 250,
     "effects": [ "COOKOFF" ]
-  },
-  {
-    "id": "38_super",
-    "copy-from": "38_special",
-    "type": "AMMO",
-    "name": { "str": ".38 Super" },
-    "description": ".38 Super ammunition with 90gr JHP bullets.  Designed in 1929, the .38 super cartridge was designed to penetrate body armor and vehicles.",
-    "price": 240,
-    "price_postapoc": 600,
-    "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
-    "count": 20,
-    "relative": { "damage": { "damage_type": "stab", "amount": 5, "armor_penetration": 4 }, "dispersion": -10 },
-    "proportional": { "recoil": 1.5 }
   },
   {
     "id": "reloaded_38_fmj",
@@ -57,15 +46,6 @@
     "copy-from": "38_special",
     "type": "AMMO",
     "name": { "str": ".38 Special, reloaded" },
-    "proportional": { "price": 0.7, "damage": { "damage_type": "stab", "amount": 0.9 }, "dispersion": 1.1 },
-    "extend": { "effects": [ "RECYCLED" ] },
-    "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
-  },
-  {
-    "id": "reloaded_38_super",
-    "copy-from": "38_super",
-    "type": "AMMO",
-    "name": { "str": ".38 Super, reloaded" },
     "proportional": { "price": 0.7, "damage": { "damage_type": "stab", "amount": 0.9 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }

--- a/data/json/items/ammo/38.json
+++ b/data/json/items/ammo/38.json
@@ -6,7 +6,7 @@
     "name": { "str": ".38 FMJ" },
     "description": ".38 Special ammunition with brass jacketed 130gr bullets.  The .38 Special round has been known from its inception for its accuracy and low recoil.",
     "//": "Base damage of 20, balance increase of two-nineths.",
-    "relative": { "damage": { "damage_type": "stab", "amount": -6, "armor_penetration": 9 } }
+    "relative": { "damage": { "damage_type": "stab", "amount": -6, "armor_penetration": 10 } }
   },
   {
     "id": "38_special",

--- a/data/json/items/ammo/38super.json
+++ b/data/json/items/ammo/38super.json
@@ -17,16 +17,38 @@
     "ammo_type": "38super",
     "casing": "38super_casing",
     "range": 14,
-    "damage": { "damage_type": "stab", "amount": 26 },
+    "//": "Base damage of 26, balance increase of two-nineths.",
+    "damage": { "damage_type": "stab", "amount": 32, "armor_penetration": 14 },
     "dispersion": 30,
     "recoil": 250,
     "effects": [ "COOKOFF" ]
+  },
+  {
+    "id": "38_super",
+    "copy-from": "38super_fmj",
+    "type": "AMMO",
+    "name": { "str": ".38 Super" },
+    "description": ".38 Super ammunition with 90gr JHP bullets.  Designed in 1929, the .38 super cartridge was designed to penetrate body armor and vehicles.",
+    "price": 240,
+    "price_postapoc": 600,
+    "count": 20,
+    "//": "Hollowpoint damage increase of 25%.",
+    "damage": { "damage_type": "stab", "amount": 40, "armor_penetration": 0 }
   },
   {
     "id": "reloaded_38super_fmj",
     "copy-from": "38super_fmj",
     "type": "AMMO",
     "name": { "str": ".38 Super FMJ, reloaded" },
+    "proportional": { "price": 0.7, "damage": { "damage_type": "stab", "amount": 0.9 }, "dispersion": 1.1 },
+    "extend": { "effects": [ "RECYCLED" ] },
+    "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
+  },
+  {
+    "id": "reloaded_38_super",
+    "copy-from": "38_super",
+    "type": "AMMO",
+    "name": { "str": ".38 Super, reloaded" },
     "proportional": { "price": 0.7, "damage": { "damage_type": "stab", "amount": 0.9 }, "dispersion": 1.1 },
     "extend": { "effects": [ "RECYCLED" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Ammo Rebalance Part 3"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

After a bit of a delay, got back to working on the ammo rebalance project. This time will be tackling the .38 and .357 calibers.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

* Balance increase of ~22% applied to .38 Special FMJ, increase of armor penetration to 9 to make it close to 25% more effective against 16 armor armor compared to JHP variant, as per GAME_BALANCE.md.
* Hollowpoint damage bonus of 25% applied to .38 Special JHP.
* Moved `38_super` and variants to 38_super.json, and set it to copy-from `38super_fmj` to make all .38 Super rounds actually count as .38 Super ammo. Recoil and disperson increases also removed since it's no longer being tweaked relative to .38 Special
* Balance increase applied to .38 Super FMJ, armor penetration of 14 added to make it 25% more effective against 16 armor compared to JHP variant.
* Balance increase applied to .357 Magnum FMJ, armor penetration of 14 added to make it close to 25% more effective against 16 armor compared to JHP variant.
* Balance increase applied to .357 SIG, armor penetration of 14 added to make it close to 25% more effective against 16 armor compared to JHP variant.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Continue putting things off.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Ran all affected files through the online linter.
2. Copied JSON files into 1238 (currently most recent build with win-64 verson ready) and load-tested.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Both before and after the stat change, there's basically nothing to distiguish .357 Magnum and .357 SIG, aside from the latter having 100 less recoil. Given the dispersion values being worked with are so low, I'm not sure what can be done to make the difference anything beyond "magazine-fed pistols exist for the latter"