### PR TITLE
Add debug overlay for submap & overmap tile boundaries

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1988,6 +1988,12 @@
   },
   {
     "type": "keybinding",
+    "name": "View Submap Grid",
+    "category": "DEFAULTMODE",
+    "id": "debug_submap_grid"
+  },
+  {
+    "type": "keybinding",
     "name": "Switch Sidebar Style",
     "category": "DEFAULTMODE",
     "id": "toggle_sidebar_style"

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -338,6 +338,8 @@ std::string action_ident( action_id act )
             return "debug_lighting";
         case ACTION_DISPLAY_RADIATION:
             return "debug_radiation";
+        case ACTION_DISPLAY_SUBMAP_GRID:
+            return "debug_submap_grid";
         case ACTION_TOGGLE_HOUR_TIMER:
             return "debug_hour_timer";
         case ACTION_TOGGLE_DEBUG_MODE:
@@ -450,6 +452,7 @@ bool can_action_change_worldstate( const action_id act )
         case ACTION_DISPLAY_VISIBILITY:
         case ACTION_DISPLAY_LIGHTING:
         case ACTION_DISPLAY_RADIATION:
+        case ACTION_DISPLAY_SUBMAP_GRID:
         case ACTION_ZOOM_OUT:
         case ACTION_ZOOM_IN:
         case ACTION_TOGGLE_PIXEL_MINIMAP:
@@ -871,6 +874,7 @@ action_id handle_action_menu()
             REGISTER_ACTION( ACTION_DISPLAY_VISIBILITY );
             REGISTER_ACTION( ACTION_DISPLAY_LIGHTING );
             REGISTER_ACTION( ACTION_DISPLAY_RADIATION );
+            REGISTER_ACTION( ACTION_DISPLAY_SUBMAP_GRID );
             REGISTER_ACTION( ACTION_TOGGLE_DEBUG_MODE );
         } else if( category == _( "Interact" ) ) {
             REGISTER_ACTION( ACTION_EXAMINE );

--- a/src/action.h
+++ b/src/action.h
@@ -315,6 +315,8 @@ enum action_id : int {
     ACTION_DISPLAY_LIGHTING,
     /** Toggle radiation map */
     ACTION_DISPLAY_RADIATION,
+    /** Toggle submap grid overlay */
+    ACTION_DISPLAY_SUBMAP_GRID,
     /** Toggle timing of the game hours */
     ACTION_TOGGLE_HOUR_TIMER,
     /** Not an action, serves as count of enumerated actions */

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -169,6 +169,7 @@ enum debug_menu_index {
     DEBUG_DISPLAY_VISIBILITY,
     DEBUG_DISPLAY_LIGHTING,
     DEBUG_DISPLAY_RADIATION,
+    DEBUG_DISPLAY_SUBMAP_GRID,
     DEBUG_LEARN_SPELLS,
     DEBUG_LEVEL_SPELLS,
     DEBUG_TEST_MAP_EXTRA_DISTRIBUTION,
@@ -234,6 +235,7 @@ static int info_uilist( bool display_all_entries = true )
             { uilist_entry( DEBUG_DISPLAY_VISIBILITY, true, 'v', _( "Toggle display visibility" ) ) },
             { uilist_entry( DEBUG_DISPLAY_LIGHTING, true, 'l', _( "Toggle display lighting" ) ) },
             { uilist_entry( DEBUG_DISPLAY_RADIATION, true, 'R', _( "Toggle display radiation" ) ) },
+            { uilist_entry( DEBUG_DISPLAY_SUBMAP_GRID, true, 'o', _( "Toggle display submap grid" ) ) },
             { uilist_entry( DEBUG_SHOW_MUT_CAT, true, 'm', _( "Show mutation category levels" ) ) },
             { uilist_entry( DEBUG_SHOW_MUT_CHANCES, true, 'u', _( "Show mutation trait chances" ) ) },
             { uilist_entry( DEBUG_BENCHMARK, true, 'b', _( "Draw benchmark" ) ) },
@@ -1620,6 +1622,9 @@ void debug()
             break;
         case DEBUG_DISPLAY_RADIATION:
             g->display_toggle_overlay( ACTION_DISPLAY_RADIATION );
+            break;
+        case DEBUG_DISPLAY_SUBMAP_GRID:
+            g->debug_submap_grid_overlay = !g->debug_submap_grid_overlay;
             break;
         case DEBUG_HOUR_TIMER:
             g->toggle_debug_hour_timer();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11362,26 +11362,16 @@ void game::perhaps_add_random_npc()
 
 bool game::display_overlay_state( const action_id action )
 {
-    const auto it = displaying_overlays.find( action );
-    if( it == displaying_overlays.end() ) {
-        return false;
-    }
-
-    return displaying_overlays[action];
+    return displaying_overlays && *displaying_overlays == action;
 }
 
 void game::display_toggle_overlay( const action_id action )
 {
-    const auto it = displaying_overlays.find( action );
-    if( it == displaying_overlays.end() ) {
-        return;
+    if( display_overlay_state( action ) ) {
+        displaying_overlays.reset();
+    } else {
+        displaying_overlays = action;
     }
-
-    const bool action_flag = it->second;
-    std::for_each( displaying_overlays.begin(), displaying_overlays.end(), []( auto & p ) {
-        p.second = false;
-    } );
-    displaying_overlays[action] = !action_flag;
 }
 
 void game::display_scent()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2393,6 +2393,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "debug_visibility" );
     ctxt.register_action( "debug_lighting" );
     ctxt.register_action( "debug_radiation" );
+    ctxt.register_action( "debug_submap_grid" );
     ctxt.register_action( "debug_hour_timer" );
     ctxt.register_action( "debug_mode" );
     ctxt.register_action( "zoom_out" );
@@ -6779,6 +6780,7 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
     ctxt.register_action( "debug_visibility" );
     ctxt.register_action( "debug_lighting" );
     ctxt.register_action( "debug_radiation" );
+    ctxt.register_action( "debug_submap_grid" );
     ctxt.register_action( "debug_hour_timer" );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "QUIT" );
@@ -6927,6 +6929,8 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
             if( !MAP_SHARING::isCompetitive() || MAP_SHARING::isDebugger() ) {
                 display_radiation();
             }
+        } else if( action == "debug_submap_grid" ) {
+            g->debug_submap_grid_overlay = !g->debug_submap_grid_overlay;
         } else if( action == "debug_hour_timer" ) {
             toggle_debug_hour_timer();
         } else if( action == "EXTENDED_DESCRIPTION" ) {

--- a/src/game.h
+++ b/src/game.h
@@ -1007,6 +1007,7 @@ class game
         point driving_view_offset;
 
         bool debug_pathfinding = false; // show NPC pathfinding on overmap ui
+        bool debug_submap_grid_overlay = false;
 
         /* tile overlays */
         // Toggle all other overlays off and flip the given overlay on/off.

--- a/src/game.h
+++ b/src/game.h
@@ -928,16 +928,8 @@ class game
         void disp_NPC_epilogues();  // Display NPC endings
 
         /* Debug functions */
-        // overlays flags (on / off)
-        std::map<action_id, bool> displaying_overlays{
-            { ACTION_DISPLAY_SCENT, false },
-            { ACTION_DISPLAY_SCENT_TYPE, false },
-            { ACTION_DISPLAY_TEMPERATURE, false },
-            { ACTION_DISPLAY_VEHICLE_AI, false },
-            { ACTION_DISPLAY_VISIBILITY, false },
-            { ACTION_DISPLAY_LIGHTING, false },
-            { ACTION_DISPLAY_RADIATION, false },
-        };
+        // currently displayed overlay (none is displayed if empty)
+        cata::optional<action_id> displaying_overlays;
         void display_scent();   // Displays the scent map
         void display_temperature();    // Displays temperature map
         void display_vehicle_ai(); // Displays vehicle autopilot AI overlay

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2413,6 +2413,10 @@ bool game::handle_action()
                 display_radiation();
                 break;
 
+            case ACTION_DISPLAY_SUBMAP_GRID:
+                g->debug_submap_grid_overlay = !g->debug_submap_grid_overlay;
+                break;
+
             case ACTION_TOGGLE_HOUR_TIMER:
                 toggle_debug_hour_timer();
                 break;


### PR DESCRIPTION
A few times I've had the need to easily check layout of submaps / overmap tiles in relation to the avatar, and this PR implements debug overlay for that.

It uses single lines to indicate submap boundaries, double lines for omt boundaries.
Submaps are also color coded:
green - part of `g->m`
cyan - loaded in the `MAPBUFFER`
blue - neither
Also includes commit https://github.com/CleverRaven/Cataclysm-DDA/commit/23ce399f37c1c00335a3c4c7949296779569c23b from DDA to minimize number of future conflicts.
![borders](https://user-images.githubusercontent.com/60584843/106535879-4794a600-6508-11eb-848d-5d5c1c1ed1e0.png)
![image](https://user-images.githubusercontent.com/60584843/106536157-e3bead00-6508-11eb-8819-30f5a8aa6f1d.png)
