### PR TITLE
Don't deallocate playing chunk if failed to set sound position

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -489,8 +489,13 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
     int channel = Mix_PlayChannel( static_cast<int>( sfx::channel::any ), effect_to_play, 0 );
     bool failed = ( channel == -1 );
     if( !failed && is_pitched ) {
-        failed = ( Mix_RegisterEffect( channel, empty_effect, cleanup_when_channel_finished,
-                                       effect_to_play ) == 0 );
+        if( Mix_RegisterEffect( channel, empty_effect, cleanup_when_channel_finished,
+                                effect_to_play ) == 0 ) {
+            // We'll be unable to de-allocate the chunk, stop the playback right now.
+            failed = true;
+            dbg( D_WARNING ) << "Mix_RegisterEffect failed: " << Mix_GetError();
+            Mix_HaltChannel( channel );
+        }
     }
     if( !failed ) {
         if( Mix_SetPosition( channel, static_cast<Sint16>( angle ), 1 ) == 0 ) {
@@ -536,8 +541,12 @@ void sfx::play_ambient_variant_sound( const std::string &id, const std::string &
         failed = ( Mix_PlayChannel( ch, effect_to_play, loops ) == -1 );
     }
     if( !failed && is_pitched ) {
-        failed = ( Mix_RegisterEffect( ch, empty_effect, cleanup_when_channel_finished,
-                                       effect_to_play ) == 0 );
+        if( Mix_RegisterEffect( ch, empty_effect, cleanup_when_channel_finished, effect_to_play ) == 0 ) {
+            // We'll be unable to de-allocate the chunk, stop the playback right now.
+            failed = true;
+            dbg( D_WARNING ) << "Mix_RegisterEffect failed: " << Mix_GetError();
+            Mix_HaltChannel( ch );
+        }
     }
     if( failed ) {
         dbg( D_ERROR ) << "Failed to play sound effect: " << Mix_GetError();

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -493,7 +493,10 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
                                        effect_to_play ) == 0 );
     }
     if( !failed ) {
-        failed = ( Mix_SetPosition( channel, static_cast<Sint16>( angle ), 1 ) == 0 );
+        if( Mix_SetPosition( channel, static_cast<Sint16>( angle ), 1 ) == 0 ) {
+            // Not critical
+            dbg( D_INFO ) << "Mix_SetPosition failed: " << Mix_GetError();
+        }
     }
     if( failed ) {
         dbg( D_ERROR ) << "Failed to play sound effect: " << Mix_GetError();


### PR DESCRIPTION
#### Purpose of change
May fix issue #101

I went to check SDL_mixer source code, and noticed that `Unsupported audio channels` error is used only in a few functions, one of them `Mix_SetPosition()`. This function is used in the game code to position some sound effects, namely pitch-shifted walking sound, and the error was introduced in SDL_mixer 2.0.2 (MXE had 2.0.4 before the recent update; not sure which version DDA uses, but most likely some older one since 2.0.2 is from October 2017).

Pitch-shifted sounds are done in such way that they dynamically allocate & pitch-shift a chunk on each `play_variant_sound` call, and then dynamically de-allocate it when playback finishes. In case of any error in `play_variant_sound`, the de-allocation happens instantly.

What I believe happens is:
1. The pitch-shifted chunk is created from the original sound, and queued to play via `Mix_PlayChannel()`
2. `Mix_RegisterEffect()` successfully registers hook for de-allocating the chunk once it's done playing
3. `Mix_SetPosition()` fails for some reason with `Unsupported audio channels` error
4. `play_variant_sound()` reacts to this failure by instantly de-allocating the chunk it just allocated
5. SDL tries to play the sound, and dereferences a dangling pointer
    Since we don't have debug symbols in SDL, backtrace looks all kinds of weird.

#### Describe the solution
1. Don't deallocate the chunk if failed to set sound position
2. If failed to register the de-allocator, halt playback before de-allocating

#### Testing
Well, the sound still works... I guess we'll wait for the feedback.