### PR TITLE
Reduce chance of dropping weapons for zombie soldiers

### DIFF
--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -70,10 +70,7 @@
     "type": "item_group",
     "id": "infantry_officer_gear",
     "subtype": "collection",
-    "entries": [
-      { "item": "binoculars", "prob": 90 },
-      { "item": "id_military", "prob": 90 }
-    ]
+    "entries": [ { "item": "binoculars", "prob": 90 }, { "item": "id_military", "prob": 90 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -70,7 +70,7 @@
     "type": "item_group",
     "id": "infantry_officer_gear",
     "subtype": "collection",
-    "entries": [ { "item": "binoculars", "prob": 90 }, { "item": "id_military", "prob": 90 }, { "item": "holster", "prob": 90 } ]
+    "entries": [ { "item": "binoculars", "prob": 90 }, { "item": "id_military", "prob": 90 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -70,7 +70,7 @@
     "type": "item_group",
     "id": "infantry_officer_gear",
     "subtype": "collection",
-    "entries": [ { "item": "binoculars", "prob": 90 }, { "item": "id_military", "prob": 90 },  { "item": "holster", "prob": 90 } ]
+    "entries": [ { "item": "binoculars", "prob": 90 }, { "item": "id_military", "prob": 90 }, { "item": "holster", "prob": 90 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -70,7 +70,7 @@
     "type": "item_group",
     "id": "infantry_officer_gear",
     "subtype": "collection",
-    "entries": [ { "item": "binoculars", "prob": 90 }, { "item": "id_military", "prob": 90 } ]
+    "entries": [ { "item": "binoculars", "prob": 90 }, { "item": "id_military", "prob": 90 },  { "item": "holster", "prob": 90 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -25,7 +25,7 @@
     "type": "item_group",
     "id": "military_standard_lmgs",
     "subtype": "distribution",
-    "entries": [ { "item": "m249", "prob": 100, "charges": [ 0, 200 ] } ]
+    "entries": [ { "item": "m249", "prob": 100, "charges": [ 0, 100 ] } ]
   },
   {
     "type": "item_group",
@@ -71,7 +71,7 @@
     "id": "infantry_officer_gear",
     "subtype": "collection",
     "entries": [
-      { "item": "holster", "contents-group": "military_standard_pistols", "prob": 90 },
+      { "item": "binoculars", "prob": 90 },
       { "item": "id_military", "prob": 90 }
     ]
   },

--- a/data/json/monsterdrops/zombie_cop.json
+++ b/data/json/monsterdrops/zombie_cop.json
@@ -12,7 +12,7 @@
       { "group": "cop_pants", "damage": [ 1, 4 ] },
       { "group": "cop_shoes", "damage": [ 1, 4 ] },
       { "group": "cop_torso", "damage": [ 1, 4 ] },
-      { "group": "cop_weapons", "prob": 50, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
+      { "group": "cop_weapons", "prob": 20, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
       { "group": "underwear", "damage": [ 1, 4 ] },
       { "group": "clothing_glasses", "prob": 5 },
       { "group": "clothing_watch", "prob": 5 },

--- a/data/json/monsterdrops/zombie_cop.json
+++ b/data/json/monsterdrops/zombie_cop.json
@@ -12,7 +12,7 @@
       { "group": "cop_pants", "damage": [ 1, 4 ] },
       { "group": "cop_shoes", "damage": [ 1, 4 ] },
       { "group": "cop_torso", "damage": [ 1, 4 ] },
-      { "group": "cop_weapons", "prob": 20, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
+      { "group": "cop_weapons", "prob": 50, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
       { "group": "underwear", "damage": [ 1, 4 ] },
       { "group": "clothing_glasses", "prob": 5 },
       { "group": "clothing_watch", "prob": 5 },

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -13,7 +13,8 @@
         ]
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_guns", "prob": 50, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
+	  { "item": "holster", "contents-group": "military_standard_pistols", "prob": 30, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },
@@ -41,7 +42,8 @@
         ]
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_guns", "prob": 50, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
+	  { "item": "holster", "contents-group": "military_standard_pistols", "prob": 30, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       {
@@ -56,7 +58,7 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "group": "military_standard_assault_rifles", "prob": 75 },
+      { "group": "military_standard_assault_rifles", "prob": 70 },
       { "group": "military_standard_lmgs", "prob": 10 },
       { "group": "military_standard_sniper_rifles", "prob": 10 },
       { "group": "military_standard_shotguns", "prob": 5 }

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -41,7 +41,7 @@
         ]
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_guns", "prob": 10 },
+      { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 10 },
       { "group": "military_patrol_food" },
       {

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -14,7 +14,13 @@
       },
       { "group": "infantry_common_gear" },
       { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
-	  { "item": "holster", "contents-group": "military_standard_pistols", "prob": 30, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
+      {
+        "item": "holster",
+        "contents-group": "military_standard_pistols",
+        "prob": 30,
+        "damage": [ 0, 2 ],
+        "dirt": [ 1500, 7050 ]
+      },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },
@@ -43,7 +49,13 @@
       },
       { "group": "infantry_common_gear" },
       { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
-	  { "item": "holster", "contents-group": "military_standard_pistols", "prob": 30, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
+      {
+        "item": "holster",
+        "contents-group": "military_standard_pistols",
+        "prob": 30,
+        "damage": [ 0, 2 ],
+        "dirt": [ 1500, 7050 ]
+      },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       {

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -13,7 +13,7 @@
         ]
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_standard_guns", "prob": 50, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },
@@ -41,7 +41,7 @@
         ]
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_standard_guns", "prob": 50, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       {

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -12,16 +12,9 @@
           { "group": "clothing_soldier_winter_set", "prob": 35, "damage": [ 1, 4 ] }
         ]
       },
-      {
-        "distribution": [
-          { "group": "military_standard_assault_rifles", "prob": 75 },
-          { "group": "military_standard_lmgs", "prob": 10 },
-          { "group": "military_standard_sniper_rifles", "prob": 10 },
-          { "group": "military_standard_shotguns", "prob": 5 }
-        ]
-      },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
+	  { "group": "military_standard_guns", "prob": 10 },
+      { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 10 },
       { "group": "military_patrol_food" },
       { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },
       { "item": "cash_card", "prob": 10, "charges": [ 0, 50000 ] },
@@ -47,22 +40,26 @@
           { "group": "clothing_soldier_winter_set", "prob": 35, "damage": [ 1, 4 ] }
         ]
       },
-      {
-        "distribution": [
-          { "group": "military_standard_assault_rifles", "contents-group": "sopmod", "prob": 75 },
-          { "group": "military_standard_lmgs", "prob": 10 },
-          { "group": "military_standard_sniper_rifles", "prob": 10 },
-          { "group": "military_standard_shotguns", "prob": 5 }
-        ]
-      },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
+	  { "group": "military_standard_guns", "prob": 10 },
+      { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 10 },
       { "group": "military_patrol_food" },
       {
         "collection": [ { "group": "infantry_officer_gear", "prob": 90 }, { "group": "infantry_medical_gear", "prob": 80 } ]
       },
       { "item": "cash_card", "prob": 10, "charges-min": 0, "charges-max": 50000 },
       { "group": "misc_smoking", "prob": 30 }
+    ]
+  },
+  {
+    "id": "military_standard_guns",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "military_standard_assault_rifles", "prob": 75 },
+      { "group": "military_standard_lmgs", "prob": 10 },
+      { "group": "military_standard_sniper_rifles", "prob": 10 },
+      { "group": "military_standard_shotguns", "prob": 5 }
     ]
   }
 ]

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -13,7 +13,7 @@
         ]
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_guns", "prob": 10,  "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 10 },
       { "group": "military_patrol_food" },
       { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -14,7 +14,7 @@
       },
       { "group": "infantry_common_gear" },
       { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
-      { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 10 },
+      { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },
       { "item": "cash_card", "prob": 10, "charges": [ 0, 50000 ] },
@@ -42,7 +42,7 @@
       },
       { "group": "infantry_common_gear" },
       { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
-      { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 10 },
+      { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       {
         "collection": [ { "group": "infantry_officer_gear", "prob": 90 }, { "group": "infantry_medical_gear", "prob": 80 } ]

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -13,7 +13,7 @@
         ]
       },
       { "group": "infantry_common_gear" },
-	  { "group": "military_standard_guns", "prob": 10 },
+      { "group": "military_standard_guns", "prob": 10 },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 10 },
       { "group": "military_patrol_food" },
       { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },
@@ -41,7 +41,7 @@
         ]
       },
       { "group": "infantry_common_gear" },
-	  { "group": "military_standard_guns", "prob": 10 },
+      { "group": "military_standard_guns", "prob": 10 },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 10 },
       { "group": "military_patrol_food" },
       {

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -13,7 +13,7 @@
         ]
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_guns", "prob": 10 },
+      { "group": "military_standard_guns", "prob": 10,  "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 10 },
       { "group": "military_patrol_food" },
       { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -14,13 +14,7 @@
       },
       { "group": "infantry_common_gear" },
       { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
-      {
-        "item": "holster",
-        "contents-group": "military_standard_pistols",
-        "prob": 30,
-        "damage": [ 0, 2 ],
-        "dirt": [ 1500, 7050 ]
-      },
+      { "group": "military_standard_pistols", "prob": 30, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },
@@ -49,13 +43,7 @@
       },
       { "group": "infantry_common_gear" },
       { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
-      {
-        "item": "holster",
-        "contents-group": "military_standard_pistols",
-        "prob": 30,
-        "damage": [ 0, 2 ],
-        "dirt": [ 1500, 7050 ]
-      },
+      { "group": "military_standard_pistols", "prob": 30, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       {

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -14,7 +14,7 @@
       },
       { "group": "infantry_common_gear" },
       { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
-      { "group": "military_standard_pistols", "prob": 30, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
+      { "item": "holster", "contents-group": "military_standard_pistols", "prob": 30 },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       { "distribution": [ { "group": "infantry_officer_gear" }, { "group": "infantry_medical_gear" } ], "prob": 25 },
@@ -43,7 +43,7 @@
       },
       { "group": "infantry_common_gear" },
       { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
-      { "group": "military_standard_pistols", "prob": 30, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
+      { "item": "holster", "contents-group": "military_standard_pistols", "prob": 30 },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
       {


### PR DESCRIPTION
Reduce chance of dropping weapons and ammo from zombie soldiers and cops.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Balance "Reduce chance of dropping weapons and ammo from zombie soldiers and cops"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: Balance "Reduce chance of dropping weapons and ammo from zombie soldiers and cops"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Currently player has 100% chance of getting weapons from zombie soldiers. With 70% it will be assault rifle. With 10% it will be LMG with good amount of ammo.
This gives player solid way of farming wepons from zombies and ammo instead of actually looting it from locations.
Additionally it unbalances game with providing solid way of getting gun and ammo early.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
1) Reduce chance of dropping wepons from soldiers from 100% to 10%, but add separate 30% chance of dropping pistol.
2) Big guns dropped from zombie soldiers will be damaged as guns dropped from cops. Pistols going to be clean.
3) Reduced max possible dropped ammo for LMGs from 200 to 100.
4) Change affecting military dead bodies also.
5) Minor change - added binoculars to officer loot to add something. Pistol was removed from there to roll chance of geting pistol separately for each soldier.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Spawn group of zombie soldiers and cops
2) Kill it with debug
3) Observe the loot. Weapons and ammo should be rare.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
Look like even in DDA was noticed that getting weapons is way too easy:
https://github.com/CleverRaven/Cataclysm-DDA/pull/40457

> Make it slightly harder to acquire an assault rifle. Military hardware is generally far too common and military monsters and locations need to spawn less often and more appropriately but that's a bigger task. Dead soldiers not getting back up was inconsistent with lore.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
