### PR TITLE
Ammo Rebalance Project: Part 4

### DIFF
--- a/data/json/items/ammo/22.json
+++ b/data/json/items/ammo/22.json
@@ -29,7 +29,7 @@
     "casing": "22_casing",
     "range": 13,
     "//": "Base damage of 12, balance increase of one-third.",
-    "damage": { "damage_type": "stab", "amount": 16, "armor_penetration": 7 },
+    "damage": { "damage_type": "stab", "amount": 16, "armor_penetration": 9 },
     "dispersion": 60,
     "recoil": 150,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/32.json
+++ b/data/json/items/ammo/32.json
@@ -18,7 +18,7 @@
     "casing": "32_casing",
     "range": 12,
     "//": "Base damage of 16, balance increase of one-third.",
-    "damage": { "damage_type": "stab", "amount": 21, "armor_penetration": 7 },
+    "damage": { "damage_type": "stab", "amount": 21, "armor_penetration": 12 },
     "dispersion": 70,
     "recoil": 150,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/357mag.json
+++ b/data/json/items/ammo/357mag.json
@@ -18,7 +18,7 @@
     "casing": "357mag_casing",
     "range": 16,
     "//": "Base damage of 28, balance increase of two-nineths.",
-    "damage": { "damage_type": "stab", "amount": 34, "armor_penetration": 14 },
+    "damage": { "damage_type": "stab", "amount": 34, "armor_penetration": 19 },
     "dispersion": 30,
     "recoil": 700,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/357sig.json
+++ b/data/json/items/ammo/357sig.json
@@ -18,7 +18,7 @@
     "casing": "357sig_casing",
     "range": 16,
     "//": "Base damage of 28, balance increase of two-nineths.",
-    "damage": { "damage_type": "stab", "amount": 34, "armor_penetration": 14 },
+    "damage": { "damage_type": "stab", "amount": 34, "armor_penetration": 19 },
     "dispersion": 30,
     "recoil": 600,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/38.json
+++ b/data/json/items/ammo/38.json
@@ -6,7 +6,7 @@
     "name": { "str": ".38 FMJ" },
     "description": ".38 Special ammunition with brass jacketed 130gr bullets.  The .38 Special round has been known from its inception for its accuracy and low recoil.",
     "//": "Base damage of 20, balance increase of two-nineths.",
-    "relative": { "damage": { "damage_type": "stab", "amount": -6, "armor_penetration": 10 } }
+    "relative": { "damage": { "damage_type": "stab", "amount": -6, "armor_penetration": 14 } }
   },
   {
     "id": "38_special",

--- a/data/json/items/ammo/380.json
+++ b/data/json/items/ammo/380.json
@@ -18,7 +18,7 @@
     "casing": "380_casing",
     "range": 13,
     "//": "Base damage of 16, balance increase of one-third.",
-    "damage": { "damage_type": "stab", "amount": 21, "armor_penetration": 8 },
+    "damage": { "damage_type": "stab", "amount": 21, "armor_penetration": 12 },
     "dispersion": 60,
     "recoil": 300,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/38super.json
+++ b/data/json/items/ammo/38super.json
@@ -18,7 +18,7 @@
     "casing": "38super_casing",
     "range": 14,
     "//": "Base damage of 26, balance increase of two-nineths.",
-    "damage": { "damage_type": "stab", "amount": 32, "armor_penetration": 14 },
+    "damage": { "damage_type": "stab", "amount": 32, "armor_penetration": 18 },
     "dispersion": 30,
     "recoil": 250,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/46.json
+++ b/data/json/items/ammo/46.json
@@ -18,7 +18,7 @@
     "casing": "46mm_casing",
     "range": 14,
     "//": "Base damage of 20, balance increase of one third.",
-    "damage": { "damage_type": "stab", "amount": 24, "armor_penetration": 25 },
+    "damage": { "damage_type": "stab", "amount": 24, "armor_penetration": 24 },
     "dispersion": 40,
     "recoil": 90,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/46.json
+++ b/data/json/items/ammo/46.json
@@ -17,7 +17,8 @@
     "ammo_type": "46",
     "casing": "46mm_casing",
     "range": 14,
-    "damage": { "damage_type": "stab", "amount": 18, "armor_penetration": 20 },
+    "//": "Base damage of 20, balance increase of one third.",
+    "damage": { "damage_type": "stab", "amount": 24, "armor_penetration": 25 },
     "dispersion": 40,
     "recoil": 90,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/57.json
+++ b/data/json/items/ammo/57.json
@@ -17,7 +17,8 @@
     "ammo_type": "57",
     "casing": "57mm_casing",
     "range": 14,
-    "damage": { "damage_type": "stab", "amount": 20, "armor_penetration": 18 },
+    "//": "Base damage of 20, balance increase of one third.  Armor penetration balanced on the assumption that this is the AP variant of a hypothetical FMJ round.",
+    "damage": { "damage_type": "stab", "amount": 26, "armor_penetration": 27 },
     "dispersion": 40,
     "recoil": 90,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/57.json
+++ b/data/json/items/ammo/57.json
@@ -18,7 +18,7 @@
     "casing": "57mm_casing",
     "range": 14,
     "//": "Base damage of 20, balance increase of one third.  Armor penetration balanced on the assumption that this is the AP variant of a hypothetical FMJ round.",
-    "damage": { "damage_type": "stab", "amount": 26, "armor_penetration": 27 },
+    "damage": { "damage_type": "stab", "amount": 26, "armor_penetration": 26 },
     "dispersion": 40,
     "recoil": 90,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/762x25.json
+++ b/data/json/items/ammo/762x25.json
@@ -45,7 +45,7 @@
     "relative": {
       "price": 2000,
       "range": -1,
-      "damage": { "damage_type": "stab", "amount": -7, "armor_penetration": 8 },
+      "damage": { "damage_type": "stab", "amount": -5, "armor_penetration": 16 },
       "recoil": -270
     }
   },

--- a/data/json/items/ammo/762x25.json
+++ b/data/json/items/ammo/762x25.json
@@ -2,7 +2,7 @@
   {
     "id": "762_25",
     "type": "AMMO",
-    "name": { "str": "7.62x25mm JHP" },
+    "name": { "str": "7.62x25mm FMJ" },
     "description": "A commercial version of the 7.62x25mm cartridge created for the armed forces of Soviet Russia.  It was derived from the 7.63x25mm cartridge used by the C96 pistol.",
     "weight": "10 g",
     "volume": "250 ml",
@@ -17,7 +17,8 @@
     "ammo_type": "762x25",
     "casing": "762_25_casing",
     "range": 13,
-    "damage": { "damage_type": "stab", "amount": 24, "armor_penetration": 2 },
+    "//": "Base damage of 24, balance increase of two-nineths.",
+    "damage": { "damage_type": "stab", "amount": 37, "armor_penetration": 16 },
     "dispersion": 120,
     "recoil": 540,
     "effects": [ "COOKOFF" ]
@@ -26,9 +27,10 @@
     "id": "762_25hot",
     "copy-from": "762_25",
     "type": "AMMO",
-    "name": { "str": "7.62x25mm FMJ hot load" },
+    "name": { "str": "7.62x25mm JHP hot load" },
     "description": "A high-pressure commercial version of the 7.62x25mm cartridge, loaded with an 85 gr. FMJ bullet.  It is more powerful than the original.",
-    "relative": { "price": 500, "range": 2, "damage": { "damage_type": "stab", "amount": 4, "armor_penetration": 3 } },
+    "//": "Hollowpoint bonus of 25%, retains armor penetration due to being a +P load.",
+    "relative": { "price": 500, "range": 2, "damage": { "damage_type": "stab", "amount": 6 } },
     "proportional": { "recoil": 1.4 }
   },
   {
@@ -43,7 +45,7 @@
     "relative": {
       "price": 2000,
       "range": -1,
-      "damage": { "damage_type": "stab", "amount": -9, "armor_penetration": 2 },
+      "damage": { "damage_type": "stab", "amount": -7, "armor_penetration": 8 },
       "recoil": -270
     }
   },

--- a/data/json/items/ammo/762x25.json
+++ b/data/json/items/ammo/762x25.json
@@ -39,6 +39,7 @@
     "type": "AMMO",
     "name": { "str": "7.62x25mm Type P" },
     "//": "Stopgap price of $1 per.  Anti-China prejudice in the pre-Cataclysm US may have made this ammo tougher to come by.",
+    "//2": "AP variant, 7/8 damage relative to FMJ variant, armor penetration matches damage.",
     "description": "A subsonic cartridge derived from the 7.62x25mm, designed for silenced firearms.  It offers good armor penetration at the cost of slightly less damage.",
     "weight": "12 g",
     "count": 50,

--- a/data/json/items/ammo/9mm.json
+++ b/data/json/items/ammo/9mm.json
@@ -17,7 +17,8 @@
     "ammo_type": "9mm",
     "casing": "9mm_casing",
     "range": 14,
-    "damage": { "damage_type": "stab", "amount": 26 },
+    "//": "Hollowpoint bonus of 25%",
+    "damage": { "damage_type": "stab", "amount": 34 },
     "dispersion": 60,
     "recoil": 500,
     "effects": [ "COOKOFF" ]
@@ -28,7 +29,8 @@
     "type": "AMMO",
     "name": { "str": "9x19mm FMJ" },
     "description": "9x19mm ammunition with a brass jacketed 115gr bullet.  It is a popular round for military, law enforcement, and civilian use even after almost 150 years.",
-    "relative": { "damage": { "damage_type": "stab", "amount": -4, "armor_penetration": 8 } }
+    "//": "Base damage of 22, balance increase of two-nineths.",
+    "relative": { "damage": { "damage_type": "stab", "amount": -7, "armor_penetration": 15 } }
   },
   {
     "id": "9mmP",
@@ -40,12 +42,12 @@
     "price_postapoc": 800,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "count": 25,
-    "relative": { "damage": { "damage_type": "stab", "amount": 2, "armor_penetration": 2 }, "dispersion": -15 },
-    "proportional": { "recoil": 1.5 }
+    "relative": { "damage": { "damage_type": "stab", "armor_penetration": 15 }, "dispersion": -15 },
+    "proportional": { "recoil": 2 }
   },
   {
     "id": "9mmP2",
-    "copy-from": "9mm",
+    "copy-from": "9mmP",
     "type": "AMMO",
     "name": { "str": "9x19mm +P+" },
     "description": "A step beyond the high-pressure 9x19mm +P round, the +P+ has even higher internal pressure offering superior damage, accuracy, and penetration.",
@@ -53,8 +55,8 @@
     "price_postapoc": 400,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "count": 10,
-    "relative": { "damage": { "damage_type": "stab", "amount": 4, "armor_penetration": 4 }, "dispersion": -30 },
-    "proportional": { "recoil": 2 }
+    "relative": { "damage": { "damage_type": "stab", "amount": 2, "armor_penetration": 2 }, "dispersion": -15 },
+    "proportional": { "recoil": 1.5 }
   },
   {
     "id": "bp_9mm",

--- a/data/json/items/ammo/9x18.json
+++ b/data/json/items/ammo/9x18.json
@@ -45,7 +45,7 @@
     "price": 200,
     "price_postapoc": 3100,
     "//": "80% damage, 150% armor penetration relative to FMJ variant.",
-    "relative": { "damage": { "damage_type": "stab", "amount": -4, "armor_penetration": 6 } }
+    "relative": { "damage": { "damage_type": "stab", "amount": -3, "armor_penetration": 6 } }
   },
   {
     "id": "bp_9x18mm",

--- a/data/json/items/ammo/9x18.json
+++ b/data/json/items/ammo/9x18.json
@@ -17,7 +17,8 @@
     "ammo_type": "9x18",
     "casing": "9x18mm_casing",
     "range": 13,
-    "damage": { "damage_type": "stab", "amount": 16, "armor_penetration": 2 },
+    "//": "Base damage of 16, balance increase of one-third.",
+    "damage": { "damage_type": "stab", "amount": 21, "armor_penetration": 12 },
     "dispersion": 60,
     "recoil": 300,
     "effects": [ "COOKOFF" ]
@@ -43,7 +44,8 @@
     "description": "9x18mm Makarov RG028 ammunition.  The RG028 round uses bullets with a hardened steel core to improve armor penetration.",
     "price": 200,
     "price_postapoc": 3100,
-    "relative": { "damage": { "damage_type": "stab", "amount": -2, "armor_penetration": 8 } }
+    "//": "80% damage, 150% armor penetration relative to FMJ variant.",
+    "relative": { "damage": { "damage_type": "stab", "amount": -4, "armor_penetration": 6 } }
   },
   {
     "id": "bp_9x18mm",

--- a/data/json/items/ammo/9x18.json
+++ b/data/json/items/ammo/9x18.json
@@ -44,7 +44,7 @@
     "description": "9x18mm Makarov RG028 ammunition.  The RG028 round uses bullets with a hardened steel core to improve armor penetration.",
     "price": 200,
     "price_postapoc": 3100,
-    "//": "80% damage, 150% armor penetration relative to FMJ variant.",
+    "//": "AP variant, 7/8 damage relative to FMJ variant, armor penetration matches damage.",
     "relative": { "damage": { "damage_type": "stab", "amount": -3, "armor_penetration": 6 } }
   },
   {

--- a/doc/GAME_BALANCE.md
+++ b/doc/GAME_BALANCE.md
@@ -270,11 +270,14 @@ Ammo ID            | Description                 | Energy, J | Dmg | Base Brl | 
 ###Adjustment Criteria
 If the resulting base damage is below specific thresholds, apply one of three multipliers. If the base damage is less than 20, the multiplier is 1.333. Else, if the base damage less than 30, the multiplier is 1.222. Else, if the base damage is less than 40, the multiplier is 1.111. Ammunition with damage of 40 or higher will generally have no arbitrary multiplier given to its basic variant.
 
-As for terminal ballistics, hollowpoints variant should be at least 25% more effective against a completely unarmored target, in order for the difference to be considered relevant. Conversely, the base FMJ variation should ideally be at least 25% more effective against a reasonable level of armor for that ammunition to encounter. This recommendation will inform how much armor penetration the two variants should have.
+For liminal cases where the base damage is 20, 30, or 40 there is room for discretion regarding which balance increase to apply, if any. Discretion should be exercised based on which solution makes that ammunition distinct from other ammunition of similar power, as having two different ammotypes with identical power should be avoided. 
 
-For ammunition that would not be expected to defeat soft body armor (i.e. kevlar), test the difference in damage against both 8 and 16 armor. For reference, 16 is the current cut protection a kevlar vest offers. In at least one of these contexts, preferably both, the standard FMJ should have 25% or higher damage than the hollowpoint version.
+As for terminal ballistics, hollowpoints variant should be at least 25% more effective against a completely unarmored target, in order for the difference to be considered relevant. Conversely, the base FMJ variation should have a combined damage and armor penetration whose total is at least 25% greater than the damage of the hollowpoint variant. This recommendation will inform how much armor penetration the two variants should have. Armor-piercing variants have seven-eigths the damage of the standard FMJ variant, and a level of penetration identical to its damage.
 
-For ammunition expected to defeat soft body armor but not hard body armor (i.e. ballistic vest with ceramic plates), perform the same tests against armor values of 23 and 45. For reference, the latter number is the current cut protection of a ceramic-plated MBR vest, and the latter is half that (rounded up). Again, at least one of those scenarios, preferably both, should involve a high enough difference in armor penetration for the FMJ variant to perform at least 25% better than the JHP variant.
+The relative combined damage plus armor penetration for each variant can likewise be summarized as follows:
+1. Hollowpoints are considered to have 100% combined damage (example: 100 damage, 0 arpen)
+2. Standard/FMJ variants are considered to have 125% combined damage, 80% damage and 45% arpen (example: 80 damage, 45 arpen)
+3. AP vairants are considered to have 140% combined damage, 70% damage and 70% arpen (example: 70 damage, 70 arpen)
 
 # LIQUIDS:
 Multi-charge items are weighed by the charge/use.  If you have an item that contains 40 uses, it'll weigh 40x as much (when found in-game) as you entered in the JSON. Liquids are priced by the 250mL unit, but handled in containers.  This can cause problems if you create something that comes in (say) a gallon jug (15 charges) and price it at the cost of a jug's worth: it'll be 15x as expensive as intended.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Ammo Rebalance Project, part 4"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Part four of the ammo rebalance project, implementing ideas as outlined in https://github.com/cataclysmbnteam/Cataclysm-BN/issues/359 This covers pistol-caliber ammunition up to 9mm caliber.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Increased 5.7mm's damage by one-third.
2. Increased 4.6mm damage by two-nineths.
3. Reflavored the standard 7.62x25mm ammo as FMJ, allowing me to make balancing a bit easier. Otherwise I'd have to tack on the hollowpoint bonus and make it 37 damage, instead of 29.
4. Overhauled how arpen bonuses are being tacked on as per musings in the tracking issue. Instead of fumbling with comparing FMJ ammo against arbitrary armor values, instead desired arpen is determined by whether damage plus arpen is at least 25% higher than the hollowpoint variant's damage. This has the advantage of making arpen less hassle to calculate but does mean more arpen across the board.
5. 9mm +P+ set to derive its stats from the +P variant.
6. Relevant damage and arpen increases also given to 9x19mm and 9x18mm.
7. Tinkered with a hypothetical method for which AP rounds could have their armor penetration calculated relative to FMJ variant. 80% damage (divides damage by 1.25 and thus inverse of the useful 25% bonuses), 150% arpen (just under the messier value from applying 25% bonus two separate times). Values that result will however potentially have more arpen than their actual damage. Not sure if it's ideal either, but it's less complex than my first idea.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. A more complicated formula for AP rounds, one that would force me to treat 5.7mm and 4.6mm as rifle rounds for the purpose of determining arpen (the formulas for which aren't even 100% decided yet), was outlined in the tracking issue.
2. Pretending the PDW rounds don't exist for as long as possible and putting a hard part of this project off for even longer.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Dumped files into JSON of most recent build I had on hand (1347).
2. Load-tested.
3. Debugged in ammo to examine stats and confirm 9x19mm and the like, especially those whose JHP variant was the base item, had the correct stat changes.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Per Coolthulhu's suggestion in the tracking issue, I ended up picking which multiplier to use for 5.7mm (being in a liminal position at 20 base damage) based on what would make it distinct from 4.6mm, the damage would've been identical to 4.6mm if I hadn't done that.

Tentative method for deciding arpen for AP variants on display here (PWD ammo, 7.62x25mm subsonic, 9x18mm steel-core), unsure yet if it's ideal but it's a lot less complicated than my initial idea for it.