### PR TITLE
Clean up game language/locale handling

### DIFF
--- a/data/raw/languages.json
+++ b/data/raw/languages.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "en",
+    "name": "English",
+    "locale": "en_US.UTF-8",
+    "lcids": [ 1033, 2057, 3081, 4105, 5129, 6153, 7177, 8201, 9225, 10249, 11273 ]
+  },
+  {
+    "id": "de",
+    "name": "Deutsch",
+    "locale": "de_DE.UTF-8",
+    "lcids": [ 1031, 2055, 3079, 4103, 5127 ]
+  },
+  {
+    "id": "es_AR",
+    "name": "Español (Argentina)",
+    "locale": "es_AR.UTF-8",
+    "lcids": [ 11274 ]
+  },
+  {
+    "id": "es_ES",
+    "name": "Español (España)",
+    "locale": "es_ES.UTF-8",
+    "lcids": [
+      1034,
+      2058,
+      3082,
+      4106,
+      5130,
+      6154,
+      7178,
+      8202,
+      9226,
+      10250,
+      12298,
+      13322,
+      14346,
+      15370,
+      16394,
+      17418,
+      18442,
+      19466,
+      20490
+    ]
+  },
+  {
+    "id": "fr",
+    "name": "Français",
+    "locale": "fr_FR.UTF-8",
+    "lcids": [ 1036, 2060, 3084, 4108, 5132 ]
+  },
+  {
+    "id": "hu",
+    "name": "Magyar",
+    "locale": "hu_HU.UTF-8",
+    "lcids": [ 1038 ]
+  },
+  {
+    "id": "ja",
+    "name": "日本語",
+    "locale": "ja_JP.UTF-8",
+    "lcids": [ 1041 ]
+  },
+  {
+    "id": "ko",
+    "name": "한국어",
+    "locale": "ko_KR.UTF-8",
+    "lcids": [ 1042 ]
+  },
+  {
+    "id": "pl",
+    "name": "Polski",
+    "locale": "pl_PL.UTF-8",
+    "lcids": [ 1045 ]
+  },
+  {
+    "id": "pt_BR",
+    "name": "Português (Brasil)",
+    "locale": "pt_BR.UTF-8",
+    "lcids": [ 1046, 2070 ]
+  },
+  {
+    "id": "ru",
+    "name": "Русский",
+    "locale": "ru_RU.UTF-8",
+    "lcids": [ 1049 ]
+  },
+  {
+    "id": "zh_CN",
+    "name": "中文 (天朝)",
+    "locale": "zh_CN.UTF-8",
+    "osx": "zh_Hans",
+    "lcids": [ 2052, 3076, 4100 ]
+  },
+  {
+    "id": "zh_TW",
+    "name": "中文 (台灣)",
+    "locale": "zh_TW.UTF-8",
+    "osx": "zh_Hant",
+    "lcids": [ 1028 ]
+  }
+]

--- a/data/raw/languages.json
+++ b/data/raw/languages.json
@@ -3,24 +3,28 @@
     "id": "en",
     "name": "English",
     "locale": "en_US.UTF-8",
+    "genders": [ "n" ],
     "lcids": [ 1033, 2057, 3081, 4105, 5129, 6153, 7177, 8201, 9225, 10249, 11273 ]
   },
   {
     "id": "de",
     "name": "Deutsch",
     "locale": "de_DE.UTF-8",
+    "genders": [  ],
     "lcids": [ 1031, 2055, 3079, 4103, 5127 ]
   },
   {
     "id": "es_AR",
     "name": "Español (Argentina)",
     "locale": "es_AR.UTF-8",
+    "genders": [  ],
     "lcids": [ 11274 ]
   },
   {
     "id": "es_ES",
     "name": "Español (España)",
     "locale": "es_ES.UTF-8",
+    "genders": [  ],
     "lcids": [
       1034,
       2058,
@@ -47,48 +51,56 @@
     "id": "fr",
     "name": "Français",
     "locale": "fr_FR.UTF-8",
+    "genders": [  ],
     "lcids": [ 1036, 2060, 3084, 4108, 5132 ]
   },
   {
     "id": "hu",
     "name": "Magyar",
     "locale": "hu_HU.UTF-8",
+    "genders": [  ],
     "lcids": [ 1038 ]
   },
   {
     "id": "ja",
     "name": "日本語",
     "locale": "ja_JP.UTF-8",
+    "genders": [  ],
     "lcids": [ 1041 ]
   },
   {
     "id": "ko",
     "name": "한국어",
     "locale": "ko_KR.UTF-8",
+    "genders": [  ],
     "lcids": [ 1042 ]
   },
   {
     "id": "pl",
     "name": "Polski",
     "locale": "pl_PL.UTF-8",
+    "genders": [  ],
     "lcids": [ 1045 ]
   },
   {
     "id": "pt_BR",
     "name": "Português (Brasil)",
     "locale": "pt_BR.UTF-8",
+    "genders": [  ],
     "lcids": [ 1046, 2070 ]
   },
   {
     "id": "ru",
     "name": "Русский",
     "locale": "ru_RU.UTF-8",
+    "genders": [  ],
     "lcids": [ 1049 ]
   },
   {
     "id": "zh_CN",
     "name": "中文 (天朝)",
     "locale": "zh_CN.UTF-8",
+    "genders": [  ],
     "osx": "zh_Hans",
     "lcids": [ 2052, 3076, 4100 ]
   },
@@ -96,6 +108,7 @@
     "id": "zh_TW",
     "name": "中文 (台灣)",
     "locale": "zh_TW.UTF-8",
+    "genders": [  ],
     "osx": "zh_Hant",
     "lcids": [ 1028 ]
   }

--- a/data/raw/languages.json
+++ b/data/raw/languages.json
@@ -1,5 +1,6 @@
 [
   {
+    "//": "See language.h for documentation",
     "id": "en",
     "name": "English",
     "locale": "en_US.UTF-8",

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -30,6 +30,7 @@
 #include "filesystem.h"
 #include "get_version.h"
 #include "input.h"
+#include "language.h"
 #include "mod_manager.h"
 #include "optional.h"
 #include "options.h"
@@ -1349,9 +1350,10 @@ std::string game_info::game_report()
 
     std::string lang = get_option<std::string>( "USE_LANG" );
     std::string lang_translated;
-    for( const options_manager::id_and_option &vItem : options_manager::lang_options ) {
-        if( vItem.first == lang ) {
-            lang_translated = vItem.second.translated();
+    for( const language_info &info : list_available_languages() ) {
+        if( lang == info.id ) {
+            lang_translated = info.name;
+            break;
         }
     }
 

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -450,14 +450,14 @@ void explosion( const tripoint &p, const explosion_data &ex )
                                              string_format( _( "taking %d damage" ), pr.second ) :
                                              _( "but takes no damage" );
             if( critter->is_player() ) {
-                add_msg( gettext( "You are hit by %s, %s." ),
+                add_msg( _( "You are hit by %s, %s." ),
                          cause_description, damage_description );
             } else if( critter->is_npc() ) {
                 critter->add_msg_if_npc(
-                    gettext( "<npcname> is hit by %s, %s." ),
+                    _( "<npcname> is hit by %s, %s." ),
                     cause_description, damage_description );
             } else {
-                add_msg( gettext( "%s is hit by %s, %s." ),
+                add_msg( _( "%s is hit by %s, %s." ),
                          critter->disp_name( false, true ), cause_description, damage_description );
             }
 

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -26,6 +26,7 @@
 #include "output.h"
 #include "path_info.h"
 #include "translations.h"
+#include "ui.h"
 #if defined(LOCALIZE)
 #  include "json.h"
 #  include "ui_manager.h"

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -43,20 +43,20 @@ std::vector<language_info> lang_options = {
     // https://www.science.co.il/language/Locale-codes.php
     // https://support.microsoft.com/de-de/help/193080/how-to-use-the-getuserdefaultlcid-windows-api-function-to-determine-op
     // https://msdn.microsoft.com/en-us/library/cc233965.aspx
-    { "en", R"(English)", "en_US.UTF-8", {{ 1033, 2057, 3081, 4105, 5129, 6153, 7177, 8201, 9225, 10249, 11273 }} },
+    { "en", R"(English)", "en_US.UTF-8", "", {{ 1033, 2057, 3081, 4105, 5129, 6153, 7177, 8201, 9225, 10249, 11273 }} },
 #if defined(LOCALIZE)
-    { "de", R"(Deutsch)", "de_DE.UTF-8", {{ 1031, 2055, 3079, 4103, 5127 }} },
-    { "es_AR", R"(Español (Argentina))", "es_AR.UTF-8", { 11274 } },
-    { "es_ES", R"(Español (España))", "es_ES.UTF-8", {{ 1034, 2058, 3082, 4106, 5130, 6154, 7178, 8202, 9226, 10250, 12298, 13322, 14346, 15370, 16394, 17418, 18442, 19466, 20490 }} },
-    { "fr", R"(Français)", "fr_FR.UTF-8", {{ 1036, 2060, 3084, 4108, 5132 }} },
-    { "hu", R"(Magyar)", "hu_HU.UTF-8", { 1038 } },
-    { "ja", R"(日本語)", "ja_JP.UTF-8", { 1041 } },
-    { "ko", R"(한국어)", "ko_KR.UTF-8", { 1042 } },
-    { "pl", R"(Polski)", "pl_PL.UTF-8", { 1045 } },
-    { "pt_BR", R"(Português (Brasil))", "pt_BR.UTF-8", {{ 1046, 2070 }} },
-    { "ru", R"(Русский)", "ru_RU.UTF-8", { 1049 } },
-    { "zh_CN", R"(中文 (天朝))", "zh_CN.UTF-8", {{ 2052, 3076, 4100 }} },
-    { "zh_TW", R"(中文 (台灣))", "zh_TW.UTF-8", { 1028 } },
+    { "de", R"(Deutsch)", "de_DE.UTF-8", "", {{ 1031, 2055, 3079, 4103, 5127 }} },
+    { "es_AR", R"(Español (Argentina))", "es_AR.UTF-8", "", { 11274 } },
+    { "es_ES", R"(Español (España))", "es_ES.UTF-8", "", {{ 1034, 2058, 3082, 4106, 5130, 6154, 7178, 8202, 9226, 10250, 12298, 13322, 14346, 15370, 16394, 17418, 18442, 19466, 20490 }} },
+    { "fr", R"(Français)", "fr_FR.UTF-8", "", {{ 1036, 2060, 3084, 4108, 5132 }} },
+    { "hu", R"(Magyar)", "hu_HU.UTF-8", "", { 1038 } },
+    { "ja", R"(日本語)", "ja_JP.UTF-8", "", { 1041 } },
+    { "ko", R"(한국어)", "ko_KR.UTF-8", "", { 1042 } },
+    { "pl", R"(Polski)", "pl_PL.UTF-8", "", { 1045 } },
+    { "pt_BR", R"(Português (Brasil))", "pt_BR.UTF-8", "", {{ 1046, 2070 }} },
+    { "ru", R"(Русский)", "ru_RU.UTF-8", "", { 1049 } },
+    { "zh_CN", R"(中文 (天朝))", "zh_CN.UTF-8", "zh_Hans", {{ 2052, 3076, 4100 }} },
+    { "zh_TW", R"(中文 (台灣))", "zh_TW.UTF-8", "zh_Hant", { 1028 } },
 #endif // LOCALIZE
 };
 
@@ -88,12 +88,12 @@ static void reload_names()
 
 #if defined(LOCALIZE)
 #if defined(MACOSX)
-std::string getOSXSystemLang()
+const std::string &getOSXSystemLang()
 {
     // Get the user's language list (in order of preference)
     CFArrayRef langs = CFLocaleCopyPreferredLanguages();
     if( CFArrayGetCount( langs ) == 0 ) {
-        return "en_US";
+        return "";
     }
 
     CFStringRef lang = static_cast<CFStringRef>( CFArrayGetValueAtIndex( langs, 0 ) );
@@ -106,7 +106,7 @@ std::string getOSXSystemLang()
         std::vector<char> lang_code_raw_slow( length, '\0' );
         bool success = CFStringGetCString( lang, lang_code_raw_slow.data(), length, kCFStringEncodingUTF8 );
         if( !success ) {
-            return "en_US";
+            return "";
         }
         lang_code = lang_code_raw_slow.data();
     }
@@ -120,13 +120,13 @@ std::string getOSXSystemLang()
      * language codes, whereas now (at least on OS X) region is distinct.
      * That is, CDDA expects 'zh_CN' but OS X might give 'zh-Hans-CN'.
      */
-    if( string_starts_with( lang_code, "zh_Hans" ) ) {
-        return "zh_CN";
-    } else if( string_starts_with( lang_code, "zh_Hant" ) ) {
-        return "zh_TW";
+    for( const language_info &info : lang_options ) {
+        if( !info.osx.empty() && string_starts_with( lang_code, info.osx ) ) {
+            return info.id;
+        }
     }
 
-    return isValidLanguage( lang_code ) ? lang_code : "en_US";
+    return to_valid_language( lang_code );
 }
 #endif // MACOSX
 

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -38,6 +38,8 @@ void update_global_locale();
 static std::string sys_c_locale;
 static std::string sys_cpp_locale;
 
+static language_info fallback_language = { "en", R"(English)", "en_US.UTF-8", "", { 1033 } };
+
 std::vector<language_info> lang_options = {
     // Note: language names are in their own language and are *not* translated at all.
     // Note: Somewhere in Github PR was better link to msdn.microsoft.com with language names.
@@ -72,7 +74,7 @@ static language_info const *get_lang_info( const std::string &lang )
     }
     // Should never happen
     debugmsg( "'%s' is not a valid language", lang );
-    return &lang_options[0];
+    return &fallback_language;
 }
 
 const std::vector<language_info> &list_available_languages()
@@ -361,12 +363,12 @@ const language_info &get_language()
     }
     std::string valid = to_valid_language( loc_name );
     if( valid.empty() ) {
-        return lang_options[0];
+        return fallback_language;
     } else {
         return *get_lang_info( valid );
     }
 #else // LOCALIZE
-    return lang_options[0];
+    return fallback_language;
 #endif // LOCALIZE
 }
 

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -47,7 +47,7 @@ static language_info const *system_language = nullptr;
 // May be nullptr if language hasn't been set yet.
 static language_info const *current_language = nullptr;
 
-static language_info fallback_language = { "en", R"(English)", "en_US.UTF-8", "", { 1033 } };
+static language_info fallback_language = { "en", R"(English)", "en_US.UTF-8", { "n" }, "", { 1033 } };
 
 std::vector<language_info> lang_options;
 
@@ -275,6 +275,7 @@ static std::vector<language_info> load_languages( const std::string &filepath )
             info.id = obj.get_string( "id" );
             info.name = obj.get_string( "name" );
             info.locale = obj.get_string( "locale" );
+            info.genders = obj.get_string_array( "genders" );
             info.osx = obj.get_string( "osx", "" );
             info.lcids = obj.get_int_array( "lcids" );
             ret.push_back( info );
@@ -282,6 +283,21 @@ static std::vector<language_info> load_languages( const std::string &filepath )
     } catch( const std::exception &e ) {
         debugmsg( "[lang] Failed to read language definitions: %s", e.what() );
         return std::vector<language_info>();
+    }
+
+    // Sanity check genders
+    const std::vector<std::string> all_genders = {{"f", "m", "n"}};
+
+    for( language_info &info : ret ) {
+        for( const std::string &g : info.genders ) {
+            if( find( all_genders.begin(), all_genders.end(), g ) == all_genders.end() ) {
+                debugmsg( "Unexpected gender '%s' in grammatical gender list for language '%d'",
+                          g, info.id );
+            }
+        }
+        if( info.genders.empty() ) {
+            info.genders.push_back( "n" );
+        }
     }
 
     return ret;

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -1,0 +1,282 @@
+#include "language.h"
+
+#if defined(LOCALIZE) && defined(__STRICT_ANSI__)
+#  undef __STRICT_ANSI__ // _putenv in minGW need that
+#  include <cstdlib>
+#  define __STRICT_ANSI__
+#endif
+
+#if defined(LOCALIZE)
+#  if defined(_WIN32)
+#  if 1 // Prevent IWYU reordering platform_win.h below mmsystem.h
+#    include "platform_win.h"
+#  endif
+#    include "mmsystem.h"
+#  endif // _WIN32
+#  if defined(MACOSX)
+#    include <CoreFoundation/CFLocale.h>
+#    include <CoreFoundation/CoreFoundation.h>
+#  endif
+#endif // LOCALIZE
+
+#include "cached_options.h"
+#include "debug.h"
+#include "name.h"
+#include "options.h"
+#include "output.h"
+#include "path_info.h"
+#include "translations.h"
+#if defined(LOCALIZE)
+#  include "json.h"
+#  include "ui_manager.h"
+#endif
+
+// Names depend on the language settings. They are loaded from different files
+// based on the currently used language. If that changes, we have to reload the
+// names.
+static void reload_names()
+{
+    Name::clear();
+    Name::load_from_file( PATH_INFO::names() );
+}
+
+#if defined(LOCALIZE)
+#if defined(MACOSX)
+std::string getOSXSystemLang()
+{
+    // Get the user's language list (in order of preference)
+    CFArrayRef langs = CFLocaleCopyPreferredLanguages();
+    if( CFArrayGetCount( langs ) == 0 ) {
+        return "en_US";
+    }
+
+    CFStringRef lang = static_cast<CFStringRef>( CFArrayGetValueAtIndex( langs, 0 ) );
+    const char *lang_code_raw_fast = CFStringGetCStringPtr( lang, kCFStringEncodingUTF8 );
+    std::string lang_code;
+    if( lang_code_raw_fast ) { // fast way, probably it's never works
+        lang_code = lang_code_raw_fast;
+    } else { // fallback to slow way
+        CFIndex length = CFStringGetLength( lang ) + 1;
+        std::vector<char> lang_code_raw_slow( length, '\0' );
+        bool success = CFStringGetCString( lang, lang_code_raw_slow.data(), length, kCFStringEncodingUTF8 );
+        if( !success ) {
+            return "en_US";
+        }
+        lang_code = lang_code_raw_slow.data();
+    }
+
+    // Convert to the underscore format expected by gettext
+    std::replace( lang_code.begin(), lang_code.end(), '-', '_' );
+
+    /**
+     * Handle special case for simplified/traditional Chinese. Simplified/Traditional
+     * is actually denoted by the region code in older iterations of the
+     * language codes, whereas now (at least on OS X) region is distinct.
+     * That is, CDDA expects 'zh_CN' but OS X might give 'zh-Hans-CN'.
+     */
+    if( string_starts_with( lang_code, "zh_Hans" ) ) {
+        return "zh_CN";
+    } else if( string_starts_with( lang_code, "zh_Hant" ) ) {
+        return "zh_TW";
+    }
+
+    return isValidLanguage( lang_code ) ? lang_code : "en_US";
+}
+#endif // MACOSX
+
+bool isValidLanguage( const std::string &lang )
+{
+    const auto languages = get_options().get_option( "USE_LANG" ).getItems();
+    return std::find_if( languages.begin(),
+    languages.end(), [&lang]( const options_manager::id_and_option & pair ) {
+        return pair.first == lang || pair.first == lang.substr( 0, pair.first.length() );
+    } ) != languages.end();
+}
+
+/* "Useful" links:
+ *  https://www.science.co.il/language/Locale-codes.php
+ *  https://support.microsoft.com/de-de/help/193080/how-to-use-the-getuserdefaultlcid-windows-api-function-to-determine-op
+ *  https://msdn.microsoft.com/en-us/library/cc233965.aspx
+ */
+std::string getLangFromLCID( const int &lcid )
+{
+    static std::map<std::string, std::set<int>> lang_lcid;
+    if( lang_lcid.empty() ) {
+        lang_lcid["en"] = {{ 1033, 2057, 3081, 4105, 5129, 6153, 7177, 8201, 9225, 10249, 11273 }};
+        lang_lcid["fr"] = {{ 1036, 2060, 3084, 4108, 5132 }};
+        lang_lcid["de"] = {{ 1031, 2055, 3079, 4103, 5127 }};
+        lang_lcid["it_IT"] = {{ 1040, 2064 }};
+        lang_lcid["es_AR"] = { 11274 };
+        lang_lcid["es_ES"] = {{ 1034, 2058, 3082, 4106, 5130, 6154, 7178, 8202, 9226, 10250, 12298, 13322, 14346, 15370, 16394, 17418, 18442, 19466, 20490 }};
+        lang_lcid["ja"] = { 1041 };
+        lang_lcid["ko"] = { 1042 };
+        lang_lcid["pl"] = { 1045 };
+        lang_lcid["pt_BR"] = {{ 1046, 2070 }};
+        lang_lcid["ru"] = { 1049 };
+        lang_lcid["zh_CN"] = {{ 2052, 3076, 4100 }};
+        lang_lcid["zh_TW"] = { 1028 };
+    }
+
+    for( auto &lang : lang_lcid ) {
+        if( lang.second.find( lcid ) != lang.second.end() ) {
+            return lang.first;
+        }
+    }
+    return "";
+}
+
+void select_language()
+{
+    auto languages = get_options().get_option( "USE_LANG" ).getItems();
+
+    languages.erase( std::remove_if( languages.begin(),
+    languages.end(), []( const options_manager::id_and_option & lang ) {
+        return lang.first.empty() || lang.second.empty();
+    } ), languages.end() );
+
+    uilist sm;
+    sm.allow_cancel = false;
+    sm.text = _( "Select your language" );
+    for( size_t i = 0; i < languages.size(); i++ ) {
+        sm.addentry( i, true, MENU_AUTOASSIGN, languages[i].second.translated() );
+    }
+    sm.query();
+
+    get_options().get_option( "USE_LANG" ).setValue( languages[sm.ret].first );
+    get_options().save();
+}
+
+void set_language()
+{
+    std::string win_or_mac_lang;
+#if defined(_WIN32)
+    win_or_mac_lang = getLangFromLCID( GetUserDefaultLCID() );
+#endif
+#if defined(MACOSX)
+    win_or_mac_lang = getOSXSystemLang();
+#endif
+    // Step 1. Setup locale settings.
+    std::string lang_opt = get_option<std::string>( "USE_LANG" ).empty() ? win_or_mac_lang :
+                           get_option<std::string>( "USE_LANG" );
+    if( !lang_opt.empty() ) {
+        // Not 'System Language'
+        // Overwrite all system locale settings. Use CDDA settings. User wants this.
+#if defined(_WIN32)
+        std::string lang_env = "LANGUAGE=" + lang_opt;
+        if( _putenv( lang_env.c_str() ) != 0 ) {
+            DebugLog( D_WARNING, D_MAIN ) << "Can't set 'LANGUAGE' environment variable";
+        }
+#else
+        if( setenv( "LANGUAGE", lang_opt.c_str(), true ) != 0 ) {
+            DebugLog( D_WARNING, D_MAIN ) << "Can't set 'LANGUAGE' environment variable";
+        }
+#endif
+        else {
+            const auto env = getenv( "LANGUAGE" );
+            if( env != nullptr ) {
+                DebugLog( D_INFO, D_MAIN ) << "[lang] Language is set to: '" << env << '\'';
+            } else {
+                DebugLog( D_WARNING, D_MAIN ) << "Can't get 'LANGUAGE' environment variable";
+            }
+        }
+    }
+
+#if defined(_WIN32)
+    // Use the ANSI code page 1252 to work around some language output bugs.
+    if( setlocale( LC_ALL, ".1252" ) == nullptr ) {
+        DebugLog( D_WARNING, D_MAIN ) << "Error while setlocale(LC_ALL, '.1252').";
+    }
+    DebugLog( D_INFO, DC_ALL ) << "[lang] C locale set to " << setlocale( LC_ALL, nullptr );
+    DebugLog( D_INFO, DC_ALL ) << "[lang] C++ locale set to " << std::locale().name();
+#endif
+
+    // Step 2. Bind to gettext domain.
+    std::string locale_dir;
+#if defined(__ANDROID__)
+    // HACK: Since we're using libintl-lite instead of libintl on Android, we hack the locale_dir to point directly to the .mo file.
+    // This is because of our hacky libintl-lite bindtextdomain() implementation.
+    auto env = getenv( "LANGUAGE" );
+    locale_dir = std::string( PATH_INFO::base_path() + "lang/mo/" + ( env ? env : "none" ) +
+                              "/LC_MESSAGES/cataclysm-bn.mo" );
+#elif (defined(__linux__) || (defined(MACOSX) && !defined(TILES)))
+    if( !PATH_INFO::base_path().empty() ) {
+        locale_dir = PATH_INFO::base_path() + "share/locale";
+    } else {
+        locale_dir = "lang/mo";
+    }
+#else
+    locale_dir = "lang/mo";
+#endif
+
+    const char *locale_dir_char = locale_dir.c_str();
+    bindtextdomain( "cataclysm-bn", locale_dir_char );
+    bind_textdomain_codeset( "cataclysm-bn", "UTF-8" );
+    textdomain( "cataclysm-bn" );
+
+    // Step 3. Finalize
+    invalidate_translations();
+    reload_names();
+}
+
+#else // !LOCALIZE
+
+#include <cstring> // strcmp
+#include <map>
+
+bool isValidLanguage( const std::string &/*lang*/ )
+{
+    return true;
+}
+
+std::string getLangFromLCID( const int &/*lcid*/ )
+{
+    return "";
+}
+
+void select_language()
+{
+    return;
+}
+
+void set_language()
+{
+    reload_names();
+    return;
+}
+
+#endif // LOCALIZE
+
+bool localized_comparator::operator()( const std::string &l, const std::string &r ) const
+{
+    // We need different implementations on each platform.  MacOS seems to not
+    // support localized comparison of strings via the standard library at all,
+    // so resort to MacOS-specific solution.  Windows cannot be expected to be
+    // using a UTF-8 locale (whereas our strings are always UTF-8) and so we
+    // must convert to wstring for comparison there.  Linux seems to work as
+    // expected on regular strings; no workarounds needed.
+    // See https://github.com/CleverRaven/Cataclysm-DDA/pull/40041 for further
+    // discussion.
+#if defined(MACOSX)
+    CFStringRef lr = CFStringCreateWithCStringNoCopy( kCFAllocatorDefault, l.c_str(),
+                     kCFStringEncodingUTF8, kCFAllocatorNull );
+    CFStringRef rr = CFStringCreateWithCStringNoCopy( kCFAllocatorDefault, r.c_str(),
+                     kCFStringEncodingUTF8, kCFAllocatorNull );
+    bool result = CFStringCompare( lr, rr, kCFCompareLocalized ) < 0;
+    CFRelease( lr );
+    CFRelease( rr );
+    return result;
+#elif defined(_WIN32)
+    return ( *this )( utf8_to_wstr( l ), utf8_to_wstr( r ) );
+#else
+    return std::locale()( l, r );
+#endif
+}
+
+bool localized_comparator::operator()( const std::wstring &l, const std::wstring &r ) const
+{
+#if defined(MACOSX)
+    return ( *this )( wstr_to_utf8( l ), wstr_to_utf8( r ) );
+#else
+    return std::locale()( l, r );
+#endif
+}

--- a/src/language.h
+++ b/src/language.h
@@ -9,6 +9,7 @@ struct language_info {
     std::string id;
     std::string name;
     std::string locale;
+    std::vector<int> lcids;
 };
 
 bool init_language_system();

--- a/src/language.h
+++ b/src/language.h
@@ -18,6 +18,7 @@ bool isValidLanguage( const std::string &lang );
 std::string getLangFromLCID( const int &lcid );
 void select_language();
 void set_language();
+const language_info &get_language();
 void update_global_locale();
 
 #endif // CATA_SRC_LANGUAGE_H

--- a/src/language.h
+++ b/src/language.h
@@ -3,10 +3,19 @@
 #define CATA_SRC_LANGUAGE_H
 
 #include <string>
+#include <vector>
 
+struct language_info {
+    std::string id;
+    std::string name;
+    std::string locale;
+};
+
+const std::vector<language_info> &list_available_languages();
 bool isValidLanguage( const std::string &lang );
 std::string getLangFromLCID( const int &lcid );
 void select_language();
 void set_language();
+void update_global_locale();
 
 #endif // CATA_SRC_LANGUAGE_H

--- a/src/language.h
+++ b/src/language.h
@@ -9,6 +9,7 @@ struct language_info {
     std::string id;
     std::string name;
     std::string locale;
+    std::string osx;
     std::vector<int> lcids;
 };
 

--- a/src/language.h
+++ b/src/language.h
@@ -11,6 +11,8 @@ struct language_info {
     std::string locale;
 };
 
+bool init_language_system();
+void prompt_select_lang_on_startup();
 const std::vector<language_info> &list_available_languages();
 bool isValidLanguage( const std::string &lang );
 std::string getLangFromLCID( const int &lcid );

--- a/src/language.h
+++ b/src/language.h
@@ -14,11 +14,7 @@ struct language_info {
 bool init_language_system();
 void prompt_select_lang_on_startup();
 const std::vector<language_info> &list_available_languages();
-bool isValidLanguage( const std::string &lang );
-std::string getLangFromLCID( const int &lcid );
-void select_language();
 void set_language();
 const language_info &get_language();
-void update_global_locale();
 
 #endif // CATA_SRC_LANGUAGE_H

--- a/src/language.h
+++ b/src/language.h
@@ -1,0 +1,12 @@
+#pragma once
+#ifndef CATA_SRC_LANGUAGE_H
+#define CATA_SRC_LANGUAGE_H
+
+#include <string>
+
+bool isValidLanguage( const std::string &lang );
+std::string getLangFromLCID( const int &lcid );
+void select_language();
+void set_language();
+
+#endif // CATA_SRC_LANGUAGE_H

--- a/src/language.h
+++ b/src/language.h
@@ -9,6 +9,24 @@ struct language_info {
     std::string id;
     std::string name;
     std::string locale;
+
+    /**
+     * List of grammatical genders. Default should be first.
+     *
+     * Use short names and try to be consistent between languages as far as
+     * possible.  Current choices are m (male), f (female), n (neuter).
+     * As appropriate we might add e.g. a (animate) or c (common).
+     * New genders must be added to all_genders in lang/extract_json_strings.py
+     * and src/language.cpp.
+     * The primary purpose of this is for NPC dialogue which might depend on
+     * gender.  Only add genders to the extent needed by such translations.
+     * They are likely only needed if they affect the first and second
+     * person.  For example, one gender suffices for English even though
+     * third person pronouns differ.
+     *
+     * Defaults to `[ "n" ]` if left emty.
+     */
+    std::vector<std::string> genders;
     std::string osx;
     std::vector<int> lcids;
 };

--- a/src/language.h
+++ b/src/language.h
@@ -5,9 +5,37 @@
 #include <string>
 #include <vector>
 
+/**
+ * Contains information on a language supported by the game.
+ *
+ * Fields here mirror JSON fields in the language definitions file.
+ */
 struct language_info {
+    /**
+     * Language id.
+     *
+     * Usually in form of `ll` or `ll_CC`
+     * (ll - language, CC - country code).
+     *
+     * Used for autodetection on Linux, and also for resolving paths to
+     * localized files (title screen ascii art, lisst of character/town names).
+     */
     std::string id;
+
+    /**
+     * Native language name.
+     */
     std::string name;
+
+    /**
+     * Locale to use on non-Windows platforms.
+     *
+     * If missing, falls back to `en_US.UTF-8`, then to user locale, then to C.
+     * If this language is used as 'System language', this field is ignored
+     * and the game uses user locale (or, if failed, C).
+     *
+     * On Windows, always uses user locale with code page 1252.
+     */
     std::string locale;
 
     /**
@@ -27,14 +55,58 @@ struct language_info {
      * Defaults to `[ "n" ]` if left emty.
      */
     std::vector<std::string> genders;
+
+    /**
+     * OSX autodetection correction (optional field).
+     *
+     * Allows the code to handle special case for Simplified/Traditional Chinese.
+     * Simplified/Traditional is actually denoted by the region code in older
+     * iterations of the language codes, whereas now (at least on OS X)
+     * region is distinct. That is, the game expects 'zh_CN' but OS X might
+     * give 'zh-Hans-CN'.
+     */
     std::string osx;
+
+    /**
+     * List of language code identifiers (LCIDs) for Windows lang autodetection.
+     *
+     * See `Windows Language Code Identifier (LCID) Reference`
+     * https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/70feba9f-294e-491e-b6eb-56532684c37f
+     */
     std::vector<int> lcids;
 };
 
+/**
+ * Initialize language system (detect system UI language, load definitions).
+ * Does not change current language/locale.
+ */
 bool init_language_system();
+
+/**
+ * Prompt for explicit language selection.
+ * The prompt is skipped if using lang other than 'System language',
+ * or if lang autodetection succeeded.
+ */
 void prompt_select_lang_on_startup();
+
+/**
+ * List of loaded language definitions.
+ * Always contains at least 1 language (English).
+ */
 const std::vector<language_info> &list_available_languages();
+
+/**
+ * Set language and locale to current value of USE_LANG option.
+ * If the value is empty, uses autodetected system language
+ * (or English, if autodetection failed) and system locale.
+ */
 void set_language();
+
+/**
+ * Current game language. May differ from USE_LANG option value
+ * if the option has been changed without subsequent `set_language()` call.
+ * If lang system has not been initialized, falls back to English.
+ */
 const language_info &get_language();
 
 #endif // CATA_SRC_LANGUAGE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -635,6 +635,7 @@ int main( int argc, char *argv[] )
 #if !defined(TILES)
     get_options().init();
     get_options().load();
+    set_language(); // Have to set locale before initializing ncurses
 #endif
 
     // in test mode don't initialize curses to avoid escape sequences being inserted into output stream
@@ -652,7 +653,9 @@ int main( int argc, char *argv[] )
         }
     }
 
+#if defined(TILES)
     set_language();
+#endif
 
     rng_set_engine_seed( seed );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 #include "game.h"
 #include "game_ui.h"
 #include "input.h"
+#include "language.h"
 #include "loading_ui.h"
 #include "runtime_handlers.h"
 #include "string_formatter.h"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -18,6 +18,7 @@
 #include "game_constants.h"
 #include "input.h"
 #include "json.h"
+#include "language.h"
 #include "line.h"
 #include "mapsharing.h"
 #include "output.h"
@@ -51,26 +52,6 @@
 
 std::map<std::string, std::string> TILESETS; // All found tilesets: <name, tileset_dir>
 std::map<std::string, std::string> SOUNDPACKS; // All found soundpacks: <name, soundpack_dir>
-
-std::vector<options_manager::id_and_option> options_manager::lang_options = {
-    { "", translate_marker( "System language" ) },
-    // Note: language names are in their own language and are *not* translated at all.
-    // Note: Somewhere in Github PR was better link to msdn.microsoft.com with language names.
-    // http://en.wikipedia.org/wiki/List_of_language_names
-    { "en", no_translation( R"(English)" ) },
-    { "de", no_translation( R"(Deutsch)" ) },
-    { "es_AR", no_translation( R"(Español (Argentina))" ) },
-    { "es_ES", no_translation( R"(Español (España))" ) },
-    { "fr", no_translation( R"(Français)" ) },
-    { "hu", no_translation( R"(Magyar)" ) },
-    { "ja", no_translation( R"(日本語)" ) },
-    { "ko", no_translation( R"(한국어)" ) },
-    { "pl", no_translation( R"(Polski)" ) },
-    { "pt_BR", no_translation( R"(Português (Brasil))" )},
-    { "ru", no_translation( R"(Русский)" ) },
-    { "zh_CN", no_translation( R"(中文 (天朝))" ) },
-    { "zh_TW", no_translation( R"(中文 (台灣))" ) },
-};
 
 options_manager &get_options()
 {
@@ -1321,9 +1302,15 @@ void options_manager::add_options_interface()
         interface_page_.items_.emplace_back();
     };
 
-    // TODO: scan for languages like we do for tilesets.
+    std::vector<options_manager::id_and_option> lang_options = {
+        { "", translate_marker( "System language" ) },
+    };
+    for( const language_info &info : list_available_languages() ) {
+        lang_options.push_back( {info.id, no_translation( info.name )} );
+    }
+
     add( "USE_LANG", "interface", translate_marker( "Language" ),
-         translate_marker( "Switch Language." ), options_manager::lang_options, "" );
+         translate_marker( "Switch Language." ), lang_options, "" );
 
     add_empty_line();
 
@@ -3067,43 +3054,4 @@ void options_manager::set_world_options( options_container *options )
     } else {
         world_options = options;
     }
-}
-
-void options_manager::update_global_locale()
-{
-    std::string lang = ::get_option<std::string>( "USE_LANG" );
-    try {
-        if( lang == "en" ) {
-            std::locale::global( std::locale( "en_US.UTF-8" ) );
-        } else if( lang == "de" ) {
-            std::locale::global( std::locale( "de_DE.UTF-8" ) );
-        } else if( lang == "es_AR" ) {
-            std::locale::global( std::locale( "es_AR.UTF-8" ) );
-        } else if( lang == "es_ES" ) {
-            std::locale::global( std::locale( "es_ES.UTF-8" ) );
-        } else if( lang == "fr" ) {
-            std::locale::global( std::locale( "fr_FR.UTF-8" ) );
-        } else if( lang == "hu" ) {
-            std::locale::global( std::locale( "hu_HU.UTF-8" ) );
-        } else if( lang == "ja" ) {
-            std::locale::global( std::locale( "ja_JP.UTF-8" ) );
-        } else if( lang == "ko" ) {
-            std::locale::global( std::locale( "ko_KR.UTF-8" ) );
-        } else if( lang == "pl" ) {
-            std::locale::global( std::locale( "pl_PL.UTF-8" ) );
-        } else if( lang == "pt_BR" ) {
-            std::locale::global( std::locale( "pt_BR.UTF-8" ) );
-        } else if( lang == "ru" ) {
-            std::locale::global( std::locale( "ru_RU.UTF-8" ) );
-        } else if( lang == "zh_CN" ) {
-            std::locale::global( std::locale( "zh_CN.UTF-8" ) );
-        } else if( lang == "zh_TW" ) {
-            std::locale::global( std::locale( "zh_TW.UTF-8" ) );
-        }
-    } catch( std::runtime_error &e ) {
-        std::locale::global( std::locale() );
-    }
-
-    DebugLog( D_INFO, DC_ALL ) << "[options] C locale set to " << setlocale( LC_ALL, nullptr );
-    DebugLog( D_INFO, DC_ALL ) << "[options] C++ locale set to " << std::locale().name();
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2881,7 +2881,6 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
     }
 
     if( lang_changed ) {
-        update_global_locale();
         set_language();
     }
     calendar::set_eternal_season( ::get_option<bool>( "ETERNAL_SEASON" ) );
@@ -3005,7 +3004,6 @@ void options_manager::load()
         deserialize( jsin );
     } );
 
-    update_global_locale();
     cache_to_globals();
 }
 

--- a/src/options.h
+++ b/src/options.h
@@ -29,7 +29,6 @@ class options_manager
                     : std::pair<std::string, translation>( first, second ) {
                 }
         };
-        static std::vector<id_and_option> lang_options;
     private:
         static std::vector<id_and_option> build_tilesets_list();
         static std::vector<id_and_option> build_soundpacks_list();
@@ -40,8 +39,6 @@ class options_manager
 
         void enable_json( const std::string &var );
         void add_retry( const std::string &var, const std::string &val );
-
-        void update_global_locale();
 
         std::map<std::string, std::string> post_json_verify;
 

--- a/src/path_info.cpp
+++ b/src/path_info.cpp
@@ -119,52 +119,22 @@ void PATH_INFO::set_standard_filenames()
 std::string find_translated_file( const std::string &base_path, const std::string &extension,
                                   const std::string &fallback )
 {
-#if defined(LOCALIZE) && !defined(__CYGWIN__)
-    std::string loc_name;
-    if( get_option<std::string>( "USE_LANG" ).empty() ) {
-#if defined(_WIN32)
-        loc_name = getLangFromLCID( GetUserDefaultLCID() );
-        if( !loc_name.empty() ) {
-            const std::string local_path = base_path + loc_name + extension;
-            if( file_exist( local_path ) ) {
-                return local_path;
-            }
-        }
-#endif
+    std::string lang = get_language().id;
 
-        const char *v = setlocale( LC_ALL, nullptr );
-        if( v != nullptr ) {
-            loc_name = v;
-        }
-    } else {
-        loc_name = get_option<std::string>( "USE_LANG" );
+    // complete locale: en_NZ
+    const std::string local_path = base_path + lang + extension;
+    if( file_exist( local_path ) ) {
+        return local_path;
     }
-    if( loc_name == "C" ) {
-        loc_name = "en";
-    }
-    if( !loc_name.empty() ) {
-        const size_t dotpos = loc_name.find( '.' );
-        if( dotpos != std::string::npos ) {
-            loc_name.erase( dotpos );
-        }
-        // complete locale: en_NZ
-        const std::string local_path = base_path + loc_name + extension;
+    const size_t p = lang.find( '_' );
+    if( p != std::string::npos ) {
+        // only the first part: en
+        const std::string local_path = base_path + lang.substr( 0, p ) + extension;
         if( file_exist( local_path ) ) {
             return local_path;
         }
-        const size_t p = loc_name.find( '_' );
-        if( p != std::string::npos ) {
-            // only the first part: en
-            const std::string local_path = base_path + loc_name.substr( 0, p ) + extension;
-            if( file_exist( local_path ) ) {
-                return local_path;
-            }
-        }
     }
-#else
-    ( void ) base_path;
-    ( void ) extension;
-#endif
+
     return fallback;
 }
 std::string PATH_INFO::autopickup()

--- a/src/path_info.cpp
+++ b/src/path_info.cpp
@@ -201,6 +201,10 @@ std::string PATH_INFO::user_fontdir()
 {
     return user_dir_value + "font/";
 }
+std::string PATH_INFO::language_defs_file()
+{
+    return datadir_value + "raw/" + "languages.json";
+}
 std::string PATH_INFO::graveyarddir()
 {
     return user_dir_value + "graveyard/";

--- a/src/path_info.cpp
+++ b/src/path_info.cpp
@@ -5,6 +5,7 @@
 
 #include "enums.h"
 #include "filesystem.h"
+#include "language.h"
 #include "options.h"
 
 #if defined(_WIN32)

--- a/src/path_info.h
+++ b/src/path_info.h
@@ -28,6 +28,7 @@ std::string fontconfig();
 std::string user_fontconfig();
 std::string fontdir();
 std::string user_fontdir();
+std::string language_defs_file();
 std::string graveyarddir();
 std::string help();
 std::string keybindings();

--- a/src/text_snippets.cpp
+++ b/src/text_snippets.cpp
@@ -178,9 +178,9 @@ snippet_id snippet_library::migrate_hash_to_id( const int old_hash )
     if( !hash_to_id_migration.has_value() ) {
         hash_to_id_migration.emplace();
         for( const auto &id_and_text : snippets_by_id ) {
-            cata::optional<int> hash = id_and_text.second.legacy_hash();
-            if( hash ) {
-                hash_to_id_migration->emplace( hash.value(), id_and_text.first );
+            std::pair<bool, int> hash = id_and_text.second.legacy_hash();
+            if( hash.first ) {
+                hash_to_id_migration->emplace( hash.second, id_and_text.first );
             }
         }
     }

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -11,8 +11,6 @@
 #include "rng.h"
 #include "text_style_check.h"
 
-static bool sanity_checked_genders = false;
-
 // int version/generation that is incremented each time language is changed
 // used to invalidate translation cache
 static int current_language_version = INVALID_LANGUAGE_VERSION + 1;
@@ -24,8 +22,6 @@ int detail::get_current_language_version()
 
 void invalidate_translations()
 {
-    sanity_checked_genders = false;
-
     // increment version to invalidate translation cache
     do {
         current_language_version++;
@@ -75,44 +71,9 @@ const char *npgettext( const char *const context, const char *const msgid,
 
 #endif // LOCALIZE
 
-static void sanity_check_genders( const std::vector<std::string> &language_genders )
-{
-    if( sanity_checked_genders ) {
-        return;
-    }
-    sanity_checked_genders = true;
-
-    constexpr std::array<const char *, 3> all_genders = {{"f", "m", "n"}};
-
-    for( const std::string &gender : language_genders ) {
-        if( find( all_genders.begin(), all_genders.end(), gender ) == all_genders.end() ) {
-            debugmsg( "Unexpected gender '%s' in grammatical gender list for "
-                      "this language", gender );
-        }
-    }
-}
-
 std::string gettext_gendered( const GenderMap &genders, const std::string &msg )
 {
-    //~ Space-separated list of grammatical genders. Default should be first.
-    //~ Use short names and try to be consistent between languages as far as
-    //~ possible.  Current choices are m (male), f (female), n (neuter).
-    //~ As appropriate we might add e.g. a (animate) or c (common).
-    //~ New genders must be added to all_genders in lang/extract_json_strings.py
-    //~ and src/translations.cpp.
-    //~ The primary purpose of this is for NPC dialogue which might depend on
-    //~ gender.  Only add genders to the extent needed by such translations.
-    //~ They are likely only needed if they affect the first and second
-    //~ person.  For example, one gender suffices for English even though
-    //~ third person pronouns differ.
-    std::string language_genders_s = pgettext( "grammatical gender list", "n" );
-    std::vector<std::string> language_genders = string_split( language_genders_s, ' ' );
-
-    sanity_check_genders( language_genders );
-
-    if( language_genders.empty() ) {
-        language_genders.push_back( "n" );
-    }
+    const std::vector<std::string> &language_genders = get_language().genders;
 
     std::vector<std::string> chosen_genders;
     for( const auto &subject_genders : genders ) {

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -1,46 +1,15 @@
 #include "translations.h"
 
-#include <array>
-#include <clocale>
-#include <cstdlib>
-#include <functional>
-#include <locale>
-
-#if defined(LOCALIZE) && defined(__STRICT_ANSI__)
-#undef __STRICT_ANSI__ // _putenv in minGW need that
-#include <cstdlib>
-
-#define __STRICT_ANSI__
-#endif
-
 #include <algorithm>
-#include <map>
-#include <memory>
-#include <ostream>
-#include <set>
-#include <string>
-#include <utility>
-#include <vector>
 
 #include "cached_options.h"
 #include "cata_utility.h"
 #include "catacharset.h"
-#include "cursesdef.h"
 #include "json.h"
-#include "name.h"
+#include "language.h"
 #include "output.h"
-#include "path_info.h"
 #include "rng.h"
 #include "text_style_check.h"
-
-// Names depend on the language settings. They are loaded from different files
-// based on the currently used language. If that changes, we have to reload the
-// names.
-static void reload_names()
-{
-    Name::clear();
-    Name::load_from_file( PATH_INFO::names() );
-}
 
 static bool sanity_checked_genders = false;
 
@@ -53,25 +22,17 @@ int detail::get_current_language_version()
     return current_language_version;
 }
 
+void invalidate_translations()
+{
+    sanity_checked_genders = false;
+
+    // increment version to invalidate translation cache
+    do {
+        current_language_version++;
+    } while( current_language_version == INVALID_LANGUAGE_VERSION );
+}
+
 #if defined(LOCALIZE)
-#include "debug.h"
-#include "options.h"
-#include "ui.h"
-#if defined(_WIN32)
-#if 1 // Prevent IWYU reordering platform_win.h below mmsystem.h
-#   include "platform_win.h"
-#endif
-#   include "mmsystem.h"
-#endif
-
-#if defined(MACOSX)
-#   include <CoreFoundation/CFLocale.h>
-#   include <CoreFoundation/CoreFoundation.h>
-
-#include "cata_utility.h"
-
-std::string getOSXSystemLang();
-#endif
 
 const char *pgettext( const char *context, const char *msgid )
 {
@@ -110,214 +71,6 @@ const char *npgettext( const char *const context, const char *const msgid,
     } else {
         return translation;
     }
-}
-
-bool isValidLanguage( const std::string &lang )
-{
-    const auto languages = get_options().get_option( "USE_LANG" ).getItems();
-    return std::find_if( languages.begin(),
-    languages.end(), [&lang]( const options_manager::id_and_option & pair ) {
-        return pair.first == lang || pair.first == lang.substr( 0, pair.first.length() );
-    } ) != languages.end();
-}
-
-/* "Useful" links:
- *  https://www.science.co.il/language/Locale-codes.php
- *  https://support.microsoft.com/de-de/help/193080/how-to-use-the-getuserdefaultlcid-windows-api-function-to-determine-op
- *  https://msdn.microsoft.com/en-us/library/cc233965.aspx
- */
-std::string getLangFromLCID( const int &lcid )
-{
-    static std::map<std::string, std::set<int>> lang_lcid;
-    if( lang_lcid.empty() ) {
-        lang_lcid["en"] = {{ 1033, 2057, 3081, 4105, 5129, 6153, 7177, 8201, 9225, 10249, 11273 }};
-        lang_lcid["fr"] = {{ 1036, 2060, 3084, 4108, 5132 }};
-        lang_lcid["de"] = {{ 1031, 2055, 3079, 4103, 5127 }};
-        lang_lcid["it_IT"] = {{ 1040, 2064 }};
-        lang_lcid["es_AR"] = { 11274 };
-        lang_lcid["es_ES"] = {{ 1034, 2058, 3082, 4106, 5130, 6154, 7178, 8202, 9226, 10250, 12298, 13322, 14346, 15370, 16394, 17418, 18442, 19466, 20490 }};
-        lang_lcid["ja"] = { 1041 };
-        lang_lcid["ko"] = { 1042 };
-        lang_lcid["pl"] = { 1045 };
-        lang_lcid["pt_BR"] = {{ 1046, 2070 }};
-        lang_lcid["ru"] = { 1049 };
-        lang_lcid["zh_CN"] = {{ 2052, 3076, 4100 }};
-        lang_lcid["zh_TW"] = { 1028 };
-    }
-
-    for( auto &lang : lang_lcid ) {
-        if( lang.second.find( lcid ) != lang.second.end() ) {
-            return lang.first;
-        }
-    }
-    return "";
-}
-
-void select_language()
-{
-    auto languages = get_options().get_option( "USE_LANG" ).getItems();
-
-    languages.erase( std::remove_if( languages.begin(),
-    languages.end(), []( const options_manager::id_and_option & lang ) {
-        return lang.first.empty() || lang.second.empty();
-    } ), languages.end() );
-
-    uilist sm;
-    sm.allow_cancel = false;
-    sm.text = _( "Select your language" );
-    for( size_t i = 0; i < languages.size(); i++ ) {
-        sm.addentry( i, true, MENU_AUTOASSIGN, languages[i].second.translated() );
-    }
-    sm.query();
-
-    get_options().get_option( "USE_LANG" ).setValue( languages[sm.ret].first );
-    get_options().save();
-}
-
-void set_language()
-{
-    std::string win_or_mac_lang;
-#if defined(_WIN32)
-    win_or_mac_lang = getLangFromLCID( GetUserDefaultLCID() );
-#endif
-#if defined(MACOSX)
-    win_or_mac_lang = getOSXSystemLang();
-#endif
-    // Step 1. Setup locale settings.
-    std::string lang_opt = get_option<std::string>( "USE_LANG" ).empty() ? win_or_mac_lang :
-                           get_option<std::string>( "USE_LANG" );
-    if( !lang_opt.empty() ) {
-        // Not 'System Language'
-        // Overwrite all system locale settings. Use CDDA settings. User wants this.
-#if defined(_WIN32)
-        std::string lang_env = "LANGUAGE=" + lang_opt;
-        if( _putenv( lang_env.c_str() ) != 0 ) {
-            DebugLog( D_WARNING, D_MAIN ) << "Can't set 'LANGUAGE' environment variable";
-        }
-#else
-        if( setenv( "LANGUAGE", lang_opt.c_str(), true ) != 0 ) {
-            DebugLog( D_WARNING, D_MAIN ) << "Can't set 'LANGUAGE' environment variable";
-        }
-#endif
-        else {
-            const auto env = getenv( "LANGUAGE" );
-            if( env != nullptr ) {
-                DebugLog( D_INFO, D_MAIN ) << "Language is set to: '" << env << '\'';
-            } else {
-                DebugLog( D_WARNING, D_MAIN ) << "Can't get 'LANGUAGE' environment variable";
-            }
-        }
-    }
-
-#if defined(_WIN32)
-    // Use the ANSI code page 1252 to work around some language output bugs.
-    if( setlocale( LC_ALL, ".1252" ) == nullptr ) {
-        DebugLog( D_WARNING, D_MAIN ) << "Error while setlocale(LC_ALL, '.1252').";
-    }
-    DebugLog( D_INFO, DC_ALL ) << "[translations] C locale set to " << setlocale( LC_ALL, nullptr );
-    DebugLog( D_INFO, DC_ALL ) << "[translations] C++ locale set to " << std::locale().name();
-#endif
-
-    // Step 2. Bind to gettext domain.
-    std::string locale_dir;
-#if defined(__ANDROID__)
-    // HACK: Since we're using libintl-lite instead of libintl on Android, we hack the locale_dir to point directly to the .mo file.
-    // This is because of our hacky libintl-lite bindtextdomain() implementation.
-    auto env = getenv( "LANGUAGE" );
-    locale_dir = std::string( PATH_INFO::base_path() + "lang/mo/" + ( env ? env : "none" ) +
-                              "/LC_MESSAGES/cataclysm-bn.mo" );
-#elif (defined(__linux__) || (defined(MACOSX) && !defined(TILES)))
-    if( !PATH_INFO::base_path().empty() ) {
-        locale_dir = PATH_INFO::base_path() + "share/locale";
-    } else {
-        locale_dir = "lang/mo";
-    }
-#else
-    locale_dir = "lang/mo";
-#endif
-
-    const char *locale_dir_char = locale_dir.c_str();
-    bindtextdomain( "cataclysm-bn", locale_dir_char );
-    bind_textdomain_codeset( "cataclysm-bn", "UTF-8" );
-    textdomain( "cataclysm-bn" );
-
-    reload_names();
-
-    sanity_checked_genders = false;
-
-    // increment version to invalidate translation cache
-    do {
-        current_language_version++;
-    } while( current_language_version == INVALID_LANGUAGE_VERSION );
-}
-
-#if defined(MACOSX)
-std::string getOSXSystemLang()
-{
-    // Get the user's language list (in order of preference)
-    CFArrayRef langs = CFLocaleCopyPreferredLanguages();
-    if( CFArrayGetCount( langs ) == 0 ) {
-        return "en_US";
-    }
-
-    CFStringRef lang = static_cast<CFStringRef>( CFArrayGetValueAtIndex( langs, 0 ) );
-    const char *lang_code_raw_fast = CFStringGetCStringPtr( lang, kCFStringEncodingUTF8 );
-    std::string lang_code;
-    if( lang_code_raw_fast ) { // fast way, probably it's never works
-        lang_code = lang_code_raw_fast;
-    } else { // fallback to slow way
-        CFIndex length = CFStringGetLength( lang ) + 1;
-        std::vector<char> lang_code_raw_slow( length, '\0' );
-        bool success = CFStringGetCString( lang, lang_code_raw_slow.data(), length, kCFStringEncodingUTF8 );
-        if( !success ) {
-            return "en_US";
-        }
-        lang_code = lang_code_raw_slow.data();
-    }
-
-    // Convert to the underscore format expected by gettext
-    std::replace( lang_code.begin(), lang_code.end(), '-', '_' );
-
-    /**
-     * Handle special case for simplified/traditional Chinese. Simplified/Traditional
-     * is actually denoted by the region code in older iterations of the
-     * language codes, whereas now (at least on OS X) region is distinct.
-     * That is, CDDA expects 'zh_CN' but OS X might give 'zh-Hans-CN'.
-     */
-    if( string_starts_with( lang_code, "zh_Hans" ) ) {
-        return "zh_CN";
-    } else if( string_starts_with( lang_code, "zh_Hant" ) ) {
-        return "zh_TW";
-    }
-
-    return isValidLanguage( lang_code ) ? lang_code : "en_US";
-}
-#endif
-
-#else // !LOCALIZE
-
-#include <cstring> // strcmp
-#include <map>
-
-bool isValidLanguage( const std::string &/*lang*/ )
-{
-    return true;
-}
-
-std::string getLangFromLCID( const int &/*lcid*/ )
-{
-    return "";
-}
-
-void select_language()
-{
-    return;
-}
-
-void set_language()
-{
-    reload_names();
-    return;
 }
 
 #endif // LOCALIZE
@@ -718,39 +471,4 @@ std::string operator+( const std::string &lhs, const translation &rhs )
 std::string operator+( const translation &lhs, const translation &rhs )
 {
     return lhs.translated() + rhs.translated();
-}
-
-bool localized_comparator::operator()( const std::string &l, const std::string &r ) const
-{
-    // We need different implementations on each platform.  MacOS seems to not
-    // support localized comparison of strings via the standard library at all,
-    // so resort to MacOS-specific solution.  Windows cannot be expected to be
-    // using a UTF-8 locale (whereas our strings are always UTF-8) and so we
-    // must convert to wstring for comparison there.  Linux seems to work as
-    // expected on regular strings; no workarounds needed.
-    // See https://github.com/CleverRaven/Cataclysm-DDA/pull/40041 for further
-    // discussion.
-#if defined(MACOSX)
-    CFStringRef lr = CFStringCreateWithCStringNoCopy( kCFAllocatorDefault, l.c_str(),
-                     kCFStringEncodingUTF8, kCFAllocatorNull );
-    CFStringRef rr = CFStringCreateWithCStringNoCopy( kCFAllocatorDefault, r.c_str(),
-                     kCFStringEncodingUTF8, kCFAllocatorNull );
-    bool result = CFStringCompare( lr, rr, kCFCompareLocalized ) < 0;
-    CFRelease( lr );
-    CFRelease( rr );
-    return result;
-#elif defined(_WIN32)
-    return ( *this )( utf8_to_wstr( l ), utf8_to_wstr( r ) );
-#else
-    return std::locale()( l, r );
-#endif
-}
-
-bool localized_comparator::operator()( const std::wstring &l, const std::wstring &r ) const
-{
-#if defined(MACOSX)
-    return ( *this )( wstr_to_utf8( l ), wstr_to_utf8( r ) );
-#else
-    return std::locale()( l, r );
-#endif
 }

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -664,14 +664,14 @@ bool translation::operator!=( const translation &that ) const
     return !operator==( that );
 }
 
-cata::optional<int> translation::legacy_hash() const
+std::pair<bool, int> translation::legacy_hash() const
 {
     if( needs_translation && !ctxt && !raw_pl ) {
-        return djb2_hash( reinterpret_cast<const unsigned char *>( raw.c_str() ) );
+        return {true, djb2_hash( reinterpret_cast<const unsigned char *>( raw.c_str() ) )};
     }
     // Otherwise the translation must have been added after snippets were changed
     // to use string ids only, so the translation doesn't have a legacy hash value.
-    return cata::nullopt;
+    return {false, 0};
 }
 
 translation to_translation( const std::string &raw )

--- a/src/translations.h
+++ b/src/translations.h
@@ -176,7 +176,7 @@ inline std::string _translate_internal( const std::string &msg )
 }
 } // namespace detail
 
-#define ngettext(STRING1, STRING2, COUNT) (COUNT < 2 ? _(STRING1) : _(STRING2))
+#define ngettext(STRING1, STRING2, COUNT) (COUNT == 1 ? _(STRING1) : _(STRING2))
 #define pgettext(STRING1, STRING2) _(STRING2)
 #define npgettext(STRING0, STRING1, STRING2, COUNT) ngettext(STRING1, STRING2, COUNT)
 

--- a/src/translations.h
+++ b/src/translations.h
@@ -19,6 +19,8 @@ namespace detail
 int get_current_language_version();
 } // namespace detail
 
+void invalidate_translations();
+
 #if !defined(translate_marker)
 /**
  * Marks a string literal to be extracted for translation. This is only for running `xgettext` via
@@ -195,11 +197,6 @@ using GenderMap = std::map<std::string, std::vector<std::string>>;
  * common).
  */
 std::string gettext_gendered( const GenderMap &genders, const std::string &msg );
-
-bool isValidLanguage( const std::string &lang );
-std::string getLangFromLCID( const int &lcid );
-void select_language();
-void set_language();
 
 class JsonIn;
 

--- a/src/translations.h
+++ b/src/translations.h
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "optional.h"
 #include "value_ptr.h"
 
 constexpr int INVALID_LANGUAGE_VERSION = 0;
@@ -301,7 +300,8 @@ class translation
         /**
          * Only used for migrating old snippet hashes into snippet ids.
          */
-        cata::optional<int> legacy_hash() const;
+        std::pair<bool, int> legacy_hash() const;
+
     private:
         translation( const std::string &ctxt, const std::string &raw );
         translation( const std::string &raw );

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -36,6 +36,7 @@
 #include "distribution_grid.h"
 #include "filesystem.h"
 #include "game.h"
+#include "language.h"
 #include "loading_ui.h"
 #include "map.h"
 #include "options.h"
@@ -109,6 +110,10 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
 
     if( !assure_dir_exist( PATH_INFO::templatedir() ) ) {
         assert( !"Unable to make templates directory.  Check permissions." );
+    }
+
+    if( !init_language_system() ) {
+        DebugLog( D_ERROR, DC_ALL ) << "Failed to init language system.";
     }
 
     get_options().init();

--- a/tests/translations_test.cpp
+++ b/tests/translations_test.cpp
@@ -1,5 +1,6 @@
 #include "catch/catch.hpp"
 
+#include "language.h"
 #include "translations.h"
 
 // wrapping in another macro to prevent collection of the test string for translation


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Cleaned up game language/locale handling"

#### Purpose of change
Problems with current game language handling code:
1. It's scattered across multiple files.
2. Everything is hardcoded.
3. It's nondeterministic. Starting the game with one language and switching to some other leads to different gettext/locale settings  when comparing to starting the game with that other language already selected.
4. It has a number of minor bugs.

#### Describe the solution
See commits. The biggest changes are:
1. Moving all language handling code into a separate `.h`/`.cpp` file.
2. Encapsulating language definitions.
3. Loading these definitions from JSON.
4. Rewriting gettext/locale code to re-set the state from scratch each time language is set (once on startup, then each time it's changed in settings).

#### Describe alternatives you've considered
1. Get rid of 'System language' and instead set game language to match detected system language.
    * This turned out impossible since I wanted to retain the ability for user to explicitly set the game to use system locale.
2. On Windows, set matching locale when selecting game language.
    * I'm probably doing something wrong, but I've tried 3 different ways and none of them work across all compilers / Windows versions (XP/7/10). The existing `.1252` turned out to be the best solution as it works in all situations (except Cygwin?).
3. Split `languages.json` into individual `language.json` files, with one language definiition per file, and possibly even auto-detect these files like we do with tilesets/soundpacks/mods.
   * I don't think it is a good idea. With BN's string amount and update frequency there's no way people will be able to make independent full game translations, so there's no need for such modularity. Also, it'll have to be worked into gettext's folder structure somehow.
4. Hide languages with missing `.mo` files.
    * That would be easy to implement, but I have vague plans (that I may or may not follow through with) to further change language/translation system, so maybe later.
5. Get rid of `gettext_gendered`. It's used literally for 1 dialogue line in the whole game: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/926f0b4dc10c7eb31c5a6891662ff1efaa307c73/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_broker.json#L116-L119 Moreover, the "grammatical gender list" that translators are supposed to define has not been defined for any language with grammatical genders. Exception is `zh_CN`, where it was defined incorrectly, and as such would give a debug message when that single dialogue line is about to be shown.
    * I would like to take a look at it later. Maybe add more usages, assign g.genders to all languages that need them. Worst case, it can always be removed.

#### Testing
MacOS High Sierra(English), Win 7 (Chinese/Russian), Win XP (English), Win 10 (Russian), Kubuntu 20.04 (English).
The game properly recognizes system UI language, and translations work.
If `languages.json` is missing/malformed, shows a debug message and falls back to English.

Remaining problems:
1. `TILES=0 LOCALIZE=0` build on Linux seems to be using `ncurses` instead of `ncursesw`, and I couldn't get it to work properly with Unicode characters (e.g. widely used in the game ellipsis). Maybe add a warning on startup / get rid of `LOCALIZE=0` build?
2. `TILES=0 LOCALIZE=1` build on Linux _really_ doesn't like it when system locale is "C". If the game starts with 'System language' and, correspondingly, system locale, Unicode chars wouldn't work at all. If 'System language' was selected through settings, Unicode chars would break until game restart. May be something with my setup.
3. On Windows with native Cygwin build, it seems to be impossible to set a locale, making it impossible to use localization, since gettext falls back to `en`. Maybe that's something with my Cygwin environment (it's pretty much stock), didn't spend too much time looking into it.