### PR TITLE
Add the option to place (construct) arc welders and connect them on a electrical grid

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4113,5 +4113,20 @@
     "pre_note": "Will only work if constructed in/on a building that has an electric grid.",
     "pre_special": "check_empty",
     "post_terrain": "f_cable_connector"
+  },
+  {
+    "type": "construction",
+	  "id": "constr_gridwelder",
+	  "description": "Place arc welder",
+	  "category": "OTHER",
+	  "required_skills": [ [ "fabrication", 0 ] ],
+	  "time": "1 m",
+	  "components": [
+      [ [ "welder", 1 ] ],
+      [ [ "jumper_cable", 1 ] ]
+    ],
+	  "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+	  "pre_special": "check_empty",
+	  "post_terrain": "f_gridwelder"
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -702,5 +702,36 @@
       "sound_fail": "clang!",
       "items": [ { "item": "power_supply", "prob": 50 } ]
     }
+  },
+    {
+    "type": "furniture",
+	  "id": "f_gridwelder",
+	  "name": "grid welder",
+	  "symbol": "#",
+	  "description": "A portable welder connected to a electrical grid.",
+	  "color": "red",
+	  "move_cost_mod": -1,
+	  "coverage": 10,
+	  "required_str": -1,
+	  "crafting_pseudo_item": "fake_gridwelder",
+	  "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
+	  "deconstruct": {
+	    "items": [
+	      { "item": "welder", "count": 1 },
+		    { "item": "jumper_cable", "count": 1 }
+	    ]
+	  },
+	  "bash": {
+	    "str_min": 4,
+	    "str_max": 30,
+	    "sound": "metal screeching!",
+	    "sound_fail": "clang!",
+	    "items": [
+	      { "item": "power_supply", "count": [ 1, 4 ] },
+		    { "item": "scrap", "count": [ 0, 2 ] },
+		    { "item": "cable", "charges": [ 1, 15 ] },
+		    { "item": "plastic_chunk", "count": [ 1, 2 ] }
+	    ]
+	  }
   }
 ]

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -177,5 +177,14 @@
     "sub": "hotplate",
     "max_charges": 1000,
     "flags": [ "USES_GRID_POWER" ]
+  },
+  {
+    "id": "fake_gridwelder",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "grid welder" },
+    "sub": "welder",
+    "max_charges": 1000,
+    "flags": [ "USES_GRID_POWER" ]
   }
 ]


### PR DESCRIPTION
#### Summary: [Content] "[Arc welders usually can be connected to electrical grids, so I added that feature]"

#### Purpose of change

The electric grid system recently added can be used already with numerous tools like arc welders so I feel like it should be a feature to be added.

#### Additional context

I will add more electrical tools like the soldering iron but I feel like it could be further refined, for example: Tilesets, I don't know if a tileset for a vehicle could work on a furniture. Besides this is my first ever pull request and I have barely any knowledge of programming, I know how to code items, furnitures, recipes through json files but that is about it.

Also, I need to add that I selected the jumper cable item in the recipe because there is no equivalent in C:DDA and C:BN for household commercial cable.