### PR TITLE
autodoc bionic removal regardless of success

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1904,6 +1904,7 @@ bool Character::uninstall_bionic( const bionic_id &b_id, player &installer, bool
 void Character::perform_uninstall( bionic_id bid, int difficulty, int success,
                                    const units::energy &power_lvl, int pl_skill )
 {
+remove_bionic( bid );
     if( success > 0 ) {
         g->events().send<event_type::removes_cbm>( getID(), bid );
 
@@ -1911,7 +1912,7 @@ void Character::perform_uninstall( bionic_id bid, int difficulty, int success,
         add_msg_player_or_npc( m_neutral, _( "Your parts are jiggled back into their familiar places." ),
                                _( "<npcname>'s parts are jiggled back into their familiar places." ) );
         add_msg( m_good, _( "Successfully removed %s." ), bid.obj().name );
-        remove_bionic( bid );
+
 
         // remove power bank provided by bionic
         mod_max_power_level( -power_lvl );


### PR DESCRIPTION
u still get butchered if the autodoc fucks up tho lol
considering adding debuff to player for failed autodoc or just for autodoc usage in general maybe?

#### Summary

SUMMARY: [Category] "Balance"

#### Purpose of change

Got frustrated when playing prototype cyborg. Autodoc feels way too punishing and random for the effort put into getting to it alive. I want to game babey!!

#### Describe the solution

Moves a pre-existing call out of an if statement

#### Describe alternatives you've considered

Potentially add a debuff of some sorts on failure or whenever the autodoc is used? Could also reimplement the mutation feature?

#### Testing

Spawned Autodoc and Autodoc couch as well as anesthetic. Got butchered as prototype cyborg while also removing a few of my cbms.

#### Additional context

This is my first time doing this sorta thing. Sorry if it comes out kinda fucky.