### PR TITLE
Enchantment/relic cleanup 1

### DIFF
--- a/data/json/artifact/premade_artifacts.json
+++ b/data/json/artifact/premade_artifacts.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "architect_cube",
+    "type": "TOOL",
+    "name": { "str": "The Architect's Cube" },
+    "description": "This is a solid cube that is much heavier than its size suggests.  When you look at it, it pulls your gaze inward until you fall through the sky, showing you a top-down view of your position with the surroundings revealed.",
+    "weight": "2 kg",
+    "volume": "100 ml",
+    "material": [ "iron" ],
+    "symbol": "]",
+    "color": "light_gray",
+    "flags": [ "TRADER_AVOID" ],
+    "relic_data": {
+      "passive_effects": [ { "has": "HELD", "condition": "ALWAYS", "ench_effects": [ { "effect": "debug_clairvoyance", "intensity": 1 } ] } ]
+    }
+  }
+]

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -1,6 +1,15 @@
-# How to add magic to a mod
+# Spells, enchantments and other custom effects
+- [Spells](#Spells)
+  * [Currently Implemented Effects and special rules](#Currently-Implemented-Effects-and-special-rules)
+  * [Spells that level up](#Spells-that-level-up)
+  * [Learning spells](#Learning-spells)
+  * [Spells in professions and NPC classes](#Spells-in-professions-and-NPC-classes)
+  * [Spells in monsters](#Spells-in-monsters)
+- [Enchantments](#Enchantments)
+  * [Fields](#Fields)
+  * [Examples](#Examples)
 
-### Spells
+# Spells
 
 In `data/mods/Magiclysm` there is a template spell, copied here for your perusal:
 
@@ -189,7 +198,7 @@ You can add a "spell" member to professions or an NPC class definition like so:
 NOTE: This makes it possible to learn spells that conflict with a class. It also does not give the prompt to gain the class. Be judicious upon adding this to a profession!
 
 
-#### Monsters
+#### Spells in monsters
 
 You can assign a spell as a special attack for a monster.
 ```json
@@ -199,62 +208,159 @@ You can assign a spell as a special attack for a monster.
 * spell_level: the level at which the spell is cast. Spells cast by monsters do not gain levels like player spells.
 * cooldown: how often the monster can cast this spell
 
-### Enchantments
-| Identifier                  | Description
-|---                          |---
-| id                          | Unique ID. Must be one continuous word, use underscores if necessary.
-| has                         | How an enchantment determines if it is in the right location in order to qualify for being active. "WIELD" - when wielded in your hand * "WORN" - when worn as armor * "HELD" - when in your inventory
-| condition                   | How an enchantment determines if you are in the right environments in order for the enchantment to qualify for being active. * "ALWAYS" - Always and forevermore * "UNDERGROUND" - When the owner of the item is below Z-level 0 * "UNDERWATER" - When the owner is in swimmable terrain * "ACTIVE" - whenever the item, mutation, bionic, or whatever the enchantment is attached to is active.
-| ench_effects                | Grants effects of specified "intensity" as long as this enchantment is applicable. Use intensity of 1 will work for effects that do not actually have intensities.
-| hit_you_effect              | A spell that activates when you melee_attack a creature.  The spell is centered on the location of the creature unless self = true, then it is centered on your location.  Follows the template for defining "fake_spell"
-| hit_me_effect               | A spell that activates when you are hit by a creature.  The spell is centered on your location.  Follows the template for defining "fake_spell"
-| intermittent_activation     | Spells that activate centered on you depending on the duration.  The spells follow the "fake_spell" template.
-| mutations                   | Which mutations are granted by this enchantment, mimicking their effects.
-| values                      | Anything that is a number that can be modified.  The id field is required, and "add" and "multiply" are optional.  A "multiply" value of -1 is -100% and a multiply of 2.5 is +250%.  Add is always before multiply. See allowed id below.
+# Enchantments
+Enchantments make it possible to specify custom effects provided by item, bionic or mutation.
 
+## Fields
+### id
+(string) Unique identifier for this enchantment.
 
+### has
+(string) How an enchantment determines if it is in the right location in order to qualify for being active.
 
+This field is relevant only for items.
+
+Values:
+* `HELD` (default) - when in your inventory
+* `WIELD` - when wielded in your hand
+* `WORN` - when worn as armor
+
+### condition
+(string) How an enchantment determines if you are in the right environments in order for the enchantment to qualify for being active.
+
+Values:
+* `ALWAYS` (default) - Always active
+* `UNDERGROUND` - When the owner of the item is below Z-level 0
+* `UNDERWATER` - When the owner is in swimmable terrain
+* `ACTIVE` - whenever the item, mutation, bionic, or whatever the enchantment is attached to is active.
+
+### emitter
+(string) Identifier of an emitter that's active as long as this enchantment is active. 
+Default: no emitter.
+
+### ench_effects
+(array) Grants effects of specified intensity as long as this enchantment is active.
+
+Syntax for single entry:
 ```C++
-  {
-    "type": "enchantment",
-    "id": "MEP_INK_GLAND_SPRAY",
-    "hit_me_effect": [
-      {
-        "id": "generic_blinding_spray_1",
-        "hit_self": false,
-        "once_in": 15,
-        "message": "Your ink glands spray some ink into %2$s's eyes.",
-        "npc_message": "%1$s's ink glands spay some ink into %2$s's eyes."
-      }
-    ]
-  },
-  {
-    "type": "enchantment",
-    "id": "ENCH_INVISIBILITY",
-    "condition": "ALWAYS",
-    "ench_effects": [ { "effect": "invisibility", "intensity": 1 } ]
-    "has": "WIELD",
-    "hit_you_effect": [ { "id": "AEA_FIREBALL" } ],
-    "hit_me_effect": [ { "id": "AEA_HEAL" } ],
-    "mutations": [ "KILLER", "PARKOUR" ],
-    "values": [ { "value": "STRENGTH", "multiply": 1.1, "add": -5 } ],
-    "intermittent_activation": {
-      "effects": [ 
+{
+  // (required) Identifier of the effect 
+  "effect": "effect_identifier",
+  
+  // (required) Intensity. Setting to 1 works for effects that do not actually have intensities.
+  "intensity": 2
+}
+```
+
+### hit_you_effect
+(array) List of spells that may be cast when enchantment is active and character melee attacks a creature.
+
+Syntax for single entry:
+```c++
+{
+  // (required) Identifier of the spell
+  "id": "spell_identifier",
+  
+  // If true, the spell is centered on the character's location.
+  // If false, the spell is centered on the attacking creature.
+  // Default: false
+  "hit_self": false,
+  
+  // Chance to trigger, one in X.
+  // Default: 1
+  "once_in": 1,
+  
+  // Message for when the spell is triggered for you.
+  // %1$s is your name, %2$s is creature's
+  // Default: no message 
+  "message": "You pierce %2$s with Magic Piercing!",
+  
+  // Message for when the spell in triggered for an NPC.
+  // %1$s is their name, %2$s is creature's
+  // Default: no message 
+  "npc_message": "%1$s pierces %2$s with Magic Piercing!",
+  
+  // TODO: broken?
+  "min_level": 1,
+  
+  // TODO: broken?
+  "max_level": 2,
+}
+```
+
+### hit_me_effect
+(array) List of spells that may be cast when enchantment is active and character gets melee attacked by a creature.
+
+Same syntax as for `hit_you_effect`.
+
+### mutations
+(array) List of mutations temporarily granted while enchantment is active.
+
+### intermittent_activation
+(object) Rules that specify random effects which occur while enchantment is active.
+
+Syntax:
+```c++
+{
+  // List of checks to run on every turn while enchantment is active.
+  "effects": [
+    {
+      // Average activation frequency.
+      // The exact chance to pass is "one in (X converted to turns)" per turn.
+      "frequency": "5 minutes",
+      
+      // List of spells to cast if the check passed.
+      "spell_effects": [
         {
-          "frequency": "1 hour",
-          "spell_effects": [
-            { "id": "AEA_ADRENALINE" }
-          ]
+          // (required) Identifier of the spell
+          "id": "nasty_random_effect",
+          
+          // TODO: broken?
+          "min_level": 1,
+          
+          // TODO: broken?
+          "max_level": 5,
+          
+          // TODO: other fields appear to be loaded, but unused
         }
       ]
     }
-  }
-
+  ]
+}
 ```
-	### Allowed id for values
-The allowed values are as follows:
 
-- Effects for the character that has the enchantment:
+### values
+(array) List of miscellaneous values to modify.
+
+Syntax for single entry:
+```c++
+{
+  // (required) Value ID to modify, refer to list below.
+  "value": "VALUE_ID_STRING"
+  
+  // Additive bonus. Optional, default is 0.
+  "add": 13.37,
+  
+  // Multiplicative bonus. Optional, default is 0.
+  "multiply": -0.3,
+}
+```
+
+Additive bonus is applied before multiplicative, like so:
+```c++
+bonus = add + base_value * multiply
+```
+
+Thus, a `multiply` value of -0.8 is -80%, and a `multiply` of 2.5 is +250%.
+
+#### IDs of modifiable values
+
+##### TODO
+
+TODO: docs for each
+
+TODO: some of these are broken/unimplemented
+
 * STRENGTH
 * DEXTERITY
 * PERCEPTION
@@ -296,7 +402,7 @@ The allowed values are as follows:
 * ARMOR_ACID
 * ARMOR_BIO
 
-- Effects for the item that has the enchantment:
+Effects for the item that has the enchantment:
 * ITEM_DAMAGE_BASH
 * ITEM_DAMAGE_CUT
 * ITEM_DAMAGE_STAB
@@ -320,3 +426,45 @@ The allowed values are as follows:
 * ITEM_COVERAGE
 * ITEM_ATTACK_SPEED
 * ITEM_WET_PROTECTION
+
+## Examples
+```json
+[
+  {
+    "//": "On-hit effect for ink glands mutation, implemented via enchantment.",
+    "type": "enchantment",
+    "id": "MEP_INK_GLAND_SPRAY",
+    "hit_me_effect": [
+      {
+        "id": "generic_blinding_spray_1",
+        "hit_self": false,
+        "once_in": 15,
+        "message": "Your ink glands spray some ink into %2$s's eyes.",
+        "npc_message": "%1$s's ink glands spay some ink into %2$s's eyes."
+      }
+    ]
+  },
+  {
+    "//": "This one would look good on a katana for an anime mod.",
+    "type": "enchantment",
+    "id": "ENCH_ULTIMATE_ASSKICK",
+    "has": "WIELD",
+    "condition": "ALWAYS",
+    "ench_effects": [ { "effect": "invisibility", "intensity": 1 } ],
+    "hit_you_effect": [ { "id": "AEA_FIREBALL" } ],
+    "hit_me_effect": [ { "id": "AEA_HEAL" } ],
+    "mutations": [ "KILLER", "PARKOUR" ],
+    "values": [ { "value": "STRENGTH", "multiply": 1.1, "add": -5 } ],
+    "intermittent_activation": {
+      "effects": [ 
+        {
+          "frequency": "1 hour",
+          "spell_effects": [
+            { "id": "AEA_ADRENALINE" }
+          ]
+        }
+      ]
+    }
+  }
+]
+```

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2264,18 +2264,18 @@ static bool magic_train( player_activity *act, player *p )
     }
     const spell_id &sp_id = spell_id( act->name );
     if( sp_id.is_valid() ) {
-        const bool knows = g->u.magic.knows_spell( sp_id );
+        const bool knows = g->u.magic->knows_spell( sp_id );
         if( knows ) {
-            spell &studying = p->magic.get_spell( sp_id );
+            spell &studying = p->magic->get_spell( sp_id );
             const int expert_multiplier = act->values.empty() ? 0 : act->values[0];
             const int xp = roll_remainder( studying.exp_modifier( *p ) * expert_multiplier );
             studying.gain_exp( xp );
             p->add_msg_if_player( m_good, _( "You learn a little about the spell: %s" ),
                                   sp_id->name );
         } else {
-            p->magic.learn_spell( act->name, *p );
+            p->magic->learn_spell( act->name, *p );
             // you can decline to learn this spell , as it may lock you out of other magic.
-            if( p->magic.knows_spell( sp_id ) ) {
+            if( p->magic->knows_spell( sp_id ) ) {
                 add_msg( m_good, _( "You learn %s." ), sp_id->name.translated() );
             } else {
                 act->set_to_null();
@@ -4662,7 +4662,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
 
     // if level is -1 then we know it's a player spell, otherwise we build it from the ground up
     spell temp_spell( sp );
-    spell &spell_being_cast = ( level_override == -1 ) ? p->magic.get_spell( sp ) : temp_spell;
+    spell &spell_being_cast = ( level_override == -1 ) ? p->magic->get_spell( sp ) : temp_spell;
 
     // if level != 1 then we need to set the spell's level
     if( level_override != -1 ) {
@@ -4737,7 +4737,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
         int cost = spell_being_cast.energy_cost( *p );
         switch( spell_being_cast.energy_source() ) {
             case mana_energy:
-                p->magic.mod_mana( *p, -cost );
+                p->magic->mod_mana( *p, -cost );
                 break;
             case stamina_energy:
                 p->mod_stamina( -cost );
@@ -4785,7 +4785,7 @@ void activity_handlers::study_spell_do_turn( player_activity *act, player *p )
         return;
     }
     if( act->get_str_value( 1 ) == "study" ) {
-        spell &studying = p->magic.get_spell( spell_id( act->name ) );
+        spell &studying = p->magic->get_spell( spell_id( act->name ) );
         if( act->get_str_value( 0 ) == "gain_level" ) {
             if( studying.get_level() < act->get_value( 1 ) ) {
                 act->moves_left = 1000000;
@@ -4807,10 +4807,10 @@ void activity_handlers::study_spell_finish( player_activity *act, player *p )
     if( act->get_str_value( 1 ) == "study" ) {
         p->add_msg_if_player( m_good, _( "You gained %i experience from your study session." ),
                               total_exp_gained );
-        const spell &sp = p->magic.get_spell( spell_id( act->name ) );
+        const spell &sp = p->magic->get_spell( spell_id( act->name ) );
         p->practice( sp.skill(), total_exp_gained, sp.get_difficulty() );
     } else if( act->get_str_value( 1 ) == "learn" && act->values[2] == 0 ) {
-        p->magic.learn_spell( act->name, *p );
+        p->magic->learn_spell( act->name, *p );
     }
     if( act->values[2] == -1 ) {
         p->add_msg_if_player( m_bad, _( "It's too dark to read." ) );

--- a/src/artifact.cpp
+++ b/src/artifact.cpp
@@ -1047,35 +1047,6 @@ std::string new_natural_artifact( artifact_natural_property prop )
     return def.get_id();
 }
 
-// Make a special debugging artifact.
-std::string architects_cube()
-{
-    it_artifact_tool def;
-
-    const artifact_tool_form_datum &info = artifact_tool_form_data[ARTTOOLFORM_CUBE];
-    def.create_name( _( info.name ) );
-    def.color = info.color;
-    def.sym = std::string( 1, info.sym );
-    def.materials.push_back( info.material );
-    def.volume = rng( info.volume_min, info.volume_max );
-    def.weight = rng( info.weight_min, info.weight_max );
-    // Set up the basic weapon type
-    const artifact_weapon_datum &weapon = artifact_weapon_data[info.base_weapon];
-    def.melee[DT_BASH] = rng( weapon.bash_min, weapon.bash_max );
-    def.melee[DT_CUT] = rng( weapon.cut_min, weapon.cut_max );
-    def.m_to_hit = rng( weapon.to_hit_min, weapon.to_hit_max );
-    if( !weapon.tag.empty() ) {
-        def.item_tags.insert( weapon.tag );
-    }
-    // Add an extra weapon perhaps?
-    // Most artifact descriptions are generated and stored using `no_translation`,
-    // also do it here for consistency
-    def.description = no_translation( _( "The architect's cube." ) );
-    def.artifact->effects_carried.push_back( AEP_SUPER_CLAIRVOYANCE );
-    item_controller->add_item_type( static_cast<itype &>( def ) );
-    return def.get_id();
-}
-
 std::vector<art_effect_passive> fill_good_passive()
 {
     std::vector<art_effect_passive> ret;

--- a/src/artifact.h
+++ b/src/artifact.h
@@ -124,7 +124,6 @@ class it_artifact_armor : public itype
 
 std::string new_artifact();
 std::string new_natural_artifact( artifact_natural_property prop );
-std::string architects_cube();
 
 // note: needs to be called by main() before MAPBUFFER.load
 void load_artifacts( const std::string &path );

--- a/src/artifact.h
+++ b/src/artifact.h
@@ -6,6 +6,7 @@
 
 #include "enums.h"
 #include "itype.h"
+#include "relic.h"
 
 class JsonObject;
 class JsonOut;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7634,7 +7634,7 @@ void Character::recalculate_enchantment_cache()
     }
 }
 
-double Character::calculate_by_enchantment( double modify, enchantment::mod value,
+double Character::calculate_by_enchantment( double modify, enchant_vals::mod value,
         bool round_output ) const
 {
     modify += enchantment_cache.get_value_add( value );
@@ -7682,28 +7682,28 @@ static void item_armor_enchantment_adjust( Character &guy, damage_unit &du, item
 {
     switch( du.type ) {
         case DT_ACID:
-            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchantment::mod::ITEM_ARMOR_ACID );
+            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchant_vals::mod::ITEM_ARMOR_ACID );
             break;
         case DT_BASH:
-            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchantment::mod::ITEM_ARMOR_BASH );
+            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchant_vals::mod::ITEM_ARMOR_BASH );
             break;
         case DT_BIOLOGICAL:
-            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchantment::mod::ITEM_ARMOR_BIO );
+            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchant_vals::mod::ITEM_ARMOR_BIO );
             break;
         case DT_COLD:
-            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchantment::mod::ITEM_ARMOR_COLD );
+            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchant_vals::mod::ITEM_ARMOR_COLD );
             break;
         case DT_CUT:
-            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchantment::mod::ITEM_ARMOR_CUT );
+            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchant_vals::mod::ITEM_ARMOR_CUT );
             break;
         case DT_ELECTRIC:
-            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchantment::mod::ITEM_ARMOR_ELEC );
+            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchant_vals::mod::ITEM_ARMOR_ELEC );
             break;
         case DT_HEAT:
-            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchantment::mod::ITEM_ARMOR_HEAT );
+            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchant_vals::mod::ITEM_ARMOR_HEAT );
             break;
         case DT_STAB:
-            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchantment::mod::ITEM_ARMOR_STAB );
+            du.amount = armor.calculate_by_enchantment( guy, du.amount, enchant_vals::mod::ITEM_ARMOR_STAB );
             break;
         default:
             return;
@@ -7717,28 +7717,28 @@ static void armor_enchantment_adjust( Character &guy, damage_unit &du )
 {
     switch( du.type ) {
         case DT_ACID:
-            du.amount = guy.calculate_by_enchantment( du.amount, enchantment::mod::ARMOR_ACID );
+            du.amount = guy.calculate_by_enchantment( du.amount, enchant_vals::mod::ARMOR_ACID );
             break;
         case DT_BASH:
-            du.amount = guy.calculate_by_enchantment( du.amount, enchantment::mod::ARMOR_BASH );
+            du.amount = guy.calculate_by_enchantment( du.amount, enchant_vals::mod::ARMOR_BASH );
             break;
         case DT_BIOLOGICAL:
-            du.amount = guy.calculate_by_enchantment( du.amount, enchantment::mod::ARMOR_BIO );
+            du.amount = guy.calculate_by_enchantment( du.amount, enchant_vals::mod::ARMOR_BIO );
             break;
         case DT_COLD:
-            du.amount = guy.calculate_by_enchantment( du.amount, enchantment::mod::ARMOR_COLD );
+            du.amount = guy.calculate_by_enchantment( du.amount, enchant_vals::mod::ARMOR_COLD );
             break;
         case DT_CUT:
-            du.amount = guy.calculate_by_enchantment( du.amount, enchantment::mod::ARMOR_CUT );
+            du.amount = guy.calculate_by_enchantment( du.amount, enchant_vals::mod::ARMOR_CUT );
             break;
         case DT_ELECTRIC:
-            du.amount = guy.calculate_by_enchantment( du.amount, enchantment::mod::ARMOR_ELEC );
+            du.amount = guy.calculate_by_enchantment( du.amount, enchant_vals::mod::ARMOR_ELEC );
             break;
         case DT_HEAT:
-            du.amount = guy.calculate_by_enchantment( du.amount, enchantment::mod::ARMOR_HEAT );
+            du.amount = guy.calculate_by_enchantment( du.amount, enchant_vals::mod::ARMOR_HEAT );
             break;
         case DT_STAB:
-            du.amount = guy.calculate_by_enchantment( du.amount, enchantment::mod::ARMOR_STAB );
+            du.amount = guy.calculate_by_enchantment( du.amount, enchant_vals::mod::ARMOR_STAB );
             break;
         default:
             return;
@@ -9668,7 +9668,7 @@ int Character::run_cost( int base_cost, bool diag ) const
             movecost += 10 * footwear_factor();
         }
 
-        movecost = calculate_by_enchantment( movecost, enchantment::mod::MOVE_COST );
+        movecost = calculate_by_enchantment( movecost, enchant_vals::mod::MOVE_COST );
         movecost /= stamina_move_cost_modifier();
     }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -42,6 +42,7 @@
 #include "iuse_actor.h"
 #include "lightmap.h"
 #include "line.h"
+#include "magic_enchantment.h"
 #include "map.h"
 #include "map_iterator.h"
 #include "map_selector.h"
@@ -7599,12 +7600,12 @@ std::string Character::get_highest_category() const
 void Character::recalculate_enchantment_cache()
 {
     // start by resetting the cache
-    enchantment_cache = enchantment();
+    *enchantment_cache = enchantment();
 
     visit_items( [&]( const item * it ) {
         for( const enchantment &ench : it->get_enchantments() ) {
             if( ench.is_active( *this, *it ) ) {
-                enchantment_cache.force_add( ench );
+                enchantment_cache->force_add( ench );
             }
         }
         return VisitResponse::NEXT;
@@ -7617,7 +7618,7 @@ void Character::recalculate_enchantment_cache()
         for( const enchantment_id &ench_id : mut.enchantments ) {
             const enchantment &ench = ench_id.obj();
             if( ench.is_active( *this, mut.activated && mut_map.second.powered ) ) {
-                enchantment_cache.force_add( ench );
+                enchantment_cache->force_add( ench );
             }
         }
     }
@@ -7628,7 +7629,7 @@ void Character::recalculate_enchantment_cache()
         for( const enchantment_id &ench_id : bid->enchantments ) {
             const enchantment &ench = ench_id.obj();
             if( ench.is_active( *this, bio.powered && bid->toggled ) ) {
-                enchantment_cache.force_add( ench );
+                enchantment_cache->force_add( ench );
             }
         }
     }
@@ -7637,8 +7638,8 @@ void Character::recalculate_enchantment_cache()
 double Character::calculate_by_enchantment( double modify, enchant_vals::mod value,
         bool round_output ) const
 {
-    modify += enchantment_cache.get_value_add( value );
-    modify *= 1.0 + enchantment_cache.get_value_multiply( value );
+    modify += enchantment_cache->get_value_add( value );
+    modify *= 1.0 + enchantment_cache->get_value_multiply( value );
     if( round_output ) {
         modify = std::round( modify );
     }
@@ -7943,13 +7944,13 @@ int Character::get_armor_fire( body_part bp ) const
 
 void Character::did_hit( Creature &target )
 {
-    enchantment_cache.cast_hit_you( *this, target );
+    enchantment_cache->cast_hit_you( *this, target );
 }
 
 void Character::on_hit( Creature *source, bodypart_id /*bp_hit*/,
                         float /*difficulty*/, dealt_projectile_attack const *const /*proj*/ )
 {
-    enchantment_cache.cast_hit_me( *this, source );
+    enchantment_cache->cast_hit_me( *this, source );
 }
 
 /*

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4484,7 +4484,7 @@ void Character::update_body( const time_point &from, const time_point &to )
     update_stomach( from, to );
     recalculate_enchantment_cache();
     if( ticks_between( from, to, 3_minutes ) > 0 ) {
-        magic.update_mana( *this->as_player(), to_turns<float>( 3_minutes ) );
+        magic->update_mana( *this->as_player(), to_turns<float>( 3_minutes ) );
     }
     const int five_mins = ticks_between( from, to, 5_minutes );
     if( five_mins > 0 ) {
@@ -9422,7 +9422,7 @@ void Character::on_effect_int_change( const efftype_id &eid, int intensity, body
 void Character::on_mutation_gain( const trait_id &mid )
 {
     morale->on_mutation_gain( mid );
-    magic.on_mutation_gain( mid, *this );
+    magic->on_mutation_gain( mid, *this );
     update_type_of_scent( mid );
     recalculate_enchantment_cache(); // mutations can have enchantments
 }
@@ -9430,7 +9430,7 @@ void Character::on_mutation_gain( const trait_id &mid )
 void Character::on_mutation_loss( const trait_id &mid )
 {
     morale->on_mutation_loss( mid );
-    magic.on_mutation_loss( mid );
+    magic->on_mutation_loss( mid );
     update_type_of_scent( mid, false );
     recalculate_enchantment_cache(); // mutations can have enchantments
 }

--- a/src/character.h
+++ b/src/character.h
@@ -929,7 +929,7 @@ class Character : public Creature, public visitable<Character>
         // recalculates enchantment cache by iterating through all held, worn, and wielded items
         void recalculate_enchantment_cache();
         // gets add and mult value from enchantment cache
-        double calculate_by_enchantment( double modify, enchantment::mod value,
+        double calculate_by_enchantment( double modify, enchant_vals::mod value,
                                          bool round_output = false ) const;
 
         /** Returns true if the player has any martial arts buffs attached */

--- a/src/character.h
+++ b/src/character.h
@@ -36,7 +36,6 @@
 #include "inventory.h"
 #include "item.h"
 #include "item_location.h"
-#include "magic.h"
 #include "memory_fast.h"
 #include "monster.h"
 #include "mtype.h"
@@ -61,6 +60,7 @@ class SkillLevelMap;
 class bionic_collection;
 class faction;
 class ma_technique;
+class known_magic;
 class player;
 class player_morale;
 class vehicle;
@@ -1502,7 +1502,7 @@ class Character : public Creature, public visitable<Character>
             }
         }
         // magic mod
-        known_magic magic;
+        pimpl<known_magic> magic;
 
         void make_bleed( body_part bp, time_duration duration, int intensity = 1,
                          bool permanent = false,

--- a/src/character.h
+++ b/src/character.h
@@ -37,7 +37,6 @@
 #include "item.h"
 #include "item_location.h"
 #include "magic.h"
-#include "magic_enchantment.h"
 #include "memory_fast.h"
 #include "monster.h"
 #include "mtype.h"
@@ -2256,7 +2255,7 @@ class Character : public Creature, public visitable<Character>
 
         // a cache of all active enchantment values.
         // is recalculated every turn in Character::recalculate_enchantment_cache
-        enchantment enchantment_cache;
+        pimpl<enchantment> enchantment_cache;
         player_activity destination_activity;
         // A unique ID number, assigned by the game class. Values should never be reused.
         character_id id;

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1422,7 +1422,7 @@ void debug()
             break;
 
         case DEBUG_SPAWN_CLAIRVOYANCE:
-            u.i_add( item( architects_cube(), calendar::turn ) );
+            u.i_add( item( "architect_cube", calendar::turn ) );
             break;
 
         case DEBUG_MAP_EDITOR:

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1806,7 +1806,7 @@ void debug()
         }
         case DEBUG_PRINT_NPC_MAGIC: {
             for( npc &guy : g->all_npcs() ) {
-                const std::vector<spell_id> spells = guy.magic.spells();
+                const std::vector<spell_id> spells = guy.magic->spells();
                 if( spells.empty() ) {
                     std::cout << guy.disp_name() << " does not know any spells." << std::endl;
                     continue;
@@ -1888,14 +1888,14 @@ void debug()
                 add_msg( m_bad, _( "There are no spells to learn.  You must install a mod that adds some." ) );
             } else {
                 for( const spell_type &learn : spell_type::get_all() ) {
-                    g->u.magic.learn_spell( &learn, g->u, true );
+                    g->u.magic->learn_spell( &learn, g->u, true );
                 }
                 add_msg( m_good,
                          _( "You have become an Archwizardpriest!  What will you do with your newfound power?" ) );
             }
             break;
         case DEBUG_LEVEL_SPELLS: {
-            std::vector<spell *> spells = g->u.magic.get_spells();
+            std::vector<spell *> spells = g->u.magic->get_spells();
             if( spells.empty() ) {
                 add_msg( m_bad, _( "Try learning some spells first." ) );
                 return;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1353,7 +1353,7 @@ static void cast_spell()
 {
     player &u = g->u;
 
-    std::vector<spell_id> spells = u.magic.spells();
+    std::vector<spell_id> spells = u.magic->spells();
 
     if( spells.empty() ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
@@ -1363,7 +1363,7 @@ static void cast_spell()
 
     bool can_cast_spells = false;
     for( spell_id sp : spells ) {
-        spell temp_spell = u.magic.get_spell( sp );
+        spell temp_spell = u.magic->get_spell( sp );
         if( temp_spell.can_cast( u ) ) {
             can_cast_spells = true;
         }
@@ -1374,12 +1374,12 @@ static void cast_spell()
                  _( "You can't cast any of the spells you know!" ) );
     }
 
-    const int spell_index = u.magic.select_spell( u );
+    const int spell_index = u.magic->select_spell( u );
     if( spell_index < 0 ) {
         return;
     }
 
-    spell &sp = *u.magic.get_spells()[spell_index];
+    spell &sp = *u.magic->get_spells()[spell_index];
 
     if( u.is_armed() && !sp.has_flag( spell_flag::NO_HANDS ) &&
         !u.weapon.has_flag( flag_MAGIC_FOCUS ) ) {
@@ -1388,7 +1388,7 @@ static void cast_spell()
         return;
     }
 
-    if( !u.magic.has_enough_energy( u, sp ) ) {
+    if( !u.magic->has_enough_energy( u, sp ) ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
                  _( "You don't have enough %s to cast the spell." ),
                  sp.energy_string() );
@@ -1409,7 +1409,7 @@ static void cast_spell()
     // [2] this value overrides the mana cost if set to 0
     cast_spell.values.emplace_back( 1 );
     cast_spell.name = sp.id().c_str();
-    if( u.magic.casting_ignore ) {
+    if( u.magic->casting_ignore ) {
         const std::vector<distraction_type> ignored_distractions = {
             distraction_type::noise,
             distraction_type::pain,

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -13,6 +13,7 @@
 #include "distribution_grid.h"
 #include "game.h"
 #include "iexamine.h"
+#include "magic_enchantment.h"
 #include "map.h"
 #include "map_iterator.h"
 #include "mapdata.h"

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -18,7 +18,6 @@
 #include "cata_utility.h"
 #include "item.h"
 #include "item_stack.h"
-#include "magic_enchantment.h"
 #include "units.h"
 #include "visitable.h"
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4817,7 +4817,7 @@ int item::lift_strength() const
 int item::attack_time() const
 {
     int ret = 65 + ( volume() / 62.5_ml + weight() / 60_gram ) / count();
-    ret = calculate_by_enchantment_wield( ret, enchantment::mod::ITEM_ATTACK_SPEED,
+    ret = calculate_by_enchantment_wield( ret, enchant_vals::mod::ITEM_ATTACK_SPEED,
                                           true );
     return ret;
 }
@@ -6496,7 +6496,7 @@ std::vector<enchantment> item::get_enchantments() const
 }
 
 double item::calculate_by_enchantment( const Character &owner, double modify,
-                                       enchantment::mod value, bool round_value ) const
+                                       enchant_vals::mod value, bool round_value ) const
 {
     double add_value = 0.0;
     double mult_value = 1.0;
@@ -6514,7 +6514,7 @@ double item::calculate_by_enchantment( const Character &owner, double modify,
     return modify;
 }
 
-double item::calculate_by_enchantment_wield( double modify, enchantment::mod value,
+double item::calculate_by_enchantment_wield( double modify, enchant_vals::mod value,
         bool round_value ) const
 {
     double add_value = 0.0;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -843,6 +843,9 @@ bool item::stacks_with( const item &rhs, bool check_components ) const
     if( type != rhs.type ) {
         return false;
     }
+    if( is_relic() && rhs.is_relic() && !( *relic_data == *rhs.relic_data ) ) {
+        return false;
+    }
     if( charges != 0 && rhs.charges != 0 && is_money() ) {
         // Dealing with nonempty cash cards
         return true;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3858,10 +3858,10 @@ nc_color item::color_in_inventory() const
             static_cast<const learn_spell_actor *>( iuse->get_actor_ptr() );
         for( const std::string &spell_id_str : actor_ptr->spells ) {
             const spell_id sp_id( spell_id_str );
-            if( u.magic.knows_spell( sp_id ) && !u.magic.get_spell( sp_id ).is_max_level() ) {
+            if( u.magic->knows_spell( sp_id ) && !u.magic->get_spell( sp_id ).is_max_level() ) {
                 ret = c_yellow;
             }
-            if( !u.magic.knows_spell( sp_id ) && u.magic.can_learn_spell( u, sp_id ) ) {
+            if( !u.magic->knows_spell( sp_id ) && u.magic->can_learn_spell( u, sp_id ) ) {
                 return c_light_blue;
             }
         }

--- a/src/item.h
+++ b/src/item.h
@@ -22,7 +22,6 @@
 #include "io_tags.h"
 #include "item_contents.h"
 #include "item_location.h"
-#include "magic_enchantment.h"
 #include "optional.h"
 #include "requirements.h"
 #include "safe_reference.h"
@@ -53,6 +52,11 @@ struct mtype;
 struct tripoint;
 template<typename T>
 class ret_val;
+
+namespace enchant_vals
+{
+enum class mod : int;
+} // namespace enchant_vals
 
 using bodytype_id = std::string;
 using faction_id = string_id<faction>;
@@ -2048,10 +2052,10 @@ class item : public visitable<item>
         const std::vector<comp_selection<tool_comp>> &get_cached_tool_selections() const;
 
         std::vector<enchantment> get_enchantments() const;
-        double calculate_by_enchantment( const Character &owner, double modify, enchantment::mod value,
+        double calculate_by_enchantment( const Character &owner, double modify, enchant_vals::mod value,
                                          bool round_value = false ) const;
         // calculates the enchantment value as if this item were wielded.
-        double calculate_by_enchantment_wield( double modify, enchantment::mod value,
+        double calculate_by_enchantment_wield( double modify, enchant_vals::mod value,
                                                bool round_value = false ) const;
 
     private:

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -8,6 +8,7 @@
 #include "player.h"
 #include "ret_val.h"
 #include "translations.h"
+#include "relic.h"
 #include "skill.h"
 
 struct tripoint;
@@ -35,6 +36,13 @@ std::string enum_to_string<condition_type>( condition_type data )
     abort();
 }
 } // namespace io
+
+itype::itype()
+{
+    melee.fill( 0 );
+}
+
+itype::~itype() = default;
 
 std::string itype::nname( unsigned int quantity ) const
 {

--- a/src/itype.h
+++ b/src/itype.h
@@ -22,7 +22,6 @@
 #include "json.h"
 #include "optional.h"
 #include "pldata.h" // add_type
-#include "relic.h"
 #include "stomach.h"
 #include "translations.h"
 #include "type_id.h"
@@ -32,6 +31,7 @@
 class Item_factory;
 class item;
 class player;
+class relic;
 struct tripoint;
 template <typename E> struct enum_traits;
 
@@ -868,9 +868,8 @@ struct itype {
         translation name = no_translation( "none" );
 
     public:
-        itype() {
-            melee.fill( 0 );
-        }
+        itype();
+        virtual ~itype();
 
         int damage_min() const {
             return count_by_charges() ? 0 : damage_min_;
@@ -1103,8 +1102,6 @@ struct itype {
         int invoke( player &p, item &it, const tripoint &pos ) const; // Picks first method or returns 0
         int invoke( player &p, item &it, const tripoint &pos, const std::string &iuse_name ) const;
         int tick( player &p, item &it, const tripoint &pos ) const;
-
-        virtual ~itype() = default;
 };
 
 #endif // CATA_SRC_ITYPE_H

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2388,8 +2388,8 @@ int learn_spell_actor::use( player &p, item &, bool, const tripoint & ) const
         const spell_id sp_id( sp_id_str );
         sp_cb.add_spell( sp_id );
         uilist_entry entry( sp_id.obj().name.translated() );
-        if( p.magic.knows_spell( sp_id ) ) {
-            const spell sp = p.magic.get_spell( sp_id );
+        if( p.magic->knows_spell( sp_id ) ) {
+            const spell sp = p.magic->get_spell( sp_id );
             entry.ctxt = string_format( _( "Level %u" ), sp.get_level() );
             if( sp.is_max_level() ) {
                 entry.ctxt += _( " (Max)" );
@@ -2398,7 +2398,7 @@ int learn_spell_actor::use( player &p, item &, bool, const tripoint & ) const
                 know_it_all = false;
             }
         } else {
-            if( p.magic.can_learn_spell( p, sp_id ) ) {
+            if( p.magic->can_learn_spell( p, sp_id ) ) {
                 entry.ctxt = _( "Study to Learn" );
                 know_it_all = false;
             } else {
@@ -2425,9 +2425,9 @@ int learn_spell_actor::use( player &p, item &, bool, const tripoint & ) const
     if( action < 0 ) {
         return 0;
     }
-    const bool knows_spell = p.magic.knows_spell( spells[action] );
+    const bool knows_spell = p.magic->knows_spell( spells[action] );
     player_activity study_spell( ACT_STUDY_SPELL,
-                                 p.magic.time_to_learn_spell( p, spells[action] ) );
+                                 p.magic->time_to_learn_spell( p, spells[action] ) );
     study_spell.str_values = {
         "", // reserved for "until you gain a spell level" option [0]
         "learn"
@@ -2452,7 +2452,7 @@ int learn_spell_actor::use( player &p, item &, bool, const tripoint & ) const
     if( study_spell.moves_total == 10100 ) {
         study_spell.str_values[0] = "gain_level";
         study_spell.values[0] = 0; // reserved for xp
-        study_spell.values[1] = p.magic.get_spell( spell_id( spells[action] ) ).get_level() + 1;
+        study_spell.values[1] = p.magic->get_spell( spell_id( spells[action] ) ).get_level() + 1;
     }
     study_spell.name = spells[action];
     p.assign_activity( study_spell, false );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1412,7 +1412,7 @@ int known_magic::max_mana( const Character &guy ) const
     const float unaugmented_mana = std::max( 0.0f,
                                    ( ( mana_base + int_bonus ) * guy.mutation_value( "mana_multiplier" ) ) +
                                    guy.mutation_value( "mana_modifier" ) - units::to_kilojoule( guy.get_power_level() ) );
-    return guy.calculate_by_enchantment( unaugmented_mana, enchantment::mod::MAX_MANA, true );
+    return guy.calculate_by_enchantment( unaugmented_mana, enchant_vals::mod::MAX_MANA, true );
 }
 
 void known_magic::update_mana( const Character &guy, float turns )
@@ -1421,7 +1421,7 @@ void known_magic::update_mana( const Character &guy, float turns )
     const float full_replenish = to_turns<float>( 8_hours );
     const float ratio = turns / full_replenish;
     mod_mana( guy, std::floor( ratio * guy.calculate_by_enchantment( max_mana( guy ) *
-                               guy.mutation_value( "mana_regen_multiplier" ), enchantment::mod::REGEN_MANA ) ) );
+                               guy.mutation_value( "mana_regen_multiplier" ), enchant_vals::mod::REGEN_MANA ) ) );
 }
 
 std::vector<spell_id> known_magic::spells() const

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2050,6 +2050,17 @@ spell fake_spell::get_spell( int min_level_override ) const
     return sp;
 }
 
+bool fake_spell::operator==( const fake_spell &rhs )const
+{
+    return id == rhs.id &&
+           max_level == rhs.max_level &&
+           level == rhs.level &&
+           self == rhs.self &&
+           trigger_once_in == rhs.trigger_once_in &&
+           trigger_message == rhs.trigger_message &&
+           npc_trigger_message == rhs.npc_trigger_message;
+}
+
 void spell_events::notify( const cata::event &e )
 {
     switch( e.type() ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -655,7 +655,7 @@ bool spell::can_cast( const Character &guy ) const
 {
     switch( type->energy_source ) {
         case mana_energy:
-            return guy.magic.available_mana() >= energy_cost( guy );
+            return guy.magic->available_mana() >= energy_cost( guy );
         case stamina_energy:
             return guy.get_stamina() >= energy_cost( guy );
         case hp_energy: {
@@ -850,7 +850,7 @@ std::string spell::energy_cur_string( const Character &guy ) const
         return colorize( to_string( units::to_kilojoule( guy.get_power_level() ) ), c_light_blue );
     }
     if( energy_source() == mana_energy ) {
-        return colorize( to_string( guy.magic.available_mana() ), c_light_blue );
+        return colorize( to_string( guy.magic->available_mana() ), c_light_blue );
     }
     if( energy_source() == stamina_energy ) {
         auto pair = get_hp_bar( guy.get_stamina(), guy.get_stamina_max() );
@@ -1302,7 +1302,7 @@ void known_magic::learn_spell( const spell_type *sp, Character &guy, bool force 
         debugmsg( "Tried to learn invalid spell" );
         return;
     }
-    if( guy.magic.knows_spell( sp->id ) ) {
+    if( guy.magic->knows_spell( sp->id ) ) {
         // you already know the spell
         return;
     }
@@ -1504,7 +1504,7 @@ class spellcasting_callback : public uilist_callback
                 int invlet = 0;
                 invlet = popup_getkey( _( "Choose a new hotkey for this spell." ) );
                 if( inv_chars.valid( invlet ) ) {
-                    const bool invlet_set = g->u.magic.set_invlet( known_spells[entnum]->id(), invlet,
+                    const bool invlet_set = g->u.magic->set_invlet( known_spells[entnum]->id(), invlet,
                                             reserved_invlets );
                     if( !invlet_set ) {
                         popup( _( "Hotkey already used." ) );
@@ -1514,7 +1514,7 @@ class spellcasting_callback : public uilist_callback
                     }
                 } else {
                     popup( _( "Hotkey removed." ) );
-                    g->u.magic.rem_invlet( known_spells[entnum]->id() );
+                    g->u.magic->rem_invlet( known_spells[entnum]->id() );
                 }
                 return true;
             }
@@ -2062,7 +2062,7 @@ void spell_events::notify( const cata::event &e )
                 std::string learn_spell_id = it->first;
                 int learn_at_level = it->second;
                 if( learn_at_level == slvl ) {
-                    g->u.magic.learn_spell( learn_spell_id, g->u );
+                    g->u.magic->learn_spell( learn_spell_id, g->u );
                     spell_type spell_learned = spell_factory.obj( spell_id( learn_spell_id ) );
                     add_msg(
                         _( "Your experience and knowledge in creating and manipulating magical energies to cast %s have opened your eyes to new possibilities, you can now cast %s." ),

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2050,7 +2050,7 @@ spell fake_spell::get_spell( int min_level_override ) const
     return sp;
 }
 
-bool fake_spell::operator==( const fake_spell &rhs )const
+bool fake_spell::operator==( const fake_spell &rhs ) const
 {
     return id == rhs.id &&
            max_level == rhs.max_level &&

--- a/src/magic.h
+++ b/src/magic.h
@@ -115,6 +115,8 @@ struct fake_spell {
     // gets the spell with an additional override for minimum level (default 0)
     spell get_spell( int min_level_override = 0 ) const;
 
+    bool operator==( const fake_spell &rhs )const;
+
     void load( const JsonObject &jo );
     void serialize( JsonOut &json ) const;
     void deserialize( JsonIn &jsin );

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -32,8 +32,8 @@ struct enum_traits<enchantment::condition> {
 };
 
 template<>
-struct enum_traits<enchantment::mod> {
-    static constexpr enchantment::mod last = enchantment::mod::NUM_MOD;
+struct enum_traits<enchant_vals::mod> {
+    static constexpr enchant_vals::mod last = enchant_vals::mod::NUM_MOD;
 };
 
 namespace io
@@ -67,75 +67,75 @@ namespace io
     }
 
     template<>
-    std::string enum_to_string<enchantment::mod>( enchantment::mod data )
+    std::string enum_to_string<enchant_vals::mod>( enchant_vals::mod data )
     {
         switch ( data ) {
-            case enchantment::mod::STRENGTH: return "STRENGTH";
-            case enchantment::mod::DEXTERITY: return "DEXTERITY";
-            case enchantment::mod::PERCEPTION: return "PERCEPTION";
-            case enchantment::mod::INTELLIGENCE: return "INTELLIGENCE";
-            case enchantment::mod::SPEED: return "SPEED";
-            case enchantment::mod::ATTACK_COST: return "ATTACK_COST";
-            case enchantment::mod::ATTACK_SPEED: return "ATTACK_SPEED";
-            case enchantment::mod::MOVE_COST: return "MOVE_COST";
-            case enchantment::mod::METABOLISM: return "METABOLISM";
-            case enchantment::mod::MAX_MANA: return "MAX_MANA";
-            case enchantment::mod::REGEN_MANA: return "REGEN_MANA";
-            case enchantment::mod::BIONIC_POWER: return "BIONIC_POWER";
-            case enchantment::mod::MAX_STAMINA: return "MAX_STAMINA";
-            case enchantment::mod::REGEN_STAMINA: return "REGEN_STAMINA";
-            case enchantment::mod::MAX_HP: return "MAX_HP";
-            case enchantment::mod::REGEN_HP: return "REGEN_HP";
-            case enchantment::mod::THIRST: return "THIRST";
-            case enchantment::mod::FATIGUE: return "FATIGUE";
-            case enchantment::mod::PAIN: return "PAIN";
-            case enchantment::mod::BONUS_DAMAGE: return "BONUS_DAMAGE";
-            case enchantment::mod::BONUS_BLOCK: return "BONUS_BLOCK";
-            case enchantment::mod::BONUS_DODGE: return "BONUS_DODGE";
-            case enchantment::mod::ATTACK_NOISE: return "ATTACK_NOISE";
-            case enchantment::mod::SPELL_NOISE: return "SPELL_NOISE";
-            case enchantment::mod::SHOUT_NOISE: return "SHOUT_NOISE";
-            case enchantment::mod::FOOTSTEP_NOISE: return "FOOTSTEP_NOISE";
-            case enchantment::mod::SIGHT_RANGE: return "SIGHT_RANGE";
-            case enchantment::mod::CARRY_WEIGHT: return "CARRY_WEIGHT";
-            case enchantment::mod::CARRY_VOLUME: return "CARRY_VOLUME";
-            case enchantment::mod::SOCIAL_LIE: return "SOCIAL_LIE";
-            case enchantment::mod::SOCIAL_PERSUADE: return "SOCIAL_PERSUADE";
-            case enchantment::mod::SOCIAL_INTIMIDATE: return "SOCIAL_INTIMIDATE";
-            case enchantment::mod::ARMOR_ACID: return "ARMOR_ACID";
-            case enchantment::mod::ARMOR_BASH: return "ARMOR_BASH";
-            case enchantment::mod::ARMOR_BIO: return "ARMOR_BIO";
-            case enchantment::mod::ARMOR_COLD: return "ARMOR_COLD";
-            case enchantment::mod::ARMOR_CUT: return "ARMOR_CUT";
-            case enchantment::mod::ARMOR_ELEC: return "ARMOR_ELEC";
-            case enchantment::mod::ARMOR_HEAT: return "ARMOR_HEAT";
-            case enchantment::mod::ARMOR_STAB: return "ARMOR_STAB";
-            case enchantment::mod::ITEM_DAMAGE_BASH: return "ITEM_DAMAGE_BASH";
-            case enchantment::mod::ITEM_DAMAGE_CUT: return "ITEM_DAMAGE_CUT";
-            case enchantment::mod::ITEM_DAMAGE_STAB: return "ITEM_DAMAGE_STAB";
-            case enchantment::mod::ITEM_DAMAGE_HEAT: return "ITEM_DAMAGE_HEAT";
-            case enchantment::mod::ITEM_DAMAGE_COLD: return "ITEM_DAMAGE_COLD";
-            case enchantment::mod::ITEM_DAMAGE_ELEC: return "ITEM_DAMAGE_ELEC";
-            case enchantment::mod::ITEM_DAMAGE_ACID: return "ITEM_DAMAGE_ACID";
-            case enchantment::mod::ITEM_DAMAGE_BIO: return "ITEM_DAMAGE_BIO";
-            case enchantment::mod::ITEM_DAMAGE_AP: return "ITEM_DAMAGE_AP";
-            case enchantment::mod::ITEM_ARMOR_BASH: return "ITEM_ARMOR_BASH";
-            case enchantment::mod::ITEM_ARMOR_CUT: return "ITEM_ARMOR_CUT";
-            case enchantment::mod::ITEM_ARMOR_STAB: return "ITEM_ARMOR_STAB";
-            case enchantment::mod::ITEM_ARMOR_HEAT: return "ITEM_ARMOR_HEAT";
-            case enchantment::mod::ITEM_ARMOR_COLD: return "ITEM_ARMOR_COLD";
-            case enchantment::mod::ITEM_ARMOR_ELEC: return "ITEM_ARMOR_ELEC";
-            case enchantment::mod::ITEM_ARMOR_ACID: return "ITEM_ARMOR_ACID";
-            case enchantment::mod::ITEM_ARMOR_BIO: return "ITEM_ARMOR_BIO";
-            case enchantment::mod::ITEM_WEIGHT: return "ITEM_WEIGHT";
-            case enchantment::mod::ITEM_ENCUMBRANCE: return "ITEM_ENCUMBRANCE";
-            case enchantment::mod::ITEM_VOLUME: return "ITEM_VOLUME";
-            case enchantment::mod::ITEM_COVERAGE: return "ITEM_COVERAGE";
-            case enchantment::mod::ITEM_ATTACK_SPEED: return "ITEM_ATTACK_SPEED";
-            case enchantment::mod::ITEM_WET_PROTECTION: return "ITEM_WET_PROTECTION";
-            case enchantment::mod::NUM_MOD: break;
+            case enchant_vals::mod::STRENGTH: return "STRENGTH";
+            case enchant_vals::mod::DEXTERITY: return "DEXTERITY";
+            case enchant_vals::mod::PERCEPTION: return "PERCEPTION";
+            case enchant_vals::mod::INTELLIGENCE: return "INTELLIGENCE";
+            case enchant_vals::mod::SPEED: return "SPEED";
+            case enchant_vals::mod::ATTACK_COST: return "ATTACK_COST";
+            case enchant_vals::mod::ATTACK_SPEED: return "ATTACK_SPEED";
+            case enchant_vals::mod::MOVE_COST: return "MOVE_COST";
+            case enchant_vals::mod::METABOLISM: return "METABOLISM";
+            case enchant_vals::mod::MAX_MANA: return "MAX_MANA";
+            case enchant_vals::mod::REGEN_MANA: return "REGEN_MANA";
+            case enchant_vals::mod::BIONIC_POWER: return "BIONIC_POWER";
+            case enchant_vals::mod::MAX_STAMINA: return "MAX_STAMINA";
+            case enchant_vals::mod::REGEN_STAMINA: return "REGEN_STAMINA";
+            case enchant_vals::mod::MAX_HP: return "MAX_HP";
+            case enchant_vals::mod::REGEN_HP: return "REGEN_HP";
+            case enchant_vals::mod::THIRST: return "THIRST";
+            case enchant_vals::mod::FATIGUE: return "FATIGUE";
+            case enchant_vals::mod::PAIN: return "PAIN";
+            case enchant_vals::mod::BONUS_DAMAGE: return "BONUS_DAMAGE";
+            case enchant_vals::mod::BONUS_BLOCK: return "BONUS_BLOCK";
+            case enchant_vals::mod::BONUS_DODGE: return "BONUS_DODGE";
+            case enchant_vals::mod::ATTACK_NOISE: return "ATTACK_NOISE";
+            case enchant_vals::mod::SPELL_NOISE: return "SPELL_NOISE";
+            case enchant_vals::mod::SHOUT_NOISE: return "SHOUT_NOISE";
+            case enchant_vals::mod::FOOTSTEP_NOISE: return "FOOTSTEP_NOISE";
+            case enchant_vals::mod::SIGHT_RANGE: return "SIGHT_RANGE";
+            case enchant_vals::mod::CARRY_WEIGHT: return "CARRY_WEIGHT";
+            case enchant_vals::mod::CARRY_VOLUME: return "CARRY_VOLUME";
+            case enchant_vals::mod::SOCIAL_LIE: return "SOCIAL_LIE";
+            case enchant_vals::mod::SOCIAL_PERSUADE: return "SOCIAL_PERSUADE";
+            case enchant_vals::mod::SOCIAL_INTIMIDATE: return "SOCIAL_INTIMIDATE";
+            case enchant_vals::mod::ARMOR_ACID: return "ARMOR_ACID";
+            case enchant_vals::mod::ARMOR_BASH: return "ARMOR_BASH";
+            case enchant_vals::mod::ARMOR_BIO: return "ARMOR_BIO";
+            case enchant_vals::mod::ARMOR_COLD: return "ARMOR_COLD";
+            case enchant_vals::mod::ARMOR_CUT: return "ARMOR_CUT";
+            case enchant_vals::mod::ARMOR_ELEC: return "ARMOR_ELEC";
+            case enchant_vals::mod::ARMOR_HEAT: return "ARMOR_HEAT";
+            case enchant_vals::mod::ARMOR_STAB: return "ARMOR_STAB";
+            case enchant_vals::mod::ITEM_DAMAGE_BASH: return "ITEM_DAMAGE_BASH";
+            case enchant_vals::mod::ITEM_DAMAGE_CUT: return "ITEM_DAMAGE_CUT";
+            case enchant_vals::mod::ITEM_DAMAGE_STAB: return "ITEM_DAMAGE_STAB";
+            case enchant_vals::mod::ITEM_DAMAGE_HEAT: return "ITEM_DAMAGE_HEAT";
+            case enchant_vals::mod::ITEM_DAMAGE_COLD: return "ITEM_DAMAGE_COLD";
+            case enchant_vals::mod::ITEM_DAMAGE_ELEC: return "ITEM_DAMAGE_ELEC";
+            case enchant_vals::mod::ITEM_DAMAGE_ACID: return "ITEM_DAMAGE_ACID";
+            case enchant_vals::mod::ITEM_DAMAGE_BIO: return "ITEM_DAMAGE_BIO";
+            case enchant_vals::mod::ITEM_DAMAGE_AP: return "ITEM_DAMAGE_AP";
+            case enchant_vals::mod::ITEM_ARMOR_BASH: return "ITEM_ARMOR_BASH";
+            case enchant_vals::mod::ITEM_ARMOR_CUT: return "ITEM_ARMOR_CUT";
+            case enchant_vals::mod::ITEM_ARMOR_STAB: return "ITEM_ARMOR_STAB";
+            case enchant_vals::mod::ITEM_ARMOR_HEAT: return "ITEM_ARMOR_HEAT";
+            case enchant_vals::mod::ITEM_ARMOR_COLD: return "ITEM_ARMOR_COLD";
+            case enchant_vals::mod::ITEM_ARMOR_ELEC: return "ITEM_ARMOR_ELEC";
+            case enchant_vals::mod::ITEM_ARMOR_ACID: return "ITEM_ARMOR_ACID";
+            case enchant_vals::mod::ITEM_ARMOR_BIO: return "ITEM_ARMOR_BIO";
+            case enchant_vals::mod::ITEM_WEIGHT: return "ITEM_WEIGHT";
+            case enchant_vals::mod::ITEM_ENCUMBRANCE: return "ITEM_ENCUMBRANCE";
+            case enchant_vals::mod::ITEM_VOLUME: return "ITEM_VOLUME";
+            case enchant_vals::mod::ITEM_COVERAGE: return "ITEM_COVERAGE";
+            case enchant_vals::mod::ITEM_ATTACK_SPEED: return "ITEM_ATTACK_SPEED";
+            case enchant_vals::mod::ITEM_WET_PROTECTION: return "ITEM_WET_PROTECTION";
+            case enchant_vals::mod::NUM_MOD: break;
         }
-        debugmsg( "Invalid enchantment::mod" );
+        debugmsg( "Invalid enchant_vals::mod" );
         abort();
     }
     // *INDENT-ON*
@@ -253,7 +253,8 @@ void enchantment::load( const JsonObject &jo, const std::string & )
 
     if( jo.has_array( "values" ) ) {
         for( const JsonObject value_obj : jo.get_array( "values" ) ) {
-            const enchantment::mod value = io::string_to_enum<mod>( value_obj.get_string( "value" ) );
+            const enchant_vals::mod value = io::string_to_enum<enchant_vals::mod>
+                                            ( value_obj.get_string( "value" ) );
             const int add = value_obj.get_int( "add", 0 );
             const double mult = value_obj.get_float( "multiply", 0.0 );
             if( add != 0 ) {
@@ -310,13 +311,13 @@ void enchantment::serialize( JsonOut &jsout ) const
 
     jsout.member( "values" );
     jsout.start_array();
-    for( int value = 0; value < mod::NUM_MOD; value++ ) {
-        mod enum_value = static_cast<mod>( value );
+    for( int value = 0; value < static_cast<int>( enchant_vals::mod::NUM_MOD ); value++ ) {
+        enchant_vals::mod enum_value = static_cast<enchant_vals::mod>( value );
         if( get_value_add( enum_value ) == 0 && get_value_multiply( enum_value ) == 0.0 ) {
             continue;
         }
         jsout.start_object();
-        jsout.member( "value", io::enum_to_string<mod>( enum_value ) );
+        jsout.member( "value", io::enum_to_string<enchant_vals::mod>( enum_value ) );
         if( get_value_add( enum_value ) != 0 ) {
             jsout.member( "add", get_value_add( enum_value ) );
         }
@@ -346,10 +347,10 @@ bool enchantment::add( const enchantment &rhs )
 
 void enchantment::force_add( const enchantment &rhs )
 {
-    for( const std::pair<const mod, int> &pair_values : rhs.values_add ) {
+    for( const std::pair<const enchant_vals::mod, int> &pair_values : rhs.values_add ) {
         values_add[pair_values.first] += pair_values.second;
     }
-    for( const std::pair<const mod, double> &pair_values : rhs.values_multiply ) {
+    for( const std::pair<const enchant_vals::mod, double> &pair_values : rhs.values_multiply ) {
         // values do not multiply against each other, they add.
         // so +10% and -10% will add to 0%
         values_multiply[pair_values.first] += pair_values.second;
@@ -377,7 +378,7 @@ void enchantment::force_add( const enchantment &rhs )
     }
 }
 
-int enchantment::get_value_add( const mod value ) const
+int enchantment::get_value_add( const enchant_vals::mod value ) const
 {
     const auto found = values_add.find( value );
     if( found == values_add.cend() ) {
@@ -386,7 +387,7 @@ int enchantment::get_value_add( const mod value ) const
     return found->second;
 }
 
-double enchantment::get_value_multiply( const mod value ) const
+double enchantment::get_value_multiply( const enchant_vals::mod value ) const
 {
     const auto found = values_multiply.find( value );
     if( found == values_multiply.cend() ) {
@@ -395,30 +396,30 @@ double enchantment::get_value_multiply( const mod value ) const
     return found->second;
 }
 
-int enchantment::mult_bonus( enchantment::mod value_type, int base_value ) const
+int enchantment::mult_bonus( enchant_vals::mod value_type, int base_value ) const
 {
     return get_value_multiply( value_type ) * base_value;
 }
 
 void enchantment::activate_passive( Character &guy ) const
 {
-    guy.mod_str_bonus( get_value_add( mod::STRENGTH ) );
-    guy.mod_str_bonus( mult_bonus( mod::STRENGTH, guy.get_str_base() ) );
+    guy.mod_str_bonus( get_value_add( enchant_vals::mod::STRENGTH ) );
+    guy.mod_str_bonus( mult_bonus( enchant_vals::mod::STRENGTH, guy.get_str_base() ) );
 
-    guy.mod_dex_bonus( get_value_add( mod::DEXTERITY ) );
-    guy.mod_dex_bonus( mult_bonus( mod::DEXTERITY, guy.get_dex_base() ) );
+    guy.mod_dex_bonus( get_value_add( enchant_vals::mod::DEXTERITY ) );
+    guy.mod_dex_bonus( mult_bonus( enchant_vals::mod::DEXTERITY, guy.get_dex_base() ) );
 
-    guy.mod_per_bonus( get_value_add( mod::PERCEPTION ) );
-    guy.mod_per_bonus( mult_bonus( mod::PERCEPTION, guy.get_per_base() ) );
+    guy.mod_per_bonus( get_value_add( enchant_vals::mod::PERCEPTION ) );
+    guy.mod_per_bonus( mult_bonus( enchant_vals::mod::PERCEPTION, guy.get_per_base() ) );
 
-    guy.mod_int_bonus( get_value_add( mod::INTELLIGENCE ) );
-    guy.mod_int_bonus( mult_bonus( mod::INTELLIGENCE, guy.get_int_base() ) );
+    guy.mod_int_bonus( get_value_add( enchant_vals::mod::INTELLIGENCE ) );
+    guy.mod_int_bonus( mult_bonus( enchant_vals::mod::INTELLIGENCE, guy.get_int_base() ) );
 
-    guy.mod_speed_bonus( get_value_add( mod::SPEED ) );
-    guy.mod_speed_bonus( mult_bonus( mod::SPEED, guy.get_speed_base() ) );
+    guy.mod_speed_bonus( get_value_add( enchant_vals::mod::SPEED ) );
+    guy.mod_speed_bonus( mult_bonus( enchant_vals::mod::SPEED, guy.get_speed_base() ) );
 
-    guy.mod_num_dodges_bonus( get_value_add( mod::BONUS_DODGE ) );
-    guy.mod_num_dodges_bonus( mult_bonus( mod::BONUS_DODGE, guy.get_num_dodges_base() ) );
+    guy.mod_num_dodges_bonus( get_value_add( enchant_vals::mod::BONUS_DODGE ) );
+    guy.mod_num_dodges_bonus( mult_bonus( enchant_vals::mod::BONUS_DODGE, guy.get_num_dodges_base() ) );
 
     if( emitter ) {
         get_map().emit_field( guy.pos(), *emitter );

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -482,3 +482,17 @@ void enchantment::cast_enchantment_spell( Character &caster, const Creature *tar
         spell_lvl.cast_all_effects( caster, trg_crtr.pos() );
     }
 }
+
+bool enchantment::operator==( const enchantment &rhs ) const
+{
+    return id == rhs.id &&
+           mutations == rhs.mutations &&
+           emitter == rhs.emitter &&
+           ench_effects == rhs.ench_effects &&
+           values_multiply == rhs.values_multiply &&
+           values_add == rhs.values_add &&
+           hit_me_effect == rhs.hit_me_effect &&
+           hit_you_effect == rhs.hit_you_effect &&
+           intermittent_activation == intermittent_activation &&
+           active_conditions == rhs.active_conditions;
+}

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -152,6 +152,8 @@ class enchantment
         const std::set<trait_id> &get_mutations() const {
             return mutations;
         }
+
+        bool operator==( const enchantment &rhs )const;
     private:
         std::set<trait_id> mutations;
         cata::optional<emit_id> emitter;

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -17,6 +17,80 @@ class Character;
 class Creature;
 class item;
 
+namespace enchant_vals
+{
+// the different types of values that can be modified by enchantments
+// either the item directly or the Character, whichever is more appropriate
+enum class mod : int {
+    // effects for the Character
+    STRENGTH,
+    DEXTERITY,
+    PERCEPTION,
+    INTELLIGENCE,
+    SPEED,
+    ATTACK_COST,
+    ATTACK_SPEED, // affects attack speed of item even if it's not the one you're wielding
+    MOVE_COST,
+    METABOLISM,
+    MAX_MANA,
+    REGEN_MANA,
+    BIONIC_POWER,
+    MAX_STAMINA,
+    REGEN_STAMINA,
+    MAX_HP,        // for all limbs! use with caution
+    REGEN_HP,
+    THIRST,        // cost or regen over time
+    FATIGUE,       // cost or regen over time
+    PAIN,          // cost or regen over time
+    BONUS_DODGE,
+    BONUS_BLOCK,
+    BONUS_DAMAGE,
+    ATTACK_NOISE,
+    SPELL_NOISE,
+    SHOUT_NOISE,
+    FOOTSTEP_NOISE,
+    SIGHT_RANGE,
+    CARRY_WEIGHT,
+    CARRY_VOLUME,
+    SOCIAL_LIE,
+    SOCIAL_PERSUADE,
+    SOCIAL_INTIMIDATE,
+    ARMOR_BASH,
+    ARMOR_CUT,
+    ARMOR_STAB,
+    ARMOR_HEAT,
+    ARMOR_COLD,
+    ARMOR_ELEC,
+    ARMOR_ACID,
+    ARMOR_BIO,
+    // effects for the item that has the enchantment
+    ITEM_DAMAGE_BASH,
+    ITEM_DAMAGE_CUT,
+    ITEM_DAMAGE_STAB,
+    ITEM_DAMAGE_HEAT,
+    ITEM_DAMAGE_COLD,
+    ITEM_DAMAGE_ELEC,
+    ITEM_DAMAGE_ACID,
+    ITEM_DAMAGE_BIO,
+    ITEM_DAMAGE_AP,      // armor piercing
+    ITEM_ARMOR_BASH,
+    ITEM_ARMOR_CUT,
+    ITEM_ARMOR_STAB,
+    ITEM_ARMOR_HEAT,
+    ITEM_ARMOR_COLD,
+    ITEM_ARMOR_ELEC,
+    ITEM_ARMOR_ACID,
+    ITEM_ARMOR_BIO,
+    ITEM_WEIGHT,
+    ITEM_ENCUMBRANCE,
+    ITEM_VOLUME,
+    ITEM_COVERAGE,
+    ITEM_ATTACK_SPEED,
+    ITEM_WET_PROTECTION,
+    NUM_MOD
+};
+} // namespace enchant_vals
+
 // an "enchantment" is what passive artifact effects used to be:
 // under certain conditions, the effect persists upon the appropriate Character
 class enchantment
@@ -37,76 +111,6 @@ class enchantment
             ACTIVE, // the item, mutation, etc. is active
             NUM_CONDITION
         };
-        // the different types of values that can be modified by enchantments
-        // either the item directly or the Character, whichever is more appropriate
-        enum mod {
-            // effects for the Character
-            STRENGTH,
-            DEXTERITY,
-            PERCEPTION,
-            INTELLIGENCE,
-            SPEED,
-            ATTACK_COST,
-            ATTACK_SPEED, // affects attack speed of item even if it's not the one you're wielding
-            MOVE_COST,
-            METABOLISM,
-            MAX_MANA,
-            REGEN_MANA,
-            BIONIC_POWER,
-            MAX_STAMINA,
-            REGEN_STAMINA,
-            MAX_HP,        // for all limbs! use with caution
-            REGEN_HP,
-            THIRST,        // cost or regen over time
-            FATIGUE,       // cost or regen over time
-            PAIN,          // cost or regen over time
-            BONUS_DODGE,
-            BONUS_BLOCK,
-            BONUS_DAMAGE,
-            ATTACK_NOISE,
-            SPELL_NOISE,
-            SHOUT_NOISE,
-            FOOTSTEP_NOISE,
-            SIGHT_RANGE,
-            CARRY_WEIGHT,
-            CARRY_VOLUME,
-            SOCIAL_LIE,
-            SOCIAL_PERSUADE,
-            SOCIAL_INTIMIDATE,
-            ARMOR_BASH,
-            ARMOR_CUT,
-            ARMOR_STAB,
-            ARMOR_HEAT,
-            ARMOR_COLD,
-            ARMOR_ELEC,
-            ARMOR_ACID,
-            ARMOR_BIO,
-            // effects for the item that has the enchantment
-            ITEM_DAMAGE_BASH,
-            ITEM_DAMAGE_CUT,
-            ITEM_DAMAGE_STAB,
-            ITEM_DAMAGE_HEAT,
-            ITEM_DAMAGE_COLD,
-            ITEM_DAMAGE_ELEC,
-            ITEM_DAMAGE_ACID,
-            ITEM_DAMAGE_BIO,
-            ITEM_DAMAGE_AP,      // armor piercing
-            ITEM_ARMOR_BASH,
-            ITEM_ARMOR_CUT,
-            ITEM_ARMOR_STAB,
-            ITEM_ARMOR_HEAT,
-            ITEM_ARMOR_COLD,
-            ITEM_ARMOR_ELEC,
-            ITEM_ARMOR_ACID,
-            ITEM_ARMOR_BIO,
-            ITEM_WEIGHT,
-            ITEM_ENCUMBRANCE,
-            ITEM_VOLUME,
-            ITEM_COVERAGE,
-            ITEM_ATTACK_SPEED,
-            ITEM_WET_PROTECTION,
-            NUM_MOD
-        };
 
         static void load_enchantment( const JsonObject &jo, const std::string &src );
         void load( const JsonObject &jo, const std::string &src = "" );
@@ -118,8 +122,8 @@ class enchantment
         // adds two enchantments together and ignores their conditions
         void force_add( const enchantment &rhs );
 
-        int get_value_add( mod value ) const;
-        double get_value_multiply( mod value ) const;
+        int get_value_add( enchant_vals::mod value ) const;
+        double get_value_multiply( enchant_vals::mod value ) const;
 
         // this enchantment has a valid condition and is in the right location
         bool is_active( const Character &guy, const item &parent ) const;
@@ -153,10 +157,10 @@ class enchantment
         cata::optional<emit_id> emitter;
         std::map<efftype_id, int> ench_effects;
         // values that add to the base value
-        std::map<mod, int> values_add;
+        std::map<enchant_vals::mod, int> values_add;
         // values that get multiplied to the base value
         // multipliers add to each other instead of multiply against themselves
-        std::map<mod, double> values_multiply;
+        std::map<enchant_vals::mod, double> values_multiply;
 
         std::vector<fake_spell> hit_me_effect;
         std::vector<fake_spell> hit_you_effect;
@@ -170,7 +174,7 @@ class enchantment
         // checks if the enchantments have the same active_conditions
         bool stacks_with( const enchantment &rhs ) const;
 
-        int mult_bonus( mod value_type, int base_value ) const;
+        int mult_bonus( enchant_vals::mod value_type, int base_value ) const;
 
         // performs cooldown and distance checks before casting enchantment spells
         void cast_enchantment_spell( Character &caster, const Creature *target,

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -171,7 +171,7 @@ class enchantment
 
         std::pair<has, condition> active_conditions;
 
-        void add_activation( const time_duration &dur, const fake_spell &fake );
+        void add_activation( const time_duration &freq, const fake_spell &fake );
 
         // checks if the enchantments have the same active_conditions
         bool stacks_with( const enchantment &rhs ) const;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -704,7 +704,7 @@ void spell_effect::recover_energy( const spell &sp, Creature &caster, const trip
     }
 
     if( energy_source == "MANA" ) {
-        p->magic.mod_mana( *p, healing );
+        p->magic->mod_mana( *p, healing );
     } else if( energy_source == "STAMINA" ) {
         p->mod_stamina( healing );
     } else if( energy_source == "FATIGUE" ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2186,7 +2186,7 @@ int Character::attack_speed( const item &weap ) const
     move_cost += skill_cost;
     move_cost -= dexbonus;
 
-    move_cost = calculate_by_enchantment( move_cost, enchantment::mod::ATTACK_SPEED, true );
+    move_cost = calculate_by_enchantment( move_cost, enchant_vals::mod::ATTACK_SPEED, true );
     // Martial arts last. Flat has to be after mult, because comments say so.
     move_cost *= ma_mult;
     move_cost += ma_move_cost;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -24,6 +24,7 @@
 #include "item.h"
 #include "item_contents.h"
 #include "itype.h"
+#include "magic_enchantment.h"
 #include "map.h"
 #include "map_iterator.h"
 #include "mapdata.h"
@@ -108,7 +109,7 @@ std::string enum_to_string<mutagen_technique>( mutagen_technique data )
 
 bool Character::has_trait( const trait_id &b ) const
 {
-    return my_mutations.count( b ) || enchantment_cache.get_mutations().count( b );
+    return my_mutations.count( b ) || enchantment_cache->get_mutations().count( b );
 }
 
 bool Character::has_trait_flag( const std::string &b ) const

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -33,6 +33,7 @@
 #include "inventory.h"
 #include "json.h"
 #include "magic.h"
+#include "magic_enchantment.h"
 #include "mapsharing.h"
 #include "martialarts.h"
 #include "monster.h"
@@ -2785,7 +2786,7 @@ std::vector<trait_id> Character::get_mutations( bool include_hidden ) const
             result.push_back( t.first );
         }
     }
-    for( const trait_id &ench_trait : enchantment_cache.get_mutations() ) {
+    for( const trait_id &ench_trait : enchantment_cache->get_mutations() ) {
         if( include_hidden || ench_trait->player_display ) {
             bool found = false;
             for( const trait_id &exist : result ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -443,8 +443,8 @@ void npc::randomize( const npc_class_id &type )
     }
     // Add spells for magiclysm mod
     for( std::pair<spell_id, int> spell_pair : type->_starting_spells ) {
-        this->magic.learn_spell( spell_pair.first, *this, true );
-        spell &sp = this->magic.get_spell( spell_pair.first );
+        this->magic->learn_spell( spell_pair.first, *this, true );
+        spell &sp = this->magic->get_spell( spell_pair.first );
         while( sp.get_level() < spell_pair.second && !sp.is_max_level() ) {
             sp.gain_level();
         }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -975,10 +975,10 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
         }
         std::vector<skill_id> trainable = p->skills_offered_to( g->u );
         std::vector<matype_id> styles = p->styles_offered_to( g->u );
-        const std::vector<spell_id> spells = p->magic.spells();
+        const std::vector<spell_id> spells = p->magic->spells();
         std::vector<spell_id> teachable_spells;
         for( const spell_id &sp : spells ) {
-            if( g->u.magic.can_learn_spell( g->u, sp ) ) {
+            if( g->u.magic->can_learn_spell( g->u, sp ) ) {
                 teachable_spells.emplace_back( sp );
             }
         }
@@ -1273,7 +1273,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
                 const matype_id styleid = matype_id( backlog.name );
                 if( !styleid.is_valid() ) {
                     const spell_id &sp_id = spell_id( backlog.name );
-                    if( p->magic.knows_spell( sp_id ) ) {
+                    if( p->magic->knows_spell( sp_id ) ) {
                         add_response( string_format( _( "Yes, let's resume training %s" ), sp_id->name ),
                                       "TALK_TRAIN_START", sp_id );
                     }
@@ -1289,13 +1289,13 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         }
         std::vector<matype_id> styles = p->styles_offered_to( g->u );
         std::vector<skill_id> trainable = p->skills_offered_to( g->u );
-        const std::vector<spell_id> spells = p->magic.spells();
+        const std::vector<spell_id> spells = p->magic->spells();
         std::vector<spell_id> teachable_spells;
         for( const spell_id &sp : spells ) {
-            const spell &temp_spell = p->magic.get_spell( sp );
-            if( g->u.magic.can_learn_spell( g->u, sp ) ) {
-                if( g->u.magic.knows_spell( sp ) ) {
-                    const spell &player_spell = g->u.magic.get_spell( sp );
+            const spell &temp_spell = p->magic->get_spell( sp );
+            if( g->u.magic->can_learn_spell( g->u, sp ) ) {
+                if( g->u.magic->knows_spell( sp ) ) {
+                    const spell &player_spell = g->u.magic->get_spell( sp );
                     if( player_spell.is_max_level() || player_spell.get_level() >= temp_spell.get_level() ) {
                         continue;
                     }
@@ -1308,8 +1308,8 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             return;
         }
         for( const spell_id &sp : teachable_spells ) {
-            const spell &temp_spell = p->magic.get_spell( sp );
-            const bool knows = g->u.magic.knows_spell( sp );
+            const spell &temp_spell = p->magic->get_spell( sp );
+            const bool knows = g->u.magic->knows_spell( sp );
             const int cost = p->calc_spell_training_cost( knows, temp_spell.get_difficulty(),
                              temp_spell.get_level() );
             std::string text;

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -914,11 +914,11 @@ void talk_function::start_training( npc &p )
         name = p.chatbin.style.str();
         // already checked if can learn this spell in npctalk.cpp
     } else if( p.chatbin.dialogue_spell.is_valid() ) {
-        const spell &temp_spell = p.magic.get_spell( sp_id );
-        const bool knows = g->u.magic.knows_spell( sp_id );
+        const spell &temp_spell = p.magic->get_spell( sp_id );
+        const bool knows = g->u.magic->knows_spell( sp_id );
         cost = p.calc_spell_training_cost( knows, temp_spell.get_difficulty(), temp_spell.get_level() );
         name = temp_spell.id().str();
-        expert_multiplier = knows ? temp_spell.get_level() - g->u.magic.get_spell( sp_id ).get_level() : 1;
+        expert_multiplier = knows ? temp_spell.get_level() - g->u.magic->get_spell( sp_id ).get_level() : 1;
         // quicker to learn with instruction as opposed to books.
         // if this is a known spell, then there is a set time to gain some exp.
         // if player doesn't know this spell, then the NPC will teach all of it
@@ -928,8 +928,8 @@ void talk_function::start_training( npc &p )
         if( knows ) {
             time = 1_hours;
         } else {
-            time = time_duration::from_seconds( clamp( g->u.magic.time_to_learn_spell( g->u, sp_id ) / 50, 7200,
-                                                21600 ) );
+            int seconds = g->u.magic->time_to_learn_spell( g->u, sp_id ) / 50;
+            time = time_duration::from_seconds( clamp( seconds, 7200, 21600 ) );
         }
     } else {
         debugmsg( "start_training with no valid skill or style set" );

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -815,16 +815,16 @@ static std::pair<nc_color, std::string> mana_stat( const player &u )
 {
     nc_color c_mana = c_red;
     std::string s_mana;
-    if( u.magic.max_mana( u ) <= 0 ) {
+    if( u.magic->max_mana( u ) <= 0 ) {
         s_mana = "--";
         c_mana = c_light_gray;
     } else {
-        if( u.magic.available_mana() >= u.magic.max_mana( u ) / 2 ) {
+        if( u.magic->available_mana() >= u.magic->max_mana( u ) / 2 ) {
             c_mana = c_light_blue;
-        } else if( u.magic.available_mana() >= u.magic.max_mana( u ) / 3 ) {
+        } else if( u.magic->available_mana() >= u.magic->max_mana( u ) / 3 ) {
             c_mana = c_yellow;
         }
-        s_mana = to_string( u.magic.available_mana() );
+        s_mana = to_string( u.magic->available_mana() );
     }
     return std::make_pair( c_mana, s_mana );
 }
@@ -1936,7 +1936,7 @@ static void print_mana( const player &u, const catacurses::window &w, const std:
                                     colorize( utf8_justify( mana_pair.second, j2 ), mana_pair.first ),
                                     //~ translation should not exceed 9 console cells
                                     utf8_justify( _( "Max Mana" ), j3 ),
-                                    colorize( utf8_justify( to_string( u.magic.max_mana( u ) ), j4 ), c_light_blue ) );
+                                    colorize( utf8_justify( to_string( u.magic->max_mana( u ) ), j4 ), c_light_blue ) );
     nc_color gray = c_light_gray;
     print_colored_text( w, point_zero, gray, gray, mana_string );
 
@@ -1969,7 +1969,7 @@ static void draw_mana_wide( const player &u, const catacurses::window &w )
 
 static bool spell_panel()
 {
-    return g->u.magic.knows_spell();
+    return g->u.magic->knows_spell();
 }
 
 bool default_render()

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -504,8 +504,8 @@ std::map<spell_id, int> profession::spells() const
 void profession::learn_spells( avatar &you ) const
 {
     for( const std::pair<spell_id, int> spell_pair : spells() ) {
-        you.magic.learn_spell( spell_pair.first, you, true );
-        spell &sp = you.magic.get_spell( spell_pair.first );
+        you.magic->learn_spell( spell_pair.first, you, true );
+        spell &sp = you.magic->get_spell( spell_pair.first );
         while( sp.get_level() < spell_pair.second && !sp.is_max_level() ) {
             sp.gain_level();
         }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2047,7 +2047,7 @@ std::vector<tripoint> target_handler::target_ui( player &pc, target_mode mode,
 std::vector<tripoint> target_handler::target_ui( spell_id sp, const bool no_fail,
         const bool no_mana )
 {
-    return target_ui( g->u.magic.get_spell( sp ), no_fail, no_mana );
+    return target_ui( g->u.magic->get_spell( sp ), no_fail, no_mana );
 }
 // does not have a targeting mode because we know this is the spellcasting version of this function
 std::vector<tripoint> target_handler::target_ui( spell &casting, const bool no_fail,

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -94,7 +94,7 @@ int relic::activate( Creature &caster, const tripoint &target ) const
     return charges_per_activation;
 }
 
-int relic::modify_value( const enchantment::mod value_type, const int value ) const
+int relic::modify_value( const enchant_vals::mod value_type, const int value ) const
 {
     int add_modifier = 0;
     double multiply_modifier = 0.0;

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -112,6 +112,15 @@ int relic::modify_value( const enchant_vals::mod value_type, const int value ) c
     return modified_value + add_modifier;
 }
 
+bool relic::operator==( const relic &rhs ) const
+{
+    return charges_per_activation == rhs.charges_per_activation &&
+           moves == rhs.moves &&
+           item_name_override == rhs.item_name_override &&
+           active_effects == rhs.active_effects &&
+           passive_effects == rhs.passive_effects;
+}
+
 std::string relic::name() const
 {
     return item_name_override.translated();

--- a/src/relic.h
+++ b/src/relic.h
@@ -42,7 +42,7 @@ class relic
 
         std::vector<enchantment> get_enchantments() const;
 
-        int modify_value( enchantment::mod value_type, int value ) const;
+        int modify_value( enchant_vals::mod value_type, int value ) const;
 };
 
 #endif // CATA_SRC_RELIC_H

--- a/src/relic.h
+++ b/src/relic.h
@@ -28,6 +28,8 @@ class relic
         // activating an artifact overrides all spell casting costs
         int moves;
     public:
+        bool operator==( const relic &rhs ) const;
+
         std::string name() const;
         // returns number of charges that should be consumed
         int activate( Creature &caster, const tripoint &target ) const;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2200,7 +2200,8 @@ void item::io( Archive &archive )
     archive.io( "light_width", light.width, nolight.width );
     archive.io( "light_dir", light.direction, nolight.direction );
 
-    archive.io( "relic_data", relic_data );
+    static const cata::value_ptr<relic> null_relic_ptr = nullptr;
+    archive.io( "relic_data", relic_data, null_relic_ptr );
 
     item_controller->migrate_item( orig, *this );
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -91,6 +91,7 @@
 #include "ranged.h"
 #include "recipe.h"
 #include "recipe_dictionary.h"
+#include "relic.h"
 #include "requirements.h"
 #include "rng.h"
 #include "scenario.h"

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -29,6 +29,7 @@
 #include "inventory.h"
 #include "item.h"
 #include "item_location.h"
+#include "magic_enchantment.h"
 #include "map.h"
 #include "messages.h"
 #include "monster.h"
@@ -1459,7 +1460,7 @@ void Character::suffer()
     suffer_without_sleep( sleep_deprivation );
     suffer_from_pain();
     //Suffer from enchantments
-    enchantment_cache.activate_passive( *this );
+    enchantment_cache->activate_passive( *this );
 
     if( calendar::once_every( 1_hours ) ) {
         add_effect( effect_accumulated_mutagen, 1_hours, num_bp, true );

--- a/tests/ranged_aiming_test.cpp
+++ b/tests/ranged_aiming_test.cpp
@@ -7,8 +7,8 @@
 #include <vector>
 
 #include "catch/catch.hpp"
-#include "artifact.h"
 #include "avatar.h"
+#include "calendar.h"
 #include "game.h"
 #include "map.h"
 #include "map_helpers.h"
@@ -29,7 +29,6 @@ static void set_up_player_vision()
 {
     g->place_player( shooter_pos );
     g->u.worn.clear();
-    g->u.clear_effects();
     g->reset_light_level();
 
     REQUIRE( !g->u.is_blind() );
@@ -101,7 +100,7 @@ TEST_CASE( "Aiming at a target behind wall", "[ranged][aiming]" )
     clear_map();
     player &shooter = g->u;
     clear_character( shooter, true );
-    shooter.i_add( item( architects_cube(), calendar::turn ) );
+    shooter.add_effect( efftype_id( "debug_clairvoyance" ), time_duration::from_seconds( 1 ) );
     arm_character( shooter, "glock_19" );
     int max_range = shooter.weapon.gun_range( &shooter );
     REQUIRE( max_range >= 5 );


### PR DESCRIPTION
#### Purpose of change
1. Remove magic-related headers from commonly included headers (recompiling is a pain otherwise)
2. Don't stack items with different relic_data
3. Fix #186 and another similar bug, with effects-from-enchantments
4. When saving game map, don't write `"relic_data": null` for every single item
5. JSONize The Architect's Cube
6. Update and expand enchantments documentation

#### Describe the solution
See commits. Some of the changes were cherry-picked from DDA repo, but due to merge conflicts and/or fixes I had to apply the final code is a bit of a mess, authorship-wise. Pretty sure I've credited everyone properly though.

#### Describe alternatives you've considered
Docs could go on the wiki once everything's up to date?

#### Testing
Manual for now. Checked that Cube of Shame survives save/load with it's `relic_data` intact, tried out the Architect's Cube.
Automated tests will have to wait until enchantment modifiers are implemented.