### PR TITLE
Aftershock craft fix

### DIFF
--- a/data/mods/Aftershock/recipes/recipe_overrides.json
+++ b/data/mods/Aftershock/recipes/recipe_overrides.json
@@ -59,6 +59,28 @@
   },
   {
     "type": "recipe",
+    "result": "wearable_atomic_light",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "electronics",
+    "skills_required": [ "survival", 3 ],
+    "difficulty": 2,
+    "time": "20 m",
+    "reversible": true,
+    "autolearn": true,
+    "using": [ [ "soldering_standard", 10 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "plut_cell", 4 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "scrap", 2 ] ],
+      [ [ "wire", 2 ] ],
+      [ [ "lens", 1 ], [ "lens_small", 1 ] ],
+      [ [ "rag", 4 ], [ "leather", 4 ], [ "duct_tape", 20 ], [ "medical_tape", 40 ], [ "cordage", 1, "LIST" ] ]
+    ]
+  },
+  {
+    "type": "recipe",
     "result": "meat_cooked",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_MEAT",

--- a/data/mods/Aftershock/recipes/recipes.json
+++ b/data/mods/Aftershock/recipes/recipes.json
@@ -334,6 +334,28 @@
   },
   {
     "type": "recipe",
+    "result": "wearable_atomic_light",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "electronics",
+    "skills_required": [ "survival", 3 ],
+    "difficulty": 2,
+    "time": "20 m",
+    "reversible": true,
+    "autolearn": true,
+    "using": [ [ "soldering_standard", 10 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "plut_cell", 4 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "scrap", 2 ] ],
+      [ [ "wire", 2 ] ],
+      [ [ "lens", 1 ], [ "lens_small", 1 ] ],
+      [ [ "rag", 4 ], [ "leather", 4 ], [ "duct_tape", 20 ], [ "medical_tape", 40 ], [ "cordage", 1, "LIST" ] ]
+    ]
+  },
+  {
+    "type": "recipe",
     "result": "reloaded_laser_pack",
     "category": "CC_AMMO",
     "subcategory": "CSC_AMMO_OTHER",

--- a/data/mods/Aftershock/recipes/recipes.json
+++ b/data/mods/Aftershock/recipes/recipes.json
@@ -334,28 +334,6 @@
   },
   {
     "type": "recipe",
-    "result": "wearable_atomic_light",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_TOOLS",
-    "skill_used": "electronics",
-    "skills_required": [ "survival", 3 ],
-    "difficulty": 2,
-    "time": "20 m",
-    "reversible": true,
-    "autolearn": true,
-    "using": [ [ "soldering_standard", 10 ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SCREW", "level": 1 } ],
-    "components": [
-      [ [ "plut_cell", 4 ] ],
-      [ [ "power_supply", 1 ] ],
-      [ [ "scrap", 2 ] ],
-      [ [ "wire", 2 ] ],
-      [ [ "lens", 1 ], [ "lens_small", 1 ] ],
-      [ [ "rag", 4 ], [ "leather", 4 ], [ "duct_tape", 20 ], [ "medical_tape", 40 ], [ "cordage", 1, "LIST" ] ]
-    ]
-  },
-  {
-    "type": "recipe",
     "result": "reloaded_laser_pack",
     "category": "CC_AMMO",
     "subcategory": "CSC_AMMO_OTHER",


### PR DESCRIPTION
Summary 
Category "Bugfixes"

Fix craft atomic headlamp

Purpose of change

All atomic items are made from plutonium, except for the headlamp, which is made from betavoltaic. And he is nowhere to be found

Describe the solution

Inserted craft from BN with replacement for plutonium

Testing

OK