### PR TITLE
[CR]Fix body temperatures being too low

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1206,7 +1206,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             // Add temperature value to the overlay_strings list for every visible tile when displaying temperature
             if( g->display_overlay_state( ACTION_DISPLAY_TEMPERATURE ) && !invisible[0] ) {
                 int temp_value = g->weather.get_temperature( pos );
-                int ctemp = fahrenheit_to_celsius( temp_value );
+                int ctemp = units::fahrenheit_to_celsius( temp_value );
                 short color;
                 const short bold = 8;
                 if( ctemp > 40 ) {
@@ -1223,9 +1223,9 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     color = catacurses::blue + bold;
                 }
                 if( get_option<std::string>( "USE_CELSIUS" ) == "celsius" ) {
-                    temp_value = fahrenheit_to_celsius( temp_value );
+                    temp_value = units::fahrenheit_to_celsius( temp_value );
                 } else if( get_option<std::string>( "USE_CELSIUS" ) == "kelvin" ) {
-                    temp_value = fahrenheit_to_kelvin( temp_value );
+                    temp_value = units::fahrenheit_to_kelvin( temp_value );
 
                 }
                 overlay_strings.emplace( player_to_screen( point( x, y ) ) + point( tile_width / 2, 0 ),

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -251,46 +251,6 @@ double convert_volume( int volume );
 double convert_volume( int volume, int *out_scale );
 
 /**
- * Convert a temperature from degrees Fahrenheit to degrees Celsius.
- *
- * @return Temperature in degrees C.
- */
-constexpr double fahrenheit_to_celsius( double fahrenheit )
-{
-    return ( ( fahrenheit - 32.0 ) * 5.0 / 9.0 );
-}
-
-/**
- * Convert a temperature from degrees Fahrenheit to Kelvin.
- *
- * @return Temperature in degrees K.
- */
-constexpr double fahrenheit_to_kelvin( double fahrenheit )
-{
-    return fahrenheit_to_celsius( fahrenheit ) + 273.15;
-}
-
-/**
- * Convert a temperature from Kelvin to degrees Fahrenheit.
- *
- * @return Temperature in degrees C.
- */
-constexpr double kelvin_to_fahrenheit( double kelvin )
-{
-    return 1.8 * ( kelvin - 273.15 ) + 32;
-}
-
-/**
- * Convert a temperature from Celsius to degrees Fahrenheit.
- *
- * @return Temperature in degrees F.
- */
-constexpr double celsius_to_fahrenheit( double celsius )
-{
-    return celsius * 9 / 5 + 32;
-}
-
-/**
  * Clamp (number and space wise) value to with,
  * taking into account the specified preferred scale,
  * returning the adjusted (shortened) scale that best fit the width,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4995,8 +4995,8 @@ void Character::update_bodytemp()
     /* Cache calls to g->get_temperature( player position ), used in several places in function */
     const auto player_local_temp = g->weather.get_temperature( pos() );
     // NOTE : visit weather.h for some details on the numbers used
-    // Converts temperature to Celsius/10
-    int Ctemperature = static_cast<int>( 100 * fahrenheit_to_celsius( player_local_temp ) );
+    // In Celsius / 100
+    int Ctemperature = static_cast<int>( 100 * units::fahrenheit_to_celsius( player_local_temp ) );
     const w_point weather = *g->weather.weather_precise;
     int vehwindspeed = 0;
     const optional_vpart_position vp = g->m.veh_at( pos() );
@@ -5017,8 +5017,8 @@ void Character::update_bodytemp()
     const bool has_climate_control = in_climate_control();
     const bool use_floor_warmth = can_use_floor_warmth();
     const cata::optional<vpart_reference> boardable = vp.part_with_feature( "BOARDABLE", true );
-    // Temperature norms
-    const int ambient_norm = 3100 - BODYTEMP_NORM;
+    // In bodytemp units
+    const int ambient_norm = 1900 - BODYTEMP_NORM;
 
     /**
      * Calculations that affect all body parts equally go here, not in the loop
@@ -5031,7 +5031,7 @@ void Character::update_bodytemp()
 
     const int lying_warmth = use_floor_warmth ? floor_warmth( pos() ) : 0;
     const int water_temperature_raw =
-        100 * fahrenheit_to_celsius( g->weather.get_water_temperature( pos() ) );
+        100 * units::fahrenheit_to_celsius( g->weather.get_water_temperature( pos() ) );
     // Rescale so that 0C is 0 (FREEZING) and 30C is 5k (NORM).
     const int water_temperature = water_temperature_raw * 5 / 3;
 
@@ -5170,8 +5170,8 @@ void Character::update_bodytemp()
         static const double change_mult_water = std::exp( -0.008 );
         const double change_mult = submerged_bp ? change_mult_water : change_mult_air;
         if( temp_cur[bp] != bp_conv ) {
-            temp_cur[bp] = static_cast<int>( temp_difference * change_mult + bp_conv +
-                                             rounding_error );
+            temp_cur[bp] = static_cast<int>( temp_difference * change_mult )
+                           + bp_conv + rounding_error;
         }
         int temp_after = temp_cur[bp];
         // PENALTIES

--- a/src/units.h
+++ b/src/units.h
@@ -473,6 +473,104 @@ inline constexpr value_type to_kusd( const quantity<value_type, money_in_cent_ta
     return to_usd( v ) / 1000.0;
 }
 
+constexpr double fahrenheit_to_celsius( double fahrenheit )
+{
+    return ( ( fahrenheit - 32.0 ) * 5.0 / 9.0 );
+}
+
+/**
+ * Convert a temperature from degrees Fahrenheit to Kelvin.
+ *
+ * @return Temperature in degrees K.
+ */
+constexpr double fahrenheit_to_kelvin( double fahrenheit )
+{
+    return fahrenheit_to_celsius( fahrenheit ) + 273.15;
+}
+
+/**
+ * Convert a temperature from Kelvin to degrees Fahrenheit.
+ *
+ * @return Temperature in degrees C.
+ */
+constexpr double kelvin_to_fahrenheit( double kelvin )
+{
+    return 1.8 * ( kelvin - 273.15 ) + 32;
+}
+
+/**
+ * Convert a temperature from Celsius to degrees Fahrenheit.
+ *
+ * @return Temperature in degrees F.
+ */
+constexpr double celsius_to_fahrenheit( double celsius )
+{
+    return celsius * 9 / 5 + 32;
+}
+
+class temperature_in_millidegree_celsius_tag
+{
+};
+
+using temperature = quantity<int, temperature_in_millidegree_celsius_tag>;
+
+const temperature temperature_min = units::temperature(
+                                        std::numeric_limits<units::temperature::value_type>::min(),
+                                        units::temperature::unit_type{} );
+
+const temperature temperature_max = units::temperature(
+                                        std::numeric_limits<units::temperature::value_type>::max(),
+                                        units::temperature::unit_type{} );
+
+template<typename value_type>
+inline constexpr quantity<value_type, temperature_in_millidegree_celsius_tag>
+from_millidegree_celsius(
+    const value_type v )
+{
+    return quantity<value_type, temperature_in_millidegree_celsius_tag>( v,
+            temperature_in_millidegree_celsius_tag{} );
+}
+
+template<typename value_type>
+inline constexpr quantity<value_type, temperature_in_millidegree_celsius_tag> from_celsius(
+    const value_type v )
+{
+    const value_type max_temperature_celsius = std::numeric_limits<value_type>::max() / 1000;
+    const value_type temperature = v > max_temperature_celsius ? max_temperature_celsius : v;
+    return from_millidegree_celsius<value_type>( temperature * 1000 );
+}
+
+template<typename value_type>
+inline constexpr quantity<value_type, temperature_in_millidegree_celsius_tag> from_fahrenheit(
+    const value_type v )
+{
+    const value_type max_temperature_fahrenheit = celsius_to_fahrenheit(
+                std::numeric_limits<value_type>::max() / 1000 );
+    const value_type temperature = v > max_temperature_fahrenheit ? max_temperature_fahrenheit : v;
+    return from_millidegree_celsius<value_type>( fahrenheit_to_celsius( temperature ) * 1000 );
+}
+
+template<typename value_type>
+inline constexpr value_type to_millidegree_celsius( const
+        quantity<value_type, temperature_in_millidegree_celsius_tag> &v )
+{
+    return v / from_millidegree_celsius<value_type>( 1 );
+}
+
+template<typename value_type>
+inline constexpr value_type to_celsius( const
+                                        quantity<value_type, temperature_in_millidegree_celsius_tag> &v )
+{
+    return to_millidegree_celsius( v ) / 1000.0;
+}
+
+template<typename value_type>
+inline constexpr value_type to_fahrenheit( const
+        quantity<value_type, temperature_in_millidegree_celsius_tag> &v )
+{
+    return celsius_to_fahrenheit( to_millidegree_celsius( v ) / 1000.0 );
+}
+
 // Streaming operators for debugging and tests
 // (for UI output other functions should be used which render in the user's
 // chosen units)
@@ -494,6 +592,11 @@ inline std::ostream &operator<<( std::ostream &o, energy_in_millijoule_tag )
 inline std::ostream &operator<<( std::ostream &o, money_in_cent_tag )
 {
     return o << "cent";
+}
+
+inline std::ostream &operator<<( std::ostream &o, temperature_in_millidegree_celsius_tag )
+{
+    return o << "mC";
 }
 
 template<typename value_type, typename tag_type>
@@ -643,6 +746,21 @@ inline constexpr units::quantity<double, units::money_in_cent_tag> operator"" _k
     return units::from_kusd( v );
 }
 
+inline constexpr units::temperature operator"" _mC( const unsigned long long v )
+{
+    return units::from_millidegree_celsius( v );
+}
+
+inline constexpr units::temperature operator"" _C( const unsigned long long v )
+{
+    return units::from_celsius( v );
+}
+
+inline constexpr units::temperature operator"" _F( const unsigned long long v )
+{
+    return units::from_fahrenheit( v );
+}
+
 namespace units
 {
 static const std::vector<std::pair<std::string, energy>> energy_units = { {
@@ -666,6 +784,12 @@ static const std::vector<std::pair<std::string, money>> money_units = { {
 static const std::vector<std::pair<std::string, volume>> volume_units = { {
         { "ml", 1_ml },
         { "L", 1_liter }
+    }
+};
+static const std::vector<std::pair<std::string, temperature>> temperature_units = { {
+        { "mC", 1_mC },
+        { "C", 1_C },
+        { "F", 1_F }
     }
 };
 } // namespace units

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -673,10 +673,10 @@ std::string print_temperature( double fahrenheit, int decimals )
 
     if( get_option<std::string>( "USE_CELSIUS" ) == "celsius" ) {
         return string_format( pgettext( "temperature in Celsius", "%sC" ),
-                              text( fahrenheit_to_celsius( fahrenheit ) ) );
+                              text( units::fahrenheit_to_celsius( fahrenheit ) ) );
     } else if( get_option<std::string>( "USE_CELSIUS" ) == "kelvin" ) {
         return string_format( pgettext( "temperature in Kelvin", "%sK" ),
-                              text( fahrenheit_to_kelvin( fahrenheit ) ) );
+                              text( units::fahrenheit_to_kelvin( fahrenheit ) ) );
     } else {
         return string_format( pgettext( "temperature in Fahrenheit", "%sF" ), text( fahrenheit ) );
     }
@@ -722,7 +722,7 @@ int get_local_windchill( double temperature_f, double humidity, double wind_mph 
         // Source : http://en.wikipedia.org/wiki/Wind_chill#Australian_Apparent_Temperature
         // Convert to meters per second.
         double wind_meters_per_sec = wind_mph * 0.44704;
-        double temperature_c = fahrenheit_to_celsius( temperature_f );
+        double temperature_c = units::fahrenheit_to_celsius( temperature_f );
 
         // Cap the vapor pressure term to 50C of extra heat, as this term
         // otherwise grows logistically to an asymptotic value of about 2e7

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -97,7 +97,7 @@ static double weather_temperature_from_common_data( const weather_generator &wg,
                      raw_noise_4d( x, y, z, modSEED ) * noise_magnitude_K;
 
     // Convert from Celsius to Fahrenheit
-    return celsius_to_fahrenheit( T );
+    return units::celsius_to_fahrenheit( T );
 }
 
 double weather_generator::get_weather_temperature( const tripoint &location, const time_point &t,
@@ -283,12 +283,12 @@ double weather_generator::get_water_temperature( const tripoint &location, const
     // For avg air temp<-10C, water is 0C
     // For avg air temp> 30C, water is 30C
     // logarithmic_range smoothing for the in-between
-    constexpr double lower_limit = celsius_to_fahrenheit( -10.0 );
-    constexpr double upper_limit = celsius_to_fahrenheit( 30.0 );
+    constexpr double lower_limit = units::celsius_to_fahrenheit( -10.0 );
+    constexpr double upper_limit = units::celsius_to_fahrenheit( 30.0 );
     const double t = logarithmic_range( static_cast<int>( 1000 * lower_limit ),
                                         static_cast<int>( 1000 * upper_limit ),
                                         static_cast<int>( 1000 * weighted_avg ) );
-    return lerp( celsius_to_fahrenheit( 0 ), celsius_to_fahrenheit( 30 ), 1.0 - t );
+    return lerp( units::celsius_to_fahrenheit( 0 ), units::celsius_to_fahrenheit( 30 ), 1.0 - t );
 }
 
 void weather_generator::test_weather( unsigned seed = 1000 ) const

--- a/tests/player_test.cpp
+++ b/tests/player_test.cpp
@@ -15,176 +15,283 @@
 #include "map_helpers.h"
 #include "weather.h"
 #include "game.h"
+#include "units.h"
+#include "hash_utils.h"
+#include "overmapbuffer.h"
+
+struct temperature_threshold {
+    constexpr temperature_threshold( int v, const char *n )
+        : value( v )
+        , name( n )
+    {}
+
+    int value;
+    const char *name;
+};
+
+#define t(x) temperature_threshold(x, #x)
+
+constexpr std::array<temperature_threshold, 7> bodytemps = {{
+        t( BODYTEMP_FREEZING ), t( BODYTEMP_VERY_COLD ), t( BODYTEMP_COLD ),
+        t( BODYTEMP_NORM ),
+        t( BODYTEMP_HOT ), t( BODYTEMP_VERY_HOT ), t( BODYTEMP_SCORCHING )
+    }
+};
+
+#undef t
 
 // Run update_bodytemp() until core body temperature settles.
-static int converge_temperature( player &p )
+static int converge_temperature( player &p, size_t iters, int start_temperature = BODYTEMP_NORM )
 {
     REQUIRE( get_weather().weather == WEATHER_CLOUDY );
     REQUIRE( get_weather().windspeed == 0 );
 
     for( int i = 0 ; i < num_bp; i++ ) {
-        p.temp_cur[i] = BODYTEMP_NORM;
+        p.temp_cur[i] = start_temperature;
     }
     for( int i = 0 ; i < num_bp; i++ ) {
-        p.temp_conv[i] = BODYTEMP_NORM;
+        p.temp_conv[i] = start_temperature;
     }
 
-    int prev_temp = p.temp_cur[0];
     bool converged = false;
-    // Run it once, to set the prev_ properly
-    p.update_bodytemp();
-    int prev_diff = prev_temp - p.temp_cur[0];
 
-    // Doesn't always converge on one number, we need to check a sign flip
-    for( int i = 0; i < 10000; i++ ) {
-        int cur_diff = prev_temp - p.temp_cur[0];
-        if( cur_diff == 0 || sgn( prev_diff ) != sgn( cur_diff ) ) {
+    using temp_array = decltype( p.temp_cur );
+    std::unordered_set<temp_array, cata::range_hash> history( iters );
+
+    for( int i = 0; i < iters; i++ ) {
+        if( history.count( p.temp_cur ) != 0 ) {
             converged = true;
             break;
-        } else if( prev_diff != cur_diff ) {
-            prev_diff = cur_diff;
         }
-        prev_temp = p.temp_cur[0];
+
+        history.emplace( p.temp_cur );
         p.update_bodytemp();
     }
 
-    CAPTURE( prev_temp );
-    CAPTURE( p.temp_cur[0] );
-    REQUIRE( converged );
+    CAPTURE( iters );
+    CAPTURE( p.temp_cur );
+    // If it doesn't converge, it's usually very close to it anyway, so don't fail
+    CHECK( converged );
     return p.temp_cur[0];
 }
 
-static int find_converging_temp( player &p, int expected_ambient, int min_bodytemp,
-                                 int max_bodytemp )
+static void equip_clothing( player &p, const std::vector<std::string> &clothing )
 {
-    REQUIRE( min_bodytemp < max_bodytemp );
-    REQUIRE( !get_map().has_flag( TFLAG_SWIMMABLE, p.pos() ) );
-    REQUIRE( !get_map().has_flag( TFLAG_DEEP_WATER, p.pos() ) );
-    int actual_ambient = expected_ambient;
-    int step = 2 * 128;
-    do {
-        step /= 2;
-        get_weather().temperature = actual_ambient;
-        get_weather().clear_temp_cache();
-        const int actual_temperature = get_weather().get_temperature( p.pos() );
-        REQUIRE( actual_temperature == actual_ambient );
-
-        int converged_temperature = converge_temperature( p );
-        bool high_enough = converged_temperature >= min_bodytemp;
-        bool low_enough  = converged_temperature <= max_bodytemp;
-        if( high_enough && low_enough ) {
-            return actual_ambient;
-        }
-
-        int direction = high_enough ? -1 : 1;
-        actual_ambient += direction * step;
-    } while( step > 0 );
-    CAPTURE( min_bodytemp );
-    CAPTURE( max_bodytemp );
-    CHECK( step > 0 );
-
-    return actual_ambient;
-}
-
-static void equip_clothing( player &p, const std::string &clothing )
-{
-    const item article( clothing, 0 );
-    p.wear_item( article );
+    for( const std::string &c : clothing ) {
+        const item article( c, 0 );
+        p.wear_item( article );
+    }
 }
 
 static std::array<int, 8> bodytemp_thresholds()
 {
-    constexpr std::array<int, 7> bodytemps = {{
-            BODYTEMP_FREEZING, BODYTEMP_VERY_COLD, BODYTEMP_COLD,
-            BODYTEMP_NORM,
-            BODYTEMP_HOT, BODYTEMP_VERY_HOT, BODYTEMP_SCORCHING
-        }
-    };
     std::array<int, 8> midpoints;
     midpoints[0] = INT_MIN;
     midpoints[7] = INT_MAX;
     for( int i = 0; i < 6; i++ ) {
-        midpoints[i + 1] = ( bodytemps[i] + bodytemps[i + 1] ) / 2;
+        midpoints[i + 1] = ( bodytemps[i].value + bodytemps[i + 1].value ) / 2;
     }
 
     return midpoints;
 }
 
 // Run the tests for each of the temperature setpoints.
-static void test_temperature_spread( player &p, const std::array<int, 7> &expected_temps )
+static void test_temperature_spread( player &p,
+                                     const std::array<units::temperature, 7> &air_temperatures )
 {
-    auto thresholds = bodytemp_thresholds();
-    std::array<int, 7> actual_temps;
+    const auto thresholds = bodytemp_thresholds();
     for( int i = 0; i < 7; i++ ) {
-        actual_temps[i] = find_converging_temp( p, expected_temps[i], thresholds[i], thresholds[i + 1] );
+        get_weather().temperature = to_fahrenheit( air_temperatures[i] );
+        get_weather().clear_temp_cache();
+        CAPTURE( air_temperatures[i] );
+        CAPTURE( get_weather().temperature );
+        int converged_temperature = converge_temperature( p, 1000, bodytemps[i].value );
+        auto expected_body_temperature = bodytemps[i].name;
+        CAPTURE( expected_body_temperature );
+        int air_temperature_celsius = to_celsius( air_temperatures[i] );
+        CAPTURE( air_temperature_celsius );
+        int min_temperature = thresholds[i];
+        int max_temperature = thresholds[i + 1];
+        CHECK( converged_temperature > min_temperature );
+        CHECK( converged_temperature < max_temperature );
     }
-    auto sorted_actual_temps = actual_temps;
-    std::sort( sorted_actual_temps.begin(), sorted_actual_temps.end() );
-    CHECK( sorted_actual_temps == actual_temps );
-    CHECK( actual_temps == expected_temps );
 }
 
-TEST_CASE( "Player body temperatures converge on expected values.", "[.bodytemp]" )
+const std::vector<std::string> light_clothing = {{
+        "hat_ball",
+        "bandana",
+        "tshirt",
+        "gloves_fingerless",
+        "jeans",
+        "socks",
+        "sneakers"
+    }
+};
+
+const std::vector<std::string> heavy_clothing = {{
+        "hat_knit",
+        "tshirt",
+        "vest",
+        "trenchcoat",
+        "gloves_wool",
+        "long_underpants",
+        "pants_army",
+        "socks_wool",
+        "boots"
+    }
+};
+
+const std::vector<std::string> arctic_clothing = {{
+        "balclava",
+        "goggles_ski",
+        "hat_hunting",
+        "under_armor",
+        "vest",
+        "coat_winter",
+        "gloves_liner",
+        "gloves_winter",
+        "long_underpants",
+        "pants_fur",
+        "socks_wool",
+        "boots_winter",
+    }
+};
+
+static void guarantee_neutral_weather( const player &p, bool also_set = true )
+{
+    REQUIRE( !get_map().has_flag( TFLAG_SWIMMABLE, p.pos() ) );
+    REQUIRE( !get_map().has_flag( TFLAG_DEEP_WATER, p.pos() ) );
+    REQUIRE( !g->is_in_sunlight( p.pos() ) );
+    if( also_set ) {
+        get_weather().weather = WEATHER_CLOUDY;
+        get_weather().weather_override = WEATHER_CLOUDY;
+        get_weather().windspeed = 0;
+        get_weather().weather_precise->humidity = 0;
+    }
+
+    const w_point weather = *g->weather.weather_precise;
+    const oter_id &cur_om_ter = overmap_buffer.ter( p.global_omt_location() );
+    bool sheltered = g->is_sheltered( p.pos() );
+    double total_windpower = get_local_windpower( g->weather.windspeed, cur_om_ter,
+                             p.pos(),
+                             g->weather.winddirection, sheltered );
+    int air_humidity = get_local_humidity( weather.humidity, g->weather.weather,
+                                           sheltered );
+    REQUIRE( air_humidity == 0 );
+    REQUIRE( total_windpower == 0.0 );
+    REQUIRE( !const_cast<player &>( p ).in_climate_control() );
+    REQUIRE( !p.can_use_floor_warmth() );
+    REQUIRE( get_heat_radiation( p.pos(), true ) == 0 );
+    REQUIRE( p.body_wetness == decltype( p.body_wetness )() );
+}
+
+TEST_CASE( "Player body temperatures within expected bounds.", "[bodytemp]" )
 {
     clear_map();
     clear_avatar();
     player &dummy = get_avatar();
-
-    const tripoint &pos = dummy.pos();
-
-    REQUIRE( !get_map().has_flag( TFLAG_SWIMMABLE, pos ) );
-    REQUIRE( !get_map().has_flag( TFLAG_DEEP_WATER, pos ) );
-    REQUIRE( !g->is_in_sunlight( pos ) );
-    get_weather().weather = WEATHER_CLOUDY;
-    get_weather().weather_override = WEATHER_CLOUDY;
-    get_weather().windspeed = 0;
-    get_weather().weather_precise->humidity = 0;
+    guarantee_neutral_weather( dummy );
 
     SECTION( "Nude target temperatures." ) {
-        test_temperature_spread( dummy, {{ 8, 35, 64, 82, 98, 110, 122 }} );
+        test_temperature_spread( dummy, {{-26_C, -11_C, 11_C, 26_C, 41_C, 56_C, 71_C,}} );
     }
 
     SECTION( "Lightly clothed target temperatures" ) {
-        equip_clothing( dummy, "hat_ball" );
-        equip_clothing( dummy, "bandana" );
-        equip_clothing( dummy, "tshirt" );
-        equip_clothing( dummy, "gloves_fingerless" );
-        equip_clothing( dummy, "jeans" );
-        equip_clothing( dummy, "socks" );
-        equip_clothing( dummy, "sneakers" );
-
-        test_temperature_spread( dummy, {{ 3, 30, 59, 80, 97, 110, 121 }} );
+        equip_clothing( dummy, light_clothing );
+        test_temperature_spread( dummy, {{-29_C, -14_C, 1_C, 24_C, 39_C, 54_C, 69_C,}} );
     }
 
     SECTION( "Heavily clothed target temperatures" ) {
-        equip_clothing( dummy, "hat_knit" );
-        equip_clothing( dummy, "tshirt" );
-        equip_clothing( dummy, "vest" );
-        equip_clothing( dummy, "trenchcoat" );
-        equip_clothing( dummy, "gloves_wool" );
-        equip_clothing( dummy, "long_underpants" );
-        equip_clothing( dummy, "pants_army" );
-        equip_clothing( dummy, "socks_wool" );
-        equip_clothing( dummy, "boots" );
-
-        test_temperature_spread( dummy, {{ -29, -2, 33, 68, 90, 104, 116 }} );
+        equip_clothing( dummy, heavy_clothing );
+        test_temperature_spread( dummy, {{-46_C, -30_C, -11_C, 8_C, 33_C, 48_C, 63_C,}} );
     }
 
     SECTION( "Arctic gear target temperatures" ) {
-        equip_clothing( dummy, "balclava" );
-        equip_clothing( dummy, "goggles_ski" );
-        equip_clothing( dummy, "hat_hunting" );
-        equip_clothing( dummy, "under_armor" );
-        equip_clothing( dummy, "vest" );
-        equip_clothing( dummy, "coat_winter" );
-        equip_clothing( dummy, "gloves_liner" );
-        equip_clothing( dummy, "gloves_winter" );
-        equip_clothing( dummy, "long_underpants" );
-        equip_clothing( dummy, "pants_fur" );
-        equip_clothing( dummy, "socks_wool" );
-        equip_clothing( dummy, "boots_winter" );
+        equip_clothing( dummy, arctic_clothing );
+        test_temperature_spread( dummy, {{-83_C, -68_C, -50_C, -24_C, 3_C, 27_C, 43_C,}} );
+    }
 
-        test_temperature_spread( dummy, {{ -95, -70, -35, 12, 62, 84, 98 }} );
+    // Just to see if it broke.
+    guarantee_neutral_weather( dummy, false );
+}
+
+/**
+ * Finds air temperatures for which body temperature is closest to exact "named" value.
+ * FREEZING, HOT, etc.
+ */
+static std::array<units::temperature, bodytemps.size()> find_temperature_points( player &p )
+{
+    std::array<std::pair<int, int>, bodytemps.size()> value_distances;
+    std::fill( value_distances.begin(), value_distances.end(), std::make_pair( 0, INT_MAX ) );
+    int last_converged_temperature = INT_MIN;
+    for( int i = -200; i < 200; i++ ) {
+        get_weather().temperature = i;
+        get_weather().clear_temp_cache();
+        CAPTURE( units::from_fahrenheit( i ) );
+        int converged_temperature = converge_temperature( p, 10000 );
+        CHECK( converged_temperature >= last_converged_temperature );
+        // 0 - FREEZING, 6 - SCORCHING
+        for( int temperature_index = 0; temperature_index < bodytemps.size(); temperature_index++ ) {
+            int distance_to_definition = std::abs( bodytemps[temperature_index].value - converged_temperature );
+            if( distance_to_definition < value_distances[temperature_index].second ) {
+                value_distances[temperature_index] = std::make_pair( i, distance_to_definition );
+            }
+        }
+        last_converged_temperature = converged_temperature;
+    }
+
+    std::array<units::temperature, 7> points;
+    std::transform( value_distances.begin(), value_distances.end(), points.begin(),
+    []( const std::pair<int, int> &pr ) {
+        // Round it to nearest full Celsius, for nicer display
+        return units::from_celsius( std::round( units::fahrenheit_to_celsius( pr.first ) ) );
+    } );
+
+    auto sorted_copy = points;
+    std::sort( sorted_copy.begin(), sorted_copy.end() );
+    CHECK( sorted_copy == points );
+    return points;
+}
+
+static void print_temperatures( const std::array<units::temperature, bodytemps.size()>
+                                &temperatures )
+{
+    std::string s = "{{";
+    for( auto &t : temperatures ) {
+        s += to_string( units::to_celsius( t ) ) + "_C,";
+    }
+    s += "}}\n";
+    cata_printf( s );
+}
+
+TEST_CASE( "Find air temperatures for given body temperatures.", "[.][bodytemp]" )
+{
+    clear_map();
+    clear_avatar();
+    player &dummy = get_avatar();
+    guarantee_neutral_weather( dummy );
+
+    SECTION( "Nude target temperatures." ) {
+        const auto points = find_temperature_points( dummy );
+        print_temperatures( points );
+    }
+
+    SECTION( "Lightly clothed target temperatures" ) {
+        equip_clothing( dummy, light_clothing );
+        const auto points = find_temperature_points( dummy );
+        print_temperatures( points );
+    }
+
+    SECTION( "Heavily clothed target temperatures" ) {
+        equip_clothing( dummy, heavy_clothing );
+        const auto points = find_temperature_points( dummy );
+        print_temperatures( points );
+    }
+
+    SECTION( "Arctic gear target temperatures" ) {
+        equip_clothing( dummy, arctic_clothing );
+        const auto points = find_temperature_points( dummy );
+        print_temperatures( points );
     }
 }
 
@@ -203,7 +310,7 @@ static int find_converging_water_temp( player &p, int expected_water, int expect
         const int actual_temperature = get_weather().get_water_temperature( p.pos() );
         REQUIRE( actual_temperature == actual_water );
 
-        int converged_temperature = converge_temperature( p );
+        int converged_temperature = converge_temperature( p, 10000 );
         bool high_enough = expected_bodytemp - tol <= converged_temperature;
         bool low_enough  = expected_bodytemp + tol >= converged_temperature;
         if( high_enough && low_enough ) {
@@ -233,7 +340,7 @@ static void test_water_temperature_spread( player &p, const std::array<int, 7> &
     CHECK( actual_temps == expected_temps );
 }
 
-TEST_CASE( "Player body temperatures in water.", "[.bodytemp]" )
+TEST_CASE( "Player body temperatures in water.", "[.][bodytemp]" )
 {
     clear_map();
     clear_avatar();
@@ -255,27 +362,13 @@ TEST_CASE( "Player body temperatures in water.", "[.bodytemp]" )
 
     // Not supposed to be very protective under water
     SECTION( "Arctic gear target temperatures" ) {
-        equip_clothing( dummy, "balclava" );
-        equip_clothing( dummy, "goggles_ski" );
-        equip_clothing( dummy, "hat_hunting" );
-        equip_clothing( dummy, "under_armor" );
-        equip_clothing( dummy, "vest" );
-        equip_clothing( dummy, "coat_winter" );
-        equip_clothing( dummy, "gloves_liner" );
-        equip_clothing( dummy, "gloves_winter" );
-        equip_clothing( dummy, "long_underpants" );
-        equip_clothing( dummy, "pants_fur" );
-        equip_clothing( dummy, "socks_wool" );
-        equip_clothing( dummy, "boots_winter" );
-
+        equip_clothing( dummy, arctic_clothing );
         test_water_temperature_spread( dummy, {{ 25, 42, 57, 76, 96, 112, 128 }} );
     }
 
     // Should keep warmth under water
     SECTION( "Swimming gear target temperatures" ) {
-        equip_clothing( dummy, "wetsuit_hood" );
-        equip_clothing( dummy, "wetsuit" );
-
+        equip_clothing( dummy, { "wetsuit_hood", "wetsuit" } );
         test_water_temperature_spread( dummy, {{ 37, 54, 69, 86, 102, 118, 134 }} );
     }
 }
@@ -302,7 +395,7 @@ static void hypothermia_check( player &p, int water_temperature, time_duration e
     CHECK( p.temp_cur[0] <= expected_temperature );
 }
 
-TEST_CASE( "Water hypothermia check.", "[.bodytemp]" )
+TEST_CASE( "Water hypothermia check.", "[.][bodytemp]" )
 {
     clear_map();
     clear_avatar();
@@ -319,14 +412,14 @@ TEST_CASE( "Water hypothermia check.", "[.bodytemp]" )
     dummy.drench( 100, body_part_set::all(), true );
 
     SECTION( "Cold" ) {
-        hypothermia_check( dummy, celsius_to_fahrenheit( 20 ), 5_minutes, BODYTEMP_COLD );
+        hypothermia_check( dummy, units::celsius_to_fahrenheit( 20 ), 5_minutes, BODYTEMP_COLD );
     }
 
     SECTION( "Very cold" ) {
-        hypothermia_check( dummy, celsius_to_fahrenheit( 10 ), 5_minutes, BODYTEMP_VERY_COLD );
+        hypothermia_check( dummy, units::celsius_to_fahrenheit( 10 ), 5_minutes, BODYTEMP_VERY_COLD );
     }
 
     SECTION( "Freezing" ) {
-        hypothermia_check( dummy, celsius_to_fahrenheit( 0 ), 5_minutes, BODYTEMP_FREEZING );
+        hypothermia_check( dummy, units::celsius_to_fahrenheit( 0 ), 5_minutes, BODYTEMP_FREEZING );
     }
 }

--- a/tests/player_test.cpp
+++ b/tests/player_test.cpp
@@ -185,7 +185,7 @@ static void guarantee_neutral_weather( const player &p, bool also_set = true )
     REQUIRE( p.body_wetness == decltype( p.body_wetness )() );
 }
 
-TEST_CASE( "Player body temperatures within expected bounds.", "[bodytemp]" )
+TEST_CASE( "Player body temperatures within expected bounds.", "[bodytemp][slow]" )
 {
     clear_map();
     clear_avatar();

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -19,6 +19,7 @@
 #include "lightmap.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "player_helpers.h"
 #include "point.h"
 #include "shadowcasting.h"
 #include "type_id.h"
@@ -54,9 +55,9 @@ static void full_map_test( const std::vector<std::string> &setup,
     const ter_id t_open_air( "t_open_air" );
 
     g->place_player( tripoint( 60, 60, 0 ) );
-    g->u.worn.clear(); // Remove any light-emitting clothing
-    g->u.clear_effects();
+    clear_avatar();
     clear_map();
+    get_weather().weather = WEATHER_CLEAR;
     g->reset_light_level();
 
     if( !!( flags & vision_test_flags::crouching ) ) {


### PR DESCRIPTION
Fixes #383

To actually figure out if I fixed it, I re-did the tests and added temperature units (currently only used in tests).

For air temperature tests, there are 4 sets of clothing:
* Nude
* Light ("hat_ball", "bandana", tshirt", "gloves_fingerless", "jeans", "socks", "sneakers") 
* Heavy ("hat_knit", "tshirt", "vest", "trenchcoat", "gloves_wool", "long_underpants", "pants_army", "socks_wool", "boots")
* Arctic ("balclava", "goggles_ski", "hat_hunting", "under_armor", "vest", "coat_winter", "gloves_liner", "gloves_winter", "long_underpants", "pants_fur", "socks_wool", "boots_winter")

There are 7 body temperature thresholds:
* BODYTEMP_FREEZING
* BODYTEMP_VERY_COLD
* BODYTEMP_COLD
* BODYTEMP_NORM
* BODYTEMP_HOT
* BODYTEMP_VERY_HOT
* BODYTEMP_SCORCHING

The body temperature values are magic. They can't be translated into real life units.

| Clothing | FR | VC | C | N | H | VH | SC |
|---|---|---|---|---|---|---|---|
| Nude | -26_C | -11_C | 11_C | 26_C | 41_C | 56_C | 71_C |
| Light | -29_C | -14_C | 1_C | 24_C | 39_C | 54_C | 69_C |
| Heavy | -46_C | -30_C | -11_C | 8_C | 33_C | 48_C | 63_C |
| Arctic | -83_C | -68_C | -50_C | -24_C | 3_C | 27_C | 43_C |

The table above shows combinations of clothing set, body temperatures, and air temperature that results in a given body temperature for a given clothing set.
Air temperatures are those which are the closest to thresholds. So lightly clothed survivor should be warm at 25_C, but comfortable at 23_C. They could be midpoints instead, but this wouldn't work for freezing and scorching and so would require special cases.

The values are calculated assuming:
* No wind
* Zero air humidity (only affects wind anyway)
* Cloudy weather (no temperature bonus from sunlight)
* Not standing in water/swimmable
* No body wetness
* No climate control
* No heat radiation (fires etc.)
* Can't use floor warmth (not sleeping, reading etc.)