### PR TITLE
Switch cata_printf to use printf

### DIFF
--- a/src/string_formatter.cpp
+++ b/src/string_formatter.cpp
@@ -204,10 +204,10 @@ std::string to_string( const double n )
 
 void cata_print_stdout( const std::string &s )
 {
-    std::cout << s;
+    fputs( s.c_str(), stdout );
 }
 
 void cata_print_stderr( const std::string &s )
 {
-    std::cerr << s;
+    fputs( s.c_str(), stderr );
 }

--- a/tests/line_test.cpp
+++ b/tests/line_test.cpp
@@ -5,12 +5,12 @@
 #include <ctime>
 #include <memory>
 #include <vector>
-#include <iostream>
 
 #include "catch/catch.hpp"
 #include "line.h"
 #include "point.h"
 #include "rng.h"
+#include "string_formatter.h"
 
 #define SGN(a) (((a)<0) ? -1 : 1)
 // Compare all future line_to implementations to the canonical one.
@@ -379,10 +379,10 @@ static void line_to_comparison( const int iterations )
             const long long diff2 =
                 std::chrono::duration_cast<std::chrono::microseconds>( end2 - start2 ).count();
 
-            std::cout << "line_to() executed " << iterations << " times in " << diff1 << " microseconds." <<
-                      std::endl;
-            std::cout << "canonical_line_to() executed " << iterations << " times in " << diff2 <<
-                      " microseconds." << std::endl;
+            cata_printf( "line_to() executed %d times in %lld microseconds.\n",
+                         iterations, diff1 );
+            cata_printf( "canonical_line_to() executed %d times in %lld microseconds.\n",
+                         iterations, diff2 );
         }
     }
 }

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -10,6 +10,7 @@
 #include "map.h"
 #include "map_memory.h"
 #include "point.h"
+#include "string_formatter.h"
 
 static constexpr tripoint p1{ -SEEX - 2, -SEEY - 3, -1 };
 static constexpr tripoint p2{ 5, 7, -1 };
@@ -83,8 +84,7 @@ TEST_CASE( "lru_cache_perf", "[.]" )
     const auto end1 = std::chrono::high_resolution_clock::now();
     const long long diff1 = std::chrono::duration_cast<std::chrono::microseconds>
                             ( end1 - start1 ).count();
-    std::cout << "completed " << max_size << " insertions in " << diff1 << " microseconds." <<
-              std::endl;
+    cata_printf( "completed %d insertions in %lld microseconds.\n", max_size, diff1 );
     /*
      * Original tripoint hash    completed 1000000 insertions in 96136925 microseconds.
      * Table based interleave v1 completed 1000000 insertions in 41435604 microseconds.

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -2,7 +2,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <iostream>
 
 #include "avatar.h"
 #include "calendar.h"
@@ -28,6 +27,7 @@
 #include "player.h"
 #include "player_helpers.h"
 #include "point.h"
+#include "string_formatter.h"
 #include "string_id.h"
 #include "type_id.h"
 
@@ -68,9 +68,9 @@ static void gen_response_lines( dialogue &d, size_t expected_count )
         response.create_option_line( d, ' ' );
     }
     if( d.responses.size() != expected_count ) {
-        std::cout << "Test failure in " << d.topic_stack.back().id.c_str() << std::endl;
+        cata_printf( "Test failure in %s\n", d.topic_stack.back().id.c_str() );
         for( talk_response &response : d.responses ) {
-            std::cout << "response: " << response.text.c_str() << std::endl;
+            cata_printf( "response: %s\n", response.text.c_str() );
         }
     }
     CAPTURE( d.responses );


### PR DESCRIPTION
#### Purpose of change
~May help with the weird test output?~
Well, that didn't work.
It also didn't break anything, so I guess it can still go in as it makes `cata_printf` behave more like vanilla `printf`. 

#### Describe the solution
Switch from C++ stream to C printf

#### Testing
Compiles, Travis is unaffected