### PR TITLE
Add debug overmap display for distribution grids

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -142,6 +142,7 @@ enum debug_menu_index {
     DEBUG_SHOW_SOUND,
     DEBUG_DISPLAY_WEATHER,
     DEBUG_DISPLAY_SCENTS,
+    DEBUG_DISPLAY_DISTRIBUTION_GRIDS,
     DEBUG_CHANGE_TIME,
     DEBUG_SET_AUTOMOVE,
     DEBUG_SHOW_MUT_CAT,
@@ -228,6 +229,7 @@ static int info_uilist( bool display_all_entries = true )
             { uilist_entry( DEBUG_SHOW_SOUND, true, 'c', _( "Show sound clustering" ) ) },
             { uilist_entry( DEBUG_DISPLAY_WEATHER, true, 'w', _( "Display weather" ) ) },
             { uilist_entry( DEBUG_DISPLAY_SCENTS, true, 'S', _( "Display overmap scents" ) ) },
+            { uilist_entry( DEBUG_DISPLAY_DISTRIBUTION_GRIDS, true, 'G', _( "Display overmap distribution grids" ) ) },
             { uilist_entry( DEBUG_DISPLAY_SCENTS_LOCAL, true, 's', _( "Toggle display local scents" ) ) },
             { uilist_entry( DEBUG_DISPLAY_SCENTS_TYPE_LOCAL, true, 'y', _( "Toggle display local scents type" ) ) },
             { uilist_entry( DEBUG_DISPLAY_TEMP, true, 'T', _( "Toggle display temperature" ) ) },
@@ -1601,6 +1603,9 @@ void debug()
             break;
         case DEBUG_DISPLAY_SCENTS:
             ui::omap::display_scents();
+            break;
+        case DEBUG_DISPLAY_DISTRIBUTION_GRIDS:
+            ui::omap::display_distribution_grids();
             break;
         case DEBUG_DISPLAY_SCENTS_LOCAL:
             g->display_toggle_overlay( ACTION_DISPLAY_SCENT );

--- a/src/distribution_grid.cpp
+++ b/src/distribution_grid.cpp
@@ -245,6 +245,18 @@ const distribution_grid &distribution_grid_tracker::grid_at( const tripoint &p )
                const_cast<distribution_grid_tracker *>( this )->grid_at( p ) );
 }
 
+std::uintptr_t distribution_grid_tracker::debug_grid_id( const tripoint &omp ) const
+{
+    tripoint sm_pos = omt_to_sm_copy( omp );
+    auto iter = parent_distribution_grids.find( sm_pos );
+    if( iter != parent_distribution_grids.end() ) {
+        distribution_grid *ret = iter->second.get();
+        return reinterpret_cast<std::uintptr_t>( ret );
+    } else {
+        return 0;
+    }
+}
+
 void distribution_grid_tracker::update( time_point to )
 {
     // TODO: Don't recalc this every update

--- a/src/distribution_grid.h
+++ b/src/distribution_grid.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_DISTRIBUTION_GRID_H
 #define CATA_SRC_DISTRIBUTION_GRID_H
 
+#include <cstdint>
 #include <vector>
 #include <map>
 #include "active_tile_data.h"
@@ -88,6 +89,12 @@ class distribution_grid_tracker
         distribution_grid &grid_at( const tripoint &p );
         const distribution_grid &grid_at( const tripoint &p ) const;
         /*@}*/
+
+        /**
+         * Identify grid at given overmap tile (for debug purposes).
+         * @returns 0 if there's no grid.
+         */
+        std::uintptr_t debug_grid_id( const tripoint &omp ) const;
 
         void update( time_point to );
         /**

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -25,6 +25,7 @@
 #include "compatibility.h"
 #include "coordinate_conversions.h"
 #include "cursesdef.h"
+#include "distribution_grid.h"
 #include "enums.h"
 #include "game.h"
 #include "game_constants.h"
@@ -87,6 +88,94 @@ static const int npm_height = 3;
 
 namespace overmap_ui
 {
+// persistent data for distribution grid debug drawing
+struct grids_draw_data {
+    public:
+        cata::optional<char> get_active( const tripoint &omp ) {
+            uintptr_t id = get_distribution_grid_tracker().debug_grid_id( omp );
+            if( id == 0 ) {
+                return cata::nullopt;
+            }
+
+            auto it = list_active.find( id );
+            if( it != list_active.end() ) {
+                return it->second;
+            }
+
+            auto ch = pick_char( [this]( char c ) -> bool {
+                for( const auto &it : list_active ) {
+                    if( it.second == c ) {
+                        return false;
+                    }
+                }
+                return true;
+            } );
+
+            char c = ch.has_value() ? *ch : '?';
+            list_active.insert( std::make_pair( id, c ) );
+            return c;
+        }
+
+        cata::optional<char> get_inactive( const tripoint &omp ) {
+            std::set<tripoint> grid = overmap_buffer.electric_grid_at( omp );
+            if( grid.size() <= 1 ) {
+                return cata::nullopt;
+            }
+            std::vector<tripoint> sorted( grid.begin(), grid.end() );
+            std::sort( sorted.begin(), sorted.end() );
+
+            // Vector hashing code by https://stackoverflow.com/a/27216842
+            std::size_t id = sorted.size();
+            for( const auto &p : sorted ) {
+                std::size_t i = std::hash<tripoint> {}( p );
+                id ^= i + 0x9e3779b9 + ( id << 6 ) + ( id >> 2 );
+            }
+
+            auto it = list_inactive.find( id );
+            if( it != list_inactive.end() ) {
+                return it->second.second;
+            }
+
+            // There may be a lot of grids visible at the same time.
+            // We have no choice but to allow repeating symbols,
+            // but also have to make sure neighbouring grids don't receive same ones.
+            auto ch = pick_char( [omp, this]( char c ) {
+                for( const auto &it : list_inactive ) {
+                    if( it.second.second != c ) {
+                        continue;
+                    }
+                    for( const tripoint &p : it.second.first ) {
+                        tripoint delta = p - omp;
+                        if( abs( delta.x ) < 5 && abs( delta.y ) < 5 && abs( delta.z ) < 5 ) {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            } );
+
+            char c = ch.has_value() ? *ch : '?';
+            list_inactive.insert( std::make_pair( id, std::make_pair( sorted, c ) ) );
+            return c;
+        }
+
+    private:
+        // Fn(char) -> bool
+        template<typename Fn>
+        cata::optional<char> pick_char( Fn filter_func ) {
+            static std::string candidates( "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" );
+            for( char c : candidates ) {
+                if( filter_func( c ) ) {
+                    return c;
+                }
+            }
+            return cata::nullopt;
+        }
+
+        std::unordered_map<std::uintptr_t, char> list_active;
+        std::unordered_map<std::size_t, std::pair<std::vector<tripoint>, char>> list_inactive;
+};
+
 // {note symbol, note color, offset to text}
 static std::tuple<char, nc_color, size_t> get_note_display_info( const std::string &note )
 {
@@ -477,7 +566,7 @@ static point draw_notes( const tripoint &origin )
 
 void draw( const catacurses::window &w, const catacurses::window &wbar, const tripoint &center,
            const tripoint &orig, bool blink, bool show_explored, bool fast_scroll, input_context *inp_ctxt,
-           const draw_data_t &data )
+           const draw_data_t &data, grids_draw_data &grids_data )
 {
     const int om_map_width  = OVERMAP_WINDOW_WIDTH;
     const int om_map_height = OVERMAP_WINDOW_HEIGHT;
@@ -773,6 +862,21 @@ void draw( const catacurses::window &w, const catacurses::window &wbar, const tr
                         } else {
                             ter_color = c_blue;
                         }
+                    }
+                }
+            }
+
+            // Are we debugging distribution grids?
+            if( blink && data.debug_grids ) {
+                cata::optional<char> ch = grids_data.get_active( omp );
+                if( ch.has_value() ) {
+                    ter_sym = *ch;
+                    ter_color = c_light_blue_yellow;
+                } else {
+                    ch = grids_data.get_inactive( omp );
+                    if( ch.has_value() ) {
+                        ter_sym = *ch;
+                        ter_color = c_light_blue;
                     }
                 }
             }
@@ -1492,10 +1596,11 @@ static tripoint display( const tripoint &orig, const draw_data_t &data = draw_da
     int fast_scroll_offset = get_option<int>( "FAST_SCROLL_OFFSET" );
     cata::optional<tripoint> mouse_pos;
     std::chrono::time_point<std::chrono::steady_clock> last_blink = std::chrono::steady_clock::now();
+    grids_draw_data grids_data;
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         draw( g->w_overmap, g->w_omlegend, curs, orig, uistate.overmap_show_overlays,
-              show_explored, fast_scroll, &ictxt, data );
+              show_explored, fast_scroll, &ictxt, data, grids_data );
     } );
 
     do {
@@ -1687,6 +1792,13 @@ void ui::omap::display_scents()
 {
     overmap_ui::draw_data_t data;
     data.debug_scent = true;
+    overmap_ui::display( g->u.global_omt_location(), data );
+}
+
+void ui::omap::display_distribution_grids()
+{
+    overmap_ui::draw_data_t data;
+    data.debug_grids = true;
     overmap_ui::display( g->u.global_omt_location(), data );
 }
 

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -38,6 +38,10 @@ void display_visible_weather();
  */
 void display_scents();
 /**
+ * Display overmap like with @ref display() and display distribution grids.
+ */
+void display_distribution_grids();
+/**
  * Display overmap like with @ref display() and display the given zone.
  */
 void display_zones( const tripoint &center, const tripoint &select, int iZoneIndex );
@@ -87,12 +91,16 @@ struct draw_data_t {
     bool debug_scent = false;
     // draw zone location.
     tripoint select = tripoint( -1, -1, -1 );
+    // draw location of a zone
     int iZoneIndex = -1;
+    // draw distribution grids
+    bool debug_grids = false;
 };
 
+struct grids_draw_data;
 void draw( const catacurses::window &w, const catacurses::window &wbar, const tripoint &center,
            const tripoint &orig, bool blink, bool show_explored, bool fast_scroll, input_context *inp_ctxt,
-           const draw_data_t &data );
+           const draw_data_t &data, grids_draw_data &grids_data );
 void create_note( const tripoint &curs );
 } // namespace overmap_ui
 #endif // CATA_SRC_OVERMAP_UI_H


### PR DESCRIPTION
#### Purpose of change
Add debug overmap display for distribution grids.
Shows 2 things:
1. Overmap tiles connected into big grids (with >= 2 overmap tiles)
2. Active grids (the ones in the grid tracker)

#### Testing
Refugee shelter with active 3-level grid (solar panel, battery, item charger)
Blinking light-blue-on-dirty-yellow
![image](https://user-images.githubusercontent.com/60584843/112235865-87e2eb80-8c50-11eb-80d7-27401337c1cb.png)
![image](https://user-images.githubusercontent.com/60584843/112235564-fc695a80-8c4f-11eb-9333-4789e73f4c2b.png)
![image](https://user-images.githubusercontent.com/60584843/112235910-9df0ac00-8c50-11eb-9f39-535ec76a2977.png)


City buildings with multi-z-level grids
Blinking light-blue-on-black
![image](https://user-images.githubusercontent.com/60584843/112235640-1f940a00-8c50-11eb-9871-1b513546461a.png)
![image](https://user-images.githubusercontent.com/60584843/112235696-376b8e00-8c50-11eb-8751-9a6e231d484c.png)

Since the code uses overmapbuffer's standard methods, there's a side effect of game generating new overmaps while scrolling the map in this mode. This was not intentional, but also seems harmless enough.