### PR TITLE
Zombie soldiers drop rebalance 2

### DIFF
--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -29,6 +29,17 @@
   },
   {
     "type": "item_group",
+    "id": "military_standard_smgs",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "hk_ump45", "prob": 15, "charges-min": 0, "charges-max": 25 },
+      { "item": "hk_mp5", "prob": 50, "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5k", "prob": 10, "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5sd", "prob": 5, "charges-min": 0, "charges-max": 30 }
+    ]
+  },
+  {
+    "type": "item_group",
     "id": "military_standard_pistols",
     "subtype": "distribution",
     "entries": [

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -33,8 +33,8 @@
     "subtype": "distribution",
     "entries": [
       { "item": "hk_ump45", "prob": 15, "charges-min": 0, "charges-max": 25 },
-      { "item": "hk_mp5", "prob": 50, "charges-min": 0, "charges-max": 30 },
-      { "item": "hk_mp5k", "prob": 10, "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5", "prob": 30, "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5k", "prob": 30, "charges-min": 0, "charges-max": 30 },
       { "item": "hk_mp5sd", "prob": 5, "charges-min": 0, "charges-max": 30 }
     ]
   },

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -32,10 +32,10 @@
     "id": "military_standard_smgs",
     "subtype": "distribution",
     "entries": [
-      { "item": "hk_ump45", "prob": 15, "charges-min": 0, "charges-max": 25 },
-      { "item": "hk_mp5", "prob": 30, "charges-min": 0, "charges-max": 30 },
-      { "item": "hk_mp5k", "prob": 30, "charges-min": 0, "charges-max": 30 },
-      { "item": "hk_mp5sd", "prob": 5, "charges-min": 0, "charges-max": 30 }
+      { "item": "hk_ump45", "prob": 20, "charges-min": 0, "charges-max": 25 },
+      { "item": "hk_mp5", "prob": 35, "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5k", "prob": 35, "charges-min": 0, "charges-max": 30 },
+      { "item": "hk_mp5sd", "prob": 10, "charges-min": 0, "charges-max": 30 }
     ]
   },
   {

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -58,11 +58,11 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "group": "military_standard_smgs", "prob": 25 },
-      { "group": "military_standard_shotguns", "prob": 25 },
-      { "group": "military_standard_assault_rifles", "prob": 20 },
-      { "group": "military_standard_lmgs", "prob": 10 },
-      { "group": "military_standard_sniper_rifles", "prob": 10 }
+      { "group": "military_standard_smgs", "prob": 30 },
+      { "group": "military_standard_shotguns", "prob": 30 },
+      { "group": "military_standard_assault_rifles", "prob": 30 },
+      { "group": "military_standard_lmgs", "prob": 5 },
+      { "group": "military_standard_sniper_rifles", "prob": 5 }
     ]
   }
 ]

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -13,7 +13,7 @@
         ]
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_standard_guns", "prob": 30, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
       { "item": "holster", "contents-group": "military_standard_pistols", "prob": 30 },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
@@ -42,7 +42,7 @@
         ]
       },
       { "group": "infantry_common_gear" },
-      { "group": "military_standard_guns", "prob": 10, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_standard_guns", "prob": 30, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
       { "item": "holster", "contents-group": "military_standard_pistols", "prob": 30 },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },
@@ -58,10 +58,11 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "group": "military_standard_assault_rifles", "prob": 70 },
+      { "group": "military_standard_smgs", "prob": 30 },
+      { "group": "military_standard_shotguns", "prob": 30 },
+      { "group": "military_standard_assault_rifles", "prob": 30 },
       { "group": "military_standard_lmgs", "prob": 10 },
-      { "group": "military_standard_sniper_rifles", "prob": 10 },
-      { "group": "military_standard_shotguns", "prob": 5 }
+      { "group": "military_standard_sniper_rifles", "prob": 10 }
     ]
   }
 ]

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -58,9 +58,9 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "group": "military_standard_smgs", "prob": 30 },
-      { "group": "military_standard_shotguns", "prob": 30 },
-      { "group": "military_standard_assault_rifles", "prob": 30 },
+      { "group": "military_standard_smgs", "prob": 25 },
+      { "group": "military_standard_shotguns", "prob": 25 },
+      { "group": "military_standard_assault_rifles", "prob": 20 },
       { "group": "military_standard_lmgs", "prob": 10 },
       { "group": "military_standard_sniper_rifles", "prob": 10 }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

SUMMARY: Balance "Zombie soldiers drop rebalance"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "Zombie soldiers drop rebalance"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
There was: 
https://github.com/cataclysmbnteam/Cataclysm-BN/pull/367
It reduced chance of getting riles from soldiers. After after some thinking a I've realised that I've made soldiers drop somewhat low and inconsistent versus zombie cops.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
1) Increase chance of dropping military guns from soldiers from 10% to 30%.
2)  Add military smg drop to zombie soldiers. It will contains different variants of MP5.
3) Decrease chance of dropping rifles from zombie soldiers by increasing chance of dropping shotungs and SMGs.

Overall you are more likely getting something bigger than pistols from zombie soldiers, but chance of getting assault rifle, LMG or sniper rifle still will be relatively low.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Spawn zobmie soldiers group.
2) Kill it with debug.
3) Observe the loot. You should see nconsistent numbersshotguns and smgs in it's drop.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
SMGs actually can be used by military. Obviously it much should be widespread mostly SpecOps or military drivers because of comact sizes.

Shotguns are different thing. Logically speaking, shotguns  should not be widespread for regular soldiers but theretically someone might have an idea to arm soldiers with shotguns intentionally for fighting vs "riot civilians".
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
