### PR TITLE
Respect magazine's default ammo override in item::ammo_default()

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7110,8 +7110,13 @@ ammotype item::ammo_type() const
 
 itype_id item::ammo_default( bool conversion ) const
 {
-    if( !ammo_types( conversion ).empty() ) {
-        itype_id res = ammotype( *ammo_types( conversion ).begin() )->default_ammotype();
+    if( is_magazine() ) {
+        return type->magazine->default_ammo;
+    }
+
+    const std::set<ammotype> &atypes = ammo_types( conversion );
+    if( !atypes.empty() ) {
+        itype_id res = ammotype( *atypes.begin() )->default_ammotype();
         if( !res.empty() ) {
             return res;
         }


### PR DESCRIPTION
#### Purpose of change
Fixes #344

#### Describe the solution
If item is a magazine, `item::ammo_default()` now returns `default_ammo` for that magazine.

#### Testing
Defined an ammo belt that specifies default_ammo different from ammotype's default ammo, debug spawned it.