### PR TITLE
Ammo Rebalance Part 5: Almost All Pistol Rounds

### DIFF
--- a/data/json/items/ammo/10mm.json
+++ b/data/json/items/ammo/10mm.json
@@ -17,7 +17,8 @@
     "ammo_type": "10mm",
     "casing": "10mm_casing",
     "range": 14,
-    "damage": { "damage_type": "stab", "amount": 31, "armor_penetration": 4 },
+    "//": "Base damage of 31, balance increase of one-nineth.",
+    "damage": { "damage_type": "stab", "amount": 34, "armor_penetration": 19 },
     "dispersion": 50,
     "recoil": 750,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/36paper.json
+++ b/data/json/items/ammo/36paper.json
@@ -14,7 +14,8 @@
     "count": 25,
     "ammo_type": "36paper",
     "range": 15,
-    "damage": { "damage_type": "stab", "amount": 19 },
+    "//": "Base damage of 19, balance increase of one-third, plus 25% hollowpoint bonus.",
+    "damage": { "damage_type": "stab", "amount": 32 },
     "dispersion": 80,
     "recoil": 210,
     "effects": [ "COOKOFF", "MUZZLE_SMOKE", "BLACKPOWDER" ]

--- a/data/json/items/ammo/40.json
+++ b/data/json/items/ammo/40.json
@@ -5,7 +5,8 @@
     "type": "AMMO",
     "name": { "str": ".40 S&W FMJ" },
     "description": ".40 S&W ammunition with 180gr FMJ bullets.  Designed to retain the 10mm Auto cartridge's power with lower recoil, the .40 S&W round became popular for law enforcement and personal defense.",
-    "relative": { "damage": { "damage_type": "stab", "amount": -3, "armor_penetration": 6 } }
+    "//": "Base damage of 23, balance increase of two-nineths.",
+    "relative": { "damage": { "damage_type": "stab", "amount": -7, "armor_penetration": 16 } }
   },
   {
     "id": "40sw",
@@ -25,7 +26,8 @@
     "ammo_type": "40",
     "casing": "40_casing",
     "range": 14,
-    "damage": { "damage_type": "stab", "amount": 26, "armor_penetration": 4 },
+    "//": "Hollowpoint bonus of 25%",
+    "damage": { "damage_type": "stab", "amount": 35 },
     "dispersion": 50,
     "recoil": 560,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/44.json
+++ b/data/json/items/ammo/44.json
@@ -4,8 +4,9 @@
     "copy-from": "44magnum",
     "type": "AMMO",
     "name": { "str": ".44 Magnum FMJ" },
-    "description": "A brass-jacketed variant of the .44 Magnum round.  This increases penetration slightly at the cost of reduced damage from expansion.",
-    "relative": { "damage": { "damage_type": "stab", "amount": -4, "armor_penetration": 8 } }
+    "description": "A brass-jacketed variant of the .44 Magnum round.  This increases penetration at the cost of reduced damage from expansion.",
+    "//": "Base damage of 36, balance increase of one-nineth.",
+    "relative": { "damage": { "damage_type": "stab", "amount": -10, "armor_penetration": 23 } }
   },
   {
     "id": "44magnum",
@@ -25,7 +26,8 @@
     "ammo_type": "44",
     "casing": "44_casing",
     "range": 16,
-    "damage": { "damage_type": "stab", "amount": 40, "armor_penetration": 4 },
+    "//": "Hollowpoint bonus of 25%",
+    "damage": { "damage_type": "stab", "amount": 50 },
     "dispersion": 30,
     "recoil": 1570,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/44paper.json
+++ b/data/json/items/ammo/44paper.json
@@ -14,7 +14,8 @@
     "count": 25,
     "ammo_type": "44paper",
     "range": 18,
-    "damage": { "damage_type": "stab", "amount": 27 },
+    "//": "Base damage of 27, balance increase of two-nineths, plus 25% hollowpoint bonus.",
+    "damage": { "damage_type": "stab", "amount": 41 },
     "dispersion": 70,
     "recoil": 580,
     "effects": [ "COOKOFF", "MUZZLE_SMOKE", "BLACKPOWDER" ]

--- a/data/json/items/ammo/45.json
+++ b/data/json/items/ammo/45.json
@@ -5,7 +5,8 @@
     "type": "AMMO",
     "name": { "str": ".45 ACP FMJ" },
     "description": ".45 ACP ammunition with 230gr FMJ bullets.  Noted for its stopping power, the .45 ACP round has been common for almost 150 years.",
-    "relative": { "damage": { "damage_type": "stab", "amount": -3, "armor_penetration": 6 } }
+    "//": "Base damage of 27, balance increase of two-nineths.",
+    "relative": { "damage": { "damage_type": "stab", "amount": -8, "armor_penetration": 18 } }
   },
   {
     "id": "45_jhp",
@@ -25,7 +26,7 @@
     "ammo_type": "45",
     "casing": "45_casing",
     "range": 16,
-    "damage": { "damage_type": "stab", "amount": 30, "armor_penetration": 2 },
+    "damage": { "damage_type": "stab", "amount": 41 },
     "dispersion": 50,
     "recoil": 600,
     "effects": [ "COOKOFF" ]
@@ -40,7 +41,8 @@
     "price_postapoc": 600,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "count": 10,
-    "relative": { "damage": { "damage_type": "stab", "amount": 4, "armor_penetration": 4 }, "dispersion": -10, "recoil": 60 }
+    "relative": { "damage": { "damage_type": "stab", "armor_penetration": 18 }, "dispersion": -10 },
+    "proportional": { "recoil": 2.0 }
   },
   {
     "id": "bp_45_acp",

--- a/data/json/items/ammo/45colt.json
+++ b/data/json/items/ammo/45colt.json
@@ -17,7 +17,8 @@
     "ammo_type": "45colt",
     "casing": "45colt_casing",
     "range": 16,
-    "damage": { "damage_type": "stab", "amount": 25, "armor_penetration": 2 },
+    "//": "Base damage of 25, balance increase of two-nineths, plus 25% hollowpoint bonus.",
+    "damage": { "damage_type": "stab", "amount": 38 },
     "dispersion": 50,
     "recoil": 600,
     "effects": [ "COOKOFF" ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Ammunition Rebalance Project Part 5"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fifth part of the ammo rebalance project, as noted on https://github.com/cataclysmbnteam/Cataclysm-BN/issues/359. This should now cover all of the pistol-caliber ammunition that would be subject to a damage increase, possibly all the bullets that'd get a base damage buff at all.

This leaves damage and arpen adjustments for FMJ, hollowpoint, and other variants of other ammo that would not be subject to a direct buff to their FMJ variant's damage. This also leaves the question of "do we scale arpen of heavy-but-slow bullets to the same amount" for another day.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Applied the one-nineths tier of balance increase to 10mm FMJ, raising its damage from 31 to 34. Increased its armor penetration to 19.
2. Applied two-nineths tier of balance increase to .40 S&W, raising FMJ variant's damage from 23 to 28. Increased armor penetration to 16, lowered arpen of JHP variant to zero.
3. Applied one-ninth tier of balance increase to .44 Magnum, raising damage from 36 to 40, JHP variant raised to 50. Arpen raised from 12 to 23 for FMJ variant, lowered to zero for JHP variant.
4. Applied one-third tier of balance increase, plus suggested hollowpoint bonus, to .36 Navy to increase damage from 19 to 32.
5. Applied two-nineths tier of balance increase, plus suggested hollowpoint bonus, to .44 Army to increase damage from 27 to 41.
6. Applied two-nineths tier of balance increase, plus JHP bonus, to .45 Long Colt. Damage increased from 25 to 38, arpen reduced to zero.
7. Applied two-nineths tier of balance increase, plus JHP bonus, to .45 ACP. Also applied reccomended tweaks to overpressure round, with the usual goal of double recoil while having both the HP bonus and FMJ's arpen.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

It might also work to restat the cap-and-ball rounds as FMJ/round-nose, especially since it nudges .44 Army to be just sligtly more damaging than .44 Magnum FMJ (albeit with 22 less Functional Damage due to arpen). .36 Navy would end up with 25 damage and 15 arpen, and .44 Army would end up with 33 damage and 19 arpen.

Alternatively, I've also pondered the idea of certain rounds, most of which will be those that aren't rifle-tier but have base damage above the threshold for a balance increase, having half the arpen they would have based off their damage. This could potentially be applied to the cap-and-ball rounds too.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Copied over JSON changes to build 1529 to load-test and check that ammo seemed to be updated as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

There was mention of an alternate non-linear formula that would make conversion a bit more even. I'm a bit leery about implementing it just yet since:
1. It seems to sharply reduce how much of a stat adjustment the 20-30 tier of ammo receives due to its nonlinearity.
2. It's a lot more complex to describe how to implement the formula properly.
3. I can't give a concise explanation of how each ammotype has been buffed in individual code comments like I'm able to currently.
4. It goes past 40 a bit and I'd need to screw around in the site where Coolthulhu got the formula from to figure out how to make it cap at 40 instead of 45.
5. Most importantly, I'd need to make it an "adjust every ammotype's numbers" PR that would be best saved for after I've gotten a rough fix on what ammotypes need a rough initial balance adjustment.