### PR TITLE
UI for editing world mod list

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1650,7 +1650,7 @@ void inventory_selector::draw_footer( const catacurses::window &w ) const
         mvwprintz( w_inv, point( 2, getmaxy( w_inv ) - 1 ), c_cyan, "< " );
         mvwprintz( w_inv, point( ( getmaxx( w_inv ) / 2 ) - 4, getmaxy( w_inv ) - 1 ), c_cyan, " >" );
 
-        std::string new_filter = spopup->query_string( /*loop=*/false, /*draw_only=*/true );
+        spopup->query_string( /*loop=*/false, /*draw_only=*/true );
     } else {
         int filter_offset = 0;
         if( has_available_choices() || !filter.empty() ) {

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -371,6 +371,7 @@ void main_menu::init_strings()
     vWorldSubItems.push_back( pgettext( "Main Menu|World", "<D|d>elete World" ) );
     vWorldSubItems.push_back( pgettext( "Main Menu|World", "<R|r>eset World" ) );
     vWorldSubItems.push_back( pgettext( "Main Menu|World", "<S|s>how World Mods" ) );
+    vWorldSubItems.push_back( pgettext( "Main Menu|World", "<E|e>dit World Mods" ) );
     vWorldSubItems.push_back( pgettext( "Main Menu|World", "<C|c>opy World Settings" ) );
     vWorldSubItems.push_back( pgettext( "Main Menu|World", "Character to <T|t>emplate" ) );
 
@@ -1296,7 +1297,16 @@ void main_menu::world_tab()
                 if( sel3 == 2 ) { // Active World Mods
                     WORLDPTR world = world_generator->get_world( all_worldnames[sel2 - 1] );
                     world_generator->show_active_world_mods( world->active_mod_order );
-
+                } else if( sel3 == 3 ) { // Edit World Mods
+                    if( query_yn( _(
+                                      "Editing mod list or mod load order may render the world unstable or completely unplayable.  "
+                                      "It is advised to manually back up world files before proceeding.  "
+                                      "If you have just started playing, consider creating new world instead.\n"
+                                      "Proceed?"
+                                  ) ) ) {
+                        WORLDPTR world = world_generator->get_world( all_worldnames[sel2 - 1] );
+                        world_generator->edit_active_world_mods( world );
+                    }
                 } else {
                     bool query_yes = false;
                     bool do_delete = false;
@@ -1310,10 +1320,10 @@ void main_menu::world_tab()
                             query_yes = true;
                             do_delete = false;
                         }
-                    } else if( sel3 == 3 ) { // Copy World settings
+                    } else if( sel3 == 4 ) { // Copy World settings
                         layer = 2;
                         world_generator->make_new_world( true, all_worldnames[sel2 - 1] );
-                    } else if( sel3 == 4 ) { // Character to Template
+                    } else if( sel3 == 5 ) { // Character to Template
                         layer = 4;
                         sel4 = 0;
                     }

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -31,6 +31,7 @@
 #include "point.h"
 #include "string_formatter.h"
 #include "string_id.h"
+#include "string_input_popup.h"
 #include "translations.h"
 #include "ui_manager.h"
 
@@ -846,6 +847,12 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
     ctxt.register_action( "REMOVE_MOD" );
     ctxt.register_action( "SAVE_DEFAULT_MODS" );
     ctxt.register_action( "VIEW_MOD_DESCRIPTION" );
+    ctxt.register_action( "FILTER" );
+
+    point filter_pos;
+    int filter_view_len = 0;
+    std::string current_filter = "init me!";
+    std::unique_ptr<string_input_popup> fpopup;
 
     catacurses::window w_header1;
     catacurses::window w_header2;
@@ -878,6 +885,14 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
         header_windows.push_back( w_header1 );
         header_windows.push_back( w_header2 );
 
+        // Specify where the popup's string would be printed
+        filter_pos = point( 2, TERMY - 8 );
+        filter_view_len = iMinScreenWidth / 2 - 11;
+        if( fpopup ) {
+            point inner_pos = filter_pos + point( 2, 0 );
+            fpopup->window( win, inner_pos, inner_pos.x + filter_view_len );
+        }
+
         ui.position_from_window( win );
     };
     init_windows( ui );
@@ -887,18 +902,49 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
     headers.push_back( _( "Mod List" ) );
     headers.push_back( _( "Mod Load Order" ) );
 
-    int tab_output = 0;
     size_t active_header = 0;
-    size_t useable_mod_count = mman->get_usable_mods().size();
     int startsel[2] = {0, 0};
     size_t cursel[2] = {0, 0};
     size_t iCurrentTab = 0;
     std::vector<mod_id> current_tab_mods;
 
-    bool recalc_tabs = true;
+    struct mod_tab {
+        std::string id;
+        std::vector<mod_id> mods;
+        std::vector<mod_id> mods_unfiltered;
+    };
+    std::vector<mod_tab> all_tabs;
+
+    for( const std::pair<std::string, std::string> &tab : get_mod_list_tabs() ) {
+        all_tabs.push_back( {
+            tab.first,
+            std::vector<mod_id>(),
+            std::vector<mod_id>()
+        } );
+    }
+
+    const std::map<std::string, std::string> &cat_tab_map = get_mod_list_cat_tab();
+    for( const mod_id &mod : mman->get_usable_mods() ) {
+        int cat_idx = mod->category.first;
+        const std::string &cat_id = get_mod_list_categories()[cat_idx].first;
+
+        std::string dest_tab = "tab_default";
+        const auto iter = cat_tab_map.find( cat_id );
+        if( iter != cat_tab_map.end() ) {
+            dest_tab = iter->second;
+        }
+
+        for( mod_tab &tab : all_tabs ) {
+            if( tab.id == dest_tab ) {
+                tab.mods_unfiltered.push_back( mod );
+                break;
+            }
+        }
+    }
 
     // Helper function for determining the currently selected mod
     const auto get_selected_mod = [&]() -> const MOD_INFORMATION* {
+        const std::vector<mod_id> &current_tab_mods = all_tabs[iCurrentTab].mods;
         if( current_tab_mods.empty() )
         {
             return nullptr;
@@ -911,6 +957,42 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
         }
         return nullptr;
     };
+
+    // Helper function for applying filter to mod tabs
+    const auto apply_filter = [&]( const std::string & filter_str ) {
+        if( filter_str == current_filter ) {
+            return;
+        }
+        const MOD_INFORMATION *selected_mod = nullptr;
+        if( active_header == 0 ) {
+            selected_mod = get_selected_mod();
+        }
+        for( mod_tab &tab : all_tabs ) {
+            if( filter_str.empty() ) {
+                tab.mods = tab.mods_unfiltered;
+            } else {
+                tab.mods.clear();
+                for( const mod_id &mod : tab.mods_unfiltered ) {
+                    std::string name = ( *mod ).name();
+                    if( lcmatch( name, filter_str ) ) {
+                        tab.mods.push_back( mod );
+                    }
+                }
+            }
+        }
+        startsel[0] = 0;
+        cursel[0] = 0;
+        // Try to restore cursor position
+        const std::vector<mod_id> &curr_tab = all_tabs[iCurrentTab].mods;
+        for( size_t i = 0; i < curr_tab.size(); i++ ) {
+            if( &*curr_tab[i] == selected_mod ) {
+                cursel[0] = i;
+                break;
+            }
+        }
+        current_filter = filter_str;
+    };
+    apply_filter( "" );
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         draw_worldgen_tabs( win, 0 );
@@ -951,7 +1033,7 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
             }
         }
 
-        //redraw tabs
+        // Draw tab names
         wmove( win, point( 2, 4 ) );
         for( size_t i = 0; i < get_mod_list_tabs().size(); i++ ) {
             wprintz( win, c_white, "[" );
@@ -961,41 +1043,67 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
             wputch( win, BORDER_COLOR, LINE_OXOX );
         }
 
+        // Draw filter
+        if( fpopup ) {
+            mvwprintz( win, filter_pos, c_cyan, "< " );
+            mvwprintz( win, filter_pos + point( filter_view_len + 2, 0 ), c_cyan, " >" );
+            // This call makes popup draw its string at position specified on popup initialization
+            fpopup->query_string( /*loop=*/false, /*draw_only=*/true );
+        } else {
+            mvwprintz( win, filter_pos, c_light_gray, "< " );
+            const char *help = current_filter.empty() ? _( "[%s] Filter" ) : _( "[%s] Filter: " );
+            wprintz( win, c_light_gray, help, ctxt.get_desc( "FILTER" ) );
+            wprintz( win, c_white, current_filter );
+            wprintz( win, c_light_gray, " >" );
+        }
+
         wnoutrefresh( w_description );
         wnoutrefresh( win );
 
-        // Redraw list
-        draw_mod_list( w_list, startsel[0], cursel[0], current_tab_mods, active_header == 0,
-                       _( "--NO AVAILABLE MODS--" ), catacurses::window() );
+        // Draw selected tab
+        const mod_tab &current_tab = all_tabs[iCurrentTab];
+        const char *msg = current_tab.mods_unfiltered.empty() ?
+                          _( "--NO AVAILABLE MODS--" ) : _( "--NO MATCHES--" );
+        draw_mod_list( w_list, startsel[0], cursel[0], current_tab.mods, active_header == 0,
+                       msg, catacurses::window() );
 
-        // Redraw active
+        // Draw active mods
         draw_mod_list( w_active, startsel[1], cursel[1], active_mod_order, active_header == 1,
                        _( "--NO ACTIVE MODS--" ), w_shift );
     } );
 
-    while( tab_output == 0 ) {
-        if( recalc_tabs ) {
-            current_tab_mods.clear();
+    const auto set_filter = [&]() {
+        fpopup = std::make_unique<string_input_popup>();
+        fpopup->max_length( 256 );
+        // current_filter is modified by apply_filter(), we have to copy the value
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+        const std::string old_filter = current_filter;
+        fpopup->text( current_filter );
 
-            for( const auto &item : mman->get_usable_mods() ) {
-                const auto &iter = get_mod_list_cat_tab().find(
-                                       get_mod_list_categories()[item->category.first].first );
+        ime_sentry sentry;
 
-                std::string sCatTab = "tab_default";
-                if( iter != get_mod_list_cat_tab().end() ) {
-                    sCatTab = _( iter->second );
-                }
+        // On next redraw, call resize callback which will configure how popup is rendered
+        ui.mark_resize();
 
-                if( sCatTab == get_mod_list_tabs()[iCurrentTab].first ) {
-                    current_tab_mods.push_back( item );
-                }
+        for( ;; ) {
+            ui_manager::redraw();
+            fpopup->query_string( /*loop=*/false );
 
-                useable_mod_count = current_tab_mods.size();
+            if( fpopup->canceled() ) {
+                apply_filter( old_filter );
+                break;
+            } else if( fpopup->confirmed() ) {
+                break;
+            } else {
+                apply_filter( fpopup->text() );
             }
+        };
 
-            recalc_tabs = false;
-        }
+        fpopup.reset();
+    };
 
+    int tab_output = 0;
+    while( tab_output == 0 ) {
         ui_manager::redraw();
 
         const int next_header = ( active_header == 1 ) ? 0 : 1;
@@ -1006,8 +1114,9 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
         size_t next_selection = selection + 1;
         size_t prev_selection = selection - 1;
         if( active_header == 0 ) {
-            next_selection = ( next_selection >= useable_mod_count ) ? 0 : next_selection;
-            prev_selection = ( prev_selection > useable_mod_count ) ? useable_mod_count - 1 : prev_selection;
+            size_t num_mods = all_tabs[iCurrentTab].mods.size();
+            next_selection = ( next_selection >= num_mods ) ? 0 : next_selection;
+            prev_selection = ( prev_selection > num_mods ) ? num_mods - 1 : prev_selection;
         } else {
             next_selection = ( next_selection >= active_mod_order.size() ) ? 0 : next_selection;
             prev_selection = ( prev_selection > active_mod_order.size() ) ? active_mod_order.size() - 1 :
@@ -1025,6 +1134,7 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
         } else if( action == "LEFT" ) {
             active_header = prev_header;
         } else if( action == "CONFIRM" ) {
+            const std::vector<mod_id> &current_tab_mods = all_tabs[iCurrentTab].mods;
             if( active_header == 0 && !current_tab_mods.empty() ) {
                 // try-add
                 mman_ui->try_add( current_tab_mods[cursel[0]], active_mod_order );
@@ -1053,8 +1163,6 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
 
                 startsel[0] = 0;
                 cursel[0] = 0;
-
-                recalc_tabs = true;
             }
 
         } else if( action == "PREV_CATEGORY_TAB" ) {
@@ -1065,8 +1173,6 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
 
                 startsel[0] = 0;
                 cursel[0] = 0;
-
-                recalc_tabs = true;
             }
         } else if( action == "NEXT_TAB" ) {
             tab_output = 1;
@@ -1083,6 +1189,8 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
             }
         } else if( action == "QUIT" && ( !on_quit || on_quit() ) ) {
             tab_output = -999;
+        } else if( action == "FILTER" ) {
+            set_filter();
         }
         // RESOLVE INPUTS
         if( last_selection != selection ) {

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -128,6 +128,7 @@ class worldfactory
 
         static void draw_worldgen_tabs( const catacurses::window &w, size_t current );
         void show_active_world_mods( const std::vector<mod_id> &world_mods );
+        void edit_active_world_mods( WORLDPTR world );
 
     private:
         std::map<std::string, std::unique_ptr<WORLD>> all_worlds;
@@ -142,7 +143,11 @@ class worldfactory
         int show_worldgen_tab_confirm( const catacurses::window &win, WORLDPTR world,
                                        const std::function<bool()> &on_quit );
 
-        void draw_modselection_borders( const catacurses::window &win, const input_context &ctxtp );
+        int show_modselection_window( const catacurses::window &win, std::vector<mod_id> &active_mod_order,
+                                      const std::function<bool()> &on_quit, bool standalone );
+        void draw_modselection_borders( const catacurses::window &win, const input_context &ctxtp,
+                                        bool standalone );
+        static void draw_empty_worldgen_tabs( const catacurses::window &w );
         void draw_mod_list( const catacurses::window &w, int &start, size_t cursor,
                             const std::vector<mod_id> &mods, bool is_active_list, const std::string &text_if_empty,
                             const catacurses::window &w_shift );


### PR DESCRIPTION
#### Purpose of change
Closes #333

#### Describe the solution
1st commit adds filtering for mod list in the world creation menu (originally written for DDA back in June https://github.com/CleverRaven/Cataclysm-DDA/commit/1253929540a101b103a12bbb2ddddb6fb6850555).

2nd commit adds new UI (basically an alternative mode for "select mods" world creation tab) that allows editing mod list and mod load order. It's accessible from the title screen (World->WorldName->Edit World Mods) and has a big fat warning on it to discourage people from recklessly breaking their saves.

#### Testing
Created new world, loaded into it, then went back to title screen and edited mod list, then loaded into the world again.
Everything seems to be working fine.