### PR TITLE
Allow despawning light turrets and laser turrets

### DIFF
--- a/data/json/monsters/turrets.json
+++ b/data/json/monsters/turrets.json
@@ -61,7 +61,7 @@
     "special_when_hit": [ "RETURN_FIRE", 100 ],
     "death_drops": {  },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE" ]
+    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "ID_CARD_DESPAWN", "CONSOLE_DESPAWN" ]
   },
   {
     "id": "mon_turret_riot",
@@ -163,7 +163,17 @@
     "special_when_hit": [ "RETURN_FIRE", 100 ],
     "death_drops": {  },
     "death_function": [ "BROKEN" ],
-    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "DROPS_AMMO" ]
+    "flags": [
+      "SEES",
+      "NOHEAD",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "IMMOBILE",
+      "NO_BREATHE",
+      "DROPS_AMMO",
+      "ID_CARD_DESPAWN",
+      "CONSOLE_DESPAWN"
+    ]
   },
   {
     "id": "mon_turret_medium",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Allows ID cards to despawn light turrets, laser turrets"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I noticed that light turrets, currently used in lab bunkers, lacked the monster flag that allows card readers to despawn them. On discussion with @Firestorm01X2 in the modder's discord, it was suggested I add that plus the flag that allows consoles to despawn them, for consistency.

And the suggestion came up to add them to laser turrets too. Right now they only show up as inactive versions the player can deploy, but this came up as a suggestion so they'll be usable in locations in the future.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Gave `ID_CARD_DESPAWN` and `CONSOLE_DESPAWN` monster flags to `mon_turret_light`
2. Gave `ID_CARD_DESPAWN` and `CONSOLE_DESPAWN` monster flags to `mon_laserturret`.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding this to all turrets, not just the others likely to see use in science and military locations.
2. Divide the `ID_CARD_DESPAWN` into two flags, one for science card readers and one for military card readers, with the former presumably only affecting light turrets and laser turrets.
3. Rewording the PR's OP in some way for the sake of an april fools day joke.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Load-tested JSON changes.
2. Debugged in a clairvoyance artifact.
3. Teleported over to a lab bunker, confirming there was a light turret on the other side.
4. Spawned and swiped a science ID card, watched turret vanish.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Science labs are probably the only case where there's a slight risk that a randomly-spawned turret will get caught up in a card reader despawn along with deliberately-placed ones, solely because for some reason turrets are a random spawn in some lab monstergroups.

They probably should be special encounters placed by mapgen chunks rather than injected into `GROUP_LAB_SECURITY` to spawn randomly. Even then I'm not sure if any lab areas with card readers call that monstergroup, so in practice it's even less likely.