### PR TITLE
Fix throwing tests being too fragile

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -10,6 +10,7 @@
 
 #include "avatar.h"
 #include "calendar.h"
+#include "cata_utility.h" // for normal_cdf
 #include "creature.h"
 #include "damage.h"
 #include "debug.h"
@@ -454,4 +455,26 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
     }
 
     return attack;
+}
+
+namespace ranged
+{
+
+double hit_chance( const dispersion_sources &dispersion, double range, double target_size,
+                   double missed_by )
+{
+    if( range <= 0 ) {
+        return 1.0;
+    }
+
+    double missed_by_tiles = missed_by * target_size;
+
+    //          T = (2*D**2 * (1 - cos V)) ** 0.5   (from iso_tangent)
+    //      cos V = 1 - T**2 / (2*D**2)
+    double cosV = 1 - missed_by_tiles * missed_by_tiles / ( 2 * range * range );
+    double needed_dispersion = ( cosV < -1.0 ? M_PI : acos( cosV ) ) * 180 * 60 / M_PI;
+
+    return normal_cdf( needed_dispersion, dispersion.avg(), dispersion.avg() / 2 );
+}
+
 }

--- a/src/ballistics.h
+++ b/src/ballistics.h
@@ -34,4 +34,20 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
         const tripoint &target_arg, const dispersion_sources &dispersion,
         Creature *origin = nullptr, const vehicle *in_veh = nullptr );
 
+namespace ranged
+{
+
+/**
+ * The chance that a fired shot reaches required accuracy - by default grazing shot.
+ *
+ * @param dispersion accuracy of the shot. Must be a purely normal distribution.
+ * @param range distance between the shooter and the target.
+ * @param target_size size of the target, in the range (0, 1].
+ * @param missed_by maximum degree of miss, in the range (0, 1]. Effectively a multiplier on @param target_size.
+ */
+double hit_chance( const dispersion_sources &dispersion, double range, double target_size,
+                   double missed_by = 1.0 );
+
+} // namespace ranged
+
 #endif // CATA_SRC_BALLISTICS_H

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -173,6 +173,11 @@ double logarithmic_range( int min, int max, int pos )
     return ( raw_logistic - LOGI_MIN ) / LOGI_RANGE;
 }
 
+double normal_cdf( double x, double mean, double stddev )
+{
+    return 0.5 * ( 1.0 + std::erf( ( x - mean ) / ( stddev * M_SQRT2 ) ) );
+}
+
 int bound_mod_to_vals( int val, int mod, int max, int min )
 {
     if( val + mod > max && max != 0 ) {

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -131,6 +131,17 @@ double logarithmic( double t );
 double logarithmic_range( int min, int max, int pos );
 
 /**
+ * Cumulative distribution function of a certain normal distribution.
+ *
+ * @param x point at which the CDF of the distribution is measured
+ * @param mean mean of the normal distribution
+ * @param stddev standard deviation of the normal distribution
+ *
+ * @return The probability that a random point from the distribution will be lesser than @param x
+ */
+double normal_cdf( double x, double mean, double stddev );
+
+/**
  * Clamp the value of a modifier in order to bound the resulting value
  *
  * Ensures that a modifier value will not cause a base value to exceed given


### PR DESCRIPTION
New expected values for throwing tests are now within `epsilon / 2` of calculated ones.
The throwing tests are still a brute force black box thing.

Maybe the nondeterministic, statistical tests should set their own RNG seed.