### PR TITLE
Missing string_utils header after header prune

### DIFF
--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -32,6 +32,7 @@
 #include "string_formatter.h"
 #include "string_id.h"
 #include "string_input_popup.h"
+#include "string_utils.h"
 #include "translations.h"
 #include "ui_manager.h"
 


### PR DESCRIPTION
I merged #434 and #426, but then noticed they are in conflict.
This should fix it.