### PR TITLE
Fix disassembly component display

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9503,7 +9503,15 @@ std::vector<item_comp> item::get_uncraft_components() const
     } else {
         //Make a new vector of components from the registered components
         for( const item &component : components ) {
-            ret.push_back( item_comp( component.typeId(), component.count() ) );
+            auto iter = std::find_if( ret.begin(), ret.end(), [component]( item_comp & obj ) {
+                return obj.type == component.typeId();
+            } );
+
+            if( iter != ret.end() ) {
+                iter->count += component.count();
+            } else {
+                ret.push_back( item_comp( component.typeId(), component.count() ) );
+            }
         }
     }
     return ret;


### PR DESCRIPTION
Summary [Content]

Port "fix disassembly component display" from dda

Purpose of change

The disassembly ui didn't stack components used in the fabrication of items (only looted items had their components stacked due to that being the way they are formated in the recipe)

Describe the solution

Port from https://github.com/CleverRaven/Cataclysm-DDA/pull/47869

Testing

- Spawn in cargo pants
- Spawn in the components needed to make cargo pants ( use short string due to them being item stacks not charges)
- Craft the cargo pants
- Enter disassembly view and compare
- Previously: the strings would show up as 3 stacks of 2
- Now: they are a single stack
