### PR TITLE
Added disassembly options for some basic undergarments and socks

### DIFF
--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -9,7 +9,6 @@
   {
     "result": "socks",
     "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
     "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 35 ] ] ]
@@ -17,7 +16,6 @@
   {
     "result": "boxer_shorts",
     "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
     "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 40 ] ] ]
@@ -25,7 +23,6 @@
   {
     "result": "boxer_briefs",
     "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
     "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 40 ] ] ]
@@ -33,7 +30,6 @@
   {
     "result": "briefs",
     "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
     "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 35 ] ] ]
@@ -41,7 +37,6 @@
   {
     "result": "panties",
     "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
     "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 35 ] ] ]
@@ -49,7 +44,6 @@
   {
     "result": "boy_shorts",
     "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
     "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 40 ] ] ]

--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -15,14 +15,6 @@
     "components": [ [ [ "thread", 35 ] ] ]
   },
   {
-    "result": "xlsocks",
-    "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
-    "time": "60 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 70 ] ] ]
-  },
-  {
     "result": "boxer_shorts",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
@@ -31,28 +23,12 @@
     "components": [ [ [ "thread", 40 ] ] ]
   },
   {
-    "result": "xlboxer_shorts",
-    "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
-    "time": "60 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 80 ] ] ]
-  },
-  {
     "result": "boxer_briefs",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
     "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 40 ] ] ]
-  },
-  {
-    "result": "xlboxer_briefs",
-    "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
-    "time": "60 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 80 ] ] ]
   },
   {
     "result": "briefs",
@@ -77,14 +53,6 @@
     "time": "30 m",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "thread", 40 ] ] ]
-  },
-  {
-    "result": "xlboy_shorts",
-    "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
-    "time": "60 m",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "thread", 80 ] ] ]
   },
   {
     "result": "down_blanket",

--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -7,6 +7,86 @@
     "components": [ [ [ "thread", 35 ] ] ]
   },
   {
+    "result": "socks",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 35 ] ] ]
+  },
+  {
+    "result": "xlsocks",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "60 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 70 ] ] ]
+  },
+  {
+    "result": "boxer_shorts",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 40 ] ] ]
+  },
+  {
+    "result": "xlboxer_shorts",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "60 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 80 ] ] ]
+  },
+  {
+    "result": "boxer_briefs",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 40 ] ] ]
+  },
+  {
+    "result": "xlboxer_briefs",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "60 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 80 ] ] ]
+  },
+  {
+    "result": "briefs",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 35 ] ] ]
+  },
+  {
+    "result": "panties",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 35 ] ] ]
+  },
+  {
+    "result": "boy_shorts",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 40 ] ] ]
+  },
+  {
+    "result": "xlboy_shorts",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "60 m",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
+    "components": [ [ [ "thread", 80 ] ] ]
+  },
+  {
     "result": "down_blanket",
     "type": "uncraft",
     "time": "20 m",


### PR DESCRIPTION
Summary [Content]

Port "added disassembly options for some basic undergarments and socks" from dda

Purpose of change

Added disassembly recipes to uncraft for many trivial things such as socks, panties, briefs, etc. All recipes produce thread, and are balanced around the existing uncraft recipe for socks_ankle. Thread amounts are all well below the amount of thread it would take to craft the item, and should pose no balance issues

Describe the solution

Port from https://github.com/CleverRaven/Cataclysm-DDA/pull/47742
Detete: xlboxer_shorts, xlsocks, xlboxer_briefs, xlboy_shorts - becouse BN dont have this items

Testing

Spawn socks and disassembled them