### PR TITLE
Fix Army Winter Pants repair difficulty

### DIFF
--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -669,6 +669,7 @@
   },
   {
     "id": "winter_pants_army",
+    "repairs_like": "jeans",
     "type": "ARMOR",
     "name": { "str_sp": "army winter pants" },
     "description": "A tough pair of pants lined with pockets, thickly padded for warmth.  Favored by the military.",


### PR DESCRIPTION
Summary [Content]

Port "Fix Army Winter Pants repair difficulty" from dda

Purpose of change

Added the ability to strengthen winter army pants (what was previously not possible)

Describe the solution

Port from https://github.com/CleverRaven/Cataclysm-DDA/pull/47691

Testing

Spawn army winter pants and strengthen them