### PR TITLE
Don't redraw if animations are enabled, but there is nothing to animate

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -989,3 +989,12 @@ void game::draw_monster_override( const tripoint &, const mtype_id &, const int,
 {
 }
 #endif
+
+bool minimap_requires_animation()
+{
+#if defined(TILES)
+    return tilecontext->minimap_requires_animation();
+#else
+    return false;
+#endif // TILES
+}

--- a/src/animation.h
+++ b/src/animation.h
@@ -31,4 +31,6 @@ struct explosion_tile {
     nc_color color;
 };
 
+bool minimap_requires_animation();
+
 #endif // CATA_SRC_ANIMATION_H

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -221,7 +221,8 @@ void cata_tiles::on_options_changed()
     settings.mode = pixel_minimap_mode_from_string( get_option<std::string>( "PIXEL_MINIMAP_MODE" ) );
     settings.brightness = get_option<int>( "PIXEL_MINIMAP_BRIGHTNESS" );
     settings.beacon_size = get_option<int>( "PIXEL_MINIMAP_BEACON_SIZE" );
-    settings.beacon_blink_interval = get_option<int>( "PIXEL_MINIMAP_BLINK" );
+    settings.beacon_blink_interval = get_option<bool>( "ANIMATIONS" ) ?
+                                     get_option<int>( "PIXEL_MINIMAP_BLINK" ) : 0;
     settings.square_pixels = get_option<bool>( "PIXEL_MINIMAP_RATIO" );
     settings.scale_to_fit = get_option<bool>( "PIXEL_MINIMAP_SCALE_TO_FIT" );
 
@@ -1532,6 +1533,11 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 void cata_tiles::draw_minimap( const point &dest, const tripoint &center, int width, int height )
 {
     minimap->draw( SDL_Rect{ dest.x, dest.y, width, height }, center );
+}
+
+bool cata_tiles::minimap_requires_animation() const
+{
+    return minimap->has_animated_elements();
 }
 
 void cata_tiles::get_window_tile_counts( const int width, const int height, int &columns,

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -288,6 +288,7 @@ class cata_tiles
 
         /** Minimap functionality */
         void draw_minimap( const point &dest, const tripoint &center, int width, int height );
+        bool minimap_requires_animation() const;
 
     protected:
         /** How many rows and columns of tiles fit into given dimensions **/

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1433,7 +1433,7 @@ bool game::do_turn()
                     }
                 }
                 sounds::process_sound_markers( &u );
-                if( !u.activity && !u.has_distant_destination() && uquit != QUIT_WATCH ) {
+                if( !u.activity && !u.has_distant_destination() && uquit != QUIT_WATCH && wait_popup ) {
                     wait_popup.reset();
                     ui_manager::redraw();
                 }

--- a/src/pixel_minimap.h
+++ b/src/pixel_minimap.h
@@ -41,6 +41,7 @@ class pixel_minimap
         void set_settings( const pixel_minimap_settings &settings );
 
         void draw( const SDL_Rect &screen_rect, const tripoint &center );
+        bool has_animated_elements() const;
 
     private:
         struct submap_cache;
@@ -76,6 +77,8 @@ class pixel_minimap
 
         //track the previous viewing area to determine if the minimap cache needs to be cleared
         tripoint cached_center_sm;
+        // track presence of animated beacons to determine whether the minimap needs to be animated
+        bool cached_has_animated_beacons;
 
         SDL_Rect screen_rect;
         SDL_Rect main_tex_clip_rect;


### PR DESCRIPTION
#### Purpose of change
Reduce CPU usage when there are no animations on screen

#### Describe the solution
Don't redraw if there is nothing to animate (no weather, SCT or beacons on the pixel minimap)

#### Testing
Walked around / waited with/without animations enabled. The program properly redraws game window.