### PR TITLE
Refresh vehicle zone cache before looking for autoconsume zones

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3041,6 +3041,9 @@ bool find_auto_consume( player &p, const bool food )
     } else {
         consume_type_zone = zone_type_id( "AUTO_DRINK" );
     }
+    if( g->m.check_vehicle_zones( g->get_levz() ) ) {
+        mgr.cache_vzones();
+    }
     const std::unordered_set<tripoint> &dest_set = mgr.get_near( consume_type_zone, g->m.getabs( pos ),
             ACTIVITY_SEARCH_DISTANCE );
     if( dest_set.empty() ) {


### PR DESCRIPTION
#### Purpose of change
Fixes #445

#### Describe the solution
As in the title

#### Testing
Make yourself hungry, get a vehicle and designate autoconsume zone. Fill it with food, then drive the vehicle a few tiles forward.
Before: waiting for an hour leaves the avatar hungry.
After: as soon as waiting starts, the avatar goes from hungry to sated and a message pops up in the sidebar reporting consumed food.