### PR TITLE
Remove unnecessary casting and branch from Character::mod_power_level

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1985,17 +1985,14 @@ void Character::set_max_power_level( const units::energy &npower_max )
 
 void Character::mod_power_level( const units::energy &npower )
 {
-    // units::energy is an int, so avoid overflow by converting it to a int64_t, then adding them
-    // If the result is greater than the max power level, set power to max
-    int64_t power = static_cast<int64_t>( units::to_millijoule( power_level ) ) +
-                    static_cast<int64_t>( units::to_millijoule( npower ) );
-    units::energy new_power;
-    if( power > units::to_millijoule( max_power_level ) ) {
-        new_power = max_power_level;
-    } else {
-        new_power = power_level + npower;
-    }
-    power_level = clamp( new_power, 0_kJ, max_power_level );
+    // Remaining capacity between current and maximum power levels we can make use of.
+    const units::energy remaining_capacity = get_max_power_level() - get_power_level();
+    // We can't add more than remaining capacity, so get the minimum of the two
+    const units::energy minned_npower = std::min( npower, remaining_capacity );
+    // new candidate power level
+    const units::energy new_power = get_power_level() + minned_npower;
+    // set new power level while prevending it from going negative
+    set_power_level( std::max( 0_kJ, new_power ) );
 }
 
 void Character::mod_max_power_level( const units::energy &npower_max )


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Simplify Character::mod_power_level"

#### Purpose of change
Function is overly complex for how simple the transform really is. The work done to prevent integer overflow can be reasoned about further and no conversion to `int64_t` is necessary. The `if-conditional` is also unnecessary. The operation being done is equivalent to calling `std::min`

#### Describe the solution
`power = power_level + npower` can overflow. The overflow is why there is a cast to `int64`. This makes sense. What doesn't make sense is not using our available domain knowledge to remove the need to cast.
There is a set range we are going to clamp to which is `[0, max_power_level]` and we need to satisfy the condition `max_power_level >= power_level + npower`. Rearranging terms `max_power - power_level >= npower`
We can use this rearrangement and force its satisfaction using `min( max_power - power_level, npower )` to clamp npower to the closed upper bound. This satisfies our requirement to prevent overflow and removes the need to cast into `int64`.

We have satisfied our upper bound, but what about the lower bound? Can the function underflow? No it cannot. If our current power level was zero, and the input was INT_MIN the calculated `new_power` value will be INT_MIN. When we satisfy our lower bound of zero using `max( 0_kJ, new_power )` we will get `0_kJ` as the result.

`power_level`, `npower`, and `max_power_level` are all in the same units and do not require calculation of values using `units::to_millijoule` so this calculation was omitted.