### PR TITLE
Ignore non-numeric keys pressed while Alt modifier is active

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1003,8 +1003,10 @@ static void begin_alt_code()
 
 static bool add_alt_code( char c )
 {
-    if( alt_down && c >= '0' && c <= '9' ) {
-        alt_buffer = alt_buffer * 10 + ( c - '0' );
+    if( alt_down ) {
+        if( c >= '0' && c <= '9' ) {
+            alt_buffer = alt_buffer * 10 + ( c - '0' );
+        }
         return true;
     }
     return false;


### PR DESCRIPTION
#### Purpose of change
Stop the game from receiving 'Tab' key when Alt+Tabbing out of the window

#### Describe the solution
Treat any key press while Alt is down as "handled", but in reality simply discard them.

#### Testing
Alt+Tabbing while in settings UI no longer changes the tab. Text input using Alt codes still works.