### PR TITLE
make iuse a namespace instead of class

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1394,9 +1394,8 @@ void iexamine::locked_object( player &p, const tripoint &examp )
 
     // if crowbar() ever eats charges or otherwise alters the passed item, rewrite this to reflect
     // changes to the original item.
-    iuse dummy;
     item temporary_item( prying_items[0]->type );
-    dummy.crowbar( &p, &temporary_item, false, examp );
+    iuse::crowbar( &p, &temporary_item, false, examp );
 }
 
 /**

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -715,8 +715,7 @@ class iuse_function_wrapper : public iuse_actor
 
         ~iuse_function_wrapper() override = default;
         int use( player &p, item &it, bool a, const tripoint &pos ) const override {
-            iuse tmp;
-            return ( tmp.*cpp_function )( &p, &it, a, pos );
+            return ( *cpp_function )( &p, &it, a, pos );
         }
         std::unique_ptr<iuse_actor> clone() const override {
             return std::make_unique<iuse_function_wrapper>( *this );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1285,8 +1285,7 @@ static void marloss_common( player &p, item &it, const trait_id &current_color )
     } else if( effect <= 6 ) { // Radiation cleanse is below
         p.add_msg_if_player( m_good, _( "You feel better all over." ) );
         p.mod_painkiller( 30 );
-        iuse dummy;
-        dummy.purifier( &p, &it, false, p.pos() );
+        iuse::purifier( &p, &it, false, p.pos() );
         if( effect == 6 ) {
             p.set_rad( 0 );
         }
@@ -1422,7 +1421,7 @@ int iuse::mycus( player *p, item *it, bool t, const tripoint &pos )
                               _( "It tastes amazing, and you finish it quickly." ) );
         p->add_msg_if_player( m_good, _( "You feel better all over." ) );
         p->mod_painkiller( 30 );
-        this->purifier( p, it, t, pos ); // Clear out some of that goo you may have floating around
+        purifier( p, it, t, pos ); // Clear out some of that goo you may have floating around
         p->set_rad( 0 );
         p->healall( 4 ); // Can't make you a whole new person, but not for lack of trying
         p->add_msg_if_player( m_good,
@@ -9386,6 +9385,8 @@ washing_requirements washing_requirements_for_volume( const units::volume &vol )
     return { water, cleanser, time };
 }
 
+static int wash_items( player *p, bool soft_items, bool hard_items );
+
 int iuse::wash_soft_items( player *p, item *, bool, const tripoint & )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
@@ -9446,7 +9447,7 @@ int iuse::wash_all_items( player *p, item *, bool, const tripoint & )
     return 0;
 }
 
-int iuse::wash_items( player *p, bool soft_items, bool hard_items )
+int wash_items( player *p, bool soft_items, bool hard_items )
 {
     if( p->is_mounted() ) {
         p->add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -231,7 +231,7 @@ int towel_common( player *, item *, bool );
 
 // Helper for handling pesky wannabe-artists
 int handle_ground_graffiti( player &p, item *it, const std::string &prefix,
-                                   const tripoint &where );
+                            const tripoint &where );
 
 // Helper for wood chopping
 int chop_moves( Character &ch, item &tool );

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -22,226 +22,224 @@ using itype_id = std::string;
 struct tripoint;
 
 // iuse methods returning a bool indicating whether to consume a charge of the item being used.
-class iuse
+namespace iuse
 {
-    public:
-        // FOOD AND DRUGS (ADMINISTRATION)
-        int sewage( player *, item *, bool, const tripoint & );
-        int honeycomb( player *, item *, bool, const tripoint & );
-        int alcohol_weak( player *, item *, bool, const tripoint & );
-        int alcohol_medium( player *, item *, bool, const tripoint & );
-        int alcohol_strong( player *, item *, bool, const tripoint & );
-        int xanax( player *, item *, bool, const tripoint & );
-        int smoking( player *, item *, bool, const tripoint & );
-        int ecig( player *, item *, bool, const tripoint & );
-        int antibiotic( player *, item *, bool, const tripoint & );
-        int eyedrops( player *, item *, bool, const tripoint & );
-        int fungicide( player *, item *, bool, const tripoint & );
-        int antifungal( player *, item *, bool, const tripoint & );
-        int antiparasitic( player *, item *, bool, const tripoint & );
-        int anticonvulsant( player *, item *, bool, const tripoint & );
-        int weed_cake( player *, item *, bool, const tripoint & );
-        int coke( player *, item *, bool, const tripoint & );
-        int meth( player *, item *, bool, const tripoint & );
-        int vaccine( player *, item *, bool, const tripoint & );
-        int flu_vaccine( player *, item *, bool, const tripoint & );
-        int poison( player *, item *, bool, const tripoint & );
-        int meditate( player *, item *, bool, const tripoint & );
-        int thorazine( player *, item *, bool, const tripoint & );
-        int prozac( player *, item *, bool, const tripoint & );
-        int sleep( player *, item *, bool, const tripoint & );
-        int datura( player *, item *, bool, const tripoint & );
-        int flumed( player *, item *, bool, const tripoint & );
-        int flusleep( player *, item *, bool, const tripoint & );
-        int inhaler( player *, item *, bool, const tripoint & );
-        int blech( player *, item *, bool, const tripoint & );
-        int blech_because_unclean( player *, item *, bool, const tripoint & );
-        int plantblech( player *, item *, bool, const tripoint & );
-        int chew( player *, item *, bool, const tripoint & );
-        int purifier( player *, item *, bool, const tripoint & );
-        int purify_iv( player *, item *, bool, const tripoint & );
-        int purify_smart( player *, item *, bool, const tripoint & );
-        int marloss( player *, item *, bool, const tripoint & );
-        int marloss_seed( player *, item *, bool, const tripoint & );
-        int marloss_gel( player *, item *, bool, const tripoint & );
-        int mycus( player *, item *, bool, const tripoint & );
-        int dogfood( player *, item *, bool, const tripoint & );
-        int catfood( player *, item *, bool, const tripoint & );
-        int feedcattle( player *, item *, bool, const tripoint & );
-        int feedbird( player *, item *, bool, const tripoint & );
-        int antiasthmatic( player *, item *, bool, const tripoint & );
-        // TOOLS
-        int extinguisher( player *, item *, bool, const tripoint & );
-        int hammer( player *, item *, bool, const tripoint & );
-        int water_purifier( player *, item *, bool, const tripoint & );
-        int directional_antenna( player *, item *, bool, const tripoint & );
-        int radio_off( player *, item *, bool, const tripoint & );
-        int radio_on( player *, item *, bool, const tripoint & );
-        int noise_emitter_off( player *, item *, bool, const tripoint & );
-        int noise_emitter_on( player *, item *, bool, const tripoint & );
-        int ma_manual( player *, item *, bool, const tripoint & );
-        int crowbar( player *, item *, bool, const tripoint & );
-        int makemound( player *, item *, bool, const tripoint & );
-        int dig( player *, item *, bool, const tripoint & );
-        int dig_channel( player *, item *, bool, const tripoint & );
-        int fill_pit( player *, item *, bool, const tripoint & );
-        int clear_rubble( player *, item *, bool, const tripoint & );
-        int siphon( player *, item *, bool, const tripoint & );
-        int chainsaw_off( player *, item *, bool, const tripoint & );
-        int chainsaw_on( player *, item *, bool, const tripoint & );
-        int elec_chainsaw_off( player *, item *, bool, const tripoint & );
-        int elec_chainsaw_on( player *, item *, bool, const tripoint & );
-        int cs_lajatang_off( player *, item *, bool, const tripoint & );
-        int cs_lajatang_on( player *, item *, bool, const tripoint & );
-        int ecs_lajatang_off( player *, item *, bool, const tripoint & );
-        int ecs_lajatang_on( player *, item *, bool, const tripoint & );
-        int carver_off( player *, item *, bool, const tripoint & );
-        int carver_on( player *, item *, bool, const tripoint & );
-        int trimmer_off( player *, item *, bool, const tripoint & );
-        int trimmer_on( player *, item *, bool, const tripoint & );
-        int circsaw_on( player *, item *, bool, const tripoint & );
-        int combatsaw_off( player *, item *, bool, const tripoint & );
-        int combatsaw_on( player *, item *, bool, const tripoint & );
-        int e_combatsaw_off( player *, item *, bool, const tripoint & );
-        int e_combatsaw_on( player *, item *, bool, const tripoint & );
-        int jackhammer( player *, item *, bool, const tripoint & );
-        int pickaxe( player *, item *, bool, const tripoint & );
-        int burrow( player *, item *, bool, const tripoint & );
-        int geiger( player *, item *, bool, const tripoint & );
-        int teleport( player *, item *, bool, const tripoint & );
-        int can_goo( player *, item *, bool, const tripoint & );
-        int throwable_extinguisher_act( player *, item *, bool, const tripoint & );
-        int directional_hologram( player *, item *, bool, const tripoint & );
-        int capture_monster_veh( player *, item *, bool, const tripoint & );
-        int capture_monster_act( player *, item *, bool, const tripoint & );
-        int granade( player *, item *, bool, const tripoint & );
-        int granade_act( player *, item *, bool, const tripoint & );
-        int c4( player *, item *, bool, const tripoint & );
-        int arrow_flammable( player *, item *, bool, const tripoint & );
-        int acidbomb_act( player *, item *, bool, const tripoint & );
-        int grenade_inc_act( player *, item *, bool, const tripoint & );
-        int molotov_lit( player *, item *, bool, const tripoint & );
-        int firecracker_pack( player *, item *, bool, const tripoint & );
-        int firecracker_pack_act( player *, item *, bool, const tripoint & );
-        int firecracker( player *, item *, bool, const tripoint & );
-        int firecracker_act( player *, item *, bool, const tripoint & );
-        int mininuke( player *, item *, bool, const tripoint & );
-        int pheromone( player *, item *, bool, const tripoint & );
-        int portal( player *, item *, bool, const tripoint & );
-        int tazer( player *, item *, bool, const tripoint & );
-        int tazer2( player *, item *, bool, const tripoint & );
-        int shocktonfa_off( player *, item *, bool, const tripoint & );
-        int shocktonfa_on( player *, item *, bool, const tripoint & );
-        int mp3( player *, item *, bool, const tripoint & );
-        int mp3_on( player *, item *, bool, const tripoint & );
-        int rpgdie( player *, item *, bool, const tripoint & );
-        int dive_tank( player *, item *, bool, const tripoint & );
-        int gasmask( player *, item *, bool, const tripoint & );
-        int portable_game( player *, item *, bool, const tripoint & );
-        int fitness_check( player *p, item *it, bool, const tripoint & );
-        int vibe( player *, item *, bool, const tripoint & );
-        int hand_crank( player *, item *, bool, const tripoint & );
-        int vortex( player *, item *, bool, const tripoint & );
-        int dog_whistle( player *, item *, bool, const tripoint & );
-        int call_of_tindalos( player *, item *, bool, const tripoint & );
-        int blood_draw( player *, item *, bool, const tripoint & );
-        int mind_splicer( player *, item *, bool, const tripoint & );
-        static void cut_log_into_planks( player & );
-        int lumber( player *, item *, bool, const tripoint & );
-        int chop_tree( player *, item *, bool, const tripoint & );
-        int chop_logs( player *, item *, bool, const tripoint & );
-        int oxytorch( player *, item *, bool, const tripoint & );
-        int hacksaw( player *, item *, bool, const tripoint & );
-        int boltcutters( player *, item *, bool, const tripoint & );
-        int mop( player *, item *, bool, const tripoint & );
-        int spray_can( player *, item *, bool, const tripoint & );
-        int towel( player *, item *, bool, const tripoint & );
-        int unfold_generic( player *, item *, bool, const tripoint & );
-        int adrenaline_injector( player *, item *, bool, const tripoint & );
-        int jet_injector( player *, item *, bool, const tripoint & );
-        int stimpack( player *, item *, bool, const tripoint & );
-        int contacts( player *, item *, bool, const tripoint & );
-        int talking_doll( player *, item *, bool, const tripoint & );
-        int bell( player *, item *, bool, const tripoint & );
-        int seed( player *, item *, bool, const tripoint & );
-        int oxygen_bottle( player *, item *, bool, const tripoint & );
-        int radio_mod( player *, item *, bool, const tripoint & );
-        int remove_all_mods( player *, item *, bool, const tripoint & );
-        int fishing_rod( player *, item *, bool, const tripoint & );
-        int fish_trap( player *, item *, bool, const tripoint & );
-        int gun_repair( player *, item *, bool, const tripoint & );
-        int gunmod_attach( player *, item *, bool, const tripoint & );
-        int toolmod_attach( player *, item *, bool, const tripoint & );
-        int rm13armor_off( player *, item *, bool, const tripoint & );
-        int rm13armor_on( player *, item *, bool, const tripoint & );
-        int unpack_item( player *, item *, bool, const tripoint & );
-        int pack_cbm( player *p, item *it, bool, const tripoint & );
-        int pack_item( player *, item *, bool, const tripoint & );
-        int radglove( player *, item *, bool, const tripoint & );
-        int robotcontrol( player *, item *, bool, const tripoint & );
-        // Helper for validating a potential taget of robot control
-        static bool robotcontrol_can_target( player *, const monster & );
-        int einktabletpc( player *, item *, bool, const tripoint & );
-        int camera( player *, item *, bool, const tripoint & );
-        int ehandcuffs( player *, item *, bool, const tripoint & );
-        int foodperson( player *, item *, bool, const tripoint & );
-        int tow_attach( player *, item *, bool, const tripoint & );
-        int cable_attach( player *, item *, bool, const tripoint & );
-        int shavekit( player *, item *, bool, const tripoint & );
-        int hairkit( player *, item *, bool, const tripoint & );
-        int weather_tool( player *, item *, bool, const tripoint & );
-        int ladder( player *, item *, bool, const tripoint & );
-        int wash_soft_items( player *, item *, bool, const tripoint & );
-        int wash_hard_items( player *, item *, bool, const tripoint & );
-        int wash_all_items( player *, item *, bool, const tripoint & );
-        int wash_items( player *p, bool soft_items, bool hard_items );
-        int solarpack( player *, item *, bool, const tripoint & );
-        int solarpack_off( player *, item *, bool, const tripoint & );
-        int weak_antibiotic( player *, item *, bool, const tripoint & );
-        int strong_antibiotic( player *, item *, bool, const tripoint & );
-        int melatonin_tablet( player *, item *, bool, const tripoint & );
-        int coin_flip( player *, item *, bool, const tripoint & );
-        int play_game( player *, item *, bool, const tripoint & );
-        int magic_8_ball( player *, item *, bool, const tripoint & );
-        int toggle_heats_food( player *, item *, bool, const tripoint & );
+// FOOD AND DRUGS (ADMINISTRATION)
+int sewage( player *, item *, bool, const tripoint & );
+int honeycomb( player *, item *, bool, const tripoint & );
+int alcohol_weak( player *, item *, bool, const tripoint & );
+int alcohol_medium( player *, item *, bool, const tripoint & );
+int alcohol_strong( player *, item *, bool, const tripoint & );
+int xanax( player *, item *, bool, const tripoint & );
+int smoking( player *, item *, bool, const tripoint & );
+int ecig( player *, item *, bool, const tripoint & );
+int antibiotic( player *, item *, bool, const tripoint & );
+int eyedrops( player *, item *, bool, const tripoint & );
+int fungicide( player *, item *, bool, const tripoint & );
+int antifungal( player *, item *, bool, const tripoint & );
+int antiparasitic( player *, item *, bool, const tripoint & );
+int anticonvulsant( player *, item *, bool, const tripoint & );
+int weed_cake( player *, item *, bool, const tripoint & );
+int coke( player *, item *, bool, const tripoint & );
+int meth( player *, item *, bool, const tripoint & );
+int vaccine( player *, item *, bool, const tripoint & );
+int flu_vaccine( player *, item *, bool, const tripoint & );
+int poison( player *, item *, bool, const tripoint & );
+int meditate( player *, item *, bool, const tripoint & );
+int thorazine( player *, item *, bool, const tripoint & );
+int prozac( player *, item *, bool, const tripoint & );
+int sleep( player *, item *, bool, const tripoint & );
+int datura( player *, item *, bool, const tripoint & );
+int flumed( player *, item *, bool, const tripoint & );
+int flusleep( player *, item *, bool, const tripoint & );
+int inhaler( player *, item *, bool, const tripoint & );
+int blech( player *, item *, bool, const tripoint & );
+int blech_because_unclean( player *, item *, bool, const tripoint & );
+int plantblech( player *, item *, bool, const tripoint & );
+int chew( player *, item *, bool, const tripoint & );
+int purifier( player *, item *, bool, const tripoint & );
+int purify_iv( player *, item *, bool, const tripoint & );
+int purify_smart( player *, item *, bool, const tripoint & );
+int marloss( player *, item *, bool, const tripoint & );
+int marloss_seed( player *, item *, bool, const tripoint & );
+int marloss_gel( player *, item *, bool, const tripoint & );
+int mycus( player *, item *, bool, const tripoint & );
+int dogfood( player *, item *, bool, const tripoint & );
+int catfood( player *, item *, bool, const tripoint & );
+int feedcattle( player *, item *, bool, const tripoint & );
+int feedbird( player *, item *, bool, const tripoint & );
+int antiasthmatic( player *, item *, bool, const tripoint & );
+// TOOLS
+int extinguisher( player *, item *, bool, const tripoint & );
+int hammer( player *, item *, bool, const tripoint & );
+int water_purifier( player *, item *, bool, const tripoint & );
+int directional_antenna( player *, item *, bool, const tripoint & );
+int radio_off( player *, item *, bool, const tripoint & );
+int radio_on( player *, item *, bool, const tripoint & );
+int noise_emitter_off( player *, item *, bool, const tripoint & );
+int noise_emitter_on( player *, item *, bool, const tripoint & );
+int ma_manual( player *, item *, bool, const tripoint & );
+int crowbar( player *, item *, bool, const tripoint & );
+int makemound( player *, item *, bool, const tripoint & );
+int dig( player *, item *, bool, const tripoint & );
+int dig_channel( player *, item *, bool, const tripoint & );
+int fill_pit( player *, item *, bool, const tripoint & );
+int clear_rubble( player *, item *, bool, const tripoint & );
+int siphon( player *, item *, bool, const tripoint & );
+int chainsaw_off( player *, item *, bool, const tripoint & );
+int chainsaw_on( player *, item *, bool, const tripoint & );
+int elec_chainsaw_off( player *, item *, bool, const tripoint & );
+int elec_chainsaw_on( player *, item *, bool, const tripoint & );
+int cs_lajatang_off( player *, item *, bool, const tripoint & );
+int cs_lajatang_on( player *, item *, bool, const tripoint & );
+int ecs_lajatang_off( player *, item *, bool, const tripoint & );
+int ecs_lajatang_on( player *, item *, bool, const tripoint & );
+int carver_off( player *, item *, bool, const tripoint & );
+int carver_on( player *, item *, bool, const tripoint & );
+int trimmer_off( player *, item *, bool, const tripoint & );
+int trimmer_on( player *, item *, bool, const tripoint & );
+int circsaw_on( player *, item *, bool, const tripoint & );
+int combatsaw_off( player *, item *, bool, const tripoint & );
+int combatsaw_on( player *, item *, bool, const tripoint & );
+int e_combatsaw_off( player *, item *, bool, const tripoint & );
+int e_combatsaw_on( player *, item *, bool, const tripoint & );
+int jackhammer( player *, item *, bool, const tripoint & );
+int pickaxe( player *, item *, bool, const tripoint & );
+int burrow( player *, item *, bool, const tripoint & );
+int geiger( player *, item *, bool, const tripoint & );
+int teleport( player *, item *, bool, const tripoint & );
+int can_goo( player *, item *, bool, const tripoint & );
+int throwable_extinguisher_act( player *, item *, bool, const tripoint & );
+int directional_hologram( player *, item *, bool, const tripoint & );
+int capture_monster_veh( player *, item *, bool, const tripoint & );
+int capture_monster_act( player *, item *, bool, const tripoint & );
+int granade( player *, item *, bool, const tripoint & );
+int granade_act( player *, item *, bool, const tripoint & );
+int c4( player *, item *, bool, const tripoint & );
+int arrow_flammable( player *, item *, bool, const tripoint & );
+int acidbomb_act( player *, item *, bool, const tripoint & );
+int grenade_inc_act( player *, item *, bool, const tripoint & );
+int molotov_lit( player *, item *, bool, const tripoint & );
+int firecracker_pack( player *, item *, bool, const tripoint & );
+int firecracker_pack_act( player *, item *, bool, const tripoint & );
+int firecracker( player *, item *, bool, const tripoint & );
+int firecracker_act( player *, item *, bool, const tripoint & );
+int mininuke( player *, item *, bool, const tripoint & );
+int pheromone( player *, item *, bool, const tripoint & );
+int portal( player *, item *, bool, const tripoint & );
+int tazer( player *, item *, bool, const tripoint & );
+int tazer2( player *, item *, bool, const tripoint & );
+int shocktonfa_off( player *, item *, bool, const tripoint & );
+int shocktonfa_on( player *, item *, bool, const tripoint & );
+int mp3( player *, item *, bool, const tripoint & );
+int mp3_on( player *, item *, bool, const tripoint & );
+int rpgdie( player *, item *, bool, const tripoint & );
+int dive_tank( player *, item *, bool, const tripoint & );
+int gasmask( player *, item *, bool, const tripoint & );
+int portable_game( player *, item *, bool, const tripoint & );
+int fitness_check( player *p, item *it, bool, const tripoint & );
+int vibe( player *, item *, bool, const tripoint & );
+int hand_crank( player *, item *, bool, const tripoint & );
+int vortex( player *, item *, bool, const tripoint & );
+int dog_whistle( player *, item *, bool, const tripoint & );
+int call_of_tindalos( player *, item *, bool, const tripoint & );
+int blood_draw( player *, item *, bool, const tripoint & );
+int mind_splicer( player *, item *, bool, const tripoint & );
+void cut_log_into_planks( player & );
+int lumber( player *, item *, bool, const tripoint & );
+int chop_tree( player *, item *, bool, const tripoint & );
+int chop_logs( player *, item *, bool, const tripoint & );
+int oxytorch( player *, item *, bool, const tripoint & );
+int hacksaw( player *, item *, bool, const tripoint & );
+int boltcutters( player *, item *, bool, const tripoint & );
+int mop( player *, item *, bool, const tripoint & );
+int spray_can( player *, item *, bool, const tripoint & );
+int towel( player *, item *, bool, const tripoint & );
+int unfold_generic( player *, item *, bool, const tripoint & );
+int adrenaline_injector( player *, item *, bool, const tripoint & );
+int jet_injector( player *, item *, bool, const tripoint & );
+int stimpack( player *, item *, bool, const tripoint & );
+int contacts( player *, item *, bool, const tripoint & );
+int talking_doll( player *, item *, bool, const tripoint & );
+int bell( player *, item *, bool, const tripoint & );
+int seed( player *, item *, bool, const tripoint & );
+int oxygen_bottle( player *, item *, bool, const tripoint & );
+int radio_mod( player *, item *, bool, const tripoint & );
+int remove_all_mods( player *, item *, bool, const tripoint & );
+int fishing_rod( player *, item *, bool, const tripoint & );
+int fish_trap( player *, item *, bool, const tripoint & );
+int gun_repair( player *, item *, bool, const tripoint & );
+int gunmod_attach( player *, item *, bool, const tripoint & );
+int toolmod_attach( player *, item *, bool, const tripoint & );
+int rm13armor_off( player *, item *, bool, const tripoint & );
+int rm13armor_on( player *, item *, bool, const tripoint & );
+int unpack_item( player *, item *, bool, const tripoint & );
+int pack_cbm( player *p, item *it, bool, const tripoint & );
+int pack_item( player *, item *, bool, const tripoint & );
+int radglove( player *, item *, bool, const tripoint & );
+int robotcontrol( player *, item *, bool, const tripoint & );
+// Helper for validating a potential taget of robot control
+bool robotcontrol_can_target( player *, const monster & );
+int einktabletpc( player *, item *, bool, const tripoint & );
+int camera( player *, item *, bool, const tripoint & );
+int ehandcuffs( player *, item *, bool, const tripoint & );
+int foodperson( player *, item *, bool, const tripoint & );
+int tow_attach( player *, item *, bool, const tripoint & );
+int cable_attach( player *, item *, bool, const tripoint & );
+int shavekit( player *, item *, bool, const tripoint & );
+int hairkit( player *, item *, bool, const tripoint & );
+int weather_tool( player *, item *, bool, const tripoint & );
+int ladder( player *, item *, bool, const tripoint & );
+int wash_soft_items( player *, item *, bool, const tripoint & );
+int wash_hard_items( player *, item *, bool, const tripoint & );
+int wash_all_items( player *, item *, bool, const tripoint & );
+int solarpack( player *, item *, bool, const tripoint & );
+int solarpack_off( player *, item *, bool, const tripoint & );
+int weak_antibiotic( player *, item *, bool, const tripoint & );
+int strong_antibiotic( player *, item *, bool, const tripoint & );
+int melatonin_tablet( player *, item *, bool, const tripoint & );
+int coin_flip( player *, item *, bool, const tripoint & );
+int play_game( player *, item *, bool, const tripoint & );
+int magic_8_ball( player *, item *, bool, const tripoint & );
+int toggle_heats_food( player *, item *, bool, const tripoint & );
 
-        // MACGUFFINS
+// MACGUFFINS
 
-        int radiocar( player *, item *, bool, const tripoint & );
-        int radiocaron( player *, item *, bool, const tripoint & );
-        int radiocontrol( player *, item *, bool, const tripoint & );
+int radiocar( player *, item *, bool, const tripoint & );
+int radiocaron( player *, item *, bool, const tripoint & );
+int radiocontrol( player *, item *, bool, const tripoint & );
 
-        int autoclave( player *, item *, bool, const tripoint & );
+int autoclave( player *, item *, bool, const tripoint & );
 
-        int multicooker( player *, item *, bool, const tripoint & );
+int multicooker( player *, item *, bool, const tripoint & );
 
-        int remoteveh( player *, item *, bool, const tripoint & );
+int remoteveh( player *, item *, bool, const tripoint & );
 
-        int craft( player *, item *, bool, const tripoint & );
+int craft( player *, item *, bool, const tripoint & );
 
-        int disassemble( player *, item *, bool, const tripoint & );
+int disassemble( player *, item *, bool, const tripoint & );
 
-        // ARTIFACTS
-        /* This function is used when an artifact is activated.
-           It examines the item's artifact-specific properties.
-           See artifact.h for a list.                        */
-        int artifact( player *, item *, bool, const tripoint & );
+// ARTIFACTS
+/* This function is used when an artifact is activated.
+   It examines the item's artifact-specific properties.
+   See artifact.h for a list.                        */
+int artifact( player *, item *, bool, const tripoint & );
 
-        // Helper for listening to music, might deserve a better home, but not sure where.
-        static void play_music( player &p, const tripoint &source, int volume, int max_morale );
-        static int towel_common( player *, item *, bool );
+// Helper for listening to music, might deserve a better home, but not sure where.
+void play_music( player &p, const tripoint &source, int volume, int max_morale );
+int towel_common( player *, item *, bool );
 
-        // Helper for handling pesky wannabe-artists
-        static int handle_ground_graffiti( player &p, item *it, const std::string &prefix,
-                                           const tripoint &where );
+// Helper for handling pesky wannabe-artists
+int handle_ground_graffiti( player &p, item *it, const std::string &prefix,
+                                   const tripoint &where );
 
-        // Helper for wood chopping
-        static int chop_moves( Character &ch, item &tool );
+// Helper for wood chopping
+int chop_moves( Character &ch, item &tool );
 
-        // LEGACY
-        int cauterize_hotplate( player *, item *, bool, const tripoint & );
+// LEGACY
+int cauterize_hotplate( player *, item *, bool, const tripoint & );
 
-};
+} // namespace iuse
 
 void remove_radio_mod( item &it, player &p );
 
@@ -253,7 +251,7 @@ struct washing_requirements {
 };
 washing_requirements washing_requirements_for_volume( const units::volume & );
 
-using use_function_pointer = int ( iuse::* )( player *, item *, bool, const tripoint & );
+using use_function_pointer = int ( * )( player *, item *, bool, const tripoint & );
 
 class iuse_actor
 {

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -680,8 +680,7 @@ void monexamine::kill_zslave( monster &z )
     if( !one_in( 3 ) ) {
         g->u.add_msg_if_player( _( "You tear out the pheromone ball from the zombie slave." ) );
         item ball( "pheromone", calendar::start_of_cataclysm );
-        iuse pheromone;
-        pheromone.pheromone( &g->u, &ball, true, g->u.pos() );
+        iuse::pheromone( &g->u, &ball, true, g->u.pos() );
     }
 }
 


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Make iuse a namespace instead of class"

#### Purpose of change
`iuse` is a stateless class, just a collection of functions. Because of this it is not necessary to use a class, and does in some cases force instancing of the `iuse` class.

#### Describe the solution
Change `class iuse` to `namespace iuse`, remove `static` keyword from functions within the namespace, and clean up appearances of `iuse` instances that are no longer necessary.
The function `iuse::wash_items` is only ever called within `iuse.cpp` so its definition can be removed from `iuse.h` and made into a static function.