### PR TITLE
Disengage parking brake when towing

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6537,7 +6537,7 @@ int vehicle::damage_direct( int p, int dmg, damage_type type )
             mon->remove_effect( effect_harnessed );
         }
         if( part_flag( p, "TOW_CABLE" ) ) {
-            invalidate_towing();
+            invalidate_towing( true );
         } else {
             remove_part( p );
         }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4189,7 +4189,7 @@ float vehicle::k_traction( float wheel_traction_area ) const
 
 int vehicle::static_drag( bool actual ) const
 {
-    return extra_drag + ( actual && !engine_on ? -1500 : 0 );
+    return extra_drag + ( actual && !engine_on && !is_towed() ? -1500 : 0 );
 }
 
 float vehicle::strain() const


### PR DESCRIPTION
Summary [Content]

Port "vehicles: towed vehicles don't set their parking brakes" from dda

Purpose of change

Disengage parking brake when towing, this will increase the towing speed and eliminate the dropping of the cable

Describe the solution

Port from https://github.com/CleverRaven/Cataclysm-DDA/pull/46508
Port from https://github.com/CleverRaven/Cataclysm-DDA/pull/46539

Testing

- Spawn 2 cars and a tow cable
- Connect them
- Try towing one car with another

Additional context

As the author said: "Developer isn't responsible for towing vehicles that stop suddenly and are rammed by their towed vehicles"