### PR TITLE
feat: Mutation selection rewrite - mutation graph

### DIFF
--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -285,4 +285,37 @@ class restore_on_out_of_scope
         // *INDENT-ON*
 };
 
+/**
+ * Both sets must be sorted!
+ */
+template<class Set1, class Set2>
+bool intersection_nonempty( const Set1 &left, const Set2 &right )
+{
+    if( left.empty() || right.empty() ) {
+        return false;
+    }
+
+    typename Set1::const_iterator iter_left = left.begin();
+    typename Set2::const_iterator iter_right = right.begin();
+    const typename Set1::const_iterator left_end = left.end();
+    const typename Set2::const_iterator right_end = right.end();
+
+    if( *right.rbegin() < *iter_left || *left.rbegin() < *iter_right ) {
+        return false;
+    }
+
+    while( iter_left != left_end && iter_right != right_end ) {
+        if( *iter_left == *iter_right ) {
+            return true;
+        }
+        if( *iter_left < *iter_right ) {
+            iter_left++;
+        } else {
+            iter_right++;
+        }
+    }
+
+    return false;
+}
+
 #endif // CATA_SRC_CATA_UTILITY_H

--- a/src/character.h
+++ b/src/character.h
@@ -962,8 +962,6 @@ class Character : public Creature, public visitable<Character>
         bool mutate_towards( const trait_id &mut );
         /** Removes a mutation, downgrading to the previous level if possible */
         void remove_mutation( const trait_id &mut, bool silent = false );
-        /** Calculate percentage chances for mutations */
-        std::map<trait_id, float> mutation_chances() const;
         /** Returns true if the player has the entered mutation child flag */
         bool has_child_flag( const trait_id &flag ) const;
         /** Removes the mutation's child flag from the player's list */

--- a/src/character.h
+++ b/src/character.h
@@ -1557,6 +1557,8 @@ class Character : public Creature, public visitable<Character>
         void pick_name( bool bUseDefault = false );
         /** Get the idents of all base traits. */
         std::vector<trait_id> get_base_traits() const;
+        /** Gets mutations that the character actually has, ignoring enchantments. */
+        std::set<trait_id> actual_mutations() const;
         /** Get the idents of all traits/mutations. */
         std::vector<trait_id> get_mutations( bool include_hidden = true ) const;
         const std::bitset<NUM_VISION_MODES> &get_vision_modes() const {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -59,6 +59,7 @@
 #include "monster.h"
 #include "monstergenerator.h"
 #include "morale_types.h"
+#include "mutation.h"
 #include "mtype.h"
 #include "npc.h"
 #include "npc_class.h"
@@ -1719,11 +1720,19 @@ void debug()
             }
             break;
 
-        case DEBUG_SHOW_MUT_CHANCES:
-            for( const auto &elem : u.mutation_chances() ) {
-                add_msg( "%s: %.2f", elem.first.c_str(), elem.second );
+        case DEBUG_SHOW_MUT_CHANCES: {
+            const std::map<trait_id, float> trait_chances = mutations::mutation_chances( u );
+            std::vector<std::pair<trait_id, float>> sorted_chances( trait_chances.begin(),
+                                                 trait_chances.end() );
+            std::sort( sorted_chances.begin(), sorted_chances.end(),
+            []( const std::pair<trait_id, float> &left, const std::pair<trait_id, float> &right ) {
+                return left.second < right.second;
+            } );
+            for( const auto &elem : sorted_chances ) {
+                add_msg( "%s: %3.2f%%", elem.first.c_str(), 100.0f * elem.second );
             }
-            break;
+        }
+        break;
 
         case DEBUG_OM_EDITOR:
             ui::omap::display_editor();

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1109,7 +1109,7 @@ static void do_purify( player &p )
 int iuse::purifier( player *p, item *it, bool, const tripoint & )
 {
     mutagen_attempt checks =
-        mutagen_common_checks( *p, *it, false, mutagen_technique::consumed_purifier );
+        mutations::mutagen_common_checks( *p, *it, false, mutagen_technique::consumed_purifier );
     if( !checks.allowed ) {
         return checks.charges_used;
     }
@@ -1121,7 +1121,7 @@ int iuse::purifier( player *p, item *it, bool, const tripoint & )
 int iuse::purify_iv( player *p, item *it, bool, const tripoint & )
 {
     mutagen_attempt checks =
-        mutagen_common_checks( *p, *it, false, mutagen_technique::injected_purifier );
+        mutations::mutagen_common_checks( *p, *it, false, mutagen_technique::injected_purifier );
     if( !checks.allowed ) {
         return checks.charges_used;
     }
@@ -1163,7 +1163,7 @@ int iuse::purify_iv( player *p, item *it, bool, const tripoint & )
 int iuse::purify_smart( player *p, item *it, bool, const tripoint & )
 {
     mutagen_attempt checks =
-        mutagen_common_checks( *p, *it, false, mutagen_technique::injected_smart_purifier );
+        mutations::mutagen_common_checks( *p, *it, false, mutagen_technique::injected_smart_purifier );
     if( !checks.allowed ) {
         return checks.charges_used;
     }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4332,7 +4332,7 @@ void mutagen_actor::load( const JsonObject &obj )
 int mutagen_actor::use( player &p, item &it, bool, const tripoint & ) const
 {
     mutagen_attempt checks =
-        mutagen_common_checks( p, it, false, mutagen_technique::consumed_mutagen );
+        mutations::mutagen_common_checks( p, it, false, mutagen_technique::consumed_mutagen );
 
     if( !checks.allowed ) {
         return checks.charges_used;
@@ -4400,7 +4400,7 @@ void mutagen_iv_actor::load( const JsonObject &obj )
 int mutagen_iv_actor::use( player &p, item &it, bool, const tripoint & ) const
 {
     mutagen_attempt checks =
-        mutagen_common_checks( p, it, false, mutagen_technique::injected_mutagen );
+        mutations::mutagen_common_checks( p, it, false, mutagen_technique::injected_mutagen );
 
     if( !checks.allowed ) {
         return checks.charges_used;
@@ -4416,7 +4416,7 @@ int mutagen_iv_actor::use( player &p, item &it, bool, const tripoint & ) const
     }
 
     // try to cross the threshold to be able to get post-threshold mutations this iv.
-    test_crossing_threshold( p, m_category );
+    mutations::test_crossing_threshold( p, m_category );
 
     // TODO: Remove the "is_player" part, implement NPC screams
     if( p.is_player() && !( p.has_trait( trait_NOPAIN ) ) && m_category.iv_sound ) {
@@ -4457,7 +4457,7 @@ int mutagen_iv_actor::use( player &p, item &it, bool, const tripoint & ) const
     }
 
     // try crossing again after getting new in-category mutations.
-    test_crossing_threshold( p, m_category );
+    mutations::test_crossing_threshold( p, m_category );
 
     return it.type->charges_to_use();
 }

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -237,7 +237,7 @@ struct mutation_branch {
         std::set<itype_id> can_only_heal_with;
         std::set<itype_id> can_heal_with;
 
-        /**List of allowed mutatrion category*/
+        /** List of allowed mutation categories */
         std::set<std::string> allowed_category;
 
         /**List of body parts locked out of bionics*/
@@ -522,9 +522,19 @@ struct mutagen_attempt {
     int charges_used;
 };
 
+namespace mutations
+{
+
 mutagen_attempt mutagen_common_checks( Character &guy, const item &it, bool strong,
                                        mutagen_technique technique );
 
 void test_crossing_threshold( Character &guy, const mutation_category_trait &m_category );
+
+/** Calculate percentage chances for mutations */
+std::map<trait_id, float> mutation_chances( const Character &guy );
+
+std::set<std::string> allowed_categories( const std::vector<trait_id> &mutation_set );
+
+} // namespace mutations
 
 #endif // CATA_SRC_MUTATION_H

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -533,7 +533,10 @@ void test_crossing_threshold( Character &guy, const mutation_category_trait &m_c
 /** Calculate percentage chances for mutations */
 std::map<trait_id, float> mutation_chances( const Character &guy );
 
-std::set<std::string> allowed_categories( const std::vector<trait_id> &mutation_set );
+/**
+ * With given mutation set, which categories are allowed?
+ */
+std::set<std::string> allowed_categories( const std::set<trait_id> &mutation_set );
 
 } // namespace mutations
 

--- a/tests/mutation_test.cpp
+++ b/tests/mutation_test.cpp
@@ -155,7 +155,7 @@ TEST_CASE( "Gaining a mutation in category makes mutations from other categories
         }
 
         npc zero_mut_dummy;
-        std::map<trait_id, float> chances_pre = zero_mut_dummy.mutation_chances();
+        std::map<trait_id, float> chances_pre = mutations::mutation_chances( zero_mut_dummy );
         float sum_pre = sum_without_category( chances_pre, cat_id );
         for( const mutation_branch &mut : mutation_branch::get_all() ) {
             if( zero_mut_dummy.mutation_ok( mut.id, false, false ) ) {
@@ -165,7 +165,7 @@ TEST_CASE( "Gaining a mutation in category makes mutations from other categories
                 npc dummy;
                 dummy.mutate_towards( mut.id );
                 THEN( "Sum of chances for mutations not of this category is lower than before" ) {
-                    std::map<trait_id, float> chances_post = dummy.mutation_chances();
+                    std::map<trait_id, float> chances_post = mutations::mutation_chances( dummy );
                     float sum_post = sum_without_category( chances_post, cat_id );
                     CHECK( sum_post < sum_pre );
                 }


### PR DESCRIPTION
Here I redesign the mutation picker to be a graph search, similar to pathfinding. Except it's pathing on a grid of trait sets, not a 3D grid.

This will help with making categories and thresholds more fluid - the old system is rather strongly focused on the highest category, the "middle" one (current) tries to bridge them, but doesn't have a good replacement for thresholds yet.
The mutation graph will help with making traits correlated rather than directly linked (opposing, replacement, requirement), without having to make both of them be in the same category. So paws and claws could go together, even if you're more of a fish at the moment.

The algorithm works like this:
* Start from current player state, which contains current mutation set
* Consider all possible additions of new traits and all possible removals of a single trait
* Consider other 1-trait changes: addition to existing (`leads_to`), replacement of one trait in the set.
* Repeat the one above until paths that require up to `n` changes are considered. `n` is based on current ability to mutate (time spent not mutating, whether using a serum, regular mutagen or weak mutagen).
* Assign chances to sets of mutations generated this way
* Pick one set and mutate to it

The above algorithm won't add and remove the same trait in one run. It prefers instantly giving you level 2-3 traits rather than giving you warning signs.