### PR TITLE
Fix vehicles not preventing water temp effects

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -63,6 +63,7 @@ class player;
 class player_morale;
 class vehicle;
 class monster;
+class weather_manager;
 struct bionic;
 struct construction;
 struct dealt_projectile_attack;
@@ -501,7 +502,7 @@ class Character : public Creature, public visitable<Character>
         /** Returns if the player has hibernation mutation and is asleep and well fed */
         bool is_hibernating() const;
         /** Maintains body temperature */
-        void update_bodytemp();
+        void update_bodytemp( const map &m, weather_manager &weather );
 
         /** Equalizes heat between body parts */
         void temp_equalizer( const bodypart_id &bp1, const bodypart_id &bp2 );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1580,7 +1580,7 @@ bool game::do_turn()
         first_redraw_since_waiting_started = true;
     }
 
-    u.update_bodytemp();
+    u.update_bodytemp( m, weather );
     u.update_body_wetness( *weather.weather_precise );
     u.apply_wetness_morale( weather.temperature );
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -273,7 +273,8 @@ int iuse_transform::use( player &p, item &it, bool t, const tripoint &pos ) cons
     }
     if( p.is_worn( *obj ) ) {
         p.reset_encumbrance();
-        p.update_bodytemp();
+        // This is most likely wrong: it doubles temperature shift for the turn!
+        p.update_bodytemp( get_map(), g->weather );
         p.on_worn_item_transform( obj_copy, *obj );
     }
     obj->item_counter = countdown > 0 ? countdown : obj->type->countdown_interval;

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -33,6 +33,7 @@
 #include "translations.h"
 #include "trap.h"
 #include "units.h"
+#include "vpart_position.h"
 #include "weather_gen.h"
 
 static const activity_id ACT_WAIT_WEATHER( "ACT_WAIT_WEATHER" );
@@ -1058,6 +1059,27 @@ int weather_manager::get_water_temperature( const tripoint & )
 void weather_manager::clear_temp_cache()
 {
     temperature_cache.clear();
+}
+
+namespace weather
+{
+
+bool is_sheltered( const map &m, const tripoint &p )
+{
+    const optional_vpart_position vp = m.veh_at( p );
+
+    return ( !m.is_outside( p ) ||
+             p.z < 0 ||
+             ( vp && vp->is_inside() ) );
+}
+
+bool is_in_sunlight( const map &m, const tripoint &p, weather_type weather )
+{
+    // TODO: Remove that game reference and include light in weather data
+    return ( m.is_outside( p ) && g->light_level( p.z ) >= 40 &&
+             ( weather == WEATHER_CLEAR || weather == WEATHER_SUNNY ) );
+}
+
 }
 
 ///@}

--- a/src/weather.h
+++ b/src/weather.h
@@ -34,6 +34,7 @@
 #include <utility>
 
 class item;
+class map;
 struct trap;
 struct rl_vec2d;
 
@@ -165,6 +166,9 @@ precip_class precip( weather_type type );
 bool rains( weather_type type );
 bool acidic( weather_type type );
 weather_effect_fn effect( weather_type type );
+
+bool is_sheltered( const map &m, const tripoint &p );
+bool is_in_sunlight( const map &m, const tripoint &p, weather_type weather );
 } // namespace weather
 
 std::string get_shortdirstring( int angle );

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -9,6 +9,7 @@
 #include "game.h"
 #include "item.h"
 #include "item_location.h"
+#include "map.h"
 #include "map_helpers.h"
 #include "monster.h"
 #include "monster_oracle.h"
@@ -152,7 +153,7 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
     SECTION( "Freezing" ) {
         g->weather.temperature = -100;
         get_weather().clear_temp_cache();
-        test_npc.update_bodytemp();
+        test_npc.update_bodytemp( get_map(), g->weather );
         CHECK( npc_needs.tick( &oracle ) == "idle" );
         item &sweater = test_npc.i_add( item( itype_id( "sweater" ) ) );
         CHECK( npc_needs.tick( &oracle ) == "wear_warmer_clothes" );

--- a/tests/player_test.cpp
+++ b/tests/player_test.cpp
@@ -65,7 +65,7 @@ static int converge_temperature( player &p, size_t iters, int start_temperature 
         }
 
         history.emplace( p.temp_cur );
-        p.update_bodytemp();
+        p.update_bodytemp( get_map(), g->weather );
     }
 
     CAPTURE( iters );
@@ -384,7 +384,7 @@ static void hypothermia_check( player &p, int water_temperature, time_duration e
 
     int actual_time;
     for( actual_time = 0; actual_time < upper_bound * 2; actual_time++ ) {
-        p.update_bodytemp();
+        p.update_bodytemp( get_map(), g->weather );
         if( p.temp_cur[0] <= expected_temperature ) {
             break;
         }


### PR DESCRIPTION
Closes #473

Body part immersion check didn't check `in_vehicle`, now it does.

Temperature code is really ugly with its dependence on global state. I refactored some barely related bits here, even though the actual fix itself is 2 lines.