### PR TITLE
Fix wrong description for ammo belt

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -410,14 +410,12 @@
   {
     "id": "MELTS",
     "type": "json_flag",
-    "context": [ "COMESTIBLE" ],
-    "info": "This food <neutral>melts when not in a very cold climate</neutral>, and tastes much <good>better</good> when <color_light_cyan>frozen</color>."
+    "context": [ "COMESTIBLE" ]
   },
   {
     "id": "MAG_DESTROY",
     "type": "json_flag",
-    "context": [ "MAGAZINE" ],
-    "info": "This food <neutral>melts when not in a very cold climate</neutral>, and tastes much <good>better</good> when <color_light_cyan>frozen</color>."
+    "context": [ "MAGAZINE" ]
   },
   {
     "id": "OUTER",


### PR DESCRIPTION
Closes #472

It was just a wrong description of a correct flag.

Also hid the `"MELTS"` flag for now, it's not supported at the moment.