### PR TITLE
Allow alt keys except for tab

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1007,7 +1007,11 @@ static bool add_alt_code( char c )
         if( c >= '0' && c <= '9' ) {
             alt_buffer = alt_buffer * 10 + ( c - '0' );
         }
-        return true;
+
+        // Hardcoded alt-tab check. TODO: Handle alt keys properly
+        if( c == '\t' ) {
+            return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
Closes #457

Partly reverts #455 by hardcoding it to only work on tab key.
We should properly support key modifiers some day, at the moment they scramble the codes, with weird results like CTRL+A being backspace and the like.