### PR TITLE
Increased log volume/weight to preserve conseration conservation of mass and volume

### DIFF
--- a/data/json/items/resources/wood.json
+++ b/data/json/items/resources/wood.json
@@ -10,8 +10,8 @@
     "price": 10000,
     "price_postapoc": 10,
     "material": "wood",
-    "weight": "9071 g",
-    "volume": "10 L",
+    "weight": "30 kg",
+    "volume": "50 L",
     "bashing": 10,
     "to_hit": -10,
     "flags": [ "FIREWOOD" ]


### PR DESCRIPTION
Increased log volume/weight to preserve conseration conservation of mass and volume and make using charcoal kiln easier since you need to cut less trees to produce more charcoal and give less routine for player.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: Bugfixes "Increased log volume/weight to preserve conseration conservation of mass and volume"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
1) Merge Fix: https://github.com/CleverRaven/Cataclysm-DDA/issues/45607
2) As side effect - it should make using charcoal kiln easier since you need to cut less trees to produce more charcoal. So less tree cutting routine for player.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Manually merge https://github.com/CleverRaven/Cataclysm-DDA/pull/45636
Change log volume/weight from 6/10 to 30/50. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Observe wood log stats
2) Try to fill charcoal kiln with logs. Now it should fit 2 logs instead of 12. So it should make charcoal burning easier. So less routine for player.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
Despite being realistic this change also making  things more logical and give less tree cutting routine for player.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
