### PR TITLE
[WIP] Quick fix for uncapping the bionic power limit of 2 MJ.

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9282,7 +9282,7 @@ std::list<item> Character::use_charges( const itype_id &what, int qty,
             return res;
         }
         if( has_power() && has_active_bionic( bio_ups ) ) {
-            int bio = std::min( units::to_kilojoule( get_power_level() ), qty );
+            int bio = std::min<int>( units::to_kilojoule( get_power_level() ), qty );
             mod_power_level( units::from_kilojoule( -bio ) );
             qty -= std::min( qty, bio );
         }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1360,7 +1360,7 @@ bool Character::feed_furnace_with( item &it )
             _( "<npcname> digests a %s for energy, they're fully powered already, so the energy is wasted." ),
             it.tname() );
     } else {
-        const int profitable_energy = std::min( energy,
+        const int profitable_energy = std::min<int>( energy,
                                                 units::to_kilojoule( get_max_power_level() - get_power_level() ) );
         if( it.count_by_charges() ) {
             add_msg_player_or_npc( m_info,

--- a/src/units_energy.h
+++ b/src/units_energy.h
@@ -13,7 +13,7 @@ class energy_in_millijoule_tag
 {
 };
 
-using energy = quantity<int, energy_in_millijoule_tag>;
+using energy = quantity<unsigned long long, energy_in_millijoule_tag>;
 
 const energy energy_min = units::energy( std::numeric_limits<units::energy::value_type>::min(),
                           units::energy::unit_type{} );

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -881,7 +881,7 @@ int visitable<Character>::charges_of( const std::string &what, int limit,
 
     if( what == "toolset" ) {
         if( p && p->has_active_bionic( bio_tools ) ) {
-            return std::min( units::to_kilojoule( p->get_power_level() ), limit );
+            return std::min<int>( units::to_kilojoule( p->get_power_level() ), limit );
         } else {
             return 0;
         }
@@ -892,7 +892,7 @@ int visitable<Character>::charges_of( const std::string &what, int limit,
         qty = sum_no_wrap( qty, charges_of( "UPS_off" ) );
         qty = sum_no_wrap( qty, static_cast<int>( charges_of( "adv_UPS_off" ) / 0.6 ) );
         if( p && p->has_active_bionic( bio_ups ) ) {
-            qty = sum_no_wrap( qty, units::to_kilojoule( p->get_power_level() ) );
+            qty = sum_no_wrap<int>( qty, units::to_kilojoule( p->get_power_level() ) );
         }
         if( p && p->is_mounted() ) {
             auto mons = p->mounted_creature.get();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->
SUMMARY: Bugfixes "Quick fix for uncapping bionic power limit of 2 MJ"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->
The maximum bionic power is arbitrarily capped to the 32bit integer overflow value (in mJ), which is slightly more than 2.1 MJ, with the justification that "15 MJ's worth of cutting-edge batteries is roughly one-third of the average person's weight" (https://github.com/CleverRaven/Cataclysm-DDA/issues/34422), despite the fact that a single light high-capacity battery, which the Power Storage Mk2 CBM is made out of, has a weight of only 40 g, takes up a mere 40 mL of volume and is capable of storing 150 kJ of power. In other words, 15 MJ's worth of light high-capacity batteries only weights 4 kg and takes up 4 L of space.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->
This solution is intended to be a temporary fix until a better one is implemented, and it relies on changing the bionic power variable's type to a 64bit integer (which translates to a practically infinite power storage cap), as well as the necessary code changes to support such change.


#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
The power cap could be circumvented by (modded) items which could conceivably exist such as an external battery pack, essentially a medium storage battery and necessary cabling stuffed into a backpack in a similar vein to the solar panel backpack.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->
I have compiled and ran the code in VS, created a random world and character, teleported to a nearby lab with an Autodoc and installed 10 Power Storage Mk2 CBMs in sequence without error, and the power cap read as the expected 2.5 MJ.

![POG](https://user-images.githubusercontent.com/22873153/115977890-da773680-a573-11eb-8233-619e7bc3d19e.PNG)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
WIP note: Power capacity does not show correctly in the bionics (p) menu when accumulated power exceeds 2 MJ and bionics don't seem to draw power at alll.