### PR TITLE
Magiclysm NPC mission dialogue fix

### DIFF
--- a/data/mods/Magiclysm/npc/TALK_HEALER_GREY.json
+++ b/data/mods/Magiclysm/npc/TALK_HEALER_GREY.json
@@ -18,7 +18,7 @@
       },
       { "text": "Wanna get outta here?", "topic": "TALK_SUGGEST_FOLLOW" },
       { "text": "Let's trade items.", "topic": "TALK_HEALER_GREY", "effect": "start_trade" },
-      { "text": "Can I do anything for you?", "topic": "TALK_MISSION_OFFER" },
+      { "text": "Can I do anything for you?", "topic": "TALK_MISSION_LIST" },
       { "text": "About the mission…", "topic": "TALK_MISSION_INQUIRE", "condition": "has_assigned_mission" },
       {
         "text": "About one of those missions…",

--- a/data/mods/Magiclysm/npc/TALK_OLD_MAGUS.json
+++ b/data/mods/Magiclysm/npc/TALK_OLD_MAGUS.json
@@ -20,7 +20,7 @@
       { "text": "Let's trade items.", "topic": "TALK_OLD_MAGUS", "effect": "start_trade" },
       {
         "text": "Can I do anything for you?",
-        "topic": "TALK_MISSION_OFFER",
+        "topic": "TALK_MISSION_LIST",
         "condition": {
           "and": [
             { "not": "has_assigned_mission" },

--- a/data/mods/Magiclysm/npc/TALK_TECHNO_KID.json
+++ b/data/mods/Magiclysm/npc/TALK_TECHNO_KID.json
@@ -18,7 +18,7 @@
       },
       { "text": "Wanna get outta here?", "topic": "TALK_SUGGEST_FOLLOW" },
       { "text": "Let's trade items.", "topic": "TALK_TECHNO_KID", "effect": "start_trade" },
-      { "text": "Can I do anything for you?", "topic": "TALK_MISSION_OFFER" },
+      { "text": "Can I do anything for you?", "topic": "TALK_MISSION_LIST" },
       { "text": "About the mission…", "topic": "TALK_MISSION_INQUIRE", "condition": "has_assigned_mission" },
       {
         "text": "About one of those missions…",


### PR DESCRIPTION
#### Summary

Bugfixes, Mods "Giving NPCs necessary dialogues related to missions"

#### Purpose of change

According to [mission docs](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/MISSIONS_JSON.md)

> Any NPC that has missions needs to have a dialogue option that leads to TALK_MISSION_LIST

NPC in Magiclysm mod were assigned TALK_MISSION_OFFER instead of TALK_MISSION_LIST, and while it works for accepting their jobs, it doesn't provide necessary function for them to say that they don't have any more jobs for the player, resulting in 
`src/npctalk_funcs.cpp:102 [void talk_function::assign_mission(npc&)] assign_mission: mission_selected == nullptr`

Except for old magus, who has necessary checks, but I've changed them too in case of future updates with more quests added and to be in line with documentation. 