### PR TITLE
Fix <npcname> not replaced in monster attack messages

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1643,8 +1643,7 @@ const std::pair<translation, nc_color> &Creature::get_attitude_ui_data( Attitude
 
 std::string Creature::replace_with_npc_name( std::string input ) const
 {
-    replace_all( input, "<npcname>", disp_name() );
-    return input;
+    return replace_all( std::move( input ), "<npcname>", disp_name() );
 }
 
 void Creature::knock_back_from( const tripoint &p )

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -272,7 +272,7 @@ void replace_name_tags( std::string &input )
 
 void replace_city_tag( std::string &input, const std::string &name )
 {
-    replace_all( input, "<city>", name );
+    input = replace_all( input, "<city>", name );
 }
 
 void replace_first( std::string &input, const std::string &what, const std::string &with )


### PR DESCRIPTION
#### Purpose of change
Fix #491

#### Describe the solution
The substring replacement utility function was changed from modify-string-in-place to return-modified-string, but the call site remained unchanged. Rectify that, and fix another similar case.

#### Testing
Spawned zombie, spawned Nodosaur, let them fight. The "zombie bites..." message is now correct.