### PR TITLE
Fix very slow empty grids

### DIFF
--- a/src/distribution_grid.cpp
+++ b/src/distribution_grid.cpp
@@ -177,13 +177,6 @@ distribution_grid &distribution_grid_tracker::make_distribution_grid_at( const t
     }
     shared_ptr_fast<distribution_grid> dist_grid = make_shared_fast<distribution_grid>
             ( submap_positions, mb );
-    if( dist_grid->empty() ) {
-        for( const tripoint &smp : submap_positions ) {
-            parent_distribution_grids.erase( smp );
-        }
-
-        return empty_grid;
-    }
     for( const tripoint &smp : submap_positions ) {
         parent_distribution_grids[smp] = dist_grid;
     }


### PR DESCRIPTION
Now that's embarrassing: I tried to optimize empty grids by not caching them, reasoning that most grids will be empty.
Every "gridded" submap tile needs some minuscule amount of time to be updated every turn.

But the result was that large empty grids were rebuilt for every single overmap tile of the grid.

Here I remove the premature optimization that caused the problem.