### PR TITLE
Buff zombie grabs, nerf infection death

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8158,8 +8158,7 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
             !source->has_effect( effect_grabbing ) ) {
             /** @EFFECT_DEX increases chance to avoid being grabbed */
 
-            if( has_grab_break_tec() && get_grab_resist() > 0 &&
-                ( rng( 0, get_dex() )  > rng( 0, 10 ) ) ) {
+            if( has_grab_break_tec() && ( rng( 0, get_dex() )  > rng( 0, 10 ) ) ) {
                 if( has_effect( effect_grabbed ) ) {
                     add_msg_if_player( m_warning, _( "The %s tries to grab you as well, but you bat it away!" ),
                                        source->disp_name() );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -131,9 +131,6 @@ void Creature::reset_bonuses()
     dodge_bonus = 0;
     block_bonus = 0;
     hit_bonus = 0;
-
-    grab_resist = 0;
-    throw_resist = 0;
 }
 
 void Creature::process_turn()
@@ -1440,15 +1437,6 @@ float Creature::get_hit_bonus() const
 {
     return hit_bonus; //base is 0
 }
-int Creature::get_grab_resist() const
-{
-    return grab_resist;
-}
-
-int Creature::get_throw_resist() const
-{
-    return throw_resist;
-}
 
 void Creature::mod_stat( const std::string &stat, float modifier )
 {
@@ -1523,15 +1511,6 @@ void Creature::mod_block_bonus( int nblock )
 void Creature::mod_hit_bonus( float nhit )
 {
     hit_bonus += nhit;
-}
-
-void Creature::set_grab_resist( int ngrabres )
-{
-    grab_resist = ngrabres;
-}
-void Creature::set_throw_resist( int nthrowres )
-{
-    throw_resist = nthrowres;
 }
 
 units::mass Creature::weight_capacity() const

--- a/src/creature.h
+++ b/src/creature.h
@@ -470,9 +470,7 @@ class Creature
         virtual float get_dodge_bonus() const;
         virtual float get_hit_bonus() const;
 
-        virtual int get_grab_resist() const;
         virtual bool has_grab_break_tec() const = 0;
-        virtual int get_throw_resist() const;
 
         /*
          * Setters for stats and bonuses
@@ -497,9 +495,6 @@ class Creature
 
         virtual void mod_dodge_bonus( float ndodge );
         virtual void mod_hit_bonus( float  nhit );
-
-        virtual void set_grab_resist( int ngrabres );
-        virtual void set_throw_resist( int nthrowres );
 
         virtual units::mass weight_capacity() const;
 
@@ -758,9 +753,6 @@ class Creature
         float dodge_bonus;
         int block_bonus;
         float hit_bonus;
-
-        int grab_resist;
-        int throw_resist;
 
         bool fake;
         Creature();

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1358,12 +1358,10 @@ void Character::perform_technique( const ma_technique &technique, Creature &t, d
     move_cost += technique.move_cost_penalty( *this );
 
     if( technique.down_dur > 0 ) {
-        if( t.get_throw_resist() == 0 ) {
-            t.add_effect( effect_downed, rng( 1_turns, time_duration::from_turns( technique.down_dur ) ) );
-            auto &bash = get_damage_unit( di.damage_units, DT_BASH );
-            if( bash.amount > 0 ) {
-                bash.amount += 3;
-            }
+        t.add_effect( effect_downed, rng( 1_turns, time_duration::from_turns( technique.down_dur ) ) );
+        auto &bash = get_damage_unit( di.damage_units, DT_BASH );
+        if( bash.amount > 0 ) {
+            bash.amount += 3;
         }
     }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2629,7 +2629,9 @@ bool mattack::grab( monster *z )
     if( !z->can_act() ) {
         return false;
     }
-    Creature *target = z->attack_target();
+    // Grabbing non-Characters not supported yet
+    player *target = dynamic_cast<player *>( z->attack_target() );
+    player *pl = target;
     if( target == nullptr || !is_adjacent( z, target, false ) ) {
         return false;
     }
@@ -2646,11 +2648,6 @@ bool mattack::grab( monster *z )
             target->on_dodge( z, z->type->melee_skill * 2 );
         }
 
-        return true;
-    }
-
-    player *pl = dynamic_cast<player *>( target );
-    if( pl == nullptr ) {
         return true;
     }
 
@@ -2682,6 +2679,8 @@ bool mattack::grab( monster *z )
                         prev_effect + z->get_grab_strength() );
     target->add_msg_player_or_npc( m_bad, _( "The %s grabs you!" ), _( "The %s grabs <npcname>!" ),
                                    z->name() );
+
+    // Only prevent bites in this turn
 
     return true;
 }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2636,10 +2636,10 @@ bool mattack::grab( monster *z )
         return false;
     }
 
-    z->moves -= 80;
     const bool uncanny = target->uncanny_dodge();
     const auto msg_type = target == &g->u ? m_warning : m_info;
     if( uncanny || dodge_check( z, target ) ) {
+        z->moves -= 40;
         target->add_msg_player_or_npc( msg_type, _( "The %s gropes at you, but you dodge!" ),
                                        _( "The %s gropes at <npcname>, but they dodge!" ),
                                        z->name() );
@@ -2653,7 +2653,7 @@ bool mattack::grab( monster *z )
 
     item &cur_weapon = pl->weapon;
     ///\EFFECT_DEX increases chance to avoid being grabbed
-    if( pl->can_grab_break( cur_weapon ) && pl->get_grab_resist() > 0 &&
+    if( pl->can_grab_break( cur_weapon ) &&
         rng( 0, pl->get_dex() ) > rng( 0, z->type->melee_sides + z->type->melee_dice ) ) {
         if( target->has_effect( effect_grabbed ) ) {
             target->add_msg_if_player( m_info, _( "The %s tries to grab you as well, but you bat it away!" ),
@@ -2680,7 +2680,12 @@ bool mattack::grab( monster *z )
     target->add_msg_player_or_npc( m_bad, _( "The %s grabs you!" ), _( "The %s grabs <npcname>!" ),
                                    z->name() );
 
-    // Only prevent bites in this turn
+    // A hit to use up our moves
+    z->melee_attack( *target );
+    // Set up a bite on the next turn
+    if( z->type->special_attacks.count( "BITE" ) != 0 ) {
+        z->set_special( "BITE", 1 );
+    }
 
     return true;
 }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1996,22 +1996,38 @@ void monster::reset_stats()
 
 void monster::reset_special( const std::string &special_name )
 {
-    set_special( special_name, type->special_attacks.at( special_name )->cooldown );
+    const auto iter = type->special_attacks.find( special_name );
+    if( iter != type->special_attacks.end() ) {
+        set_special( special_name, iter->second->cooldown );
+    }
 }
 
 void monster::reset_special_rng( const std::string &special_name )
 {
-    set_special( special_name, rng( 0, type->special_attacks.at( special_name )->cooldown ) );
+    const auto iter = type->special_attacks.find( special_name );
+    if( iter != type->special_attacks.end() ) {
+        set_special( special_name, rng( 0, iter->second->cooldown ) );
+    }
 }
 
 void monster::set_special( const std::string &special_name, int time )
 {
-    special_attacks[ special_name ].cooldown = time;
+    const auto iter = special_attacks.find( special_name );
+    if( iter != special_attacks.end() ) {
+        iter->second.cooldown = time;
+    } else {
+        debugmsg( "%s has no special attack %s", disp_name().c_str(), special_name.c_str() );
+    }
 }
 
 void monster::disable_special( const std::string &special_name )
 {
-    special_attacks.at( special_name ).enabled = false;
+    const auto iter = special_attacks.find( special_name );
+    if( iter != special_attacks.end() ) {
+        iter->second.enabled = false;
+    } else {
+        debugmsg( "%s has no special attack %s", disp_name().c_str(), special_name.c_str() );
+    }
 }
 
 int monster::shortest_special_cooldown() const

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1000,12 +1000,8 @@ void player::hardcoded_effects( effect &it )
             }
         }
         if( !recovered ) {
-            // Death happens
-            if( dur > 1_days ) {
-                add_msg_if_player( m_bad, _( "You succumb to the infection." ) );
-                g->events().send<event_type::dies_of_infection>( getID() );
-                hurtall( 500, nullptr );
-            } else if( has_effect( effect_strong_antibiotic ) ) {
+            // Don't kill if the player is on antibiotics
+            if( has_effect( effect_strong_antibiotic ) ) {
                 it.mod_duration( -1_turns );
             } else if( has_effect( effect_antibiotic ) ) {
                 // No progression
@@ -1013,6 +1009,10 @@ void player::hardcoded_effects( effect &it )
                 if( calendar::once_every( 4_turns ) ) {
                     it.mod_duration( 1_turns );
                 }
+            } else if( dur > 1_days ) {
+                add_msg_if_player( m_bad, _( "You succumb to the infection." ) );
+                g->events().send<event_type::dies_of_infection>( getID() );
+                hurtall( 500, nullptr );
             } else {
                 it.mod_duration( 1_turns );
             }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2976,9 +2976,6 @@ void Creature::store( JsonOut &jsout ) const
     jsout.member( "block_bonus", block_bonus );
     jsout.member( "hit_bonus", hit_bonus );
 
-    jsout.member( "grab_resist", grab_resist );
-    jsout.member( "throw_resist", throw_resist );
-
     // fake is not stored, it's temporary anyway, only used to fire with a gun.
 }
 
@@ -3032,9 +3029,6 @@ void Creature::load( const JsonObject &jsin )
     jsin.read( "dodge_bonus", dodge_bonus );
     jsin.read( "block_bonus", block_bonus );
     jsin.read( "hit_bonus", hit_bonus );
-
-    jsin.read( "grab_resist", grab_resist );
-    jsin.read( "throw_resist", throw_resist );
 
     jsin.read( "underwater", underwater );
 


### PR DESCRIPTION
Zombie grabs get a minor buff:
* On miss, they only cost 40 moves (down from 80)
* On success, they don't cost anything and instantly follow up with a regular attack and set bite cooldown to 1

Infection no longer kills a player who is currently on antibiotics.

Also removed bugged `throw_resist` and `grab_resist` stats. They were checked, but never set.
As a result, player can now use grab breaking techniques.