### PR TITLE
Call `map::restock_fruits` on save to respect transform_into for in-bubble plants

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6682,6 +6682,18 @@ void map::saven( const tripoint &grid )
 
     dbg( D_INFO ) << "map::saven abs: " << abs
                   << "  gridn: " << gridn;
+
+    // An edge case: restock_fruits relies on last_touched, so we must call it before save
+    if( season_of_year( calendar::turn ) != season_of_year( submap_to_save->last_touched ) ) {
+        const time_duration time_since_last_actualize = calendar::turn - submap_to_save->last_touched;
+        for( int x = 0; x < SEEX; x++ ) {
+            for( int y = 0; y < SEEY; y++ ) {
+                const tripoint pnt = sm_to_ms_copy( grid ) + point( x, y );
+                restock_fruits( pnt, time_since_last_actualize );
+            }
+        }
+    }
+
     submap_to_save->last_touched = calendar::turn;
     MAPBUFFER.add_submap( abs, submap_to_save );
 }
@@ -7167,12 +7179,6 @@ void map::actualize( const tripoint &grid )
             decay_cosmetic_fields( pnt, time_since_last_actualize );
         }
     }
-    /*
-        for( const auto &pr : tmpsub->active_furniture ) {
-            const tripoint pnt = sm_to_ms_copy( grid ) + pr.first;
-            pr.second->update( tmpsub->last_touched, calendar::turn, *this, pnt );
-        }
-    */
 
     // the last time we touched the submap, is right now.
     tmpsub->last_touched = calendar::turn;


### PR DESCRIPTION
Fixes #415

The issue was caused by `map::restock_fruits` being only called on load, but relying just on `calendar::turn` and `submap::last_touched`. `submap::last_touched` is updated both on load and on save.
The result was that `map::restock_fruits` couldn't update underbrushes, fruit trees etc. that were in the bubble when the season changed.

The fix is very specific to this particular bug.
`produce_sap` and `rad_scorch` could also fit here, but those two should be called on every save and I decided to gate the update behind season change check, since it's somewhat expensive (requires iterating over all saved tiles).
For now `produce_sap` and `rad_scorch` will stay buggy in that plants in the bubble are not affected by them.