### PR TITLE
Port DDA's fix for dragged safe's contents spilling if there is an item in the way

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9860,8 +9860,8 @@ bool game::grabbed_furn_move( const tripoint &dp )
 
     const bool dst_item_ok = !m.has_flag( "NOITEM", fdest ) &&
                              !m.has_flag( "SWIMMABLE", fdest ) &&
-                             !m.has_flag( "DESTROY_ITEM", fdest ) &&
-                             only_liquid_items;
+                             !m.has_flag( "DESTROY_ITEM", fdest );
+
     const bool src_item_ok = m.furn( fpos ).obj().has_flag( "CONTAINER" ) ||
                              m.furn( fpos ).obj().has_flag( "FIRE_CONTAINER" ) ||
                              m.furn( fpos ).obj().has_flag( "SEALED" );
@@ -9889,7 +9889,7 @@ bool game::grabbed_furn_move( const tripoint &dp )
         u.moves -= 100;
         u.mod_pain( 1 ); // Hurt ourselves.
         return true; // furniture and or obstacle wins.
-    } else if( !src_item_ok && !dst_item_ok && dst_items > 0 ) {
+    } else if( !src_item_ok && !only_liquid_items && dst_items > 0 ) {
         add_msg( _( "There's stuff in the way." ) );
         u.moves -= 50;
         return true;


### PR DESCRIPTION
#### Purpose of change
Fix #492

#### Describe the solution
Cherry-pick CleverRaven#47473

#### Testing
Dragging a safe over items now swaps safe and items (with safe's contents remaining inside).
