### PR TITLE
Prune some includes

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2314,7 +2314,7 @@ void activity_handlers::train_finish( player_activity *act, player *p )
         const martialart &mastyle = ma_id.obj();
         // Trained martial arts,
         g->events().send<event_type::learns_martial_art>( p->getID(), ma_id );
-        p->martial_arts_data.learn_style( mastyle.id, p->is_avatar() );
+        p->martial_arts_data->learn_style( mastyle.id, p->is_avatar() );
     } else if( !magic_train( act, p ) ) {
         debugmsg( "train_finish without a valid skill or style or spell name" );
     }

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -542,7 +542,7 @@ bool avatar::read( item_location loc, const bool continuous )
         }
         if( it.type->use_methods.count( "MA_MANUAL" ) ) {
 
-            if( martial_arts_data.has_martialart( martial_art_learned_from( *it.type ) ) ) {
+            if( martial_arts_data->has_martialart( martial_art_learned_from( *it.type ) ) ) {
                 add_msg_if_player( m_info, _( "You already know all this book has to teach." ) );
                 activity.set_to_null();
                 return false;
@@ -1269,7 +1269,7 @@ void avatar::reset_stats()
     }
 
     // Apply static martial arts buffs
-    martial_arts_data.ma_static_effects( *this );
+    martial_arts_data->ma_static_effects( *this );
 
     if( calendar::once_every( 1_minutes ) ) {
         update_mental_focus();

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -12,7 +12,6 @@
 
 #include "craft_command.h"
 #include "inventory.h"
-#include "map.h"
 #include "memory_fast.h"
 #include "optional.h"
 #include "point.h"
@@ -31,6 +30,7 @@ class item;
 class Item_group;
 class mission_data;
 class recipe;
+class tinymap;
 
 struct expansion_data {
     std::string type;
@@ -53,7 +53,7 @@ class window;
 namespace base_camps
 {
 
-enum tab_mode {
+enum tab_mode : int {
     TAB_MAIN,
     TAB_N,
     TAB_NE,

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -469,7 +469,7 @@ bool Character::activate_bionic( int b, bool eff_only )
     } else if( bio.id == bio_cqb ) {
         add_msg_activate();
         const avatar *you = as_avatar();
-        if( you && !martial_arts_data.pick_style( *you ) ) {
+        if( you && !martial_arts_data->pick_style( *you ) ) {
             bio.powered = false;
             add_msg_if_player( m_info, _( "You change your mind and turn it off." ) );
             return false;
@@ -999,7 +999,7 @@ bool Character::deactivate_bionic( int b, bool eff_only )
             invalidate_crafting_inventory();
         }
     } else if( bio.id == bio_cqb ) {
-        martial_arts_data.selected_style_check();
+        martial_arts_data->selected_style_check();
     } else if( bio.id == bio_remote ) {
         if( g->remoteveh() != nullptr && !has_active_item( "remotevehcontrol" ) ) {
             g->setremoteveh( nullptr );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -18,6 +18,7 @@
 #include "bionics.h"
 #include "cata_utility.h"
 #include "catacharset.h"
+#include "character_martial_arts.h"
 #include "clzones.h"
 #include "colony.h"
 #include "construction.h"
@@ -3279,7 +3280,7 @@ void Character::normalize()
 {
     Creature::normalize();
 
-    martial_arts_data.reset_style();
+    martial_arts_data->reset_style();
     weapon = item( "null", calendar::start_of_cataclysm );
 
     recalc_hp();

--- a/src/character.h
+++ b/src/character.h
@@ -36,7 +36,6 @@
 #include "item.h"
 #include "item_location.h"
 #include "memory_fast.h"
-#include "mtype.h"
 #include "optional.h"
 #include "pimpl.h"
 #include "player_activity.h"

--- a/src/character.h
+++ b/src/character.h
@@ -23,7 +23,6 @@
 #include "bodypart.h"
 #include "calendar.h"
 #include "character_id.h"
-#include "character_martial_arts.h"
 #include "color.h"
 #include "creature.h"
 #include "cursesdef.h"
@@ -55,6 +54,7 @@ class JsonOut;
 class SkillLevel;
 class SkillLevelMap;
 class bionic_collection;
+class character_martial_arts;
 class faction;
 class ma_technique;
 class known_magic;
@@ -919,9 +919,7 @@ class Character : public Creature, public visitable<Character>
         /** Returns true if the player has any martial arts buffs attached */
         bool has_mabuff( const mabuff_id &buff_id ) const;
         /** Returns true if the player has a grab breaking technique available */
-        bool has_grab_break_tec() const override {
-            return martial_arts_data.has_grab_break_tec();
-        }
+        bool has_grab_break_tec() const override;
 
         /** Returns the to hit bonus from martial arts buffs */
         float mabuff_tohit_bonus() const;
@@ -1599,7 +1597,7 @@ class Character : public Creature, public visitable<Character>
 
         int scent;
         pimpl<bionic_collection> my_bionics;
-        character_martial_arts martial_arts_data;
+        pimpl<character_martial_arts> martial_arts_data;
 
         stomach_contents stomach;
         std::list<consumption_event> consumption_history;

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -12,6 +12,7 @@
 #include "bionics.h"
 #include "calendar.h"
 #include "cata_utility.h"
+#include "craft_command.h"
 #include "debug.h"
 #include "enums.h"
 #include "flat_set.h"

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1395,7 +1395,7 @@ void debug()
             add_msg( _( "Your eyes blink rapidly as knowledge floods your brain." ) );
             for( auto &style : all_martialart_types() ) {
                 if( style != matype_id( "style_none" ) ) {
-                    u.martial_arts_data.add_martialart( style );
+                    u.martial_arts_data->add_martialart( style );
                 }
             }
             add_msg( m_good, _( "You now know a lot more than just 10 styles of kung fu." ) );

--- a/src/faction_camp.h
+++ b/src/faction_camp.h
@@ -6,8 +6,6 @@
 #include <vector>
 #include <utility>
 
-#include "basecamp.h"
-
 namespace catacurses
 {
 class window;
@@ -16,6 +14,10 @@ class npc;
 struct point;
 struct tripoint;
 struct mission_entry;
+namespace base_camps
+{
+enum tab_mode : int;
+};
 
 enum class farm_ops {
     plow = 1,

--- a/src/faction_camp.h
+++ b/src/faction_camp.h
@@ -17,7 +17,7 @@ struct mission_entry;
 namespace base_camps
 {
 enum tab_mode : int;
-};
+}
 
 enum class farm_ops {
     plow = 1,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8778,8 +8778,8 @@ void game::wield( item_location &loc )
         u.unwield();
 
         if( is_unwielding ) {
-            if( !u.martial_arts_data.selected_is_none() ) {
-                u.martial_arts_data.martialart_use_message( u );
+            if( !u.martial_arts_data->selected_is_none() ) {
+                u.martial_arts_data->martialart_use_message( u );
             }
             return;
         }
@@ -10040,7 +10040,7 @@ void game::on_move_effects()
     }
 
     // apply martial art move bonuses
-    u.martial_arts_data.ma_onmove_effects( u );
+    u.martial_arts_data->ma_onmove_effects( u );
 
     sfx::do_ambient();
 }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1981,7 +1981,7 @@ bool game::handle_action()
                 break;
 
             case ACTION_PICK_STYLE:
-                u.martial_arts_data.pick_style( u );
+                u.martial_arts_data->pick_style( u );
                 break;
 
             case ACTION_RELOAD_ITEM:

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3248,7 +3248,7 @@ void item::combat_info( std::vector<iteminfo> &info, const iteminfo_query *parts
 
     // display which martial arts styles character can use with this weapon
     if( parts->test( iteminfo_parts::DESCRIPTION_APPLICABLEMARTIALARTS ) ) {
-        const std::string valid_styles = g->u.martial_arts_data.enumerate_known_styles( typeId() );
+        const std::string valid_styles = g->u.martial_arts_data->enumerate_known_styles( typeId() );
         if( !valid_styles.empty() ) {
             insert_separation_line( info );
             info.push_back( iteminfo( "DESCRIPTION",
@@ -3994,7 +3994,7 @@ nc_color item::color_in_inventory() const
                 u.get_skill_level( tmp.skill ) < tmp.level ) {
                 ret = c_light_blue;
             } else if( type->can_use( "MA_MANUAL" ) &&
-                       !u.martial_arts_data.has_martialart( martial_art_learned_from( *type ) ) ) {
+                       !u.martial_arts_data->has_martialart( martial_art_learned_from( *type ) ) ) {
                 ret = c_light_blue;
             } else if( tmp.skill && // Book can't improve skill right now, but maybe later: pink
                        u.get_skill_level_object( tmp.skill ).can_train() &&
@@ -4115,8 +4115,8 @@ void item::on_wield( player &p, int mv )
     }
     p.add_msg_if_player( m_neutral, msg, tname() );
 
-    if( !p.martial_arts_data.selected_is_none() ) {
-        p.martial_arts_data.martialart_use_message( p );
+    if( !p.martial_arts_data->selected_is_none() ) {
+        p.martial_arts_data->martialart_use_message( p );
     }
 
     // Update encumbrance in case we were wearing it

--- a/src/item.h
+++ b/src/item.h
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "calendar.h"
-#include "craft_command.h"
 #include "enums.h"
 #include "flat_set.h"
 #include "gun_mode.h"
@@ -47,6 +46,9 @@ class relic;
 struct islot_comestible;
 struct itype;
 struct item_comp;
+template<typename CompType>
+struct comp_selection;
+struct tool_comp;
 struct mtype;
 struct tripoint;
 template<typename T>

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2248,7 +2248,7 @@ int iuse::ma_manual( player *p, item *it, bool, const tripoint & )
         return 0;
     }
 
-    p->martial_arts_data.learn_style( style_to_learn, p->is_avatar() );
+    p->martial_arts_data->learn_style( style_to_learn, p->is_avatar() );
 
     return 1;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -163,6 +163,7 @@ map::map( int mapsize, bool zlev )
 }
 
 map::~map() = default;
+map &map::operator=( map && ) = default;
 
 static submap null_submap;
 

--- a/src/map.h
+++ b/src/map.h
@@ -326,10 +326,11 @@ class map
     public:
         // Constructors & Initialization
         map( int mapsize = MAPSIZE, bool zlev = false );
-        map( bool zlev ) : map( MAPSIZE, zlev ) { }
+        explicit map( bool zlev ) : map( MAPSIZE, zlev ) { }
         virtual ~map();
 
-        map &operator=( map && ) = default;
+        map &operator=( const map & ) = delete;
+        map &operator=( map && );
 
         /**
          * Sets a dirty flag on the a given cache.

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -452,13 +452,13 @@ bool ma_requirements::is_valid_character( const Character &u ) const
     bool cqb = u.has_active_bionic( bio_cqb );
     // There are 4 different cases of "armedness":
     // Truly unarmed, unarmed weapon, style-allowed weapon, generic weapon
-    bool melee_style = u.martial_arts_data.selected_strictly_melee();
+    bool melee_style = u.martial_arts_data->selected_strictly_melee();
     bool is_armed = u.is_armed();
     bool unarmed_weapon = is_armed && u.used_weapon().has_flag( flag_UNARMED_WEAPON );
-    bool forced_unarmed = u.martial_arts_data.selected_force_unarmed();
+    bool forced_unarmed = u.martial_arts_data->selected_force_unarmed();
     bool weapon_ok = is_valid_weapon( u.weapon );
-    bool style_weapon = u.martial_arts_data.selected_has_weapon( u.weapon.typeId() );
-    bool all_weapons = u.martial_arts_data.selected_allow_melee();
+    bool style_weapon = u.martial_arts_data->selected_has_weapon( u.weapon.typeId() );
+    bool all_weapons = u.martial_arts_data->selected_allow_melee();
 
     bool unarmed_ok = !is_armed || ( unarmed_weapon && unarmed_weapons_allowed );
     bool melee_ok = melee_allowed && weapon_ok && ( style_weapon || all_weapons );
@@ -938,18 +938,18 @@ bool player::can_grab_break( const item &weap ) const
         return false;
     }
 
-    ma_technique tec = martial_arts_data.get_grab_break_tec( weap );
+    ma_technique tec = martial_arts_data->get_grab_break_tec( weap );
 
     return tec.is_valid_character( *this );
 }
 
 bool Character::can_miss_recovery( const item &weap ) const
 {
-    if( !martial_arts_data.has_miss_recovery_tec( weap ) ) {
+    if( !martial_arts_data->has_miss_recovery_tec( weap ) ) {
         return false;
     }
 
-    ma_technique tec = martial_arts_data.get_miss_recovery_tec( weap );
+    ma_technique tec = martial_arts_data->get_miss_recovery_tec( weap );
 
     return tec.is_valid_character( *this );
 }
@@ -1193,6 +1193,11 @@ bool Character::has_mabuff( const mabuff_id &id ) const
     return search_ma_buff_effect( *effects, [&id]( const ma_buff & b, const effect & ) {
         return b.id == id;
     } );
+}
+
+bool Character::has_grab_break_tec() const
+{
+    return martial_arts_data->has_grab_break_tec();
 }
 
 bool character_martial_arts::has_martialart( const matype_id &ma ) const

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -20,6 +20,7 @@
 #include "material.h"
 #include "messages.h"
 #include "monster.h"
+#include "mtype.h"
 #include "npc.h"
 #include "player.h"
 #include "point.h"

--- a/src/mattack_actors.h
+++ b/src/mattack_actors.h
@@ -13,7 +13,6 @@
 #include "damage.h"
 #include "magic.h"
 #include "mattack_common.h"
-#include "mtype.h"
 #include "translations.h"
 #include "type_id.h"
 #include "weighted_list.h"
@@ -21,6 +20,7 @@
 class Creature;
 class JsonObject;
 class monster;
+struct mon_effect_data;
 
 class leap_actor : public mattack_actor
 {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -132,7 +132,7 @@ std::string melee_message( const ma_technique &tec, Character &p,
 
 const item &Character::used_weapon() const
 {
-    return martial_arts_data.selected_force_unarmed() ? null_item_reference() : weapon;
+    return martial_arts_data->selected_force_unarmed() ? null_item_reference() : weapon;
 }
 
 item &Character::used_weapon()
@@ -439,7 +439,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
             }
 
             if( can_miss_recovery( cur_weapon ) ) {
-                ma_technique tec = martial_arts_data.get_miss_recovery_tec( cur_weapon );
+                ma_technique tec = martial_arts_data->get_miss_recovery_tec( cur_weapon );
                 add_msg( _( tec.avatar_message ), t.disp_name() );
             } else if( stumble_pen >= 60 ) {
                 add_msg( m_bad, _( "You miss and stumble with the momentum." ) );
@@ -465,12 +465,12 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
 
         // Cap stumble penalty, heavy weapons are quite weak already
         move_cost += std::min( 60, stumble_pen );
-        if( martial_arts_data.has_miss_recovery_tec( cur_weapon ) ) {
+        if( martial_arts_data->has_miss_recovery_tec( cur_weapon ) ) {
             move_cost /= 2;
         }
 
         // trigger martial arts on-miss effects
-        martial_arts_data.ma_onmiss_effects( *this );
+        martial_arts_data->ma_onmiss_effects( *this );
     } else {
         melee::melee_stats.hit_count += 1;
         // Remember if we see the monster at start - it may change
@@ -580,7 +580,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
 
             if( critical_hit ) {
                 // trigger martial arts on-crit effects
-                martial_arts_data.ma_oncrit_effects( *this );
+                martial_arts_data->ma_oncrit_effects( *this );
             }
 
         }
@@ -589,7 +589,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
 
         if( t.is_dead_state() ) {
             // trigger martial arts on-kill effects
-            martial_arts_data.ma_onkill_effects( *this );
+            martial_arts_data->ma_onkill_effects( *this );
         }
     }
 
@@ -609,7 +609,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
     add_msg( m_debug, "Stamina burn: %d", std::min( -50, mod_sta ) );
     mod_moves( -move_cost );
     // trigger martial arts on-attack effects
-    martial_arts_data.ma_onattack_effects( *this );
+    martial_arts_data->ma_onattack_effects( *this );
     // some things (shattering weapons) can harm the attacking creature.
     check_dead_state();
     did_hit( t );
@@ -665,7 +665,7 @@ void player::reach_attack( const tripoint &p )
 
     if( critter == nullptr ) {
         add_msg_if_player( _( "You swing at the air." ) );
-        if( martial_arts_data.has_miss_recovery_tec( weapon ) ) {
+        if( martial_arts_data->has_miss_recovery_tec( weapon ) ) {
             move_cost /= 3; // "Probing" is faster than a regular miss
         }
 
@@ -1086,7 +1086,7 @@ matec_id Character::pick_technique( Creature &t, const item &weap,
                                     bool crit, bool dodge_counter, bool block_counter )
 {
 
-    const std::vector<matec_id> all = martial_arts_data.get_all_techniques( weap );
+    const std::vector<matec_id> all = martial_arts_data->get_all_techniques( weap );
 
     std::vector<matec_id> possible;
 
@@ -1488,12 +1488,12 @@ void Character::perform_technique( const ma_technique &technique, Creature &t, d
     }
 
     //player has a very small chance, based on their intelligence, to learn a style whilst using the CQB bionic
-    if( has_active_bionic( bio_cqb ) && !martial_arts_data.knows_selected_style() ) {
+    if( has_active_bionic( bio_cqb ) && !martial_arts_data->knows_selected_style() ) {
         /** @EFFECT_INT slightly increases chance to learn techniques when using CQB bionic */
         // Enhanced Memory Banks bionic doubles chance to learn martial art
         const int bionic_boost = has_active_bionic( bionic_id( bio_memory ) ) ? 2 : 1;
         if( one_in( ( 1400 - ( get_int() * 50 ) ) / bionic_boost ) ) {
-            martial_arts_data.learn_current_style_CQB( is_player() );
+            martial_arts_data->learn_current_style_CQB( is_player() );
         }
     }
 }
@@ -1538,7 +1538,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
 
     // fire martial arts on-getting-hit-triggered effects
     // these fire even if the attack is blocked (you still got hit)
-    martial_arts_data.ma_ongethit_effects( *this );
+    martial_arts_data->ma_ongethit_effects( *this );
 
     if( blocks_left < 1 ) {
         return false;
@@ -1555,7 +1555,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     block_bonus = blocking_ability( shield );
     bool conductive_shield = shield.conductive();
     bool unarmed = weapon.has_flag( "UNARMED_WEAPON" );
-    bool force_unarmed = martial_arts_data.is_force_unarmed();
+    bool force_unarmed = martial_arts_data->is_force_unarmed();
 
     int melee_skill = get_skill_level( skill_melee );
     int unarmed_skill = get_skill_level( skill_unarmed );
@@ -1572,7 +1572,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     /** @EFFECT_STR increases attack blocking effectiveness with a limb or worn/wielded item */
     /** @EFFECT_UNARMED increases attack blocking effectiveness with a limb or worn/wielded item */
     if( ( unarmed || force_unarmed ) ) {
-        if( martial_arts_data.can_limb_block( *this ) ) {
+        if( martial_arts_data->can_limb_block( *this ) ) {
             // block_bonus for limb blocks will be added when the limb is decided
             block_score = str_cur + melee_skill + unarmed_skill;
         } else if( has_shield ) {
@@ -1599,9 +1599,9 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         handle_melee_wear( shield, wear_modifier );
     } else {
         //Choose which body part to block with, assume left side first
-        if( martial_arts_data.can_leg_block( *this ) && martial_arts_data.can_arm_block( *this ) ) {
+        if( martial_arts_data->can_leg_block( *this ) && martial_arts_data->can_arm_block( *this ) ) {
             bp_hit = one_in( 2 ) ? bodypart_id( "leg_l" ) : bodypart_id( "arm_l" );
-        } else if( martial_arts_data.can_leg_block( *this ) ) {
+        } else if( martial_arts_data->can_leg_block( *this ) ) {
             bp_hit = bodypart_id( "leg_l" );
         } else {
             bp_hit = bodypart_id( "arm_l" );
@@ -1715,7 +1715,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
                            damage_blocked_description, thing_blocked_with );
 
     // fire martial arts block-triggered effects
-    martial_arts_data.ma_onblock_effects( *this );
+    martial_arts_data->ma_onblock_effects( *this );
 
     // Check if we have any block counters
     matec_id tec = pick_technique( *source, shield, false, false, true );
@@ -1843,7 +1843,7 @@ std::string Character::melee_special_effects( Creature &t, damage_instance &d, i
     }
 
     // on-hit effects for martial arts
-    martial_arts_data.ma_onhit_effects( *this );
+    martial_arts_data->ma_onhit_effects( *this );
 
     return dump;
 }
@@ -2239,7 +2239,7 @@ double player::melee_value( const item &weap ) const
     }
 
     // value style weapons more
-    if( !martial_arts_data.enumerate_known_styles( weap.type->get_id() ).empty() ) {
+    if( !martial_arts_data->enumerate_known_styles( weap.type->get_id() ).empty() ) {
         my_value *= 1.5;
     }
 

--- a/src/mission.h
+++ b/src/mission.h
@@ -12,7 +12,6 @@
 #include "character_id.h"
 #include "enums.h"
 #include "game_constants.h"
-#include "mtype.h"
 #include "npc_favor.h"
 #include "omdata.h"
 #include "optional.h"

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2662,11 +2662,11 @@ bool mattack::grab( monster *z )
             target->add_msg_if_player( m_info, _( "The %s tries to grab you as well, but you bat it away!" ),
                                        z->name() );
         } else if( pl->is_throw_immune() && ( !pl->is_armed() ||
-                                              pl->martial_arts_data.selected_has_weapon( pl->weapon.typeId() ) ) ) {
+                                              pl->martial_arts_data->selected_has_weapon( pl->weapon.typeId() ) ) ) {
             target->add_msg_if_player( m_info, _( "The %s tries to grab you…" ), z->name() );
             thrown_by_judo( z );
         } else if( pl->has_grab_break_tec() ) {
-            ma_technique tech = pl->martial_arts_data.get_grab_break_tec( cur_weapon );
+            ma_technique tech = pl->martial_arts_data->get_grab_break_tec( cur_weapon );
             target->add_msg_player_or_npc( m_info, _( tech.avatar_message ), _( tech.npc_message ), z->name() );
         } else {
             target->add_msg_player_or_npc( m_info, _( "The %s tries to grab you, but you break its grab!" ),
@@ -5151,7 +5151,7 @@ bool mattack::bio_op_takedown( monster *z )
             foe->add_effect( effect_downed, 3_turns );
         }
     } else if( ( !foe->is_armed() ||
-                 foe->martial_arts_data.selected_has_weapon( foe->weapon.typeId() ) ) &&
+                 foe->martial_arts_data->selected_has_weapon( foe->weapon.typeId() ) ) &&
                !thrown_by_judo( z ) ) {
         // Saved by the tentacle-bracing! :)
         hit = bodypart_id( "torso" );

--- a/src/monster.h
+++ b/src/monster.h
@@ -20,8 +20,6 @@
 #include "cursesdef.h"
 #include "damage.h"
 #include "enums.h"
-#include "item.h"
-#include "mtype.h"
 #include "optional.h"
 #include "pldata.h"
 #include "point.h"
@@ -34,6 +32,7 @@ class JsonIn;
 class JsonObject;
 class JsonOut;
 class effect;
+class item;
 class player;
 struct dealt_projectile_attack;
 struct pathfinding_settings;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -40,7 +40,7 @@ using itype_id = std::string;
 
 // These are triggers which may affect the monster's anger or morale.
 // They are handled in monster::check_triggers(), in monster.cpp
-enum class mon_trigger {
+enum class mon_trigger : int {
     STALK,              // Increases when following the player
     MEAT,               // Meat or a corpse nearby
     HOSTILE_WEAK,       // Hurt hostile player/npc/monster seen

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -587,14 +587,14 @@ bool avatar::create( character_type type, const std::string &tempname )
     for( const trait_id &t : get_base_traits() ) {
         std::vector<matype_id> styles;
         for( const matype_id &s : t->initial_ma_styles ) {
-            if( !martial_arts_data.has_martialart( s ) ) {
+            if( !martial_arts_data->has_martialart( s ) ) {
                 styles.push_back( s );
             }
         }
         if( !styles.empty() ) {
             const matype_id ma_type = choose_ma_style( type, styles, *this );
-            martial_arts_data.add_martialart( ma_type );
-            martial_arts_data.set_style( ma_type );
+            martial_arts_data->add_martialart( ma_type );
+            martial_arts_data->set_style( ma_type );
         }
     }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1463,7 +1463,7 @@ std::vector<skill_id> npc::skills_offered_to( const player &p ) const
 
 std::vector<matype_id> npc::styles_offered_to( const player &p ) const
 {
-    return p.martial_arts_data.get_unknown_styles( martial_arts_data );
+    return p.martial_arts_data->get_unknown_styles( *martial_arts_data );
 }
 
 void npc::decide_needs()

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -909,7 +909,7 @@ void talk_function::start_training( npc &p )
         cost = calc_skill_training_cost( p, skill );
         time = calc_skill_training_time( p, skill );
         name = skill.str();
-    } else if( p.chatbin.style.is_valid() && !g->u.martial_arts_data.has_martialart( style ) ) {
+    } else if( p.chatbin.style.is_valid() && !g->u.martial_arts_data->has_martialart( style ) ) {
         cost = calc_ma_style_training_cost( p, style );
         time = calc_ma_style_training_time( p, style );
         name = p.chatbin.style.str();

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -20,13 +20,13 @@
 #include "enums.h"
 #include "enum_conversions.h"
 #include "game_constants.h"
+#include "memory_fast.h"
 #include "mongroup.h"
 #include "omdata.h"
 #include "optional.h"
 #include "overmap_types.h" // IWYU pragma: keep
 #include "pimpl.h"
 #include "point.h"
-#include "regional_settings.h"
 #include "string_id.h"
 #include "type_id.h"
 
@@ -39,6 +39,7 @@ class map_extra;
 class monster;
 class npc;
 class overmap_connection;
+struct regional_settings;
 template <typename E> struct enum_traits;
 
 namespace pf
@@ -326,7 +327,7 @@ class overmap
 
         // TODO: Should depend on coordinates
         const regional_settings &get_settings() const {
-            return settings;
+            return *settings;
         }
 
         void clear_mon_groups();
@@ -393,7 +394,7 @@ class overmap
         // TODO: Should have individual instances grouped by placement (ie. 2 adjacent houses aren't one house)
         std::unordered_map<tripoint, overmap_special_id> overmap_special_placements;
 
-        regional_settings settings;
+        pimpl<regional_settings> settings;
 
         oter_id get_default_terrain( int z ) const;
 

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -1414,7 +1414,7 @@ static void draw_weapon_labels( const avatar &u, const catacurses::window &w )
     // NOLINTNEXTLINE(cata-use-named-point-constants)
     mvwprintz( w, point( 1, 1 ), c_light_gray, _( "Style:" ) );
     trim_and_print( w, point( 8, 0 ), getmaxx( w ) - 8, c_light_gray, u.weapname() );
-    mvwprintz( w, point( 8, 1 ), c_light_gray, "%s", u.martial_arts_data.selected_style_name( u ) );
+    mvwprintz( w, point( 8, 1 ), c_light_gray, "%s", u.martial_arts_data->selected_style_name( u ) );
     wnoutrefresh( w );
 }
 
@@ -1499,7 +1499,7 @@ static void draw_env_compact( avatar &u, const catacurses::window &w )
     // wielded item
     trim_and_print( w, point( 8, 0 ), getmaxx( w ) - 8, c_light_gray, u.weapname() );
     // style
-    mvwprintz( w, point( 8, 1 ), c_light_gray, "%s", u.martial_arts_data.selected_style_name( u ) );
+    mvwprintz( w, point( 8, 1 ), c_light_gray, "%s", u.martial_arts_data->selected_style_name( u ) );
     // location
     mvwprintz( w, point( 8, 2 ), c_white, utf8_truncate( overmap_buffer.ter(
                    u.global_omt_location() )->get_name(), getmaxx( w ) - 8 ) );
@@ -1883,7 +1883,7 @@ static void draw_weapon_classic( const avatar &u, const catacurses::window &w )
     trim_and_print( w, point( 10, 0 ), getmaxx( w ) - 24, c_light_gray, u.weapname() );
 
     // Print in sidebar currently used martial style.
-    const std::string style = u.martial_arts_data.selected_style_name( u );
+    const std::string style = u.martial_arts_data->selected_style_name( u );
 
     if( !style.empty() ) {
         const auto style_color = u.is_armed() ? c_red : c_blue;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -398,8 +398,8 @@ void player::process_turn()
     for( auto &style : autolearn_martialart_types() ) {
         const matype_id &ma( style );
 
-        if( !martial_arts_data.has_martialart( ma ) && can_autolearn( ma ) ) {
-            martial_arts_data.add_martialart( ma );
+        if( !martial_arts_data->has_martialart( ma ) && can_autolearn( ma ) ) {
+            martial_arts_data->add_martialart( ma );
             add_msg_if_player( m_info, _( "You have learned a new style: %s!" ), ma.obj().name );
         }
     }
@@ -829,7 +829,7 @@ void player::pause()
     }
 
     // on-pause effects for martial arts
-    martial_arts_data.ma_onpause_effects( *this );
+    martial_arts_data->ma_onpause_effects( *this );
 
     if( is_npc() ) {
         // The stuff below doesn't apply to NPCs
@@ -958,7 +958,7 @@ void player::on_dodge( Creature *source, float difficulty )
     difficulty = std::max( difficulty, 0.0f );
     practice( skill_dodge, difficulty * 2, difficulty );
 
-    martial_arts_data.ma_ondodge_effects( *this );
+    martial_arts_data->ma_ondodge_effects( *this );
 
     // For adjacent attackers check for techniques usable upon successful dodge
     if( source && square_dist( pos(), source->pos() ) == 1 ) {

--- a/src/player.h
+++ b/src/player.h
@@ -18,7 +18,6 @@
 #include "character.h"
 #include "character_id.h"
 #include "color.h"
-#include "craft_command.h"
 #include "creature.h"
 #include "cursesdef.h"
 #include "enums.h"
@@ -33,6 +32,7 @@
 #include "type_id.h"
 
 class basecamp;
+class craft_command;
 class effect;
 class faction;
 class inventory;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -456,11 +456,11 @@ void overmap::unserialize( std::istream &fin )
         } else if( name == "region_id" ) {
             std::string new_region_id;
             jsin.read( new_region_id );
-            if( settings.id != new_region_id ) {
+            if( settings->id != new_region_id ) {
                 t_regional_settings_map_citr rit = region_settings_map.find( new_region_id );
                 if( rit != region_settings_map.end() ) {
                     // TODO: optimize
-                    settings = rit->second;
+                    settings = pimpl<regional_settings>( rit->second );
                 }
             }
         } else if( name == "mongroups" ) {
@@ -951,7 +951,7 @@ void overmap::serialize( std::ostream &fout ) const
     json.end_array();
 
     // temporary, to allow user to manually switch regions during play until regionmap is done.
-    json.member( "region_id", settings.id );
+    json.member( "region_id", settings->id );
     fout << std::endl;
 
     save_monster_groups( json );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -424,8 +424,9 @@ void Character::load( const JsonObject &data )
         if( !temp_selected_style.is_valid() ) {
             temp_selected_style = matype_id( "style_none" );
         }
-        martial_arts_data = character_martial_arts( temp_styles, temp_selected_style,
-                            temp_keep_hands_free );
+        martial_arts_data = pimpl<character_martial_arts>( character_martial_arts(
+                                temp_styles, temp_selected_style, temp_keep_hands_free
+                            ) );
     } else {
         data.read( "martial_arts_data", martial_arts_data );
     }

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "calendar.h"
+#include "craft_command.h"
 #include "map.h"
 #include "player.h"
 #include "veh_type.h"


### PR DESCRIPTION
#### Purpose of change
Build speedup

#### Describe alternatives you've considered
Buying a better PC

#### Testing
Compiles

#### Additional context
That's pretty much it.

It'd be nice to remove `item.h` and `colony.h` from various headers (by rough estimation they are indirectly included 60 and 120 times), but the code appears too entwined to do that easily, especially in these chains:
* `item.h` <- `inventory.h` <- `character.h` <- `npc.h` and `avatar.h`
* `item.h` and `colony.h` <- `item_stack.h` <- `map.h` and `vehicle.h`
* `item.h` and `colony.h` <- `submap.h`