### PR TITLE
Implement idle animations

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -998,3 +998,12 @@ bool minimap_requires_animation()
     return false;
 #endif // TILES
 }
+
+bool terrain_requires_animation()
+{
+#if defined(TILES)
+    return tilecontext->terrain_requires_animation();
+#else
+    return false;
+#endif // TILES
+}

--- a/src/animation.h
+++ b/src/animation.h
@@ -32,5 +32,6 @@ struct explosion_tile {
 };
 
 bool minimap_requires_animation();
+bool terrain_requires_animation();
 
 #endif // CATA_SRC_ANIMATION_H

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -895,6 +895,7 @@ void tileset_loader::load_tilejson_from_file( const JsonObject &config )
             curr_tile.multitile = t_multi;
             curr_tile.rotates = t_rota;
             curr_tile.height_3d = t_h3d;
+            curr_tile.animated = entry.get_bool( "animated", false );
         }
     }
     dbg( D_INFO ) << "Tile Width: " << ts.tile_width << " Tile Height: " << ts.tile_height <<
@@ -2002,6 +2003,23 @@ bool cata_tiles::draw_from_id_string( std::string id, TILE_CATEGORY category,
         c ^= b;
         c -= rot32( b, 24 );
         loc_rand = c;
+
+        // idle tile animations:
+        if( display_tile.animated ) {
+            // idle animations run during the user's turn, and the animation speed
+            // needs to be defined by the tileset to look good, so we use system clock:
+            auto now = std::chrono::system_clock::now();
+            auto now_ms = std::chrono::time_point_cast<std::chrono::milliseconds>( now );
+            auto value = now_ms.time_since_epoch();
+            // aiming roughly at the standard 60 frames per second:
+            int animation_frame = value.count() / 17;
+            // offset by log_rand so that everything does not blink at the same time:
+            animation_frame += loc_rand;
+            int frames_in_loop = display_tile.fg.get_weight();
+            // loc_rand is actually the weighed index of the selected tile, and
+            // for animations the "weight" is the number of frames to show the tile for:
+            loc_rand = animation_frame % frames_in_loop;
+        }
     }
 
     //draw it!

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -261,6 +261,43 @@ struct formatted_text {
     formatted_text( const std::string &text, int color, direction text_direction );
 };
 
+class idle_animation_manager
+{
+    private:
+        int frame = 0;
+        bool enabled_ = false;
+        bool present_ = false;
+
+    public:
+        /** Set whether idle animations are enabled. */
+        inline void set_enabled( bool enabled ) {
+            enabled_ = enabled;
+        }
+
+        /** Prepare for redraw (clear cache, advance frame) */
+        void prepare_for_redraw();
+
+        /** Whether idle animations are enabled */
+        inline bool enabled() const {
+            return enabled_;
+        }
+
+        /** Current frame (0..59) */
+        inline int current_frame() const {
+            return frame;
+        }
+
+        /** Mark presence of an idle animation on screen */
+        inline void mark_present() {
+            present_ = true;
+        }
+
+        /** Whether there are idle animations on screen */
+        inline bool present() const {
+            return present_;
+        }
+};
+
 /** type used for color blocks overlays.
  * first: The SDL blend mode used for the color.
  * second:
@@ -286,6 +323,8 @@ class cata_tiles
         void draw( const point &dest, const tripoint &center, int width, int height,
                    std::multimap<point, formatted_text> &overlay_strings,
                    color_block_overlay_container &color_blocks );
+
+        bool terrain_requires_animation() const;
 
         /** Minimap functionality */
         void draw_minimap( const point &dest, const tripoint &center, int width, int height );
@@ -516,6 +555,8 @@ class cata_tiles
         int screentile_height = 0;
         float tile_ratiox = 0.0f;
         float tile_ratioy = 0.0f;
+
+        idle_animation_manager idle_animations;
 
         bool in_animation = false;
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -282,7 +282,7 @@ class idle_animation_manager
             return enabled_;
         }
 
-        /** Current frame (0..59) */
+        /** Current animation frame (increments by approx. 60 per second) */
         inline int current_frame() const {
             return frame;
         }

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -40,6 +40,7 @@ struct tile_type {
     weighted_int_list<std::vector<int>> fg, bg;
     bool multitile = false;
     bool rotates = false;
+    bool animated = false;
     int height_3d = 0;
     point offset = point_zero;
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -248,7 +248,6 @@ input_context game::get_player_input( std::string &action )
 
         bool animate_weather = bWeatherEffect && get_option<bool>( "ANIMATION_RAIN" );
         bool animate_sct = !SCT.vSCT.empty() && uquit != QUIT_WATCH && get_option<bool>( "ANIMATION_SCT" );
-        bool animate_pixel_minimap = minimap_requires_animation();
 
         shared_ptr_fast<game::draw_callback_t> animation_cb =
         make_shared_fast<game::draw_callback_t>( [&]() {
@@ -327,8 +326,10 @@ input_context game::get_player_input( std::string &action )
                 // Stop animation when done
                 animate_sct = !SCT.vSCT.empty();
             }
-            if( animate_pixel_minimap ) {
-                // TODO: we redraw *everything* just to animate a couple blinking dots on the minimap.
+            // We don't cache these checks as their result may change after 1st redraw
+            if( minimap_requires_animation() || terrain_requires_animation() ) {
+                // TODO: we redraw *everything* just to animate a couple blinking dots
+                //       on the minimap or a few tiles.
                 //       This is far from ideal, and can probably be done much cheaper
                 //       (update only part of the screen? draw static parts into a texture?)
                 invalidate_main_ui_adaptor();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9568,7 +9568,7 @@ const cata::value_ptr<islot_comestible> &item::get_comestible() const
 bool item::has_clothing_mod() const
 {
     for( const clothing_mod &cm : clothing_mods::get_all() ) {
-        if( has_own_flag( cm.flag ) > 0 ) {
+        if( has_own_flag( cm.flag ) ) {
             return true;
         }
     }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2259,29 +2259,29 @@ void hflesh_to_flesh( itype &item_template )
 
 void Item_factory::npc_implied_flags( itype &item_template )
 {
-    if( item_template.use_methods.count( "explosion" ) > 0 ) {
+    if( item_template.use_methods.count( "explosion" ) ) {
         item_template.item_tags.insert( "DANGEROUS" );
     }
 
-    if( item_template.has_flag( "DANGEROUS" ) > 0 ) {
+    if( item_template.has_flag( "DANGEROUS" ) ) {
         item_template.item_tags.insert( "NPC_THROW_NOW" );
     }
 
-    if( item_template.has_flag( "BOMB" ) > 0 ) {
+    if( item_template.has_flag( "BOMB" ) ) {
         item_template.item_tags.insert( "NPC_ACTIVATE" );
     }
 
-    if( item_template.has_flag( "NPC_THROW_NOW" ) > 0 ) {
+    if( item_template.has_flag( "NPC_THROW_NOW" ) ) {
         item_template.item_tags.insert( "NPC_THROWN" );
     }
 
-    if( item_template.has_flag( "NPC_ACTIVATE" ) > 0 ||
-        item_template.has_flag( "NPC_THROWN" ) > 0 ) {
+    if( item_template.has_flag( "NPC_ACTIVATE" ) ||
+        item_template.has_flag( "NPC_THROWN" ) ) {
         item_template.item_tags.insert( "NPC_ALT_ATTACK" );
     }
 
-    if( item_template.has_flag( "DANGEROUS" ) > 0 ||
-        item_template.has_flag( "PSEUDO" ) > 0 ) {
+    if( item_template.has_flag( "DANGEROUS" ) ||
+        item_template.has_flag( "PSEUDO" ) ) {
         item_template.item_tags.insert( "TRADER_AVOID" );
     }
 }


### PR DESCRIPTION
#### Purpose of change
Implement idle animations.
Turns out UDP already has a bunch of them (e.g. for spore clouds), but they went unused as BN lacks relevant code.

#### Describe the solution
Cherry-picked CleverRaven#40342, then heavily modified it:
1. Made the code request redraws if there are idle animations on screen (required due to changes from #451).
2. If animations are disabled, fall back to showing the first frame of the animation (instead of random frame).
3. Added random stagger to trap/item animations to make them look nicer.

#### Testing
Tested with UDP on:
1. spore clouds and 'Spore dusted' status effect
2. lit torches, both wielded and dropped
3. dissectors

CPU usage stays at ≤1% when none of those are visible, and at ≈8% otherwise.
When animations are disabled, all monsters/items use same tile (and CPU remains at ≤1%).

#### Additional context
![BN-idle-anim](https://user-images.githubusercontent.com/60584843/117207715-edec9200-adfc-11eb-8566-b2018c9b3275.gif)