### PR TITLE
Port DDA's bodypart instance class

### DIFF
--- a/data/json/anatomy.json
+++ b/data/json/anatomy.json
@@ -7,6 +7,6 @@
   {
     "id": "default_anatomy",
     "type": "anatomy",
-    "parts": [ "torso" ]
+    "parts": [ "torso", "head" ]
   }
 ]

--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -19,6 +19,7 @@
     "hot_morale_mod": 2,
     "cold_morale_mod": 2,
     "squeamish_penalty": 6,
+    "base_hp": 60,
     "bionic_slots": 80
   },
   {
@@ -41,6 +42,7 @@
     "hot_morale_mod": 2,
     "cold_morale_mod": 2,
     "squeamish_penalty": 7,
+    "base_hp": 60,
     "bionic_slots": 18
   },
   {
@@ -60,6 +62,7 @@
     "legacy_id": "EYES",
     "stylish_bonus": 2,
     "squeamish_penalty": 8,
+    "base_hp": 60,
     "bionic_slots": 4
   },
   {
@@ -81,6 +84,7 @@
     "hot_morale_mod": 2,
     "cold_morale_mod": 2,
     "squeamish_penalty": 9,
+    "base_hp": 60,
     "bionic_slots": 4
   },
   {
@@ -105,6 +109,7 @@
     "hot_morale_mod": 0.5,
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 5,
+    "base_hp": 60,
     "bionic_slots": 20
   },
   {
@@ -128,6 +133,7 @@
     "hot_morale_mod": 0.5,
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 5,
+    "base_hp": 60,
     "bionic_slots": 20
   },
   {
@@ -151,6 +157,7 @@
     "hot_morale_mod": 0.5,
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 3,
+    "base_hp": 60,
     "bionic_slots": 5
   },
   {
@@ -174,6 +181,7 @@
     "hot_morale_mod": 0.5,
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 3,
+    "base_hp": 60,
     "bionic_slots": 5
   },
   {
@@ -198,6 +206,7 @@
     "hot_morale_mod": 0.5,
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 5,
+    "base_hp": 60,
     "bionic_slots": 30
   },
   {
@@ -222,6 +231,7 @@
     "hot_morale_mod": 0.5,
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 5,
+    "base_hp": 60,
     "bionic_slots": 30
   },
   {
@@ -245,6 +255,7 @@
     "hot_morale_mod": 0.5,
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 3,
+    "base_hp": 60,
     "bionic_slots": 7
   },
   {
@@ -268,6 +279,7 @@
     "hot_morale_mod": 0.5,
     "cold_morale_mod": 0.5,
     "squeamish_penalty": 3,
+    "base_hp": 60,
     "bionic_slots": 7
   },
   {
@@ -284,6 +296,7 @@
     "hit_size_relative": [ 0, 0, 0 ],
     "hit_difficulty": 0,
     "side": "both",
+    "base_hp": 60,
     "legacy_id": "NUM_BP"
   }
 ]

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -437,7 +437,6 @@ This section describes each json file and their contents. Each json has their ow
 | hot_morale_mod    | (_optional_) Mood effect of being too hot on this part. (default: `0`)
 | cold_morale_mod   | (_optional_) Mood effect of being too cold on this part. (default: `0`)
 | squeamish_penalty | (_optional_) Mood effect of wearing filthy clothing on this part. (default: `0`)
-| stat_hp_mods      | (_optional_) Values modifiying hp_max of this part following this formula: `hp_max += int_mod*int_max + dex_mod*dex_max + str_mod*str_max + per_mod*per_max + health_mod*get_healthy()` with X_max being the unmodifed value of the X stat and get_healthy() being the hidden health stat of the character.
 | bionic_slots      | (_optional_) How many bionic slots does this part have.
 
 ```C++

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -461,7 +461,6 @@ This section describes each json file and their contents. Each json has their ow
     "cold_morale_mod": 2,
     "squeamish_penalty": 6,
     "base_hp": 60,
-    "stat_hp_mods": { "int_mod": 4.0, "dex_mod": 1.0, "str_mod": 1.0, "per_mod": 1.0, "health_mod": 1.0 },
     "bionic_slots": 80
   }
 ```

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -421,22 +421,24 @@ This section describes each json file and their contents. Each json has their ow
 
 | Identifier        | Description
 |---                |---
-| id                | Unique ID. Must be one continuous word, use underscores if necessary.
-| name              | In-game name displayed.
-| accusative        | Accusative form for this bodypart.
-| heading           | How it's displayed in headings.
-| heading_multiple  | Plural form of heading.
-| hp_bar_ui_text    | How it's displayed next to the hp bar in the panel.
-| main_part         | What is the main part this one is attached to. (If this is a main part it's attached to itself)
-| opposite_part     | What is the opposite part ot this one in case of a pair.
-| hit_size          | Size of the body part when doing an unweighted selection.
-| hit_size_relative | Hit sizes for attackers who are smaller, equal in size, and bigger.
-| hit_difficulty    | How hard is it to hit a given body part, assuming "owner" is hit. Higher number means good hits will veer towards this part, lower means this part is unlikely to be hit by inaccurate attacks. Formula is `chance *= pow(hit_roll, hit_difficulty)`
-| stylish_bonus     | Mood bonus associated with wearing fancy clothing on this part. (default: `0`)
-| hot_morale_mod    | Mood effect of being too hot on this part. (default: `0`)
-| cold_morale_mod   | Mood effect of being too cold on this part. (default: `0`)
-| squeamish_penalty | Mood effect of wearing filthy clothing on this part. (default: `0`)
-| bionic_slots      | How many bionic slots does this part have.
+| id                | (_mandatory_) Unique ID. Must be one continuous word, use underscores if necessary.
+| name              | (_mandatory_) In-game name displayed.
+| accusative        | (_mandatory_) Accusative form for this bodypart.
+| heading           | (_mandatory_) How it's displayed in headings.
+| heading_multiple  | (_mandatory_) Plural form of heading.
+| hp_bar_ui_text    | (_mandatory_) How it's displayed next to the hp bar in the panel.
+| main_part         | (_mandatory_) What is the main part this one is attached to. (If this is a main part it's attached to itself)
+| base_hp           | (_mandatory_) The amount of hp this part has before any modification.
+| opposite_part     | (_mandatory_) What is the opposite part ot this one in case of a pair.
+| hit_size          | (_mandatory_) Size of the body part when doing an unweighted selection.
+| hit_size_relative | (_mandatory_) Hit sizes for attackers who are smaller, equal in size, and bigger.
+| hit_difficulty    | (_mandatory_) How hard is it to hit a given body part, assuming "owner" is hit. Higher number means good hits will veer towards this part, lower means this part is unlikely to be hit by inaccurate attacks. Formula is `chance *= pow(hit_roll, hit_difficulty)`
+| stylish_bonus     | (_optional_) Mood bonus associated with wearing fancy clothing on this part. (default: `0`)
+| hot_morale_mod    | (_optional_) Mood effect of being too hot on this part. (default: `0`)
+| cold_morale_mod   | (_optional_) Mood effect of being too cold on this part. (default: `0`)
+| squeamish_penalty | (_optional_) Mood effect of wearing filthy clothing on this part. (default: `0`)
+| stat_hp_mods      | (_optional_) Values modifiying hp_max of this part following this formula: `hp_max += int_mod*int_max + dex_mod*dex_max + str_mod*str_max + per_mod*per_max + health_mod*get_healthy()` with X_max being the unmodifed value of the X stat and get_healthy() being the hidden health stat of the character.
+| bionic_slots      | (_optional_) How many bionic slots does this part have.
 
 ```C++
   {
@@ -459,6 +461,8 @@ This section describes each json file and their contents. Each json has their ow
     "hot_morale_mod": 2,
     "cold_morale_mod": 2,
     "squeamish_penalty": 6,
+    "base_hp": 60,
+    "stat_hp_mods": { "int_mod": 4.0, "dex_mod": 1.0, "str_mod": 1.0, "per_mod": 1.0, "health_mod": 1.0 },
     "bionic_slots": 80
   }
 ```

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4639,26 +4639,24 @@ void activity_handlers::tree_communion_do_turn( player_activity *act, player *p 
 
 static void blood_magic( player *p, int cost )
 {
-    static std::array<body_part, 6> part = { {
-            bp_head, bp_torso, bp_arm_l, bp_arm_r, bp_leg_l, bp_leg_r
-        }
-    };
-    int max_hp_part = 0;
     std::vector<uilist_entry> uile;
-    for( int i = 0; i < num_hp_parts; i++ ) {
-        uilist_entry entry( i, p->hp_cur[i] > cost, i + 49, body_part_hp_bar_ui_text( part[i] ) );
-        if( p->hp_cur[max_hp_part] < p->hp_cur[i] ) {
-            max_hp_part = i;
-        }
-        const std::pair<std::string, nc_color> &hp = get_hp_bar( p->hp_cur[i], p->hp_max[i] );
+    std::vector<bodypart_id> parts;
+    int i = 0;
+    for( const std::pair<const bodypart_str_id, bodypart> &part : p->get_body() ) {
+        const int hp_cur = part.second.get_hp_cur();
+        uilist_entry entry( i, hp_cur > cost, i + 49, body_part_hp_bar_ui_text( part.first->token ) );
+
+        const std::pair<std::string, nc_color> &hp = get_hp_bar( hp_cur, part.second.get_hp_max() );
         entry.ctxt = colorize( hp.first, hp.second );
         uile.emplace_back( entry );
+        parts.push_back( part.first.id() );
+        i++;
     }
     int action = -1;
     while( action < 0 ) {
         action = uilist( _( "Choose part\nto draw blood from." ), uile );
     }
-    p->hp_cur[action] -= cost;
+    p->mod_part_hp_cur( parts[action], - cost );
     p->mod_pain( std::max( 1, cost / 3 ) );
 }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4642,14 +4642,14 @@ static void blood_magic( player *p, int cost )
     std::vector<uilist_entry> uile;
     std::vector<bodypart_id> parts;
     int i = 0;
-    for( const std::pair<const bodypart_str_id, bodypart> &part : p->get_body() ) {
-        const int hp_cur = part.second.get_hp_cur();
-        uilist_entry entry( i, hp_cur > cost, i + 49, body_part_hp_bar_ui_text( part.first->token ) );
+    for( const bodypart_id &bp : p->get_all_body_parts( true ) ) {
+        const int hp_cur = p->get_part_hp_cur( bp );
+        uilist_entry entry( i, hp_cur > cost, i + 49, body_part_hp_bar_ui_text( bp ) );
 
-        const std::pair<std::string, nc_color> &hp = get_hp_bar( hp_cur, part.second.get_hp_max() );
+        const std::pair<std::string, nc_color> &hp = get_hp_bar( hp_cur, p->get_part_hp_max( bp ) );
         entry.ctxt = colorize( hp.first, hp.second );
         uile.emplace_back( entry );
-        parts.push_back( part.first.id() );
+        parts.push_back( bp );
         i++;
     }
     int action = -1;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1484,38 +1484,38 @@ void Character::process_bionic( int b )
                        static_cast<std::string>( bio_hydraulics ) );
     } else if( bio.id == bio_nanobots ) {
         if( get_power_level() >= 40_J ) {
-            std::forward_list<int> bleeding_bp_parts;
-            for( const body_part bp : all_body_parts ) {
-                if( has_effect( effect_bleed, bp ) ) {
-                    bleeding_bp_parts.push_front( static_cast<int>( bp ) );
+            std::forward_list<bodypart_id> bleeding_bp_parts;
+            for( const bodypart_id bp : get_all_body_parts() ) {
+                if( has_effect( effect_bleed, bp->token ) ) {
+                    bleeding_bp_parts.push_front( bp );
                 }
             }
-            std::vector<int> damaged_hp_parts;
-            for( int i = 0; i < num_hp_parts; i++ ) {
-                if( hp_cur[i] > 0 && hp_cur[i] < hp_max[i] ) {
-                    damaged_hp_parts.push_back( i );
+            std::vector<bodypart_id> damaged_hp_parts;
+            for( const std::pair<const bodypart_str_id, bodypart> &part : get_body() ) {
+                const int hp_cur = part.second.get_hp_cur();
+                if( hp_cur > 0 && hp_cur < part.second.get_hp_max() ) {
+                    damaged_hp_parts.push_back( part.first.id() );
                     // only healed and non-hp parts will have a chance of bleeding removal
-                    bleeding_bp_parts.remove( static_cast<int>( hp_to_bp( static_cast<hp_part>( i ) ) ) );
+                    bleeding_bp_parts.remove( part.first.id() );
                 }
             }
             if( calendar::once_every( 60_turns ) ) {
                 bool try_to_heal_bleeding = true;
                 if( get_stored_kcal() >= 5 && !damaged_hp_parts.empty() ) {
-                    const hp_part part_to_heal = static_cast<hp_part>( damaged_hp_parts[ rng( 0,
-                                                      damaged_hp_parts.size() - 1 ) ] );
+                    const bodypart_id part_to_heal = damaged_hp_parts[ rng( 0, damaged_hp_parts.size() - 1 ) ];
                     heal( part_to_heal, 1 );
                     mod_stored_kcal( -5 );
-                    const body_part bp_healed = hp_to_bp( part_to_heal );
-                    int hp_percent = float( hp_cur[part_to_heal] ) / hp_max[part_to_heal] * 100;
-                    if( has_effect( effect_bleed, bp_healed ) && rng( 0, 100 ) < hp_percent ) {
-                        remove_effect( effect_bleed, bp_healed );
+                    int hp_percent = static_cast<float>( get_part_hp_cur( part_to_heal ) ) / get_part_hp_max(
+                                         part_to_heal ) * 100;
+                    if( has_effect( effect_bleed, part_to_heal->token ) && rng( 0, 100 ) < hp_percent ) {
+                        remove_effect( effect_bleed, part_to_heal->token );
                         try_to_heal_bleeding = false;
                     }
                 }
 
                 // if no bleed was removed, try to remove it on some other part
                 if( try_to_heal_bleeding && !bleeding_bp_parts.empty() && rng( 0, 1 ) == 1 ) {
-                    remove_effect( effect_bleed, static_cast<body_part>( bleeding_bp_parts.front() ) );
+                    remove_effect( effect_bleed,  bleeding_bp_parts.front()->token );
                 }
 
             }
@@ -2208,41 +2208,39 @@ void Character::perform_install( bionic_id bid, bionic_id upbid, int difficulty,
 
 void Character::do_damage_for_bionic_failure( int min_damage, int max_damage )
 {
-    std::set<body_part> bp_hurt;
+    std::set<bodypart_id> bp_hurt;
     for( const bodypart_id &bp : get_all_body_parts() ) {
-        const body_part enum_bp = bp->token;
-        if( has_effect( effect_under_op, enum_bp ) && enum_bp != num_bp ) {
-            if( bp_hurt.count( mutate_to_main_part( enum_bp ) ) > 0 ) {
+        if( has_effect( effect_under_op, bp->token ) ) {
+            if( bp_hurt.count( bp->main_part ) > 0 ) {
                 continue;
             }
-            bp_hurt.emplace( mutate_to_main_part( enum_bp ) );
+            bp_hurt.emplace( bp->main_part );
         }
     }
 
     if( bp_hurt.empty() ) {
         // If no bodypart associetd with bionic- just damage torso.
         // Special check for power storage - it does not belong to any body part.
-        bp_hurt.emplace( bp_torso );
+        bp_hurt.emplace( bodypart_str_id( "torso" ) );
     }
 
-    for( const body_part enum_bp : bp_hurt ) {
-        const hp_part hppart = bp_to_hp( enum_bp );
+    for( const bodypart_id &bp : bp_hurt ) {
         int damage = rng( min_damage, max_damage );
-        int hp = get_hp( hppart );
-        if( damage >= hp && ( hppart == hp_head || hppart == hp_torso ) ) {
-            add_effect( effect_infected, 1_hours, enum_bp );
+        int hp = get_hp( bp );
+        if( damage >= hp && ( bp == bodypart_str_id( "head" ) || bp == bodypart_str_id( "torso" ) ) ) {
+            add_effect( effect_infected, 1_hours, bp->token );
             add_msg_player_or_npc( m_bad, _( "Your %s is infected." ), _( "<npcname>'s %s is infected." ),
-                                   body_part_name_accusative( enum_bp ) );
+                                   body_part_name_accusative( bp ) );
             damage = hp * 0.8f;
         }
-        apply_damage( this, bodypart_id( convert_bp( enum_bp ) ), damage, true );
+        apply_damage( this, bp, damage, true );
         if( damage > 15 )
             add_msg_player_or_npc( m_bad, _( "Your %s is severely damaged." ),
                                    _( "<npcname>'s %s is severely damaged." ),
-                                   body_part_name_accusative( enum_bp ) );
+                                   body_part_name_accusative( bp ) );
         else
             add_msg_player_or_npc( m_bad, _( "Your %s is damaged." ), _( "<npcname>'s %s is damaged." ),
-                                   body_part_name_accusative( enum_bp ) );
+                                   body_part_name_accusative( bp ) );
 
     }
 }

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -14,6 +14,8 @@
 #include "pldata.h"
 #include "type_id.h"
 
+static const anatomy_id anatomy_human_anatomy( "human_anatomy" );
+
 side opposite_side( side s )
 {
     switch( s ) {
@@ -229,6 +231,8 @@ void body_part_type::load( const JsonObject &jo, const std::string & )
     mandatory( jo, was_loaded, "hit_difficulty", hit_difficulty );
     mandatory( jo, was_loaded, "hit_size_relative", hit_size_relative );
 
+    mandatory( jo, was_loaded, "base_hp", base_hp );
+
     mandatory( jo, was_loaded, "legacy_id", legacy_id );
     token = legacy_id_to_enum( legacy_id );
 
@@ -301,26 +305,38 @@ void body_part_type::check() const
 
 std::string body_part_name( body_part bp, int number )
 {
-    const auto &bdy = get_bp( bp );
+    return body_part_name( convert_bp( bp ), number );
+}
+
+std::string body_part_name( const bodypart_id &bp, int number )
+{
     // See comments in `body_part_type::load` about why these two strings are
     // not a single translation object with plural enabled.
-    return number > 1 ? bdy.name_multiple.translated() : bdy.name.translated();
+    return number > 1 ? bp->name_multiple.translated() : bp->name.translated();
 }
 
 std::string body_part_name_accusative( body_part bp, int number )
 {
-    const auto &bdy = get_bp( bp );
+    return body_part_name_accusative( convert_bp( bp ), number );
+}
+
+std::string body_part_name_accusative( const bodypart_id &bp, int number )
+{
     // See comments in `body_part_type::load` about why these two strings are
     // not a single translation object with plural enabled.
-    return number > 1 ? bdy.accusative_multiple.translated() : bdy.accusative.translated();
+    return number > 1 ? bp->accusative_multiple.translated() : bp->accusative.translated();
 }
 
 std::string body_part_name_as_heading( body_part bp, int number )
 {
-    const auto &bdy = get_bp( bp );
+    return body_part_name_as_heading( convert_bp( bp ), number );
+}
+
+std::string body_part_name_as_heading( const bodypart_id &bp, int number )
+{
     // See comments in `body_part_type::load` about why these two strings are
     // not a single translation object with plural enabled.
-    return number > 1 ? bdy.name_as_heading_multiple.translated() : bdy.name_as_heading.translated();
+    return number > 1 ? bp->name_as_heading_multiple.translated() : bp->name_as_heading.translated();
 }
 
 std::string body_part_hp_bar_ui_text( body_part bp )
@@ -353,4 +369,115 @@ body_part opposite_body_part( body_part bp )
 std::string get_body_part_id( body_part bp )
 {
     return get_bp( bp ).legacy_id;
+}
+
+bodypart_id bodypart::get_id() const
+{
+    return id;
+}
+
+void bodypart::set_hp_to_max()
+{
+    hp_cur = hp_max;
+}
+
+bool bodypart::is_at_max_hp() const
+{
+    return hp_cur == hp_max;
+}
+
+int bodypart::get_hp_cur() const
+{
+    return hp_cur;
+}
+
+int bodypart::get_hp_max() const
+{
+    return hp_max;
+}
+
+int bodypart::get_healed_total() const
+{
+    return healed_total;
+}
+
+int bodypart::get_damage_bandaged() const
+{
+    return damage_bandaged;
+}
+
+int bodypart::get_damage_disinfected() const
+{
+    return damage_disinfected;
+}
+
+void bodypart::set_hp_cur( int set )
+{
+    hp_cur = set;
+}
+
+void bodypart::set_hp_max( int set )
+{
+    hp_max = set;
+}
+
+void bodypart::set_healed_total( int set )
+{
+    healed_total = set;
+}
+
+void bodypart::set_damage_bandaged( int set )
+{
+    damage_bandaged = set;
+}
+
+void bodypart::set_damage_disinfected( int set )
+{
+    damage_disinfected = set;
+}
+
+void bodypart::mod_hp_cur( int mod )
+{
+    hp_cur += mod;
+}
+
+void bodypart::mod_hp_max( int mod )
+{
+    hp_max += mod;
+}
+
+void bodypart::mod_healed_total( int mod )
+{
+    healed_total += mod;
+}
+
+void bodypart::mod_damage_bandaged( int mod )
+{
+    damage_bandaged += mod;
+}
+
+void bodypart::mod_damage_disinfected( int mod )
+{
+    damage_disinfected += mod;
+}
+
+void bodypart::serialize( JsonOut &json ) const
+{
+    json.start_object();
+    json.member( "id", id );
+    json.member( "hp_cur", hp_cur );
+    json.member( "hp_max", hp_max );
+    json.member( "damage_bandaged", damage_bandaged );
+    json.member( "damage_disinfected", damage_disinfected );
+    json.end_object();
+}
+
+void bodypart::deserialize( JsonIn &jsin )
+{
+    JsonObject jo = jsin.get_object();
+    jo.read( "id", id, true );
+    jo.read( "hp_cur", hp_cur, true );
+    jo.read( "hp_max", hp_max, true );
+    jo.read( "damage_bandaged", damage_bandaged, true );
+    jo.read( "damage_disinfected", damage_disinfected, true );
 }

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -339,9 +339,9 @@ std::string body_part_name_as_heading( const bodypart_id &bp, int number )
     return number > 1 ? bp->name_as_heading_multiple.translated() : bp->name_as_heading.translated();
 }
 
-std::string body_part_hp_bar_ui_text( body_part bp )
+std::string body_part_hp_bar_ui_text( const bodypart_id &bp )
 {
-    return _( get_bp( bp ).hp_bar_ui_text );
+    return _( bp->hp_bar_ui_text );
 }
 
 std::string encumb_text( body_part bp )

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -275,7 +275,7 @@ std::string body_part_name_as_heading( body_part bp, int number );
 std::string body_part_name_as_heading( const bodypart_id &bp, int number );
 
 /** Returns the body part text to be displayed in the HP bar */
-std::string body_part_hp_bar_ui_text( body_part bp );
+std::string body_part_hp_bar_ui_text( const bodypart_id &bp );
 
 /** Returns the matching encumbrance text for a given body_part token. */
 std::string encumb_text( body_part bp );

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -13,6 +13,9 @@
 #include "translations.h"
 
 class JsonObject;
+class JsonIn;
+class JsonOut;
+
 template <typename E> struct enum_traits;
 
 // The order is important ; pldata.h has to be in the same order
@@ -111,10 +114,10 @@ struct body_part_type {
         //Morale parameters
         float hot_morale_mod = 0;
         float cold_morale_mod = 0;
-
         float stylish_bonus = 0;
-
         int squeamish_penalty = 0;
+
+        int base_hp = 60;
 
         void load( const JsonObject &jo, const std::string &src );
         void finalize();
@@ -134,6 +137,50 @@ struct body_part_type {
         }
     private:
         int bionic_slots_ = 0;
+};
+
+class bodypart
+{
+    private:
+        bodypart_str_id id;
+
+        int hp_cur;
+        int hp_max;
+
+        int healed_total = 0;
+        /** Not used yet*/
+        int damage_bandaged = 0;
+        int damage_disinfected = 0;
+
+    public:
+        bodypart(): id( bodypart_str_id( "num_bp" ) ), hp_cur( 0 ), hp_max( 0 ) {}
+        bodypart( bodypart_str_id id ): id( id ), hp_cur( id->base_hp ), hp_max( id->base_hp )  {}
+
+        bodypart_id get_id() const;
+
+        void set_hp_to_max();
+        bool is_at_max_hp() const;
+
+        int get_hp_cur() const;
+        int get_hp_max() const;
+        int get_healed_total() const;
+        int get_damage_bandaged() const;
+        int get_damage_disinfected() const;
+
+        void set_hp_cur( int set );
+        void set_hp_max( int set );
+        void set_healed_total( int set );
+        void set_damage_bandaged( int set );
+        void set_damage_disinfected( int set );
+
+        void mod_hp_cur( int mod );
+        void mod_hp_max( int mod );
+        void mod_healed_total( int mod );
+        void mod_damage_bandaged( int mod );
+        void mod_damage_disinfected( int mod );
+
+        void serialize( JsonOut &json ) const;
+        void deserialize( JsonIn &jsin );
 };
 
 class body_part_set
@@ -215,14 +262,17 @@ const std::array<size_t, 12> bp_aiOther = {{0, 1, 2, 3, 5, 4, 7, 6, 9, 8, 11, 10
 
 /** Returns the matching name of the body_part token. */
 std::string body_part_name( body_part bp, int number = 1 );
+std::string body_part_name( const bodypart_id &bp, int number = 1 );
 
 /** Returns the matching accusative name of the body_part token, i.e. "Shrapnel hits your X".
  *  These are identical to body_part_name above in English, but not in some other languages. */
 std::string body_part_name_accusative( body_part bp, int number = 1 );
+std::string body_part_name_accusative( const bodypart_id &bp, int number = 1 );
 
 /** Returns the name of the body parts in a context where the name is used as
  * a heading or title e.g. "Left Arm". */
 std::string body_part_name_as_heading( body_part bp, int number );
+std::string body_part_name_as_heading( const bodypart_id &bp, int number );
 
 /** Returns the body part text to be displayed in the HP bar */
 std::string body_part_hp_bar_ui_text( body_part bp );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -390,8 +390,6 @@ Character::Character() :
     next_climate_control_check( calendar::before_time_starts ),
     last_climate_control_ret( false )
 {
-    hp_cur.fill( 0 );
-    hp_max.fill( 1 );
     str_max = 0;
     dex_max = 0;
     per_max = 0;
@@ -1274,10 +1272,10 @@ int Character::get_working_arm_count() const
     }
 
     int limb_count = 0;
-    if( !is_limb_disabled( hp_arm_l ) ) {
+    if( !is_limb_disabled( bodypart_id( "arm_l" ) ) ) {
         limb_count++;
     }
-    if( !is_limb_disabled( hp_arm_r ) ) {
+    if( !is_limb_disabled( bodypart_id( "arm_r" ) ) ) {
         limb_count++;
     }
     if( has_bionic( bio_blaster ) && limb_count > 0 ) {
@@ -1291,30 +1289,25 @@ int Character::get_working_arm_count() const
 int Character::get_working_leg_count() const
 {
     int limb_count = 0;
-    if( !is_limb_broken( hp_leg_l ) ) {
+    if( !is_limb_broken( bodypart_id( "leg_l" ) ) ) {
         limb_count++;
     }
-    if( !is_limb_broken( hp_leg_r ) ) {
+    if( !is_limb_broken( bodypart_id( "leg_r" ) ) ) {
         limb_count++;
     }
     return limb_count;
 }
 
-bool Character::is_limb_hindered( hp_part limb ) const
+bool Character::is_limb_disabled( const bodypart_id &limb ) const
 {
-    return hp_cur[limb] < hp_max[limb] * .40;
-}
-
-bool Character::is_limb_disabled( hp_part limb ) const
-{
-    return hp_cur[limb] <= hp_max[limb] * .125;
+    return get_part_hp_cur( limb ) <= get_part_hp_max( limb ) * .125;
 }
 
 // this is the source of truth on if a limb is broken so all code to determine
 // if a limb is broken should point here to make any future changes to breaking easier
-bool Character::is_limb_broken( hp_part limb ) const
+bool Character::is_limb_broken( const bodypart_id &limb ) const
 {
-    return hp_cur[limb] == 0;
+    return get_part_hp_cur( limb ) == 0;
 }
 
 bool Character::can_run()
@@ -1653,7 +1646,6 @@ void Character::process_turn()
 
 void Character::recalc_hp()
 {
-    int new_max_hp[num_hp_parts];
     int str_boost_val = 0;
     cata::optional<skill_boost> str_boost = skill_boost::get( "str" );
     if( str_boost ) {
@@ -1666,27 +1658,25 @@ void Character::recalc_hp()
     // Mutated toughness stacks with starting, by design.
     float hp_mod = 1.0f + mutation_value( "hp_modifier" ) + mutation_value( "hp_modifier_secondary" );
     float hp_adjustment = mutation_value( "hp_adjustment" ) + ( str_boost_val * 3 );
-    for( auto &elem : new_max_hp ) {
-        /** @EFFECT_STR_MAX increases base hp */
-        elem = 60 + str_max * 3 + hp_adjustment;
-        elem *= hp_mod;
-    }
-    if( has_trait( trait_GLASSJAW ) ) {
-        new_max_hp[hp_head] *= 0.8;
-    }
-    for( int i = 0; i < num_hp_parts; i++ ) {
-        // Only recalculate when max changes,
-        // otherwise we end up walking all over due to rounding errors.
-        if( new_max_hp[i] == hp_max[i] ) {
-            continue;
+    calc_all_parts_hp( hp_mod, hp_adjustment, str_max );
+}
+
+void Character::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_max )
+{
+    for( std::pair<const bodypart_str_id, bodypart> &part : get_body() ) {
+        int new_max = ( part.first->base_hp + str_max * 3 + hp_adjustment ) * hp_mod;
+
+        if( has_trait( trait_id( "GLASSJAW" ) ) && part.first == bodypart_str_id( "head" ) ) {
+            new_max *= 0.8;
         }
-        // hp_max must be positive to avoiud undefined behavior.
-        hp_max[i] = std::max( hp_max[i], 1 );
-        float max_hp_ratio = static_cast<float>( new_max_hp[i] ) /
-                             static_cast<float>( hp_max[i] );
-        hp_cur[i] = std::ceil( static_cast<float>( hp_cur[i] ) * max_hp_ratio );
-        hp_cur[i] = std::max( std::min( hp_cur[i], new_max_hp[i] ), 1 );
-        hp_max[i] = new_max_hp[i];
+
+        float max_hp_ratio = static_cast<float>( new_max ) /
+                             static_cast<float>( part.second.get_hp_max() );
+
+        int new_cur = std::ceil( static_cast<float>( part.second.get_hp_cur() ) * max_hp_ratio );
+
+        part.second.set_hp_max( std::max( new_max, 1 ) );
+        part.second.set_hp_cur( std::max( std::min( new_cur, new_max ), 1 ) );
     }
 }
 
@@ -2882,7 +2872,7 @@ ret_val<bool> Character::can_wear( const item &it, bool with_equip_change ) cons
             if( !it.covers( bp->token ) ) {
                 continue;
             }
-            if( is_limb_broken( bp_to_hp( bp->token ) ) && !worn_with_flag( flag_SPLINT, bp ) ) {
+            if( is_limb_broken( bp ) && !worn_with_flag( flag_SPLINT, bp ) ) {
                 need_splint = true;
                 break;
             }
@@ -3283,6 +3273,7 @@ void Character::normalize()
     martial_arts_data->reset_style();
     weapon = item( "null", calendar::start_of_cataclysm );
 
+    set_body();
     recalc_hp();
 }
 
@@ -4364,7 +4355,7 @@ void Character::on_damage_of_type( int adjusted_damage, damage_type type, const 
             }
             const std::map<bodypart_str_id, size_t> &bodyparts = info.occupied_bodyparts;
             if( bodyparts.find( bp.id() ) != bodyparts.end() ) {
-                const int bp_hp = hp_cur[bp_to_hp( bp->token )];
+                const int bp_hp = get_part_hp_cur( bp );
                 // The chance to incapacitate is as high as 50% if the attack deals damage equal to one third of the body part's current health.
                 if( x_in_y( adjusted_damage * 3, bp_hp ) && one_in( 2 ) ) {
                     if( i.incapacitated_time == 0_turns ) {
@@ -4421,8 +4412,8 @@ void Character::regen( int rate_multiplier )
 
     // include healing effects
     for( int i = 0; i < num_hp_parts; i++ ) {
-        body_part bp = hp_to_bp( static_cast<hp_part>( i ) );
-        float healing = healing_rate_medicine( rest, convert_bp( bp ).id() ) * to_turns<int>( 5_minutes );
+        const bodypart_id &bp = convert_bp( hp_to_bp( static_cast<hp_part>( i ) ) ).id();
+        float healing = healing_rate_medicine( rest, bp ) * to_turns<int>( 5_minutes );
 
         int healing_apply = roll_remainder( healing );
         healed_bp( i, healing_apply );
@@ -4431,7 +4422,7 @@ void Character::regen( int rate_multiplier )
             damage_bandaged[i] -= healing_apply;
             if( damage_bandaged[i] <= 0 ) {
                 damage_bandaged[i] = 0;
-                remove_effect( effect_bandaged, bp );
+                remove_effect( effect_bandaged, bp->token );
                 add_msg_if_player( _( "Bandaged wounds on your %s healed." ), body_part_name( bp ) );
             }
         }
@@ -4439,20 +4430,20 @@ void Character::regen( int rate_multiplier )
             damage_disinfected[i] -= healing_apply;
             if( damage_disinfected[i] <= 0 ) {
                 damage_disinfected[i] = 0;
-                remove_effect( effect_disinfected, bp );
+                remove_effect( effect_disinfected, bp->token );
                 add_msg_if_player( _( "Disinfected wounds on your %s healed." ), body_part_name( bp ) );
             }
         }
 
         // remove effects if the limb was healed by other way
-        if( has_effect( effect_bandaged, bp ) && ( hp_cur[i] == hp_max[i] ) ) {
+        if( has_effect( effect_bandaged, bp->token ) && ( get_part( bp )->is_at_max_hp() ) ) {
             damage_bandaged[i] = 0;
-            remove_effect( effect_bandaged, bp );
+            remove_effect( effect_bandaged, bp->token );
             add_msg_if_player( _( "Bandaged wounds on your %s healed." ), body_part_name( bp ) );
         }
-        if( has_effect( effect_disinfected, bp ) && ( hp_cur[i] == hp_max[i] ) ) {
+        if( has_effect( effect_disinfected, bp->token ) && ( get_part( bp )->is_at_max_hp() ) ) {
             damage_disinfected[i] = 0;
-            remove_effect( effect_disinfected, bp );
+            remove_effect( effect_disinfected, bp->token );
             add_msg_if_player( _( "Disinfected wounds on your %s healed." ), body_part_name( bp ) );
         }
     }
@@ -4464,11 +4455,11 @@ void Character::regen( int rate_multiplier )
 
 void Character::enforce_minimum_healing()
 {
-    for( int i = 0; i < num_hp_parts; i++ ) {
-        if( healed_total[i] <= 0 ) {
-            heal( static_cast<hp_part>( i ), 1 );
+    for( const bodypart_id &bp : get_all_body_parts() ) {
+        if( get_part_healed_total( bp ) <= 0 ) {
+            heal( bp, 1 );
         }
-        healed_total[i] = 0;
+        set_part_healed_total( bp, 0 );
     }
 }
 
@@ -4818,11 +4809,11 @@ void Character::check_needs_extremes()
     if( get_stim() > 250 ) {
         add_msg_if_player( m_bad, _( "You have a sudden heart attack!" ) );
         g->events().send<event_type::dies_from_drug_overdose>( getID(), efftype_id() );
-        hp_cur[hp_torso] = 0;
+        set_part_hp_cur( bodypart_id( "torso" ), 0 );
     } else if( get_stim() < -200 || get_painkiller() > 240 ) {
         add_msg_if_player( m_bad, _( "Your breathing stops completely." ) );
         g->events().send<event_type::dies_from_drug_overdose>( getID(), efftype_id() );
-        hp_cur[hp_torso] = 0;
+        set_part_hp_cur( bodypart_id( "torso" ), 0 );
     } else if( has_effect( effect_jetinjector ) && get_effect_dur( effect_jetinjector ) > 40_minutes ) {
         if( !( has_trait( trait_NOPAIN ) ) ) {
             add_msg_if_player( m_bad, _( "Your heart spasms painfully and stops." ) );
@@ -4830,15 +4821,15 @@ void Character::check_needs_extremes()
             add_msg_if_player( _( "Your heart spasms and stops." ) );
         }
         g->events().send<event_type::dies_from_drug_overdose>( getID(), effect_jetinjector );
-        hp_cur[hp_torso] = 0;
+        set_part_hp_cur( bodypart_id( "torso" ), 0 );
     } else if( get_effect_dur( effect_adrenaline ) > 50_minutes ) {
         add_msg_if_player( m_bad, _( "Your heart spasms and stops." ) );
         g->events().send<event_type::dies_from_drug_overdose>( getID(), effect_adrenaline );
-        hp_cur[hp_torso] = 0;
+        set_part_hp_cur( bodypart_id( "torso" ), 0 );
     } else if( get_effect_int( effect_drunk ) > 4 ) {
         add_msg_if_player( m_bad, _( "Your breathing slows down to a stop." ) );
         g->events().send<event_type::dies_from_drug_overdose>( getID(), effect_drunk );
-        hp_cur[hp_torso] = 0;
+        set_part_hp_cur( bodypart_id( "torso" ), 0 );
     }
 
     // check if we've starved
@@ -4846,7 +4837,7 @@ void Character::check_needs_extremes()
         if( get_stored_kcal() <= 0 ) {
             add_msg_if_player( m_bad, _( "You have starved to death." ) );
             g->events().send<event_type::dies_of_starvation>( getID() );
-            hp_cur[hp_torso] = 0;
+            set_part_hp_cur( bodypart_id( "torso" ), 0 );
         } else if( calendar::once_every( 6_hours ) ) {
             std::string category;
             if( get_kcal_percent() < 0.1f ) {
@@ -4871,7 +4862,7 @@ void Character::check_needs_extremes()
         if( get_thirst() >= thirst_levels::dead ) {
             add_msg_if_player( m_bad, _( "You have died of dehydration." ) );
             g->events().send<event_type::dies_of_thirst>( getID() );
-            hp_cur[hp_torso] = 0;
+            set_part_hp_cur( bodypart_id( "torso" ), 0 );
         } else if( get_thirst() >= lerp( +thirst_levels::parched, +thirst_levels::dead, 0.333f ) &&
                    calendar::once_every( 30_minutes ) ) {
             add_msg_if_player( m_warning, _( "Even your eyes feel dry…" ) );
@@ -5591,21 +5582,15 @@ Character::comfort_response_t Character::base_comfort_value( const tripoint &p )
 
 int Character::blood_loss( const bodypart_id &bp ) const
 {
-    int hp_cur_sum = 1;
-    int hp_max_sum = 1;
+    int hp_cur_sum = get_part_hp_cur( bp );
+    int hp_max_sum = get_part_hp_max( bp );
 
     if( bp == bodypart_id( "leg_l" ) || bp == bodypart_id( "leg_r" ) ) {
-        hp_cur_sum = hp_cur[hp_leg_l] + hp_cur[hp_leg_r];
-        hp_max_sum = hp_max[hp_leg_l] + hp_max[hp_leg_r];
+        hp_cur_sum = get_part_hp_cur( bodypart_id( "leg_l" ) ) + get_part_hp_cur( bodypart_id( "leg_r" ) );
+        hp_max_sum = get_part_hp_max( bodypart_id( "leg_l" ) ) + get_part_hp_max( bodypart_id( "leg_r" ) );
     } else if( bp == bodypart_id( "arm_l" ) || bp == bodypart_id( "arm_r" ) ) {
-        hp_cur_sum = hp_cur[hp_arm_l] + hp_cur[hp_arm_r];
-        hp_max_sum = hp_max[hp_arm_l] + hp_max[hp_arm_r];
-    } else if( bp == bodypart_id( "torso" ) ) {
-        hp_cur_sum = hp_cur[hp_torso];
-        hp_max_sum = hp_max[hp_torso];
-    } else if( bp == bodypart_id( "head" ) ) {
-        hp_cur_sum = hp_cur[hp_head];
-        hp_max_sum = hp_max[hp_head];
+        hp_cur_sum = get_part_hp_cur( bodypart_id( "arm_l" ) ) + get_part_hp_cur( bodypart_id( "arm_r" ) );
+        hp_max_sum = get_part_hp_max( bodypart_id( "arm_l" ) ) + get_part_hp_max( bodypart_id( "arm_r" ) );
     }
 
     hp_cur_sum = std::min( hp_max_sum, std::max( 0, hp_cur_sum ) );
@@ -5668,9 +5653,8 @@ hp_part Character::body_window( const std::string &menu_header,
         const auto &e = parts[i];
         const bodypart_id &bp = e.bp;
         const body_part bp_token = bp->token;
-        const hp_part hp = e.hp;
-        const int maximal_hp = hp_max[hp];
-        const int current_hp = hp_cur[hp];
+        const int maximal_hp = get_part_hp_max( bp );
+        const int current_hp = get_part_hp_cur( bp );
         // This will c_light_gray if the part does not have any effects cured by the item/effect
         // (e.g. it cures only bites, but the part does not have a bite effect)
         const nc_color state_col = limb_color( bp, bleed > 0.0f, bite > 0.0f, infect > 0.0f );
@@ -5678,7 +5662,7 @@ hp_part Character::body_window( const std::string &menu_header,
         // The same as in the main UI sidebar. Independent of the capability of the healing item/effect!
         const nc_color all_state_col = limb_color( bp, true, true, true );
         // Broken means no HP can be restored, it requires surgical attention.
-        const bool limb_is_broken = is_limb_broken( hp );
+        const bool limb_is_broken = is_limb_broken( bp );
         const bool limb_is_mending = worn_with_flag( flag_SPLINT, bp );
 
         if( show_all ) {
@@ -6403,19 +6387,17 @@ std::string Character::extended_description() const
 
     // This is a stripped-down version of the body_window function
     // This should be extracted into a separate function later on
-    for( const bodypart_id bp : bps ) {
+    for( const bodypart_id &bp : bps ) {
         // Hide appendix from the player
         if( bp->id.str() == "num_bp" ) {
             continue;
         }
         const std::string &bp_heading = body_part_name_as_heading( bp->token, 1 );
-        hp_part hp = bp_to_hp( bp->token );
 
-        const int maximal_hp = hp_max[hp];
-        const int current_hp = hp_cur[hp];
         const nc_color state_col = limb_color( bp, true, true, true );
         nc_color name_color = state_col;
-        auto hp_bar = get_hp_bar( current_hp, maximal_hp, false );
+        std::pair<std::string, nc_color> hp_bar = get_hp_bar( get_part_hp_cur( bp ), get_part_hp_max( bp ),
+                false );
 
         ss += colorize( left_justify( bp_heading, longest ), name_color );
         ss += colorize( hp_bar.first, hp_bar.second );
@@ -8009,18 +7991,17 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam, const
         // Or if we're debugging and don't want to die
         return;
     }
-    body_part enum_bp = hurt->token;
-    hp_part hurtpart = bp_to_hp( enum_bp );
-    if( hurtpart == num_hp_parts ) {
+
+    if( hurt == bodypart_id( "num_bp" ) ) {
         debugmsg( "Wacky body part hurt!" );
-        hurtpart = hp_torso;
+        hurt = bodypart_id( "torso" );
     }
 
     mod_pain( dam / 2 );
 
-    const int dam_to_bodypart = std::min( dam, hp_cur[hurtpart] );
+    const int dam_to_bodypart = std::min( dam, get_part_hp_cur( hurt ) );
 
-    hp_cur[hurtpart] -= dam_to_bodypart;
+    mod_part_hp_cur( hurt, - dam_to_bodypart );
     g->events().send<event_type::character_takes_damage>( getID(), dam_to_bodypart );
 
     if( !weapon.is_null() && !as_player()->can_wield( weapon ).success() &&
@@ -8030,9 +8011,9 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam, const
         put_into_vehicle_or_drop( *this, item_drop_reason::tumbling, { weapon } );
         i_rem( &weapon );
     }
-    if( has_effect( effect_mending, enum_bp ) && ( source == nullptr ||
+    if( has_effect( effect_mending, hurt->token ) && ( source == nullptr ||
             !source->is_hallucination() ) ) {
-        effect &e = get_effect( effect_mending, enum_bp );
+        effect &e = get_effect( effect_mending, hurt->token );
         float remove_mend = dam / 20.0f;
         e.mod_duration( -e.get_max_duration() * remove_mend );
     }
@@ -8044,10 +8025,10 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam, const
     if( !bypass_med ) {
         // remove healing effects if damaged
         int remove_med = roll_remainder( dam / 5.0f );
-        if( remove_med > 0 && has_effect( effect_bandaged, enum_bp ) ) {
+        if( remove_med > 0 && has_effect( effect_bandaged, hurt->token ) ) {
             remove_med -= reduce_healing_effect( effect_bandaged, remove_med, hurt );
         }
-        if( remove_med > 0 && has_effect( effect_disinfected, enum_bp ) ) {
+        if( remove_med > 0 && has_effect( effect_disinfected, hurt->token ) ) {
             reduce_healing_effect( effect_disinfected, remove_med, hurt );
         }
     }
@@ -8079,8 +8060,7 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
             //monster hits player melee
             SCT.add( point( posx(), posy() ),
                      direction_from( point_zero, point( posx() - source->posx(), posy() - source->posy() ) ),
-                     get_hp_bar( dam, get_hp_max( player::bp_to_hp( bp->token ) ) ).first, m_bad,
-                     body_part_name( bp->token ), m_neutral );
+                     get_hp_bar( dam, get_hp_max( bp ) ).first, m_bad, body_part_name( bp ), m_neutral );
         }
     }
 
@@ -8235,69 +8215,20 @@ int Character::reduce_healing_effect( const efftype_id &eff_id, int remove_med,
     return intensity;
 }
 
-void Character::heal( body_part healed, int dam )
-{
-    hp_part healpart;
-    switch( healed ) {
-        case bp_eyes:
-        // Fall through to head damage
-        case bp_mouth:
-        // Fall through to head damage
-        case bp_head:
-            healpart = hp_head;
-            break;
-        case bp_torso:
-            healpart = hp_torso;
-            break;
-        case bp_hand_l:
-            // Shouldn't happen, but fall through to arms
-            debugmsg( "Heal against hands!" );
-        /* fallthrough */
-        case bp_arm_l:
-            healpart = hp_arm_l;
-            break;
-        case bp_hand_r:
-            // Shouldn't happen, but fall through to arms
-            debugmsg( "Heal against hands!" );
-        /* fallthrough */
-        case bp_arm_r:
-            healpart = hp_arm_r;
-            break;
-        case bp_foot_l:
-            // Shouldn't happen, but fall through to legs
-            debugmsg( "Heal against feet!" );
-        /* fallthrough */
-        case bp_leg_l:
-            healpart = hp_leg_l;
-            break;
-        case bp_foot_r:
-            // Shouldn't happen, but fall through to legs
-            debugmsg( "Heal against feet!" );
-        /* fallthrough */
-        case bp_leg_r:
-            healpart = hp_leg_r;
-            break;
-        default:
-            debugmsg( "Wacky body part healed!" );
-            healpart = hp_torso;
-    }
-    heal( healpart, dam );
-}
-
-void Character::heal( hp_part healed, int dam )
+void Character::heal( const bodypart_id &healed, int dam )
 {
     if( !is_limb_broken( healed ) ) {
-        int effective_heal = std::min( dam, hp_max[healed] - hp_cur[healed] );
-        hp_cur[healed] += effective_heal;
+        int effective_heal = std::min( dam, get_part_hp_max( healed ) - get_part_hp_cur( healed ) );
+        mod_part_hp_cur( healed, effective_heal );
         g->events().send<event_type::character_heals_damage>( getID(), effective_heal );
     }
 }
 
 void Character::healall( int dam )
 {
-    for( int healed_part = 0; healed_part < num_hp_parts; healed_part++ ) {
-        heal( static_cast<hp_part>( healed_part ), dam );
-        healed_bp( healed_part, dam );
+    for( const bodypart_id &bp : get_all_body_parts() ) {
+        heal( bp, dam );
+        mod_part_healed_total( bp, dam );
     }
 }
 
@@ -8307,11 +8238,10 @@ void Character::hurtall( int dam, Creature *source, bool disturb /*= true*/ )
         return;
     }
 
-    for( int i = 0; i < num_hp_parts; i++ ) {
-        const hp_part bp = static_cast<hp_part>( i );
+    for( const bodypart_id &bp : get_all_body_parts() ) {
         // Don't use apply_damage here or it will annoy the player with 6 queries
-        const int dam_to_bodypart = std::min( dam, hp_cur[bp] );
-        hp_cur[bp] -= dam_to_bodypart;
+        const int dam_to_bodypart = std::min( dam, get_part_hp_cur( bp ) );
+        mod_part_hp_cur( bp, - dam_to_bodypart );
         g->events().send<event_type::character_takes_damage>( getID(), dam_to_bodypart );
     }
 
@@ -8336,7 +8266,8 @@ int Character::hitall( int dam, int vary, Creature *source )
 void Character::on_hurt( Creature *source, bool disturb /*= true*/ )
 {
     if( has_trait( trait_ADRENALINE ) && !has_effect( effect_adrenaline ) &&
-        ( hp_cur[hp_head] < 25 || hp_cur[hp_torso] < 15 ) ) {
+        ( get_part_hp_cur( bodypart_id( "head" ) ) < 25 ||
+          get_part_hp_cur( bodypart_id( "torso" ) ) < 15 ) ) {
         add_effect( effect_adrenaline, 20_minutes );
     }
 
@@ -9637,17 +9568,16 @@ int Character::run_cost( int base_cost, bool diag ) const
         }
         if( has_trait( trait_M_IMMUNE ) && on_fungus ) {
             if( movecost > 75 ) {
-                movecost =
-                    75; // Mycal characters are faster on their home territory, even through things like shrubs
+                // Mycal characters are faster on their home territory, even through things like shrubs
+                movecost = 75;
             }
         }
-        if( is_limb_hindered( hp_leg_l ) ) {
-            movecost += 25;
-        }
 
-        if( is_limb_hindered( hp_leg_r ) ) {
-            movecost += 25;
-        }
+        // Linearly increase move cost relative to individual leg hp.
+        movecost += 50 * ( 1 - static_cast<float>( get_part_hp_cur( bodypart_id( "leg_l" ) ) ) /
+                           static_cast<float>( get_part_hp_max( bodypart_id( "leg_l" ) ) ) );
+        movecost += 50 * ( 1 - static_cast<float>( get_part_hp_cur( bodypart_id( "leg_r" ) ) ) /
+                           static_cast<float>( get_part_hp_max( bodypart_id( "leg_r" ) ) ) );
         movecost *= mutation_value( "movecost_modifier" );
         if( flatground ) {
             movecost *= mutation_value( "movecost_flatground_modifier" );
@@ -9960,50 +9890,17 @@ bool Character::has_weapon() const
     return !unarmed_attack();
 }
 
-int Character::get_hp() const
-{
-    return get_hp( num_hp_parts );
-}
-
 int Character::get_lowest_hp() const
 {
     // Set lowest_hp to an arbitrarily large number.
     int lowest_hp = 999;
-    for( int cur_hp : this->hp_cur ) {
+    for( const std::pair<const bodypart_str_id, bodypart> &elem : get_body() ) {
+        const int cur_hp = elem.second.get_hp_cur();
         if( cur_hp < lowest_hp ) {
             lowest_hp = cur_hp;
         }
     }
     return lowest_hp;
-}
-
-int Character::get_hp( hp_part bp ) const
-{
-    if( bp < num_hp_parts ) {
-        return hp_cur[bp];
-    }
-    int hp_total = 0;
-    for( int i = 0; i < num_hp_parts; ++i ) {
-        hp_total += hp_cur[i];
-    }
-    return hp_total;
-}
-
-int Character::get_hp_max() const
-{
-    return get_hp_max( num_hp_parts );
-}
-
-int Character::get_hp_max( hp_part bp ) const
-{
-    if( bp < num_hp_parts ) {
-        return hp_max[bp];
-    }
-    int hp_total = 0;
-    for( int i = 0; i < num_hp_parts; ++i ) {
-        hp_total += hp_max[i];
-    }
-    return hp_total;
 }
 
 Creature::Attitude Character::attitude_to( const Creature &other ) const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7999,10 +7999,12 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam, const
 
     mod_pain( dam / 2 );
 
-    const int dam_to_bodypart = std::min( dam, get_part_hp_cur( hurt->main_part ) );
+    const bodypart_id &part_to_damage = hurt->main_part;
 
-    mod_part_hp_cur( hurt->main_part, - dam_to_bodypart );
-    g->events().send<event_type::character_takes_damage>( getID(), dam_to_bodypart );
+    const int dam_to_bodypart = std::min( dam, get_part_hp_cur( part_to_damage ) );
+
+    mod_part_hp_cur( part_to_damage, - dam_to_bodypart );
+    get_event_bus().send<event_type::character_takes_damage>( getID(), dam_to_bodypart );
 
     if( !weapon.is_null() && !as_player()->can_wield( weapon ).success() &&
         can_unwield( weapon ).success() ) {
@@ -8011,9 +8013,9 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam, const
         put_into_vehicle_or_drop( *this, item_drop_reason::tumbling, { weapon } );
         i_rem( &weapon );
     }
-    if( has_effect( effect_mending, hurt->main_part->token ) && ( source == nullptr ||
+    if( has_effect( effect_mending, part_to_damage->token ) && ( source == nullptr ||
             !source->is_hallucination() ) ) {
-        effect &e = get_effect( effect_mending, hurt->main_part->token );
+        effect &e = get_effect( effect_mending, part_to_damage->token );
         float remove_mend = dam / 20.0f;
         e.mod_duration( -e.get_max_duration() * remove_mend );
     }
@@ -8025,11 +8027,11 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam, const
     if( !bypass_med ) {
         // remove healing effects if damaged
         int remove_med = roll_remainder( dam / 5.0f );
-        if( remove_med > 0 && has_effect( effect_bandaged, hurt->main_part->token ) ) {
-            remove_med -= reduce_healing_effect( effect_bandaged, remove_med, hurt->main_part );
+        if( remove_med > 0 && has_effect( effect_bandaged, part_to_damage->token ) ) {
+            remove_med -= reduce_healing_effect( effect_bandaged, remove_med, part_to_damage );
         }
-        if( remove_med > 0 && has_effect( effect_disinfected, hurt->main_part->token ) ) {
-            reduce_healing_effect( effect_disinfected, remove_med, hurt->main_part );
+        if( remove_med > 0 && has_effect( effect_disinfected, part_to_damage->token ) ) {
+            reduce_healing_effect( effect_disinfected, remove_med, part_to_damage );
         }
     }
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7999,9 +7999,9 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam, const
 
     mod_pain( dam / 2 );
 
-    const int dam_to_bodypart = std::min( dam, get_part_hp_cur( hurt ) );
+    const int dam_to_bodypart = std::min( dam, get_part_hp_cur( hurt->main_part ) );
 
-    mod_part_hp_cur( hurt, - dam_to_bodypart );
+    mod_part_hp_cur( hurt->main_part, - dam_to_bodypart );
     g->events().send<event_type::character_takes_damage>( getID(), dam_to_bodypart );
 
     if( !weapon.is_null() && !as_player()->can_wield( weapon ).success() &&
@@ -8011,9 +8011,9 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam, const
         put_into_vehicle_or_drop( *this, item_drop_reason::tumbling, { weapon } );
         i_rem( &weapon );
     }
-    if( has_effect( effect_mending, hurt->token ) && ( source == nullptr ||
+    if( has_effect( effect_mending, hurt->main_part->token ) && ( source == nullptr ||
             !source->is_hallucination() ) ) {
-        effect &e = get_effect( effect_mending, hurt->token );
+        effect &e = get_effect( effect_mending, hurt->main_part->token );
         float remove_mend = dam / 20.0f;
         e.mod_duration( -e.get_max_duration() * remove_mend );
     }
@@ -8025,11 +8025,11 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam, const
     if( !bypass_med ) {
         // remove healing effects if damaged
         int remove_med = roll_remainder( dam / 5.0f );
-        if( remove_med > 0 && has_effect( effect_bandaged, hurt->token ) ) {
-            remove_med -= reduce_healing_effect( effect_bandaged, remove_med, hurt );
+        if( remove_med > 0 && has_effect( effect_bandaged, hurt->main_part->token ) ) {
+            remove_med -= reduce_healing_effect( effect_bandaged, remove_med, hurt->main_part );
         }
-        if( remove_med > 0 && has_effect( effect_disinfected, hurt->token ) ) {
-            reduce_healing_effect( effect_disinfected, remove_med, hurt );
+        if( remove_med > 0 && has_effect( effect_disinfected, hurt->main_part->token ) ) {
+            reduce_healing_effect( effect_disinfected, remove_med, hurt->main_part );
         }
     }
 }
@@ -8238,7 +8238,7 @@ void Character::hurtall( int dam, Creature *source, bool disturb /*= true*/ )
         return;
     }
 
-    for( const bodypart_id &bp : get_all_body_parts() ) {
+    for( const bodypart_id &bp : get_all_body_parts( true ) ) {
         // Don't use apply_damage here or it will annoy the player with 6 queries
         const int dam_to_bodypart = std::min( dam, get_part_hp_cur( bp ) );
         mod_part_hp_cur( bp, - dam_to_bodypart );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1663,7 +1663,8 @@ void Character::recalc_hp()
 
 void Character::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_max )
 {
-    for( std::pair<const bodypart_str_id, bodypart> &part : get_body() ) {
+    for( const std::pair<const bodypart_str_id, bodypart> &part : get_body() ) {
+        bodypart &bp = *get_part( part.first );
         int new_max = ( part.first->base_hp + str_max * 3 + hp_adjustment ) * hp_mod;
 
         if( has_trait( trait_id( "GLASSJAW" ) ) && part.first == bodypart_str_id( "head" ) ) {
@@ -1671,12 +1672,12 @@ void Character::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_ma
         }
 
         float max_hp_ratio = static_cast<float>( new_max ) /
-                             static_cast<float>( part.second.get_hp_max() );
+                             static_cast<float>( bp.get_hp_max() );
 
-        int new_cur = std::ceil( static_cast<float>( part.second.get_hp_cur() ) * max_hp_ratio );
+        int new_cur = std::ceil( static_cast<float>( bp.get_hp_cur() ) * max_hp_ratio );
 
-        part.second.set_hp_max( std::max( new_max, 1 ) );
-        part.second.set_hp_cur( std::max( std::min( new_cur, new_max ), 1 ) );
+        bp.set_hp_max( std::max( new_max, 1 ) );
+        bp.set_hp_cur( std::max( std::min( new_cur, new_max ), 1 ) );
     }
 }
 

--- a/src/character.h
+++ b/src/character.h
@@ -591,6 +591,8 @@ class Character : public Creature, public visitable<Character>
 
         /** Recalculates HP after a change to max strength */
         void recalc_hp();
+        /** Sets hp for all body parts */
+        void calc_all_parts_hp( float hp_mod = 0.0, float hp_adjust = 0.0, int str_max = 0 );
         /** Modifies the player's sight values
          *  Must be called when any of the following change:
          *  This must be called when any of the following change:
@@ -788,11 +790,11 @@ class Character : public Creature, public visitable<Character>
         /** Returns the number of functioning legs */
         int get_working_leg_count() const;
         /** Returns true if the limb is disabled(12.5% or less hp)*/
-        bool is_limb_disabled( hp_part limb ) const;
+        bool is_limb_disabled( const bodypart_id &limb ) const;
         /** Returns true if the limb is hindered(40% or less hp) */
         bool is_limb_hindered( hp_part limb ) const;
         /** Returns true if the limb is broken */
-        bool is_limb_broken( hp_part limb ) const;
+        bool is_limb_broken( const bodypart_id &limb ) const;
         /** source of truth of whether a Character can run */
         bool can_run();
         /** Hurts all body parts for dam, no armor reduction */
@@ -802,9 +804,7 @@ class Character : public Creature, public visitable<Character>
         /** Handles effects that happen when the player is damaged and aware of the fact. */
         void on_hurt( Creature *source, bool disturb = true );
         /** Heals a body_part for dam */
-        void heal( body_part healed, int dam );
-        /** Heals an hp_part for dam */
-        void heal( hp_part healed, int dam );
+        void heal( const bodypart_id &healed, int dam );
         /** Heals all body parts for dam */
         void healall( int dam );
         /**
@@ -1580,7 +1580,7 @@ class Character : public Creature, public visitable<Character>
         bool male;
 
         std::list<item> worn;
-        std::array<int, num_hp_parts> hp_cur, hp_max, damage_bandaged, damage_disinfected;
+        std::array<int, num_hp_parts> damage_bandaged, damage_disinfected;
         bool nv_cached;
         // Means player sit inside vehicle on the tile he is now
         bool in_vehicle;
@@ -2078,11 +2078,6 @@ class Character : public Creature, public visitable<Character>
 
         // used in debugging all health
         int get_lowest_hp() const;
-
-        int get_hp( hp_part bp ) const override;
-        int get_hp() const override;
-        int get_hp_max( hp_part bp ) const override;
-        int get_hp_max() const override;
         bool has_weapon() const override;
         void shift_destination( const point &shift );
         // Auto move methods

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1393,13 +1393,14 @@ void Creature::set_anatomy( anatomy_id anat )
     creature_anatomy = anat;
 }
 
-std::map<bodypart_str_id, bodypart> Creature::get_body() const
+const std::map<bodypart_str_id, bodypart> &Creature::get_body() const
 {
     return body;
 }
 
 void Creature::set_body()
 {
+    body.clear();
     for( const bodypart_id &bp : get_anatomy()->get_bodyparts() ) {
         body.emplace( bp.id(), bodypart( bp.id() ) );
     }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -583,40 +583,40 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
         add_effect( effect_bounced, 1_turns );
     }
 
-    body_part bp_hit;
+    bodypart_id bp_hit;
     double hit_value = missed_by + rng_float( -0.5, 0.5 );
     if( targetted_crit_allowed || magic ) { //default logic for selecting bodypart
         if( goodhit < accuracy_critical && hit_value <= 0.2 ) {
-            bp_hit = bp_head;
+            bp_hit = bodypart_str_id( "head" );
         } else if( hit_value <= 0.4 || magic ) {
-            bp_hit = bp_torso;
+            bp_hit = bodypart_str_id( "torso" );
         } else if( one_in( 4 ) ) {
             if( one_in( 2 ) ) {
-                bp_hit = bp_leg_l;
+                bp_hit = bodypart_str_id( "leg_l" );
             } else {
-                bp_hit = bp_leg_r;
+                bp_hit = bodypart_str_id( "leg_r" );
             }
         } else {
             if( one_in( 2 ) ) {
-                bp_hit = bp_arm_l;
+                bp_hit = bodypart_str_id( "arm_l" );
             } else {
-                bp_hit = bp_arm_r;
+                bp_hit = bodypart_str_id( "arm_r" );
             }
         }
     } else { // no crit logic for selecting bodypart
         if( hit_value <= 0.4 && !one_in( 4 ) ) {
-            bp_hit = one_in( 3 ) ? bp_head : bp_torso;
+            bp_hit = one_in( 3 ) ? bodypart_str_id( "head" ) : bodypart_str_id( "torso" );
         } else if( one_in( 4 ) ) {
             if( one_in( 2 ) ) {
-                bp_hit = bp_leg_l;
+                bp_hit = bodypart_str_id( "leg_l" );
             } else {
-                bp_hit = bp_leg_r;
+                bp_hit = bodypart_str_id( "leg_r" );
             }
         } else {
             if( one_in( 2 ) ) {
-                bp_hit = bp_arm_l;
+                bp_hit = bodypart_str_id( "arm_l" );
             } else {
-                bp_hit = bp_arm_r;
+                bp_hit = bodypart_str_id( "arm_r" );
             }
         }
     }
@@ -655,16 +655,14 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
     impact.mult_damage( damage_mult );
 
     if( proj_effects.count( "NOGIB" ) > 0 ) {
-        float dmg_ratio = static_cast<float>( impact.total_damage() ) / get_hp_max( player::bp_to_hp(
-                              bp_hit ) );
+        float dmg_ratio = static_cast<float>( impact.total_damage() ) / get_hp_max( bp_hit );
         if( dmg_ratio > 1.25f ) {
             impact.mult_damage( 1.0f / dmg_ratio );
         }
     }
 
-    const bodypart_id bp_hit_id = convert_bp( bp_hit ).id();
-    dealt_dam = deal_damage( source, bp_hit_id, impact );
-    dealt_dam.bp_hit = bp_hit;
+    dealt_dam = deal_damage( source, bp_hit, impact );
+    dealt_dam.bp_hit = bp_hit->token;
 
     // Apply ammo effects to target.
     if( proj.proj_effects.count( "TANGLE" ) ) {
@@ -690,19 +688,19 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
     }
     if( proj.proj_effects.count( "INCENDIARY" ) ) {
         if( made_of( material_id( "veggy" ) ) || made_of_any( cmat_flammable ) ) {
-            add_effect( effect_onfire, rng( 2_turns, 6_turns ), bp_hit );
+            add_effect( effect_onfire, rng( 2_turns, 6_turns ), bp_hit->token );
         } else if( made_of_any( cmat_flesh ) && one_in( 4 ) ) {
-            add_effect( effect_onfire, rng( 1_turns, 4_turns ), bp_hit );
+            add_effect( effect_onfire, rng( 1_turns, 4_turns ), bp_hit->token );
         }
     } else if( proj.proj_effects.count( "IGNITE" ) ) {
         if( made_of( material_id( "veggy" ) ) || made_of_any( cmat_flammable ) ) {
-            add_effect( effect_onfire, 6_turns, bp_hit );
+            add_effect( effect_onfire, 6_turns, bp_hit->token );
         } else if( made_of_any( cmat_flesh ) ) {
-            add_effect( effect_onfire, 10_turns, bp_hit );
+            add_effect( effect_onfire, 10_turns, bp_hit->token );
         }
     }
 
-    if( bp_hit == bp_head && proj_effects.count( "BLINDS_EYES" ) ) {
+    if( bp_hit == bodypart_str_id( "head" ) && proj_effects.count( "BLINDS_EYES" ) ) {
         // TODO: Change this to require bp_eyes
         add_env_effect( effect_blind, bp_eyes, 5, rng( 3_turns, 10_turns ) );
     }
@@ -1395,6 +1393,98 @@ void Creature::set_anatomy( anatomy_id anat )
     creature_anatomy = anat;
 }
 
+std::map<bodypart_str_id, bodypart> Creature::get_body() const
+{
+    return body;
+}
+
+void Creature::set_body()
+{
+    for( const bodypart_id &bp : get_anatomy()->get_bodyparts() ) {
+        body.emplace( bp.id(), bodypart( bp.id() ) );
+    }
+}
+
+bodypart *Creature::get_part( const bodypart_id &id )
+{
+    auto found = body.find( id.id() );
+    if( found == body.end() ) {
+        debugmsg( "Could not find bodypart %s in %s's body", id.id().c_str(), get_name() );
+        return nullptr;
+    }
+    return &found->second;
+}
+
+bodypart Creature::get_part( const bodypart_id &id ) const
+{
+    auto found = body.find( id.id() );
+    if( found == body.end() ) {
+        debugmsg( "Could not find bodypart %s in %s's body", id.id().c_str(), get_name() );
+        return bodypart();
+    }
+    return found->second;
+}
+
+int Creature::get_part_hp_cur( const bodypart_id &id ) const
+{
+    return get_part( id ).get_hp_cur();
+}
+
+int Creature::get_part_hp_max( const bodypart_id &id ) const
+{
+    return get_part( id ).get_hp_max();
+}
+
+int Creature::get_part_healed_total( const bodypart_id &id ) const
+{
+    return get_part( id ).get_healed_total();
+}
+
+void Creature::set_part_hp_cur( const bodypart_id &id, int set )
+{
+    get_part( id )->set_hp_cur( set );
+}
+
+void Creature::set_part_hp_max( const bodypart_id &id, int set )
+{
+    get_part( id )->set_hp_max( set );
+}
+
+void Creature::set_part_healed_total( const bodypart_id &id, int set )
+{
+    get_part( id )->set_healed_total( set );
+}
+
+void Creature::mod_part_hp_cur( const bodypart_id &id, int mod )
+{
+    get_part( id )->mod_hp_cur( mod );
+}
+
+void Creature::mod_part_hp_max( const bodypart_id &id, int mod )
+{
+    get_part( id )->mod_hp_max( mod );
+}
+
+void Creature::mod_part_healed_total( const bodypart_id &id, int mod )
+{
+    get_part( id )->mod_healed_total( mod );
+}
+
+void Creature::set_all_parts_hp_cur( const int set )
+{
+    for( std::pair<const bodypart_str_id, bodypart> &elem : body ) {
+        elem.second.set_hp_cur( set );
+    }
+}
+
+void Creature::set_all_parts_hp_to_max()
+{
+    for( std::pair<const bodypart_str_id, bodypart> &elem : body ) {
+        elem.second.set_hp_to_max();
+    }
+}
+
+
 bodypart_id Creature::get_random_body_part( bool main ) const
 {
     // TODO: Refuse broken limbs, adjust for mutations
@@ -1404,17 +1494,49 @@ bodypart_id Creature::get_random_body_part( bool main ) const
 
 std::vector<bodypart_id> Creature::get_all_body_parts( bool only_main ) const
 {
-    // TODO: Remove broken parts, parts removed by mutations etc.
-
-    const std::vector<bodypart_id> &all_bps = get_anatomy()->get_bodyparts();
-    std::vector<bodypart_id> main_bps;
-
-    for( const bodypart_id bp : all_bps ) {
-        if( bp->main_part.id() == bp ) {
-            main_bps.emplace_back( bp );
+    std::vector<bodypart_id> all_bps;
+    for( const std::pair<const bodypart_str_id, bodypart> &elem : body ) {
+        if( only_main && elem.first->main_part != elem.first ) {
+            continue;
         }
+        all_bps.push_back( elem.first );
     }
-    return only_main ? main_bps : all_bps;
+
+    return  all_bps;
+}
+
+int Creature::get_hp( const bodypart_id &bp ) const
+{
+    if( bp != bodypart_id( "num_bp" ) ) {
+        return get_part_hp_cur( bp );
+    }
+    int hp_total = 0;
+    for( const std::pair<const bodypart_str_id, bodypart> &elem : get_body() ) {
+        hp_total += elem.second.get_hp_cur();
+    }
+    return hp_total;
+}
+
+int Creature::get_hp() const
+{
+    return get_hp( bodypart_id( "num_bp" ) );
+}
+
+int Creature::get_hp_max( const bodypart_id &bp ) const
+{
+    if( bp != bodypart_id( "num_bp" ) ) {
+        return get_part_hp_max( bp );
+    }
+    int hp_total = 0;
+    for( const std::pair<const bodypart_str_id, bodypart> &elem : get_body() ) {
+        hp_total += elem.second.get_hp_max();
+    }
+    return hp_total;
+}
+
+int Creature::get_hp_max() const
+{
+    return get_hp_max( bodypart_id( "num_bp" ) );
 }
 
 int Creature::get_speed_base() const

--- a/src/creature.h
+++ b/src/creature.h
@@ -466,7 +466,7 @@ class Creature
          */
         std::vector<bodypart_id> get_all_body_parts( bool only_main = false ) const;
 
-        std::map<bodypart_str_id, bodypart> get_body() const;
+        const std::map<bodypart_str_id, bodypart> &get_body() const;
         void set_body();
         bodypart *get_part( const bodypart_id &id );
         bodypart get_part( const bodypart_id &id ) const;

--- a/src/creature.h
+++ b/src/creature.h
@@ -428,10 +428,10 @@ class Creature
 
         virtual int get_speed() const;
         virtual m_size get_size() const = 0;
-        virtual int get_hp( hp_part bp ) const = 0;
-        virtual int get_hp() const = 0;
-        virtual int get_hp_max( hp_part bp ) const = 0;
-        virtual int get_hp_max() const = 0;
+        virtual int get_hp( const bodypart_id &bp ) const;
+        virtual int get_hp() const;
+        virtual int get_hp_max( const bodypart_id &bp ) const;
+        virtual int get_hp_max() const;
         virtual int hp_percentage() const = 0;
         virtual bool made_of( const material_id &m ) const = 0;
         virtual bool made_of_any( const std::set<material_id> &ms ) const = 0;
@@ -450,7 +450,12 @@ class Creature
             return false;
         }
 
+    private:
+        /**anatomy is the plan of the creature's body*/
         anatomy_id creature_anatomy = anatomy_id( "default_anatomy" );
+        /**this is the actual body of the creature*/
+        std::map<bodypart_str_id, bodypart> body;
+    public:
         anatomy_id get_anatomy() const;
         void set_anatomy( anatomy_id anat );
 
@@ -460,6 +465,27 @@ class Creature
          * @param only_main If true, only displays parts that can have hit points
          */
         std::vector<bodypart_id> get_all_body_parts( bool only_main = false ) const;
+
+        std::map<bodypart_str_id, bodypart> get_body() const;
+        void set_body();
+        bodypart *get_part( const bodypart_id &id );
+        bodypart get_part( const bodypart_id &id ) const;
+
+        int get_part_hp_cur( const bodypart_id &id ) const;
+        int get_part_hp_max( const bodypart_id &id ) const;
+
+        int get_part_healed_total( const bodypart_id &id ) const;
+
+        void set_part_hp_cur( const bodypart_id &id, int set );
+        void set_part_hp_max( const bodypart_id &id, int set );
+        void set_part_healed_total( const bodypart_id &id, int set );
+        void mod_part_hp_cur( const bodypart_id &id, int mod );
+        void mod_part_hp_max( const bodypart_id &id, int mod );
+        void mod_part_healed_total( const bodypart_id &id, int mod );
+
+
+        void set_all_parts_hp_cur( int set );
+        void set_all_parts_hp_to_max();
 
         virtual int get_speed_base() const;
         virtual int get_speed_bonus() const;

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -636,36 +636,49 @@ void character_edit_menu()
         }
         break;
         case D_HP: {
+            const int torso_hp = p.get_part_hp_cur( bodypart_id( "torso" ) );
+            const int head_hp = p.get_part_hp_cur( bodypart_id( "head" ) );
+            const int arm_l_hp = p.get_part_hp_cur( bodypart_id( "arm_l" ) );
+            const int arm_r_hp = p.get_part_hp_cur( bodypart_id( "arm_r" ) );
+            const int leg_l_hp = p.get_part_hp_cur( bodypart_id( "leg_l" ) );
+            const int leg_r_hp = p.get_part_hp_cur( bodypart_id( "leg_r" ) );
             uilist smenu;
-            smenu.addentry( 0, true, 'q', "%s: %d", _( "Torso" ), p.hp_cur[hp_torso] );
-            smenu.addentry( 1, true, 'w', "%s: %d", _( "Head" ), p.hp_cur[hp_head] );
-            smenu.addentry( 2, true, 'a', "%s: %d", _( "Left arm" ), p.hp_cur[hp_arm_l] );
-            smenu.addentry( 3, true, 's', "%s: %d", _( "Right arm" ), p.hp_cur[hp_arm_r] );
-            smenu.addentry( 4, true, 'z', "%s: %d", _( "Left leg" ), p.hp_cur[hp_leg_l] );
-            smenu.addentry( 5, true, 'x', "%s: %d", _( "Right leg" ), p.hp_cur[hp_leg_r] );
+            smenu.addentry( 0, true, 'q', "%s: %d", _( "Torso" ), torso_hp );
+            smenu.addentry( 1, true, 'w', "%s: %d", _( "Head" ), head_hp );
+            smenu.addentry( 2, true, 'a', "%s: %d", _( "Left arm" ), arm_l_hp );
+            smenu.addentry( 3, true, 's', "%s: %d", _( "Right arm" ), arm_r_hp );
+            smenu.addentry( 4, true, 'z', "%s: %d", _( "Left leg" ), leg_l_hp );
+            smenu.addentry( 5, true, 'x', "%s: %d", _( "Right leg" ), leg_r_hp );
             smenu.addentry( 6, true, 'e', "%s: %d", _( "All" ), p.get_lowest_hp() );
             smenu.query();
-            int *bp_ptr = nullptr;
+            bodypart_str_id bp = bodypart_str_id( "no_a_real_part" );
+            int bp_ptr = -1;
             bool all_select = false;
 
             switch( smenu.ret ) {
                 case 0:
-                    bp_ptr = &p.hp_cur[hp_torso];
+                    bp = bodypart_str_id( "torso" );
+                    bp_ptr = torso_hp;
                     break;
                 case 1:
-                    bp_ptr = &p.hp_cur[hp_head];
+                    bp = bodypart_str_id( "head" );
+                    bp_ptr = head_hp;
                     break;
                 case 2:
-                    bp_ptr = &p.hp_cur[hp_arm_l];
+                    bp = bodypart_str_id( "arm_l" );
+                    bp_ptr = arm_l_hp;
                     break;
                 case 3:
-                    bp_ptr = &p.hp_cur[hp_arm_r];
+                    bp = bodypart_str_id( "arm_r" );
+                    bp_ptr = arm_r_hp;
                     break;
                 case 4:
-                    bp_ptr = &p.hp_cur[hp_leg_l];
+                    bp = bodypart_str_id( "leg_l" );
+                    bp_ptr = leg_l_hp;
                     break;
                 case 5:
-                    bp_ptr = &p.hp_cur[hp_leg_r];
+                    bp = bodypart_str_id( "leg_r" );
+                    bp_ptr = leg_r_hp;
                     break;
                 case 6:
                     all_select = true;
@@ -674,19 +687,17 @@ void character_edit_menu()
                     break;
             }
 
-            if( bp_ptr != nullptr ) {
+            if( bp.is_valid() ) {
                 int value;
-                if( query_int( value, _( "Set the hitpoints to?  Currently: %d" ), *bp_ptr ) && value >= 0 ) {
-                    *bp_ptr = value;
+                if( query_int( value, _( "Set the hitpoints to?  Currently: %d" ), bp_ptr ) && value >= 0 ) {
+                    p.set_part_hp_cur( bp.id(), value );
                     p.reset_stats();
                 }
             } else if( all_select ) {
                 int value;
                 if( query_int( value, _( "Set the hitpoints to?  Currently: %d" ), p.get_lowest_hp() ) &&
                     value >= 0 ) {
-                    for( int &cur_hp : p.hp_cur ) {
-                        cur_hp = value;
-                    }
+                    p.set_all_parts_hp_cur( value );
                     p.reset_stats();
                 }
             }
@@ -1334,7 +1345,7 @@ void debug()
         case DEBUG_KILL_NPCS:
             for( npc &guy : g->all_npcs() ) {
                 add_msg( _( "%s's head implodes!" ), guy.name );
-                guy.hp_cur[bp_head] = 0;
+                guy.set_part_hp_cur( bodypart_id( "head" ), 0 );
             }
             break;
 
@@ -1538,13 +1549,19 @@ void debug()
 
         // Damage Self
         case DEBUG_DAMAGE_SELF: {
+            const int torso_hp = u.get_part_hp_cur( bodypart_id( "torso" ) );
+            const int head_hp = u.get_part_hp_cur( bodypart_id( "head" ) );
+            const int arm_l_hp = u.get_part_hp_cur( bodypart_id( "arm_l" ) );
+            const int arm_r_hp = u.get_part_hp_cur( bodypart_id( "arm_r" ) );
+            const int leg_l_hp = u.get_part_hp_cur( bodypart_id( "leg_l" ) );
+            const int leg_r_hp = u.get_part_hp_cur( bodypart_id( "leg_r" ) );
             uilist smenu;
-            smenu.addentry( 0, true, 'q', "%s: %d", _( "Torso" ), u.hp_cur[hp_torso] );
-            smenu.addentry( 1, true, 'w', "%s: %d", _( "Head" ), u.hp_cur[hp_head] );
-            smenu.addentry( 2, true, 'a', "%s: %d", _( "Left arm" ), u.hp_cur[hp_arm_l] );
-            smenu.addentry( 3, true, 's', "%s: %d", _( "Right arm" ), u.hp_cur[hp_arm_r] );
-            smenu.addentry( 4, true, 'z', "%s: %d", _( "Left leg" ), u.hp_cur[hp_leg_l] );
-            smenu.addentry( 5, true, 'x', "%s: %d", _( "Right leg" ), u.hp_cur[hp_leg_r] );
+            smenu.addentry( 0, true, 'q', "%s: %d", _( "Torso" ), torso_hp );
+            smenu.addentry( 1, true, 'w', "%s: %d", _( "Head" ), head_hp );
+            smenu.addentry( 2, true, 'a', "%s: %d", _( "Left arm" ), arm_l_hp );
+            smenu.addentry( 3, true, 's', "%s: %d", _( "Right arm" ), arm_r_hp );
+            smenu.addentry( 4, true, 'z', "%s: %d", _( "Left leg" ), leg_l_hp );
+            smenu.addentry( 5, true, 'x', "%s: %d", _( "Right leg" ), leg_r_hp );
             smenu.query();
             bodypart_id part;
             int dbg_damage;

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -114,9 +114,7 @@ bool tutorial_game::init()
     g->u.int_cur = g->u.int_max;
     g->u.dex_cur = g->u.dex_max;
 
-    for( int i = 0; i < num_hp_parts; i++ ) {
-        g->u.hp_cur[i] = g->u.hp_max[i];
-    }
+    g->u.set_all_parts_hp_to_max();
 
     const oter_id rock( "rock" );
     //~ default name for the tutorial

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4661,9 +4661,9 @@ void iexamine::autodoc( player &p, const tripoint &examp )
         case BONESETTING: {
             int broken_limbs_count = 0;
             for( int i = 0; i < num_hp_parts; i++ ) {
-                const bool broken = patient.is_limb_broken( static_cast<hp_part>( i ) );
-                body_part part = player::hp_to_bp( static_cast<hp_part>( i ) );
-                effect &existing_effect = patient.get_effect( effect_mending, part );
+                const bodypart_id &part = convert_bp( player::hp_to_bp( static_cast<hp_part>( i ) ) ).id();
+                const bool broken = patient.is_limb_broken( part );
+                effect &existing_effect = patient.get_effect( effect_mending, part->token );
                 // Skip part if not broken or already healed 50%
                 if( !broken || ( !existing_effect.is_null() &&
                                  existing_effect.get_duration() >
@@ -4676,7 +4676,7 @@ void iexamine::autodoc( player &p, const tripoint &examp )
                                                _( "The machine rapidly sets and splints <npcname>'s broken %s." ),
                                                body_part_name( part ) );
                 // TODO: fail here if unable to perform the action, i.e. can't wear more, trait mismatch.
-                if( !patient.worn_with_flag( flag_SPLINT, convert_bp( part ).id() ) ) {
+                if( !patient.worn_with_flag( flag_SPLINT, part ) ) {
                     item splint;
                     if( i == hp_arm_l || i == hp_arm_r ) {
                         splint = item( "arm_splint", calendar::start_of_cataclysm );
@@ -4687,8 +4687,8 @@ void iexamine::autodoc( player &p, const tripoint &examp )
                     cata::optional<std::list<item>::iterator> worn_item =
                         patient.wear( equipped_splint, false );
                 }
-                patient.add_effect( effect_mending, 0_turns, part, true );
-                effect &mending_effect = patient.get_effect( effect_mending, part );
+                patient.add_effect( effect_mending, 0_turns, part->token, true );
+                effect &mending_effect = patient.get_effect( effect_mending, part->token );
                 mending_effect.set_duration( mending_effect.get_max_duration() - 5_days );
             }
             if( broken_limbs_count == 0 ) {
@@ -5645,7 +5645,7 @@ void iexamine::dimensional_portal( player &p, const tripoint &pos )
         }
 
         case 1:
-            p.hp_cur[hp_torso] = 0;
+            p.set_all_parts_hp_cur( 0 );
             g->m.translate_radius( t_dimensional_portal, t_thconc_floor, 5, pos, true );
             g->win();
             break;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -703,7 +703,12 @@ bool item::is_unarmed_weapon() const
 
 bool item::covers( const body_part bp ) const
 {
-    return get_covered_body_parts().test( bp );
+    return covers( convert_bp( bp ) );
+}
+
+bool item::covers( const bodypart_id &bp ) const
+{
+    return get_covered_body_parts().test( bp->token );
 }
 
 body_part_set item::get_covered_body_parts() const
@@ -4016,9 +4021,9 @@ void item::on_wear( Character &p )
     if( is_sided() && get_side() == side::BOTH ) {
         if( has_flag( flag_SPLINT ) ) {
             set_side( side::LEFT );
-            if( ( covers( bp_leg_l ) && p.is_limb_broken( hp_leg_r ) &&
+            if( ( covers( bodypart_id( "leg_l" ) ) && p.is_limb_broken( bodypart_id( "leg_r" ) ) &&
                   !p.worn_with_flag( flag_SPLINT, bodypart_id( "leg_r" ) ) ) ||
-                ( covers( bp_arm_l ) && p.is_limb_broken( hp_arm_r ) &&
+                ( covers( bodypart_id( "arm_l" ) ) && p.is_limb_broken( bodypart_id( "arm_r" ) ) &&
                   !p.worn_with_flag( flag_SPLINT, bodypart_id( "arm_r" ) ) ) ) {
                 set_side( side::RIGHT );
             }

--- a/src/item.h
+++ b/src/item.h
@@ -1474,6 +1474,7 @@ class item : public visitable<item>
          * Whether this item (when worn) covers the given body part.
          */
         bool covers( body_part bp ) const;
+        bool covers( const bodypart_id &bp ) const;
         /**
          * Bitset of all covered body parts.
          *

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3581,10 +3581,11 @@ int iuse::granade_act( player *p, item *it, bool t, const tripoint &pos )
                         /** @EFFECT_PER_MAX increases possible granade per buff */
                         buff_stat( g->u.per_max, rng( 0, g->u.per_max / 2 ) );
                         g->u.recalc_hp();
-                        for( int part = 0; part < num_hp_parts; part++ ) {
-                            g->u.hp_cur[part] *= 1 + rng( 0, 20 ) * .1;
-                            if( g->u.hp_cur[part] > g->u.hp_max[part] ) {
-                                g->u.hp_cur[part] = g->u.hp_max[part];
+                        for( const bodypart_id &bp : g->u.get_all_body_parts() ) {
+                            g->u.set_part_hp_cur( bp, g->u.get_part_hp_cur( bp ) * rng_float( 1, 1.2 ) );
+                            const int hp_max = g->u.get_part_hp_max( bp );
+                            if( g->u.get_part_hp_cur( bp ) > hp_max ) {
+                                g->u.set_part_hp_cur( bp, hp_max );
                             }
                         }
                     }
@@ -3620,9 +3621,10 @@ int iuse::granade_act( player *p, item *it, bool t, const tripoint &pos )
                         /** @EFFECT_PER_MAX increases possible granade per debuff (NEGATIVE) */
                         g->u.per_max -= rng( 0, g->u.per_max / 2 );
                         g->u.recalc_hp();
-                        for( int part = 0; part < num_hp_parts; part++ ) {
-                            if( g->u.hp_cur[part] > 0 ) {
-                                g->u.hp_cur[part] = rng( 1, g->u.hp_cur[part] );
+                        for( const bodypart_id &bp : g->u.get_all_body_parts() ) {
+                            const int hp_cur = g->u.get_part_hp_cur( bp );
+                            if( hp_cur > 0 ) {
+                                g->u.set_part_hp_cur( bp, rng( 1, hp_cur ) );
                             }
                         }
                     }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3647,10 +3647,12 @@ int heal_actor::finish_using( player &healer, player &patient, item &it, hp_part
     float practice_amount = limb_power * 3.0f;
     const int dam = get_heal_value( healer, healed );
 
-    if( ( patient.hp_cur[healed] >= 1 ) && ( dam > 0 ) ) { // Prevent first-aid from mending limbs
-        patient.heal( healed, dam );
-    } else if( ( patient.hp_cur[healed] >= 1 ) && ( dam < 0 ) ) {
-        const bodypart_id bp = convert_bp( player::hp_to_bp( healed ) ).id();
+    const bodypart_id bp = convert_bp( Character::hp_to_bp( healed ) ).id();
+    const int cur_hp = patient.get_part_hp_cur( bp );
+
+    if( ( cur_hp >= 1 ) && ( dam > 0 ) ) { // Prevent first-aid from mending limbs
+        patient.heal( bp, dam );
+    } else if( ( cur_hp >= 1 ) && ( dam < 0 ) ) {
         patient.apply_damage( nullptr, bp, -dam ); //hurt takes + damage
     }
 
@@ -3739,7 +3741,7 @@ int heal_actor::finish_using( player &healer, player &patient, item &it, hp_part
         patient.add_effect( effect_bandaged, 1_turns, bp_healed );
         effect &e = patient.get_effect( effect_bandaged, bp_healed );
         e.set_duration( e.get_int_dur_factor() * bandages_intensity );
-        patient.damage_bandaged[healed] = patient.hp_max[healed] - patient.hp_cur[healed];
+        patient.damage_bandaged[healed] = patient.get_part_hp_max( bp ) - patient.get_part_hp_cur( bp );
         practice_amount += 2 * bandages_intensity;
     }
     if( disinfectant_power > 0 ) {
@@ -3747,7 +3749,7 @@ int heal_actor::finish_using( player &healer, player &patient, item &it, hp_part
         patient.add_effect( effect_disinfected, 1_turns, bp_healed );
         effect &e = patient.get_effect( effect_disinfected, bp_healed );
         e.set_duration( e.get_int_dur_factor() * disinfectant_intensity );
-        patient.damage_disinfected[healed] = patient.hp_max[healed] - patient.hp_cur[healed];
+        patient.damage_disinfected[healed] = patient.get_part_hp_max( bp ) - patient.get_part_hp_cur( bp );
         practice_amount += 2 * disinfectant_intensity;
     }
     practice_amount = std::max( 9.0f, practice_amount );
@@ -3780,14 +3782,14 @@ static hp_part pick_part_to_heal(
             return num_hp_parts;
         }
 
-        body_part bp = player::hp_to_bp( healed_part );
-        if( ( infect && patient.has_effect( effect_infected, bp ) ) ||
-            ( bite && patient.has_effect( effect_bite, bp ) ) ||
-            ( bleed && patient.has_effect( effect_bleed, bp ) ) ) {
+        const bodypart_id &bp = convert_bp( player::hp_to_bp( healed_part ) ).id();
+        if( ( infect && patient.has_effect( effect_infected, bp->token ) ) ||
+            ( bite && patient.has_effect( effect_bite, bp->token ) ) ||
+            ( bleed && patient.has_effect( effect_bleed, bp->token ) ) ) {
             return healed_part;
         }
 
-        if( patient.is_limb_broken( healed_part ) ) {
+        if( patient.is_limb_broken( bp ) ) {
             if( healed_part == hp_arm_l || healed_part == hp_arm_r ) {
                 add_msg( m_info, _( "That arm is broken.  It needs surgical attention or a splint." ) );
             } else if( healed_part == hp_leg_l || healed_part == hp_leg_r ) {
@@ -3799,7 +3801,7 @@ static hp_part pick_part_to_heal(
             continue;
         }
 
-        if( force || patient.hp_cur[healed_part] < patient.hp_max[healed_part] ) {
+        if( force || patient.get_part_hp_cur( bp ) < patient.get_part_hp_max( bp ) ) {
             return healed_part;
         }
     }
@@ -3807,7 +3809,7 @@ static hp_part pick_part_to_heal(
 
 hp_part heal_actor::use_healing_item( player &healer, player &patient, item &it, bool force ) const
 {
-    hp_part healed = num_hp_parts;
+    bodypart_id healed = bodypart_id( "num_bp" );
     const int head_bonus = get_heal_value( healer, hp_head );
     const int limb_power = get_heal_value( healer, hp_arm_l );
     const int torso_bonus = get_heal_value( healer, hp_torso );
@@ -3823,31 +3825,31 @@ hp_part heal_actor::use_healing_item( player &healer, player &patient, item &it,
         // NPCs heal whatever has sustained the most damaged that they can heal but never
         // rebandage parts
         int highest_damage = 0;
-        for( int i = 0; i < num_hp_parts; i++ ) {
+        for( const std::pair<const bodypart_str_id, bodypart> &elem : patient.get_body() ) {
+            const bodypart &part = elem.second;
             int damage = 0;
-            const body_part i_bp = player::hp_to_bp( static_cast<hp_part>( i ) );
-            if( ( !patient.has_effect( effect_bandaged, i_bp ) && bandages_power > 0 ) ||
-                ( !patient.has_effect( effect_disinfected, i_bp ) && disinfectant_power > 0 ) ) {
-                damage += patient.hp_max[i] - patient.hp_cur[i];
-                damage += bleed * patient.get_effect_dur( effect_bleed, i_bp ) / 5_minutes;
-                damage += bite * patient.get_effect_dur( effect_bite, i_bp ) / 10_minutes;
-                damage += infect * patient.get_effect_dur( effect_infected, i_bp ) / 10_minutes;
+            if( ( !patient.has_effect( effect_bandaged, elem.first->token ) && bandages_power > 0 ) ||
+                ( !patient.has_effect( effect_disinfected, elem.first->token ) && disinfectant_power > 0 ) ) {
+                damage += part.get_hp_max() - part.get_hp_cur();
+                damage += bleed * patient.get_effect_dur( effect_bleed, elem.first->token ) / 5_minutes;
+                damage += bite * patient.get_effect_dur( effect_bite, elem.first->token ) / 10_minutes;
+                damage += infect * patient.get_effect_dur( effect_infected, elem.first->token ) / 10_minutes;
             }
             if( damage > highest_damage ) {
                 highest_damage = damage;
-                healed = static_cast<hp_part>( i );
+                healed = elem.first.id();
             }
         }
     } else if( patient.is_player() ) {
         // Player healing self - let player select
         if( healer.activity.id() != ACT_FIRSTAID ) {
             const std::string menu_header = _( "Select a body part for: " ) + it.tname();
-            healed = pick_part_to_heal( healer, patient, menu_header,
-                                        limb_power, head_bonus, torso_bonus,
-                                        bleed, bite, infect, force,
-                                        get_bandaged_level( healer ),
-                                        get_disinfected_level( healer ) );
-            if( healed == num_hp_parts ) {
+            healed = convert_bp( Character::hp_to_bp( pick_part_to_heal( healer, patient, menu_header,
+                                 limb_power, head_bonus, torso_bonus,
+                                 bleed, bite, infect, force,
+                                 get_bandaged_level( healer ),
+                                 get_disinfected_level( healer ) ) ) ).id();
+            if( healed == bodypart_id( "num_bp" ) ) {
                 add_msg( m_info, _( "Never mind." ) );
                 return num_hp_parts; // canceled
             }
@@ -3855,10 +3857,11 @@ hp_part heal_actor::use_healing_item( player &healer, player &patient, item &it,
         // Brick healing if using a first aid kit for the first time.
         if( long_action && healer.activity.id() != ACT_FIRSTAID ) {
             // Cancel and wait for activity completion.
-            return healed;
+            return Character::bp_to_hp( healed->token );
         } else if( healer.activity.id() == ACT_FIRSTAID ) {
             // Completed activity, extract body part from it.
-            healed = static_cast<hp_part>( healer.activity.values[0] );
+            healed = convert_bp( Character::hp_to_bp( static_cast<hp_part>
+                                 ( healer.activity.values[0] ) ) ).id();
         }
     } else {
         // Player healing NPC
@@ -3867,18 +3870,18 @@ hp_part heal_actor::use_healing_item( player &healer, player &patient, item &it,
                                         //~ %1$s: patient name, %2$s: healing item name
                                         "Select a body part of %1$s for %2$s:" ),
                                         patient.disp_name(), it.tname() );
-        healed = pick_part_to_heal( healer, patient, menu_header,
-                                    limb_power, head_bonus, torso_bonus,
-                                    bleed, bite, infect, force,
-                                    get_bandaged_level( healer ),
-                                    get_disinfected_level( healer ) );
+        healed = convert_bp( Character::hp_to_bp( pick_part_to_heal( healer, patient, menu_header,
+                             limb_power, head_bonus, torso_bonus,
+                             bleed, bite, infect, force,
+                             get_bandaged_level( healer ),
+                             get_disinfected_level( healer ) ) ) ).id();
     }
 
-    if( healed != num_hp_parts ) {
-        finish_using( healer, patient, it, healed );
+    if( healed != bodypart_id( "num_bp" ) ) {
+        finish_using( healer, patient, it, Character::bp_to_hp( healed->token ) );
     }
 
-    return healed;
+    return Character::bp_to_hp( healed->token );
 }
 
 void heal_actor::info( const item &, std::vector<iteminfo> &dump ) const

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -674,8 +674,8 @@ bool spell::can_cast( const Character &guy ) const
         case stamina_energy:
             return guy.get_stamina() >= energy_cost( guy );
         case hp_energy: {
-            for( int i = 0; i < num_hp_parts; i++ ) {
-                if( energy_cost( guy ) < guy.hp_cur[i] ) {
+            for( const std::pair<const bodypart_str_id, bodypart> &elem : guy.get_body() ) {
+                if( energy_cost( guy ) < elem.second.get_hp_cur() ) {
                     return true;
                 }
             }
@@ -1473,8 +1473,8 @@ bool known_magic::has_enough_energy( const Character &guy, spell &sp ) const
         case stamina_energy:
             return guy.get_stamina() >= cost;
         case hp_energy:
-            for( int i = 0; i < num_hp_parts; i++ ) {
-                if( guy.hp_cur[i] > cost ) {
+            for( const std::pair<const bodypart_str_id, bodypart> &elem : guy.get_body() ) {
+                if( elem.second.get_hp_cur() > cost ) {
                     return true;
                 }
             }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -139,18 +139,15 @@ void spell_effect::pain_split( const spell &sp, Creature &caster, const tripoint
     int num_limbs = 0; // number of limbs effected (broken don't count)
     int total_hp = 0; // total hp among limbs
 
-    for( const int &part : p->hp_cur ) {
-        if( part != 0 ) {
-            num_limbs++;
-            total_hp += part;
+    for( const std::pair<const bodypart_str_id, bodypart> &elem : p->get_body() ) {
+        if( elem.first == bodypart_str_id( "num_bp" ) ) {
+            continue;
         }
+        num_limbs++;
+        total_hp += elem.second.get_hp_cur();
     }
-    for( int &part : p->hp_cur ) {
-        const int hp_each = total_hp / num_limbs;
-        if( part != 0 ) {
-            part = hp_each;
-        }
-    }
+    const int hp_each = total_hp / num_limbs;
+    p->set_all_parts_hp_cur( hp_each );
 }
 
 static bool in_spell_aoe( const tripoint &start, const tripoint &end, const int &radius,

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -981,7 +981,8 @@ bool character_martial_arts::can_arm_block( const Character &owner ) const
                             skill_unarmed );
 
     // Success conditions.
-    if( !owner.is_limb_broken( hp_arm_l ) || !owner.is_limb_broken( hp_arm_r ) ) {
+    if( !owner.is_limb_broken( bodypart_id( "arm_l" ) ) ||
+        !owner.is_limb_broken( bodypart_id( "arm_r" ) ) ) {
         if( unarmed_skill >= ma.arm_block ) {
             return true;
         } else if( ma.arm_block_with_bio_armor_arms && owner.has_bionic( bio_armor_arms ) ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1607,11 +1607,11 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
 
         // Check if we should actually use the right side to block
         if( bp_hit == bodypart_id( "leg_l" ) ) {
-            if( hp_cur[hp_leg_r] > hp_cur[hp_leg_l] ) {
+            if( get_part_hp_cur( bodypart_id( "leg_r" ) ) > get_part_hp_cur( bodypart_id( "leg_l" ) ) ) {
                 bp_hit = bodypart_id( "leg_r" );
             }
         } else {
-            if( hp_cur[hp_arm_r] > hp_cur[hp_arm_l] ) {
+            if( get_part_hp_cur( bodypart_id( "arm_r" ) ) > get_part_hp_cur( bodypart_id( "arm_l" ) ) ) {
                 bp_hit = bodypart_id( "arm_r" );
             }
         }

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -200,18 +200,18 @@ void memorial_logger::write( std::ostream &file, const std::string &epitaph ) co
     //HP
 
     const auto limb_hp =
-    [&file, &indent, &u]( const std::string & desc, const hp_part bp ) {
+    [&file, &indent, &u]( const std::string & desc, const bodypart_id bp ) {
         file << indent <<
-             string_format( desc, u.get_hp( bp ), u.get_hp_max( bp ) ) << eol;
+             string_format( desc, u.get_part_hp_cur( bp ), u.get_part_hp_max( bp ) ) << eol;
     };
 
     file << _( "Final HP:" ) << eol;
-    limb_hp( _( " Head: %d/%d" ), hp_head );
-    limb_hp( _( "Torso: %d/%d" ), hp_torso );
-    limb_hp( _( "L Arm: %d/%d" ), hp_arm_l );
-    limb_hp( _( "R Arm: %d/%d" ), hp_arm_r );
-    limb_hp( _( "L Leg: %d/%d" ), hp_leg_l );
-    limb_hp( _( "R Leg: %d/%d" ), hp_leg_r );
+    limb_hp( _( " Head: %d/%d" ), bodypart_id( "head" ) );
+    limb_hp( _( "Torso: %d/%d" ), bodypart_id( "torso" ) );
+    limb_hp( _( "L Arm: %d/%d" ), bodypart_id( "arm_l" ) );
+    limb_hp( _( "R Arm: %d/%d" ), bodypart_id( "arm_r" ) );
+    limb_hp( _( "L Leg: %d/%d" ), bodypart_id( "leg_l" ) );
+    limb_hp( _( "R Leg: %d/%d" ), bodypart_id( "leg_r" ) );
     file << eol;
 
     //Stats

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -821,7 +821,7 @@ void talk_function::caravan_return( npc &p, const std::string &dest, const std::
     int money = 0;
     for( const auto &elem : caravan_party ) {
         //Scrub temporary party members and the dead
-        if( elem->hp_cur[hp_torso] == 0 && elem->has_companion_mission() ) {
+        if( elem->get_part_hp_cur( bodypart_id( "torso" ) ) == 0 && elem->has_companion_mission() ) {
             overmap_buffer.remove_npc( comp->getID() );
             money += ( time / 600 ) * 9;
         } else if( elem->has_companion_mission() ) {
@@ -865,7 +865,7 @@ void talk_function::attack_random( const std::vector< monster * > &group,
     const auto def = random_entry( defender );
     att->melee_attack( *def );
     //monster mon;
-    if( def->hp_cur[hp_torso] <= 0 || def->is_dead() ) {
+    if( def->get_part_hp_cur( bodypart_id( "torso" ) ) <= 0 || def->is_dead() ) {
         popup( _( "%s is wasted by %s!" ), def->name, att->type->nname() );
     }
 }
@@ -886,7 +886,7 @@ void talk_function::attack_random( const std::vector<npc_ptr> &attacker,
     }
     ///\EFFECT_DODGE_NPC increases avoidance of random attacks
     if( rng( -1, best_score ) >= rng( 0, def->get_skill_level( skill_dodge ) ) ) {
-        def->hp_cur[hp_torso] = 0;
+        def->set_part_hp_cur( bodypart_id( "torso" ), 0 );
         popup( _( "%s is wasted by %s!" ), def->name, att->name );
     } else {
         popup( _( "%s dodges %s's attack!" ), def->name, att->name );
@@ -899,7 +899,7 @@ int talk_function::combat_score( const std::vector<npc_ptr> &group )
 {
     int score = 0;
     for( const auto &elem : group ) {
-        if( elem->hp_cur[hp_torso] != 0 ) {
+        if( elem->get_part_hp_cur( bodypart_id( "torso" ) ) != 0 ) {
             const skill_id best = elem->best_skill();
             if( best ) {
                 score += elem->get_skill_level( best );
@@ -1604,7 +1604,8 @@ bool talk_function::force_on_force( const std::vector<npc_ptr> &defender,
         }
         std::vector<npc_ptr> remaining_def;
         for( const auto &elem : defender ) {
-            if( !elem->is_dead() && elem->hp_cur[hp_torso] >= 0 && elem->hp_cur[hp_head] >= 0 ) {
+            if( !elem->is_dead() && elem->get_part_hp_cur( bodypart_id( "torso" ) ) >= 0 &&
+                elem->get_part_hp_cur( bodypart_id( "head" ) ) >= 0 ) {
                 remaining_def.push_back( elem );
             }
         }
@@ -1663,13 +1664,13 @@ void talk_function::force_on_force( const std::vector<npc_ptr> &defender,
     while( true ) {
         std::vector<npc_ptr> remaining_att;
         for( const auto &elem : attacker ) {
-            if( elem->hp_cur[hp_torso] != 0 ) {
+            if( elem->get_part_hp_cur( bodypart_id( "torso" ) ) != 0 ) {
                 remaining_att.push_back( elem );
             }
         }
         std::vector<npc_ptr> remaining_def;
         for( const auto &elem : defender ) {
-            if( elem->hp_cur[hp_torso] != 0 ) {
+            if( elem->get_part_hp_cur( bodypart_id( "torso" ) ) != 0 ) {
                 remaining_def.push_back( elem );
             }
         }
@@ -1679,7 +1680,7 @@ void talk_function::force_on_force( const std::vector<npc_ptr> &defender,
         if( attack > defense * 3 ) {
             attack_random( remaining_att, remaining_def );
             if( defense == 0 || ( remaining_def.size() == 1 &&
-                                  remaining_def[0]->hp_cur[hp_torso] == 0 ) ) {
+                                  remaining_def[0]->get_part_hp_cur( bodypart_id( "torso" ) ) == 0 ) ) {
                 popup( _( "%s forces are destroyed!" ), defender[0]->get_faction()->name );
             } else {
                 popup( _( "%s forces retreat from combat!" ), defender[0]->get_faction()->name );
@@ -1688,7 +1689,7 @@ void talk_function::force_on_force( const std::vector<npc_ptr> &defender,
         } else if( attack * 3 < defense ) {
             attack_random( remaining_def, remaining_att );
             if( attack == 0 || ( remaining_att.size() == 1 &&
-                                 remaining_att[0]->hp_cur[hp_torso] == 0 ) ) {
+                                 remaining_att[0]->get_part_hp_cur( bodypart_id( "torso" ) ) == 0 ) ) {
                 popup( _( "%s forces are destroyed!" ), attacker[0]->get_faction()->name );
             } else {
                 popup( _( "%s forces retreat from combat!" ), attacker[0]->get_faction()->name );

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -752,7 +752,7 @@ void mdeath::jabberwock( monster &z )
 void mdeath::gameover( monster &z )
 {
     add_msg( m_bad, _( "The %s was destroyed!  GAME OVER!" ), z.name() );
-    g->u.hp_cur[hp_torso] = 0;
+    g->u.set_part_hp_cur( bodypart_id( "torso" ), 0 );
 }
 
 void mdeath::kill_breathers( monster &/*z*/ )

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -238,6 +238,8 @@ monster::monster()
     last_updated = calendar::start_of_cataclysm;
     udder_timer = calendar::turn;
     horde_attraction = MHA_NULL;
+    set_anatomy( anatomy_id( "default_anatomy" ) );
+    set_body();
 }
 
 monster::monster( const mtype_id &id ) : monster()
@@ -1156,7 +1158,7 @@ monster_attitude monster::attitude( const Character *u ) const
 
 int monster::hp_percentage() const
 {
-    return get_hp( hp_torso ) * 100 / get_hp_max();
+    return get_hp( bodypart_id( "torso" ) ) * 100 / get_hp_max();
 }
 
 void monster::process_triggers()
@@ -2850,7 +2852,7 @@ void monster::on_damage_of_type( int amt, damage_type dt, const bodypart_id &bp 
     }
 }
 
-int monster::get_hp_max( hp_part ) const
+int monster::get_hp_max( const bodypart_id & ) const
 {
     return type->hp;
 }
@@ -2860,7 +2862,7 @@ int monster::get_hp_max() const
     return type->hp;
 }
 
-int monster::get_hp( hp_part ) const
+int monster::get_hp( const bodypart_id & ) const
 {
     return hp;
 }

--- a/src/monster.h
+++ b/src/monster.h
@@ -109,9 +109,9 @@ class monster : public Creature
         units::mass get_weight() const override;
         units::mass weight_capacity() const override;
         units::volume get_volume() const;
-        int get_hp( hp_part ) const override;
+        int get_hp( const bodypart_id & ) const override;
         int get_hp() const override;
-        int get_hp_max( hp_part ) const override;
+        int get_hp_max( const bodypart_id & ) const override;
         int get_hp_max() const override;
         int hp_percentage() const override;
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -368,6 +368,7 @@ void avatar::randomize( const bool random_scenario, points_left &points, bool pl
         }
         loops++;
     }
+    set_body();
 }
 
 bool avatar::create( character_type type, const std::string &tempname )
@@ -419,7 +420,7 @@ bool avatar::create( character_type type, const std::string &tempname )
                              "Saving will override the already existing character.\n\n"
                              "Continue anyways?" ), name );
     };
-
+    set_body();
     const bool allow_reroll = type == character_type::RANDOM;
     tab_direction result = tab_direction::QUIT;
     do {
@@ -495,9 +496,6 @@ bool avatar::create( character_type type, const std::string &tempname )
     save_template( _( "Last Character" ), points );
 
     recalc_hp();
-    for( int i = 0; i < num_hp_parts; i++ ) {
-        hp_cur[i] = hp_max[i];
-    }
 
     if( has_trait( trait_SMELLY ) ) {
         scent = 800;
@@ -510,7 +508,7 @@ bool avatar::create( character_type type, const std::string &tempname )
 
     // Grab the skills from the profession, if there are any
     // We want to do this before the recipes
-    for( auto &e : prof->skills() ) {
+    for( const profession::StartingSkill &e : prof->skills() ) {
         mod_skill_level( e.first, e.second );
     }
 
@@ -578,7 +576,7 @@ bool avatar::create( character_type type, const std::string &tempname )
         addictions.push_back( *iter );
     }
 
-    for( auto &bio : prof->CBMs() ) {
+    for( const bionic_id &bio : prof->CBMs() ) {
         add_bionic( bio );
     }
     // Adjust current energy level to maximum
@@ -844,7 +842,8 @@ tab_direction set_stats( avatar &u, points_left &points )
                                _( "Increasing Str further costs 2 points." ) );
                 }
                 u.recalc_hp();
-                mvwprintz( w_description, point_zero, COL_STAT_NEUTRAL, _( "Base HP: %d" ), u.hp_max[0] );
+                mvwprintz( w_description, point_zero, COL_STAT_NEUTRAL, _( "Base HP: %d" ),
+                           u.get_part_hp_max( bodypart_id( "head" ) ) );
                 // NOLINTNEXTLINE(cata-use-named-point-constants)
                 mvwprintz( w_description, point( 0, 1 ), COL_STAT_NEUTRAL, _( "Carry weight: %.1f %s" ),
                            convert_weight( u.weight_capacity() ), weight_units() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -625,7 +625,7 @@ float npc::character_danger( const Character &uc ) const
     }
     ret += u_weap_val;
 
-    ret += hp_percentage() * get_hp_max( hp_torso ) / 100.0 / my_weap_val;
+    ret += hp_percentage() * get_hp_max( bodypart_id( "torso" ) ) / 100.0 / my_weap_val;
 
     ret += my_gun ? u.get_dodge() / 2 : u.get_dodge();
 
@@ -1735,35 +1735,33 @@ healing_options npc::patient_assessment( const Character &c )
     healing_options try_to_fix;
     try_to_fix.clear_all();
 
-    for( int i = 0; i < num_hp_parts; i++ ) {
-        const hp_part part = static_cast<hp_part>( i );
-        const body_part bp_wounded = hp_to_bp( part );
+    for( const std::pair<const bodypart_str_id, bodypart> &elem : c.get_body() ) {
 
-        if( c.has_effect( effect_bleed, bp_wounded ) ) {
+        if( c.has_effect( effect_bleed, elem.first->token ) ) {
             try_to_fix.bleed = true;
         }
 
-        if( c.has_effect( effect_bite, bp_wounded ) ) {
+        if( c.has_effect( effect_bite, elem.first->token ) ) {
             try_to_fix.bite = true;
         }
 
-        if( c.has_effect( effect_infected, bp_wounded ) ) {
+        if( c.has_effect( effect_infected, elem.first->token ) ) {
             try_to_fix.infect = true;
         }
         int part_threshold = 75;
-        if( part == hp_head ) {
+        if( elem.first == bodypart_str_id( "head" ) ) {
             part_threshold += 20;
-        } else if( part == hp_torso ) {
+        } else if( elem.first == bodypart_str_id( "torso" ) ) {
             part_threshold += 10;
         }
         part_threshold = std::min( 80, part_threshold );
-        part_threshold = part_threshold * c.hp_max[i] / 100;
+        part_threshold = part_threshold * elem.second.get_hp_max() / 100;
 
-        if( c.hp_cur[i] <= part_threshold ) {
-            if( !c.has_effect( effect_bandaged, bp_wounded ) ) {
+        if( elem.second.get_hp_cur() <= part_threshold ) {
+            if( !c.has_effect( effect_bandaged, elem.first->token ) ) {
                 try_to_fix.bandage = true;
             }
-            if( !c.has_effect( effect_disinfected, bp_wounded ) ) {
+            if( !c.has_effect( effect_disinfected, elem.first->token ) ) {
                 try_to_fix.disinfect = true;
             }
         }
@@ -4553,8 +4551,8 @@ void npc::do_reload( const item &it )
 bool npc::adjust_worn()
 {
     bool any_broken = false;
-    for( int i = 0; i < num_hp_parts; i++ ) {
-        if( is_limb_broken( static_cast<hp_part>( i ) ) ) {
+    for( const bodypart_id &bp : get_all_body_parts() ) {
+        if( is_limb_broken( bp ) ) {
             any_broken = true;
             break;
         }
@@ -4564,9 +4562,9 @@ bool npc::adjust_worn()
         return false;
     }
     const auto covers_broken = [this]( const item & it, side s ) {
-        const auto covered = it.get_covered_body_parts( s );
-        for( size_t i = 0; i < num_hp_parts; i++ ) {
-            if( hp_cur[ i ] <= 0 && covered.test( hp_to_bp( static_cast<hp_part>( i ) ) ) ) {
+        const body_part_set covered = it.get_covered_body_parts( s );
+        for( const std::pair<const bodypart_str_id, bodypart> &elem : get_body() ) {
+            if( elem.second.get_hp_cur() <= 0 && covered.test( elem.first->token ) ) {
                 return true;
             }
         }

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -555,7 +555,7 @@ void talk_function::give_aid( npc &p )
     p.add_effect( effect_currently_busy, 30_minutes );
     for( int i = 0; i < num_hp_parts; i++ ) {
         const body_part bp_healed = player::hp_to_bp( static_cast<hp_part>( i ) );
-        g->u.heal( static_cast<hp_part>( i ), 5 * rng( 2, 5 ) );
+        g->u.heal( convert_bp( bp_healed ), 5 * rng( 2, 5 ) );
         if( g->u.has_effect( effect_bite, bp_healed ) ) {
             g->u.remove_effect( effect_bite, bp_healed );
         }
@@ -579,7 +579,7 @@ void talk_function::give_all_aid( npc &p )
         if( guy.is_walking_with() && rl_dist( guy.pos(), g->u.pos() ) < PICKUP_RANGE ) {
             for( int i = 0; i < num_hp_parts; i++ ) {
                 const body_part bp_healed = player::hp_to_bp( static_cast<hp_part>( i ) );
-                guy.heal( static_cast<hp_part>( i ), 5 * rng( 2, 5 ) );
+                guy.heal( convert_bp( bp_healed ), 5 * rng( 2, 5 ) );
                 if( guy.has_effect( effect_bite, bp_healed ) ) {
                     guy.remove_effect( effect_bite, bp_healed );
                 }

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -877,16 +877,16 @@ static void draw_limb_health( avatar &u, const catacurses::window &w, int limb_i
             wprintz( w, color, sym );
         }
     };
-    if( u.is_limb_broken( static_cast<hp_part>( limb_index ) ) && ( limb_index >= hp_arm_l &&
-            limb_index <= hp_leg_r ) ) {
+    const bodypart_id bp = convert_bp( avatar::hp_to_bp( static_cast<hp_part>( limb_index ) ) ).id();
+    if( u.is_limb_broken( bp.id() ) && ( limb_index >= hp_arm_l &&
+                                         limb_index <= hp_leg_r ) ) {
         //Limb is broken
         std::string limb = "~~%~~";
         nc_color color = c_light_red;
 
-        const auto bp = avatar::hp_to_bp( static_cast<hp_part>( limb_index ) );
-        if( u.worn_with_flag( "SPLINT", convert_bp( bp ).id() ) ) {
+        if( u.worn_with_flag( "SPLINT",  bp ) ) {
             static const efftype_id effect_mending( "mending" );
-            const auto &eff = u.get_effect( effect_mending, bp );
+            const auto &eff = u.get_effect( effect_mending, bp->token );
             const int mend_perc = eff.is_null() ? 0.0 : 100 * eff.get_duration() / eff.get_max_duration();
 
             if( is_self_aware || u.has_effect( effect_got_checked ) ) {
@@ -904,10 +904,12 @@ static void draw_limb_health( avatar &u, const catacurses::window &w, int limb_i
         return;
     }
 
-    std::pair<std::string, nc_color> hp = get_hp_bar( u.hp_cur[limb_index], u.hp_max[limb_index] );
+    const int hp_cur = u.get_part_hp_cur( bp );
+    const int hp_max = u.get_part_hp_max( bp );
+    std::pair<std::string, nc_color> hp = get_hp_bar( hp_cur, hp_max );
 
     if( is_self_aware || u.has_effect( effect_got_checked ) ) {
-        wprintz( w, hp.second, "%3d  ", u.hp_cur[limb_index] );
+        wprintz( w, hp.second, "%3d  ", hp_cur );
     } else {
         wprintz( w, hp.second, hp.first );
 

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -928,7 +928,7 @@ static void draw_limb2( avatar &u, const catacurses::window &w )
     werase( w );
     // print limb health
     for( int i = 0; i < num_hp_parts; i++ ) {
-        const std::string str = body_part_hp_bar_ui_text( part[i]->token );
+        const std::string str = body_part_hp_bar_ui_text( part[i] );
         if( i % 2 == 0 ) {
             wmove( w, point( 0, i / 2 ) );
         } else {
@@ -1164,7 +1164,7 @@ static void draw_limb_narrow( avatar &u, const catacurses::window &w )
             nx = 19;
         }
 
-        std::string str = body_part_hp_bar_ui_text( part[i]->token );
+        std::string str = body_part_hp_bar_ui_text( part[i] );
         wmove( w, point( nx, ny ) );
         str = left_justify( str, 5 );
         wprintz( w, u.limb_color( part[i], true, true, true ), str + ":" );
@@ -1188,7 +1188,7 @@ static void draw_limb_wide( avatar &u, const catacurses::window &w )
         int ny = offset / 45;
         int nx = offset % 45;
         std::string str = string_format( " %s: ",
-                                         left_justify( body_part_hp_bar_ui_text( parts[i].first->token ), 5 ) );
+                                         left_justify( body_part_hp_bar_ui_text( parts[i].first ), 5 ) );
         nc_color part_color = u.limb_color( parts[i].first, true, true, true );
         print_colored_text( w, point( nx, ny ), part_color, c_white, str );
         draw_limb_health( u, w, parts[i].second );
@@ -1573,7 +1573,7 @@ static void draw_health_classic( avatar &u, const catacurses::window &w )
 
     // print limb health
     for( int i = 0; i < num_hp_parts; i++ ) {
-        const std::string str = body_part_hp_bar_ui_text( part[i]->token );
+        const std::string str = body_part_hp_bar_ui_text( part[i] );
         wmove( w, point( 8, i ) );
         wprintz( w, u.limb_color( part[i], true, true, true ), str );
         wmove( w, point( 14, i ) );

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -937,7 +937,8 @@ int player::intimidation() const
 
 bool player::is_dead_state() const
 {
-    return hp_cur[hp_head] <= 0 || hp_cur[hp_torso] <= 0;
+    return get_part_hp_cur( bodypart_id( "head" ) ) <= 0 ||
+           get_part_hp_cur( bodypart_id( "torso" ) ) <= 0;
 }
 
 void player::on_dodge( Creature *source, float difficulty )
@@ -1375,14 +1376,16 @@ void player::knock_back_to( const tripoint &to )
 
 int player::hp_percentage() const
 {
+    const bodypart_id head_id = bodypart_id( "head" );
+    const bodypart_id torso_id = bodypart_id( "torso" );
     int total_cur = 0;
     int total_max = 0;
     // Head and torso HP are weighted 3x and 2x, respectively
-    total_cur = hp_cur[hp_head] * 3 + hp_cur[hp_torso] * 2;
-    total_max = hp_max[hp_head] * 3 + hp_max[hp_torso] * 2;
-    for( int i = hp_arm_l; i < num_hp_parts; i++ ) {
-        total_cur += hp_cur[i];
-        total_max += hp_max[i];
+    total_cur = get_part_hp_cur( head_id ) * 3 + get_part_hp_cur( torso_id ) * 2;
+    total_max = get_part_hp_max( head_id ) * 3 + get_part_hp_max( torso_id ) * 2;
+    for( const std::pair< const bodypart_str_id, bodypart> &elem : get_body() ) {
+        total_cur += elem.second.get_hp_cur();
+        total_max += elem.second.get_hp_max();
     }
 
     return ( 100 * total_cur ) / total_max;
@@ -4417,9 +4420,7 @@ void player::environmental_revert_effect()
     addictions.clear();
     morale->clear();
 
-    for( int part = 0; part < num_hp_parts; part++ ) {
-        hp_cur[part] = hp_max[part];
-    }
+    set_all_parts_hp_to_max();
     set_hunger( 0 );
     set_thirst( 0 );
     set_fatigue( 0 );

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -377,7 +377,8 @@ static void draw_stats_info( const catacurses::window &w_info,
                         _( "Strength affects your melee damage, the amount of weight you can carry, your total HP, "
                            "your resistance to many diseases, and the effectiveness of actions which require brute force." ) );
         print_colored_text( w_info, point( 1, 3 ), col_temp, c_light_gray,
-                            string_format( _( "Base HP: <color_white>%d</color>" ), you.hp_max[1] ) );
+                            string_format( _( "Base HP: <color_white>%d</color>" ),
+                                           you.get_part_hp_max( bodypart_id( "torso" ) ) ) );
         print_colored_text( w_info, point( 1, 4 ), col_temp, c_light_gray,
                             string_format( _( "Carry weight (%s): <color_white>%.1f</color>" ), weight_units(),
                                            convert_weight( you.weight_capacity() ) ) );

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -877,7 +877,7 @@ void player::hardcoded_effects( effect &it )
                     _( "You dissolve into beautiful paroxysms of energy.  Life fades from your nebulae and you are no more." ) );
             }
             g->events().send<event_type::dies_from_drug_overdose>( getID(), id );
-            hp_cur[hp_torso] = 0;
+            set_part_hp_cur( bodypart_id( "torso" ), 0 );
         }
     } else if( id == effect_grabbed ) {
         set_num_blocks_bonus( get_num_blocks_bonus() - 1 );
@@ -1273,19 +1273,17 @@ void player::hardcoded_effects( effect &it )
             }
         }
     } else if( id == effect_mending ) {
-        if( !is_limb_broken( bp_to_hp( bp ) ) ) {
+        if( !is_limb_broken( convert_bp( bp ) ) ) {
             it.set_duration( 0_turns );
         }
     } else if( id == effect_disabled ) {
-        if( !is_limb_broken( bp_to_hp( bp ) ) ) {
+        if( !is_limb_broken( convert_bp( bp ) ) ) {
             // Just unpause, in case someone added it as a temporary effect (numbing poison etc.)
             it.unpause_effect();
         }
     } else if( id == effect_panacea ) {
         // restore health all body parts, dramatically reduce pain
-        for( int i = 0; i < num_hp_parts; i++ ) {
-            hp_cur[i] += 10;
-        }
+        healall( 1 );
         mod_pain( -10 );
     }
 }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -543,14 +543,23 @@ void Character::load( const JsonObject &data )
         data.read( "hp_cur", hp_cur );
         std::array<int, 6> hp_max;
         data.read( "hp_max", hp_max );
-        set_part_hp_cur( bodypart_id( "head" ), hp_cur[0] );
         set_part_hp_max( bodypart_id( "head" ), hp_max[0] );
-        set_part_hp_cur( bodypart_id( "torso" ), hp_cur[1] );
+        set_part_hp_cur( bodypart_id( "head" ), hp_cur[0] );
+
         set_part_hp_max( bodypart_id( "torso" ), hp_max[1] );
+        set_part_hp_cur( bodypart_id( "torso" ), hp_cur[1] );
+
+        set_part_hp_max( bodypart_id( "arm_l" ), hp_max[2] );
         set_part_hp_cur( bodypart_id( "arm_l" ), hp_cur[2] );
+
         set_part_hp_max( bodypart_id( "arm_r" ), hp_max[3] );
+        set_part_hp_cur( bodypart_id( "arm_r" ), hp_cur[3] );
+
+        set_part_hp_max( bodypart_id( "leg_l" ), hp_max[4] );
         set_part_hp_cur( bodypart_id( "leg_l" ), hp_cur[4] );
+
         set_part_hp_max( bodypart_id( "leg_r" ), hp_max[5] );
+        set_part_hp_cur( bodypart_id( "leg_r" ), hp_cur[5] );
     }
 
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -536,7 +536,9 @@ void Character::load( const JsonObject &data )
         on_item_wear( w );
     }
 
-    if( data.has_object( "hp_cur" ) ) {
+    if( data.has_array( "hp_cur" ) ) {
+        set_anatomy( anatomy_id( "human_anatomy" ) );
+        set_body();
         std::array<int, 6> hp_cur;
         data.read( "hp_cur", hp_cur );
         std::array<int, 6> hp_max;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -536,13 +536,21 @@ void Character::load( const JsonObject &data )
         on_item_wear( w );
     }
 
-    if( !data.read( "hp_cur", hp_cur ) ) {
-        debugmsg( "Error, incompatible hp_cur in save file '%s'", parray.str() );
+    if( data.has_object( "hp_cur" ) ) {
+        std::array<int, 6> hp_cur;
+        data.read( "hp_cur", hp_cur );
+        std::array<int, 6> hp_max;
+        data.read( "hp_max", hp_max );
+        set_part_hp_cur( bodypart_id( "head" ), hp_cur[0] );
+        set_part_hp_max( bodypart_id( "head" ), hp_max[0] );
+        set_part_hp_cur( bodypart_id( "torso" ), hp_cur[1] );
+        set_part_hp_max( bodypart_id( "torso" ), hp_max[1] );
+        set_part_hp_cur( bodypart_id( "arm_l" ), hp_cur[2] );
+        set_part_hp_max( bodypart_id( "arm_r" ), hp_max[3] );
+        set_part_hp_cur( bodypart_id( "leg_l" ), hp_cur[4] );
+        set_part_hp_max( bodypart_id( "leg_r" ), hp_max[5] );
     }
 
-    if( !data.read( "hp_max", hp_max ) ) {
-        debugmsg( "Error, incompatible hp_max in save file '%s'", parray.str() );
-    }
 
     inv.clear();
     if( data.has_member( "inv" ) ) {
@@ -788,9 +796,6 @@ void player::store( JsonOut &json ) const
     json.member( "id", getID() );
 
     // potential incompatibility with future expansion
-    // TODO: consider ["parts"]["head"]["hp_cur"] instead of ["hp_cur"][head_enum_value]
-    json.member( "hp_cur", hp_cur );
-    json.member( "hp_max", hp_max );
     json.member( "damage_bandaged", damage_bandaged );
     json.member( "damage_disinfected", damage_disinfected );
     // "Looks like I picked the wrong week to quit smoking." - Steve McCroskey
@@ -2977,6 +2982,8 @@ void Creature::store( JsonOut &jsout ) const
     jsout.member( "block_bonus", block_bonus );
     jsout.member( "hit_bonus", hit_bonus );
 
+    jsout.member( "body", body );
+
     // fake is not stored, it's temporary anyway, only used to fire with a gun.
 }
 
@@ -3032,6 +3039,8 @@ void Creature::load( const JsonObject &jsin )
     jsin.read( "hit_bonus", hit_bonus );
 
     jsin.read( "underwater", underwater );
+
+    jsin.read( "body", body );
 
     fake = false; // see Creature::load
 

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -402,24 +402,25 @@ void start_location::add_map_extra( const tripoint &omtstart, const std::string 
 
 void start_location::handle_heli_crash( player &u ) const
 {
-    for( int i = 2; i < num_hp_parts; i++ ) { // Skip head + torso for balance reasons.
-        const auto part = static_cast<hp_part>( i );
-        const auto bp_part = player::hp_to_bp( part );
+    for( const bodypart_id &bp : u.get_all_body_parts() ) {
+        if( bp == bodypart_id( "head" ) || bp == bodypart_id( "torso" ) ) {
+            continue;// Skip head + torso for balance reasons.
+        }
         const int roll = static_cast<int>( rng( 1, 8 ) );
         switch( roll ) {
             // Damage + Bleed
             case 1:
             case 2:
-                u.make_bleed( convert_bp( bp_part ).id(), 6_minutes );
+                u.make_bleed( bp, 6_minutes );
             /* fallthrough */
             case 3:
             case 4:
             // Just damage
             case 5: {
-                const auto maxHp = u.get_hp_max( part );
+                const int maxHp = u.get_hp_max( bp );
                 // Body part health will range from 33% to 66% with occasional bleed
                 const int dmg = static_cast<int>( rng( maxHp / 3, maxHp * 2 / 3 ) );
-                u.apply_damage( nullptr, convert_bp( bp_part ).id(), dmg );
+                u.apply_damage( nullptr, bp, dmg );
                 break;
             }
             // No damage

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -175,20 +175,20 @@ static float addiction_scaling( float at_min, float at_max, float add_lvl )
 
 void Character::suffer_water_damage( const mutation_branch &mdata )
 {
-    for( const body_part bp : all_body_parts ) {
-        const float wetness_percentage = static_cast<float>( body_wetness[bp] ) /
-                                         drench_capacity[bp];
+    for( const std::pair<const bodypart_str_id, bodypart> &elem : get_body() ) {
+        const float wetness_percentage = static_cast<float>( body_wetness[elem.first->token] ) /
+                                         drench_capacity[elem.first->token];
         const int dmg = mdata.weakness_to_water * wetness_percentage;
         if( dmg > 0 ) {
-            apply_damage( nullptr, convert_bp( bp ).id(), dmg );
+            apply_damage( nullptr, elem.first, dmg );
             add_msg_player_or_npc( m_bad, _( "Your %s is damaged by the water." ),
                                    _( "<npcname>'s %s is damaged by the water." ),
-                                   body_part_name( bp ) );
-        } else if( dmg < 0 && hp_cur[bp_to_hp( bp )] != hp_max[bp_to_hp( bp )] ) {
-            heal( bp, std::abs( dmg ) );
+                                   body_part_name( elem.first ) );
+        } else if( dmg < 0 && elem.second.is_at_max_hp() ) {
+            heal( elem.first, std::abs( dmg ) );
             add_msg_player_or_npc( m_good, _( "Your %s is healed by the water." ),
                                    _( "<npcname>'s %s is healed by the water." ),
-                                   body_part_name( bp ) );
+                                   body_part_name( elem.first ) );
         }
     }
 }
@@ -1405,10 +1405,9 @@ void Character::suffer()
 {
     const int current_stim = get_stim();
     // TODO: Remove this section and encapsulate hp_cur
-    for( int i = 0; i < num_hp_parts; i++ ) {
-        body_part bp = hp_to_bp( static_cast<hp_part>( i ) );
-        if( hp_cur[i] <= 0 ) {
-            add_effect( effect_disabled, 1_turns, bp, true );
+    for( const std::pair<const bodypart_str_id, bodypart> &elem : get_body() ) {
+        if( elem.second.get_hp_cur() <= 0 ) {
+            add_effect( effect_disabled, 1_turns, elem.first->token, true );
         }
     }
 
@@ -1542,8 +1541,8 @@ void Character::mend( int rate_multiplier )
 {
     // Wearing splints can slowly mend a broken limb back to 1 hp.
     bool any_broken = false;
-    for( int i = 0; i < num_hp_parts; i++ ) {
-        if( is_limb_broken( static_cast<hp_part>( i ) ) ) {
+    for( const bodypart_id &bp : get_all_body_parts() ) {
+        if( is_limb_broken( bp ) ) {
             any_broken = true;
             break;
         }
@@ -1611,33 +1610,32 @@ void Character::mend( int rate_multiplier )
         return;
     }
 
-    for( int i = 0; i < num_hp_parts; i++ ) {
-        const bool broken = is_limb_broken( static_cast<hp_part>( i ) );
+    for( const bodypart_id &bp : get_all_body_parts() ) {
+        const bool broken = is_limb_broken( bp );
         if( !broken ) {
             continue;
         }
 
-        body_part part = hp_to_bp( static_cast<hp_part>( i ) );
-        if( needs_splint && !worn_with_flag( "SPLINT", convert_bp( part ).id() ) ) {
+        if( needs_splint && !worn_with_flag( "SPLINT",  bp ) ) {
             continue;
         }
 
         const time_duration dur_inc = 1_turns * roll_remainder( rate_multiplier * healing_factor );
-        auto &eff = get_effect( effect_mending, part );
+        auto &eff = get_effect( effect_mending, bp->token );
         if( eff.is_null() ) {
-            add_effect( effect_mending, dur_inc, part, true );
+            add_effect( effect_mending, dur_inc, bp->token, true );
             continue;
         }
 
         eff.set_duration( eff.get_duration() + dur_inc );
 
         if( eff.get_duration() >= eff.get_max_duration() ) {
-            hp_cur[i] = 1;
-            remove_effect( effect_mending, part );
-            g->events().send<event_type::broken_bone_mends>( getID(), part );
+            set_part_hp_cur( bp, 1 );
+            remove_effect( effect_mending, bp->token );
+            g->events().send<event_type::broken_bone_mends>( getID(), bp->token );
             //~ %s is bodypart
             add_msg_if_player( m_good, _( "Your %s has started to mend!" ),
-                               body_part_name( part ) );
+                               body_part_name( bp ) );
         }
     }
 }

--- a/tests/encumbrance_test.cpp
+++ b/tests/encumbrance_test.cpp
@@ -25,6 +25,7 @@ static void test_encumbrance_on(
 )
 {
     CAPTURE( body_part );
+    p.set_body();
     p.clear_mutations();
     p.worn.clear();
     if( tweak_player ) {

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -325,7 +325,7 @@ TEST_CASE( "caffeine and atomic caffeine", "[iuse][caff][atomic_caff]" )
 TEST_CASE( "towel", "[iuse][towel]" )
 {
     avatar dummy;
-
+    dummy.set_body();
     item &towel = dummy.i_add( item( "towel", calendar::start_of_cataclysm,
                                      item::default_charges_tag{} ) );
 

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -67,10 +67,9 @@ static avatar get_sanitized_player()
 {
     // You'd think that this hp stuff would be in the c'tor...
     avatar ret = avatar();
+    ret.set_body();
     ret.recalc_hp();
-    for( int i = 0; i < num_hp_parts; i++ ) {
-        ret.hp_cur[i] = ret.hp_max[i];
-    }
+
     // Set these insanely high so can_eat doesn't return TOO_FULL
     ret.set_hunger( 10000 );
     ret.set_thirst( 10000 );

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -51,6 +51,7 @@ bool player_has_item_of_type( const std::string &type )
 
 void clear_character( player &dummy, bool debug_storage )
 {
+    dummy.set_body();
     dummy.normalize(); // In particular this clears martial arts style
 
     // Remove first worn item until there are none left.
@@ -105,6 +106,10 @@ void clear_character( player &dummy, bool debug_storage )
     dummy.set_dex_bonus( 0 );
     dummy.set_int_bonus( 0 );
     dummy.set_per_bonus( 0 );
+    dummy.reset_bonuses();
+    dummy.set_speed_base( 100 );
+    dummy.set_speed_bonus( 0 );
+    dummy.set_all_parts_hp_to_max();
 
     dummy.cash = 0;
 

--- a/tests/reload_option_test.cpp
+++ b/tests/reload_option_test.cpp
@@ -56,6 +56,7 @@ TEST_CASE( "belt_reload_option", "[reload],[reload_option],[gun]" )
 {
     const time_point bday = calendar::start_of_cataclysm;
     avatar dummy;
+    dummy.set_body();
 
     item &belt = dummy.i_add( item( "belt308", bday, 0 ) );
     item &ammo = dummy.i_add( item( "308", bday, belt.ammo_capacity() ) );


### PR DESCRIPTION
It's mostly a port of Fris0uman's HP to bodypart PR: #41194 
Plus a fix for `hp_cur/max` loading.

Changes from DDA version:
* Dropped the `hp_scaling` structure. Back to hardcoded `3 * str` bonus. I don't see much use for it. Maybe I'll port it when "weird" limbs become a thing.
* Max hp calculation moved from `Creature` to `Character`, because `Creature` has no use for it, so it's wrong to keep it there.
* Dropped square root from speed penalty due to leg damage. It's now linear from 0 to 50 per leg.

TODO:
* [x] Port necessary fixes as well