### PR TITLE
Revert "Skip and report duplicate tiles in tileset", fix sprite replacement mods

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -275,7 +275,11 @@ tileset::find_tile_type_by_season( const std::string &id, season_type season ) c
 
 tile_type &tileset::create_tile_type( const std::string &id, tile_type &&new_tile_type )
 {
-    auto inserted = tile_ids.insert( std::make_pair( id, new_tile_type ) ).first;
+    // Must overwrite existing tile
+    // TODO: c++17 - replace [] + find() with insert_or_assign()
+    tile_ids[id] = std::move( new_tile_type );
+    auto inserted = tile_ids.find( id );
+
     const std::string &inserted_id = inserted->first;
     tile_type &inserted_tile = inserted->second;
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -7,7 +7,6 @@
 #include <memory>
 #include <string>
 #include <tuple>
-#include <unordered_set>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -139,8 +138,6 @@ class tileset
         std::vector<texture> overexposed_tile_values;
         std::vector<texture> memory_tile_values;
 
-        std::unordered_set<std::string> duplicate_ids;
-
         std::unordered_map<std::string, tile_type> tile_ids;
         // caches both "default" and "_season_XXX" tile variants (to reduce the number of lookups)
         // either variant can be either a `nullptr` or a pointer/reference to the real value (stored inside `tile_ids`)
@@ -181,9 +178,6 @@ class tileset
         }
         const texture *get_memory_tile( const size_t index ) const {
             return get_if_available( index, memory_tile_values );
-        }
-        const std::unordered_set<std::string> &get_duplicate_ids() const {
-            return duplicate_ids;
         }
 
         tile_type &create_tile_type( const std::string &id, tile_type &&new_tile_type );
@@ -242,8 +236,14 @@ class tileset_loader
         void add_ascii_subtile( tile_type &curr_tile, const std::string &t_id, int sprite_id,
                                 const std::string &s_id );
         void load_ascii_set( const JsonObject &entry );
-
-        tile_type *load_tile( const JsonObject &entry, const std::string &id );
+        /**
+         * Create a new tile_type, add it to tile_ids (using <B>id</B>).
+         * Set the fg and bg properties of it (loaded from the json object).
+         * Makes sure each is either -1, or in the interval [0,size).
+         * If it's in that interval, adds offset to it, if it's not in the
+         * interval (and not -1), throw an std::string error.
+         */
+        tile_type &load_tile( const JsonObject &entry, const std::string &id );
 
         void load_tile_spritelists( const JsonObject &entry, weighted_int_list<std::vector<int>> &vs,
                                     const std::string &objname );
@@ -589,9 +589,6 @@ class cata_tiles
         template<typename Iter, typename Func>
         void lr_generic( Iter begin, Iter end, Func id_func, TILE_CATEGORY category,
                          const std::string &prefix );
-
-        void tile_loading_report_dups();
-
         /** Lighting */
         void init_light();
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -236,13 +236,7 @@ class tileset_loader
         void add_ascii_subtile( tile_type &curr_tile, const std::string &t_id, int sprite_id,
                                 const std::string &s_id );
         void load_ascii_set( const JsonObject &entry );
-        /**
-         * Create a new tile_type, add it to tile_ids (using <B>id</B>).
-         * Set the fg and bg properties of it (loaded from the json object).
-         * Makes sure each is either -1, or in the interval [0,size).
-         * If it's in that interval, adds offset to it, if it's not in the
-         * interval (and not -1), throw an std::string error.
-         */
+
         tile_type &load_tile( const JsonObject &entry, const std::string &id );
 
         void load_tile_spritelists( const JsonObject &entry, weighted_int_list<std::vector<int>> &vs,


### PR DESCRIPTION
#### Purpose of change
Fix sprite replacement mods after #516

#### Describe the solution
Revert 1e0f7b9d89434a83966170db2b27351c379abdcf, overwrite tiles same way as it was before optimizations.

#### Testing
Running around with UDP and changing seasons.
Also tested with sprite replacement mod from CleverRaven#45563