### PR TITLE
[DinoMod] More NPCs know about dinos

### DIFF
--- a/data/mods/DinoMod/NPC/Mr_Lapin.json
+++ b/data/mods/DinoMod/NPC/Mr_Lapin.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "TALK_WARRENER",
+    "type": "talk_topic",
+    "responses": [ { "text": "What can you tell me about the dinosaurs?", "topic": "TALK_WARRENER_DINOSAURS" } ]
+  },
+  {
+    "id": "TALK_WARRENER_DINOSAURS",
+    "type": "talk_topic",
+    "dynamic_line": "I am afraid that is drifting far out of my area of expertise, but I would be willing to bet some of the little ones might be worth something to you if you tamed them and raised them.  No fur to speak of, but feathers might be of some use, and meat and eggs could help.  I'm not sure what they eat, but I hope it isn't rabbits or people on the more rabbit adjacent end of things.",
+    "responses": [ { "text": "Maybe dinosaurs and rabbits aren't so different.", "topic": "TALK_WARRENER" } ]
+  }
+]

--- a/data/mods/DinoMod/NPC/NC_Yoshimi.json
+++ b/data/mods/DinoMod/NPC/NC_Yoshimi.json
@@ -16,7 +16,7 @@
     "name": "DinoLab survivor",
     "job_description": "Need to learn what happened…",
     "common": false,
-    "worn_override": [ "NC_SCIENTIST_coat" ],
+    "worn_override": "NC_SCIENTIST_coat",
     "carry_override": "NC_DOCTOR_misc",
     "weapon_override": "EMPTY_GROUP",
     "traits": [

--- a/data/mods/DinoMod/NPC/NC_Yoshimi.json
+++ b/data/mods/DinoMod/NPC/NC_Yoshimi.json
@@ -16,7 +16,7 @@
     "name": "DinoLab survivor",
     "job_description": "Need to learn what happened…",
     "common": false,
-    "worn_override": [ "NC_DOCTOR_coat", "NC_DOCTOR_pants_male", "NC_DOCTOR_eyes" ],
+    "worn_override": [ "NC_SCIENTIST_coat" ],
     "carry_override": "NC_DOCTOR_misc",
     "weapon_override": "EMPTY_GROUP",
     "traits": [

--- a/data/mods/DinoMod/NPC/NC_Yoshimi.json
+++ b/data/mods/DinoMod/NPC/NC_Yoshimi.json
@@ -1,0 +1,117 @@
+[
+  {
+    "type": "npc",
+    "id": "yoshimi",
+    "name_unique": "Yoshimi",
+    "name_suffix": "DinoLab survivor",
+    "class": "dm_dinolab_survivor",
+    "attitude": 0,
+    "mission": 0,
+    "chat": "TALK_Yoshimi_1",
+    "faction": "no_faction"
+  },
+  {
+    "type": "npc_class",
+    "id": "dm_dinolab_survivor",
+    "name": "DinoLab survivor",
+    "job_description": "Need to learn what happened…",
+    "common": false,
+    "worn_override": [ "NC_DOCTOR_coat", "NC_DOCTOR_pants_male", "NC_DOCTOR_eyes" ],
+    "carry_override": "NC_DOCTOR_misc",
+    "weapon_override": "EMPTY_GROUP",
+    "traits": [
+      [ "PRETTY", 100 ],
+      [ "ANIMALEMPATH2", 100 ],
+      [ "QUICK", 100 ],
+      [ "LIZ_EYE", 100 ],
+      [ "SCALES", 100 ],
+      [ "NAILS", 100 ],
+      [ "RAP_TALONS", 100 ],
+      [ "THRESH_RAPTOR", 100 ],
+      [ "ARM_FEATHERS", 100 ]
+    ],
+    "skills": [
+      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "constant": -4 } ] } ] } },
+      { "skill": "firstaid", "bonus": { "rng": [ 4, 8 ] } }
+    ]
+  },
+  {
+    "type": "effect_type",
+    "id": "u_met_yoshimi"
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Yoshimi_1",
+    "dynamic_line": {
+      "u_has_var": "u_met_yoshimi",
+      "type": "general",
+      "context": "meeting",
+      "value": "yes",
+      "yes": [
+        "How can I help you survivor?",
+        "Seen any interesting specimens?  I mean dinosaurs.",
+        "I was just imagining you transforming into a tyrannosaurus rex.  Of course that's impossible.  Unless…"
+      ],
+      "no": "Please leave me be, I am but a humble muck farmer in this humble muck."
+    },
+    "responses": [
+      {
+        "text": "You are dressed like a scientist.  Are you a scientist?  You look like a dinosaur.  Are you a dinosaur?  Are you a scientist dinosaur?",
+        "effect": { "u_add_var": "u_met_yoshimi", "type": "general", "context": "meeting", "value": "yes" },
+        "condition": { "not": { "u_has_var": "u_met_yoshimi", "type": "general", "context": "meeting", "value": "yes" } },
+        "topic": "TALK_yoshimi_firstmeet"
+      },
+      {
+        "text": "Die demon mutant!",
+        "effect": [ { "u_add_var": "u_met_yoshimi", "type": "general", "context": "meeting", "value": "yes" }, "insult_combat" ],
+        "condition": { "not": { "u_has_var": "u_met_sadie", "type": "general", "context": "meeting", "value": "yes" } },
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "How did you get here?",
+        "condition": { "and": [ { "u_has_var": "u_met_yoshimi", "type": "general", "context": "meeting", "value": "yes" } ] },
+        "topic": "TALK_yoshimi_ask_past"
+      },
+      {
+        "text": "How are things here?",
+        "condition": { "and": [ { "u_has_var": "u_met_yoshimi", "type": "general", "context": "meeting", "value": "yes" } ] },
+        "topic": "TALK_yoshimi_ask_mood"
+      },
+      { "text": "Goodbye.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_yoshimi_firstmeet",
+    "dynamic_line": "You have seen through my ruse.  In retrospect I should have prepared a costume of some kind.  Unimportant!  You haven't attacked me or tried to seduce me so you aren't like the others.  Had any bad headaches recently, strange mood swings, strong urges, desire for human flesh?",
+    "responses": [
+      { "text": "Only the usual.  What are you really?", "topic": "TALK_yoshimi_what" },
+      { "text": "You are aware of the Cataclysm then?", "topic": "TALK_yoshimi_cataclysm" },
+      { "text": "I'd rather not say at this point.", "topic": "TALK_Yoshimi_1" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_yoshimi_what",
+    "dynamic_line": "I am a hard working professional in a challenging field adjusting to a recent change in circumstances.  That is all you need to know.",
+    "responses": [ { "text": "I should go.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_yoshimi_ask_past",
+    "dynamic_line": "My manager Dr. Tingle made some important mistakes and I have had to make some quick decisions I would rather not go into detail on.  In retrospect our faculties may have been influenced by external factors.  Suffice to say Dr. Tingle is no longer with us but died doing what they wanted most in the world.  And I escaped alive.",
+    "responses": [ { "text": "Let's talk about something else.", "topic": "TALK_Yoshimi_1" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_yoshimi_cataclysm",
+    "dynamic_line": "Look at me.  Yes, I am aware.  The question is what happens next.",
+    "responses": [ { "text": "Yes.  Let's talk about something else.", "topic": "TALK_Yoshimi_1" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_yoshimi_ask_mood",
+    "dynamic_line": "I just got here actually, I've found it wise to move a lot recently.  There may be some interesting specimens nearby.  I mean dinosaurs.",
+    "responses": [ { "text": "Interesting.", "topic": "TALK_Yoshimi_1" } ]
+  }
+]

--- a/data/mods/DinoMod/NPC/NPC_Alonso_Lautrec.json
+++ b/data/mods/DinoMod/NPC/NPC_Alonso_Lautrec.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "TALK_REFUGEE_Alonso_2",
+    "type": "talk_topic",
+    "responses": [ { "text": "What can you tell me about the dinosaurs?", "topic": "TALK_REFUGEE_Alonso_DINOSAURS" } ]
+  },
+  {
+    "id": "TALK_REFUGEE_Alonso_DINOSAURS",
+    "type": "talk_topic",
+    "dynamic_line": "It could be a mighty challenge, but Alonso knows there are some that are into this, no?  I think they call themselves escalier, which is Italian for the scaly banana.  Or staircase.  It is not important, I mean to say that people love who they love, and the dinosaur, she does the same, and there is no shame in what two people or dinosaurs do in the escalier.  Alonso does not judge you.  You do you.  And maybe Alonso as well when you are done with the you doing.",
+    "responses": [ { "text": "Thank you so much.", "topic": "TALK_NONE" } ]
+  }
+]

--- a/data/mods/DinoMod/NPC/NPC_Brigitte_LaCroix.json
+++ b/data/mods/DinoMod/NPC/NPC_Brigitte_LaCroix.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "TALK_BONE_SEER",
+    "type": "talk_topic",
+    "responses": [ { "text": "What can you tell me about the dinosaurs?", "topic": "TALK_BONE_SEER_DINOSAURS" } ]
+  },
+  {
+    "id": "TALK_BONE_SEER_DINOSAURS",
+    "type": "talk_topic",
+    "dynamic_line": "Their song is older than ours, but also different.  We have much to learn from their old bones.  I knew a man once who sang not of bones but of meat.  If you find him, you will know the face of Bo.  He has listened hardest to them, but I do not know if he hears.",
+    "responses": [ { "text": "That explains everything, thank you.", "topic": "TALK_BONE_SEER" } ]
+  }
+]

--- a/data/mods/DinoMod/NPC/TALK_NC_FARMER.json
+++ b/data/mods/DinoMod/NPC/TALK_NC_FARMER.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "TALK_NC_FARMER",
+    "type": "talk_topic",
+    "responses": [
+      {
+        "text": "Strange greeting, ignoring that.  What can you tell me about the dinosaurs?",
+        "topic": "TALK_NC_FARMER_DINOSAURS"
+      }
+    ]
+  },
+  {
+    "id": "TALK_NC_FARMER_DINOSAURS",
+    "type": "talk_topic",
+    "dynamic_line": "Cute things aren't they!  Like big birds with big appetites.  The plant eaters are okay unless they get spooked.  Then it's time to hide on the roof for a while until they calm down.  I gave one some cattle feed and they seemed to like it fine, let me pet it and followed me around some. I bet you could tame them if they're young, maybe even some of the grown ones. A man came out here a while ago saying they were coming, that it was their time and we needed to get with them or get out of the way.  The man said I should follow him to the Swamper church, but I'm too busy here.  A whole lot of people went with him though.",
+    "responses": [ { "text": "I'm sure they're fine.  What was that question again?", "topic": "TALK_NC_FARMER" } ]
+  }
+]

--- a/data/mods/DinoMod/NPC/TALK_SURVIVOR_CHEF.json
+++ b/data/mods/DinoMod/NPC/TALK_SURVIVOR_CHEF.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "TALK_NC_SURVIVOR_CHEF",
+    "type": "talk_topic",
+    "responses": [ { "text": "What can you tell me about the dinosaurs?", "topic": "TALK_NC_SURVIVOR_CHEF_DINOSAURS" } ]
+  },
+  {
+    "id": "TALK_NC_SURVIVOR_CHEF_DINOSAURS",
+    "type": "talk_topic",
+    "dynamic_line": "That's a lot of meat to break down.  You're going to want to get together a real butcher setup, hooks and all, rig up a way to keep the meat cold or even better frozen, and figure out some way to make it last longer.  Could do jerky, maybe get a canning operation going.  The main thing is to work fast before it goes bad.  Hey, I know a pretty good cook who could help with that.  No, she's dead.  I'm here though.",
+    "responses": [ { "text": "I'm getting hungry.", "topic": "TALK_NC_SURVIVOR_CHEF" } ]
+  }
+]

--- a/data/mods/DinoMod/hints.json
+++ b/data/mods/DinoMod/hints.json
@@ -11,7 +11,8 @@
       "I know there aren't alligators in the sewer, but I heard there was some kind of big lizard down there.  Probably not a good idea to check.",
       "Some of those big dinosaurs seem halfway all right.  I bet if you fed them something nice and gave them a pet you could ride them like a pony.  Or maybe they'd eat you instead.",
       "I saw something with a large fin in the water.  It was the size of a whale and gave me a menacing feeling.  I'm gonna think twice before going back there.",
-      "One time I found a strange egg out in the woods.  It was probably a dinosaur, but I cooked it and it was pretty good!"
+      "One time I found a strange egg out in the woods.  It was probably a dinosaur, but I cooked it and it was pretty good!",
+      "I got a bunch of these big lizards to follow me around and it was great and then they smashed up the place I was staying and then a bunch of other places I wanted to set up.  Maybe I should have tied them down?"
     ]
   }
 ]

--- a/data/mods/DinoMod/lab_notes.json
+++ b/data/mods/DinoMod/lab_notes.json
@@ -7,7 +7,9 @@
       "Research proceeds apace on our visitors.  While Operation Major Laser did not receive enough funding as hoped, our more humble bio-operator protocols were already prepared and are proceeding ahead of schedule.  The hosts are most receptive to improvement.",
       "Dr. Yoshimi has been reprimanded for unauthorized contact with the procompsignathids.  Disgusting behavior, and a terrible example to the junior researchers.",
       "Dr. Yoshimi has escaped, along with an unknown number of dinosaurs.  Unfortunately, we have bigger problems with XE037.",
-      "Strange sounds have been reported from the swamp nearby.  An enhanced security team was dispatched, but has not returned in 48 hours.  The facility is on lockdown.  We can’t let them get back in."
+      "Strange sounds have been reported from the swamp nearby.  An enhanced security team was dispatched, but has not returned in 48 hours.  The facility is on lockdown.  We can’t let them get back in.",
+      "Tingle lab situation normal.  Dr. Tingle believes the Acrocanthosaurus is the best fit for hybridization and Tingle lab is working on safety protocols to provide the needed material to Dr. Tingle.  Velociraptor is another possibility given prior research.  Testing with chickens and the velociraptor specimens suggests some resistance.",
+      "Tingle lab situation critical.  Dr. Tingle violated safety protocols last night and attempted to secure genetic material directly, possibly under the influence of some drug or toxin, given the anatomical impossibility and danger of the procedure.  The Acrocanthosaurus specimen has escaped into the facility."
     ]
   }
 ]

--- a/data/mods/DinoMod/mapgen/nested/shack_nested.json
+++ b/data/mods/DinoMod/mapgen/nested/shack_nested.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "NC_Yoshimi_spawn",
+    "object": { "mapgensize": [ 1, 1 ], "place_npcs": [ { "class": "dm_dinolab_survivor", "x": 0, "y": 0 } ] }
+  }
+]

--- a/data/mods/DinoMod/mapgen/nested/shack_nested.json
+++ b/data/mods/DinoMod/mapgen/nested/shack_nested.json
@@ -3,6 +3,6 @@
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "NC_Yoshimi_spawn",
-    "object": { "mapgensize": [ 1, 1 ], "place_npcs": [ { "class": "DinoLab survivor", "x": 0, "y": 0 } ] }
+    "object": { "mapgensize": [ 1, 1 ], "place_npcs": [ { "class": "yoshimi", "x": 0, "y": 0 } ] }
   }
 ]

--- a/data/mods/DinoMod/mapgen/nested/shack_nested.json
+++ b/data/mods/DinoMod/mapgen/nested/shack_nested.json
@@ -3,6 +3,6 @@
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "NC_Yoshimi_spawn",
-    "object": { "mapgensize": [ 1, 1 ], "place_npcs": [ { "class": "dm_dinolab_survivor", "x": 0, "y": 0 } ] }
+    "object": { "mapgensize": [ 1, 1 ], "place_npcs": [ { "class": "DinoLab survivor", "x": 0, "y": 0 } ] }
   }
 ]

--- a/data/mods/DinoMod/mapgen/swamp_shack.json
+++ b/data/mods/DinoMod/mapgen/swamp_shack.json
@@ -1,0 +1,125 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "hunter_shack" ],
+    "weight": 100,
+    "object": {
+      "fill_ter": "t_floor",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "       -----------      ",
+        "       -CSn.....d-      ",
+        "       -....---+--      ",
+        "       -B..D-@..d-      ",
+        "       -B...-@..d-      ",
+        "       -bbTc-s.ss-      ",
+        "       ---o---+---      ",
+        "        =V,,^,,,,,      ",
+        "       ,,,,,,,,X=       ",
+        "       ,=&&,xxXX=       ",
+        "        =========       ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "swamp_background" ],
+      "mapping": {
+        "B": { "items": [ { "item": "novels", "chance": 50 }, { "item": "textbooks", "chance": 25 } ] },
+        "C": { "items": [ { "item": "kitchen", "chance": 50 }, { "item": "fridge", "chance": 50 } ] },
+        "D": { "items": { "item": "dresser", "chance": 75 } },
+        "X": { "items": [ { "item": "hardware", "chance": 30 }, { "item": "mischw", "chance": 30 } ] },
+        "b": { "items": { "item": "bed", "chance": 60 } },
+        "d": { "items": { "item": "NC_HUNTER_misc", "chance": 50 } },
+        "s": { "items": { "item": "traveler", "chance": 15 } },
+        "x": { "items": [ { "item": "cleaning", "chance": 30 }, { "item": "hardware_plumbing", "chance": 30 } ] }
+      },
+      "place_loot": [ { "item": "net", "x": 11, "y": 14, "chance": 100 }, { "item": "stepladder", "x": 11, "y": 16, "chance": 50 } ],
+      "terrain": {
+        "&": "t_dirt",
+        "+": "t_door_c",
+        ",": [ "t_dirt", "t_dirt", "t_dirt", "t_dirt", "t_dirt", "t_dirt", "t_grass" ],
+        "-": "t_wall_wood",
+        ".": "t_floor",
+        "=": "t_dirt",
+        "V": "t_dirt",
+        "X": "t_dirt",
+        "^": "t_dirt",
+        "o": "t_window_domestic",
+        "x": "t_dirt"
+      },
+      "furniture": {
+        "&": "f_kiln_empty",
+        "=": "f_sandbag_wall",
+        "@": "f_smoking_rack",
+        "B": "f_bookcase",
+        "C": "f_cupboard",
+        "D": "f_dresser",
+        "S": "f_woodstove",
+        "T": "f_table",
+        "V": "f_fvat_empty",
+        "X": "f_crate_c",
+        "^": "f_bulletin",
+        "b": "f_makeshift_bed",
+        "c": "f_chair",
+        "d": "f_rack",
+        "n": "f_counter",
+        "s": "f_counter",
+        "x": "f_crate_o"
+      },
+      "place_nested": [
+        { "chunks": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 0, 6 ], "neighbors": { "north": "forest_water" } },
+        {
+          "chunks": [ "cattail", "null" ],
+          "x": [ 7, 17 ],
+          "y": [ 0, 6 ],
+          "neighbors": { "north": "forest_water" },
+          "repeat": 4
+        },
+        { "chunks": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 0, 6 ], "neighbors": { "north": "forest_water" } },
+        { "chunks": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 0, 6 ], "neighbors": { "east": "forest_water" } },
+        {
+          "chunks": [ "cattail", "null" ],
+          "x": [ 18, 23 ],
+          "y": [ 7, 17 ],
+          "neighbors": { "east": "forest_water" },
+          "repeat": 4
+        },
+        { "chunks": [ "cattail", "null" ], "x": [ 18, 23 ], "y": [ 18, 23 ], "neighbors": { "east": "forest_water" } },
+        { "chunks": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 18, 23 ], "neighbors": { "south": "forest_water" } },
+        {
+          "chunks": [ "cattail", "null" ],
+          "x": [ 7, 17 ],
+          "y": [ 18, 23 ],
+          "neighbors": { "south": "forest_water" },
+          "repeat": 4
+        },
+        {
+          "chunks": [ "cattail", "null" ],
+          "x": [ 18, 23 ],
+          "y": [ 18, 23 ],
+          "neighbors": { "south": "forest_water" }
+        },
+        { "chunks": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 0, 6 ], "neighbors": { "west": "forest_water" } },
+        {
+          "chunks": [ "cattail", "null" ],
+          "x": [ 0, 6 ],
+          "y": [ 7, 17 ],
+          "neighbors": { "west": "forest_water" },
+          "repeat": 4
+        },
+        { "chunks": [ "cattail", "null" ], "x": [ 0, 6 ], "y": [ 18, 23 ], "neighbors": { "west": "forest_water" } },
+        { "chunks": [ "NC_Yoshimi_spawn" ], "x": [ 10 ], "y": [ 8 ] }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
#### Summary

SUMMARY: [Mods] "More DinoMod NPC content"

#### Purpose of change

Make DinoMod feel more like a part of the world, build out more of the DinoMod plotline and connect with content, more player hints

#### Describe the solution

New dialogue for many existing NPCs. New rope hint. New lab notes. New DinoLab NPC who knows a lot about dinos but won't say much. New location variant to spawn that new NPC.

#### Describe alternatives you've considered

Extensive references to Dinosaurs Attack!, Land of the Lost, Land Before Time, Dinosaurs, the Dinobots, Dino Riders, Denver the Last Dinosaur, Cadillacs and Dinosaurs, Dinosaur Jr.

#### Testing

Game loads no errors, Yoshimi spawns, looks right, dialogue works. The location isn't where expected and they seem to be moving around in odd ways but it's not game breaking

![image](https://user-images.githubusercontent.com/26608431/119085967-b8d26900-b9d2-11eb-918f-ddbe67d09436.png)

![image](https://user-images.githubusercontent.com/26608431/119086001-c7b91b80-b9d2-11eb-9974-f64cf8e46005.png)


#### Additional context

"What can you tell me about the dinosaurs?" -The player