### PR TITLE
Fix recipe for long_pole to match dda

### DIFF
--- a/data/json/recipes/recipe_weapon.json
+++ b/data/json/recipes/recipe_weapon.json
@@ -2727,11 +2727,12 @@
     "skill_used": "fabrication",
     "difficulty": 5,
     "time": "5 h 40 m",
-    "book_learn": [ [ "textbook_weapeast", 6 ] ],
+    "book_learn": [ [ "textbook_weapeast", 4 ] ],
+    "autolearn": true,
     "qualities": [ { "id": "SAW_W", "level": 1 }, { "id": "CUT", "level": 1 } ],
     "//": "a long pole is a single piece of wood, and the heavy stick just isn't large enough.",
     "components": [
-      [ [ "log", 1 ] ],
+      [ [ "wood_beam", 1 ] ],
       [
         [ "any_tallow", 4, "LIST" ],
         [ "cooking_oil", 32 ],


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Recipe for long poles is now autolearnable and requires heavy wooden beam instead of log matching dda."

#### Purpose of change

The recipe for long pole isn't autolearnable and can be only found in the book textbook_weapeast. 

It is autolearnable in dda and can also be crafted at a lower fabrication level with the book. 

It also requires a wood_beam in dda instead of a single log. This tiny change should match dda and make pikes easier to craft but slightly more expensive.

For comparison:  https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/json/recipes/other/parts_construction.json
