### PR TITLE
Generate bionics on death, damage them on surgery

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -1108,5 +1108,10 @@
     "type": "item_action",
     "id": "CRAFT",
     "name": { "str": "Work on craft" }
+  },
+  {
+    "type": "item_action",
+    "id": "NOTE_BIONICS",
+    "name": { "str": "Turn off" }
   }
 ]

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -205,7 +205,8 @@
       [ "chem_hydrogen_peroxide", 5 ],
       [ "strong_antibiotic", 1 ],
       [ "antibiotics", 5 ],
-      [ "weak_antibiotic", 15 ]
+      [ "weak_antibiotic", 15 ],
+      [ "bionic_scanner", 5 ]
     ]
   },
   {

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -585,6 +585,7 @@
       [ "bronze_medal", 3 ],
       [ "silver_medal", 2 ],
       [ "gold_medal", 1 ],
+      [ "bionic_scanner", 5 ],
       { "group": "tinware", "prob": 10 }
     ]
   },

--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -125,7 +125,8 @@
       [ "chem_muriatic_acid", 2 ],
       [ "chem_hexamine", 2 ],
       [ "denat_alcohol", 1 ],
-      [ "remotevehcontrol", 5 ]
+      [ "remotevehcontrol", 5 ],
+      [ "bionic_scanner", 5 ]
     ]
   },
   {
@@ -422,7 +423,8 @@
       [ "bfipowder", 15 ],
       [ "quikclot", 10 ],
       [ "anesthetic", 20 ],
-      [ "anesthetic_kit", 10 ]
+      [ "anesthetic_kit", 10 ],
+      [ "bionic_scanner", 5 ]
     ]
   },
   {
@@ -465,7 +467,8 @@
       [ "rack_test_tube", 5 ],
       [ "flask_glass", 10 ],
       [ "beaker", 10 ],
-      [ "test_tube", 10 ]
+      [ "test_tube", 10 ],
+      [ "bionic_scanner", 5 ]
     ]
   }
 ]

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -441,7 +441,8 @@
       [ "toolbox", 5 ],
       [ "tool_belt", 10 ],
       [ "clamp", 10 ],
-      [ "wrench", 10 ]
+      [ "wrench", 10 ],
+      [ "bionic_scanner", 5 ]
     ]
   },
   {

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -601,5 +601,57 @@
       ]
     ],
     "magazine_well": 1
+  },
+  {
+    "id": "bionic_scanner",
+    "type": "TOOL",
+    "name": { "str": "bionic scanner" },
+    "description": "A small metal scanner specialized in detecting bionic hardware.  Activate to start scanning nearby corpses for bionics.",
+    "weight": "141 g",
+    "volume": "250 ml",
+    "price": 10000,
+    "price_postapoc": 5000,
+    "material": [ "plastic", "aluminum" ],
+    "symbol": ";",
+    "color": "magenta",
+    "ammo": "battery",
+    "use_action": {
+      "target": "bionic_scanner_on",
+      "msg": "You start scanning for bionics.",
+      "active": true,
+      "need_charges": 1,
+      "need_charges_msg": "The scanner doesn't have enough power.",
+      "type": "transform"
+    },
+    "magazines": [
+      [
+        "battery",
+        [
+          "light_plus_battery_cell",
+          "light_minus_battery_cell",
+          "light_minus_disposable_cell",
+          "light_battery_cell",
+          "light_disposable_cell",
+          "light_atomic_battery_cell",
+          "light_minus_atomic_battery_cell"
+        ]
+      ]
+    ]
+  },
+  {
+    "id": "bionic_scanner_on",
+    "type": "TOOL",
+    "name": { "str": "bionic scanner (on)" },
+    "description": "A small metal scanner specialized in detecting bionic hardware.  Used automatically whenever you look at corpses that might contain bionics.  Consumes power proportional to number of bionics identified this way.",
+    "weight": "141 g",
+    "volume": "250 ml",
+    "price": 10000,
+    "price_postapoc": 5000,
+    "material": [ "plastic", "aluminum" ],
+    "symbol": ";",
+    "color": "magenta",
+    "use_action": "NOTE_BIONICS",
+    "revert_to": "bionic_scanner",
+    "revert_msg": "The %s shuts down."
   }
 ]

--- a/data/json/recipes/recipe_electronics.json
+++ b/data/json/recipes/recipe_electronics.json
@@ -2372,5 +2372,28 @@
       [ [ "power_supply", 1 ] ],
       [ [ "turret_chassis", 1 ] ]
     ]
+  },
+  {
+    "type": "recipe",
+    "result": "bionic_scanner",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_OTHER",
+    "skill_used": "electronics",
+    "skills_required": [ [ "computer", 2 ] ],
+    "difficulty": 4,
+    "time": "1 h",
+    "reversible": true,
+    "decomp_learn": 5,
+    "book_learn": [ [ "recipe_lab_elec", 4 ], [ "textbook_electronics", 5 ] ],
+    "using": [ [ "soldering_standard", 20 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
+    "components": [
+      [ [ "plastic_chunk", 4 ] ],
+      [ [ "superglue", 1 ] ],
+      [ [ "cable", 5 ] ],
+      [ [ "small_lcd_screen", 1 ] ],
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ]
+    ]
   }
 ]

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -472,14 +472,13 @@ static bool check_butcher_cbm( const int roll )
     return !failed;
 }
 
-static void extract_or_wreck_cbms( const std::list<item *> &cbms, int roll,
+static void extract_or_wreck_cbms( const std::list<item> &cbms, int roll,
                                    player &p )
 {
     if( roll < 0 ) {
         return;
     }
-    for( const item *it_ptr : cbms ) {
-        item it( *it_ptr );
+    for( item it : cbms ) {
         // For some stupid reason, zombie pheromones are dropped using bionic type
         // This complicates things
         if( it.is_bionic() ) {
@@ -1286,7 +1285,11 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
         int roll = roll_butchery() - corpse_item.damage_level( 4 );
         roll = roll < 0 ? 0 : roll;
         add_msg( m_debug, _( "Roll penalty for corpse damage = %s" ), 0 - corpse_item.damage_level( 4 ) );
-        extract_or_wreck_cbms( corpse_item.contents.all_items_top(), roll, *p );
+        std::list<item> cbms = corpse_item.components;
+        for( const item *it : corpse_item.contents.all_items_top() ) {
+            cbms.push_back( *it );
+        }
+        extract_or_wreck_cbms( cbms, roll, *p );
     }
 
     //end messages and effects

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9673,10 +9673,10 @@ void Character::place_corpse()
     // Restore amount of installed pseudo-modules of Power Storage Units
     std::pair<int, int> storage_modules = amount_of_storage_bionics();
     for( int i = 0; i < storage_modules.first; ++i ) {
-        body.put_in( item( "bio_power_storage" ) );
+        body.components.push_back( item( "bio_power_storage" ) );
     }
     for( int i = 0; i < storage_modules.second; ++i ) {
-        body.put_in( item( "bio_power_storage_mkII" ) );
+        body.components.push_back( item( "bio_power_storage_mkII" ) );
     }
     g->m.add_item_or_charges( pos(), body );
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9666,7 +9666,7 @@ void Character::place_corpse()
             cbm.set_flag( "NO_STERILE" );
             cbm.set_flag( "NO_PACKED" );
             cbm.faults.emplace( fault_id( "fault_bionic_salvaged" ) );
-            body.put_in( cbm );
+            body.components.push_back( cbm );
         }
     }
 

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1513,8 +1513,9 @@ bool Character::can_consume( const item &it ) const
         return true;
     }
     // Checking NO_RELOAD to prevent consumption of `battery` when contained in `battery_car` (#20012)
+    // Can't consume from corpses since they can contain pre-generated items which might be comestible
     return !it.is_container_empty() && !it.has_flag( flag_NO_RELOAD ) &&
-           can_consume_as_is( it.contents.front() );
+           !it.is_corpse() && can_consume_as_is( it.contents.front() );
 }
 
 item &Character::get_consumable_from( item &it ) const

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1513,9 +1513,8 @@ bool Character::can_consume( const item &it ) const
         return true;
     }
     // Checking NO_RELOAD to prevent consumption of `battery` when contained in `battery_car` (#20012)
-    // Can't consume from corpses since they can contain pre-generated items which might be comestible
     return !it.is_container_empty() && !it.has_flag( flag_NO_RELOAD ) &&
-           !it.is_corpse() && can_consume_as_is( it.contents.front() );
+           can_consume_as_is( it.contents.front() );
 }
 
 item &Character::get_consumable_from( item &it ) const

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5076,8 +5076,8 @@ bool game::revive_corpse( const tripoint &p, item &it )
 
     critter.no_extra_death_drops = true;
     critter.add_effect( effect_downed, 5_turns, num_bp, true );
-    for( const item *it : it.contents.all_items_top() ) {
-        critter.corpse_contents.push_back( *it );
+    for( const item *cnt : it.contents.all_items_top() ) {
+        critter.corpse_contents.push_back( *cnt );
     }
 
     if( it.get_var( "zlave" ) == "zlave" ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5076,8 +5076,8 @@ bool game::revive_corpse( const tripoint &p, item &it )
 
     critter.no_extra_death_drops = true;
     critter.add_effect( effect_downed, 5_turns, num_bp, true );
-    for( const item *cnt : it.contents.all_items_top() ) {
-        critter.corpse_contents.push_back( *cnt );
+    for( const item &component : it.components ) {
+        critter.corpse_components.push_back( component );
     }
 
     if( it.get_var( "zlave" ) == "zlave" ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5076,6 +5076,9 @@ bool game::revive_corpse( const tripoint &p, item &it )
 
     critter.no_extra_death_drops = true;
     critter.add_effect( effect_downed, 5_turns, num_bp, true );
+    for( const item *it : it.contents.all_items_top() ) {
+        critter.corpse_contents.push_back( *it );
+    }
 
     if( it.get_var( "zlave" ) == "zlave" ) {
         critter.add_effect( effect_pacified, 1_turns, num_bp, true );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -579,7 +579,10 @@ class comestible_inventory_preset : public inventory_selector_preset
         }
 
         bool is_shown( const item_location &loc ) const override {
-            return p.can_consume( *loc );
+            // If an item was inserted into a non-container, we can't eat it.
+            // For example, we couldn't eat an item mod made of meat
+            return p.can_consume( *loc ) &&
+                   ( loc.where() != item_location::type::container || loc.parent_item()->is_container() );
         }
 
         std::string get_denial( const item_location &loc ) const override {

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -138,11 +138,15 @@ void harvest_list::check_consistency()
         auto error_func = [&]( const harvest_entry & entry ) {
             std::string errorlist;
             bool item_valid = true;
+            if( ( entry.type == "bionic" || entry.type == "bionic_group" ) && entry.mass_ratio != 0.0f ) {
+                errorlist += string_format( "\"mass_ratio\" != 0.0, but type %s", entry.type.c_str() );
+            }
             if( !( item::type_is_defined( entry.drop ) || ( entry.type == "bionic_group" &&
                     item_group::group_is_defined( item_group_id( entry.drop ) ) ) ) ) {
                 item_valid = false;
                 errorlist += entry.drop;
             }
+
             // non butchery harvests need to be excluded
             if( hl_id.substr( 0, 14 ) != "harvest_inline" ) {
                 if( entry.type == "null" ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2963,7 +2963,8 @@ void item::component_info( std::vector<iteminfo> &info, const iteminfo_query *pa
     if( is_craft() ) {
         info.push_back( iteminfo( "DESCRIPTION", string_format( _( "Using: %s" ),
                                   _( components_to_string() ) ) ) );
-    } else {
+        // Ugly hack warning! Corpses have CBMs as their components
+    } else if( !is_corpse() ) {
         info.push_back( iteminfo( "DESCRIPTION", string_format( _( "Made from: %s" ),
                                   _( components_to_string() ) ) ) );
     }
@@ -6161,8 +6162,9 @@ bool item::is_brewable() const
 
 bool item::is_food_container() const
 {
-    return ( !contents.empty() && contents.front().is_food() ) || ( is_craft() &&
-            craft_data_->making->create_result().is_food_container() );
+    return ( !contents.empty() && contents.front().is_food() ) ||
+           ( is_craft() &&
+             craft_data_->making->create_result().is_food_container() );
 }
 
 bool item::is_med_container() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2967,6 +2967,14 @@ void item::component_info( std::vector<iteminfo> &info, const iteminfo_query *pa
     } else if( !is_corpse() ) {
         info.push_back( iteminfo( "DESCRIPTION", string_format( _( "Made from: %s" ),
                                   _( components_to_string() ) ) ) );
+    } else if( get_var( "bionics_scanned_by", -1 ) != get_avatar().getID().get_value() ) {
+        // TODO: Extract into a more proper place (function in namespace)
+        std::string bionics_string = enumerate_as_string( components.begin(), components.end(),
+        []( const item & entry ) -> std::string {
+            return entry.is_bionic() ? entry.display_name() : "";
+        }, enumeration_conjunction::none );
+        info.push_back( iteminfo( "DESCRIPTION", string_format( _( "Contains: %s" ),
+                                  bionics_string ) ) );
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2967,7 +2967,7 @@ void item::component_info( std::vector<iteminfo> &info, const iteminfo_query *pa
     } else if( !is_corpse() ) {
         info.push_back( iteminfo( "DESCRIPTION", string_format( _( "Made from: %s" ),
                                   _( components_to_string() ) ) ) );
-    } else if( get_var( "bionics_scanned_by", -1 ) != get_avatar().getID().get_value() ) {
+    } else if( get_var( "bionics_scanned_by", -1 ) == get_avatar().getID().get_value() ) {
         // TODO: Extract into a more proper place (function in namespace)
         std::string bionics_string = enumerate_as_string( components.begin(), components.end(),
         []( const item & entry ) -> std::string {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -901,6 +901,7 @@ void Item_factory::init()
     add_iuse( "MYCUS", &iuse::mycus );
     add_iuse( "NOISE_EMITTER_OFF", &iuse::noise_emitter_off );
     add_iuse( "NOISE_EMITTER_ON", &iuse::noise_emitter_on );
+    add_iuse( "NOTE_BIONICS", &iuse::note_bionics );
     add_iuse( "OXYGEN_BOTTLE", &iuse::oxygen_bottle );
     add_iuse( "OXYTORCH", &iuse::oxytorch );
     add_iuse( "PACK_CBM", &iuse::pack_cbm );

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -89,21 +89,12 @@ const use_function *itype::get_use( const std::string &iuse_name ) const
     return iter != use_methods.end() ? &iter->second : nullptr;
 }
 
-int itype::tick( player &p, item &it, const tripoint &pos ) const
+void itype::tick( player &p, item &it, const tripoint &pos ) const
 {
-    // Note: can go higher than current charge count
     // Maybe should move charge decrementing here?
-    int charges_to_use = 0;
     for( auto &method : use_methods ) {
-        const int val = method.second.call( p, it, true, pos );
-        if( charges_to_use < 0 || val < 0 ) {
-            charges_to_use = -1;
-        } else {
-            charges_to_use += val;
-        }
+        method.second.call( p, it, true, pos );
     }
-
-    return charges_to_use;
 }
 
 int itype::invoke( player &p, item &it, const tripoint &pos ) const

--- a/src/itype.h
+++ b/src/itype.h
@@ -1111,7 +1111,7 @@ struct itype {
         // Here "invoke" means "actively use". "Tick" means "active item working"
         int invoke( player &p, item &it, const tripoint &pos ) const; // Picks first method or returns 0
         int invoke( player &p, item &it, const tripoint &pos, const std::string &iuse_name ) const;
-        int tick( player &p, item &it, const tripoint &pos ) const;
+        void tick( player &p, item &it, const tripoint &pos ) const;
 };
 
 #endif // CATA_SRC_ITYPE_H

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2267,7 +2267,7 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
                 []( const item & entry ) -> std::string {
                     return entry.is_bionic() ? entry.display_name() : "";
                 }, enumeration_conjunction::none );
-                p->add_msg_if_player( m_good, _( "A %0$s located %1$s contains %2$s" ),
+                p->add_msg_if_player( m_good, _( "A %1$s located %2$s contains %3$s" ),
                                       corpse.display_name().c_str(),
                                       direction_name( direction_from( pt, p->pos() ) ).c_str(),
                                       bionics_string.c_str()

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2267,7 +2267,7 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
                 []( const item & entry ) -> std::string {
                     return entry.is_bionic() ? entry.display_name() : "";
                 }, enumeration_conjunction::none );
-                p->add_msg_if_player( m_good, _( "A %0s located %1s contains %2s" ),
+                p->add_msg_if_player( m_good, _( "A %0$s located %1$s contains %2$s" ),
                                       corpse.display_name().c_str(),
                                       direction_name( direction_from( pt, p->pos() ) ).c_str(),
                                       bionics_string.c_str()

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -78,6 +78,7 @@ int radio_off( player *, item *, bool, const tripoint & );
 int radio_on( player *, item *, bool, const tripoint & );
 int noise_emitter_off( player *, item *, bool, const tripoint & );
 int noise_emitter_on( player *, item *, bool, const tripoint & );
+int note_bionics( player *, item *, bool, const tripoint & );
 int ma_manual( player *, item *, bool, const tripoint & );
 int crowbar( player *, item *, bool, const tripoint & );
 int makemound( player *, item *, bool, const tripoint & );

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -902,17 +902,22 @@ void make_mon_corpse( monster &z, int damageLvl )
     if( z.has_effect( effect_no_ammo ) ) {
         corpse.set_var( "no_ammo", "no_ammo" );
     }
-    // Pre-gen bionic on death rather than on butcher
-    for( const harvest_entry &entry : *z.type->harvest ) {
-        if( entry.type == "bionic" || entry.type == "bionic_group" ) {
-            std::vector<item> contained_bionics =
-                entry.type == "bionic"
-                ? butcher_cbm_item( entry.drop, calendar::turn, entry.flags, entry.faults )
-                : butcher_cbm_group( item_group_id( entry.drop ), calendar::turn, entry.flags, entry.faults );
-            for( const item &it : contained_bionics ) {
-                corpse.put_in( it );
+    if( !z.no_extra_death_drops ) {
+        // Pre-gen bionic on death rather than on butcher
+        for( const harvest_entry &entry : *z.type->harvest ) {
+            if( entry.type == "bionic" || entry.type == "bionic_group" ) {
+                std::vector<item> contained_bionics =
+                    entry.type == "bionic"
+                    ? butcher_cbm_item( entry.drop, calendar::turn, entry.flags, entry.faults )
+                    : butcher_cbm_group( item_group_id( entry.drop ), calendar::turn, entry.flags, entry.faults );
+                for( const item &it : contained_bionics ) {
+                    corpse.put_in( it );
+                }
             }
         }
+    }
+    for( const item &it : z.corpse_contents ) {
+        corpse.put_in( it );
     }
     get_map().add_item_or_charges( z.pos(), corpse );
 }

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -848,31 +848,19 @@ void mdeath::broken_ammo( monster &z )
     mdeath::broken( z );
 }
 
-static std::vector<item> butcher_cbm_item( const std::string &what,
+static std::vector<item> butcher_cbm_item( const itype_id &what,
         const time_point &birthday, const std::vector<std::string> &flags,
         const std::vector<fault_id> &faults )
 {
-    if( item::find_type( itype_id( what ) )->bionic ) {
-        item cbm( what, birthday );
-        for( const std::string &flg : flags ) {
-            cbm.set_flag( flg );
-        }
-        for( const fault_id &flt : faults ) {
-            cbm.faults.emplace( flt );
-        }
-
-        return { cbm};
-    } else {
-        item something( what, birthday );
-        for( const std::string &flg : flags ) {
-            something.set_flag( flg );
-        }
-        for( const fault_id &flt : faults ) {
-            something.faults.emplace( flt );
-        }
-
-        return {something};
+    item something( what, birthday );
+    for( const std::string &flg : flags ) {
+        something.set_flag( flg );
     }
+    for( const fault_id &flt : faults ) {
+        something.faults.emplace( flt );
+    }
+
+    return {something};
 }
 
 static std::vector<item> butcher_cbm_group( const item_group_id &group,
@@ -911,13 +899,14 @@ void make_mon_corpse( monster &z, int damageLvl )
                     ? butcher_cbm_item( entry.drop, calendar::turn, entry.flags, entry.faults )
                     : butcher_cbm_group( item_group_id( entry.drop ), calendar::turn, entry.flags, entry.faults );
                 for( const item &it : contained_bionics ) {
-                    corpse.put_in( it );
+                    // Disgusting hack: use components instead of contents to hide stuff
+                    corpse.components.push_back( it );
                 }
             }
         }
     }
-    for( const item &it : z.corpse_contents ) {
-        corpse.put_in( it );
+    for( const item &it : z.corpse_components ) {
+        corpse.components.push_back( it );
     }
     get_map().add_item_or_charges( z.pos(), corpse );
 }

--- a/src/monster.h
+++ b/src/monster.h
@@ -443,7 +443,7 @@ class monster : public Creature
         tripoint wander_pos; // Wander destination - Just try to move in that direction
         int wandf;           // Urge to wander - Increased by sound, decrements each move
         std::vector<item> inv; // Inventory
-        std::vector<item> corpse_contents; // Inventory, but extracted with butchery, not dropped
+        std::vector<item> corpse_components; // Hack to make bionic corpses generate CBMs on death
         Character *mounted_player = nullptr; // player that is mounting this creature
         character_id mounted_player_id; // id of player that is mounting this creature ( for save/load )
         character_id dragged_foe_id; // id of character being dragged by the monster

--- a/src/monster.h
+++ b/src/monster.h
@@ -443,6 +443,7 @@ class monster : public Creature
         tripoint wander_pos; // Wander destination - Just try to move in that direction
         int wandf;           // Urge to wander - Increased by sound, decrements each move
         std::vector<item> inv; // Inventory
+        std::vector<item> corpse_contents; // Inventory, but extracted with butchery, not dropped
         Character *mounted_player = nullptr; // player that is mounting this creature
         character_id mounted_player_id; // id of player that is mounting this creature ( for save/load )
         character_id dragged_foe_id; // id of character being dragged by the monster

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1944,7 +1944,7 @@ void monster::load( const JsonObject &data )
     horde_attraction = static_cast<monster_horde_attraction>( data.get_int( "horde_attraction", 0 ) );
 
     data.read( "inv", inv );
-    data.read( "corpse_contents", corpse_contents );
+    data.read( "corpse_components", corpse_components );
     data.read( "dragged_foe_id", dragged_foe_id );
 
     if( data.has_int( "ammo" ) && !type->starting_ammo.empty() ) {
@@ -2038,7 +2038,7 @@ void monster::store( JsonOut &json ) const
         json.member( "horde_attraction", horde_attraction );
     }
     json.member( "inv", inv );
-    json.member( "corpse_contents", corpse_contents );
+    json.member( "corpse_components", corpse_components );
 
     json.member( "dragged_foe_id", dragged_foe_id );
     // storing the rider

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1944,6 +1944,7 @@ void monster::load( const JsonObject &data )
     horde_attraction = static_cast<monster_horde_attraction>( data.get_int( "horde_attraction", 0 ) );
 
     data.read( "inv", inv );
+    data.read( "corpse_contents", corpse_contents );
     data.read( "dragged_foe_id", dragged_foe_id );
 
     if( data.has_int( "ammo" ) && !type->starting_ammo.empty() ) {
@@ -2037,6 +2038,7 @@ void monster::store( JsonOut &json ) const
         json.member( "horde_attraction", horde_attraction );
     }
     json.member( "inv", inv );
+    json.member( "corpse_contents", corpse_contents );
 
     json.member( "dragged_foe_id", dragged_foe_id );
     // storing the rider


### PR DESCRIPTION
Mass-dissecting corpses when hunting for That One CBM is boring. Now bionics will be pre-generated on monster's death and surgery will only extract them - possibly wrecking them in the process.
The player will be able to notice what bionics are there in the corpse, to see if it's worth the effort. Gamey, let's handwave it as "autodoc tattoos some medical info on implantation, that's how you know what's in the corpse". `// TODO: Put that in lore`

Increased dissection time with bad tools to compensate. 5 times slower with X-acto knife, 1.25 times slower with bionic scalpel.

* [x] Fix zombies with bionics rezing and having a different set of bionics after second death
* [x] Fix bionic-containing corpses producing all the bionics when destroyed from damage rather than butchery
* [x] Retheme the autodoc tattoo thing into a bionic scanner thing, then add that scanner to drops