### PR TITLE
Fix allegedly night-invis monsters lacking the relevant flag

### DIFF
--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -98,6 +98,7 @@
       "NO_BREATHE",
       "REVIVES",
       "PUSH_MON",
+      "NIGHT_INVISIBILITY",
       "FILTHY"
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fixes black-ops and hunter-killer zombies lacking night cloaking like their description implies."

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I was looking at the JSON for black-ops and hunter-killer zombies to double-check whether I had a drop override for them in one of my mods, when I realized they were lacking the `NIGHT_INVISIBILITY` flag, despite their descriptions overtyl stating they're invisible in the dark. From what I could find, there's no sign of this being a deliberate change, it seems to just be a mistake.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Gave `mon_zombie_soldier_blackops_1` the `NIGHT_INVISIBILITY` flag, thus also allowing `mon_zombie_soldier_blackops_2` to inherit the flag via its copy-from.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Changing the description to not allude to what seems to be literally the primary gimmick of these monsters.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Tested for correct lint and syntax of affected file.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

This is also present in DDA and in fact was evidently present since one of the commits in the PR that added them: https://github.com/CleverRaven/Cataclysm-DDA/pull/28093

As far as I can tell it doesn't look like it was intentional, nothing seems to hint at talk about night invisibility being an issue. Instead, what it looks like is a mistake caused during a commit that changed black-ops zombies to no longer inherit from soldier zombies. It went from gaining `NIGHT_INVISIBILITY` via extend to what appears to be a blind copy-paste of the zombie soldier's flags.