### PR TITLE
Add laptop battery to Computer Hacker profession

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1572,12 +1572,10 @@
     "name": "Computer Hacker",
     "description": "Caffeine pills and all-nighters in front of a computer screen have given you skills in an area that seem, on the face of it, distinctly less-than-useful when the world has ended.  Unless you manage to find a military mainframe.",
     "points": 1,
-    "skills": [
-      { "level": 4, "name": "computer" }
-    ],
+    "skills": [ { "level": 4, "name": "computer" } ],
     "items": {
       "both": {
-        "items": [ "pants", "tshirt_text", "socks", "sneakers", "mbag", "smart_phone", "caffeine" ],
+        "items": [ "pants", "linuxtshirt", "socks", "sneakers", "mbag", "smart_phone", "caffeine" ],
         "entries": [
           { "item": "light_plus_battery_cell", "ammo-item": "battery", "charges": 150, "container-item": "portable_game" },
           { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "laptop" }

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1572,11 +1572,16 @@
     "name": "Computer Hacker",
     "description": "Caffeine pills and all-nighters in front of a computer screen have given you skills in an area that seem, on the face of it, distinctly less-than-useful when the world has ended.  Unless you manage to find a military mainframe.",
     "points": 1,
-    "skills": [ { "level": 4, "name": "computer" } ],
+    "skills": [
+      { "level": 4, "name": "computer" }
+    ],
     "items": {
       "both": {
-        "items": [ "pants", "tshirt_text", "socks", "sneakers", "mbag", "laptop", "smart_phone", "caffeine" ],
-        "entries": [ { "item": "light_plus_battery_cell", "ammo-item": "battery", "charges": 150, "container-item": "portable_game" } ]
+        "items": [ "pants", "tshirt_text", "socks", "sneakers", "mbag", "smart_phone", "caffeine" ],
+        "entries": [
+          { "item": "light_plus_battery_cell", "ammo-item": "battery", "charges": 150, "container-item": "portable_game" },
+          { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "laptop" }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "panties" ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1575,7 +1575,7 @@
     "skills": [ { "level": 4, "name": "computer" } ],
     "items": {
       "both": {
-        "items": [ "pants", "linuxtshirt", "socks", "sneakers", "mbag", "smart_phone", "caffeine" ],
+        "items": [ "pants", "tshirt_text", "socks", "sneakers", "mbag", "smart_phone", "caffeine" ],
         "entries": [
           { "item": "light_plus_battery_cell", "ammo-item": "battery", "charges": 150, "container-item": "portable_game" },
           { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "laptop" }


### PR DESCRIPTION
The 'computer hacker' profession came with a laptop but no battery so I have changed it to include a laptop with a battery pre-installed

(after all, who goes out with a laptop and no battery!)