### PR TITLE
Clear more types on data unload

### DIFF
--- a/src/ascii_art.cpp
+++ b/src/ascii_art.cpp
@@ -28,6 +28,11 @@ bool string_id<ascii_art>::is_valid() const
     return ascii_art_factory.is_valid( *this );
 }
 
+void ascii_art::reset()
+{
+    ascii_art_factory.reset();
+}
+
 void ascii_art::load_ascii_art( const JsonObject &jo, const std::string &src )
 {
     ascii_art_factory.load( jo, src );

--- a/src/ascii_art.h
+++ b/src/ascii_art.h
@@ -13,6 +13,7 @@ class JsonObject;
 class ascii_art
 {
     public:
+        static void reset();
         static void load_ascii_art( const JsonObject &jo, const std::string &src );
         void load( const JsonObject &jo, const std::string & );
         bool was_loaded;

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -159,6 +159,11 @@ void zone_type::load_zones( const JsonObject &jo, const std::string &src )
     zone_type_factory.load( jo, src );
 }
 
+void zone_type::reset_zones()
+{
+    zone_type_factory.reset();
+}
+
 void zone_type::load( const JsonObject &jo, const std::string & )
 {
     mandatory( jo, was_loaded, "name", name_ );

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -48,6 +48,7 @@ class zone_type
         std::string name() const;
         std::string desc() const;
 
+        static void reset_zones();
         static void load_zones( const JsonObject &jo, const std::string &src );
         void load( const JsonObject &jo, const std::string & );
         /**

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1816,7 +1816,7 @@ void Creature::add_msg_player_or_say( const game_message_params &params, const t
     return add_msg_player_or_say( params, pc.translated(), npc.translated() );
 }
 
-std::vector <int> Creature::dispersion_for_even_chance_of_good_hit = { {
+static std::vector<int> default_dispersion_for_ecogh = { {
         1731, 859, 573, 421, 341, 286, 245, 214, 191, 175,
         151, 143, 129, 118, 114, 107, 101, 94, 90, 78,
         78, 78, 74, 71, 68, 66, 62, 61, 59, 57,
@@ -1825,10 +1825,16 @@ std::vector <int> Creature::dispersion_for_even_chance_of_good_hit = { {
         33, 33, 32, 30, 30, 30, 30, 29, 28
     }
 };
+std::vector<int> Creature::dispersion_for_even_chance_of_good_hit = default_dispersion_for_ecogh;
 
 void Creature::load_hit_range( const JsonObject &jo )
 {
     if( jo.has_array( "even_good" ) ) {
         jo.read( "even_good", dispersion_for_even_chance_of_good_hit );
     }
+}
+
+void Creature::reset_hit_range()
+{
+    dispersion_for_even_chance_of_good_hit = default_dispersion_for_ecogh;
 }

--- a/src/creature.h
+++ b/src/creature.h
@@ -796,6 +796,7 @@ class Creature
         body_part select_body_part( Creature *source, int hit_roll ) const;
 
         static void load_hit_range( const JsonObject & );
+        static void reset_hit_range();
         // Empirically determined by "synthetic_range_test" in tests/ranged_balance.cpp.
         static std::vector <int> dispersion_for_even_chance_of_good_hit;
         /**

--- a/src/disease.cpp
+++ b/src/disease.cpp
@@ -27,6 +27,11 @@ void disease_type::load_disease_type( const JsonObject &jo, const std::string &s
     disease_factory.load( jo, src );
 }
 
+void disease_type::reset()
+{
+    disease_factory.reset();
+}
+
 void disease_type::load( const JsonObject &jo, const std::string & )
 {
     disease_type new_disease;

--- a/src/disease.h
+++ b/src/disease.h
@@ -19,6 +19,7 @@ class disease_type
         void load( const JsonObject &jo, const std::string & );
         static const std::vector<disease_type> &get_all();
         static void check_disease_consistency();
+        static void reset();
         bool was_loaded;
 
         diseasetype_id id;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -190,8 +190,6 @@ void DynamicDataLoader::add( const std::string &type, std::function<void( const 
     }
 }
 
-void load_charge_removal_blacklist( const JsonObject &jo, const std::string &src );
-
 void DynamicDataLoader::initialize()
 {
     // all of the applicable types that can be loaded, along with their loading functions
@@ -320,7 +318,7 @@ void DynamicDataLoader::initialize()
         item_controller->load_migration( jo );
     } );
 
-    add( "charge_removal_blacklist", load_charge_removal_blacklist );
+    add( "charge_removal_blacklist", charge_removal_blacklist::load );
 
     add( "MONSTER", []( const JsonObject & jo, const std::string & src ) {
         MonsterGenerator::generator().load_monster( jo, src );
@@ -485,13 +483,18 @@ void DynamicDataLoader::unload_data()
     ammo_effects::reset();
     ammunition_type::reset();
     anatomy::reset();
+    ascii_art::reset();
     behavior::reset();
     body_part_type::reset();
+    charge_removal_blacklist::reset();
     clear_techniques_and_martial_arts();
     clothing_mods::reset();
     construction_categories::reset();
+    Creature::reset_hit_range();
+    disease_type::reset();
     dreams.clear();
     emit::reset();
+    enchantment::reset();
     event_statistic::reset();
     event_transformation::reset();
     faction_template::reset();
@@ -499,10 +502,14 @@ void DynamicDataLoader::unload_data()
     field_types::reset();
     gates::reset();
     harvest_list::reset();
+    item_action_generator::generator().reset();
     item_controller->reset();
     json_flag::reset();
+    MapExtras::reset();
+    mapgen_palette::reset();
     materials::reset();
     mission_type::reset();
+    monfactions::reset();
     MonsterGenerator::generator().reset();
     MonsterGroupManager::ClearMonsterGroups();
     morale_type_data::reset();
@@ -516,9 +523,9 @@ void DynamicDataLoader::unload_data()
     overmap_locations::reset();
     overmap_specials::reset();
     overmap_terrains::reset();
+    overmap::reset_obsolete_terrains();
     profession::reset();
     quality::reset();
-    reset_monster_adjustment();
     recipe_dictionary::reset();
     recipe_group::reset();
     requirement_data::reset();
@@ -528,6 +535,8 @@ void DynamicDataLoader::unload_data()
     reset_furn_ter();
     reset_mapgens();
     reset_mod_tileset();
+    reset_monster_adjustment();
+    reset_mutation_types();
     reset_overlay_ordering();
     reset_recipe_categories();
     reset_region_settings();
@@ -537,19 +546,22 @@ void DynamicDataLoader::unload_data()
     scenario::reset();
     scent_type::reset();
     score::reset();
-    Skill::reset();
     skill_boost::reset();
+    Skill::reset();
+    SkillDisplayType::reset();
     SNIPPET.clear_snippets();
     spell_type::reset_all();
     start_locations::reset();
+    ter_furn_transform::reset_all();
     trap::reset();
     unload_talk_topics();
+    vehicle_prototype::reset();
     VehicleGroup::reset();
     VehiclePlacement::reset();
     VehicleSpawn::reset();
-    vehicle_prototype::reset();
     vitamin::reset();
     vpart_info::reset();
+    zone_type::reset_zones();
 #if defined(LOCALIZE)
     l10n_data::unload_mod_catalogues();
 #endif
@@ -619,7 +631,7 @@ void DynamicDataLoader::finalize_loaded_data( loading_ui &ui )
             { _( "Harvest lists" ), &harvest_list::finalize_all },
             { _( "Anatomies" ), &anatomy::finalize_all },
             { _( "Mutations" ), &mutation_branch::finalize },
-            { _( "Achivements" ), &achievement::finalize },
+            { _( "Achievements" ), &achievement::finalize },
 #if defined(LOCALIZE)
             {_( "Localization" ), &l10n_data::load_mod_catalogues },
 #endif
@@ -714,7 +726,7 @@ void DynamicDataLoader::check_consistency( loading_ui &ui )
             { _( "Statistics" ), &event_statistic::check_consistency },
             { _( "Scent types" ), &scent_type::check_scent_consistency },
             { _( "Scores" ), &score::check_consistency },
-            { _( "Achivements" ), &achievement::check_consistency },
+            { _( "Achievements" ), &achievement::check_consistency },
             { _( "Disease types" ), &disease_type::check_disease_consistency },
             { _( "Factions" ), &faction_template::check_consistency },
         }

--- a/src/item.h
+++ b/src/item.h
@@ -2251,4 +2251,11 @@ inline bool is_crafting_component( const item &component )
            !component.is_filthy();
 }
 
+namespace charge_removal_blacklist
+{
+const std::set<itype_id> &get();
+void load( const JsonObject &jo );
+void reset();
+}
+
 #endif // CATA_SRC_ITEM_H

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -223,6 +223,11 @@ void item_action_generator::check_consistency() const
     }
 }
 
+void item_action_generator::reset()
+{
+    item_actions.clear();
+}
+
 void game::item_action_menu()
 {
     const auto &gen = item_action_generator::generator();

--- a/src/item_action.h
+++ b/src/item_action.h
@@ -56,6 +56,7 @@ class item_action_generator
 
         void load_item_action( const JsonObject &jo );
         void check_consistency() const;
+        void reset();
 };
 
 #endif // CATA_SRC_ITEM_ACTION_H

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -155,24 +155,29 @@ static void migrate_ench_vals_enums( std::string &s )
 
 namespace
 {
-generic_factory<enchantment> spell_factory( "enchantment" );
+generic_factory<enchantment> enchant_factory( "enchantment" );
 } // namespace
 
 template<>
 const enchantment &string_id<enchantment>::obj() const
 {
-    return spell_factory.obj( *this );
+    return enchant_factory.obj( *this );
 }
 
 template<>
 bool string_id<enchantment>::is_valid() const
 {
-    return spell_factory.is_valid( *this );
+    return enchant_factory.is_valid( *this );
 }
 
 void enchantment::load_enchantment( const JsonObject &jo, const std::string &src )
 {
-    spell_factory.load( jo, src );
+    enchant_factory.load( jo, src );
+}
+
+void enchantment::reset()
+{
+    enchant_factory.reset();
 }
 
 bool enchantment::is_active( const Character &guy, const item &parent ) const

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -115,6 +115,7 @@ class enchantment
 
         static void load_enchantment( const JsonObject &jo, const std::string &src );
         void load( const JsonObject &jo, const std::string &src = "" );
+        static void reset();
 
         // attempts to add two like enchantments together.
         // if their conditions don't match, return false. else true.

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -2983,6 +2983,11 @@ void check_consistency()
     extras.check();
 }
 
+void reset()
+{
+    extras.reset();
+}
+
 void debug_spawn_test()
 {
     uilist mx_menu;

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -73,6 +73,7 @@ void apply_function( const std::string &id, map &m, const tripoint &abs_sub );
 
 void load( const JsonObject &jo, const std::string &src );
 void check_consistency();
+void reset();
 
 void debug_spawn_test();
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2125,6 +2125,11 @@ void mapgen_palette::load( const JsonObject &jo, const std::string &src )
     palettes[ ret.id ] = ret;
 }
 
+void mapgen_palette::reset()
+{
+    palettes.clear();
+}
+
 const mapgen_palette &mapgen_palette::get( const palette_id &id )
 {
     const auto iter = palettes.find( id );

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -237,6 +237,8 @@ class mapgen_palette
          * If "palette" field is specified, those palettes will be loaded recursively.
          */
         static void load( const JsonObject &jo, const std::string &src );
+        /** Unload all palettes. */
+        static void reset();
 
         /**
          * Returns a palette with given id. If not found, debugmsg and returns a dummy.

--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -121,6 +121,12 @@ mf_attitude monfaction::attitude( const mfaction_id &other ) const
     return MFA_FRIENDLY;
 }
 
+void monfactions::reset()
+{
+    faction_list.clear();
+    faction_map.clear();
+}
+
 void monfactions::finalize()
 {
     if( faction_list.empty() ) {

--- a/src/monfaction.h
+++ b/src/monfaction.h
@@ -19,6 +19,7 @@ using mfaction_att_map = std::unordered_map< mfaction_id, mf_attitude >;
 
 namespace monfactions
 {
+void reset();
 void finalize();
 void load_monster_faction( const JsonObject &jo );
 mfaction_id get_or_add_faction( const mfaction_str_id &id );

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -482,6 +482,7 @@ struct mutation_category_trait {
 };
 
 void load_mutation_type( const JsonObject &jsobj );
+void reset_mutation_types();
 bool mutation_category_is_valid( const std::string &cat );
 bool mutation_type_exists( const std::string &id );
 std::vector<trait_id> get_mutations_in_types( const std::set<std::string> &ids );

--- a/src/mutation_type.cpp
+++ b/src/mutation_type.cpp
@@ -16,6 +16,11 @@ void load_mutation_type( const JsonObject &jsobj )
     mutation_types[new_type.id] = new_type;
 }
 
+void reset_mutation_types()
+{
+    mutation_types.clear();
+}
+
 bool mutation_type_exists( const std::string &id )
 {
     return mutation_types.find( id ) != mutation_types.end();

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -432,7 +432,7 @@ class overmap
         void process_mongroups();
         void move_hordes();
 
-        static bool obsolete_terrain( const std::string &ter );
+        static bool is_obsolete_terrain( const std::string &ter );
         void convert_terrain( const std::unordered_map<tripoint, std::string> &needs_conversion );
 
         // Overall terrain
@@ -530,6 +530,7 @@ class overmap
         void save_monster_groups( JsonOut &jo ) const;
     public:
         static void load_obsolete_terrains( const JsonObject &jo );
+        static void reset_obsolete_terrains();
 };
 
 bool is_river( const oter_id &ter );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -329,7 +329,12 @@ void overmap::load_obsolete_terrains( const JsonObject &jo )
     }
 }
 
-bool overmap::obsolete_terrain( const std::string &ter )
+void overmap::reset_obsolete_terrains()
+{
+    obsolete_terrains.clear();
+}
+
+bool overmap::is_obsolete_terrain( const std::string &ter )
 {
     return obsolete_terrains.find( ter ) != obsolete_terrains.end();
 }
@@ -432,7 +437,7 @@ void overmap::unserialize( std::istream &fin )
                             jsin.read( tmp_ter );
                             jsin.read( count );
                             jsin.end_array();
-                            if( obsolete_terrain( tmp_ter ) ) {
+                            if( is_obsolete_terrain( tmp_ter ) ) {
                                 for( int p = i; p < i + count; p++ ) {
                                     needs_conversion.emplace( tripoint( p, j, z - OVERMAP_DEPTH ),
                                                               tmp_ter );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2136,12 +2136,23 @@ static void load_legacy_craft_data( io::JsonObjectOutputArchive &, T & )
 {
 }
 
-static std::set<itype_id> charge_removal_blacklist;
-
-void load_charge_removal_blacklist( const JsonObject &jo, const std::string &src );
-void load_charge_removal_blacklist( const JsonObject &jo, const std::string &/*src*/ )
+namespace charge_removal_blacklist
 {
-    charge_removal_blacklist = jo.get_tags( "list" );
+static std::set<itype_id> removal_list;
+
+const std::set<itype_id> &get()
+{
+    return removal_list;
+}
+void load( const JsonObject &jo )
+{
+    std::set<itype_id> d = jo.get_tags( "list" );
+    removal_list.insert( d.begin(), d.end() );
+}
+void reset()
+{
+    removal_list.clear();
+}
 }
 
 template<typename Archive>
@@ -2310,7 +2321,7 @@ void item::io( Archive &archive )
     if( charges != 0 && !type->can_have_charges() ) {
         // Types that are known to have charges, but should not have them.
         // We fix it here, but it's expected from bugged saves and does not require a message.
-        if( charge_removal_blacklist.count( type->get_id() ) == 0 ) {
+        if( charge_removal_blacklist::get().count( type->get_id() ) == 0 ) {
             debugmsg( "Item %s was loaded with charges, but can not have any!", type->get_id() );
         }
         charges = 0;

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -155,6 +155,11 @@ void SkillDisplayType::load( const JsonObject &jsobj )
     skillTypes.push_back( sk );
 }
 
+void SkillDisplayType::reset()
+{
+    skillTypes.clear();
+}
+
 const SkillDisplayType &SkillDisplayType::get_skill_type( const skill_displayType_id &id )
 {
     for( auto &i : skillTypes ) {

--- a/src/skill.h
+++ b/src/skill.h
@@ -233,6 +233,7 @@ class SkillDisplayType
     public:
         static std::vector<SkillDisplayType> skillTypes;
         static void load( const JsonObject &jsobj );
+        static void reset();
 
         static const SkillDisplayType &get_skill_type( const skill_displayType_id & );
 


### PR DESCRIPTION
Map extras are not cleared on data unload, leading to erroneous debug messages when loading world with different mod set (to reproduce, load a world with Dinomod, then a world without Dinomod).

This PR fixes that, and adds clearing code to a bunch more types as a preventive measure.
Also renamed a few things here and there.