### PR TITLE
Prevent disabled recharging stations from working

### DIFF
--- a/src/active_tile_data.cpp
+++ b/src/active_tile_data.cpp
@@ -209,7 +209,7 @@ void charger_tile::update_internal( time_point to, const tripoint &p, distributi
                     const int missing = grid.mod_resource( -1 );
                     if( missing == 0 ) {
                         if( n.is_battery() ) {
-                            n.set_energy( 1_kJ );
+                            n.mod_energy( 1_kJ );
                         } else {
                             n.ammo_set( "battery", n.ammo_remaining() + 1 );
                         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -530,7 +530,7 @@ item &item::activate()
     return *this;
 }
 
-units::energy item::set_energy( const units::energy &qty )
+units::energy item::mod_energy( const units::energy &qty )
 {
     if( !is_battery() ) {
         debugmsg( "Tried to set energy of non-battery item" );

--- a/src/item.h
+++ b/src/item.h
@@ -234,7 +234,7 @@ class item : public visitable<item>
          * @param qty energy quantity to add (can be negative)
          * @return 0 valued energy quantity on success
          */
-        units::energy set_energy( const units::energy &qty );
+        units::energy mod_energy( const units::energy &qty );
 
         /**
          * Filter setting the ammo for this instance


### PR DESCRIPTION
As in title.
Removed 15% inefficiency from charging stations. It was just small enough not to matter.

Also renamed `item::set_energy` to `item::mod_energy`, because that's what it does.