### PR TITLE
Fix Guneet being able to duplicate his sword

### DIFF
--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Guneet_Singh.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Guneet_Singh.json
@@ -24,7 +24,7 @@
     "bonus_per": { "rng": [ -2, 2 ] },
     "worn_override": "REFUGEE_Guneet_worn",
     "carry_override": "REFUGEE_Guneet_carried",
-    "weapon_override": "REFUGEE_Guneet_wield",
+    "weapon_override": "EMPTY_GROUP",
     "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_SouthAsian" } ],
     "skills": [
       { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "rng": [ 0, -5 ] } ] } ] } }

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Guneet_Singh.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Guneet_Singh.json
@@ -40,7 +40,8 @@
       { "item": "tshirt_text" },
       { "item": "jeans_red" },
       { "item": "turban" },
-      { "item": "sneakers" }
+      { "item": "sneakers" },
+      { "group": "REFUGEE_Guneet_wield" }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->


SUMMARY: Bugfixes "Fix buggy weapon duplication caused by NPC spawning with wielding a contained weapon"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This updates Guneet Signh's weapon spawn to be consistent with how Maldeep and Mangalpreet's weapons are spawned, having them all start wearing the weapon in its sheath/scabbard, instead of wielding the whole thing, scabbard and all.

This prevents the issues that cropped up due to https://github.com/cataclysmbnteam/Cataclysm-BN/issues/559, but does not fix whatever weirdness may be the underlying cause. Since NPCs probably should be set to spawn either wearing a contained weapon, or wielding their weapon while wearing its intended container separately, this is probably a low-priority bug. Spawning holding a sword in its scabbard is a fairly weird state of readiness to be in.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed Guneet's wield override to `EMPTY_GROUP`
2. Added a spawn of `REFUGEE_Guneet_wield` in Guneet's wear override, same way the other Signhs have their weapons spawed.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Leaving Guneet with the ability to duplicate swords as a convenient testbed for fixing whatever actually causes this bug. It can be re-introduced deliberately for testing should that come up, though.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Spawn into the refugee center.
2. Wait a turn.
3. Observe that all three of the Signhs are happily wielding their weapon of choice without any sword-duplication magic powers involved.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

As mentioned, this fixes the problems observed due to https://github.com/cataclysmbnteam/Cataclysm-BN/issues/559 but not whatever was going on codewise to cause sword magic to occur.