### PR TITLE
Allow changing DebugLog severity during runtime + some tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,21 +115,6 @@ DEBUGSYMS = -g
 # Tells ccache to keep comments, as they can be meaningful to the compiler (as to suppress warnings).
 export CCACHE_COMMENTS=1
 
-# Disable debug. Comment this out to get logging.
-#DEFINES = -DENABLE_LOGGING
-
-# Limit debug to level. Comment out all for all levels.
-#DEFINES += -DDEBUG_INFO
-#DEFINES += -DDEBUG_WARNING
-#DEFINES += -DDEBUG_ERROR
-#DEFINES += -DDEBUG_PEDANTIC_INFO
-
-# Limit debug to section. Comment out all for all levels.
-#DEFINES += -DDEBUG_ENABLE_MAIN
-#DEFINES += -DDEBUG_ENABLE_MAP
-#DEFINES += -DDEBUG_ENABLE_MAP_GEN
-#DEFINES += -DDEBUG_ENABLE_GAME
-
 # Explicitly let 'char' to be 'signed char' to fix #18776
 OTHERS += -fsigned-char
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -101,8 +101,6 @@
 
 static const efftype_id effect_sheared( "sheared" );
 
-#define dbg(x) DebugLog((x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
-
 static const activity_id ACT_ADV_INVENTORY( "ACT_ADV_INVENTORY" );
 static const activity_id ACT_AIM( "ACT_AIM" );
 static const activity_id ACT_ARMOR_LAYERS( "ACT_ARMOR_LAYERS" );
@@ -1829,7 +1827,6 @@ void activity_handlers::hotwire_finish( player_activity *act, player *p )
             add_msg( _( "The red wire always starts the engine, doesn't it?" ) );
         }
     } else {
-        dbg( D_ERROR ) << "game:process_activity: ACT_HOTWIRE_CAR: vehicle not found";
         debugmsg( "process_activity ACT_HOTWIRE_CAR: vehicle not found" );
     }
     act->set_to_null();
@@ -2296,8 +2293,6 @@ void activity_handlers::vehicle_finish( player_activity *act, player *p )
     act->set_to_null();
     if( !p->is_npc() ) {
         if( act->values.size() < 7 ) {
-            dbg( D_ERROR ) << "game:process_activity: invalid ACT_VEHICLE values: "
-                           << act->values.size();
             debugmsg( "process_activity invalid ACT_VEHICLE values:%d",
                       act->values.size() );
         } else {
@@ -2310,7 +2305,6 @@ void activity_handlers::vehicle_finish( player_activity *act, player *p )
                 }
                 return;
             } else {
-                dbg( D_ERROR ) << "game:process_activity: ACT_VEHICLE: vehicle not found";
                 debugmsg( "process_activity ACT_VEHICLE: vehicle not found" );
             }
         }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -87,7 +87,7 @@ static const std::string flag_RELOAD_AND_SHOOT( "RELOAD_AND_SHOOT" );
 static const std::string flag_RESTRICT_HANDS( "RESTRICT_HANDS" );
 static const std::string flag_SWIMMABLE( "SWIMMABLE" );
 
-#define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
+#define dbg(x) DebugLog((x), DC::SDL)
 
 bool can_fire_turret( avatar &you, const map &m, const turret_data &turret );
 
@@ -233,9 +233,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         }
     }
 
-    dbg( D_PEDANTIC_INFO ) << "game:plmove: From (" <<
-                           you.posx() << "," << you.posy() << "," << you.posz() << ") to (" <<
-                           dest_loc.x << "," << dest_loc.y << "," << dest_loc.z << ")";
+    dbg( DL::Debug ) << "game:plmove: From " << you.pos() << " to " << dest_loc;
 
     if( g->disable_robot( dest_loc ) ) {
         return false;
@@ -496,8 +494,6 @@ bool avatar_action::ramp_move( avatar &you, map &m, const tripoint &dest_loc )
 void avatar_action::swim( map &m, avatar &you, const tripoint &p )
 {
     if( !m.has_flag( flag_SWIMMABLE, p ) ) {
-        dbg( D_ERROR ) << "game:plswim: Tried to swim in "
-                       << m.tername( p ) << "!";
         debugmsg( "Tried to swim in %s!", m.tername( p ) );
         return;
     }

--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -14,7 +14,7 @@
 #include "string_formatter.h"
 #include "type_id.h"
 
-#define dbg(x) DebugLog((x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
+#define dbg(x) DebugLogFL((x),DC::Game)
 
 Creature_tracker::Creature_tracker() = default;
 
@@ -265,9 +265,9 @@ bool Creature_tracker::kill_marked_for_death()
         if( !critter.is_dead() ) {
             continue;
         }
-        dbg( D_INFO ) << string_format( "cleanup_dead: critter %d,%d,%d hp:%d %s",
-                                        critter.posx(), critter.posy(), critter.posz(),
-                                        critter.get_hp(), critter.name() );
+        dbg( DL::Info ) << string_format( "cleanup_dead: critter %s hp:%d %s",
+                                          critter.pos().to_string(), critter.get_hp(), critter.name() );
+
         critter.die( nullptr );
         monster_is_dead = true;
     }

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -27,6 +27,8 @@
 #include "cached_options.h"
 #include "color.h"
 #include "cursesdef.h"
+#include "enum_bitset.h"
+#include "enum_conversions.h"
 #include "filesystem.h"
 #include "get_version.h"
 #include "input.h"
@@ -81,13 +83,8 @@
 // Static defines                                                   {{{1
 // ---------------------------------------------------------------------
 
-#if (defined(DEBUG) || defined(_DEBUG)) && !defined(NDEBUG)
-static int debugLevel = DL_ALL;
-static int debugClass = DC_ALL;
-#else
-static int debugLevel = D_ERROR;
-static int debugClass = D_MAIN;
-#endif
+static enum_bitset<DL> debugLevel;
+static enum_bitset<DC> debugClass;
 
 /** True during game startup, when debugmsgs cannot be displayed yet. */
 static bool buffering_debugmsgs = true;
@@ -294,8 +291,7 @@ void realDebugmsg( const char *filename, const char *line, const char *funcname,
     if( capturing ) {
         captured += text;
     } else {
-        DebugLog( D_ERROR, D_MAIN ) << filename << ":" << line << " [" << funcname << "] " << text <<
-                                    std::flush;
+        *detail::realDebugLog( DL::Error, DC::DebugMsg, filename, line, funcname ) << text;
     }
 
     if( test_mode ) {
@@ -313,16 +309,63 @@ void realDebugmsg( const char *filename, const char *line, const char *funcname,
 // Normal functions                                                 {{{1
 // ---------------------------------------------------------------------
 
-void limitDebugLevel( int level_bitmask )
+template<typename E>
+static std::string fmt_mask( const enum_bitset<E> &mask )
 {
-    DebugLog( DL_ALL, DC_ALL ) << "Set debug level to: " << level_bitmask;
-    debugLevel = level_bitmask;
+    if( mask.test_all() ) {
+        return "ALL";
+    } else if( !mask.test_any() ) {
+        return "NONE";
+    } else {
+        std::stringstream ss;
+        ss << "[";
+        bool first = true;
+        for( size_t i = 0; i < enum_bitset<E>::size(); i++ ) {
+            E &&e = static_cast<E>( i );
+            if( !mask.test( e ) ) {
+                continue;
+            }
+            if( first ) {
+                first = false;
+            } else {
+                ss << " ";
+            }
+            ss << io::enum_to_string<E>( e );
+        }
+        ss << "]";
+        return ss.str();
+    }
 }
 
-void limitDebugClass( int class_bitmask )
+void setDebugLogLevels( const enum_bitset<DL> &mask, bool silent )
 {
-    DebugLog( DL_ALL, DC_ALL ) << "Set debug class to: " << class_bitmask;
-    debugClass = class_bitmask;
+    if( mask == debugLevel ) {
+        return;
+    }
+    if( !silent ) {
+        DebugLog( DL::Info, DC::Main ) << "Set debug levels to: " << fmt_mask( mask );
+    }
+    debugLevel = mask;
+}
+
+void setDebugLogClasses( const enum_bitset<DC> &mask, bool silent )
+{
+    if( mask == debugClass ) {
+        return;
+    }
+    if( !silent ) {
+        DebugLog( DL::Info, DC::Main ) << "Set debug classes to: " << fmt_mask( mask );
+    }
+    debugClass = mask;
+}
+
+static bool checkDebugLevelClass( DL lev, DC cl )
+{
+    if( lev == DL::Error || cl == DC::DebugMsg ) {
+        return true;
+    } else {
+        return debugClass.test( cl ) && debugLevel.test( lev );
+    }
 }
 
 // Debug only                                                       {{{1
@@ -428,7 +471,6 @@ DebugFile::~DebugFile()
 void DebugFile::deinit()
 {
     if( file && file.get() != &std::cerr ) {
-        *file << "\n";
         *file << get_time() << " : Log shutdown.\n";
         *file << "-----------------------------------------\n\n";
     }
@@ -466,14 +508,14 @@ void DebugFile::init( DebugOutput output_mode, const std::string &filename )
             file = std::make_shared<std::ofstream>(
                        filename.c_str(), std::ios::out | std::ios::app );
             *file << "\n\n-----------------------------------------\n";
-            *file << get_time() << " : Starting log.";
-            DebugLog( D_INFO, D_MAIN ) << "Cataclysm DDA version " << getVersionString();
+            *file << get_time() << " : Starting log.\n";
+            DebugLog( DL::Info, DC::Main ) << "Cataclysm BN version " << getVersionString();
             if( rename_failed ) {
-                DebugLog( D_ERROR, DC_ALL ) << "Moving the previous log file to "
-                                            << oldfile << " failed.\n"
-                                            << "Check the file permissions.  This "
-                                            "program will continue to use the "
-                                            "previous log file.";
+                DebugLog( DL::Info, DC::Main ) << "Moving the previous log file to "
+                                               << oldfile << " failed.\n"
+                                               << "Check the file permissions.  This "
+                                               "program will continue to use the "
+                                               "previous log file.";
             }
         }
         break;
@@ -490,50 +532,8 @@ void DebugFile::init( DebugOutput output_mode, const std::string &filename )
 
 void setupDebug( DebugOutput output_mode )
 {
-    int level = 0;
-
-#if defined(DEBUG_INFO)
-    level |= D_INFO;
-#endif
-
-#if defined(DEBUG_WARNING)
-    level |= D_WARNING;
-#endif
-
-#if defined(DEBUG_ERROR)
-    level |= D_ERROR;
-#endif
-
-#if defined(DEBUG_PEDANTIC_INFO)
-    level |= D_PEDANTIC_INFO;
-#endif
-
-    if( level != 0 ) {
-        limitDebugLevel( level );
-    }
-
-    int cl = 0;
-
-#if defined(DEBUG_ENABLE_MAIN)
-    cl |= D_MAIN;
-#endif
-
-#if defined(DEBUG_ENABLE_MAP)
-    cl |= D_MAP;
-#endif
-
-#if defined(DEBUG_ENABLE_MAP_GEN)
-    cl |= D_MAP_GEN;
-#endif
-
-#if defined(DEBUG_ENABLE_GAME)
-    cl |= D_GAME;
-#endif
-
-    if( cl != 0 ) {
-        limitDebugClass( cl );
-    }
-
+    setDebugLogLevels( enum_bitset<DL>().set( DL::Info ).set( DL::Warn ).set( DL::Error ), true );
+    setDebugLogClasses( enum_bitset<DC>().set( DC::Main ).set( DC::DebugMsg ), true );
     debugFile().init( output_mode, PATH_INFO::debug() );
 }
 
@@ -545,52 +545,47 @@ void deinitDebug()
 // OStream Operators                                                {{{2
 // ---------------------------------------------------------------------
 
-static std::ostream &operator<<( std::ostream &out, DebugLevel lev )
+namespace io
 {
-    if( lev != DL_ALL ) {
-        if( lev & D_INFO ) {
-            out << "INFO ";
-        }
-        if( lev & D_WARNING ) {
-            out << "WARNING ";
-        }
-        if( lev & D_ERROR ) {
-            out << "ERROR ";
-        }
-        if( lev & D_PEDANTIC_INFO ) {
-            out << "PEDANTIC ";
-        }
+template<>
+std::string enum_to_string<DL>( DL x )
+{
+    switch( x ) {
+        // *INDENT-OFF*
+        case DL::Info: return "INFO";
+        case DL::Warn: return "WARNING";
+        case DL::Error: return "ERROR";
+        case DL::Debug: return "DEBUG";
+        // *INDENT-ON*
+        case DL::Num:
+            break;
     }
-    return out;
+    debugmsg( "Invalid debug level" );
+    abort();
 }
 
-static std::ostream &operator<<( std::ostream &out, DebugClass cl )
+template<>
+std::string enum_to_string<DC>( DC x )
 {
-    if( cl != DC_ALL ) {
-        if( cl & D_MAIN ) {
-            out << "MAIN ";
-        }
-        if( cl & D_MAP ) {
-            out << "MAP ";
-        }
-        if( cl & D_MAP_GEN ) {
-            out << "MAP_GEN ";
-        }
-        if( cl & D_NPC ) {
-            out << "NPC ";
-        }
-        if( cl & D_GAME ) {
-            out << "GAME ";
-        }
-        if( cl & D_SDL ) {
-            out << "SDL ";
-        }
-        if( cl & D_MMAP ) {
-            out << "MMAP ";
-        }
+    switch( x ) {
+        // *INDENT-OFF*
+        case DC::DebugMsg: return "DEBUGMSG";
+        case DC::DebugModeMsg: return "DMODE";
+        case DC::Game: return "GAME";
+        case DC::Main: return "MAIN";
+        case DC::Map: return "MAP";
+        case DC::MapGen: return "MAPGEN";
+        case DC::MapMem: return "MAPMEM";
+        case DC::NPC: return "NPC";
+        case DC::SDL: return "SDL";
+        // *INDENT-ON*
+        case DC::Num:
+            break;
     }
-    return out;
+    debugmsg( "Invalid debug class" );
+    abort();
 }
+} // namespace io
 
 #if defined(BACKTRACE)
 #if !defined(_WIN32) && !defined(__CYGWIN__)
@@ -1030,30 +1025,47 @@ void debug_write_backtrace( std::ostream &out )
 }
 #endif
 
-std::ostream &DebugLog( DebugLevel lev, DebugClass cl )
+detail::DebugLogGuard::~DebugLogGuard()
 {
-    if( lev & D_ERROR ) {
+    *s << std::endl;
+}
+
+detail::DebugLogGuard detail::realDebugLog( DL lev, DC cl, const char *filename,
+        const char *line, const char *funcname )
+{
+    if( lev == DL::Error ) {
         error_observed = true;
     }
 
-    // Error are always logged, they are important,
-    // Messages from D_MAIN come from debugmsg and are equally important.
-    if( ( lev & debugLevel && cl & debugClass ) || lev & D_ERROR || cl & D_MAIN ) {
+    if( checkDebugLevelClass( lev, cl ) ) {
         std::ostream &out = debugFile().get_file();
-        out << std::endl;
         out << get_time() << " ";
-        out << lev;
-        if( cl != debugClass ) {
-            out << cl;
+        out << io::enum_to_string<DL>( lev ) << " ";
+        if( cl != DC::Main ) {
+            out << io::enum_to_string<DC>( cl ) << " ";
         }
         out << ": ";
+        if( filename ) {
+            out << filename;
+            if( line ) {
+                out << ":" << line;
+            }
+            if( funcname ) {
+                out << " ";
+            } else {
+                out << ": ";
+            }
+        }
+        if( funcname ) {
+            out << "[" << funcname << "] ";
+        }
 
         // Backtrace on error.
 #if defined(BACKTRACE)
         // Push the first retrieved value back by a second so it won't match.
         static time_t next_backtrace = time( nullptr ) - 1;
         time_t now = time( nullptr );
-        if( lev == D_ERROR && now >= next_backtrace ) {
+        if( lev == DL::Error && now >= next_backtrace ) {
             out << "(error message will follow backtrace)";
             debug_write_backtrace( out );
             time_t after = time( nullptr );
@@ -1063,12 +1075,12 @@ std::ostream &DebugLog( DebugLevel lev, DebugClass cl )
         }
 #endif
 
-        return out;
+        return DebugLogGuard( out );
     }
 
     static NullBuf nullBuf;
     static std::ostream nullStream( &nullBuf );
-    return nullStream;
+    return DebugLogGuard( nullStream );
 }
 
 std::string game_info::operating_system()

--- a/src/debug.h
+++ b/src/debug.h
@@ -2,8 +2,6 @@
 #ifndef CATA_SRC_DEBUG_H
 #define CATA_SRC_DEBUG_H
 
-#include "string_formatter.h"
-
 /**
  *      debugmsg(msg, ...)
  * varg-style functions: the first argument is the format (see printf),
@@ -14,34 +12,37 @@
  * The message is also logged with DebugLog, a separate call to DebugLog
  * is not needed.
  *
- *      DebugLog
+ *      DebugLog(lev, cl)  and  DebugLogFL(lev, cl)
  * The main debugging system. It uses debug levels (how critical/important
  * the message is) and debug classes (which part of the code it comes from,
  * e.g. mapgen, SDL, npcs). This allows disabling debug classes and levels
  * (e.g. only write SDL messages, but no npc or map related ones).
- * It returns a reference to an outputs stream. Simply write your message into
+ * It returns a reference to an output stream. Simply write your message into
  * that stream (using the << operators).
  * DebugLog always returns a stream that starts on a new line. Don't add a
- * newline at the end of your debug message.
+ * newline at the end of your debug message, as it is automatically appended
+ * once the reference goes out of scope.
  * If the specific debug level or class have been disabled, the message is
  * actually discarded, otherwise it is written to a log file.
+ * Errors are logged regardless of whether debug class is enabled.
+ * DebugLogFL version also logs source file name and line number.
  * If a single source file contains mostly messages for the same debug class
  * (e.g. mapgen.cpp), create and use the macro dbg.
  *
- *      dbg
+ *      dbg(lev)
  * Usually a single source contains only debug messages for a single debug class
- * (e.g. mapgen.cpp contains only messages for D_MAP_GEN, npcmove.cpp only D_NPC).
+ * (e.g. mapgen.cpp contains only messages for DC::MapGen, npcmove.cpp only DC::NPC).
  * Those files contain a macro at top:
 @code
-#define dbg(x) DebugLog((x), D_NPC) << __FILE__ << ":" << __LINE__ << ": "
+#define dbg(x) DebugLogFL((x), DC::NPC)
 @endcode
  * It allows to call the debug system and just supply the debug level, the debug
  * class is automatically inserted as it is the same for the whole file. Also this
  * adds the file name and the line of the statement to the debug message.
  * This can be replicated in any source file, just copy the above macro and change
- * D_NPC to the debug class to use. Don't add this macro to a header file
+ * DC::NPC to the debug class to use. Don't add this macro to a header file
  * as the debug class is source file specific.
- * As dbg calls DebugLog, it returns the stream, its usage is the same.
+ * As dbg calls DebugLog, it returns the stream reference, its usage is the same.
  */
 
 // Includes                                                         {{{1
@@ -51,6 +52,10 @@
 #include <type_traits>
 #include <utility>
 #include <functional>
+
+#include "string_formatter.h"
+template<typename T> struct enum_traits;
+template<typename E> class enum_bitset;
 
 #define STRING2(x) #x
 #define STRING(x) STRING2(x)
@@ -62,11 +67,10 @@
 #endif
 
 /**
- * Debug message of level D_ERROR and class D_MAIN, also includes the source
- * file name and line, uses varg style arguments, teh first argument must be
+ * Debug message of level DL::Error and class DC::DebugMsg, also includes the source
+ * file name and line, uses varg style arguments, the first argument must be
  * a printf style format string.
  */
-
 #define debugmsg(...) realDebugmsg(__FILE__, STRING(__LINE__), __FUNCTION_NAME__, __VA_ARGS__)
 
 // Don't use this, use debugmsg instead.
@@ -111,47 +115,67 @@ std::string game_report();
 // Enumerations                                                     {{{1
 // ---------------------------------------------------------------------
 
-/**
- * If you add an entry, add an entry in that function:
- * std::ostream &operator<<(std::ostream &out, DebugLevel lev)
- */
-enum DebugLevel {
-    D_INFO          = 1,
-    D_WARNING       = 1 << 2,
-    D_ERROR         = 1 << 3,
-    D_PEDANTIC_INFO = 1 << 4,
-
-    DL_ALL = ( 1 << 5 ) - 1
+/** Debug level */
+enum class DL : int {
+    /**
+     * Debug information (default: disabled).
+     */
+    Debug,
+    /**
+     * Information (default: enabled).
+     */
+    Info,
+    /**
+     * Warning (default: enabled).
+     */
+    Warn,
+    /**
+     * Error (default: enabled).
+     * Errors are logged regardless of whether debug class is enabled
+     * and have backtrace appended to them.
+     */
+    Error,
+    /**
+     * Unused
+     */
+    Num,
 };
 
-inline DebugLevel operator|( DebugLevel l, DebugLevel r )
-{
-    return static_cast<DebugLevel>(
-               static_cast<std::underlying_type_t<DebugLevel>>( l ) | r );
-}
+template <>
+struct enum_traits<DL> {
+    static constexpr DL last = DL::Num;
+};
 
-/**
- * Debugging areas can be enabled for each of those areas separately.
- * If you add an entry, add an entry in that function:
- * std::ostream &operator<<(std::ostream &out, DebugClass cl)
- */
-enum DebugClass {
-    /** Messages from realDebugmsg */
-    D_MAIN    = 1,
-    /** Related to map and mapbuffer (map.cpp, mapbuffer.cpp) */
-    D_MAP     = 1 << 2,
-    /** Mapgen (mapgen*.cpp), also overmap.cpp */
-    D_MAP_GEN = 1 << 3,
+/** Debug class */
+enum class DC : int {
+    /** (internal) Messages from realDebugmsg */
+    DebugMsg,
+    /** (internal) Debug-type messages from message log */
+    DebugModeMsg,
     /** Main game class */
-    D_GAME    = 1 << 4,
-    /** npcs*.cpp */
-    D_NPC     = 1 << 5,
-    /** SDL & tiles & anything graphical */
-    D_SDL     = 1 << 6,
+    Game,
+    /**
+     * Generic messages related to game startup and operation.
+     * Enabled by default.
+     */
+    Main,
+    /** Related to map and mapbuffer (map.cpp, mapbuffer.cpp) */
+    Map,
+    /** Mapgen (mapgen*.cpp), also overmap.cpp */
+    MapGen,
     /** Related to tile memory (map_memory.cpp) */
-    D_MMAP    = 1 << 7,
+    MapMem,
+    /** npcs*.cpp */
+    NPC,
+    /** SDL & tiles & anything graphical & sound */
+    SDL,
+    /** Unused */
+    Num,
+};
 
-    DC_ALL    = ( 1 << 30 ) - 1
+template <>
+struct enum_traits<DC> {
+    static constexpr DC last = DC::Num;
 };
 
 enum class DebugOutput {
@@ -167,17 +191,14 @@ void deinitDebug();
 // Function Declarations                                            {{{1
 // ---------------------------------------------------------------------
 /**
- * Set debug levels that should be logged. bitmask is a OR-combined
- * set of DebugLevel values. Use 0 to disable all.
- * Note that D_ERROR is always logged.
+ * Set debug levels that should be logged.
  */
-void limitDebugLevel( int );
+void setDebugLogLevels( const enum_bitset<DL> &mask, bool silent = false );
+
 /**
- * Set the debug classes should be logged. bitmask is a OR-combined
- * set of DebugClass values. Use 0 to disable all.
- * Note that D_UNSPECIFIC is always logged.
+ * Set debug classes that should be logged.
  */
-void limitDebugClass( int );
+void setDebugLogClasses( const enum_bitset<DC> &mask, bool silent = false );
 
 /**
  * @return true if any error has been logged in this run.
@@ -200,8 +221,42 @@ void replay_buffered_debugmsg_prompts();
 // Debug Only                                                       {{{1
 // ---------------------------------------------------------------------
 
-// See documentation at the top.
-std::ostream &DebugLog( DebugLevel, DebugClass );
+namespace detail
+{
+/**
+ * Debug log guard.
+ *
+ * Appends newline and flushes the log when goes out of scope.
+ * Dereference to get the underlying stream.
+ */
+class DebugLogGuard
+{
+        std::ostream *s;
+    public:
+        explicit DebugLogGuard( std::ostream &s ) : s( &s ) {}
+        ~DebugLogGuard();
+
+        std::ostream &operator*() {
+            return *s;
+        }
+        const std::ostream &operator*() const {
+            return *s;
+        }
+};
+
+DebugLogGuard realDebugLog( DL lev, DC cl, const char *filename,
+                            const char *line, const char *funcname );
+}
+
+/**
+ * DebugLog. See documentation at the top of the file.
+ */
+#define DebugLog(lev, cl) *detail::realDebugLog(lev, cl, nullptr, nullptr, nullptr)
+
+/**
+ * Like DebugLog, but includes source file name and line number.
+ */
+#define DebugLogFL(lev, cl) *detail::realDebugLog(lev, cl, __FILE__, STRING(__LINE__), nullptr)
 
 #if defined(BACKTRACE)
 /**

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -111,7 +111,6 @@ extern std::map<std::string, weighted_int_list<std::shared_ptr<mapgen_function_j
 #include "sdl_wrappers.h"
 #endif
 
-#define dbg(x) DebugLog((x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
 namespace debug_menu
 {
 
@@ -1210,18 +1209,18 @@ void benchmark( const int max_difference, bench_kind kind )
         draw_counter++;
     }
 
-    DebugLog( D_INFO, DC_ALL ) << bench_name << ":\n" <<
-                               "\n| USE_TILES |  RENDERER | FRAMEBUFFER_ACCEL | USE_COLOR_MODULATED_TEXTURES | FPS |" <<
-                               "\n|:---:|:---:|:---:|:---:|:---:|\n| " <<
-                               get_option<bool>( "USE_TILES" ) << " | " <<
+    DebugLog( DL::Info, DC::Main ) << bench_name << ":\n" <<
+                                   "\n| USE_TILES |  RENDERER | FRAMEBUFFER_ACCEL | USE_COLOR_MODULATED_TEXTURES | FPS |" <<
+                                   "\n|:---:|:---:|:---:|:---:|:---:|\n| " <<
+                                   get_option<bool>( "USE_TILES" ) << " | " <<
 #if !defined(__ANDROID__)
-                               get_option<std::string>( "RENDERER" ) << " | " <<
+                                   get_option<std::string>( "RENDERER" ) << " | " <<
 #else
-                               get_option<bool>( "SOFTWARE_RENDERING" ) << " | " <<
+                                   get_option<bool>( "SOFTWARE_RENDERING" ) << " | " <<
 #endif
-                               get_option<bool>( "FRAMEBUFFER_ACCEL" ) << " | " <<
-                               get_option<bool>( "USE_COLOR_MODULATED_TEXTURES" ) << " | " <<
-                               static_cast<int>( 1000.0 * draw_counter / static_cast<double>( difference ) ) << " |\n";
+                                   get_option<bool>( "FRAMEBUFFER_ACCEL" ) << " | " <<
+                                   get_option<bool>( "USE_COLOR_MODULATED_TEXTURES" ) << " | " <<
+                                   static_cast<int>( 1000.0 * draw_counter / static_cast<double>( difference ) ) << " |\n";
 
     std::string msg_txt;
     switch( kind ) {
@@ -1305,7 +1304,7 @@ void debug()
                 mfus += string_format( "%s;%d\n", io::enum_to_string<m_flag>( m_flag_stat.first ),
                                        m_flag_stat.second );
             }
-            DebugLog( D_INFO, DC_ALL ) << "Monster flag usage statistics:\nFLAG;COUNT\n" << mfus;
+            DebugLog( DL::Info, DC::Main ) << "Monster flag usage statistics:\nFLAG;COUNT\n" << mfus;
             std::fill( MonsterGenerator::generator().m_flag_usage_stats.begin(),
                        MonsterGenerator::generator().m_flag_usage_stats.end(), 0 );
             popup_top( "Monster flag usage statistics were dumped to debug.log and cleared." );
@@ -1355,8 +1354,7 @@ void debug()
 
         case DEBUG_SPAWN_VEHICLE:
             if( m.veh_at( u.pos() ) ) {
-                dbg( D_ERROR ) << "game:load: There's already vehicle here";
-                debugmsg( "There's already vehicle here" );
+                add_msg( m_bad, "There's already vehicle here." );
             } else {
                 // Vector of name, id so that we can sort by name
                 std::vector<std::pair<std::string, vproto_id>> veh_strings;
@@ -1901,7 +1899,7 @@ void debug()
             // generate a game report, useful for bug reporting.
             std::string report = game_info::game_report();
             // write to log
-            DebugLog( DL_ALL, DC_ALL ) << " GAME REPORT:\n" << report;
+            DebugLog( DL::Info, DC::Main ) << " GAME REPORT:\n" << report;
             std::string popup_msg = _( "Report written to debug.log" );
 #if defined(TILES)
             // copy to clipboard

--- a/src/dependency_tree.cpp
+++ b/src/dependency_tree.cpp
@@ -390,7 +390,7 @@ void dependency_tree::check_for_strongly_connected_components()
     for( auto &elem : strongly_connected_components ) {
         if( elem.size() > 1 ) {
             for( auto &elem_node : elem ) {
-                DebugLog( D_PEDANTIC_INFO, DC_ALL ) << "--" << elem_node->key.str() << "\n";
+                //DebugLog( DL::Debug, DC::Game ) << "--" << elem_node->key.str() << "\n";
                 in_circular_connection.insert( elem_node );
             }
 

--- a/src/enum_bitset.h
+++ b/src/enum_bitset.h
@@ -7,6 +7,11 @@
 
 #include "enum_traits.h"
 
+namespace io
+{
+template<typename E> std::string enum_to_string( E );
+}
+
 template<typename E>
 class enum_bitset
 {
@@ -52,18 +57,35 @@ class enum_bitset
             return *this;
         }
 
-        enum_bitset &reset( E e ) {
+        enum_bitset &set_all() {
+            bits.set();
+            return *this;
+        }
+
+        enum_bitset &clear( E e ) {
             bits.reset( get_pos( e ) );
             return *this;
         }
 
-        enum_bitset &reset() {
+        enum_bitset &clear_all() {
             bits.reset();
             return *this;
         }
 
         bool test( E e ) const {
             return bits.test( get_pos( e ) );
+        }
+
+        bool test_all() const {
+            return bits.all();
+        }
+
+        bool test_any() const {
+            return bits.any();
+        }
+
+        size_t count() const {
+            return bits.count();
         }
 
         static constexpr size_t size() noexcept {
@@ -75,7 +97,6 @@ class enum_bitset
             return static_cast<size_t>( static_cast<typename std::underlying_type<E>::type>( e ) );
         }
 
-    private:
         std::bitset<enum_bitset<E>::size()> bits;
 };
 

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -31,6 +31,8 @@
 #   include <unistd.h>
 #endif
 
+#define dbg(x) DebugLog((x), DC::Main)
+
 #if defined _WIN32
 static bool do_mkdir( const std::string &path )
 {
@@ -166,7 +168,7 @@ void for_each_dir_entry( const std::string &path, Function function )
     const dir_ptr root = opendir( path.c_str() );
     if( !root ) {
         const auto e_str = strerror( errno );
-        DebugLog( D_WARNING, D_MAIN ) << "opendir [" << path << "] failed with \"" << e_str << "\".";
+        dbg( DL::Warn ) << "opendir [" << path << "] failed with \"" << e_str << "\".";
         return;
     }
 
@@ -183,7 +185,7 @@ std::string resolve_path( const std::string &full_path )
     const auto result_str = realpath( full_path.c_str(), nullptr );
     if( !result_str ) {
         const auto e_str = strerror( errno );
-        DebugLog( D_WARNING, D_MAIN ) << "realpath [" << full_path << "] failed with \"" << e_str << "\".";
+        dbg( DL::Warn ) << "realpath [" << full_path << "] failed with \"" << e_str << "\".";
         return {};
     }
 
@@ -209,7 +211,7 @@ bool is_directory_stat( const std::string &full_path )
 #endif
     if( stat_ret != 0 ) {
         const auto e_str = strerror( errno );
-        DebugLog( D_WARNING, D_MAIN ) << "stat [" << full_path << "] failed with \"" << e_str << "\".";
+        dbg( DL::Warn ) << "stat [" << full_path << "] failed with \"" << e_str << "\".";
         return false;
     }
 

--- a/src/font_loader.h
+++ b/src/font_loader.h
@@ -79,8 +79,8 @@ class font_loader
             if( !file_exist( user_fontconfig ) ) {
                 if( !copy_file( fontconfig, user_fontconfig ) ) {
                     try_user = false;
-                    DebugLog( D_ERROR, D_SDL ) << "failed to create user font config file "
-                                               << user_fontconfig;
+                    DebugLog( DL::Error, DC::SDL ) << "failed to create user font config file "
+                                                   << user_fontconfig;
                 }
             }
             if( try_user ) {
@@ -89,14 +89,14 @@ class font_loader
                     load_throws( user_fontconfig );
                     return;
                 } catch( const std::exception &e ) {
-                    DebugLog( D_ERROR, D_SDL ) << e.what();
+                    DebugLog( DL::Error, DC::SDL ) << e.what();
                 }
                 *this = copy;
             }
             try {
                 load_throws( fontconfig );
             } catch( const std::exception &e ) {
-                DebugLog( D_ERROR, D_SDL ) << e.what();
+                DebugLog( DL::Error, DC::SDL ) << e.what();
                 abort();
             }
         }

--- a/src/fungal_effects.cpp
+++ b/src/fungal_effects.cpp
@@ -28,6 +28,8 @@
 #include "translations.h"
 #include "type_id.h"
 
+#define dbg(x) DebugLogFL((x), DC::Game)
+
 static const efftype_id effect_fungus( "fungus" );
 static const efftype_id effect_spores( "spores" );
 static const efftype_id effect_stunned( "stunned" );
@@ -229,8 +231,7 @@ void fungal_effects::spread_fungus_one_tile( const tripoint &p, const int growth
                 return it.is_seed();
             } );
             if( seed == items.end() || !seed->is_seed() ) {
-                DebugLog( D_ERROR, DC_ALL ) << "No seed item in the PLANT terrain at position " <<
-                                            string_format( "%d,%d,%d.", p.x, p.y, p.z );
+                dbg( DL::Warn ) << "No seed item in the PLANT terrain at position " << p;
             } else {
                 *seed = item( "fungal_seeds", calendar::turn );
             }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -177,7 +177,7 @@ class computer;
 #   include <tchar.h>
 #endif
 
-#define dbg(x) DebugLog((x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
+#define dbg(x) DebugLogFL((x),DC::Game)
 
 const int core_version = 6;
 static constexpr int DANGEROUS_PROXIMITY = 5;
@@ -2584,7 +2584,7 @@ bool game::is_game_over()
             uquit = QUIT_DIED;
         } else {
             // Something funky happened here, just die.
-            dbg( D_ERROR ) << "no deathcam option given to options, defaulting to QUIT_DIED";
+            dbg( DL::Error ) << "no deathcam option given to options, defaulting to QUIT_DIED";
             uquit = QUIT_DIED;
         }
         return is_game_over();
@@ -3022,14 +3022,11 @@ void game::write_memorial_file( std::string sLastWords )
 
     //Check if both dirs exist. Nested assure_dir_exist fails if the first dir of the nested dir does not exist.
     if( !assure_dir_exist( memorial_dir ) ) {
-        dbg( D_ERROR ) << "game:write_memorial_file: Unable to make memorial directory.";
         debugmsg( "Could not make '%s' directory", memorial_dir );
         return;
     }
 
     if( !assure_dir_exist( memorial_active_world_dir ) ) {
-        dbg( D_ERROR ) <<
-                       "game:write_memorial_file: Unable to make active world directory in memorial directory.";
         debugmsg( "Could not make '%s' directory", memorial_active_world_dir );
         return;
     }
@@ -4303,12 +4300,10 @@ void game::monmove()
     for( monster &critter : all_monsters() ) {
         // Critters in impassable tiles get pushed away, unless it's not impassable for them
         if( !critter.is_dead() && m.impassable( critter.pos() ) && !critter.can_move_to( critter.pos() ) ) {
-            dbg( D_ERROR ) << "game:monmove: " << critter.name()
-                           << " can't move to its location!  (" << critter.posx()
-                           << ":" << critter.posy() << ":" << critter.posz() << "), "
-                           << m.tername( critter.pos() );
-            add_msg( m_debug, "%s can't move to its location!  (%d,%d,%d), %s", critter.name(),
-                     critter.posx(), critter.posy(), critter.posz(), m.tername( critter.pos() ) );
+            std::string msg = string_format( "%s can't move to its location!  %s  %s", critter.name(),
+                                             critter.pos().to_string(), m.tername( critter.pos() ) );
+            dbg( DL::Error ) << msg;
+            add_msg( m_debug, msg );
             bool okay = false;
             for( const tripoint &dest : m.points_in_radius( critter.pos(), 3 ) ) {
                 if( critter.can_move_to( dest ) && is_empty( dest ) ) {
@@ -4721,9 +4716,7 @@ void game::use_computer( const tripoint &p )
         if( m.has_flag( "CONSOLE", p ) ) { //Console without map data
             add_msg( m_bad, _( "The console doesn't display anything coherent." ) );
         } else {
-            dbg( D_ERROR ) << "game:use_computer: Tried to use computer at (" <<
-                           p.x << ", " << p.y << ", " << p.z << ") - none there";
-            debugmsg( "Tried to use computer at (%d, %d, %d) - none there", p.x, p.y, p.z );
+            debugmsg( "Tried to use computer at %s - none there", p.to_string() );
         }
         return;
     }
@@ -6751,8 +6744,6 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
         } );
         ui->mark_resize();
     }
-
-    dbg( D_PEDANTIC_INFO ) << ": calling handle_input()";
 
     std::string action;
     input_context ctxt( "LOOK" );

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -238,7 +238,7 @@ void defense_game::init_map()
         case DEFLOC_NULL:
         case NUM_DEFENSE_LOCATIONS:
             defloc_special = overmap_special_id( "house_two_story_basement" );
-            DebugLog( D_ERROR, D_GAME ) << "defense location is invalid: " << location;
+            debugmsg( "Invalid defense location %d", location );
             break;
 
         case DEFLOC_HOSPITAL:
@@ -316,7 +316,7 @@ void defense_game::init_to_style( defense_style new_style )
 
     switch( new_style ) {
         case NUM_DEFENSE_STYLES:
-            DebugLog( D_ERROR, D_GAME ) << "invalid defense style: " << new_style;
+            debugmsg( "invalid defense style: %d", new_style );
             break;
         case DEFENSE_EASY:
         // fall through to custom
@@ -1135,7 +1135,7 @@ std::vector<itype_id> caravan_items( caravan_category cat )
             break;
 
         case NUM_CARAVAN_CATEGORIES:
-            DebugLog( D_ERROR, D_GAME ) << "invalid caravan category: " << cat;
+            debugmsg( "Invalid caravan category %d", cat );
             return ret;
     }
 

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -708,7 +708,7 @@ struct handler<std::bitset<N>> {
 template<typename E>
 struct handler<enum_bitset<E>> {
     void clear( enum_bitset<E> &container ) const {
-        container.reset();
+        container.clear_all();
     }
     template<typename T>
     void insert( enum_bitset<E> &container, const T &data ) const {
@@ -716,7 +716,7 @@ struct handler<enum_bitset<E>> {
     }
     template<typename T>
     void erase( enum_bitset<E> &container, const T &data ) const {
-        container.reset( data );
+        container.clear( data );
     }
     static constexpr bool is_container = true;
 };

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -120,7 +120,7 @@ static const std::string flag_RELOAD_ONE( "RELOAD_ONE" );
 
 static const std::string flag_SLEEP_IGNORE( "SLEEP_IGNORE" );
 
-#define dbg(x) DebugLog((x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
+#define dbg(x) DebugLogFL((x),DC::Game)
 
 #if defined(__ANDROID__)
 extern std::map<std::string, std::list<input_event>> quick_shortcuts_map;
@@ -430,7 +430,6 @@ static void pldrive( const tripoint &p )
         remote = false;
     }
     if( !veh ) {
-        dbg( D_ERROR ) << "game::pldrive: can't find vehicle!  Drive mode is now off.";
         debugmsg( "game::pldrive error: can't find vehicle!  Drive mode is now off." );
         u.in_vehicle = false;
         return;
@@ -2480,7 +2479,7 @@ bool game::handle_action()
     gamemode->post_action( act );
 
     u.movecounter = ( !u.is_dead_state() ? ( before_action_moves - u.moves ) : 0 );
-    dbg( D_INFO ) << string_format( "%s: [%d] %d - %d = %d", action_ident( act ),
-                                    to_turn<int>( calendar::turn ), before_action_moves, u.movecounter, u.moves );
+    dbg( DL::Info ) << string_format( "%s: [%d] %d - %d = %d", action_ident( act ),
+                                      to_turn<int>( calendar::turn ), before_action_moves, u.movecounter, u.moves );
     return ( !u.is_dead_state() );
 }

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -38,8 +38,6 @@
 #include "vehicle.h"
 #include "vpart_position.h"
 
-#define dbg(x) DebugLog((x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
-
 // All serialize_liquid_source functions should add the same number of elements to the vectors of
 // the activity. This makes it easier to distinguish the values of the source and the values of the target.
 static void serialize_liquid_source( player_activity &act, const vehicle &veh, const int part_num,
@@ -161,7 +159,6 @@ static bool get_liquid_target( item &liquid, item *const source, const int radiu
                                liquid_dest_opt &target )
 {
     if( !liquid.made_of( LIQUID ) ) {
-        dbg( D_ERROR ) << "game:handle_liquid: Tried to handle_liquid a non-liquid!";
         debugmsg( "Tried to handle_liquid a non-liquid!" );
         // "canceled by the user" because we *can* not handle it.
         return false;
@@ -307,7 +304,6 @@ static bool perform_liquid_transfer( item &liquid, const tripoint *const source_
 {
     bool transfer_ok = false;
     if( !liquid.made_of( LIQUID ) ) {
-        dbg( D_ERROR ) << "game:handle_liquid: Tried to handle_liquid a non-liquid!";
         debugmsg( "Tried to handle_liquid a non-liquid!" );
         // "canceled by the user" because we *can* not handle it.
         return transfer_ok;
@@ -401,7 +397,6 @@ bool handle_liquid( item &liquid, item *const source, const int radius,
                     const monster *const source_mon )
 {
     if( liquid.made_of( SOLID ) ) {
-        dbg( D_ERROR ) << "game:handle_liquid: Tried to handle_liquid a non-liquid!";
         debugmsg( "Tried to handle_liquid a non-liquid!" );
         // "canceled by the user" because we *can* not handle it.
         return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -620,17 +620,17 @@ int main( int argc, char *argv[] )
 #if defined(TILES)
     SDL_version compiled;
     SDL_VERSION( &compiled );
-    DebugLog( D_INFO, DC_ALL ) << "SDL version used during compile is "
-                               << static_cast<int>( compiled.major ) << "."
-                               << static_cast<int>( compiled.minor ) << "."
-                               << static_cast<int>( compiled.patch );
+    DebugLog( DL::Info, DC::Main ) << "SDL version used during compile is "
+                                   << static_cast<int>( compiled.major ) << "."
+                                   << static_cast<int>( compiled.minor ) << "."
+                                   << static_cast<int>( compiled.patch );
 
     SDL_version linked;
     SDL_GetVersion( &linked );
-    DebugLog( D_INFO, DC_ALL ) << "SDL version used during linking and in runtime is "
-                               << static_cast<int>( linked.major ) << "."
-                               << static_cast<int>( linked.minor ) << "."
-                               << static_cast<int>( linked.patch );
+    DebugLog( DL::Info, DC::Main ) << "SDL version used during linking and in runtime is "
+                                   << static_cast<int>( linked.major ) << "."
+                                   << static_cast<int>( linked.minor ) << "."
+                                   << static_cast<int>( linked.patch );
 #endif
 
 #if !defined(TILES)
@@ -649,7 +649,7 @@ int main( int argc, char *argv[] )
         } catch( const std::exception &err ) {
             // can't use any curses function as it has not been initialized
             std::cerr << "Error while initializing the interface: " << err.what() << std::endl;
-            DebugLog( D_ERROR, DC_ALL ) << "Error while initializing the interface: " << err.what() << "\n";
+            DebugLog( DL::Error, DC::Main ) << "Error while initializing the interface: " << err.what();
             return 1;
         }
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6731,18 +6731,8 @@ void map::loadn( const tripoint &grid, const bool update_vehicles )
     static const oter_id rock( "empty_rock" );
     static const oter_id air( "open_air" );
 
-    /*
-    dbg( DL::Debug ) << "map::loadn( game=" << g.get()
-                     << ", world=" << abs_sub
-                     << ", grid=" << grid << " )";
-    */
-
     const tripoint grid_abs_sub = abs_sub.xy() + grid;
     const size_t gridn = get_nonant( grid );
-
-    /*
-    dbg( DL::Debug ) << "map::loadn grid_abs_sub: " << grid_abs_sub << "  gridn: " << gridn;
-    */
 
     const int old_abs_z = abs_sub.z; // Ugly, but necessary at the moment
     abs_sub.z = grid.z;

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -13,7 +13,7 @@ const int mm_submap::default_symbol = 0;
 
 #define MM_SIZE (MAPSIZE * 2)
 
-#define dbg(x) DebugLog((x),D_MMAP) << __FILE__ << ":" << __LINE__ << ": "
+#define dbg(x) DebugLog((x),DC::MapMem)
 
 static std::string find_legacy_mm_file()
 {
@@ -124,7 +124,7 @@ bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )
         }
     }
 
-    dbg( D_INFO ) << "Preparing memory map for area: pos: " << sm_pos << " size: " << sm_size;
+    dbg( DL::Info ) << "Preparing memory map for area: pos: " << sm_pos << " size: " << sm_size;
 
     cache_pos = sm_pos;
     cache_size = sm_size;
@@ -158,7 +158,7 @@ shared_ptr_fast<mm_submap> map_memory::allocate_submap( const tripoint &sm_pos )
     shared_ptr_fast<mm_submap> ret;
     tripoint reg = reg_coord_pair( sm_pos ).reg;
 
-    dbg( D_INFO ) << "Allocated mm_region " << reg << " [" << mmr_to_sm_copy( reg ) << "]";
+    dbg( DL::Info ) << "Allocated mm_region " << reg << " [" << mmr_to_sm_copy( reg ) << "]";
 
     for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
         for( size_t x = 0; x < MM_REG_SIZE; x++ ) {
@@ -215,7 +215,7 @@ shared_ptr_fast<mm_submap> map_memory::load_submap( const tripoint &sm_pos )
         return nullptr;
     }
 
-    dbg( D_INFO ) << "Loaded mm_region " << p.reg << " [" << mmr_to_sm_copy( p.reg ) << "]";
+    dbg( DL::Info ) << "Loaded mm_region " << p.reg << " [" << mmr_to_sm_copy( p.reg ) << "]";
 
     shared_ptr_fast<mm_submap> ret;
 
@@ -278,14 +278,14 @@ void map_memory::load( const tripoint &pos )
 
     coord_pair p( pos );
     tripoint start = p.sm - tripoint( MM_SIZE / 2, MM_SIZE / 2, 0 );
-    dbg( D_INFO ) << "[LOAD] Loading memory map around " << p.sm << ". Loading submaps within " << start
-                  << "->" << start + tripoint( MM_SIZE, MM_SIZE, 0 );
+    dbg( DL::Info ) << "[LOAD] Loading memory map around " << p.sm << ". Loading submaps within "
+                    << start << "->" << start + tripoint( MM_SIZE, MM_SIZE, 0 );
     for( int dy = 0; dy < MM_SIZE; dy++ ) {
         for( int dx = 0; dx < MM_SIZE; dx++ ) {
             fetch_submap( start + tripoint( dx, dy, 0 ) );
         }
     }
-    dbg( D_INFO ) << "[LOAD] Done.";
+    dbg( DL::Info ) << "[LOAD] Done.";
 }
 
 bool map_memory::save( const tripoint &pos )
@@ -296,7 +296,7 @@ bool map_memory::save( const tripoint &pos )
 
     clear_cache();
 
-    dbg( D_INFO ) << "N submaps before save: " << submaps.size();
+    dbg( DL::Info ) << "N submaps before save: " << submaps.size();
 
     // Since mm_submaps are always allocated in regions,
     // we are certain that each region will be filled.
@@ -310,8 +310,8 @@ bool map_memory::save( const tripoint &pos )
     constexpr point MM_HSIZE_P = point( MM_SIZE / 2, MM_SIZE / 2 );
     rectangle rect_keep( sm_center.xy() - MM_HSIZE_P, sm_center.xy() + MM_HSIZE_P );
 
-    dbg( D_INFO ) << "[SAVE] Saving memory map around " << sm_center << ". Keeping submaps within " <<
-                  rect_keep.p_min << "->" << rect_keep.p_max;
+    dbg( DL::Info ) << "[SAVE] Saving memory map around " << sm_center << ". Keeping submaps within "
+                    << rect_keep.p_min << "->" << rect_keep.p_max;
 
     bool result = true;
 
@@ -338,7 +338,7 @@ bool map_memory::save( const tripoint &pos )
         tripoint regp_sm = mmr_to_sm_copy( regp );
         rectangle rect_reg( regp_sm.xy(), regp_sm.xy() + point( MM_REG_SIZE, MM_REG_SIZE ) );
         if( rect_reg.overlaps_half_open( rect_keep ) ) {
-            dbg( D_INFO ) << "Keeping mm_region " << regp << " [" << regp_sm << "]";
+            dbg( DL::Info ) << "Keeping mm_region " << regp << " [" << regp_sm << "]";
             // Put submaps back
             for( size_t y = 0; y < MM_REG_SIZE; y++ ) {
                 for( size_t x = 0; x < MM_REG_SIZE; x++ ) {
@@ -348,12 +348,12 @@ bool map_memory::save( const tripoint &pos )
                 }
             }
         } else {
-            dbg( D_INFO ) << "Dropping mm_region " << regp << " [" << regp_sm << "]";
+            dbg( DL::Info ) << "Dropping mm_region " << regp << " [" << regp_sm << "]";
         }
     }
 
-    dbg( D_INFO ) << "[SAVE] Done.";
-    dbg( D_INFO ) << "N submaps after save: " << submaps.size();
+    dbg( DL::Info ) << "[SAVE] Done.";
+    dbg( DL::Info ) << "N submaps after save: " << submaps.size();
 
     return result;
 }

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -87,8 +87,6 @@ void mapbuffer::remove_submap( tripoint addr )
 
 submap *mapbuffer::lookup_submap( const tripoint &p )
 {
-    //DebugLog( DL::Debug, DC::Map ) << "mapbuffer::lookup_submap " << p;
-
     const auto iter = submaps.find( p );
     if( iter == submaps.end() ) {
         try {

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -25,8 +25,6 @@
 #include "translations.h"
 #include "ui_manager.h"
 
-#define dbg(x) DebugLog((x),D_MAP) << __FILE__ << ":" << __LINE__ << ": "
-
 static std::string find_quad_path( const std::string &dirname, const tripoint &om_addr )
 {
     return string_format( "%s/%d.%d.%d.map", dirname, om_addr.x, om_addr.y, om_addr.z );
@@ -80,7 +78,7 @@ void mapbuffer::remove_submap( tripoint addr )
 {
     auto m_target = submaps.find( addr );
     if( m_target == submaps.end() ) {
-        debugmsg( "Tried to remove non-existing submap %d,%d,%d", addr.x, addr.y, addr.z );
+        debugmsg( "Tried to remove non-existing submap %s", addr.to_string() );
         return;
     }
     delete m_target->second;
@@ -89,14 +87,14 @@ void mapbuffer::remove_submap( tripoint addr )
 
 submap *mapbuffer::lookup_submap( const tripoint &p )
 {
-    dbg( D_INFO ) << "mapbuffer::lookup_submap( x[" << p.x << "], y[" << p.y << "], z[" << p.z << "])";
+    //DebugLog( DL::Debug, DC::Map ) << "mapbuffer::lookup_submap " << p;
 
     const auto iter = submaps.find( p );
     if( iter == submaps.end() ) {
         try {
             return unserialize_submaps( p );
         } catch( const std::exception &err ) {
-            debugmsg( "Failed to load submap (%d,%d,%d): %s", p.x, p.y, p.z, err.what() );
+            debugmsg( "Failed to load submap %s: %s", p.to_string(), err.what() );
         }
         return nullptr;
     }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -94,7 +94,7 @@ static const mongroup_id GROUP_ZOMBIE_COP( "GROUP_ZOMBIE_COP" );
 
 static const trait_id trait_NPC_STATIC_NPC( "NPC_STATIC_NPC" );
 
-#define dbg(x) DebugLog((x),D_MAP_GEN) << __FILE__ << ":" << __LINE__ << ": "
+#define dbg(x) DebugLogFL((x),DC::MapGen)
 
 #define MON_RADIUS 3
 
@@ -105,8 +105,8 @@ static void build_mine_room( room_type type, const point &p1, const point &p2, m
 // x%2 and y%2 must be 0!
 void map::generate( const tripoint &p, const time_point &when )
 {
-    dbg( D_INFO ) << "map::generate( g[" << g.get() << "], p[" << p << "], "
-                  "when[" << to_string( when ) << "] )";
+    dbg( DL::Info ) << "map::generate( g[" << g.get() << "], p[" << p <<
+                    "], when[" << to_string( when ) << "] )";
 
     set_abs_sub( p );
 
@@ -194,7 +194,7 @@ void map::generate( const tripoint &p, const time_point &when )
     // And finally save used submaps and delete the rest.
     for( int i = 0; i < my_MAPSIZE; i++ ) {
         for( int j = 0; j < my_MAPSIZE; j++ ) {
-            dbg( D_INFO ) << "map::generate: submap (" << i << "," << j << ")";
+            dbg( DL::Info ) << "map::generate: submap (" << i << "," << j << ")";
 
             const tripoint pos( i, j, p.z );
             if( i <= 1 && j <= 1 ) {
@@ -5866,8 +5866,8 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint &p, const int d
         return nullptr;
     }
     if( !inbounds( p ) ) {
-        dbg( D_WARNING ) << string_format( "Out of bounds add_vehicle t=%s d=%d p=%d,%d,%d", type.c_str(),
-                                           dir, p.x, p.y, p.z );
+        dbg( DL::Warn ) << string_format( "Out of bounds add_vehicle t=%s d=%d p=%s",
+                                          type.c_str(), dir, p.to_string() );
         return nullptr;
     }
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -176,6 +176,10 @@ class messages_impl
                 return;
             }
 
+            if( type == m_debug ) {
+                DebugLog( DL::Info, DC::DebugModeMsg ) << msg;
+            }
+
             game_message m = game_message( std::move( msg ), type );
 
             refresh_cooldown( m, flags );

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -31,8 +31,6 @@
 #include "string_formatter.h"
 #include "translations.h"
 
-#define dbg(x) DebugLog((x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
-
 mission mission_type::create( const character_id &npc_id ) const
 {
     mission ret;
@@ -77,7 +75,6 @@ mission *mission::find( int id )
     if( iter != world_missions.end() ) {
         return &iter->second;
     }
-    dbg( D_ERROR ) << "requested mission with uid " << id << " does not exist";
     debugmsg( "requested mission with uid %d does not exist", id );
     return nullptr;
 }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1248,8 +1248,8 @@ bool mattack::science( monster *const z ) // I said SCIENCE again!
     // choose and do a valid attack
     const int attack_index = get_random_index( valid_attack_count );
     switch( valid_attacks[attack_index] ) {
-        default :
-            DebugLog( D_WARNING, D_GAME ) << "Bad enum value in science.";
+        default:
+            debugmsg( "Bad attack enum value %d", valid_attacks[attack_index] );
             break;
         case att_shock :
             z->moves -= att_cost_shock;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -464,9 +464,9 @@ void monster::plan()
     const auto actual_faction = friendly == 0 ? faction : mfaction_str_id( "player" );
     const auto &myfaction_iter = factions.find( actual_faction );
     if( myfaction_iter == factions.end() ) {
-        DebugLog( D_ERROR, D_GAME ) << disp_name() << " tried to find faction "
-                                    << actual_faction.id().str()
-                                    << " which wasn't loaded in game::monmove";
+        DebugLog( DL::Error, DC::Game ) << disp_name() << " tried to find faction "
+                                        << actual_faction.id().str()
+                                        << " which wasn't loaded in game::monmove";
         swarms = false;
         group_morale = false;
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4140,10 +4140,9 @@ void npc::set_omt_destination()
         return;
     }
 
-    DebugLog( D_INFO, DC_ALL ) << "npc::set_omt_destination - new goal for NPC [" << get_name() <<
-                               "] with [" << get_need_str_id( needs.front() ) <<
-                               "] is [" << dest_type <<
-                               "] in [" << goal.x << "," << goal.y << "," << goal.z << "].";
+    DebugLog( DL::Info, DC::Main ) << "npc::set_omt_destination - new goal for NPC [" << get_name()
+                                   << "] with [" << get_need_str_id( needs.front() )
+                                   << "] is [" << dest_type << "] in " << goal << ".";
 }
 
 void npc::go_to_omt_destination()

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -114,8 +114,6 @@ static std::map<std::string, json_talk_topic> json_talk_topics;
 // Every OWED_VAL that the NPC owes you counts as +1 towards convincing
 #define OWED_VAL 1000
 
-#define dbg(x) DebugLog((x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
-
 int topic_category( const talk_topic &the_topic );
 
 const talk_topic &special_talk( char ch );
@@ -1408,7 +1406,7 @@ int talk_trial::calc_chance( const dialogue &d ) const
     int chance = difficulty;
     switch( type ) {
         case NUM_TALK_TRIALS:
-            dbg( D_ERROR ) << "called calc_chance with invalid talk_trial value: " << type;
+            debugmsg( "Called calc_chance with invalid talk_trial value %d", type );
             break;
         case TALK_TRIAL_LIE:
             chance += u.talk_skill() - p.talk_skill() + p.op_of_u.trust * 3;

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -51,7 +51,7 @@ void npc_trading::transfer_items( std::vector<item_pricing> &stuff, player &give
         }
 
         if( ip.loc.get_item() == nullptr ) {
-            DebugLog( D_ERROR, D_NPC ) << "Null item being traded in npc_trading::transfer_items";
+            debugmsg( "Null item being traded in npc_trading::transfer_items" );
             continue;
         }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -127,12 +127,12 @@ void options_manager::addOptionToPage( const std::string &name, const std::strin
     for( Page &p : pages_ ) {
         if( p.id_ == page ) {
             // Don't add duplicate options to the page
-            for( const cata::optional<std::string> &i : p.items_ ) {
-                if( i.has_value() && i.value() == name ) {
+            for( const PageItem &i : p.items_ ) {
+                if( i.type == ItemType::Option && i.data == name ) {
                     return;
                 }
             }
-            p.items_.emplace_back( name );
+            p.items_.emplace_back( ItemType::Option, name, adding_to_group_ );
             return;
         }
     }
@@ -409,10 +409,56 @@ void options_manager::add_empty_line( const std::string &sPageIn )
 {
     for( Page &p : pages_ ) {
         if( p.id_ == sPageIn ) {
-            p.items_.emplace_back();
+            p.items_.emplace_back( ItemType::BlankLine, "", adding_to_group_ );
             break;
         }
     }
+}
+
+void options_manager::add_option_group( const std::string &page_id,
+                                        const options_manager::Group &group,
+                                        std::function<void( const std::string & )> entries )
+{
+    if( !adding_to_group_.empty() ) {
+        // Nested groups are not allowed
+        debugmsg( "Tried to create option group '%s' from within group '%s'.",
+                  group.id_, adding_to_group_ );
+        return;
+    }
+    for( Group &g : groups_ ) {
+        if( g.id_ == group.id_ ) {
+            debugmsg( "Option group with id '%s' already exists", group.id_ );
+            return;
+        }
+    }
+    groups_.push_back( group );
+    adding_to_group_ = groups_.back().id_;
+
+    for( Page &p : pages_ ) {
+        if( p.id_ == page_id ) {
+            p.items_.emplace_back( ItemType::GroupHeader, group.id_, adding_to_group_ );
+            break;
+        }
+    }
+
+    entries( page_id );
+
+    adding_to_group_.clear();
+}
+
+const options_manager::Group &options_manager::find_group( const std::string &id ) const
+{
+    static Group null_group;
+    if( id.empty() ) {
+        return null_group;
+    }
+    for( const Group &g : groups_ ) {
+        if( g.id_ == id ) {
+            return g;
+        }
+    }
+    debugmsg( "Option group with id '%d' does not exist.", id );
+    return null_group;
 }
 
 void options_manager::cOpt::setPrerequisites( const std::string &sOption,
@@ -1030,8 +1076,9 @@ bool android_get_default_setting( const char *settings_name, bool default_value 
 
 void options_manager::Page::removeRepeatedEmptyLines()
 {
-    const auto empty = [&]( const cata::optional<std::string> &v ) -> bool {
-        return !v || get_options().get_option( *v ).is_hidden();
+    const auto empty = [&]( const PageItem & it ) -> bool {
+        return it.type == ItemType::BlankLine ||
+        ( it.type == ItemType::Option && get_options().get_option( it.data ).is_hidden() );
     };
 
     while( !items_.empty() && empty( items_.front() ) ) {
@@ -2457,7 +2504,7 @@ static void refresh_tiles( bool, bool, bool )
 #endif // TILES
 
 static void draw_borders_external(
-    const catacurses::window &w, int horizontal_level, const std::map<int, bool> &mapLines,
+    const catacurses::window &w, int horizontal_level, const std::set<int> &vert_lines,
     const bool world_options_only )
 {
     if( !world_options_only ) {
@@ -2466,18 +2513,16 @@ static void draw_borders_external(
     // intersections
     mvwputch( w, point( 0, horizontal_level ), BORDER_COLOR, LINE_XXXO ); // |-
     mvwputch( w, point( getmaxx( w ) - 1, horizontal_level ), BORDER_COLOR, LINE_XOXX ); // -|
-    for( auto &mapLine : mapLines ) {
-        if( mapLine.second ) {
-            mvwputch( w, point( mapLine.first + 1, getmaxy( w ) - 1 ), BORDER_COLOR, LINE_XXOX ); // _|_
-        }
+    for( auto &x : vert_lines ) {
+        mvwputch( w, point( x + 1, getmaxy( w ) - 1 ), BORDER_COLOR, LINE_XXOX ); // _|_
     }
     wnoutrefresh( w );
 }
 
-static void draw_borders_internal( const catacurses::window &w, std::map<int, bool> &mapLines )
+static void draw_borders_internal( const catacurses::window &w, std::set<int> &vert_lines )
 {
     for( int i = 0; i < getmaxx( w ); ++i ) {
-        if( mapLines[i] ) {
+        if( vert_lines.count( i ) != 0 ) {
             // intersection
             mvwputch( w, point( i, 0 ), BORDER_COLOR, LINE_OXXX );
         } else {
@@ -2487,6 +2532,59 @@ static void draw_borders_internal( const catacurses::window &w, std::map<int, bo
     }
     wnoutrefresh( w );
 }
+
+std::string
+options_manager::PageItem::fmt_tooltip( const Group &group,
+                                        const options_manager::options_container &cont ) const
+{
+    switch( type ) {
+        case ItemType::BlankLine:
+            return "";
+        case ItemType::GroupHeader: {
+            return group.tooltip_.translated();
+        }
+        case ItemType::Option: {
+            const std::string &opt_name = data;
+            const cOpt &opt = cont.find( opt_name )->second;
+            std::string ret = string_format( "%s #%s",
+                                             opt.getTooltip(),
+                                             opt.getDefaultText() );
+#if defined(TILES) || defined(_WIN32)
+            if( opt_name == "TERMINAL_X" ) {
+                int new_window_width = 0;
+                new_window_width = projected_window_width();
+
+                ret += " -- ";
+                ret += string_format(
+                           vgettext( "The window will be %d pixel wide with the selected value.",
+                                     "The window will be %d pixels wide with the selected value.",
+                                     new_window_width ), new_window_width );
+            } else if( opt_name == "TERMINAL_Y" ) {
+                int new_window_height = 0;
+                new_window_height = projected_window_height();
+
+                ret += " -- ";
+                ret += string_format(
+                           vgettext( "The window will be %d pixel tall with the selected value.",
+                                     "The window will be %d pixels tall with the selected value.",
+                                     new_window_height ), new_window_height );
+            }
+#endif
+            return ret;
+        }
+        default:
+            abort();
+    }
+}
+
+/** String with color */
+struct string_col {
+    std::string s;
+    nc_color col;
+
+    string_col() : col( c_black ) { }
+    string_col( const std::string &s, nc_color col ) : s( s ), col( col ) { }
+};
 
 std::string options_manager::show( bool ingame, const bool world_options_only,
                                    const std::function<bool()> &on_quit )
@@ -2507,13 +2605,20 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
         ingame = false;
     }
 
-    std::map<int, bool> mapLines;
-    mapLines[4] = true;
-    mapLines[60] = true;
+    std::set<int> vert_lines;
+    vert_lines.insert( 4 );
+    vert_lines.insert( 60 );
 
     int iCurrentPage = world_options_only ? iWorldOptPage : 0;
     int iCurrentLine = 0;
     int iStartPos = 0;
+
+    std::unordered_map<std::string, bool> groups_state;
+    groups_state.emplace( "", true ); // Non-existent group
+    for( const Group &g : groups_ ) {
+        // Start collapsed
+        groups_state.emplace( g.id_, false );
+    }
 
     input_context ctxt( "OPTIONS" );
     ctxt.register_cardinal();
@@ -2571,36 +2676,104 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
     ui.on_screen_resize( init_windows );
     init_windows( ui );
     ui.on_redraw( [&]( const ui_adaptor & ) {
+        werase( w_options_header );
+        werase( w_options_border );
+        werase( w_options_tooltip );
+        werase( w_options );
+
         if( world_options_only ) {
             worldfactory::draw_worldgen_tabs( w_options_border, 1 );
         }
 
-        draw_borders_external( w_options_border, iTooltipHeight + 1 + iWorldOffset, mapLines,
+        draw_borders_external( w_options_border, iTooltipHeight + 1 + iWorldOffset, vert_lines,
                                world_options_only );
-        draw_borders_internal( w_options_header, mapLines );
-
-        Page &page = pages_[iCurrentPage];
-        auto &page_items = page.items_;
+        draw_borders_internal( w_options_header, vert_lines );
 
         auto &cOPTIONS = ( ingame || world_options_only ) && iCurrentPage == iWorldOptPage ?
                          ACTIVE_WORLD_OPTIONS : OPTIONS;
 
-        //Clear the lines
-        for( int i = 0; i < iContentHeight; i++ ) {
-            for( int j = 0; j < iMinScreenWidth - 2; j++ ) {
-                if( mapLines[j] ) {
-                    mvwputch( w_options, point( j, i ), BORDER_COLOR, LINE_XOXO );
-                } else {
-                    mvwputch( w_options, point( j, i ), c_black, ' ' );
-                }
+        const Page &page = pages_[iCurrentPage];
+        const std::vector<PageItem> &page_items = page.items_;
 
-                if( i < iTooltipHeight ) {
-                    mvwputch( w_options_tooltip, point( j, i ), c_black, ' ' );
+        // Cache visible entries
+        std::vector<int> visible_items;
+        visible_items.reserve( page_items.size() );
+        int curr_line_visible = 0;
+        const auto is_visible = [&]( int i ) -> bool {
+            const PageItem &it = page_items[i];
+            switch( it.type )
+            {
+                case ItemType::GroupHeader:
+                    return true;
+                case ItemType::BlankLine:
+                case ItemType::Option:
+                    return groups_state[it.group];
+                default:
+                    abort();
+            }
+        };
+        for( int i = 0; i < static_cast<int>( page_items.size() ); i++ ) {
+            if( is_visible( i ) ) {
+                visible_items.push_back( i );
+                if( i == iCurrentLine ) {
+                    curr_line_visible = static_cast<int>( visible_items.size() );
                 }
             }
         }
 
-        calcStartPos( iStartPos, iCurrentLine, iContentHeight, page_items.size() );
+        // Format name & value strings for given entry
+        const auto fmt_name_value = [&]( const PageItem & it, bool is_selected )
+        -> std::pair<string_col, string_col> {
+            const char *IN_GROUP_PREFIX = ": ";
+            switch( it.type )
+            {
+                case ItemType::BlankLine: {
+                    std::string name = it.group.empty() ? "" : IN_GROUP_PREFIX;
+                    return { string_col( name, c_white ), string_col() };
+                }
+                case ItemType::GroupHeader: {
+                    bool expanded = groups_state[it.group];
+                    std::string name = expanded ? "- " : "+ ";
+                    name += find_group( it.group ).name_.translated();
+                    return std::make_pair( string_col( name, c_white ), string_col() );
+                }
+                case options_manager::ItemType::Option: {
+                    const cOpt &opt = cOPTIONS.find( it.data )->second;
+                    const bool hasPrerequisite = opt.hasPrerequisite();
+                    const bool hasPrerequisiteFulfilled = opt.checkPrerequisite();
+
+                    std::string name_prefix = it.group.empty() ? "" : IN_GROUP_PREFIX;
+                    string_col name( name_prefix + opt.getMenuText(), !hasPrerequisite ||
+                                     hasPrerequisiteFulfilled ? c_white : c_light_gray );
+
+                    nc_color cLineColor;
+                    if( hasPrerequisite && !hasPrerequisiteFulfilled ) {
+                        cLineColor = c_light_gray;
+                    } else if( opt.getValue() == "false" || opt.getValue() == "disabled" || opt.getValue() == "off" ) {
+                        cLineColor = c_light_red;
+                    } else {
+                        cLineColor = c_light_green;
+                    }
+
+                    string_col value( opt.getValueName(), is_selected ? hilite( cLineColor ) : cLineColor );
+
+                    return std::make_pair( name, value );
+                }
+                default:
+                    abort();
+            }
+        };
+
+        // Draw separation lines
+        for( int x : vert_lines ) {
+            for( int y = 0; y < iContentHeight; y++ ) {
+                mvwputch( w_options, point( x, y ), BORDER_COLOR, LINE_XOXO );
+            }
+        }
+
+        // Update scroll position
+        calcStartPos( iStartPos, curr_line_visible, iContentHeight,
+                      static_cast<int>( visible_items.size() ) );
 
         // where the column with the names starts
         const size_t name_col = 5;
@@ -2609,52 +2782,33 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
         // 2 for the space between name and value column, 3 for the ">> "
         const size_t name_width = value_col - name_col - 2 - 3;
         const size_t value_width = getmaxx( w_options ) - value_col;
-        //Draw options
-        size_t iBlankOffset = 0; // Offset when blank line is printed.
+        // Draw options
         for( int i = iStartPos;
-             i < iStartPos + ( iContentHeight > static_cast<int>( page_items.size() ) ?
-                               static_cast<int>( page_items.size() ) : iContentHeight ); i++ ) {
+             i < iStartPos + ( iContentHeight > static_cast<int>( visible_items.size() ) ?
+                               static_cast<int>( visible_items.size() ) : iContentHeight ); i++ ) {
 
             int line_pos = i - iStartPos; // Current line position in window.
 
-            mvwprintz( w_options, point( 1, line_pos ), c_white, "%d", i + 1 - iBlankOffset );
+            mvwprintz( w_options, point( 1, line_pos ), c_white, "%d", visible_items[i] + 1 );
 
-            if( iCurrentLine == i ) {
-                mvwprintz( w_options, point( name_col, line_pos ), c_yellow, ">> " );
-            } else {
-                mvwprintz( w_options, point( name_col, line_pos ), c_yellow, "   " );
+            bool is_selected = visible_items[i] == iCurrentLine;
+            if( is_selected ) {
+                mvwprintz( w_options, point( name_col, line_pos ), c_yellow, ">>" );
             }
 
-            const auto &opt_name = page_items[i];
-            if( !opt_name ) {
-                continue;
-            }
+            const PageItem &curr_item = page_items[visible_items[i]];
+            auto name_value = fmt_name_value( curr_item, is_selected );
 
-            nc_color cLineColor = c_light_green;
-            const cOpt &current_opt = cOPTIONS[*opt_name];
-            const bool hasPrerequisite = current_opt.hasPrerequisite();
-            const bool hasPrerequisiteFulfilled = current_opt.checkPrerequisite();
+            const std::string name = utf8_truncate( name_value.first.s, name_width );
+            mvwprintz( w_options, point( name_col + 3, line_pos ), name_value.first.col, name );
 
-            const std::string name = utf8_truncate( current_opt.getMenuText(), name_width );
-            mvwprintz( w_options, point( name_col + 3, line_pos ), !hasPrerequisite ||
-                       hasPrerequisiteFulfilled ? c_white : c_light_gray, name );
-
-            if( hasPrerequisite && !hasPrerequisiteFulfilled ) {
-                cLineColor = c_light_gray;
-
-            } else if( current_opt.getValue() == "false" || current_opt.getValue() == "disabled" ||
-                       current_opt.getValue() == "off" ) {
-                cLineColor = c_light_red;
-            }
-
-            const std::string value = utf8_truncate( current_opt.getValueName(), value_width );
-            mvwprintz( w_options, point( value_col, line_pos ),
-                       iCurrentLine == i ? hilite( cLineColor ) : cLineColor,
-                       value );
+            const std::string value = utf8_truncate( name_value.second.s, value_width );
+            mvwprintz( w_options, point( value_col, line_pos ), name_value.second.col, value );
         }
 
         draw_scrollbar( w_options_border, iCurrentLine, iContentHeight,
-                        page_items.size(), point( 0, iTooltipHeight + 2 + iWorldOffset ), BORDER_COLOR );
+                        static_cast<int>( visible_items.size() ),
+                        point( 0, iTooltipHeight + 2 + iWorldOffset ), BORDER_COLOR );
         wnoutrefresh( w_options_border );
 
         //Draw Tabs
@@ -2676,47 +2830,9 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
 
         wnoutrefresh( w_options_header );
 
-        const std::string &opt_name = *page_items[iCurrentLine];
-        cOpt &current_opt = cOPTIONS[opt_name];
-
-#if defined(TILES) || defined(_WIN32)
-        if( opt_name == "TERMINAL_X" ) {
-            int new_terminal_x = 0;
-            int new_window_width = 0;
-            std::stringstream value_conversion( current_opt.getValueName() );
-
-            value_conversion >> new_terminal_x;
-            new_window_width = projected_window_width();
-
-            fold_and_print( w_options_tooltip, point_zero, iMinScreenWidth - 2, c_white,
-                            vgettext( "%s #%s -- The window will be %d pixel wide with the selected value.",
-                                      "%s #%s -- The window will be %d pixels wide with the selected value.",
-                                      new_window_width ),
-                            current_opt.getTooltip(),
-                            current_opt.getDefaultText(),
-                            new_window_width );
-        } else if( opt_name == "TERMINAL_Y" ) {
-            int new_terminal_y = 0;
-            int new_window_height = 0;
-            std::stringstream value_conversion( current_opt.getValueName() );
-
-            value_conversion >> new_terminal_y;
-            new_window_height = projected_window_height();
-
-            fold_and_print( w_options_tooltip, point_zero, iMinScreenWidth - 2, c_white,
-                            vgettext( "%s #%s -- The window will be %d pixel tall with the selected value.",
-                                      "%s #%s -- The window will be %d pixels tall with the selected value.",
-                                      new_window_height ),
-                            current_opt.getTooltip(),
-                            current_opt.getDefaultText(),
-                            new_window_height );
-        } else
-#endif
-        {
-            fold_and_print( w_options_tooltip, point_zero, iMinScreenWidth - 2, c_white, "%s #%s",
-                            current_opt.getTooltip(),
-                            current_opt.getDefaultText() );
-        }
+        const PageItem &curr_item = page_items[iCurrentLine];
+        std::string tooltip = curr_item.fmt_tooltip( find_group( curr_item.group ), cOPTIONS );
+        fold_and_print( w_options_tooltip, point_zero, iMinScreenWidth - 2, c_white, tooltip );
 
         if( ingame && iCurrentPage == iWorldOptPage ) {
             mvwprintz( w_options_tooltip, point( 3, 3 ), c_light_red, "%s", _( "Note: " ) );
@@ -2737,9 +2853,6 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
         auto &cOPTIONS = ( ingame || world_options_only ) && iCurrentPage == iWorldOptPage ?
                          ACTIVE_WORLD_OPTIONS : OPTIONS;
 
-        const std::string &opt_name = *page_items[iCurrentLine];
-        cOpt &current_opt = cOPTIONS[opt_name];
-
         const std::string action = ctxt.handle_input();
 
         if( world_options_only && ( action == "NEXT_TAB" || action == "PREV_TAB" ||
@@ -2747,15 +2860,77 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
             return action;
         }
 
-        bool hasPrerequisite = current_opt.hasPrerequisite();
-        bool hasPrerequisiteFulfilled = current_opt.checkPrerequisite();
+        const PageItem &curr_item = page_items[iCurrentLine];
 
-        if( hasPrerequisite && !hasPrerequisiteFulfilled &&
-            ( action == "RIGHT" || action == "LEFT" || action == "CONFIRM" ) ) {
-            popup( _( "Prerequisite for this option not met!\n(%s)" ),
-                   get_options().get_option( current_opt.getPrerequisite() ).getMenuText() );
-            continue;
-        }
+        const auto on_select_option = [&]() {
+            cOpt &current_opt = cOPTIONS[curr_item.data];
+
+            bool hasPrerequisite = current_opt.hasPrerequisite();
+            bool hasPrerequisiteFulfilled = current_opt.checkPrerequisite();
+
+            if( hasPrerequisite && !hasPrerequisiteFulfilled ) {
+                popup( _( "Prerequisite for this option not met!\n(%s)" ),
+                       get_options().get_option( current_opt.getPrerequisite() ).getMenuText() );
+                return;
+            }
+
+            if( action == "LEFT" ) {
+                current_opt.setPrev();
+            } else if( action == "RIGHT" ) {
+                current_opt.setNext();
+            } else {
+                assert( action == "CONFIRM" );
+                if( current_opt.getType() == "bool" || current_opt.getType() == "string_select" ||
+                    current_opt.getType() == "string_input" || current_opt.getType() == "int_map" ) {
+                    current_opt.setNext();
+                } else {
+                    const bool is_int = current_opt.getType() == "int";
+                    const bool is_float = current_opt.getType() == "float";
+                    const std::string old_opt_val = current_opt.getValueName();
+                    const std::string opt_val = string_input_popup()
+                                                .title( current_opt.getMenuText() )
+                                                .width( 10 )
+                                                .text( old_opt_val )
+                                                .only_digits( is_int )
+                                                .query_string();
+                    if( !opt_val.empty() && opt_val != old_opt_val ) {
+                        if( is_float ) {
+                            std::istringstream ssTemp( opt_val );
+                            // This uses the current locale, to allow the users
+                            // to use their own decimal format.
+                            float tmpFloat;
+                            ssTemp >> tmpFloat;
+                            if( ssTemp ) {
+                                current_opt.setValue( tmpFloat );
+
+                            } else {
+                                popup( _( "Invalid input: not a number" ) );
+                            }
+                        } else {
+                            // option is of type "int": string_input_popup
+                            // has taken care that the string contains
+                            // only digits, parsing is done in setValue
+                            current_opt.setValue( opt_val );
+                        }
+                    }
+                }
+            }
+        };
+
+        const auto is_selectable = [&]( int i ) -> bool {
+            const PageItem &curr_item = page_items[i];
+            switch( curr_item.type )
+            {
+                case ItemType::BlankLine:
+                    return false;
+                case ItemType::GroupHeader:
+                    return true;
+                case ItemType::Option:
+                    return groups_state[curr_item.group];
+                default:
+                    abort();
+            }
+        };
 
         if( action == "DOWN" ) {
             do {
@@ -2763,18 +2938,14 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
                 if( iCurrentLine >= static_cast<int>( page_items.size() ) ) {
                     iCurrentLine = 0;
                 }
-            } while( !page_items[iCurrentLine] );
+            } while( !is_selectable( iCurrentLine ) );
         } else if( action == "UP" ) {
             do {
                 iCurrentLine--;
                 if( iCurrentLine < 0 ) {
                     iCurrentLine = page_items.size() - 1;
                 }
-            } while( !page_items[iCurrentLine] );
-        } else if( action == "RIGHT" ) {
-            current_opt.setNext();
-        } else if( action == "LEFT" ) {
-            current_opt.setPrev();
+            } while( !is_selectable( iCurrentLine ) );
         } else if( action == "NEXT_TAB" ) {
             iCurrentLine = 0;
             iStartPos = 0;
@@ -2791,40 +2962,23 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
                 iCurrentPage = pages_.size() - 1;
             }
             sfx::play_variant_sound( "menu_move", "default", 100 );
-        } else if( action == "CONFIRM" ) {
-            if( current_opt.getType() == "bool" || current_opt.getType() == "string_select" ||
-                current_opt.getType() == "string_input" || current_opt.getType() == "int_map" ) {
-                current_opt.setNext();
-            } else {
-                const bool is_int = current_opt.getType() == "int";
-                const bool is_float = current_opt.getType() == "float";
-                const std::string old_opt_val = current_opt.getValueName();
-                const std::string opt_val = string_input_popup()
-                                            .title( current_opt.getMenuText() )
-                                            .width( 10 )
-                                            .text( old_opt_val )
-                                            .only_digits( is_int )
-                                            .query_string();
-                if( !opt_val.empty() && opt_val != old_opt_val ) {
-                    if( is_float ) {
-                        std::istringstream ssTemp( opt_val );
-                        // This uses the current locale, to allow the users
-                        // to use their own decimal format.
-                        float tmpFloat;
-                        ssTemp >> tmpFloat;
-                        if( ssTemp ) {
-                            current_opt.setValue( tmpFloat );
-
-                        } else {
-                            popup( _( "Invalid input: not a number" ) );
-                        }
-                    } else {
-                        // option is of type "int": string_input_popup
-                        // has taken care that the string contains
-                        // only digits, parsing is done in setValue
-                        current_opt.setValue( opt_val );
-                    }
+        } else if( action == "RIGHT" || action == "LEFT" || action == "CONFIRM" ) {
+            switch( curr_item.type ) {
+                case ItemType::Option: {
+                    on_select_option();
+                    break;
                 }
+                case ItemType::GroupHeader: {
+                    bool &state = groups_state[curr_item.data];
+                    state = !state;
+                    break;
+                }
+                case ItemType::BlankLine: {
+                    // Should never happen
+                    break;
+                }
+                default:
+                    abort();
             }
         } else if( action == "QUIT" ) {
             break;
@@ -2929,11 +3083,11 @@ void options_manager::serialize( JsonOut &json ) const
     json.start_array();
 
     for( const Page &p : pages_ ) {
-        for( const cata::optional<std::string> &opt_name : p.items_ ) {
-            if( !opt_name ) {
+        for( const PageItem &it : p.items_ ) {
+            if( it.type != ItemType::Option ) {
                 continue;
             }
-            const auto iter = options.find( *opt_name );
+            const auto iter = options.find( it.data );
             if( iter != options.end() ) {
                 const auto &opt = iter->second;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -61,24 +61,18 @@ options_manager &get_options()
     return single_instance;
 }
 
-options_manager::options_manager() :
-    general_page_( "general", to_translation( "General" ) ),
-    interface_page_( "interface", to_translation( "Interface" ) ),
-    graphics_page_( "graphics", to_translation( "Graphics" ) ),
-    debug_page_( "debug", to_translation( "Debug" ) ),
-    world_default_page_( "world_default", to_translation( "World Defaults" ) ),
-    android_page_( "android", to_translation( "Android" ) )
+options_manager::options_manager()
 {
-    pages_.emplace_back( general_page_ );
-    pages_.emplace_back( interface_page_ );
-    pages_.emplace_back( graphics_page_ );
+    pages_.emplace_back( "general", to_translation( "General" ) );
+    pages_.emplace_back( "interface", to_translation( "Interface" ) );
+    pages_.emplace_back( "graphics", to_translation( "Graphics" ) );
     // when sharing maps only admin is allowed to change these.
     if( !MAP_SHARING::isCompetitive() || MAP_SHARING::isAdmin() ) {
-        pages_.emplace_back( world_default_page_ );
-        pages_.emplace_back( debug_page_ );
+        pages_.emplace_back( "world_default", to_translation( "World Defaults" ) );
+        pages_.emplace_back( "debug", to_translation( "Debug" ) );
     }
 #if defined(__ANDROID__)
-    pages_.emplace_back( android_page_ );
+    pages_.emplace_back( "android", to_translation( "Android" ) );
 #endif
 
     mMigrateOption = { {"DELETE_WORLD", { "WORLD_END", { {"no", "keep" }, {"yes", "delete"} } } } };
@@ -409,6 +403,16 @@ void options_manager::add( const std::string &sNameIn, const std::string &sPageI
     addOptionToPage( sNameIn, sPageIn );
 
     options[sNameIn] = thisOpt;
+}
+
+void options_manager::add_empty_line( const std::string &sPageIn )
+{
+    for( Page &p : pages_ ) {
+        if( p.id_ == sPageIn ) {
+            p.items_.emplace_back();
+            break;
+        }
+    }
 }
 
 void options_manager::cOpt::setPrerequisites( const std::string &sOption,
@@ -1067,7 +1071,7 @@ void options_manager::init()
 void options_manager::add_options_general()
 {
     const auto add_empty_line = [&]() {
-        general_page_.items_.emplace_back();
+        this->add_empty_line( "general" );
     };
 
     add( "DEF_CHAR_NAME", "general", translate_marker( "Default character name" ),
@@ -1301,7 +1305,7 @@ void options_manager::add_options_general()
 void options_manager::add_options_interface()
 {
     const auto add_empty_line = [&]() {
-        interface_page_.items_.emplace_back();
+        this->add_empty_line( "interface" );
     };
 
     std::vector<options_manager::id_and_option> lang_options = {
@@ -1612,7 +1616,7 @@ void options_manager::add_options_interface()
 void options_manager::add_options_graphics()
 {
     const auto add_empty_line = [&]() {
-        graphics_page_.items_.emplace_back();
+        this->add_empty_line( "graphics" );
     };
 
     add( "ANIMATIONS", "graphics", translate_marker( "Animations" ),
@@ -1906,7 +1910,7 @@ void options_manager::add_options_graphics()
 void options_manager::add_options_debug()
 {
     const auto add_empty_line = [&]() {
-        debug_page_.items_.emplace_back();
+        this->add_empty_line( "debug" );
     };
 
     add( "REPORT_UNUSED_JSON_FIELDS", "debug", translate_marker( "Report unused JSON fields" ),
@@ -2004,7 +2008,7 @@ void options_manager::add_options_debug()
 void options_manager::add_options_world_default()
 {
     const auto add_empty_line = [&]() {
-        world_default_page_.items_.emplace_back();
+        this->add_empty_line( "world_default" );
     };
 
     add( "CORE_VERSION", "world_default", translate_marker( "Core version data" ),
@@ -2175,7 +2179,7 @@ void options_manager::add_options_android()
 {
 #if defined(__ANDROID__)
     const auto add_empty_line = [&]() {
-        android_page_.items_.emplace_back();
+        this->add_empty_line( "android" );
     };
 
     add( "ANDROID_QUICKSAVE", "android", translate_marker( "Quicksave on app lose focus" ),
@@ -2488,7 +2492,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
                                    const std::function<bool()> &on_quit )
 {
     const int iWorldOptPage = std::find_if( pages_.begin(), pages_.end(), [&]( const Page & p ) {
-        return &p == &world_default_page_;
+        return p.id_ == "world_default";
     } ) - pages_.begin();
 
     // temporary alias so the code below does not need to be changed
@@ -2663,7 +2667,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
                              _( "Current world" ) );
                 } else {
                     wprintz( w_options_header, iCurrentPage == i ? hilite( c_light_green ) : c_light_green,
-                             "%s", pages_[i].get().name_ );
+                             "%s", pages_[i].name_ );
                 }
                 wprintz( w_options_header, c_white, "]" );
                 wputch( w_options_header, BORDER_COLOR, LINE_OXOX );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1725,60 +1725,66 @@ void options_manager::add_options_graphics()
 
     add_empty_line();
 
-    add( "FONT_BLENDING", "graphics", translate_marker( "Font blending" ),
-         translate_marker( "If true, fonts will look better." ),
-         false, COPT_CURSES_HIDE
-       );
+#if defined(TILES)
+    add_option_group( "graphics", Group( "font_params", to_translation( "Font settings" ),
+                                         to_translation( "Font display settings.  To change font type or source file, edit fonts.json in config directory." ) ),
+    [&]( const std::string & page_id ) {
+        add( "USE_DRAW_ASCII_LINES_ROUTINE", page_id, translate_marker( "SDL ASCII lines" ),
+             translate_marker( "Use SDL ASCII line drawing routine instead of Unicode Line Drawing characters.  Use this option when your selected font doesn't contain necessary glyphs." ),
+             true, COPT_CURSES_HIDE
+           );
 
-    add( "FONT_WIDTH", "graphics", translate_marker( "Font width" ),
-         translate_marker( "Set the font width.  Requires restart." ),
-         8, 100, 8, COPT_CURSES_HIDE
-       );
+        add( "FONT_BLENDING", page_id, translate_marker( "Font blending" ),
+             translate_marker( "If true, fonts will look better." ),
+             false, COPT_CURSES_HIDE
+           );
 
-    add( "FONT_HEIGHT", "graphics", translate_marker( "Font height" ),
-         translate_marker( "Set the font height.  Requires restart." ),
-         8, 100, 16, COPT_CURSES_HIDE
-       );
+        add( "FONT_WIDTH", page_id, translate_marker( "Font width" ),
+             translate_marker( "Set the font width.  Requires restart." ),
+             8, 100, 8, COPT_CURSES_HIDE
+           );
 
-    add( "FONT_SIZE", "graphics", translate_marker( "Font size" ),
-         translate_marker( "Set the font size.  Requires restart." ),
-         8, 100, 16, COPT_CURSES_HIDE
-       );
+        add( "FONT_HEIGHT", page_id, translate_marker( "Font height" ),
+             translate_marker( "Set the font height.  Requires restart." ),
+             8, 100, 16, COPT_CURSES_HIDE
+           );
 
-    add( "MAP_FONT_WIDTH", "graphics", translate_marker( "Map font width" ),
-         translate_marker( "Set the map font width.  Requires restart." ),
-         8, 100, 16, COPT_CURSES_HIDE
-       );
+        add( "FONT_SIZE", page_id, translate_marker( "Font size" ),
+             translate_marker( "Set the font size.  Requires restart." ),
+             8, 100, 16, COPT_CURSES_HIDE
+           );
 
-    add( "MAP_FONT_HEIGHT", "graphics", translate_marker( "Map font height" ),
-         translate_marker( "Set the map font height.  Requires restart." ),
-         8, 100, 16, COPT_CURSES_HIDE
-       );
+        add( "MAP_FONT_WIDTH", page_id, translate_marker( "Map font width" ),
+             translate_marker( "Set the map font width.  Requires restart." ),
+             8, 100, 16, COPT_CURSES_HIDE
+           );
 
-    add( "MAP_FONT_SIZE", "graphics", translate_marker( "Map font size" ),
-         translate_marker( "Set the map font size.  Requires restart." ),
-         8, 100, 16, COPT_CURSES_HIDE
-       );
+        add( "MAP_FONT_HEIGHT", page_id, translate_marker( "Map font height" ),
+             translate_marker( "Set the map font height.  Requires restart." ),
+             8, 100, 16, COPT_CURSES_HIDE
+           );
 
-    add( "OVERMAP_FONT_WIDTH", "graphics", translate_marker( "Overmap font width" ),
-         translate_marker( "Set the overmap font width.  Requires restart." ),
-         8, 100, 16, COPT_CURSES_HIDE
-       );
+        add( "MAP_FONT_SIZE", page_id, translate_marker( "Map font size" ),
+             translate_marker( "Set the map font size.  Requires restart." ),
+             8, 100, 16, COPT_CURSES_HIDE
+           );
 
-    add( "OVERMAP_FONT_HEIGHT", "graphics", translate_marker( "Overmap font height" ),
-         translate_marker( "Set the overmap font height.  Requires restart." ),
-         8, 100, 16, COPT_CURSES_HIDE
-       );
+        add( "OVERMAP_FONT_WIDTH", page_id, translate_marker( "Overmap font width" ),
+             translate_marker( "Set the overmap font width.  Requires restart." ),
+             8, 100, 16, COPT_CURSES_HIDE
+           );
 
-    add( "OVERMAP_FONT_SIZE", "graphics", translate_marker( "Overmap font size" ),
-         translate_marker( "Set the overmap font size.  Requires restart." ),
-         8, 100, 16, COPT_CURSES_HIDE
-       );
+        add( "OVERMAP_FONT_HEIGHT", page_id, translate_marker( "Overmap font height" ),
+             translate_marker( "Set the overmap font height.  Requires restart." ),
+             8, 100, 16, COPT_CURSES_HIDE
+           );
 
-    add( "USE_DRAW_ASCII_LINES_ROUTINE", "graphics", translate_marker( "SDL ASCII lines" ),
-         translate_marker( "Use SDL ASCII line drawing routine instead of Unicode Line Drawing characters.  Use this option when your selected font doesn't contain necessary glyphs." ),
-         true, COPT_CURSES_HIDE
-       );
+        add( "OVERMAP_FONT_SIZE", page_id, translate_marker( "Overmap font size" ),
+             translate_marker( "Set the overmap font size.  Requires restart." ),
+             8, 100, 16, COPT_CURSES_HIDE
+           );
+    } );
+#endif // TILES
 
     add( "ENABLE_ASCII_ART_ITEM", "graphics",
          translate_marker( "Enable ASCII art in item descriptions" ),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -13,6 +13,7 @@
 #include "cursesdef.h"
 #include "cursesport.h"
 #include "debug.h"
+#include "enum_bitset.h"
 #include "filesystem.h"
 #include "fstream_utils.h"
 #include "game.h"
@@ -54,6 +55,89 @@
 
 std::map<std::string, std::string> TILESETS; // All found tilesets: <name, tileset_dir>
 std::map<std::string, std::string> SOUNDPACKS; // All found soundpacks: <name, soundpack_dir>
+
+struct debug_log_level {
+    DL id;
+    std::string opt_id;
+    std::string opt_name;
+    std::string opt_descr;
+    bool opt_default;
+};
+struct debug_log_class {
+    DC id;
+    std::string opt_id;
+    std::string opt_name;
+    std::string opt_descr;
+    bool opt_default;
+};
+// If you change default values here, update documentation in debug.h
+// No option for 'Error' level because errors are serious
+// and should be enabled at all times.
+static const std::vector<debug_log_level> debug_log_levels = { {
+        {
+            DL::Debug, "DEBUGLOG_LEV_DEBUG", translate_marker( "Debug" ),
+            translate_marker( "Debug information" ),
+            false
+        },
+        {
+            DL::Info, "DEBUGLOG_LEV_INFO", translate_marker( "Info" ),
+            translate_marker( "General information" ),
+            true
+        },
+        {
+            DL::Warn, "DEBUGLOG_LEV_WARNING", translate_marker( "Warning" ),
+            translate_marker( "Warnings" ),
+            true
+        },
+    }
+};
+// If you change default values here, update documentation in debug.h
+// No option for 'DebugMsg' class because it's used only for errors.
+static const std::vector<debug_log_class> debug_log_classes = { {
+        {
+            DC::Game, "DEBUGLOG_CL_GAME", translate_marker( "Game" ),
+            translate_marker( "Messages from main game class." ),
+            false
+        },
+        {
+            DC::DebugModeMsg, "DEBUGLOG_CL_DEBUGMODE", translate_marker( "Debug mode" ),
+            translate_marker( "Debug-type messages from in-game message log (when debug mode is enabled)." ),
+            false
+        },
+        {
+            DC::Main, "DEBUGLOG_CL_MAIN", translate_marker( "Main" ),
+            translate_marker( "Generic messages related to game startup and operation." ),
+            true
+        },
+        {
+            DC::Map, "DEBUGLOG_CL_MAP", translate_marker( "Map" ),
+            translate_marker( "Messages related to map and mapbuffer (map.cpp, mapbuffer.cpp)." ),
+            false
+        },
+        {
+            DC::MapGen, "DEBUGLOG_CL_MAPGEN", translate_marker( "Mapgen" ),
+            translate_marker( "Messages related to mapgen (mapgen*.cpp) and overmap (overmap.cpp)." ),
+            false
+        },
+        {
+            DC::MapMem, "DEBUGLOG_CL_MAPMEM", translate_marker( "Map memory" ),
+            translate_marker( "Messages related to tile memory (map_memory.cpp)." ),
+            false
+        },
+        {
+            DC::NPC, "DEBUGLOG_CL_NPC", translate_marker( "NPC" ),
+            translate_marker( "Messages related to NPCs (npcs*.cpp)." ),
+            false
+        },
+        {
+            //~ SDL stands for Simple DirectMedia Layer, leave it as is.
+            DC::SDL, "DEBUGLOG_CL_SDL", translate_marker( "SDL" ),
+            //~ SDL stands for Simple DirectMedia Layer, leave it as is.
+            translate_marker( "Messages related to SDL, tiles, tilesets and sound." ),
+            false
+        },
+    }
+};
 
 options_manager &get_options()
 {
@@ -1973,6 +2057,23 @@ void options_manager::add_options_debug()
 
     add_empty_line();
 
+    add_option_group( "debug", Group( "debug_log", to_translation( "Logging" ),
+                                      to_translation( "Configure debug.log verbosity." ) ),
+    [&]( const std::string & page_id ) {
+        for( const debug_log_level &e : debug_log_levels ) {
+            add( e.opt_id, page_id, e.opt_name, e.opt_descr, e.opt_default );
+        }
+
+        add_empty_line();
+
+        for( const debug_log_class &e : debug_log_classes ) {
+            add( e.opt_id, page_id, e.opt_name, e.opt_descr, e.opt_default );
+        }
+    }
+                    );
+
+    add_empty_line();
+
     add( "DISTANCE_INITIAL_VISIBILITY", "debug", translate_marker( "Distance initial visibility" ),
          translate_marker( "Determines the scope, which is known in the beginning of the game." ),
          3, 20, 15
@@ -3148,6 +3249,19 @@ std::string options_manager::migrateOptionValue( const std::string &name,
 
 void options_manager::cache_to_globals()
 {
+    enum_bitset<DL> levels;
+    levels.set( DL::Error );
+    for( const debug_log_level &e : debug_log_levels ) {
+        levels.set( e.id, ::get_option<bool>( e.opt_id ) );
+    }
+    enum_bitset<DC> classes;
+    classes.set( DC::DebugMsg ).set( DC::Main );
+    for( const debug_log_class &e : debug_log_classes ) {
+        classes.set( e.id, ::get_option<bool>( e.opt_id ) );
+    }
+    setDebugLogLevels( levels );
+    setDebugLogClasses( classes );
+
     json_report_unused_fields = ::get_option<bool>( "REPORT_UNUSED_JSON_FIELDS" );
     trigdist = ::get_option<bool>( "CIRCLEDIST" );
     use_tiles = ::get_option<bool>( "USE_TILES" );

--- a/src/options.h
+++ b/src/options.h
@@ -288,14 +288,10 @@ class options_manager
                 Page( const std::string &id, const translation &name ) : id_( id ), name_( name ) { }
         };
 
-        Page general_page_;
-        Page interface_page_;
-        Page graphics_page_;
-        Page debug_page_;
-        Page world_default_page_;
-        Page android_page_;
+        std::vector<Page> pages_;
 
-        std::vector<std::reference_wrapper<Page>> pages_;
+        /** Add empty line to page. */
+        void add_empty_line( const std::string &sPageIn );
 };
 
 bool use_narrow_sidebar(); // short-circuits to on if terminal is too small

--- a/src/options.h
+++ b/src/options.h
@@ -267,21 +267,57 @@ class options_manager
         options_container options;
         cata::optional<options_container *> world_options;
 
+        /** Option group. */
+        class Group
+        {
+            public:
+                /** Group identifier. Should be unique across all pages. */
+                std::string id_;
+                /** Group name */
+                translation name_;
+                /** Tooltip with description */
+                translation tooltip_;
+
+                Group() {};
+                Group( const std::string &id, const translation &name, const translation &tooltip )
+                    : id_( id ), name_( name ), tooltip_( tooltip ) { }
+        };
+
+        /** Page item type. */
+        enum class ItemType {
+            BlankLine,
+            GroupHeader,
+            Option,
+        };
+
+        /** Single page item (entry). */
+        class PageItem
+        {
+            public:
+                ItemType type;
+                std::string data;
+                /** Empty if not assigned to any group. */
+                std::string group;
+
+                PageItem() : type( ItemType::BlankLine ) { }
+                PageItem( ItemType type, const std::string &data, const std::string &group )
+                    : type( type ), data( data ), group( group ) { }
+
+                std::string fmt_tooltip( const Group &group, const options_container &cont ) const;
+        };
+
         /**
          * A page (or tab) to be displayed in the options UI.
-         * It contains a @ref id that is used to detect what options should go into this
-         * page (see @ref cOpt::getPage).
-         * It also has a name that will be translated and displayed.
-         * And it has items, each item is either nothing (will be represented as empty line
-         * in the UI) or the name of an option.
          */
         class Page
         {
             public:
+                /** Page identifier */
                 std::string id_;
+                /** Page name */
                 translation name_;
-
-                std::vector<cata::optional<std::string>> items_;
+                /** Page items (entries) */
+                std::vector<PageItem> items_;
 
                 void removeRepeatedEmptyLines();
 
@@ -289,9 +325,28 @@ class options_manager
         };
 
         std::vector<Page> pages_;
+        std::string adding_to_group_;
+        std::vector<Group> groups_;
+
+        /**
+         * Specify option group.
+         *
+         * Option groups are used for visual separation of options on pages,
+         * and allow some additional UI functionality (i.e. collapse/expand).
+         *
+         * @param page_id Page to create group at.
+         * @param group Group to create.
+         * @param entries Page entries added within this closure will be assigned to the group.
+         *                Receives "page_id" as it's only argument.
+         */
+        void add_option_group( const std::string &page_id, const Group &group,
+                               std::function<void( const std::string & )> entries );
 
         /** Add empty line to page. */
         void add_empty_line( const std::string &sPageIn );
+
+        /** Find group by id. */
+        const Group &find_group( const std::string &id ) const;
 };
 
 bool use_narrow_sidebar(); // short-circuits to on if terminal is too small

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -68,7 +68,7 @@ static const mongroup_id GROUP_ZOMBIE( "GROUP_ZOMBIE" );
 
 class map_extra;
 
-#define dbg(x) DebugLog((x),D_MAP_GEN) << __FILE__ << ":" << __LINE__ << ": "
+#define dbg(x) DebugLogFL((x),DC::MapGen)
 
 #define BUILDINGCHANCE 4
 #define MIN_ANT_SIZE 8
@@ -381,8 +381,7 @@ void overmap_land_use_code::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "sym", symbol, unicode_codepoint_from_symbol_reader, NULL_UNICODE );
 
     if( symbol == NULL_UNICODE ) {
-        DebugLog( D_ERROR, D_GAME ) << "`sym` node is not defined properly for `land_use_code`: "
-                                    << id.c_str() << " (" << name << ")";
+        debugmsg( "sym is not defined properly for land_use_code %s (%s)", id.c_str(), name );
     }
 
     assign( jo, "color", color, strict );
@@ -609,8 +608,7 @@ void oter_type_t::load( const JsonObject &jo, const std::string &src )
         }
     } else {
         if( symbol == NULL_UNICODE && !jo.has_string( "abstract" ) ) {
-            DebugLog( D_ERROR, D_MAP_GEN ) << "sym is not defined for overmap_terrain: "
-                                           << id.c_str() << " (" << name << ")";
+            debugmsg( "sym is not defined for overmap_terrain %s (%s)", id.c_str(), name );
         }
         if( !jo.has_string( "sym" ) && jo.has_number( "sym" ) ) {
             debugmsg( "sym is defined as number instead of string for overmap_terrain %s (%s)", id.c_str(),
@@ -1533,11 +1531,11 @@ void overmap::generate( const overmap *north, const overmap *east,
                         overmap_special_batch &enabled_specials )
 {
     if( g->gametype() == SGAME_DEFENSE ) {
-        dbg( D_INFO ) << "overmap::generate skipped in Defense special game mode!";
+        dbg( DL::Info ) << "overmap::generate skipped in Defense special game mode!";
         return;
     }
 
-    dbg( D_INFO ) << "overmap::generate start…";
+    dbg( DL::Info ) << "overmap::generate start";
 
     clear_labs();
 
@@ -1578,7 +1576,7 @@ void overmap::generate( const overmap *north, const overmap *east,
     // Place the monsters, now that the terrain is laid out
     place_mongroups();
     place_radios();
-    dbg( D_INFO ) << "overmap::generate done";
+    dbg( DL::Info ) << "overmap::generate done";
 }
 
 bool overmap::generate_sub( const int z )
@@ -4645,7 +4643,8 @@ void overmap::add_mon_group( const mongroup &group )
                 pop_here = ( static_cast<double>( rad - dist ) / rad ) * pop / total_area;
             }
             if( pop_here > pop || pop_here < 0 ) {
-                DebugLog( D_ERROR, D_GAME ) << group.type.str() << ": invalid population here: " << pop_here;
+                dbg( DL::Error ) << "overmap::add_mon_group: " << group.type.str()
+                                 << " - invalid population here: " << pop_here;
             }
             int p = std::max( 0, static_cast<int>( std::floor( pop_here ) ) );
             if( pop_here - p != 0 ) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1944,8 +1944,7 @@ int player::invlet_to_position( const int linvlet ) const
     }
     const char invlet = static_cast<char>( linvlet );
     if( is_npc() ) {
-        DebugLog( D_WARNING,  D_GAME ) << "Why do you need to call player::invlet_to_position on npc " <<
-                                       name;
+        debugmsg( "Called player::invlet_to_position on NPC (%s)", name );
     }
     if( weapon.invlet == invlet ) {
         return -1;

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -4,7 +4,7 @@
 #include "platform_win.h"
 #include "string_utils.h"
 
-#define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
+#define dbg(x) DebugLogFL((x),DC::SDL)
 
 // bitmap font size test
 // return face index that has this size or below
@@ -56,7 +56,7 @@ std::unique_ptr<Font> Font::load_font( SDL_Renderer_Ptr &renderer, SDL_PixelForm
                                                   palette,
                                                   PATH_INFO::fontdir() + typeface ) );
                 } catch( std::exception &err ) {
-                    dbg( D_ERROR ) << "Failed to load font " << typeface << ": " << err.what();
+                    dbg( DL::Error ) << "Failed to load font " << typeface << ": " << err.what();
                     // Continue to load as truetype font
                 }
             }
@@ -67,7 +67,7 @@ std::unique_ptr<Font> Font::load_font( SDL_Renderer_Ptr &renderer, SDL_PixelForm
         return std::unique_ptr<Font>( std::make_unique<CachedTTFFont>( width, height,
                                       palette, typeface, fontsize, fontblending ) );
     } catch( std::exception &err ) {
-        dbg( D_ERROR ) << "Failed to load font " << typeface << ": " << err.what();
+        dbg( DL::Error ) << "Failed to load font " << typeface << ": " << err.what();
     }
     return nullptr;
 }
@@ -247,10 +247,10 @@ CachedTTFFont::CachedTTFFont(
 
     for( const std::string &tf : typefaces ) {
         if( !file_exist( tf ) ) {
-            DebugLog( D_WARNING, DC_ALL ) << "Truetype font not found at " << tf;
+            dbg( DL::Warn ) << "Truetype font not found at " << tf;
             continue;
         }
-        DebugLog( D_INFO, DC_ALL ) << "Loading truetype font " << tf;
+        dbg( DL::Info ) << "Loading truetype font " << tf;
         typeface = tf;
         break;
     }
@@ -276,7 +276,7 @@ SDL_Texture_Ptr CachedTTFFont::create_glyph( SDL_Renderer_Ptr &renderer, const s
     const auto function = fontblending ? TTF_RenderUTF8_Blended : TTF_RenderUTF8_Solid;
     SDL_Surface_Ptr sglyph( function( font.get(), ch.c_str(), windowsPalette[color] ) );
     if( !sglyph ) {
-        dbg( D_ERROR ) << "Failed to create glyph for " << ch << ": " << TTF_GetError();
+        dbg( DL::Error ) << "Failed to create glyph for " << ch << ": " << TTF_GetError();
         return nullptr;
     }
     /* SDL interprets each pixel as a 32-bit number, so our masks must depend
@@ -365,7 +365,7 @@ BitmapFont::BitmapFont(
     const std::string &typeface_path )
     : Font( w, h, palette )
 {
-    dbg( D_INFO ) << "Loading bitmap font [" + typeface_path + "].";
+    dbg( DL::Info ) << "Loading bitmap font [" + typeface_path + "].";
     SDL_Surface_Ptr asciiload = load_image( typeface_path.c_str() );
     assert( asciiload );
     if( asciiload->w * asciiload->h < ( width * height * 256 ) ) {

--- a/src/sdl_geometry.cpp
+++ b/src/sdl_geometry.cpp
@@ -2,6 +2,8 @@
 #include "sdl_geometry.h"
 #include "debug.h"
 
+#define dbg(x) DebugLogFL((x),DC::SDL)
+
 void GeometryRenderer::horizontal_line( const SDL_Renderer_Ptr &renderer, const point &pos, int x2,
                                         int thickness, const SDL_Color &color ) const
 {
@@ -56,10 +58,10 @@ ColorModulatedGeometryRenderer::ColorModulatedGeometryRenderer( const SDL_Render
         if( !tex_enable ) {
             tex.reset();
         }
-        DebugLog( D_INFO, DC_ALL ) << "ColorModulatedGeometryRenderer constructor() = " <<
-                                   ( tex_enable ? "FAIL" : "SUCCESS" ) << ". tex_enable = " << tex_enable;
+        dbg( DL::Info ) << "ColorModulatedGeometryRenderer constructor() = " <<
+                        ( tex_enable ? "FAIL" : "SUCCESS" ) << ". tex_enable = " << tex_enable;
     } else {
-        DebugLog( D_ERROR, DC_ALL ) << "CreateRGBSurface failed: " << SDL_GetError();
+        dbg( DL::Error ) << "CreateRGBSurface failed: " << SDL_GetError();
     }
 }
 

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -18,14 +18,14 @@
 #   endif
 #endif // TILES
 
-#define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
+#define dbg(x) DebugLogFL((x),DC::SDL)
 
 bool printErrorIf( const bool condition, const char *const message )
 {
     if( !condition ) {
         return false;
     }
-    dbg( D_ERROR ) << message << ": " << SDL_GetError();
+    dbg( DL::Error ) << message << ": " << SDL_GetError();
     return true;
 }
 
@@ -41,11 +41,11 @@ void RenderCopy( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &textur
                  const SDL_Rect *srcrect, const SDL_Rect *dstrect )
 {
     if( !renderer ) {
-        dbg( D_ERROR ) << "Tried to render to a null renderer";
+        dbg( DL::Error ) << "Tried to render to a null renderer";
         return;
     }
     if( !texture ) {
-        dbg( D_ERROR ) << "Tried to render a null texture";
+        dbg( DL::Error ) << "Tried to render a null texture";
         return;
     }
     printErrorIf( SDL_RenderCopy( renderer.get(), texture.get(), srcrect, dstrect ) != 0,
@@ -56,7 +56,7 @@ SDL_Texture_Ptr CreateTexture( const SDL_Renderer_Ptr &renderer, Uint32 format, 
                                int w, int h )
 {
     if( !renderer ) {
-        dbg( D_ERROR ) << "Tried to create texture with a null renderer";
+        dbg( DL::Error ) << "Tried to create texture with a null renderer";
         return SDL_Texture_Ptr();
     }
     SDL_Texture_Ptr result( SDL_CreateTexture( renderer.get(), format, access, w, h ) );
@@ -68,11 +68,11 @@ SDL_Texture_Ptr CreateTextureFromSurface( const SDL_Renderer_Ptr &renderer,
         const SDL_Surface_Ptr &surface )
 {
     if( !renderer ) {
-        dbg( D_ERROR ) << "Tried to create texture with a null renderer";
+        dbg( DL::Error ) << "Tried to create texture with a null renderer";
         return SDL_Texture_Ptr();
     }
     if( !surface ) {
-        dbg( D_ERROR ) << "Tried to create texture from a null surface";
+        dbg( DL::Error ) << "Tried to create texture from a null surface";
         return SDL_Texture_Ptr();
     }
     SDL_Texture_Ptr result( SDL_CreateTextureFromSurface( renderer.get(), surface.get() ) );
@@ -84,7 +84,7 @@ void SetRenderDrawColor( const SDL_Renderer_Ptr &renderer, const Uint8 r, const 
                          const Uint8 b, const Uint8 a )
 {
     if( !renderer ) {
-        dbg( D_ERROR ) << "Tried to use a null renderer";
+        dbg( DL::Error ) << "Tried to use a null renderer";
         return;
     }
     printErrorIf( SDL_SetRenderDrawColor( renderer.get(), r, g, b, a ) != 0,
@@ -99,7 +99,7 @@ void RenderDrawPoint( const SDL_Renderer_Ptr &renderer, const point &p )
 void RenderFillRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *const rect )
 {
     if( !renderer ) {
-        dbg( D_ERROR ) << "Tried to use a null renderer";
+        dbg( DL::Error ) << "Tried to use a null renderer";
         return;
     }
     printErrorIf( SDL_RenderFillRect( renderer.get(), rect ) != 0, "SDL_RenderFillRect failed" );
@@ -108,7 +108,7 @@ void RenderFillRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *const rec
 void FillRect( const SDL_Surface_Ptr &surface, const SDL_Rect *const rect, Uint32 color )
 {
     if( !surface ) {
-        dbg( D_ERROR ) << "Tried to use a null surface";
+        dbg( DL::Error ) << "Tried to use a null surface";
         return;
     }
     printErrorIf( SDL_FillRect( surface.get(), rect, color ) != 0, "SDL_FillRect failed" );
@@ -117,7 +117,7 @@ void FillRect( const SDL_Surface_Ptr &surface, const SDL_Rect *const rect, Uint3
 void SetTextureBlendMode( const SDL_Texture_Ptr &texture, SDL_BlendMode blendMode )
 {
     if( !texture ) {
-        dbg( D_ERROR ) << "Tried to use a null texture";
+        dbg( DL::Error ) << "Tried to use a null texture";
     }
 
     throwErrorIf( SDL_SetTextureBlendMode( texture.get(), blendMode ) != 0,
@@ -127,7 +127,7 @@ void SetTextureBlendMode( const SDL_Texture_Ptr &texture, SDL_BlendMode blendMod
 bool SetTextureColorMod( const SDL_Texture_Ptr &texture, Uint32 r, Uint32 g, Uint32 b )
 {
     if( !texture ) {
-        dbg( D_ERROR ) << "Tried to use a null texture";
+        dbg( DL::Error ) << "Tried to use a null texture";
         return true;
     }
     return printErrorIf( SDL_SetTextureColorMod( texture.get(), r, g, b ) != 0,
@@ -137,7 +137,7 @@ bool SetTextureColorMod( const SDL_Texture_Ptr &texture, Uint32 r, Uint32 g, Uin
 void SetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, const SDL_BlendMode blendMode )
 {
     if( !renderer ) {
-        dbg( D_ERROR ) << "Tried to use a null renderer";
+        dbg( DL::Error ) << "Tried to use a null renderer";
         return;
     }
     printErrorIf( SDL_SetRenderDrawBlendMode( renderer.get(), blendMode ) != 0,
@@ -147,7 +147,7 @@ void SetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, const SDL_BlendMo
 void GetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, SDL_BlendMode &blend_mode )
 {
     if( !renderer ) {
-        dbg( D_ERROR ) << "Tried to use a null renderer";
+        dbg( DL::Error ) << "Tried to use a null renderer";
         return;
     }
     printErrorIf( SDL_GetRenderDrawBlendMode( renderer.get(), &blend_mode ) != 0,
@@ -168,7 +168,7 @@ SDL_Surface_Ptr load_image( const char *const path )
 void SetRenderTarget( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &texture )
 {
     if( !renderer ) {
-        dbg( D_ERROR ) << "Tried to use a null renderer";
+        dbg( DL::Error ) << "Tried to use a null renderer";
         return;
     }
     // a null texture is fine for SDL
@@ -179,7 +179,7 @@ void SetRenderTarget( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &t
 void RenderClear( const SDL_Renderer_Ptr &renderer )
 {
     if( !renderer ) {
-        dbg( D_ERROR ) << "Tried to use a null renderer";
+        dbg( DL::Error ) << "Tried to use a null renderer";
         return;
     }
     printErrorIf( SDL_RenderClear( renderer.get() ) != 0, "SDL_RenderCopy failed" );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -82,7 +82,7 @@
 #include "worldfactory.h"
 #endif
 
-#define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
+#define dbg(x) DebugLogFL((x),DC::SDL)
 
 //***********************************
 //Globals                           *
@@ -319,7 +319,7 @@ static void WinCreate()
         SDL_GetRenderDriverInfo( i, &ri );
         if( renderer_name == ri.name ) {
             renderer_id = i;
-            DebugLog( D_INFO, DC_ALL ) << "Active renderer: " << renderer_id << "/" << ri.name;
+            DebugLog( DL::Info, DC::Main ) << "Active renderer: " << renderer_id << "/" << ri.name;
             break;
         }
     }
@@ -331,7 +331,7 @@ static void WinCreate()
     SDL_SetHint( SDL_HINT_RENDER_BATCHING, get_option<bool>( "RENDER_BATCHING" ) ? "1" : "0" );
 #endif
     if( !software_renderer ) {
-        dbg( D_INFO ) << "Attempting to initialize accelerated SDL renderer.";
+        dbg( DL::Info ) << "Attempting to initialize accelerated SDL renderer.";
 
         renderer.reset( SDL_CreateRenderer( ::window.get(), renderer_id, SDL_RENDERER_ACCELERATED |
                                             SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE ) );
@@ -339,8 +339,8 @@ static void WinCreate()
                           "Failed to initialize accelerated renderer, falling back to software rendering" ) ) {
             software_renderer = true;
         } else if( !SetupRenderTarget() ) {
-            dbg( D_ERROR ) <<
-                           "Failed to initialize display buffer under accelerated rendering, falling back to software rendering.";
+            dbg( DL::Error ) << "Failed to initialize display buffer under accelerated rendering, "
+                             "falling back to software rendering.";
             software_renderer = true;
             display_buffer.reset();
             renderer.reset();
@@ -387,8 +387,8 @@ static void WinCreate()
 
     if( get_option<bool>( "ENABLE_JOYSTICK" ) && numjoy >= 1 ) {
         if( numjoy > 1 ) {
-            dbg( D_WARNING ) <<
-                             "You have more than one gamepads/joysticks plugged in, only the first will be used.";
+            dbg( DL::Warn ) << "You have more than one gamepads/joysticks plugged in, "
+                            "only the first will be used.";
         }
         joystick = SDL_JoystickOpen( 0 );
         printErrorIf( joystick == nullptr, "SDL_JoystickOpen failed" );
@@ -403,8 +403,8 @@ static void WinCreate()
     // Set up audio mixer.
     init_sound();
 
-    DebugLog( D_INFO, DC_ALL ) << "USE_COLOR_MODULATED_TEXTURES is set to " <<
-                               get_option<bool>( "USE_COLOR_MODULATED_TEXTURES" );
+    dbg( DL::Info ) << "USE_COLOR_MODULATED_TEXTURES is set to " <<
+                    get_option<bool>( "USE_COLOR_MODULATED_TEXTURES" );
     //initialize the alternate rectangle texture for replacing SDL_RenderFillRect
     if( get_option<bool>( "USE_COLOR_MODULATED_TEXTURES" ) && !software_renderer ) {
         geometry = std::make_unique<ColorModulatedGeometryRenderer>( renderer );
@@ -2880,7 +2880,7 @@ static void init_term_size_and_scaling_factor()
                 max_height = current_display.h;
             }
         } else {
-            dbg( D_WARNING ) << "Failed to get current Display Mode, assuming infinite display size.";
+            dbg( DL::Warn ) << "Failed to get current Display Mode, assuming infinite display size.";
             max_width = INT_MAX;
             max_height = INT_MAX;
         }
@@ -2888,7 +2888,7 @@ static void init_term_size_and_scaling_factor()
         if( terminal_x * fontwidth > max_width ||
             FULL_SCREEN_WIDTH * fontwidth * scaling_factor > max_width ) {
             if( FULL_SCREEN_WIDTH * fontwidth * scaling_factor > max_width ) {
-                dbg( D_WARNING ) << "SCALING_FACTOR set too high for display size, resetting to 1";
+                dbg( DL::Warn ) << "SCALING_FACTOR set too high for display size, resetting to 1";
                 scaling_factor = 1;
                 terminal_x = max_width / fontwidth;
                 terminal_y = max_height / fontheight;
@@ -2901,7 +2901,7 @@ static void init_term_size_and_scaling_factor()
         if( terminal_y * fontheight > max_height ||
             FULL_SCREEN_HEIGHT * fontheight * scaling_factor > max_height ) {
             if( FULL_SCREEN_HEIGHT * fontheight * scaling_factor > max_height ) {
-                dbg( D_WARNING ) << "SCALING_FACTOR set too high for display size, resetting to 1";
+                dbg( DL::Warn ) << "SCALING_FACTOR set too high for display size, resetting to 1";
                 scaling_factor = 1;
                 terminal_x = max_width / fontwidth;
                 terminal_y = max_height / fontheight;
@@ -2961,12 +2961,12 @@ void catacurses::init_interface()
 
     WinCreate();
 
-    dbg( D_INFO ) << "Initializing SDL Tiles context";
+    dbg( DL::Info ) << "Initializing SDL Tiles context";
     tilecontext = std::make_unique<cata_tiles>( renderer, geometry );
     try {
         tilecontext->load_tileset( get_option<std::string>( "TILES" ), true );
     } catch( const std::exception &err ) {
-        dbg( D_ERROR ) << "failed to check for tileset: " << err.what();
+        dbg( DL::Error ) << "failed to check for tileset: " << err.what();
         // use_tiles is the cached value of the USE_TILES option.
         // most (all?) code refers to this to see if cata_tiles should be used.
         // Setting it to false disables this from getting used.

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -59,7 +59,7 @@
 #       include "mingw.thread.h"
 #   endif
 
-#   define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
+#   define dbg(x) DebugLogFL((x),DC::SDL)
 #endif
 
 weather_type previous_weather;
@@ -621,7 +621,7 @@ bool sfx::is_channel_playing( channel channel )
 void sfx::stop_sound_effect_fade( channel channel, int duration )
 {
     if( Mix_FadeOutChannel( static_cast<int>( channel ), duration ) == -1 ) {
-        dbg( D_ERROR ) << "Failed to stop sound effect: " << Mix_GetError();
+        dbg( DL::Error ) << "Failed to stop sound effect: " << Mix_GetError();
     }
 }
 
@@ -1039,11 +1039,11 @@ void sfx::generate_melee_sound( const tripoint &source, const tripoint &target, 
                 the_thread.detach();
             }
         } catch( std::system_error &err ) {
-            dbg( D_ERROR ) << "Failed to detach melee sound thread: std::system_error: " << err.what();
+            dbg( DL::Error ) << "Failed to detach melee sound thread: std::system_error: " << err.what();
         }
     } catch( std::system_error &err ) {
         // not a big deal, just skip playing the sound.
-        dbg( D_ERROR ) << "Failed to create melee sound thread: std::system_error: " << err.what();
+        dbg( DL::Error ) << "Failed to create melee sound thread: std::system_error: " << err.what();
     }
 }
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -37,7 +37,7 @@
 #include "veh_type.h"
 #include "vpart_position.h"
 
-#define dbg(x) DebugLog((x),D_MAP) << __FILE__ << ":" << __LINE__ << ": "
+#define dbg(x) DebugLogFL((x),DC::Map)
 
 static const itype_id fuel_type_muscle( "muscle" );
 static const itype_id fuel_type_animal( "animal" );
@@ -1427,8 +1427,7 @@ vehicle *vehicle::act_on_map()
 {
     const tripoint pt = global_pos3();
     if( !g->m.inbounds( pt ) ) {
-        dbg( D_INFO ) << "stopping out-of-map vehicle.  (x,y,z)=(" << pt.x << "," << pt.y << "," << pt.z <<
-                      ")";
+        dbg( DL::Info ) << "stopping out-of-map vehicle at global pos " << pt;
         stop( false );
         of_turn = 0;
         is_falling = false;

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -223,8 +223,8 @@ void worldfactory::set_active_world( WORLDPTR world )
 bool WORLD::save( const bool is_conversion ) const
 {
     if( !assure_dir_exist( folder_path() ) ) {
-        DebugLog( D_ERROR, DC_ALL ) << "Unable to create or open world[" << world_name <<
-                                    "] directory for saving";
+        DebugLog( DL::Error, DC::Main ) << "Unable to create or open world[" << world_name
+                                        << "] directory for saving";
         return false;
     }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@ CATA_LIB=../$(BUILD_PREFIX)cataclysm.a
 # built with BUILD_PREFIX set, you must set it for this invocation as well.
 ODIR ?= obj
 
-LDFLAGS += -L.
+LDFLAGS += -lpthread -L.
 
 # Enabling benchmarks
 DEFINES += -DCATCH_CONFIG_ENABLE_BENCHMARKING

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -113,7 +113,7 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
     }
 
     if( !init_language_system() ) {
-        DebugLog( D_ERROR, DC_ALL ) << "Failed to init language system.";
+        DebugLog( DL::Error, DC::Main ) << "Failed to init language system.";
     }
 
     get_options().init();
@@ -296,7 +296,7 @@ int main( int argc, const char *argv[] )
     if( seed ) {
         rng_set_engine_seed( seed );
     }
-    DebugLog( D_INFO, DC_ALL ) << "Randomness seeded to: " << seed;
+    DebugLog( DL::Info, DC::Main ) << "Randomness seeded to: " << seed;
 
     try {
         // TODO: Only init game if we're running tests that need it.
@@ -331,7 +331,7 @@ int main( int argc, const char *argv[] )
 
     if( seed ) {
         // Also print the seed at the end so it can be easily found
-        DebugLog( D_INFO, DC_ALL ) << "Randomness seeded to: " << seed;
+        DebugLog( DL::Info, DC::Main ) << "Randomness seeded to: " << seed;
     }
 
     if( error_during_initialization ) {


### PR DESCRIPTION
#### Purpose of change
As @Coolthulhu mentioned in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/525#issuecomment-842450063 , our logging system - DebugLog - in extremely awkward to use.

Debug levels and classes are enabled via preprocessor macros, so there's no way to change them once the game is compiled.
This could've been explained by performance concerns, as in theory, compiler should optimize away disabled log statements.
But after some testing and profiling it turned that neither Visual Studio with Release configuration nor `gcc` with `RELEASE=1 LTO=1` are smart enough to do that.

As such, there should be no harm in unhardcoding debug severity.

#### Describe the solution
1. Change debug levels & classes to be proper enums, and use `enum_bitset` to track currently enabled levels & classes. This makes it no longer possible to define message as belonging to multiple levels/classes, but such functionality was used only once anyway.
2. Remove `#define`s from the Makefile, and instead add a bunch of boolean options for controlling each class & level.
3. Add new debug class for exclusively logging `debugmsg`s.
4. Add new debug class for logging messages that show up in the sidebar when debug mode is ON.
5. Rename "PEDANTIC_INFO" debug level to "Debug".
6. Change all usages of "DC_ALL" and "DL_ALL" into something more appropriate.
7. Tweak some `DebugLog`/`debugmsg` invocations to better fit their intended purpose.
8. Make `DebugLog` append newline and flush at the end of each line rather than at the beginning. This allows interleaving `DebugLog` and `cata_printf` statements in test mode without turning the result into a mess, and seeing messages immediately when using the log for live debugging.
9. Allow `DebugLog` to capture file name & line number (as a new `DebugLogFL` macro).
10. Implement collapsible groups for option manager, and use such group for DebugLog settings.

~~All actual changes are in the last 3 commits, the rest - from #554. #554 is not required for this one, I've just used it to avoid merge conflicts.~~ Force-pushed.

#### Describe alternatives you've considered
1. Switch to some lightweight logging library? Fairly sure there are tons of great ones out there.
2. More debug classes?
3. Separate debug class for JSON? Should make it possible to report JSON problems with varying severity
4. Allow disabling Error level? I'm somewhat concerned about people mistakenly disabling it and then submitting useless logs...

#### Testing
The log looks more or less how it used to.
Tileset loading report is properly flushed (it used to require additional empty line for that).
When running tests, messages from DebugLog look fine when interleaved with regular output:
<details>

  <summary> Example output from local run </summary>

  ```
 . . .
0.000 s: address should be same when translation is absent
0.000 s: translations_macro_char_address
0.000 s: current address of the arg should be returned when translation is absent
0.000 s: translations_macro_char_address
15:34:42.254 INFO : Language is set to: 'en_US'/'en_US'
15:34:42.255 INFO : C locale set to 'en_US.UTF-8'
15:34:42.255 INFO : C++ locale set to 'en_US.UTF-8'
15:34:42.750 INFO : Language is set to: 'fr_FR'/'fr_FR'
15:34:42.750 INFO : C locale set to 'fr_FR.UTF-8'
15:34:42.750 INFO : C++ locale set to 'fr_FR.UTF-8'
15:34:43.230 INFO : Language is set to: 'ru_RU'/'ru_RU'
15:34:43.230 INFO : C locale set to 'ru_RU.UTF-8'
15:34:43.231 INFO : C++ locale set to 'ru_RU.UTF-8'
15:34:43.581 INFO : Using experimental system, language set to 'en_US'
15:34:43.581 INFO : C locale set to 'en_US.UTF-8'
15:34:43.581 INFO : C++ locale set to 'en_US.UTF-8'
15:34:44.137 INFO : Using experimental system, language set to 'fr_FR'
15:34:44.137 INFO : C locale set to 'fr_FR.UTF-8'
15:34:44.137 INFO : C++ locale set to 'fr_FR.UTF-8'
15:34:44.628 INFO : Using experimental system, language set to 'ru_RU'
15:34:44.628 INFO : C locale set to 'ru_RU.UTF-8'
15:34:44.628 INFO : C++ locale set to 'ru_RU.UTF-8'
15:34:45.023 INFO : Language is set to: 'en_US'/'en_US'
15:34:45.023 INFO : C locale set to 'en_US.utf-8'
15:34:45.023 INFO : C++ locale set to 'en_US.utf-8'
3.250 s: translations_actually_translate
0.000 s: units_have_correct_ratios
0.000 s: energy parsing from JSON
0.000 s: time_duration parsing from JSON
0.000 s: value_ptr copy constructor
 . . .
  ```

</details>

Not sure what's up with Travis, as it appears to be always buffering `stdout` but immediately printing `stderr`:
<details>

  <summary> Example output from Travis </summary>

  ```
 . . .
12:37:52.010 WARNING : opendir [modded/gfx/] failed with "No such file or directory".
12:37:52.029 WARNING : opendir [modded/mods/] failed with "No such file or directory".
12:37:53.862 WARNING : opendir [modded/save/Tom/mods/] failed with "No such file or directory".
// Tests started
// stderr output from "translations_actually_translate" test
12:38:48.099 INFO : Language is set to: 'en_US'/'en_US'
12:38:48.099 INFO : C locale set to 'en_US.UTF-8'
12:38:48.099 INFO : C++ locale set to 'en_US.UTF-8'
12:38:48.311 INFO : Language is set to: 'fr_FR'/'fr_FR'
12:38:48.312 INFO : C locale set to 'fr_FR.UTF-8'
12:38:48.312 INFO : C++ locale set to 'fr_FR.UTF-8'
12:38:48.522 INFO : Language is set to: 'ru_RU'/'ru_RU'
12:38:48.525 INFO : C locale set to 'ru_RU.UTF-8'
12:38:48.525 INFO : C++ locale set to 'ru_RU.UTF-8'
12:38:48.669 INFO : Using experimental system, language set to 'en_US'
12:38:48.669 INFO : C locale set to 'en_US.UTF-8'
12:38:48.669 INFO : C++ locale set to 'en_US.UTF-8'
12:38:48.901 INFO : Using experimental system, language set to 'fr_FR'
12:38:48.901 INFO : C locale set to 'fr_FR.UTF-8'
12:38:48.901 INFO : C++ locale set to 'fr_FR.UTF-8'
12:38:49.116 INFO : Using experimental system, language set to 'ru_RU'
12:38:49.116 INFO : C locale set to 'ru_RU.UTF-8'
12:38:49.116 INFO : C++ locale set to 'ru_RU.UTF-8'
12:38:49.283 INFO : Language is set to: 'en_US'/'en_US'
12:38:49.283 INFO : C locale set to 'en_US.UTF-8'
12:38:49.283 INFO : C++ locale set to 'en_US.UTF-8'

// stdout output from tests - buffered and printed at the end of the run?
Starting the actual test at Tue Jun  1 12:37:59 2021
0.169 s: place_active_item_at_various_coordinates
0.141 s: load_all_base_game_mos
0.261 s: recipe_permutations
0.322 s: soldier zombie
0.322 s: effective vs actual damage per second
0.555 s: smoker zombie
0.555 s: effective vs actual damage per second
0.507 s: survivor zombie
0.507 s: effective vs actual damage per second
0.323 s: soldier zombie
0.324 s: accuracy increases success
0.625 s: smoker zombie
0.626 s: accuracy increases success
0.442 s: survivor zombie
0.442 s: accuracy increases success
0.383 s: grid_and_vehicle_outside_bubble
0.503 s: grid_and_vehicle_outside_bubble
0.420 s: grid_and_vehicle_outside_bubble
0.350 s: grid_and_vehicle_outside_bubble
0.607 s: tripoint_hash_distribution
0.254 s: line_to_boundaries
0.246 s: map_bounds_checking
0.390 s: place_player_can_safely_move_multiple_submaps
0.487 s: monster_speed_square
0.580 s: monster_speed_trig
17.544 s: starting_items
0.578 s: npc_can_target_player
1.922 s: default_overmap_generation_always_succeeds
1.181 s: default_overmap_generation_has_non_mandatory_specials_at_origin
0.181 s: Exactly one endgame lab finale is generated in 0,0 overmap
0.187 s: Lightly clothed target temperatures
0.198 s: Player body temperatures within expected bounds.
0.398 s: Heavily clothed target temperatures
0.409 s: Player body temperatures within expected bounds.
0.418 s: Arctic gear target temperatures
0.429 s: Player body temperatures within expected bounds.
3.470 s: an unskilled shooter with an inaccurate shotgun
3.480 s: unskilled_shooter_accuracy
0.385 s: x_in_y_distribution
0.449 s:      When: the avatar runs the required distance
0.449 s:     Given: a new game
0.449 s: achievement_marathon
0.449 s: movement
0.449 s: achievments_tracker
0.198 s:      When: the avatar does the required actions
0.198 s:     Given: a new game
0.198 s: achievement_swim_merit_badge
0.198 s: movement
0.198 s: achievments_tracker
2.138 s: starve_test
0.907 s: starve_test_hunger3
5.669 s: all_nutrition_starve_test
0.290 s: string_ids_intern_test
0.113 s: test_player_vs_zombie_rock_basestats
0.125 s: basic_throwing_sanity_tests
0.159 s: test_player_vs_zombie_javelin_iron_basestats
0.170 s: basic_throwing_sanity_tests
0.249 s: test_player_vs_zombie_rock_athlete
0.261 s: basic_throwing_sanity_tests
0.315 s: test_player_vs_zombie_javelin_iron_athlete
0.327 s: basic_throwing_sanity_tests
0.110 s: mid_skill_basestats_rock
0.123 s: throwing_skill_impact_test
0.536 s: test_player_kills_zombie_with_rock_basestats
0.547 s: player_kills_zombie_before_reach
1.392 s: translations_actually_translate                     // <- actual test that produced log messages
0.109 s: car on pavement
0.109 s: vehicle_efficiency
0.109 s: car on dirt
0.109 s: vehicle_efficiency
0.122 s: suv on pavement
 . . .
  ```

</details>
