### PR TITLE
Prevent fuel leaks if vpart is outside reality bubble

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4139,7 +4139,8 @@ item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
     auto valid_tile = [&]( const tripoint & e ) {
         if( !inbounds( e ) ) {
             // should never happen
-            debugmsg( "add_item_or_charges: tripoint %s is out of bounds", e.to_string() );
+            debugmsg( "add_item_or_charges: %s is out of bounds (adding item '%s' [%d])",
+                      e.to_string(), obj.typeId().c_str(), obj.charges );
             return false;
         }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5164,6 +5164,11 @@ void vehicle::slow_leak()
         point q = coord_translate( p.mount );
         const tripoint dest = global_pos3() + tripoint( q, 0 );
 
+        if( fuel != fuel_type_battery && !g->m.inbounds( dest ) ) {
+            // Don't try to leak off the edge of the world
+            continue;
+        }
+
         // damaged batteries self-discharge without leaking, plutonium leaks slurry
         if( fuel != fuel_type_battery && fuel != fuel_type_plutonium_cell ) {
             item leak( fuel, calendar::turn, qty );


### PR DESCRIPTION
#### Purpose of change
Vehicles leaking fuel while outside reality bubble cause spammy debugmsg on current build.

#### Describe the solution
Prevent fuel leaks if vpart is outside reality bubble.

#### Describe alternatives you've considered
Allow leaks, but erase leaked fuel? I have no attachment to either solution.

#### Testing
Took a walk around a city.
