### PR TITLE
Fix permanence for some effects

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -373,7 +373,7 @@
     "id": "earphones",
     "name": [ "Wearing earphones" ],
     "desc": [ "You are wearing earphones and can't hear much from outside world." ],
-    "permanent": true,
+    "max_duration": "1 s",
     "rating": "bad"
   },
   {
@@ -526,6 +526,7 @@
     "name": [ "Sleep Deprived" ],
     "desc": [ "Your sleep debt has been steadily increasing for a while.  You should get some rest." ],
     "rating": "bad",
+    "permanent": true,
     "max_intensity": 100,
     "int_dur_factor": 480,
     "resist_effects": [ "meth" ],
@@ -1405,7 +1406,7 @@
   {
     "type": "effect_type",
     "id": "music",
-    "permanent": true
+    "max_duration": "1 s"
   },
   {
     "type": "effect_type",

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1507,12 +1507,7 @@ void monster::melee_attack( Creature &target, float accuracy )
 
     if( total_dealt > 6 && stab_cut > 0 && has_flag( MF_BLEED ) ) {
         // Maybe should only be if DT_CUT > 6... Balance question
-        if( target.is_player() || target.is_npc() ) {
-            target.add_effect( effect_bleed, 6_minutes, bp_hit );
-        } else {
-            target.add_effect( effect_bleed, 6_minutes, bp_hit );
-        }
-
+        target.add_effect( effect_bleed, 6_minutes, bp_hit );
     }
 }
 


### PR DESCRIPTION
#### Purpose of change
* Fix #571 by removing "permanent" from `earphones` effect.
* Fix musical instruments by removing "permanent" from `music` effect.
* Add "max_duration" to both to fix affected saves.
* Add "permanent" to `sleep_deprivation` effect to match other fake effects.

#### Testing
mp3, violin.