### PR TITLE
Add a few more grid-powered constructions

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4160,6 +4160,18 @@
   },
   {
     "type": "construction",
+    "id": "constr_gridkiln",
+    "description": "Place Electric Kiln",
+    "category": "OTHER",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "1 m",
+    "components": [ [ [ "kiln", 1 ] ], [ [ "cable", 5 ] ], [ [ "power_supply", 1 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_terrain": "f_gridkiln"
+  },
+  {
+    "type": "construction",
     "id": "constr_gridelectrolysis_kit",
     "description": "Place Electrolysis Kit",
     "category": "OTHER",
@@ -4169,5 +4181,41 @@
     "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
     "pre_special": "check_empty",
     "post_terrain": "f_gridelectrolysis_kit"
+  },
+  {
+    "type": "construction",
+    "id": "constr_griddehydrator",
+    "description": "Place Food Dehydrator",
+    "category": "OTHER",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "1 m",
+    "components": [ [ [ "dehydrator", 1 ] ], [ [ "cable", 5 ] ], [ [ "power_supply", 1 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_terrain": "f_griddehydrator"
+  },
+  {
+    "type": "construction",
+    "id": "constr_gridfood_processor",
+    "description": "Place Food Processor",
+    "category": "OTHER",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "1 m",
+    "components": [ [ [ "food_processor", 1 ] ], [ [ "cable", 5 ] ], [ [ "power_supply", 1 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_terrain": "f_gridfood_processor"
+  },
+  {
+    "type": "construction",
+    "id": "constr_gridvac_sealer",
+    "description": "Place Vaccuum Sealer",
+    "category": "OTHER",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "1 m",
+    "components": [ [ [ "vac_sealer", 1 ] ], [ [ "cable", 5 ] ], [ [ "power_supply", 1 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_terrain": "f_gridvac_sealer"
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -819,7 +819,7 @@
   {
     "type": "furniture",
     "id": "f_gridfood_processor",
-    "name": "grid foid pricessor",
+    "name": "grid food processor",
     "symbol": "U",
     "description": "A food processor connected to a electrical grid.  Capable of slicing, chopping, shredding, grinding, pureeing and mixing.",
     "color": "blue",

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -706,6 +706,7 @@
   {
     "type": "furniture",
     "id": "f_gridwelder",
+    "looks_like": "welder",
     "name": "grid welder",
     "symbol": "#",
     "description": "A portable welder connected to a electrical grid.",
@@ -734,6 +735,7 @@
   {
     "type": "furniture",
     "id": "f_gridforge",
+    "looks_like": "forge",
     "name": "grid forge",
     "symbol": "U",
     "description": "A portable electric forge connected to a electrical grid.",
@@ -762,6 +764,7 @@
   {
     "type": "furniture",
     "id": "f_gridkiln",
+    "looks_like": "kiln",
     "name": "grid kiln",
     "symbol": "U",
     "description": "A portable electric kiln connected to a electrical grid.",
@@ -790,6 +793,7 @@
   {
     "type": "furniture",
     "id": "f_griddehydrator",
+    "looks_like": "dehydrator",
     "name": "grid food dehydrator",
     "symbol": "U",
     "description": "A portable food dehydrator connected to a electrical grid, that could be useful for preserving food.",
@@ -819,6 +823,7 @@
   {
     "type": "furniture",
     "id": "f_gridfood_processor",
+    "looks_like": "food_processor",
     "name": "grid food processor",
     "symbol": "U",
     "description": "A food processor connected to a electrical grid.  Capable of slicing, chopping, shredding, grinding, pureeing and mixing.",
@@ -848,6 +853,7 @@
   {
     "type": "furniture",
     "id": "f_gridvac_sealer",
+    "looks_like": "vac_sealer",
     "name": "grid vacuum sealer",
     "symbol": "U",
     "description": "A portable heat sealer unit, connected to a electrical grid.  It could be used for vacuum-packing food to preserve it.",
@@ -877,6 +883,7 @@
   {
     "type": "furniture",
     "id": "f_gridelectrolysis_kit",
+    "looks_like": "electrolysis_kit",
     "name": "grid electrolysis kit",
     "symbol": "=",
     "description": "A electrolysis kit connected to a electrical grid.",

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -761,6 +761,121 @@
   },
   {
     "type": "furniture",
+    "id": "f_gridkiln",
+    "name": "grid kiln",
+    "symbol": "U",
+    "description": "A portable electric kiln connected to a electrical grid.",
+    "color": "light_red",
+    "move_cost_mod": -1,
+    "coverage": 10,
+    "required_str": -1,
+    "crafting_pseudo_item": "fake_gridkiln",
+    "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
+    "deconstruct": {
+      "items": [ { "item": "kiln", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+    },
+    "bash": {
+      "str_min": 8,
+      "str_max": 30,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "power_supply", "count": [ 1, 4 ] },
+        { "item": "scrap", "count": [ 0, 2 ] },
+        { "item": "cable", "charges": [ 1, 4 ] },
+        { "item": "element", "count": [ 2, 6 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_griddehydrator",
+    "name": "grid food dehydrator",
+    "symbol": "U",
+    "description": "A portable food dehydrator connected to a electrical grid, that could be useful for preserving food.",
+    "color": "blue",
+    "move_cost_mod": -1,
+    "coverage": 10,
+    "required_str": -1,
+    "crafting_pseudo_item": "fake_griddehydrator",
+    "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
+    "deconstruct": {
+      "items": [ { "item": "dehydrator", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+    },
+    "bash": {
+      "str_min": 8,
+      "str_max": 16,
+      "sound": "crunch!",
+      "sound_fail": "whump.",
+      "items": [
+        { "item": "power_supply", "count": [ 1, 4 ] },
+        { "item": "scrap", "count": [ 0, 4 ] },
+        { "item": "plastic_chunk", "count": [ 0, 9 ] },
+        { "item": "cable", "charges": [ 1, 4 ] },
+        { "item": "element", "count": [ 2, 6 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_gridfood_processor",
+    "name": "grid foid pricessor",
+    "symbol": "U",
+    "description": "A food processor connected to a electrical grid.  Capable of slicing, chopping, shredding, grinding, pureeing and mixing.",
+    "color": "blue",
+    "move_cost_mod": -1,
+    "coverage": 10,
+    "required_str": -1,
+    "crafting_pseudo_item": "fake_gridfood_processor",
+    "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
+    "deconstruct": {
+      "items": [ { "item": "food_processor", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+    },
+    "bash": {
+      "str_min": 8,
+      "str_max": 16,
+      "sound": "crunch!",
+      "sound_fail": "whump.",
+      "items": [
+        { "item": "power_supply", "count": [ 1, 4 ] },
+        { "item": "scrap", "count": [ 0, 4 ] },
+        { "item": "plastic_chunk", "count": [ 0, 9 ] },
+        { "item": "cable", "charges": [ 1, 4 ] },
+        { "item": "element", "count": [ 2, 6 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_gridvac_sealer",
+    "name": "grid vacuum sealer",
+    "symbol": "U",
+    "description": "A portable heat sealer unit, connected to a electrical grid.  It could be used for vacuum-packing food to preserve it.",
+    "color": "blue",
+    "move_cost_mod": -1,
+    "coverage": 10,
+    "required_str": -1,
+    "crafting_pseudo_item": "fake_gridvac_sealer",
+    "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
+    "deconstruct": {
+      "items": [ { "item": "vac_sealer", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
+    },
+    "bash": {
+      "str_min": 8,
+      "str_max": 16,
+      "sound": "crunch!",
+      "sound_fail": "whump.",
+      "items": [
+        { "item": "power_supply", "count": [ 1, 4 ] },
+        { "item": "scrap", "count": [ 0, 4 ] },
+        { "item": "plastic_chunk", "count": [ 0, 9 ] },
+        { "item": "cable", "charges": [ 1, 4 ] },
+        { "item": "element", "count": [ 2, 6 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_gridelectrolysis_kit",
     "name": "grid electrolysis kit",
     "symbol": "=",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -197,6 +197,42 @@
     "flags": [ "USES_GRID_POWER" ]
   },
   {
+    "id": "fake_gridkiln",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "grid kiln" },
+    "sub": "kiln",
+    "max_charges": 2500,
+    "flags": [ "USES_GRID_POWER" ]
+  },
+  {
+    "id": "fake_griddehydrator",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "grid food dehydrator" },
+    "sub": "dehydrator",
+    "max_charges": 2500,
+    "flags": [ "USES_GRID_POWER" ]
+  },
+  {
+    "id": "fake_gridfood_processor",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "grid food processor" },
+    "sub": "food_processor",
+    "max_charges": 2500,
+    "flags": [ "USES_GRID_POWER" ]
+  },
+  {
+    "id": "fake_gridvac_sealer",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "grid vacuum sealer" },
+    "sub": "vac_sealer",
+    "max_charges": 2500,
+    "flags": [ "USES_GRID_POWER" ]
+  },
+  {
     "id": "fake_gridelectrolysis_kit",
     "copy-from": "fake_item",
     "type": "TOOL",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Content "Adds grid-powered options for kilns and a few electric cooking tools"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I finally started looking into the grid-based applicances to see how that worked, and decided it'd be fairly easy to add a few extra options. Went with fairly simple stuff for the time being, basic things that are readily used in recipes.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added a construction for plugging an electric brick kiln into the grid.
2. Three basic food-related grid options as well. Dehyrdators, food processors, and vaccuum sealers. Decided to keep it fairly simple as far as food-related tools go.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. I was tempted to see how well a grid-installed FOODCO kitchen buddy would work, but I don't think an item can be set to substitute for mulitple tools, so it wouldn't have really been doable.
2. Makeshift vacuum sealers could also be an option. Only issue is that ideally I'd just add makeshift sealers as an option for the construction, but then deconstructing it would allow you to change one type of tool into the other.
3. I was going to add a reloading bench, combining the function of a workbench with grid-powered handloading tools, before I remembered that the heating function of hand presses had loooong ago been separated from the tool so they're no longer electronic.
4. Water purifiers could be added for its crafting use since clean water can be crafted using charges of a water purifier, but its use action wouldn't be accessible via this method.

In addition, there are some furniture items currently used for flavor that'd be useful if made grid-compatible, with some potential future uses, but each has potential complications:
1. There's an electric arc furnace, `f_arc_furnace`, that's different from the other arc furnace item, `f_arcfurnace_empty`. The latter has a hardcoded examine action as part of the process of making acetylene for torches, no idea if the former could be adapted to do the same thing off grid power. I get the feeling the latter might rely on the magic of "lab power is implied to be powering this" like with autoclaves and centrifuges, and that whoever added one of those furnitures was unaware the other existed, depending on which version came first.
2. Drill press would obviously be useful long-term for machining stuff, maybe even one of the things we'd need for that realistic craftable STEN idea I was dreaming of a long time ago. Biggest complication there is that drills are used as either a quality or a tool depending on the recipe, and a drill press would only be able to properly draw power when it's being used for its tool function.
3. Tablesaw, mitre saw, and bandsaw are all basically just variations on something that could be used instead of a wood saw. That runs into the same issue as circular saws however, in that sane behavior can only be achieved via its use as a tool, but sawing is based on quality. They wouldn't be usable unless every recipe, construction, and vehicle upkeep in the game involving sawing was changed from using quality to specifying tools (which would have a side effect of making circular saws no longer useless, too).
4. Router tables, planers, and joiners probably would have some misc specialized uses in some recipes but nothing absolutely essential comes to mind.
5. Hydraulic press would probably be handy for bending metal, fitting bearings, or just for putting on your best attempt at a Finnish accent and compacting items into scrap.
6. Getting the power lathe working is probably the other thing standing in the way of some good home-brew gunsmithing as well as other machining recipes.
7. Air compressors would be useful for the handful of recipes that currently only allow a hand pump, but that might also run into current issues of pressurization being rooted in a quality.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Ported JSON changes over to build 1999, load-tested them.
2. Debugged in all recipes.
3. Map edited the new furniture into the evac shelter, since it has a convenient grid already set up.
4. Examined recipes for clay items, dehydrated foods, stuff using the food processor, and vacuum-sealed food to confirm the grid-powered furniture was counting as a valid tool.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

One final thought: Would a separate construction category for grid-related stuff be warranted if enough options are added to the list?