### PR TITLE
Display fixes for new bionic butchering

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -478,19 +478,20 @@ static void extract_or_wreck_cbms( const std::list<item> &cbms, int roll,
         return;
     }
     for( item it : cbms ) {
+        static const itype_id burn_out_bionic( "burnt_out_bionic" );
         // For some stupid reason, zombie pheromones are dropped using bionic type
         // This complicates things
         if( it.is_bionic() ) {
-            if( check_butcher_cbm( roll ) ) {
+            if( check_butcher_cbm( roll ) || it.typeId() == burn_out_bionic ) {
                 add_msg( m_good, _( "You discover a %s!" ), it.tname() );
             } else {
                 // We convert instead of recreating so that it keeps flags and faults
-                it.convert( itype_id( "burnt_out_bionic" ) );
-                add_msg( m_bad, _( "You discover a %s!" ), it.tname() );
+                it.convert( burn_out_bionic );
+                add_msg( m_bad, _( "Your imprecise surgery damaged a bionic, producing a %s." ), it.tname() );
             }
         } else {
             if( !check_butcher_cbm( roll ) ) {
-                add_msg( m_bad, _( "You discover only damaged organs." ) );
+                add_msg( m_bad, _( "Your imprecise surgery destroyed some organs." ) );
                 continue;
             } else {
                 add_msg( m_good, _( "You discover a %s!" ), it.tname() );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2254,14 +2254,20 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
                 continue;
             }
 
-            int cbm_count = std::distance( corpse.components.begin(), corpse.components.end() );
-            if( cbm_count > it->ammo_consume( cbm_count, pos ) ) {
+            std::vector<const item *> cbms;
+            for( const item &maybe_cbm : corpse.components ) {
+                if( maybe_cbm.is_bionic() ) {
+                    cbms.push_back( &maybe_cbm );
+                }
+            }
+
+            if( static_cast<int>( cbms.size() ) > it->ammo_consume( cbms.size(), pos ) ) {
                 it->deactivate( p, true );
                 return 0;
             }
 
             corpse.set_var( "bionics_scanned_by", p->getID().get_value() );
-            if( cbm_count > 0 ) {
+            if( cbms.size() > 0 ) {
                 std::string bionics_string =
                     enumerate_as_string( corpse.components.begin(), corpse.components.end(),
                 []( const item & entry ) -> std::string {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2269,9 +2269,9 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
             corpse.set_var( "bionics_scanned_by", p->getID().get_value() );
             if( cbms.size() > 0 ) {
                 std::string bionics_string =
-                    enumerate_as_string( corpse.components.begin(), corpse.components.end(),
-                []( const item & entry ) -> std::string {
-                    return entry.is_bionic() ? entry.display_name() : "";
+                    enumerate_as_string( cbms.begin(), cbms.end(),
+                []( const item * entry ) -> std::string {
+                    return entry->display_name();
                 }, enumeration_conjunction::none );
                 p->add_msg_if_player( m_good, _( "A %1$s located %2$s contains %3$s" ),
                                       corpse.display_name().c_str(),


### PR DESCRIPTION
Closes #567

Two fixes:
* Bionic detector now ignores not-bionic items more consistently
* Surgery messages are more specific, saying "You ruined this bionic/organ" rather than "You found a ruined bionic/organ"