### PR TITLE
Keep NPCs satiated if NPC needs are disabled

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4554,7 +4554,7 @@ void Character::update_stomach( const time_point &from, const time_point &to )
         // Digest nutrients in stomach
         food_summary digested_to_body = stomach.digest( rates, five_mins );
         // Apply nutrients, unless this is an NPC and NO_NPC_FOOD is enabled.
-        if( !is_npc() || !get_option<bool>( "NO_NPC_FOOD" ) ) {
+        if( !npc_no_food ) {
             mod_stored_kcal( digested_to_body.nutr.kcal );
             vitamins_mod( digested_to_body.nutr.vitamins, false );
         }
@@ -4567,6 +4567,12 @@ void Character::update_stomach( const time_point &from, const time_point &to )
     if( !foodless && rates.thirst > 0.0f ) {
         mod_thirst( roll_remainder( rates.thirst * five_mins ) );
     }
+
+    if( npc_no_food ) {
+        set_thirst( static_cast<int>( thirst_levels::hydrated ) );
+        set_stored_kcal( get_healthy_kcal() );
+    }
+
     // Mycus and Metabolic Rehydration makes thirst unnecessary
     // since water is not limited by intake but by absorption, we can just set thirst to zero
     if( mycus || mouse ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1519,6 +1519,8 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
     }
     if( debug && parts->test( iteminfo_parts::BASE_DEBUG ) ) {
         if( g != nullptr ) {
+            info.push_back( iteminfo( "BASE", string_format( "itype_id: %s",
+                                      typeId().c_str() ) ) );
             info.push_back( iteminfo( "BASE", _( "age (hours): " ), "", iteminfo::lower_is_better,
                                       to_hours<int>( age() ) ) );
             info.push_back( iteminfo( "BASE", _( "charges: " ), "", iteminfo::lower_is_better,


### PR DESCRIPTION
#### Purpose of change
This crutch should counteract all sources of thirst and hunger NPC may be affected by.
Fixes #579.

Includes a nice change ported from CleverRaven#47336 that adds item's `itype_id` to debug item info display.

#### Testing
In provided save, NPC now asks for water only if needs are enabled (`no-npc-food` mod is removed before load).
NPCs gain thirst/hunger without the mod, stay satiated with it.
Avatar thirst/hunger gains are unaffected.
Faction camps still require food for operation.