### PR TITLE
Add a use to military webbing belts

### DIFF
--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -246,12 +246,14 @@
     "looks_like": "leather_belt",
     "color": "yellow",
     "covers": [ "TORSO" ],
+    "encumbrance": 1,
     "use_action": {
       "type": "holster",
       "holster_prompt": "Stick what into your belt",
       "holster_msg": "You tuck your %s into your %s",
-      "max_volume": "1 L",
-      "max_weight": "1200 g",
+      "max_volume": "1250 ml",
+      "max_weight": "1500 g",
+      "min_volume": "40 ml",
       "draw_cost": 60,
       "flags": [ "BELT_CLIP" ]
     },

--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -246,6 +246,15 @@
     "looks_like": "leather_belt",
     "color": "yellow",
     "covers": [ "TORSO" ],
+    "use_action": {
+      "type": "holster",
+      "holster_prompt": "Stick what into your belt",
+      "holster_msg": "You tuck your %s into your %s",
+      "max_volume": "1 L",
+      "max_weight": "1200 g",
+      "draw_cost": 60,
+      "flags": [ "BELT_CLIP" ]
+    },
     "flags": [ "WAIST", "WATER_FRIENDLY" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Adds a belt-clip use action to webbing belts"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

On noticing this item on a military profession, I was curious what it could hold only to find it completely lacked any storage or even the ability to clip something on it, something even the generic leather belt has. I checked to see if maybe DDA had something implemented for it and nope, so put together a basic belt-clip storage action for it for consistency.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Added a `holster` use action to the webbing belt. Based primarily off the stats used by the standard leather belt, with weight and volume allowances in between leather belts and police duty belts, while retaining the leather belt's slightly high draw cost.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Making it have pouches to represent ALICE and MOLLE belts, but modern MOLLE equipment would most likely be already represented in-game by the chest rig item, and/or the magazine pouches on MBR vests.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected JSON file for syntax and load errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

If there's a particular BELT_CLIP item that would be especially desirable as the baseline for what its weight and volume limits ought to be, let me know. My rough guess would be an entrenching tool would be the most obvious thing you'd want to hang from it, which at 1 liter volume will indeed fit on the belt, with about half the weight limit to spare too.