### PR TITLE
[WIP] Add constant that sets seconds per full turn

### DIFF
--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -284,7 +284,7 @@ std::pair<int, clipped_unit> clipped_time( const time_duration &d )
     }
 
     if( d < 1_minutes ) {
-        const int sec = to_seconds<int>( d ) * seconds_per_turn;
+        const int sec = to_seconds<int>( d );
         return { sec, clipped_unit::second };
     } else if( d < 1_hours ) {
         const int min = to_minutes<int>( d );
@@ -397,7 +397,7 @@ std::string to_string_time_of_day( const time_point &p )
 {
     const int hour = hour_of_day<int>( p );
     const int minute = minute_of_hour<int>( p );
-    const int second = ( to_seconds<int>( time_past_midnight( p ) ) * seconds_per_turn ) % 60;
+    const int second = ( to_seconds<int>( time_past_midnight( p ) ) ) % 60;
     const std::string format_type = get_option<std::string>( "24_HOUR" );
 
     if( format_type == "military" ) {

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -284,7 +284,7 @@ std::pair<int, clipped_unit> clipped_time( const time_duration &d )
     }
 
     if( d < 1_minutes ) {
-        const int sec = to_seconds<int>( d );
+        const int sec = to_seconds<int>( d ) * seconds_per_turn;
         return { sec, clipped_unit::second };
     } else if( d < 1_hours ) {
         const int min = to_minutes<int>( d );
@@ -397,7 +397,7 @@ std::string to_string_time_of_day( const time_point &p )
 {
     const int hour = hour_of_day<int>( p );
     const int minute = minute_of_hour<int>( p );
-    const int second = ( to_seconds<int>( time_past_midnight( p ) ) ) % 60;
+    const int second = ( to_seconds<int>( time_past_midnight( p ) ) * seconds_per_turn ) % 60;
     const std::string format_type = get_option<std::string>( "24_HOUR" );
 
     if( format_type == "military" ) {

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -213,7 +213,7 @@ class time_duration
         }
         template<typename T>
         static constexpr time_duration from_minutes( const T m ) {
-            return from_seconds( m * 60 );
+            return from_turns( m * 60 / seconds_per_turn );
         }
         template<typename T>
         static constexpr time_duration from_hours( const T h ) {

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -149,7 +149,12 @@ constexpr time_duration operator*( T lhs, const time_duration &rhs );
 template<typename T>
 inline time_duration &operator*=( time_duration &lhs, T rhs );
 
-// seconds per full turn
+/**
+ * Represents seconds per full turn. Currently the only supported value is 1
+ * In future that value may be changed
+ * TODO: Reserach option to move it to game options
+ * Changing it to something else than 1 will require checking and fixing other mechanics
+ */
 static constexpr int seconds_per_turn = 6;
 
 /**

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -246,7 +246,7 @@ class time_duration
         }
         template<typename T>
         friend constexpr T to_seconds( const time_duration &duration ) {
-            return duration.turns_;
+            return duration.turns_* seconds_per_turn;
         }
         template<typename T>
         friend constexpr T to_minutes( const time_duration &duration ) {

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -155,7 +155,7 @@ inline time_duration &operator*=( time_duration &lhs, T rhs );
  * In future seconds per full turn may be changed
  * TODO: Research possibility to move it to game options
  */
-static constexpr int seconds_per_turn = 6;
+static constexpr int seconds_per_turn = 1;
 
 /**
  * A duration defined as a number of specific time units.
@@ -209,7 +209,7 @@ class time_duration
         }
         template<typename T>
         static constexpr time_duration from_seconds( const T t ) {
-            return time_duration( t ) / seconds_per_turn;
+            return time_duration( t );
         }
         template<typename T>
         static constexpr time_duration from_minutes( const T m ) {
@@ -246,7 +246,7 @@ class time_duration
         }
         template<typename T>
         friend constexpr T to_seconds( const time_duration &duration ) {
-            return duration.turns_ * seconds_per_turn;
+            return duration.turns_ / seconds_per_turn;
         }
         template<typename T>
         friend constexpr T to_minutes( const time_duration &duration ) {

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -213,7 +213,7 @@ class time_duration
         }
         template<typename T>
         static constexpr time_duration from_minutes( const T m ) {
-            return from_turns( m * 60 / seconds_per_turn );
+            return from_seconds( m * 60 );
         }
         template<typename T>
         static constexpr time_duration from_hours( const T h ) {

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -149,6 +149,9 @@ constexpr time_duration operator*( T lhs, const time_duration &rhs );
 template<typename T>
 inline time_duration &operator*=( time_duration &lhs, T rhs );
 
+// seconds per full turn
+static constexpr int seconds_per_turn = 6;
+
 /**
  * A duration defined as a number of specific time units.
  * Currently it stores the number (as integer) of turns.
@@ -205,7 +208,7 @@ class time_duration
         }
         template<typename T>
         static constexpr time_duration from_minutes( const T m ) {
-            return from_turns( m * 60 );
+            return from_turns( m * 60 / seconds_per_turn );
         }
         template<typename T>
         static constexpr time_duration from_hours( const T h ) {
@@ -242,19 +245,19 @@ class time_duration
         }
         template<typename T>
         friend constexpr T to_minutes( const time_duration &duration ) {
-            return static_cast<T>( duration.turns_ ) / static_cast<T>( 60 );
+            return static_cast<T>( duration.turns_ ) / static_cast<T>( 60 / seconds_per_turn );
         }
         template<typename T>
         friend constexpr T to_hours( const time_duration &duration ) {
-            return static_cast<T>( duration.turns_ ) / static_cast<T>( 60 * 60 );
+            return static_cast<T>( duration.turns_ ) / static_cast<T>( 60 * 60 / seconds_per_turn );
         }
         template<typename T>
         friend constexpr T to_days( const time_duration &duration ) {
-            return static_cast<T>( duration.turns_ ) / static_cast<T>( 60 * 60 * 24 );
+            return static_cast<T>( duration.turns_ ) / static_cast<T>( 60 * 60 * 24 / seconds_per_turn );
         }
         template<typename T>
         friend constexpr T to_weeks( const time_duration &duration ) {
-            return static_cast<T>( duration.turns_ ) / static_cast<T>( 60 * 60 * 24 * 7 );
+            return static_cast<T>( duration.turns_ ) / static_cast<T>( 60 * 60 * 24 * 7 / seconds_per_turn );
         }
         template<typename T>
         friend constexpr T to_moves( const time_duration &duration ) {

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -209,11 +209,11 @@ class time_duration
         }
         template<typename T>
         static constexpr time_duration from_seconds( const T t ) {
-            return time_duration( t / seconds_per_turn );
+            return time_duration( t );
         }
         template<typename T>
         static constexpr time_duration from_minutes( const T m ) {
-            return from_seconds( m * 60 );
+            return from_turns( m * 60 / seconds_per_turn );
         }
         template<typename T>
         static constexpr time_duration from_hours( const T h ) {

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -152,10 +152,10 @@ inline time_duration &operator*=( time_duration &lhs, T rhs );
 /**
  * Represents seconds per full turn. Currently the only supported value is 1
  * Changing it to something else than 1 will require checking and fixing other mechanics
- * In future that value may be changed
+ * In future seconds per full turn may be changed
  * TODO: Reserach option to move it to game options
  */
-static constexpr int seconds_per_turn = 6;
+static constexpr int seconds_per_turn = 1;
 
 /**
  * A duration defined as a number of specific time units.

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -155,7 +155,7 @@ inline time_duration &operator*=( time_duration &lhs, T rhs );
  * In future seconds per full turn may be changed
  * TODO: Research possibility to move it to game options
  */
-static constexpr int seconds_per_turn = 1;
+static constexpr int seconds_per_turn = 6;
 
 /**
  * A duration defined as a number of specific time units.
@@ -209,7 +209,7 @@ class time_duration
         }
         template<typename T>
         static constexpr time_duration from_seconds( const T t ) {
-            return time_duration( t );
+            return time_duration( t ) / seconds_per_turn;
         }
         template<typename T>
         static constexpr time_duration from_minutes( const T m ) {
@@ -246,7 +246,7 @@ class time_duration
         }
         template<typename T>
         friend constexpr T to_seconds( const time_duration &duration ) {
-            return duration.turns_ / seconds_per_turn;
+            return duration.turns_ * seconds_per_turn;
         }
         template<typename T>
         friend constexpr T to_minutes( const time_duration &duration ) {

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -151,9 +151,9 @@ inline time_duration &operator*=( time_duration &lhs, T rhs );
 
 /**
  * Represents seconds per full turn. Currently the only supported value is 1
+ * Changing it to something else than 1 will require checking and fixing other mechanics
  * In future that value may be changed
  * TODO: Reserach option to move it to game options
- * Changing it to something else than 1 will require checking and fixing other mechanics
  */
 static constexpr int seconds_per_turn = 6;
 

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -155,7 +155,7 @@ inline time_duration &operator*=( time_duration &lhs, T rhs );
  * In future seconds per full turn may be changed
  * TODO: Research possibility to move it to game options
  */
-static constexpr int seconds_per_turn = 6;
+static constexpr int seconds_per_turn = 1;
 
 /**
  * A duration defined as a number of specific time units.

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -153,7 +153,7 @@ inline time_duration &operator*=( time_duration &lhs, T rhs );
  * Represents seconds per full turn. Currently the only supported value is 1
  * Changing it to something else than 1 will require checking and fixing other mechanics
  * In future seconds per full turn may be changed
- * TODO: Reserach option to move it to game options
+ * TODO: Research option to move it to game options
  */
 static constexpr int seconds_per_turn = 1;
 

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -246,7 +246,7 @@ class time_duration
         }
         template<typename T>
         friend constexpr T to_seconds( const time_duration &duration ) {
-            return duration.turns_;
+            return duration.turns_ / seconds_per_turn;
         }
         template<typename T>
         friend constexpr T to_minutes( const time_duration &duration ) {

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -246,7 +246,7 @@ class time_duration
         }
         template<typename T>
         friend constexpr T to_seconds( const time_duration &duration ) {
-            return duration.turns_* seconds_per_turn;
+            return duration.turns_;
         }
         template<typename T>
         friend constexpr T to_minutes( const time_duration &duration ) {

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -153,7 +153,7 @@ inline time_duration &operator*=( time_duration &lhs, T rhs );
  * Represents seconds per full turn. Currently the only supported value is 1
  * Changing it to something else than 1 will require checking and fixing other mechanics
  * In future seconds per full turn may be changed
- * TODO: Research option to move it to game options
+ * TODO: Research possibility to move it to game options
  */
 static constexpr int seconds_per_turn = 1;
 

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -246,7 +246,7 @@ class time_duration
         }
         template<typename T>
         friend constexpr T to_seconds( const time_duration &duration ) {
-            return duration.turns_ / seconds_per_turn;
+            return duration.turns_;
         }
         template<typename T>
         friend constexpr T to_minutes( const time_duration &duration ) {

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -209,11 +209,11 @@ class time_duration
         }
         template<typename T>
         static constexpr time_duration from_seconds( const T t ) {
-            return time_duration( t );
+            return time_duration( t / seconds_per_turn );
         }
         template<typename T>
         static constexpr time_duration from_minutes( const T m ) {
-            return from_turns( m * 60 / seconds_per_turn );
+            return from_seconds( m * 60 );
         }
         template<typename T>
         static constexpr time_duration from_hours( const T h ) {

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -155,7 +155,7 @@ inline time_duration &operator*=( time_duration &lhs, T rhs );
  * In future seconds per full turn may be changed
  * TODO: Research possibility to move it to game options
  */
-static constexpr int seconds_per_turn = 1;
+static constexpr int seconds_per_turn = 6;
 
 /**
  * A duration defined as a number of specific time units.

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2157,6 +2157,11 @@ void options_manager::add_options_debug()
          translate_marker( "If true, enables experimental translation system that allows mods to ship their own translation files." ),
          false
        );
+
+    add("SECONDS_PER_TURN", "debug", translate_marker("Number os second per full turn"),
+        translate_marker("Number os second per full turn"),
+        1, 1000, 1
+    );
 }
 
 void options_manager::add_options_world_default()

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2159,7 +2159,7 @@ void options_manager::add_options_debug()
        );
 
     add("SECONDS_PER_TURN", "debug", translate_marker("Number os second per full turn"),
-        translate_marker("Number os second per full turn"),
+        translate_marker("Number os second per full turn (100 moves)"),
         1, 1000, 1
     );
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2158,10 +2158,10 @@ void options_manager::add_options_debug()
          false
        );
 
-    add("SECONDS_PER_TURN", "debug", translate_marker("Number os second per full turn"),
-        translate_marker("Number os second per full turn (100 moves)"),
-        1, 1000, 1
-    );
+    add( "SECONDS_PER_TURN", "debug", translate_marker( "Number os second per full turn" ),
+         translate_marker( "Number os second per full turn (100 moves)" ),
+         1, 1000, 1
+       );
 }
 
 void options_manager::add_options_world_default()

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2157,11 +2157,6 @@ void options_manager::add_options_debug()
          translate_marker( "If true, enables experimental translation system that allows mods to ship their own translation files." ),
          false
        );
-
-    add( "SECONDS_PER_TURN", "debug", translate_marker( "Number os second per full turn" ),
-         translate_marker( "Number os second per full turn (100 moves)" ),
-         1, 1000, 1
-       );
 }
 
 void options_manager::add_options_world_default()


### PR DESCRIPTION
This attempt at least to try to seconds per turn configurable. It is more attempt or prototype it.
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
Make turn per second configurable
There was change in DDA: https://github.com/CleverRaven/Cataclysm-DDA/pull/30253
It is changed game pacing significantly. And slowed down waiting periods for users with slow PCs.

SUMMARY: Balance "Make turn per second configurable"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: Balance "Make seconds per turn configurable"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Despite it looked good on paper and "realistic" it unavoidable slowed down game pacing and increases waiting for long actions times for low end PCs.
Usually other games uses abstracted time. There is no need to striclty follow 1 turn = 1 second. Especially considering that distances in Cataclysm very absracted.
Also setting turn to 6 second may work kinda like 600% optimisation in some cases since waiting pereiod for long actions will be reduced at 6 times.
So I've decided to try to make it configurable or at least try to.

**For now I am only encapsulation second per turn to compile time constant to simplify testing and as future remainder**.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Original plan:
1) Make turn per second configurable. Via code constants (easier) or via debug option (harder). Make sure that game at least working with second per turn=6. Keep default value as 1 second, because changing it guranteed to produce unitnended effects
2) Deattach tactical actions from time to turns if needed. Clear potential problelems. Still keep default value, for turn per second.
3) Set new default second per turn to 6 second (or something else)

Here I am trying to figure out step 1.
For now I've just inroduced constant to quickly changeing seconds per turn value. It would be good to put it in debug option, but is it actually needed?

For now I am only encapsulation second per turn to compile time constant to simplify testing and as future remainder.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
This PR could be ended up as light refactoring by putting second per turn to constant. Even that will be good.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Make sure that second per turn set to 1 second (default value) working as before.
2) Make sure that after setting second per turn to 6 second game at least keep working.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
None.