### PR TITLE
Port improvements & fixes for transparency and seen caches

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -273,6 +273,8 @@ std::string action_ident( action_id act )
             return "debug_vehicle_ai";
         case ACTION_DISPLAY_VISIBILITY:
             return "debug_visibility";
+        case ACTION_DISPLAY_TRANSPARENCY:
+            return "debug_transparency";
         case ACTION_DISPLAY_LIGHTING:
             return "debug_lighting";
         case ACTION_DISPLAY_RADIATION:
@@ -391,6 +393,7 @@ bool can_action_change_worldstate( const action_id act )
         case ACTION_DISPLAY_VISIBILITY:
         case ACTION_DISPLAY_LIGHTING:
         case ACTION_DISPLAY_RADIATION:
+        case ACTION_DISPLAY_TRANSPARENCY:
         case ACTION_DISPLAY_SUBMAP_GRID:
         case ACTION_ZOOM_OUT:
         case ACTION_ZOOM_IN:
@@ -812,6 +815,7 @@ action_id handle_action_menu()
             REGISTER_ACTION( ACTION_DISPLAY_VEHICLE_AI );
             REGISTER_ACTION( ACTION_DISPLAY_VISIBILITY );
             REGISTER_ACTION( ACTION_DISPLAY_LIGHTING );
+            REGISTER_ACTION( ACTION_DISPLAY_TRANSPARENCY );
             REGISTER_ACTION( ACTION_DISPLAY_RADIATION );
             REGISTER_ACTION( ACTION_DISPLAY_SUBMAP_GRID );
             REGISTER_ACTION( ACTION_TOGGLE_DEBUG_MODE );

--- a/src/action.h
+++ b/src/action.h
@@ -315,6 +315,8 @@ enum action_id : int {
     ACTION_DISPLAY_LIGHTING,
     /** Toggle radiation map */
     ACTION_DISPLAY_RADIATION,
+    /** Toggle transparency map */
+    ACTION_DISPLAY_TRANSPARENCY,
     /** Toggle submap grid overlay */
     ACTION_DISPLAY_SUBMAP_GRID,
     /** Toggle timing of the game hours */

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1466,6 +1466,10 @@ void avatar::set_movement_mode( character_movemode new_mode )
             return;
         }
     }
+    if( move_mode == CMM_CROUCH || new_mode == CMM_CROUCH ) {
+        // crouching affects visibility
+        get_map().set_seen_cache_dirty( pos().z );
+    }
     move_mode = new_mode;
 }
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1199,6 +1199,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             }
         }
     }
+    const point quarter_tile( tile_width / 4, tile_height / 4 );
     if( g->display_overlay_state( ACTION_DISPLAY_VEHICLE_AI ) ) {
         for( const point &pt_elem : collision_checkpoints ) {
             overlay_strings.emplace( player_to_screen( pt_elem ) + point( tile_width / 2, 0 ),
@@ -1336,35 +1337,44 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     formatted_text( visibility_str, catacurses::black, direction::NORTH ) );
             }
 
+            static std::vector<SDL_Color> lighting_colors;
+            // color hue in the range of [0..10], 0 being white,  10 being blue
+            auto draw_debug_tile = [&]( const int color_hue, const std::string & text ) {
+                if( lighting_colors.empty() ) {
+                    SDL_Color white = { 255, 255, 255, 255 };
+                    SDL_Color blue = { 0, 0, 255, 255 };
+                    lighting_colors = color_linear_interpolate( white, blue, 9 );
+                }
+                point tile_pos = player_to_screen( point( x, y ) );
+
+                // color overlay
+                SDL_Color color = lighting_colors[std::min( std::max( 0, color_hue ), 10 )];
+                color.a = 100;
+                color_blocks.first = SDL_BLENDMODE_BLEND;
+                color_blocks.second.emplace( tile_pos, color );
+
+                // string overlay
+                overlay_strings.emplace( tile_pos + quarter_tile, formatted_text( text, catacurses::black,
+                                         direction::NORTH ) );
+            };
+
             if( g->display_overlay_state( ACTION_DISPLAY_LIGHTING ) ) {
-                static std::vector<SDL_Color> lighting_colors;
                 if( g->displaying_lighting_condition == 0 ) {
-                    if( lighting_colors.empty() ) {
-                        SDL_Color white = { 255, 255, 255, 255 };
-                        SDL_Color blue = { 0, 0, 255, 255 };
-                        lighting_colors = color_linear_interpolate( white, blue, 9 );
-                    }
-
+                    const float light = here.ambient_light_at( {x, y, center.z} );
                     // note: lighting will be constrained in the [1.0, 11.0] range.
-                    float ambient = g->m.ambient_light_at( {x, y, center.z} );
-                    float lighting = std::max( 1.0, LIGHT_AMBIENT_LIT - ambient + 1.0 );
-
-                    auto tile_pos = player_to_screen( point( x, y ) );
-
-                    // color overlay
-                    auto color = lighting_colors[static_cast<int>( lighting ) - 1];
-                    color.a = 100;
-                    color_blocks.first = SDL_BLENDMODE_BLEND;
-                    color_blocks.second.emplace( tile_pos, color );
-
-                    // string overlay
-                    overlay_strings.emplace( tile_pos + point( tile_width / 4, tile_height / 4 ),
-                                             formatted_text( string_format( "%.1f", ambient ), catacurses::black, direction::NORTH ) );
+                    int intensity = static_cast<int>( std::max( 1.0, LIGHT_AMBIENT_LIT - light + 1.0 ) ) - 1;
+                    draw_debug_tile( intensity, string_format( "%.1f", light ) );
                 }
             }
 
-            if( !invisible[0] && apply_vision_effects( pos, g->m.get_visibility( ll, cache ) ) ) {
+            if( g->display_overlay_state( ACTION_DISPLAY_TRANSPARENCY ) ) {
+                const float tr = here.light_transparency( {x, y, center.z} );
+                int intensity =  tr <= LIGHT_TRANSPARENCY_SOLID ? 10 :  static_cast<int>
+                                 ( ( tr - LIGHT_TRANSPARENCY_OPEN_AIR ) * 8 );
+                draw_debug_tile( intensity, string_format( "%.2f", tr ) );
+            }
 
+            if( !invisible[0] && apply_vision_effects( pos, here.get_visibility( ll, cache ) ) ) {
                 const Creature *critter = g->critter_at( pos, true );
                 if( has_draw_override( pos ) || has_memory_at( pos ) ||
                     ( critter && ( g->u.sees_with_infrared( *critter ) || g->u.sees_with_specials( *critter ) ) ) ) {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -172,6 +172,7 @@ enum debug_menu_index {
     DEBUG_DISPLAY_VISIBILITY,
     DEBUG_DISPLAY_LIGHTING,
     DEBUG_DISPLAY_RADIATION,
+    DEBUG_DISPLAY_TRANSPARENCY,
     DEBUG_DISPLAY_SUBMAP_GRID,
     DEBUG_LEARN_SPELLS,
     DEBUG_LEVEL_SPELLS,
@@ -238,6 +239,7 @@ static int info_uilist( bool display_all_entries = true )
             { uilist_entry( DEBUG_DISPLAY_VEHICLE_AI, true, 'V', _( "Toggle display vehicle autopilot overlay" ) ) },
             { uilist_entry( DEBUG_DISPLAY_VISIBILITY, true, 'v', _( "Toggle display visibility" ) ) },
             { uilist_entry( DEBUG_DISPLAY_LIGHTING, true, 'l', _( "Toggle display lighting" ) ) },
+            { uilist_entry( DEBUG_DISPLAY_TRANSPARENCY, true, 'p', _( "Toggle display transparency" ) ) },
             { uilist_entry( DEBUG_DISPLAY_RADIATION, true, 'R', _( "Toggle display radiation" ) ) },
             { uilist_entry( DEBUG_DISPLAY_SUBMAP_GRID, true, 'o', _( "Toggle display submap grid" ) ) },
             { uilist_entry( DEBUG_SHOW_MUT_CAT, true, 'm', _( "Show mutation category levels" ) ) },
@@ -1646,6 +1648,9 @@ void debug()
             break;
         case DEBUG_DISPLAY_RADIATION:
             g->display_toggle_overlay( ACTION_DISPLAY_RADIATION );
+            break;
+        case DEBUG_DISPLAY_TRANSPARENCY:
+            g->display_toggle_overlay( ACTION_DISPLAY_TRANSPARENCY );
             break;
         case DEBUG_DISPLAY_SUBMAP_GRID:
             g->debug_submap_grid_overlay = !g->debug_submap_grid_overlay;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6906,6 +6906,10 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
             if( !MAP_SHARING::isCompetitive() || MAP_SHARING::isDebugger() ) {
                 display_lighting();
             }
+        } else if( action == "debug_transparency" ) {
+            if( !MAP_SHARING::isCompetitive() || MAP_SHARING::isDebugger() ) {
+                display_transparency();
+            }
         } else if( action == "debug_radiation" ) {
             if( !MAP_SHARING::isCompetitive() || MAP_SHARING::isDebugger() ) {
                 display_radiation();
@@ -11488,6 +11492,13 @@ void game::display_radiation()
 {
     if( use_tiles ) {
         display_toggle_overlay( ACTION_DISPLAY_RADIATION );
+    }
+}
+
+void game::display_transparency()
+{
+    if( use_tiles ) {
+        display_toggle_overlay( ACTION_DISPLAY_TRANSPARENCY );
     }
 }
 

--- a/src/game.h
+++ b/src/game.h
@@ -939,6 +939,7 @@ class game
         void display_visibility(); // Displays visibility map
         void display_lighting(); // Displays lighting conditions heat map
         void display_radiation(); // Displays radiation map
+        void display_transparency(); // Displays transparency map
 
         // prints the IRL time in ms of the last full in-game hour
         class debug_hour_timer

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2433,6 +2433,11 @@ bool game::handle_action()
                 display_radiation();
                 break;
 
+            case ACTION_DISPLAY_TRANSPARENCY:
+                if( MAP_SHARING::isCompetitive() && !MAP_SHARING::isDebugger() ) {
+                    break;    //don't do anything when sharing and not debugger
+                }
+                display_transparency();
             case ACTION_DISPLAY_SUBMAP_GRID:
                 g->debug_submap_grid_overlay = !g->debug_submap_grid_overlay;
                 break;

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -84,14 +84,18 @@ bool map::build_transparency_cache( const int zlev )
     auto &transparency_cache = map_cache.transparency_cache;
     auto &outside_cache = map_cache.outside_cache;
 
-    if( !map_cache.transparency_cache_dirty ) {
+    if( map_cache.transparency_cache_dirty.none() ) {
         return false;
     }
 
-    // Default to just barely not transparent.
-    std::uninitialized_fill_n(
-        &transparency_cache[0][0], MAPSIZE_X * MAPSIZE_Y,
-        static_cast<float>( LIGHT_TRANSPARENCY_OPEN_AIR ) );
+    // if true, all submaps are invalid (can use batch init)
+    bool rebuild_all = map_cache.transparency_cache_dirty.all();
+
+    if( rebuild_all ) {
+        // Default to just barely not transparent.
+        std::uninitialized_fill_n( &transparency_cache[0][0], MAPSIZE_X * MAPSIZE_Y,
+                                   static_cast<float>( LIGHT_TRANSPARENCY_OPEN_AIR ) );
+    }
 
     const float sight_penalty = weather::sight_penalty( g->weather.weather );
 
@@ -100,52 +104,61 @@ bool map::build_transparency_cache( const int zlev )
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
             const auto cur_submap = get_submap_at_grid( {smx, smy, zlev} );
 
-            float zero_value = LIGHT_TRANSPARENCY_OPEN_AIR;
-            for( int sx = 0; sx < SEEX; ++sx ) {
-                for( int sy = 0; sy < SEEY; ++sy ) {
-                    const int x = sx + smx * SEEX;
-                    const int y = sy + smy * SEEY;
+            const point sm_offset = sm_to_ms_copy( point( smx, smy ) );
 
-                    float &value = transparency_cache[x][y];
-                    if( cur_submap->is_uniform && sx + sy > 0 ) {
-                        value = zero_value;
+            if( !rebuild_all && !map_cache.transparency_cache_dirty[smx * MAPSIZE + smy] ) {
+                continue;
+            }
+
+            // calculates transparency of a single tile
+            // x,y - coords in map local coords
+            auto calc_transp = [&]( const point & p ) {
+                const point sp = p - sm_offset;
+                float value = LIGHT_TRANSPARENCY_OPEN_AIR;
+
+                if( !( cur_submap->get_ter( sp ).obj().transparent &&
+                       cur_submap->get_furn( sp ).obj().transparent ) ) {
+                    return LIGHT_TRANSPARENCY_SOLID;
+                }
+                if( outside_cache[p.x][p.y] ) {
+                    // FIXME: Places inside vehicles haven't been marked as
+                    // inside yet so this is incorrectly penalising for
+                    // weather in vehicles.
+                    value *= sight_penalty;
+                }
+                for( const auto &fld : cur_submap->get_field( sp ) ) {
+                    const field_entry &cur = fld.second;
+                    if( cur.is_transparent() ) {
                         continue;
                     }
+                    // Fields are either transparent or not, however we want some to be translucent
+                    value = value * cur.translucency();
+                }
+                // TODO: [lightmap] Have glass reduce light as well
+                return value;
+            };
 
-                    if( !( cur_submap->get_ter( { sx, sy } ).obj().transparent &&
-                           cur_submap->get_furn( {sx, sy } ).obj().transparent ) ) {
-                        value = LIGHT_TRANSPARENCY_SOLID;
-                        zero_value = LIGHT_TRANSPARENCY_SOLID;
-                        continue;
+            if( cur_submap->is_uniform ) {
+                float value = calc_transp( sm_offset );
+                // if rebuild_all==true all values were already set to LIGHT_TRANSPARENCY_OPEN_AIR
+                if( !rebuild_all || value != LIGHT_TRANSPARENCY_OPEN_AIR ) {
+                    for( int sx = 0; sx < SEEX; ++sx ) {
+                        // init all sy indices in one go
+                        std::uninitialized_fill_n( &transparency_cache[sm_offset.x + sx][sm_offset.y], SEEY, value );
                     }
-
-                    if( outside_cache[x][y] ) {
-                        // FIXME: Places inside vehicles haven't been marked as
-                        // inside yet so this is incorrectly penalising for
-                        // weather in vehicles.
-                        value *= sight_penalty;
+                }
+            } else {
+                for( int sx = 0; sx < SEEX; ++sx ) {
+                    const int x = sx + sm_offset.x;
+                    for( int sy = 0; sy < SEEY; ++sy ) {
+                        const int y = sy + sm_offset.y;
+                        transparency_cache[x][y] = calc_transp( { x, y } );
                     }
-                    if( cur_submap->is_uniform ) {
-                        if( value == LIGHT_TRANSPARENCY_OPEN_AIR ) {
-                            break;
-                        }
-                        zero_value = value;
-                        continue;
-                    }
-                    for( const auto &fld : cur_submap->get_field( { sx, sy } ) ) {
-                        const field_entry &cur = fld.second;
-                        if( cur.is_transparent() ) {
-                            continue;
-                        }
-                        // Fields are either transparent or not, however we want some to be translucent
-                        value = value * cur.translucency();
-                    }
-                    // TODO: [lightmap] Have glass reduce light as well
                 }
             }
         }
     }
-    map_cache.transparency_cache_dirty = false;
+    map_cache.transparency_cache_dirty.reset();
     return true;
 }
 
@@ -173,7 +186,6 @@ bool map::build_vision_transparency_cache( const int zlev )
         } else if( is_crouching && coverage( loc ) >= 30 ) {
             // If we're crouching behind an obstacle, we can't see past it.
             vision_transparency_cache[loc.x][loc.y] = LIGHT_TRANSPARENCY_SOLID;
-            map_cache.transparency_cache_dirty = true;
             dirty = true;
         }
     }
@@ -1216,12 +1228,20 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
         &camera_cache[0][0], map_dimensions, light_transparency_solid );
 
     if( !fov_3d ) {
-        std::uninitialized_fill_n(
-            &seen_cache[0][0], map_dimensions, light_transparency_solid );
-        seen_cache[origin.x][origin.y] = VISIBILITY_FULL;
+        for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+            auto &cur_cache = get_cache( z );
+            if( z == target_z || cur_cache.seen_cache_dirty ) {
+                std::uninitialized_fill_n(
+                    &cur_cache.seen_cache[0][0], map_dimensions, light_transparency_solid );
+                cur_cache.seen_cache_dirty = false;
+            }
 
-        castLightAll<float, float, sight_calc, sight_check, update_light, accumulate_transparency>(
-            seen_cache, transparency_cache, origin.xy(), 0 );
+            if( z == target_z ) {
+                seen_cache[origin.x][origin.y] = VISIBILITY_FULL;
+                castLightAll<float, float, sight_calc, sight_check, update_light, accumulate_transparency>(
+                    seen_cache, transparency_cache, origin.xy(), 0 );
+            }
+        }
     } else {
         // Cache the caches (pointers to them)
         array_of_grids_of<const float> transparency_caches;
@@ -1234,6 +1254,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
             floor_caches[z + OVERMAP_DEPTH] = &cur_cache.floor_cache;
             std::uninitialized_fill_n(
                 &cur_cache.seen_cache[0][0], map_dimensions, light_transparency_solid );
+            cur_cache.seen_cache_dirty = false;
         }
         if( origin.z == target_z ) {
             get_cache( origin.z ).seen_cache[origin.x][origin.y] = VISIBILITY_FULL;

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -10,6 +10,7 @@
 
 #include "avatar.h"
 #include "calendar.h"
+#include "cata_utility.h"
 #include "character.h"
 #include "colony.h"
 #include "field.h"
@@ -168,9 +169,7 @@ bool map::build_vision_transparency_cache( const int zlev )
     for( const tripoint &loc : points_in_radius( p, 1 ) ) {
         if( loc == p ) {
             // The tile player is standing on should always be visible
-            if( ( has_furn( p ) && !furn( p )->transparent ) || !ter( p )->transparent ) {
-                vision_transparency_cache[p.x][p.y] = LIGHT_TRANSPARENCY_CLEAR;
-            }
+            vision_transparency_cache[p.x][p.y] = LIGHT_TRANSPARENCY_OPEN_AIR;
         } else if( is_crouching && coverage( loc ) >= 30 ) {
             // If we're crouching behind an obstacle, we can't see past it.
             vision_transparency_cache[loc.x][loc.y] = LIGHT_TRANSPARENCY_SOLID;
@@ -209,8 +208,8 @@ void map::build_sunlight_cache( int pzlev )
     const int zlev_min = zlevels ? -OVERMAP_DEPTH : pzlev;
     // Start at the topmost populated zlevel to avoid unnecessary raycasting
     // Plus one zlevel to prevent clipping inside structures
-    const int zlev_max = zlevels ? std::min( std::max( calc_max_populated_zlev() + 1, pzlev + 1 ),
-                         OVERMAP_HEIGHT ) : pzlev;
+    const int zlev_max = zlevels ? clamp( calc_max_populated_zlev() + 1, pzlev + 1,
+                                          OVERMAP_HEIGHT ) : pzlev;
 
     // true if all previous z-levels are fully transparent to light (no floors, transparency >= air)
     bool fully_outside = true;
@@ -333,9 +332,9 @@ void map::build_sunlight_cache( int pzlev )
                     if( prev_transparency > LIGHT_TRANSPARENCY_SOLID &&
                         !prev_floor_cache[prev_x][prev_y] &&
                         ( prev_light_max = prev_lm[prev_x][prev_y].max() ) > 0.0 ) {
-                        const float light_level = std::max( inside_light_level, prev_light_max *
-                                                            LIGHT_TRANSPARENCY_OPEN_AIR
-                                                            / prev_transparency );
+                        const float light_level = clamp( prev_light_max * LIGHT_TRANSPARENCY_OPEN_AIR / prev_transparency,
+                                                         inside_light_level, prev_light_max );
+
                         if( i == 0 ) {
                             lm[x][y].fill( light_level );
                             fully_inside &= light_level <= inside_light_level;
@@ -622,7 +621,8 @@ map::apparent_light_info map::apparent_light_helper( const level_cache &map_cach
     const bool obstructed = vis <= LIGHT_TRANSPARENCY_SOLID + 0.1;
 
     auto is_opaque = [&map_cache]( const point & p ) {
-        return map_cache.transparency_cache[p.x][p.y] <= LIGHT_TRANSPARENCY_SOLID;
+        return map_cache.transparency_cache[p.x][p.y] <= LIGHT_TRANSPARENCY_SOLID &&
+               map_cache.vision_transparency_cache[p.x][p.y] <= LIGHT_TRANSPARENCY_SOLID;
     };
 
     const bool p_opaque = is_opaque( p.xy() );
@@ -717,7 +717,7 @@ lit_level map::apparent_light_at( const tripoint &p, const visibility_variables 
     if( a.apparent_light > LIGHT_AMBIENT_LIT ) {
         return LL_LIT;
     }
-    if( a.apparent_light > cache.vision_threshold ) {
+    if( a.apparent_light >= cache.vision_threshold ) {
         return LL_LOW;
     } else {
         return LL_BLANK;
@@ -738,7 +738,7 @@ bool map::pl_sees( const tripoint &t, const int max_range ) const
     const apparent_light_info a = apparent_light_helper( map_cache, t );
     const float light_at_player = map_cache.lm[g->u.posx()][g->u.posy()].max();
     return !a.obstructed &&
-           ( a.apparent_light > g->u.get_vision_threshold( light_at_player ) ||
+           ( a.apparent_light >= g->u.get_vision_threshold( light_at_player ) ||
              map_cache.sm[t.x][t.y] > 0.0 );
 }
 
@@ -1052,7 +1052,7 @@ template<int xx, int xy, int yx, int yy, typename T, typename Out,
 void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                 const T( &input_array )[MAPSIZE_X][MAPSIZE_Y],
                 const point &offset, int offsetDistance,
-                T numerator = 1.0,
+                T numerator = VISIBILITY_FULL,
                 int row = 1, float start = 1.0f, float end = 0.0f,
                 T cumulative_transparency = LIGHT_TRANSPARENCY_OPEN_AIR );
 
@@ -1218,7 +1218,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
     if( !fov_3d ) {
         std::uninitialized_fill_n(
             &seen_cache[0][0], map_dimensions, light_transparency_solid );
-        seen_cache[origin.x][origin.y] = LIGHT_TRANSPARENCY_CLEAR;
+        seen_cache[origin.x][origin.y] = VISIBILITY_FULL;
 
         castLightAll<float, float, sight_calc, sight_check, update_light, accumulate_transparency>(
             seen_cache, transparency_cache, origin.xy(), 0 );
@@ -1236,7 +1236,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
                 &cur_cache.seen_cache[0][0], map_dimensions, light_transparency_solid );
         }
         if( origin.z == target_z ) {
-            get_cache( origin.z ).seen_cache[origin.x][origin.y] = LIGHT_TRANSPARENCY_CLEAR;
+            get_cache( origin.z ).seen_cache[origin.x][origin.y] = VISIBILITY_FULL;
         }
         cast_zlight<float, sight_calc, sight_check, accumulate_transparency>(
             seen_caches, transparency_caches, floor_caches, origin, 0, 1.0 );

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -16,12 +16,26 @@ static constexpr float LIGHT_AMBIENT_DIM = 5.0f;
 // The threshold between things being shadowed and being brightly lit.
 static constexpr float LIGHT_AMBIENT_LIT = 10.0f;
 
+/**
+ * Transparency 101:
+ * Transparency usually ranges between 0.038 (open air) and 0.38 (regular smoke).
+ * The bigger the value, the more opaque it is (less light goes through).
+ * To make sense of the specific value:
+ * For transparency t, vision becomes "obstructed" (see map::apparent_light_helper) after
+ *   ≈ (2.3 / t) consequent tiles of transparency `t`  ( derived from 1 / e^(dist * t) = 0.1 )
+ *   e.g. for smoke with effective transparency 0.38  it's 2.3/0.38 ≈ 6 tiles
+ *  for clean air with t=0.038  dist = 2.3/0.038 ≈ 60 tiles
+ *
+ * Note:  LIGHT_TRANSPARENCY_SOLID=0 is a special case (it indicates completely opaque tile)
+ * */
 static constexpr float LIGHT_TRANSPARENCY_SOLID = 0.0f;
 // Calculated to run out at 60 squares.
 // Cumulative transparency should drop to 0.1 or lower over 60 squares,
 // Bright sunlight should drop to LIGHT_AMBIENT_LOW over 60 squares.
 static constexpr float LIGHT_TRANSPARENCY_OPEN_AIR = 0.038376418216f;
-static constexpr float LIGHT_TRANSPARENCY_CLEAR = 1.0f;
+
+// indicates starting (full) visibility (for seen_cache)
+static constexpr float VISIBILITY_FULL = 1.0f;
 
 #define LIGHT_RANGE(b) static_cast<int>( -std::log(LIGHT_AMBIENT_LOW / static_cast<float>(b)) * (1.0 / LIGHT_TRANSPARENCY_OPEN_AIR) )
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5393,7 +5393,7 @@ void map::remove_field( const tripoint &p, const field_type_id &field_to_remove 
                                                   p.y / SEEX ) * MAPSIZE ) ) );
         }
         const auto &fdata = field_to_remove.obj();
-        if( fdata.is_transparent() ) {
+        if( !fdata.is_transparent() ) {
             set_transparency_cache_dirty( p.z );
             set_seen_cache_dirty( p );
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1331,7 +1331,7 @@ void map::furn_set( const tripoint &p, const furn_id &new_furniture )
         field_furn_locs.push_back( p );
     }
     if( old_t.transparent != new_t.transparent ) {
-        set_transparency_cache_dirty( p.z );
+        set_transparency_cache_dirty( p );
         set_seen_cache_dirty( p );
     }
 
@@ -1590,7 +1590,7 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain )
     }
 
     if( old_t.transparent != new_t.transparent ) {
-        set_transparency_cache_dirty( p.z );
+        set_transparency_cache_dirty( p );
         set_seen_cache_dirty( p );
     }
 
@@ -5327,18 +5327,19 @@ bool map::dangerous_field_at( const tripoint &p )
     return false;
 }
 
-bool map::add_field( const tripoint &p, const field_type_id &type, int intensity,
-                     const time_duration &age )
+bool map::add_field( const tripoint &p, const field_type_id &type_id, int intensity,
+                     const time_duration &age, bool hit_player )
 {
     if( !inbounds( p ) ) {
         return false;
     }
 
-    if( !type ) {
+    if( !type_id ) {
         return false;
     }
 
-    intensity = std::min( intensity, type.obj().get_max_intensity() );
+    const field_type &fd_type = *type_id;
+    intensity = std::min( intensity, fd_type.get_max_intensity() );
     if( intensity <= 0 ) {
         return false;
     }
@@ -5348,7 +5349,7 @@ bool map::add_field( const tripoint &p, const field_type_id &type, int intensity
     current_submap->is_uniform = false;
     invalidate_max_populated_zlev( p.z );
 
-    if( current_submap->get_field( l ).add_field( type, intensity, age ) ) {
+    if( current_submap->get_field( l ).add_field( type_id, intensity, age ) ) {
         //Only adding it to the count if it doesn't exist.
         if( !current_submap->field_count++ ) {
             get_cache( p.z ).field_cache.set( static_cast<size_t>( p.x / SEEX + ( (
@@ -5356,21 +5357,26 @@ bool map::add_field( const tripoint &p, const field_type_id &type, int intensity
         }
     }
 
-    if( g != nullptr && this == &get_map() && p == g->u.pos() ) {
-        creature_in_field( g->u ); //Hit the player with the field if it spawned on top of them.
+    if( hit_player ) {
+        Character &player_character = get_player_character();
+        if( g != nullptr && this == &get_map() && p == player_character.pos() ) {
+            //Hit the player with the field if it spawned on top of them.
+            creature_in_field( player_character );
+        }
     }
 
     // Dirty the transparency cache now that field processing doesn't always do it
-    // TODO: Make it skip transparent fields
-    set_transparency_cache_dirty( p.z );
-    set_seen_cache_dirty( p );
+    if( fd_type.dirty_transparency_cache || !fd_type.is_transparent() ) {
+        set_transparency_cache_dirty( p );
+        set_seen_cache_dirty( p );
+    }
 
-    if( type.obj().is_dangerous() ) {
+    if( fd_type.is_dangerous() ) {
         set_pathfinding_cache_dirty( p.z );
     }
 
     // Ensure blood type fields don't hang in the air
-    if( zlevels && type.obj().accelerated_decay ) {
+    if( zlevels && fd_type.accelerated_decay ) {
         support_dirty( p );
     }
 
@@ -5393,8 +5399,8 @@ void map::remove_field( const tripoint &p, const field_type_id &field_to_remove 
                                                   p.y / SEEX ) * MAPSIZE ) ) );
         }
         const auto &fdata = field_to_remove.obj();
-        if( !fdata.is_transparent() ) {
-            set_transparency_cache_dirty( p.z );
+        if( fdata.dirty_transparency_cache || !fdata.is_transparent() ) {
+            set_transparency_cache_dirty( p );
             set_seen_cache_dirty( p );
         }
         if( fdata.is_dangerous() ) {
@@ -6774,7 +6780,7 @@ void map::loadn( const tripoint &grid, const bool update_vehicles )
 
     // New submap changes the content of the map and all caches must be recalculated
     set_transparency_cache_dirty( grid.z );
-    set_seen_cache_dirty( tripoint_zero );
+    set_seen_cache_dirty( grid.z );
     set_outside_cache_dirty( grid.z );
     set_floor_cache_dirty( grid.z );
     set_pathfinding_cache_dirty( grid.z );
@@ -7818,10 +7824,12 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     const int maxz = zlevels ? OVERMAP_HEIGHT : zlev;
     bool seen_cache_dirty = false;
     for( int z = minz; z <= maxz; z++ ) {
+        // trigger FOV recalculation only when there is a change on the player's level or if fov_3d is enabled
+        const bool affects_seen_cache =  z == zlev || fov_3d;
         build_outside_cache( z );
         build_transparency_cache( z );
-        seen_cache_dirty |= build_floor_cache( z );
-        seen_cache_dirty |= get_cache( z ).seen_cache_dirty;
+        seen_cache_dirty |= ( build_floor_cache( z ) && affects_seen_cache );
+        seen_cache_dirty |= get_cache( z ).seen_cache_dirty && affects_seen_cache;
         do_vehicle_caching( z );
     }
     seen_cache_dirty |= build_vision_transparency_cache( zlev );
@@ -7941,7 +7949,7 @@ void map::draw_fill_background( const ter_id &type )
 {
     // Need to explicitly set caches dirty - set_ter would do it before
     set_transparency_cache_dirty( abs_sub.z );
-    set_seen_cache_dirty( tripoint_zero );
+    set_seen_cache_dirty( abs_sub.z );
     set_outside_cache_dirty( abs_sub.z );
     set_pathfinding_cache_dirty( abs_sub.z );
 
@@ -8318,7 +8326,7 @@ const level_cache &map::access_cache( int zlev ) const
 level_cache::level_cache()
 {
     const int map_dimensions = MAPSIZE_X * MAPSIZE_Y;
-    transparency_cache_dirty = true;
+    transparency_cache_dirty.set();
     outside_cache_dirty = true;
     floor_cache_dirty = false;
     constexpr four_quadrants four_zeros( 0.0f );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1014,7 +1014,7 @@ void map::board_vehicle( const tripoint &pos, player *p )
 
     p->setpos( pos );
     p->in_vehicle = true;
-    if( p == &g->u ) {
+    if( p->is_avatar() ) {
         g->update_map( g->u );
     }
 }
@@ -1150,7 +1150,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp )
                 complete = false;
                 continue;
             }
-            if( psg == &g->u ) {
+            if( psg->is_avatar() ) {
                 // If passenger is you, we need to update the map
                 need_update = true;
                 z_change = dp.z;
@@ -5204,7 +5204,7 @@ void map::remove_trap( const tripoint &p )
 
     trap_id tid = current_submap->get_trap( l );
     if( tid != tr_null ) {
-        if( g != nullptr && this == &g->m ) {
+        if( g != nullptr && this == &get_map() ) {
             g->u.add_known_trap( p, tr_null.obj() );
         }
 
@@ -5356,7 +5356,7 @@ bool map::add_field( const tripoint &p, const field_type_id &type, int intensity
         }
     }
 
-    if( g != nullptr && this == &g->m && p == g->u.pos() ) {
+    if( g != nullptr && this == &get_map() && p == g->u.pos() ) {
         creature_in_field( g->u ); //Hit the player with the field if it spawned on top of them.
     }
 
@@ -7415,7 +7415,7 @@ void map::spawn_monsters_submap( const tripoint &gp, bool ignore_sight )
             const auto valid_location = [&]( const tripoint & p ) {
                 // Checking for creatures via g is only meaningful if this is the main game map.
                 // If it's some local map instance, the coordinates will most likely not even match.
-                return ( !g || &g->m != this || !g->critter_at( p ) ) && tmp.can_move_to( p );
+                return ( !g || &get_map() != this || !g->critter_at( p ) ) && tmp.can_move_to( p );
             };
 
             const auto place_it = [&]( const tripoint & p ) {

--- a/src/map.h
+++ b/src/map.h
@@ -286,10 +286,25 @@ struct level_cache {
     // false, if corresponding terrain has flag "NO_FLOOR", true otherwise
     // i.e. true == has floor
     bool floor_cache[MAPSIZE_X][MAPSIZE_Y];
+
+    // stores cached transparency of the tiles
+    // units: "transparency" (see LIGHT_TRANSPARENCY_OPEN_AIR)
     float transparency_cache[MAPSIZE_X][MAPSIZE_Y];
+
+    // stores "adjusted transparency" of the tiles
+    // initial values derived from transparency_cache, uses same units
+    // examples of adjustment: changed transparency on player's tile and special case for crouching
     float vision_transparency_cache[MAPSIZE_X][MAPSIZE_Y];
+
+    // stores "visibility" of the tiles to the player
+    // values range from 1 (fully visible to player) to 0 (not visible)
     float seen_cache[MAPSIZE_X][MAPSIZE_Y];
+
+    // same as `seen_cache` (same units) but contains values for cameras and mirrors
+    // effective "visibility_cache" is calculated as "max(seen_cache, camera_cache)"
     float camera_cache[MAPSIZE_X][MAPSIZE_Y];
+
+    // stores resulting apparent brightness to player, calculated by map::apparent_light_at
     lit_level visibility_cache[MAPSIZE_X][MAPSIZE_Y];
     std::bitset<MAPSIZE_X *MAPSIZE_Y> map_memory_seen_cache;
     std::bitset<MAPSIZE *MAPSIZE> field_cache;

--- a/src/map.h
+++ b/src/map.h
@@ -20,6 +20,7 @@
 #include "bodypart.h"
 #include "calendar.h"
 #include "colony.h"
+#include "coordinate_conversions.h"
 #include "enums.h"
 #include "filter_utils.h"
 #include "game_constants.h"
@@ -268,9 +269,9 @@ struct level_cache {
     level_cache();
     level_cache( const level_cache &other ) = default;
 
-    bool transparency_cache_dirty;
-    bool outside_cache_dirty;
-    bool floor_cache_dirty;
+    std::bitset<MAPSIZE *MAPSIZE> transparency_cache_dirty;
+    bool outside_cache_dirty = false;
+    bool floor_cache_dirty = false;
     bool seen_cache_dirty = false;
 
     four_quadrants lm[MAPSIZE_X][MAPSIZE_Y];
@@ -362,20 +363,38 @@ class map
         /*@{*/
         void set_transparency_cache_dirty( const int zlev ) {
             if( inbounds_z( zlev ) ) {
-                get_cache( zlev ).transparency_cache_dirty = true;
+                get_cache( zlev ).transparency_cache_dirty.set();
+            }
+        }
+
+        // more granular version of the transparency cache invalidation
+        // preferred over map::set_transparency_cache_dirty( const int zlev )
+        // p is in local coords ("ms")
+        void set_transparency_cache_dirty( const tripoint &p ) {
+            if( inbounds( p ) ) {
+                const tripoint smp = ms_to_sm_copy( p );
+                get_cache( smp.z ).transparency_cache_dirty.set( smp.x * MAPSIZE + smp.y );
             }
         }
 
         void set_seen_cache_dirty( const tripoint change_location ) {
-            if( inbounds_z( change_location.z ) ) {
+            if( inbounds( change_location ) ) {
                 level_cache &cache = get_cache( change_location.z );
                 if( cache.seen_cache_dirty ) {
                     return;
                 }
-                if( change_location == tripoint_zero ||
-                    cache.seen_cache[change_location.x][change_location.y] != 0.0 ) {
+                if( cache.seen_cache[change_location.x][change_location.y] != 0.0 ||
+                    cache.camera_cache[change_location.x][change_location.y] != 0.0 ) {
                     cache.seen_cache_dirty = true;
                 }
+            }
+        }
+
+        // invalidates seen cache for the whole zlevel unconditionally
+        void set_seen_cache_dirty( const int zlevel ) {
+            if( inbounds_z( zlevel ) ) {
+                level_cache &cache = get_cache( zlevel );
+                cache.seen_cache_dirty = true;
             }
         }
 
@@ -405,7 +424,7 @@ class map
             if( inbounds_z( zlev ) ) {
                 level_cache &ch = get_cache( zlev );
                 ch.floor_cache_dirty = true;
-                ch.transparency_cache_dirty = true;
+                ch.transparency_cache_dirty.set();
                 ch.seen_cache_dirty = true;
                 ch.outside_cache_dirty = true;
             }
@@ -522,13 +541,13 @@ class map
         // Versions of the above that don't do bounds checks
         maptile maptile_at_internal( const tripoint &p ) const;
         maptile maptile_at_internal( const tripoint &p );
-        maptile maptile_has_bounds( const tripoint &p, bool bounds_checked );
-        std::array<maptile, 8> get_neighbors( const tripoint &p );
+        std::pair<tripoint, maptile> maptile_has_bounds( const tripoint &p, bool bounds_checked );
+        std::array<std::pair<tripoint, maptile>, 8> get_neighbors( const tripoint &p );
         void spread_gas( field_entry &cur, const tripoint &p, int percent_spread,
                          const time_duration &outdoor_age_speedup, scent_block &sblk );
         void create_hot_air( const tripoint &p, int intensity );
         bool gas_can_spread_to( field_entry &cur, const maptile &dst );
-        void gas_spread_to( field_entry &cur, maptile &dst );
+        void gas_spread_to( field_entry &cur, maptile &dst, const tripoint &p );
         int burn_body_part( player &u, field_entry &cur, body_part bp, int scale );
     public:
 
@@ -1289,8 +1308,8 @@ class map
         // Spawns byproducts from items destroyed in fire.
         void create_burnproducts( const tripoint &p, const item &fuel, const units::mass &burned_mass );
         // See fields.cpp
-        bool process_fields();
-        bool process_fields_in_submap( submap *current_submap, const tripoint &submap_pos );
+        void process_fields();
+        void process_fields_in_submap( submap *current_submap, const tripoint &submap_pos );
         /**
          * Apply field effects to the creature when it's on a square with fields.
          */
@@ -1371,8 +1390,8 @@ class map
          * Add field entry at point, or set intensity if present
          * @return false if the field could not be created (out of bounds), otherwise true.
          */
-        bool add_field( const tripoint &p, const field_type_id &type, int intensity = INT_MAX,
-                        const time_duration &age = 0_turns );
+        bool add_field( const tripoint &p, const field_type_id &type_id, int intensity = INT_MAX,
+                        const time_duration &age = 0_turns, bool hit_player = true );
         /**
          * Remove field entry at xy, ignored if the field entry is not present.
          */

--- a/src/map.h
+++ b/src/map.h
@@ -368,7 +368,7 @@ class map
 
         void set_seen_cache_dirty( const tripoint change_location ) {
             if( inbounds_z( change_location.z ) ) {
-                level_cache cache = get_cache( change_location.z );
+                level_cache &cache = get_cache( change_location.z );
                 if( cache.seen_cache_dirty ) {
                     return;
                 }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -289,7 +289,7 @@ bool melee_actor::call( monster &z ) const
     int hitspread = target->deal_melee_attack( &z, dice( acc, 10 ) );
 
     if( hitspread < 0 ) {
-        auto msg_type = target == &g->u ? m_warning : m_info;
+        auto msg_type = target->is_avatar() ? m_warning : m_info;
         sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos() ),
                                  sfx::get_heard_angle( z.pos() ) );
         target->add_msg_player_or_npc( msg_type, miss_msg_u, miss_msg_npc, z.name() );

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -135,7 +135,7 @@ bool scent_map::inbounds( const tripoint &p ) const
     const int levz = gm.get_levz();
     const bool scent_map_z_level_inbounds = ( p.z == levz ) ||
                                             ( std::abs( p.z - levz ) == SCENT_MAP_Z_REACH &&
-                                                    gm.m.valid_move( p, tripoint( p.xy(), levz ), false, true ) );
+                                                    get_map().valid_move( p, tripoint( p.xy(), levz ), false, true ) );
     if( !scent_map_z_level_inbounds ) {
         return false;
     }

--- a/src/submap.h
+++ b/src/submap.h
@@ -311,16 +311,6 @@ struct maptile {
             return sm->get_field( pos() ).find_field( field_to_find );
         }
 
-        bool add_field( const field_type_id &field_to_add, const int new_intensity,
-                        const time_duration &new_age ) {
-            const bool ret = sm->get_field( pos() ).add_field( field_to_add, new_intensity, new_age );
-            if( ret ) {
-                sm->field_count++;
-            }
-
-            return ret;
-        }
-
         int get_radiation() const {
             return sm->get_radiation( pos() );
         }

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -29,7 +29,7 @@ bool teleport::teleport( Creature &critter, int min_distance, int max_distance, 
         return false;
     }
     player *const p = critter.as_player();
-    const bool c_is_u = p != nullptr && p == &g->u;
+    const bool c_is_u = p != nullptr && p->is_avatar();
     int tries = 0;
     tripoint origin = critter.pos();
     tripoint new_pos = origin;
@@ -75,7 +75,7 @@ bool teleport::teleport( Creature &critter, int min_distance, int max_distance, 
             poor_player->add_msg_if_player( m_warning, _( "You feel disjointed." ) );
             return false;
         } else {
-            const bool poor_soul_is_u = ( poor_soul == &g->u );
+            const bool poor_soul_is_u = ( poor_soul->is_avatar() );
             if( poor_soul_is_u ) {
                 add_msg( m_bad, _( "…" ) );
                 add_msg( m_bad, _( "You explode into thousands of fragments." ) );

--- a/tests/ground_destroy_test.cpp
+++ b/tests/ground_destroy_test.cpp
@@ -4,7 +4,6 @@
 
 #include "avatar.h"
 #include "catch/catch.hpp"
-#include "game.h"
 #include "int_id.h"
 #include "item.h"
 #include "itype.h"
@@ -28,12 +27,13 @@ TEST_CASE( "pavement_destroy", "[.]" )
     const bool zlevels_set = get_option<bool>( "ZLEVELS" );
     INFO( "ZLEVELS is " << zlevels_set );
     clear_map_and_put_player_underground();
+    map &here = get_map();
     // Populate the map with pavement.
-    g->m.ter_set( tripoint_zero, ter_id( "t_pavement" ) );
+    here.ter_set( tripoint_zero, ter_id( "t_pavement" ) );
 
     // Destroy it
-    g->m.destroy( tripoint_zero, true );
-    ter_id after_destroy = g->m.ter( tripoint_zero );
+    here.destroy( tripoint_zero, true );
+    ter_id after_destroy = here.ter( tripoint_zero );
     if( after_destroy == flat_roof_id ) {
         FAIL( flat_roof_id.obj().name() << " found after destroying pavement" );
     } else {
@@ -57,12 +57,13 @@ TEST_CASE( "explosion_on_ground", "[.]" )
     std::vector<ter_id> test_terrain_id = {
         ter_id( "t_dirt" ), ter_id( "t_grass" )
     };
+    map &here = get_map();
     int idx = 0;
     const int area_dim = 16;
     // Populate map with various test terrain.
     for( int x = 0; x < area_dim; x++ ) {
         for( int y = 0; y < area_dim; y++ ) {
-            g->m.ter_set( tripoint( x, y, 0 ), test_terrain_id[idx] );
+            here.ter_set( tripoint( x, y, 0 ), test_terrain_id[idx] );
             idx = ( idx + 1 ) % test_terrain_id.size();
         }
     }
@@ -73,13 +74,13 @@ TEST_CASE( "explosion_on_ground", "[.]" )
     const tripoint area_center( area_dim / 2, area_dim / 2, 0 );
     item rdx_keg( rdx_keg_typeid );
     rdx_keg.charges = 0;
-    rdx_keg.type->invoke( g->u, rdx_keg, area_center );
+    rdx_keg.type->invoke( get_avatar(), rdx_keg, area_center );
 
     // Check area to see if any t_flat_roof is present.
     for( int x = 0; x < area_dim; x++ ) {
         for( int y = 0; y < area_dim; y++ ) {
             tripoint pt( x, y, 0 );
-            ter_id t_id = g->m.ter( pt );
+            ter_id t_id = here.ter( pt );
             if( t_id == flat_roof_id ) {
                 FAIL( "After explosion, " << t_id.obj().name() << " found at " << x << "," << y );
             }
@@ -108,11 +109,12 @@ TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
 
     clear_map_and_put_player_underground();
 
+    map &here = get_map();
     const int area_dim = 24;
     for( int x = 0; x < area_dim; x++ ) {
         for( int y = 0; y < area_dim; y++ ) {
-            g->m.ter_set( tripoint( x, y, 0 ), floor_id );
-            g->m.ter_set( tripoint( x, y, -1 ), rock_floor_id );
+            here.ter_set( tripoint( x, y, 0 ), floor_id );
+            here.ter_set( tripoint( x, y, -1 ), rock_floor_id );
         }
     }
     // Detonate an RDX keg item in the middle of the populated map space
@@ -122,14 +124,14 @@ TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
     const tripoint area_center( area_dim / 2, area_dim / 2, 0 );
     item rdx_keg( rdx_keg_typeid );
     rdx_keg.charges = 0;
-    rdx_keg.type->invoke( g->u, rdx_keg, area_center );
+    rdx_keg.type->invoke( get_avatar(), rdx_keg, area_center );
 
     // Check z0 for open air
     bool found_open_air = false;
     for( int x = 0; x < area_dim; x++ ) {
         for( int y = 0; y < area_dim; y++ ) {
             tripoint pt( x, y, 0 );
-            ter_id t_id = g->m.ter( pt );
+            ter_id t_id = here.ter( pt );
             INFO( "t " << t_id.obj().name() << " at " << x << "," << y );
             if( t_id == open_air_id ) {
                 found_open_air = true;
@@ -167,10 +169,11 @@ TEST_CASE( "collapse_checks", "[.]" )
     INFO( "ZLEVELS is " << zlevels_set );
     clear_map_and_put_player_underground();
 
+    map &here = get_map();
     // build a structure
     const tripoint &midair = tripoint( tripoint_zero.xy(), tripoint_zero.z + 1 );
-    for( const tripoint &pt : g->m.points_in_radius( midair, wall_size, 1 ) ) {
-        g->m.ter_set( pt, floor_id );
+    for( const tripoint &pt : here.points_in_radius( midair, wall_size, 1 ) ) {
+        here.ter_set( pt, floor_id );
     }
     std::set<tripoint> corners;
     for( int delta_z = 0; delta_z < 3; delta_z++ ) {
@@ -178,31 +181,31 @@ TEST_CASE( "collapse_checks", "[.]" )
             for( int delta_y = 0; delta_y <= 1; delta_y++ ) {
                 const tripoint pt( delta_x * wall_size, delta_y * wall_size, delta_z );
                 corners.insert( pt );
-                g->m.ter_set( pt, wall_id );
+                here.ter_set( pt, wall_id );
             }
         }
     }
 
     // make sure it's a valid structure
-    for( const tripoint &pt : g->m.points_in_radius( midair, wall_size, 1 ) ) {
+    for( const tripoint &pt : here.points_in_radius( midair, wall_size, 1 ) ) {
         if( corners.find( pt ) != corners.end() ) {
-            REQUIRE( g->m.ter( pt ) == wall_id );
+            REQUIRE( here.ter( pt ) == wall_id );
         } else {
-            REQUIRE( g->m.ter( pt ) == floor_id );
+            REQUIRE( here.ter( pt ) == floor_id );
         }
     }
 
     // destroy the floor on the first floor; floor above should not collapse
-    for( const tripoint &pt : g->m.points_in_radius( tripoint_zero, wall_size ) ) {
+    for( const tripoint &pt : here.points_in_radius( tripoint_zero, wall_size ) ) {
         if( corners.find( pt ) == corners.end() ) {
-            g->m.destroy( pt, true );
+            here.destroy( pt, true );
         }
     }
-    for( const tripoint &pt : g->m.points_in_radius( midair, wall_size ) ) {
+    for( const tripoint &pt : here.points_in_radius( midair, wall_size ) ) {
         if( corners.find( pt ) != corners.end() ) {
-            CHECK( g->m.ter( pt ) == wall_id );
+            CHECK( here.ter( pt ) == wall_id );
         } else {
-            CHECK( g->m.ter( pt ) == floor_id );
+            CHECK( here.ter( pt ) == floor_id );
         }
     }
 
@@ -210,17 +213,17 @@ TEST_CASE( "collapse_checks", "[.]" )
     for( int delta_x = 0; delta_x <= 1; delta_x++ ) {
         for( int delta_y = 0; delta_y <= 1; delta_y++ ) {
             const tripoint pt( delta_x * wall_size, delta_y * wall_size, 0 );
-            g->m.destroy( pt, true );
+            here.destroy( pt, true );
         }
     }
     int open_air_count = 0;
     int tile_count = 0;
     int no_wall_count = 0;
-    for( const tripoint &pt : g->m.points_in_radius( midair, wall_size, 1 ) ) {
+    for( const tripoint &pt : here.points_in_radius( midair, wall_size, 1 ) ) {
         if( pt.z == 0 ) {
             continue;
         }
-        const ter_id t_id = g->m.ter( pt );
+        const ter_id t_id = here.ter( pt );
         tile_count += 1;
         if( t_id == t_open_air ) {
             open_air_count += 1;

--- a/tests/shadowcasting_test.cpp
+++ b/tests/shadowcasting_test.cpp
@@ -50,7 +50,7 @@ static void oldCastLight( float ( &output_cache )[MAPSIZE * SEEX][MAPSIZE * SEEY
 
             //check if it's within the visible area and mark visible if so
             if( rl_dist( tripoint_zero, delta ) <= radius ) {
-                output_cache[currentX][currentY] = LIGHT_TRANSPARENCY_CLEAR;
+                output_cache[currentX][currentY] = VISIBILITY_FULL;
             }
 
             if( blocked ) {
@@ -116,7 +116,7 @@ static void randomly_fill_transparency(
             if( rng() < numerator ) {
                 square = LIGHT_TRANSPARENCY_SOLID;
             } else {
-                square = LIGHT_TRANSPARENCY_CLEAR;
+                square = LIGHT_TRANSPARENCY_OPEN_AIR;
             }
         }
     }
@@ -405,9 +405,9 @@ static void shadowcasting_3d_2d( const int iterations )
 
 // T, O and V are 'T'ransparent, 'O'paque and 'V'isible.
 // X marks the player location, which is not set to visible by this algorithm.
-static constexpr float T = LIGHT_TRANSPARENCY_CLEAR;
+static constexpr float T = LIGHT_TRANSPARENCY_OPEN_AIR;
 static constexpr float O = LIGHT_TRANSPARENCY_SOLID;
-static constexpr float V = LIGHT_TRANSPARENCY_CLEAR;
+static constexpr float V = LIGHT_TRANSPARENCY_OPEN_AIR;
 static constexpr float X = LIGHT_TRANSPARENCY_SOLID;
 
 const point ORIGIN( 65, 65 );
@@ -478,7 +478,7 @@ static void run_spot_check( const grid_overlay &test_case, const grid_overlay &e
 
 TEST_CASE( "shadowcasting_slope_inversion_regression_test", "[shadowcasting]" )
 {
-    grid_overlay test_case( { 7, 8 }, LIGHT_TRANSPARENCY_CLEAR );
+    grid_overlay test_case( { 7, 8 }, LIGHT_TRANSPARENCY_OPEN_AIR );
     test_case.data = {
         {T, T, T, T, T, T, T, T, T, T},
         {T, O, T, T, T, T, T, T, T, T},
@@ -493,7 +493,7 @@ TEST_CASE( "shadowcasting_slope_inversion_regression_test", "[shadowcasting]" )
         {T, T, T, T, T, T, T, T, T, T}
     };
 
-    grid_overlay expected_results( { 7, 8 }, LIGHT_TRANSPARENCY_CLEAR );
+    grid_overlay expected_results( { 7, 8 }, LIGHT_TRANSPARENCY_OPEN_AIR );
     expected_results.data = {
         {O, O, O, V, V, V, V, V, V, V},
         {O, V, V, O, V, V, V, V, V, V},
@@ -513,7 +513,7 @@ TEST_CASE( "shadowcasting_slope_inversion_regression_test", "[shadowcasting]" )
 
 TEST_CASE( "shadowcasting_pillar_behavior_cardinally_adjacent", "[shadowcasting]" )
 {
-    grid_overlay test_case( { 1, 4 }, LIGHT_TRANSPARENCY_CLEAR );
+    grid_overlay test_case( { 1, 4 }, LIGHT_TRANSPARENCY_OPEN_AIR );
     test_case.data = {
         {T, T, T, T, T, T, T, T, T},
         {T, T, T, T, T, T, T, T, T},
@@ -526,7 +526,7 @@ TEST_CASE( "shadowcasting_pillar_behavior_cardinally_adjacent", "[shadowcasting]
         {T, T, T, T, T, T, T, T, T}
     };
 
-    grid_overlay expected_results( { 1, 4 }, LIGHT_TRANSPARENCY_CLEAR );
+    grid_overlay expected_results( { 1, 4 }, LIGHT_TRANSPARENCY_OPEN_AIR );
     expected_results.data = {
         {V, V, V, V, V, V, V, O, O},
         {V, V, V, V, V, V, O, O, O},
@@ -545,7 +545,7 @@ TEST_CASE( "shadowcasting_pillar_behavior_cardinally_adjacent", "[shadowcasting]
 TEST_CASE( "shadowcasting_pillar_behavior_2_1_diagonal_gap", "[shadowcasting]" )
 {
     // NOLINTNEXTLINE(cata-use-named-point-constants)
-    grid_overlay test_case( { 1, 1 }, LIGHT_TRANSPARENCY_CLEAR );
+    grid_overlay test_case( { 1, 1 }, LIGHT_TRANSPARENCY_OPEN_AIR );
     test_case.data = {
         {T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T},
         {T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T},
@@ -559,7 +559,7 @@ TEST_CASE( "shadowcasting_pillar_behavior_2_1_diagonal_gap", "[shadowcasting]" )
     };
 
     // NOLINTNEXTLINE(cata-use-named-point-constants)
-    grid_overlay expected_results( { 1, 1 }, LIGHT_TRANSPARENCY_CLEAR );
+    grid_overlay expected_results( { 1, 1 }, LIGHT_TRANSPARENCY_OPEN_AIR );
     expected_results.data = {
         {V, V, V, V, V, V, V, V, V, V, V, V, V, V, V, V, V, V},
         {V, X, V, V, V, V, V, V, V, V, V, V, V, V, V, V, V, V},
@@ -577,7 +577,7 @@ TEST_CASE( "shadowcasting_pillar_behavior_2_1_diagonal_gap", "[shadowcasting]" )
 
 TEST_CASE( "shadowcasting_vision_along_a_wall", "[shadowcasting]" )
 {
-    grid_overlay test_case( { 8, 2 }, LIGHT_TRANSPARENCY_CLEAR );
+    grid_overlay test_case( { 8, 2 }, LIGHT_TRANSPARENCY_OPEN_AIR );
     test_case.data = {
         {T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T},
         {T, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, T},
@@ -590,7 +590,7 @@ TEST_CASE( "shadowcasting_vision_along_a_wall", "[shadowcasting]" )
         {T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T}
     };
 
-    grid_overlay expected_results( { 8, 2 }, LIGHT_TRANSPARENCY_CLEAR );
+    grid_overlay expected_results( { 8, 2 }, LIGHT_TRANSPARENCY_OPEN_AIR );
     expected_results.data = {
         {O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O},
         {V, V, V, V, V, V, V, V, V, V, V, V, V, V, V, V, V, V},

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -2,9 +2,8 @@
 #include <set>
 #include <vector>
 
-#include "avatar.h"
 #include "catch/catch.hpp"
-#include "game.h"
+#include "character.h"
 #include "map.h"
 #include "vehicle.h"
 #include "type_id.h"
@@ -12,26 +11,28 @@
 
 TEST_CASE( "vehicle_split_section" )
 {
+    map &here = get_map();
+    Character &player_character = get_player_character();
     for( int dir = 0; dir < 360; dir += 15 ) {
-        CHECK( !g->u.in_vehicle );
+        CHECK( !player_character.in_vehicle );
         const tripoint test_origin( 15, 15, 0 );
-        g->u.setpos( test_origin );
+        player_character.setpos( test_origin );
         tripoint vehicle_origin = tripoint( 10, 10, 0 );
-        VehicleList vehs = g->m.get_vehicles();
+        VehicleList vehs = here.get_vehicles();
         vehicle *veh_ptr;
         for( auto &vehs_v : vehs ) {
             veh_ptr = vehs_v.v;
-            g->m.destroy_vehicle( veh_ptr );
+            here.destroy_vehicle( veh_ptr );
         }
-        REQUIRE( g->m.get_vehicles().empty() );
-        veh_ptr = g->m.add_vehicle( vproto_id( "cross_split_test" ), vehicle_origin, dir, 0, 0 );
+        REQUIRE( here.get_vehicles().empty() );
+        veh_ptr = here.add_vehicle( vproto_id( "cross_split_test" ), vehicle_origin, dir, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
         std::set<tripoint> original_points = veh_ptr->get_points( true );
 
-        g->m.destroy( vehicle_origin );
+        here.destroy( vehicle_origin );
         veh_ptr->part_removal_cleanup();
         REQUIRE( veh_ptr->get_parts_at( vehicle_origin, "", part_status_flag::available ).empty() );
-        vehs = g->m.get_vehicles();
+        vehs = here.get_vehicles();
         // destroying the center frame results in 4 new vehicles
         CHECK( vehs.size() == 4 );
         if( vehs.size() == 4 ) {
@@ -59,19 +60,19 @@ TEST_CASE( "vehicle_split_section" )
                     }
                 }
             }
-            g->m.destroy_vehicle( vehs[ 3 ].v );
-            g->m.destroy_vehicle( vehs[ 2 ].v );
-            g->m.destroy_vehicle( vehs[ 1 ].v );
-            g->m.destroy_vehicle( vehs[ 0 ].v );
+            here.destroy_vehicle( vehs[ 3 ].v );
+            here.destroy_vehicle( vehs[ 2 ].v );
+            here.destroy_vehicle( vehs[ 1 ].v );
+            here.destroy_vehicle( vehs[ 0 ].v );
         }
-        REQUIRE( g->m.get_vehicles().empty() );
+        REQUIRE( here.get_vehicles().empty() );
         vehicle_origin = tripoint( 20, 20, 0 );
-        veh_ptr = g->m.add_vehicle( vproto_id( "circle_split_test" ), vehicle_origin, dir, 0, 0 );
+        veh_ptr = here.add_vehicle( vproto_id( "circle_split_test" ), vehicle_origin, dir, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        g->m.destroy( vehicle_origin );
+        here.destroy( vehicle_origin );
         veh_ptr->part_removal_cleanup();
         REQUIRE( veh_ptr->get_parts_at( vehicle_origin, "", part_status_flag::available ).empty() );
-        vehs = g->m.get_vehicles();
+        vehs = here.get_vehicles();
         CHECK( vehs.size() == 1 );
         if( vehs.size() == 1 ) {
             CHECK( vehs[ 0 ].v->parts.size() == 38 );

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -8,7 +8,6 @@
 #include <utility>
 #include <vector>
 
-#include "avatar.h"
 #include "calendar.h"
 #include "catch/catch.hpp"
 #include "character.h"
@@ -54,6 +53,7 @@ static void full_map_test( const std::vector<std::string> &setup,
     const ter_id t_flat_roof( "t_flat_roof" );
     const ter_id t_open_air( "t_open_air" );
 
+    Character &player_character = get_player_character();
     g->place_player( tripoint( 60, 60, 0 ) );
     clear_avatar();
     clear_map();
@@ -61,16 +61,16 @@ static void full_map_test( const std::vector<std::string> &setup,
     g->reset_light_level();
 
     if( !!( flags & vision_test_flags::crouching ) ) {
-        g->u.set_movement_mode( character_movemode::CMM_CROUCH );
+        player_character.set_movement_mode( character_movemode::CMM_CROUCH );
     } else {
-        g->u.set_movement_mode( character_movemode::CMM_WALK );
+        player_character.set_movement_mode( character_movemode::CMM_WALK );
     }
 
-    REQUIRE( !g->u.is_blind() );
-    REQUIRE( !g->u.in_sleep_state() );
-    REQUIRE( !g->u.has_effect( effect_narcosis ) );
+    REQUIRE( !player_character.is_blind() );
+    REQUIRE( !player_character.in_sleep_state() );
+    REQUIRE( !player_character.has_effect( effect_narcosis ) );
 
-    g->u.recalc_sight_limits();
+    player_character.recalc_sight_limits();
 
     calendar::turn = time;
 
@@ -94,10 +94,10 @@ static void full_map_test( const std::vector<std::string> &setup,
                 case 'V':
                 case 'U':
                 case 'u':
-                    origin = g->u.pos() - point( x, y );
+                    origin = player_character.pos() - point( x, y );
                     if( setup[y][x] == 'V' ) {
                         item headlamp( "wearable_light_on" );
-                        g->u.worn.push_back( headlamp );
+                        player_character.worn.push_back( headlamp );
                     }
                     break;
             }
@@ -107,7 +107,7 @@ static void full_map_test( const std::vector<std::string> &setup,
     {
         // Sanity check on player placement
         REQUIRE( origin.z < OVERMAP_HEIGHT );
-        tripoint player_offset = g->u.pos() - origin;
+        tripoint player_offset = player_character.pos() - origin;
         REQUIRE( player_offset.y >= 0 );
         REQUIRE( player_offset.y < height );
         REQUIRE( player_offset.x >= 0 );
@@ -116,6 +116,7 @@ static void full_map_test( const std::vector<std::string> &setup,
         REQUIRE( ( player_char == 'U' || player_char == 'u' || player_char == 'V' ) );
     }
 
+    map &here = get_map();
     for( int y = 0; y < height; ++y ) {
         for( int x = 0; x < width; ++x ) {
             const tripoint p = origin + point( x, y );
@@ -124,21 +125,21 @@ static void full_map_test( const std::vector<std::string> &setup,
                 case ' ':
                     break;
                 case 'L':
-                    g->m.ter_set( p, t_utility_light );
-                    g->m.ter_set( above, t_flat_roof );
+                    here.ter_set( p, t_utility_light );
+                    here.ter_set( above, t_flat_roof );
                     break;
                 case '#':
-                    g->m.ter_set( p, t_brick_wall );
-                    g->m.ter_set( above, t_flat_roof );
+                    here.ter_set( p, t_brick_wall );
+                    here.ter_set( above, t_flat_roof );
                     break;
                 case '=':
-                    g->m.ter_set( p, t_window_frame );
-                    g->m.ter_set( above, t_flat_roof );
+                    here.ter_set( p, t_window_frame );
+                    here.ter_set( above, t_flat_roof );
                     break;
                 case '-':
                 case 'u':
-                    g->m.ter_set( p, t_floor );
-                    g->m.ter_set( above, t_flat_roof );
+                    here.ter_set( p, t_floor );
+                    here.ter_set( above, t_flat_roof );
                     break;
                 case 'U':
                 case 'V':
@@ -154,17 +155,17 @@ static void full_map_test( const std::vector<std::string> &setup,
     // player's vision_threshold is based on the previous lighting level (so
     // they might, for example, have poor nightvision due to having just been
     // in daylight)
-    g->m.update_visibility_cache( origin.z );
-    g->m.invalidate_map_cache( origin.z );
-    g->m.build_map_cache( origin.z );
-    g->m.update_visibility_cache( origin.z );
-    g->m.invalidate_map_cache( origin.z );
-    g->m.build_map_cache( origin.z );
+    here.update_visibility_cache( origin.z );
+    here.invalidate_map_cache( origin.z );
+    here.build_map_cache( origin.z );
+    here.update_visibility_cache( origin.z );
+    here.invalidate_map_cache( origin.z );
+    here.build_map_cache( origin.z );
 
-    const level_cache &cache = g->m.access_cache( origin.z );
-    const level_cache &above_cache = g->m.access_cache( origin.z + 1 );
+    const level_cache &cache = here.access_cache( origin.z );
+    const level_cache &above_cache = here.access_cache( origin.z + 1 );
     const visibility_variables &vvcache =
-        g->m.get_visibility_variables_cache();
+        here.get_visibility_variables_cache();
 
     std::ostringstream fields;
     std::ostringstream transparency;
@@ -181,7 +182,7 @@ static void full_map_test( const std::vector<std::string> &setup,
         for( int x = 0; x < width; ++x ) {
             const tripoint p = origin + point( x, y );
             const map::apparent_light_info al = map::apparent_light_helper( cache, p );
-            for( auto &pr : g->m.field_at( p ) ) {
+            for( auto &pr : here.field_at( p ) ) {
                 fields << pr.second.name() << ',';
             }
             fields << ' ';
@@ -203,10 +204,10 @@ static void full_map_test( const std::vector<std::string> &setup,
         floor_above << '\n';
     }
 
-    INFO( "zlevels: " << g->m.has_zlevels() );
+    INFO( "zlevels: " << here.has_zlevels() );
     INFO( "origin: " << origin );
-    INFO( "player: " << g->u.pos() );
-    INFO( "unimpaired_range: " << g->u.unimpaired_range() );
+    INFO( "player: " << player_character.pos() );
+    INFO( "unimpaired_range: " << player_character.unimpaired_range() );
     INFO( "vision_threshold: " << vvcache.vision_threshold );
     INFO( "time: " << to_string( time ) );
     INFO( "fields:\n" << fields.str() );
@@ -224,7 +225,7 @@ static void full_map_test( const std::vector<std::string> &setup,
     for( int y = 0; y < height; ++y ) {
         for( int x = 0; x < width; ++x ) {
             const tripoint p = origin + point( x, y );
-            const lit_level level = g->m.apparent_light_at( p, vvcache );
+            const lit_level level = here.apparent_light_at( p, vvcache );
             const char exp_char = expected_results[y][x];
             if( exp_char < '0' || exp_char > '9' ) {
                 FAIL( "unexpected result char '" <<

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -93,6 +93,7 @@ static void full_map_test( const std::vector<std::string> &setup,
             switch( setup[y][x] ) {
                 case 'V':
                 case 'U':
+                case 'H':
                 case 'u':
                     origin = player_character.pos() - point( x, y );
                     if( setup[y][x] == 'V' ) {
@@ -113,7 +114,7 @@ static void full_map_test( const std::vector<std::string> &setup,
         REQUIRE( player_offset.x >= 0 );
         REQUIRE( player_offset.x < width );
         char player_char = setup[player_offset.y][player_offset.x];
-        REQUIRE( ( player_char == 'U' || player_char == 'u' || player_char == 'V' ) );
+        REQUIRE( ( player_char == 'U' || player_char == 'u' || player_char == 'V' || player_char == 'H' ) );
     }
 
     map &here = get_map();
@@ -129,6 +130,7 @@ static void full_map_test( const std::vector<std::string> &setup,
                     here.ter_set( above, t_flat_roof );
                     break;
                 case '#':
+                case 'H':
                     here.ter_set( p, t_brick_wall );
                     here.ter_set( above, t_flat_roof );
                     break;
@@ -337,6 +339,7 @@ static const time_point midday = calendar::turn_zero + 12_hours;
 // 'U' - player, outdoors
 // 'u' - player, indoors
 // 'V' - player, with light in inventory
+// 'H' - player, indoors, standing inside a wall
 // 'L' - light, indoors
 // '#' - wall
 // '=' - window frame
@@ -583,6 +586,35 @@ TEST_CASE( "vision_single_tile_skylight", "[shadowcasting][vision]" )
             "66666666666",
         },
         midday,
+        vision_test_flags::none
+    };
+
+    t.test_all();
+}
+
+TEST_CASE( "vision_player_opaque_neighbors_still_visible_night", "[shadowcasting][vision]" )
+{
+    /**
+     *  Even when stating inside the opaque wall and surrounded by opaque walls,
+     *  you should see yourself and immediate surrounding.
+     *  (walls here simulate the behavior of the fully opaque fields, e.g. thick smoke)
+     */
+    vision_test_case t {
+        {
+            "#####",
+            "#####",
+            "##H##",
+            "#####",
+            "#####",
+        },
+        {
+            "66666",
+            "61116",
+            "61116",
+            "61116",
+            "66666",
+        },
+        midnight,
         vision_test_flags::none
     };
 


### PR DESCRIPTION
#### Purpose of change
Fixing bugs, improving performance.

#### Describe the solution
PRs being ported:
CleverRaven#41741
CleverRaven#44093
CleverRaven#44112
CleverRaven#44181
CleverRaven#44108
Also some changes from CleverRaven#41935 to minimize merge conflicts.

#### Testing
Removing cobwebs now properly updates vision.
Player sprite and neighboring tiles are now visible when in thick smoke.

In best-case test scenario (3D FoV on, avatar in clear field and a small enclosed room 2 submaps away with a smoke vent inside) waiting for 2 in-game hours went down from 33 seconds to 12 seconds.

That cache copy bug was as insane performance hog actually:
![image](https://user-images.githubusercontent.com/60584843/121788109-3a34aa00-cbd3-11eb-81f4-6a7f0ba269ea.png)