### PR TITLE
Clear deferred JSON on data unload

### DIFF
--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -388,6 +388,8 @@ class generic_factory
         void reset() {
             list.clear();
             map.clear();
+            abstracts.clear();
+            deferred.clear();
         }
         /**
          * Returns all the loaded objects. It can be used to iterate over them.

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2649,20 +2649,22 @@ void Item_factory::reset()
 
 void Item_factory::clear()
 {
-    m_template_groups.clear();
-
     iuse_function_list.clear();
 
-    m_templates.clear();
+    deferred.clear();
+    m_abstracts.clear();
     m_runtimes.clear();
+    m_template_groups.clear();
+    m_templates.clear();
 
-    item_blacklist.clear();
-
-    tool_subtypes.clear();
-
-    repair_tools.clear();
     gun_tools.clear();
     repair_actions.clear();
+    repair_tools.clear();
+    tool_subtypes.clear();
+
+    item_blacklist.clear();
+    migrated_ammo.clear();
+    migrated_magazines.clear();
     migrations.clear();
 
     frozen = false;

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -193,6 +193,7 @@ std::string enum_to_string<mission_goal>( mission_goal data )
 } // namespace io
 
 generic_factory<mission_type> mission_type_factory( "mission_type" );
+static DynamicDataLoader::deferred_json deferred;
 
 /** @relates string_id */
 template<>
@@ -216,6 +217,7 @@ void mission_type::load_mission_type( const JsonObject &jo, const std::string &s
 void mission_type::reset()
 {
     mission_type_factory.reset();
+    deferred.clear();
 }
 
 template <typename Fun>
@@ -231,8 +233,6 @@ void assign_function( const JsonObject &jo, const std::string &id, Fun &target,
         }
     }
 }
-
-static DynamicDataLoader::deferred_json deferred;
 
 void mission_type::load( const JsonObject &jo, const std::string &src )
 {

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -469,6 +469,7 @@ void recipe_dictionary::finalize()
 
 void recipe_dictionary::reset()
 {
+    deferred.clear();
     recipe_dict.blueprints.clear();
     recipe_dict.autolearn.clear();
     recipe_dict.recipes.clear();

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -680,6 +680,7 @@ void vpart_info::check()
 
 void vpart_info::reset()
 {
+    deferred.clear();
     vpart_info_all.clear();
     abstract_parts.clear();
 }


### PR DESCRIPTION
#### Purpose of change
Fix #384.

#### Describe the solution
Clear deferred JSON on data unload.
The actual change that fixes the issue is addition of `deferred.clear()` in `Item_factory::clear()`, the rest is added for the good measure.

#### Testing
Retraced reproduction steps, debug message no longer shows up.