### PR TITLE
[CR]Linking items up as one drop, for combined pickup later

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -246,7 +246,7 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
             }
             const tripoint src = target.position();
             const int distance = src.z == dest.z ? std::max( rl_dist( src, dest ), 1 ) : 1;
-            who.mod_moves( -Pickup::cost_to_move_item( who, newit ) * distance );
+            who.mod_moves( -pickup::cost_to_move_item( who, newit ) * distance );
             if( to_vehicle ) {
                 put_into_vehicle_or_drop( who, item_drop_reason::deliberate, { newit }, dest );
             } else {
@@ -311,7 +311,7 @@ void pickup_activity_actor::do_turn( player_activity &, Character &who )
     const bool autopickup = who.activity.auto_resume;
 
     // False indicates that the player canceled pickup when met with some prompt
-    const bool keep_going = Pickup::do_pickup( target_items, quantities, autopickup );
+    const bool keep_going = pickup::do_pickup( target_items, autopickup );
 
     // If there are items left we ran out of moves, so continue the activity
     // Otherwise, we are done.
@@ -336,7 +336,6 @@ void pickup_activity_actor::serialize( JsonOut &jsout ) const
     jsout.start_object();
 
     jsout.member( "target_items", target_items );
-    jsout.member( "quantities", quantities );
     jsout.member( "starting_pos", starting_pos );
 
     jsout.end_object();
@@ -344,12 +343,11 @@ void pickup_activity_actor::serialize( JsonOut &jsout ) const
 
 std::unique_ptr<activity_actor> pickup_activity_actor::deserialize( JsonIn &jsin )
 {
-    pickup_activity_actor actor( {}, {}, cata::nullopt );
+    pickup_activity_actor actor( {}, cata::nullopt );
 
     JsonObject data = jsin.get_object();
 
     data.read( "target_items", actor.target_items );
-    data.read( "quantities", actor.quantities );
     data.read( "starting_pos", actor.starting_pos );
 
     return actor.clone();

--- a/src/activity_actor.h
+++ b/src/activity_actor.h
@@ -10,6 +10,7 @@
 #include "item_location.h"
 #include "optional.h"
 #include "pickup.h"
+#include "pickup_token.h"
 #include "point.h"
 #include "type_id.h"
 

--- a/src/activity_actor.h
+++ b/src/activity_actor.h
@@ -9,7 +9,6 @@
 #include "clone_ptr.h"
 #include "item_location.h"
 #include "optional.h"
-#include "pickup.h"
 #include "pickup_token.h"
 #include "point.h"
 #include "type_id.h"

--- a/src/activity_actor.h
+++ b/src/activity_actor.h
@@ -9,6 +9,7 @@
 #include "clone_ptr.h"
 #include "item_location.h"
 #include "optional.h"
+#include "pickup.h"
 #include "point.h"
 #include "type_id.h"
 
@@ -128,8 +129,7 @@ class pickup_activity_actor : public activity_actor
 {
     private:
         /** Target items and the quantities thereof */
-        std::vector<item_location> target_items;
-        std::vector<int> quantities;
+        std::vector<pickup::pick_drop_selection> target_items;
 
         /**
          * Position of the character when the activity is started. This is
@@ -140,10 +140,10 @@ class pickup_activity_actor : public activity_actor
         cata::optional<tripoint> starting_pos;
 
     public:
-        pickup_activity_actor( const std::vector<item_location> &target_items,
-                               const std::vector<int> &quantities,
-                               const cata::optional<tripoint> &starting_pos ) : target_items( target_items ),
-            quantities( quantities ), starting_pos( starting_pos ) {}
+        pickup_activity_actor( const std::vector<pickup::pick_drop_selection> &target_items,
+                               const cata::optional<tripoint> &starting_pos )
+            : target_items( target_items )
+            , starting_pos( starting_pos ) {}
 
         activity_id get_type() const override {
             return activity_id( "ACT_PICKUP" );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -584,7 +584,8 @@ std::list<act_item> reorder_for_dropping( Character &p, const drop_locations &dr
 std::list<item> obtain_and_tokenize_items( player &p, std::list<act_item> &items )
 {
     std::list<item> res;
-    item_drop_token last_token = drop_token::make_next();
+    drop_token_provider &token_provider = drop_token::get_provider();
+    item_drop_token last_token = token_provider.make_next( calendar::turn );
     units::volume last_storage_volume = items.front().loc->get_storage();
     while( !items.empty() && ( p.is_npc() || p.moves > 0 || items.front().consumed_moves == 0 ) ) {
         act_item &ait = items.front();
@@ -607,7 +608,7 @@ std::list<item> obtain_and_tokenize_items( player &p, std::list<act_item> &items
 
         // Hack: if it consumes zero moves, it must have been contained
         // TODO: Properly mark containment somehow
-        *current_drop.drop_token = drop_token::make_next();
+        *current_drop.drop_token = token_provider.make_next( calendar::turn );;
         if( ait.consumed_moves == 0 && last_storage_volume >= current_drop.volume() ) {
             last_storage_volume -= current_drop.volume();
             current_drop.drop_token->parent_number = last_token.parent_number;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -533,7 +533,7 @@ std::list<act_item> reorder_for_dropping( Character &p, const drop_locations &dr
                                      - p.volume_capacity() + dropped_worn_storage;
     if( excessive_volume > 0_ml ) {
         invslice old_inv = p.inv.slice();
-        for( size_t i = 0; i < old_inv.size(); i++ ) {
+        for( size_t i = 0; i < old_inv.size() && excessive_volume > 0_ml; i++ ) {
             // TODO: Reimplement random dropping?
             if( inv_indices.count( i ) != 0 ) {
                 continue;
@@ -543,8 +543,10 @@ std::list<act_item> reorder_for_dropping( Character &p, const drop_locations &dr
                 act_item to_drop = act_item( item_location( p, &*iter ), iter->count(), 0 );
                 inv.push_back( to_drop );
                 excessive_volume -= to_drop.loc->volume();
+                if( excessive_volume <= 0_ml ) {
+                    break;
+                }
             }
-
         }
     }
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -175,7 +175,7 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
 
     // can't use constant reference here because of the spill_contents()
     for( auto it : items ) {
-        if( Pickup::handle_spillable_contents( c, it, g->m ) ) {
+        if( pickup::handle_spillable_contents( c, it, g->m ) ) {
             continue;
         }
         if( veh.add_item( part, it ) ) {
@@ -888,7 +888,7 @@ static int move_cost_cart( const item &it, const tripoint &src, const tripoint &
     const int MAX_COST = 500;
 
     // cost to move item into the cart
-    const int pickup_cost = Pickup::cost_to_move_item( g->u, it );
+    const int pickup_cost = pickup::cost_to_move_item( g->u, it );
 
     // cost to move item out of the cart
     const int drop_cost = pickup_cost;
@@ -3183,7 +3183,7 @@ bool find_auto_consume( player &p, const bool food )
                 continue;
             }
 
-            p.mod_moves( -Pickup::cost_to_move_item( p, *it ) * std::max( rl_dist( p.pos(),
+            p.mod_moves( -pickup::cost_to_move_item( p, *it ) * std::max( rl_dist( p.pos(),
                          g->m.getlocal( loc ) ), 1 ) );
             item_location item_loc;
             if( vp ) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -520,7 +520,7 @@ std::list<act_item> reorder_for_dropping( Character &p, const drop_locations &dr
     } );
 
     units::volume excessive_volume = p.volume_carried() - dropped_inv_contents
-                                     - p.volume_capacity() + dropped_worn_storage;
+                                     - p.volume_capacity_reduced_by( dropped_worn_storage );
     if( excessive_volume > 0_ml ) {
         invslice old_inv = p.inv.slice();
         for( size_t i = 0; i < old_inv.size() && excessive_volume > 0_ml; i++ ) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -529,9 +529,9 @@ std::list<act_item> reorder_for_dropping( Character &p, const drop_locations &dr
                 continue;
             }
             std::list<item> &inv_stack = *old_inv[i];
-            for( auto iter = inv_stack.begin(); iter != inv_stack.end(); iter++ ) {
+            for( item &item : inv_stack ) {
                 // Note: zero cost, but won't be contained on drop
-                act_item to_drop = act_item( item_location( p, &*iter ), iter->count(), 0 );
+                act_item to_drop = act_item( item_location( p, &item ), item.count(), 0 );
                 inv.push_back( to_drop );
                 excessive_volume -= to_drop.loc->volume();
                 if( excessive_volume <= 0_ml ) {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -945,9 +945,10 @@ bool advanced_inventory::move_all_items( bool nested_call )
             }
 
             if( dpane.get_area() == AIM_INVENTORY ) {
+                std::vector<pickup::pick_drop_selection> targets = pickup::optimize_pickup( target_items,
+                        quantities );
                 g->u.assign_activity( player_activity( pickup_activity_actor(
-                        target_items,
-                        quantities,
+                        targets,
                         panes[src].in_vehicle() ? cata::nullopt : cata::optional<tripoint>( g->u.pos() )
                                                        ) ) );
             } else {
@@ -1174,9 +1175,10 @@ void advanced_inventory::start_activity( const aim_location destarea, const aim_
         }
 
         if( destarea == AIM_INVENTORY ) {
+            std::vector<pickup::pick_drop_selection> targets = pickup::optimize_pickup( target_items,
+                    quantities );
             g->u.assign_activity( player_activity( pickup_activity_actor(
-                    target_items,
-                    quantities,
+                    targets,
                     from_vehicle ? cata::nullopt : cata::optional<tripoint>( g->u.pos() )
                                                    ) ) );
         } else {

--- a/src/character.h
+++ b/src/character.h
@@ -1373,8 +1373,10 @@ class Character : public Creature, public visitable<Character>
             const units::volume &mod,
             const std::map<const item *, int> &without_items = {} ) const;
 
-        bool can_pickVolume( const item &it, bool safe = false ) const;
-        bool can_pickWeight( const item &it, bool safe = true ) const;
+        bool can_pick_volume( const item &it ) const;
+        bool can_pick_volume( units::volume volume ) const;
+        bool can_pick_weight( const item &it, bool safe = true ) const;
+        bool can_pick_weight( units::mass weight, bool safe = true ) const;
         /**
          * Checks if character stats and skills meet minimum requirements for the item.
          * Prints an appropriate message if requirements not met.

--- a/src/character.h
+++ b/src/character.h
@@ -1352,7 +1352,7 @@ class Character : public Creature, public visitable<Character>
 
         /// Sometimes we need to calculate hypothetical volume or weight.  This
         /// struct offers two possible tweaks: a collection of items and
-        /// coutnts to remove, or an entire replacement inventory.
+        /// counts to remove, or an entire replacement inventory.
         struct item_tweaks {
             item_tweaks() = default;
             item_tweaks( const std::map<const item *, int> &w ) :

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -759,7 +759,7 @@ void conditional_t<T>::set_can_stow_weapon( bool is_npc )
         if( is_npc ) {
             actor = dynamic_cast<player *>( d.beta );
         }
-        return !actor->unarmed_attack() && actor->can_pickVolume( actor->weapon );
+        return !actor->unarmed_attack() && actor->can_pick_volume( actor->weapon );
     };
 }
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -699,8 +699,8 @@ static item_location set_item_inventory( player &p, item &newit )
 {
     p.inv.assign_empty_invlet( newit, p );
     // We might not have space for the item
-    if( p.can_pickVolume( newit ) &&
-        p.can_pickWeight( newit, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
+    if( p.can_pick_volume( newit ) &&
+        p.can_pick_weight( newit, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
         item &item_in_inv = p.i_add( newit );
         add_msg( m_info, "%c - %s", item_in_inv.invlet == 0 ? ' ' : item_in_inv.invlet,
                  item_in_inv.tname() );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -583,6 +583,7 @@ const inventory &Character::crafting_inventory( const tripoint &src_pos, int rad
 void Character::invalidate_crafting_inventory()
 {
     cached_time = calendar::before_time_starts;
+    cached_position = tripoint_min;
 }
 
 void player::make_craft( const recipe_id &id_to_make, int batch_size, const tripoint &loc )

--- a/src/drop_token.cpp
+++ b/src/drop_token.cpp
@@ -1,5 +1,6 @@
 #include "calendar.h"
 #include "drop_token.h"
+#include "game.h"
 #include "json.h"
 
 void item_drop_token::serialize( JsonOut &jsout ) const
@@ -21,22 +22,30 @@ void item_drop_token::deserialize( JsonIn &jsin )
     jo.read( "parent_number", parent_number );
 }
 
-namespace drop_token
+item_drop_token drop_token_provider::make_next( time_point tp )
 {
-
-item_drop_token make_next()
-{
-    // TODO: Implement properly
-    static time_point last_turn = calendar::before_time_starts;
-    static int last_drop = 0;
-    if( calendar::turn != last_turn ) {
-        last_turn = calendar::turn;
+    if( tp != last_turn ) {
+        last_turn = tp;
         last_drop = 0;
     }
 
     last_drop++;
 
-    return item_drop_token{ calendar::turn, last_drop, last_drop };
+    return item_drop_token{ tp, last_drop, last_drop };
+}
+
+void drop_token_provider::clear()
+{
+    last_turn = calendar::before_time_starts;
+    last_drop = 0;
+}
+
+namespace drop_token
+{
+
+drop_token_provider &get_provider()
+{
+    return *g->token_provider;
 }
 
 } // namespace drop_token

--- a/src/drop_token.cpp
+++ b/src/drop_token.cpp
@@ -22,16 +22,16 @@ void item_drop_token::deserialize( JsonIn &jsin )
     jo.read( "parent_number", parent_number );
 }
 
-item_drop_token drop_token_provider::make_next( time_point tp )
+item_drop_token drop_token_provider::make_next( time_point turn )
 {
-    if( tp != last_turn ) {
-        last_turn = tp;
+    if( turn != last_turn ) {
+        last_turn = turn;
         last_drop = 0;
     }
 
     last_drop++;
 
-    return item_drop_token{ tp, last_drop, last_drop };
+    return item_drop_token{ turn, last_drop, last_drop };
 }
 
 void drop_token_provider::clear()
@@ -40,12 +40,29 @@ void drop_token_provider::clear()
     last_drop = 0;
 }
 
+void drop_token_provider::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+
+    jsout.member( "last_turn", last_turn );
+    jsout.member( "last_drop", last_drop );
+
+    jsout.end_object();
+}
+
+void drop_token_provider::deserialize( JsonIn &jsin )
+{
+    JsonObject jo = jsin.get_object();
+    jo.read( "last_turn", last_turn );
+    jo.read( "last_drop", last_drop );
+}
+
 namespace drop_token
 {
 
 drop_token_provider &get_provider()
 {
-    return *g->token_provider;
+    return *g->token_provider_ptr;
 }
 
 } // namespace drop_token

--- a/src/drop_token.cpp
+++ b/src/drop_token.cpp
@@ -1,0 +1,19 @@
+#include "drop_token.h"
+
+namespace drop_token
+{
+
+item_drop_token make_next()
+{
+    // TODO: Implement properly
+    static time_point last_turn;
+    static int last_drop = 0;
+    if( calendar::turn != last_turn ) {
+        last_turn = calendar::turn;
+        last_drop = 0;
+    }
+
+    return item_drop_token{ calendar::turn, last_drop, 0 };
+}
+
+};

--- a/src/drop_token.cpp
+++ b/src/drop_token.cpp
@@ -1,3 +1,4 @@
+#include "calendar.h"
 #include "drop_token.h"
 
 namespace drop_token
@@ -6,12 +7,14 @@ namespace drop_token
 item_drop_token make_next()
 {
     // TODO: Implement properly
-    static time_point last_turn;
+    static time_point last_turn = time_point::from_turn( -1 );
     static int last_drop = 0;
     if( calendar::turn != last_turn ) {
         last_turn = calendar::turn;
         last_drop = 0;
     }
+
+    last_drop++;
 
     return item_drop_token{ calendar::turn, last_drop, last_drop };
 }

--- a/src/drop_token.cpp
+++ b/src/drop_token.cpp
@@ -13,7 +13,7 @@ item_drop_token make_next()
         last_drop = 0;
     }
 
-    return item_drop_token{ calendar::turn, last_drop, 0 };
+    return item_drop_token{ calendar::turn, last_drop, last_drop };
 }
 
 };

--- a/src/drop_token.cpp
+++ b/src/drop_token.cpp
@@ -27,7 +27,7 @@ namespace drop_token
 item_drop_token make_next()
 {
     // TODO: Implement properly
-    static time_point last_turn = time_point::before_time_starts;
+    static time_point last_turn = calendar::before_time_starts;
     static int last_drop = 0;
     if( calendar::turn != last_turn ) {
         last_turn = calendar::turn;

--- a/src/drop_token.cpp
+++ b/src/drop_token.cpp
@@ -27,7 +27,7 @@ namespace drop_token
 item_drop_token make_next()
 {
     // TODO: Implement properly
-    static time_point last_turn = time_point::from_turn( -1 );
+    static time_point last_turn = time_point::before_time_starts;
     static int last_drop = 0;
     if( calendar::turn != last_turn ) {
         last_turn = calendar::turn;

--- a/src/drop_token.cpp
+++ b/src/drop_token.cpp
@@ -19,7 +19,7 @@ item_drop_token make_next()
     return item_drop_token{ calendar::turn, last_drop, last_drop };
 }
 
-}
+} // namespace drop_token
 
 std::ostream &operator<<( std::ostream &os, const item_drop_token &dt )
 {

--- a/src/drop_token.cpp
+++ b/src/drop_token.cpp
@@ -19,4 +19,13 @@ item_drop_token make_next()
     return item_drop_token{ calendar::turn, last_drop, last_drop };
 }
 
-};
+}
+
+std::ostream &operator<<( std::ostream &os, const item_drop_token &dt )
+{
+    os << "{turn:" << to_turn<int>( dt.turn )
+       << ", drop:" << dt.drop_number
+       << ", parent:" << dt.parent_number
+       << '}';
+    return os;
+}

--- a/src/drop_token.cpp
+++ b/src/drop_token.cpp
@@ -1,5 +1,25 @@
 #include "calendar.h"
 #include "drop_token.h"
+#include "json.h"
+
+void item_drop_token::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+
+    jsout.member( "turn", turn );
+    jsout.member( "drop_number", drop_number );
+    jsout.member( "parent_number", parent_number );
+
+    jsout.end_object();
+}
+
+void item_drop_token::deserialize( JsonIn &jsin )
+{
+    JsonObject jo = jsin.get_object();
+    jo.read( "turn", turn );
+    jo.read( "drop_number", drop_number );
+    jo.read( "parent_number", parent_number );
+}
 
 namespace drop_token
 {

--- a/src/drop_token.h
+++ b/src/drop_token.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef CATA_SRC_ITEM_DROP_TOKEN_H
-#define CATA_SRC_ITEM_DROP_TOKEN_H
+#ifndef CATA_SRC_DROP_TOKEN_H
+#define CATA_SRC_DROP_TOKEN_H
 
 #include <iostream>
 
@@ -47,8 +47,8 @@ namespace drop_token
 
 item_drop_token make_next();
 
-}
+} // namespace drop_token
 
 std::ostream &operator<<( std::ostream &os, const item_drop_token &dt );
 
-#endif // CATA_SRC_ITEM_DROP_TOKEN_H
+#endif // CATA_SRC_DROP_TOKEN_H

--- a/src/drop_token.h
+++ b/src/drop_token.h
@@ -48,10 +48,23 @@ class item_drop_token
         void deserialize( JsonIn &jsin );
 };
 
+class drop_token_provider
+{
+    private:
+        time_point last_turn = calendar::before_time_starts;
+        int last_drop = 0;
+    public:
+        drop_token_provider() = default;
+        drop_token_provider( const drop_token_provider & ) = delete;
+
+        item_drop_token make_next( time_point turn );
+        void clear();
+};
+
 namespace drop_token
 {
 
-item_drop_token make_next();
+drop_token_provider &get_provider();
 
 } // namespace drop_token
 

--- a/src/drop_token.h
+++ b/src/drop_token.h
@@ -1,0 +1,30 @@
+#pragma once
+#ifndef CATA_SRC_ITEM_DROP_TOKEN_H
+#define CATA_SRC_ITEM_DROP_TOKEN_H
+
+#include "calendar.h"
+
+class item_drop_token
+{
+    public:
+        time_point turn;
+        int drop_number;
+        int parent_number;
+
+        item_drop_token() : item_drop_token( time_point(), 0, 0 )
+        {}
+        item_drop_token( time_point turn, int drop_number, int parent_number )
+            : turn( turn )
+            , drop_number( drop_number )
+            , parent_number( parent_number )
+        {}
+};
+
+namespace drop_token
+{
+
+item_drop_token make_next();
+
+};
+
+#endif // CATA_SRC_ITEM_DROP_TOKEN_H

--- a/src/drop_token.h
+++ b/src/drop_token.h
@@ -2,11 +2,14 @@
 #ifndef CATA_SRC_ITEM_DROP_TOKEN_H
 #define CATA_SRC_ITEM_DROP_TOKEN_H
 
+#include <iostream>
+
 #include "calendar.h"
 
 class item_drop_token
 {
     public:
+        // TODO: private
         time_point turn;
         int drop_number;
         int parent_number;
@@ -27,6 +30,16 @@ class item_drop_token
         bool operator!=( const item_drop_token &other ) const {
             return !( *this == other );
         }
+        bool is_child_of( const item_drop_token &other ) const {
+            return turn == other.turn
+                   && parent_number == other.drop_number
+                   && drop_number != other.drop_number;
+        }
+        bool is_sibling_of( const item_drop_token &other ) const {
+            return turn == other.turn
+                   && parent_number == other.parent_number &&
+                   !is_child_of( other );
+        }
 };
 
 namespace drop_token
@@ -35,5 +48,7 @@ namespace drop_token
 item_drop_token make_next();
 
 }
+
+std::ostream &operator<<( std::ostream &os, const item_drop_token &dt );
 
 #endif // CATA_SRC_ITEM_DROP_TOKEN_H

--- a/src/drop_token.h
+++ b/src/drop_token.h
@@ -6,13 +6,16 @@
 
 #include "calendar.h"
 
+class JsonOut;
+class JsonIn;
+
 class item_drop_token
 {
     public:
         // TODO: private
-        time_point turn;
-        int drop_number;
-        int parent_number;
+        time_point turn = calendar::turn_zero;
+        int drop_number = 0;
+        int parent_number = 0;
 
         item_drop_token() : item_drop_token( time_point(), 0, 0 )
         {}
@@ -40,6 +43,9 @@ class item_drop_token
                    && parent_number == other.parent_number &&
                    !is_child_of( other );
         }
+
+        void serialize( JsonOut &jsout ) const;
+        void deserialize( JsonIn &jsin );
 };
 
 namespace drop_token

--- a/src/drop_token.h
+++ b/src/drop_token.h
@@ -55,10 +55,12 @@ class drop_token_provider
         int last_drop = 0;
     public:
         drop_token_provider() = default;
-        drop_token_provider( const drop_token_provider & ) = delete;
 
         item_drop_token make_next( time_point turn );
         void clear();
+
+        void serialize( JsonOut &jsout ) const;
+        void deserialize( JsonIn &jsin );
 };
 
 namespace drop_token

--- a/src/drop_token.h
+++ b/src/drop_token.h
@@ -24,6 +24,9 @@ class item_drop_token
                    && drop_number == other.drop_number
                    && parent_number == other.parent_number;
         }
+        bool operator!=( const item_drop_token &other ) const {
+            return !( *this == other );
+        }
 };
 
 namespace drop_token
@@ -31,6 +34,6 @@ namespace drop_token
 
 item_drop_token make_next();
 
-};
+}
 
 #endif // CATA_SRC_ITEM_DROP_TOKEN_H

--- a/src/drop_token.h
+++ b/src/drop_token.h
@@ -18,6 +18,12 @@ class item_drop_token
             , drop_number( drop_number )
             , parent_number( parent_number )
         {}
+
+        bool operator==( const item_drop_token &other ) const {
+            return turn == other.turn
+                   && drop_number == other.drop_number
+                   && parent_number == other.parent_number;
+        }
 };
 
 namespace drop_token

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -592,7 +592,7 @@ void game::setup()
     remoteveh_cache_time = calendar::before_time_starts;
     remoteveh_cache = nullptr;
 
-    token_provider->clear();
+    token_provider_ptr->clear();
     // back to menu for save loading, new game etc
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -59,6 +59,7 @@
 #include "debug.h"
 #include "dependency_tree.h"
 #include "distribution_grid.h"
+#include "drop_token.h"
 #include "editmap.h"
 #include "enums.h"
 #include "event.h"
@@ -590,6 +591,8 @@ void game::setup()
 
     remoteveh_cache_time = calendar::before_time_starts;
     remoteveh_cache = nullptr;
+
+    token_provider->clear();
     // back to menu for save loading, new game etc
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5757,7 +5757,7 @@ void game::examine( const tripoint &examp )
         } else {
             sounds::process_sound_markers( &u );
             if( !u.is_mounted() ) {
-                Pickup::pick_up( examp, 0 );
+                pickup::pick_up( examp, 0 );
             }
         }
     }
@@ -5782,12 +5782,12 @@ void game::pickup( const tripoint &p )
     } );
     add_draw_callback( hilite_cb );
 
-    Pickup::pick_up( p, 0 );
+    pickup::pick_up( p, 0 );
 }
 
 void game::pickup_feet()
 {
-    Pickup::pick_up( u.pos(), 1 );
+    pickup::pick_up( u.pos(), 1 );
 }
 
 //Shift player by one tile, look_around(), then restore previous position.
@@ -9607,7 +9607,7 @@ point game::place_player( const tripoint &dest_loc )
     if( !u.is_mounted() && get_option<bool>( "AUTO_PICKUP" ) && !u.is_hauling() &&
         ( !get_option<bool>( "AUTO_PICKUP_SAFEMODE" ) || mostseen == 0 ) &&
         ( m.has_items( u.pos() ) || get_option<bool>( "AUTO_PICKUP_ADJACENT" ) ) ) {
-        Pickup::pick_up( u.pos(), -1 );
+        pickup::pick_up( u.pos(), -1 );
     }
 
     // If the new tile is a boardable part, board it

--- a/src/game.h
+++ b/src/game.h
@@ -989,7 +989,7 @@ class game
 
         pimpl<Creature_tracker> critter_tracker;
         pimpl<faction_manager> faction_manager_ptr;
-        pimpl<drop_token_provider> token_provider;
+        pimpl<drop_token_provider> token_provider_ptr;
 
         /** Used in main.cpp to determine what type of quit is being performed. */
         quit_status uquit;

--- a/src/game.h
+++ b/src/game.h
@@ -36,6 +36,7 @@ class Creature_tracker;
 class item;
 class monster;
 class spell_events;
+class drop_token_provider;
 
 static constexpr int DEFAULT_TILESET_ZOOM = 16;
 
@@ -988,6 +989,7 @@ class game
 
         pimpl<Creature_tracker> critter_tracker;
         pimpl<faction_manager> faction_manager_ptr;
+        pimpl<drop_token_provider> token_provider;
 
         /** Used in main.cpp to determine what type of quit is being performed. */
         quit_status uquit;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -408,9 +408,9 @@ class pickup_inventory_preset : public inventory_selector_preset
             if( !p.has_item( *loc ) ) {
                 if( loc->made_of( LIQUID ) ) {
                     return _( "Can't pick up spilt liquids" );
-                } else if( !p.can_pickVolume( *loc ) && p.is_armed() ) {
+                } else if( !p.can_pick_volume( *loc ) && p.is_armed() ) {
                     return _( "Too big to pick up" );
-                } else if( !p.can_pickWeight( *loc, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
+                } else if( !p.can_pick_weight( *loc, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
                     return _( "Too heavy to pick up" );
                 }
             }

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -1061,7 +1061,7 @@ void defense_game::caravan()
             }
 
             for( int j = 0; j < item_count[0][i]; j++ ) {
-                if( g->u.can_pickVolume( tmp ) && g->u.can_pickWeight( tmp ) ) {
+                if( g->u.can_pick_volume( tmp ) && g->u.can_pick_weight( tmp ) ) {
                     g->u.i_add( tmp );
                 } else { // Could fit it in the inventory!
                     dropped_some = true;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1702,8 +1702,8 @@ static bool drink_nectar( player &p )
 static void handle_harvest( player &p, const std::string &itemid, bool force_drop )
 {
     item harvest = item( itemid );
-    if( !force_drop && p.can_pickVolume( harvest, true ) &&
-        p.can_pickWeight( harvest, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
+    if( !force_drop && p.can_pick_volume( harvest ) &&
+        p.can_pick_weight( harvest, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
         p.i_add( harvest );
         p.add_msg_if_player( _( "You harvest: %s." ), harvest.tname() );
     } else {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2796,7 +2796,7 @@ void iexamine::fireplace( player &p, const tripoint &examp )
     switch( selection_menu.ret ) {
         case 0:
             none( p, examp );
-            Pickup::pick_up( examp, 0 );
+            pickup::pick_up( examp, 0 );
             return;
         case 1: {
             for( auto &firestarter : firestarters ) {
@@ -3464,7 +3464,7 @@ void iexamine::tree_maple_tapped( player &p, const tripoint &examp )
 
         case REMOVE_CONTAINER: {
             g->u.assign_activity( player_activity( pickup_activity_actor(
-            { item_location( map_cursor( examp ), container ) }, { 0 }, g->u.pos() ) ) );
+            { { item_location( map_cursor( examp ), container ), cata::nullopt, {} } }, g->u.pos() ) ) );
             return;
         }
 
@@ -3751,7 +3751,7 @@ void iexamine::reload_furniture( player &p, const tripoint &examp )
             for( auto &itm : items ) {
                 if( itm.type == ammo ) {
                     g->u.assign_activity( player_activity( pickup_activity_actor(
-                    { item_location( map_cursor( examp ), &itm ) }, { 0 }, g->u.pos() ) ) );
+                    { { item_location( map_cursor( examp ), &itm ), cata::nullopt, {} } }, g->u.pos() ) ) );
                     return;
                 }
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -35,6 +35,7 @@
 #include "damage.h"
 #include "debug.h"
 #include "dispersion.h"
+#include "drop_token.h"
 #include "effect.h" // for weed_msg
 #include "enums.h"
 #include "explosion.h"

--- a/src/item.h
+++ b/src/item.h
@@ -21,6 +21,7 @@
 #include "item_contents.h"
 #include "item_location.h"
 #include "optional.h"
+#include "pimpl.h"
 #include "safe_reference.h"
 #include "string_id.h"
 #include "type_id.h"
@@ -46,6 +47,7 @@ class relic;
 struct islot_comestible;
 struct itype;
 struct item_comp;
+class item_drop_token;
 template<typename CompType>
 struct comp_selection;
 struct tool_comp;
@@ -2216,6 +2218,12 @@ class item : public visitable<item>
         bool has_clothing_mod() const;
         float get_clothing_mod_val( clothing_mod_type type ) const;
         void update_clothing_mod_val();
+
+        /**
+         * Two items are dropped in same "batch" if they have identical drop tokens
+         * Ideally, this would be stored outside item class.
+         */
+        pimpl<item_drop_token> drop_token;
 };
 
 bool item_compare_by_charges( const item &left, const item &right );

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -577,7 +577,7 @@ class item_location::impl::item_in_container : public item_location::impl
             if( !target() ) {
                 return 0;
             }
-            // a temporary measure before pockets
+
             return INVENTORY_HANDLING_PENALTY + container.obtain_cost( ch, qty );
         }
 };

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -603,7 +603,7 @@ void starting_inv( npc &who, const npc_class_id &type )
                         type == NC_BOUNTY_HUNTER );
         qty = rng( qty, qty * 2 );
 
-        while( qty-- != 0 && who.can_pickVolume( ammo ) ) {
+        while( qty-- != 0 && who.can_pick_volume( ammo ) ) {
             // TODO: give NPC a default magazine instead
             res.push_back( ammo );
         }
@@ -623,7 +623,7 @@ void starting_inv( npc &who, const npc_class_id &type )
             if( !one_in( 3 ) && tmp.has_flag( "VARSIZE" ) ) {
                 tmp.set_flag( "FIT" );
             }
-            if( who.can_pickVolume( tmp ) ) {
+            if( who.can_pick_volume( tmp ) ) {
                 res.push_back( tmp );
             }
         }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3918,8 +3918,8 @@ void npc::mug_player( player &mark )
     for( std::list<item> *stack : slice ) {
         item &front_stack = stack->front();
         if( value( front_stack ) >= best_value &&
-            can_pickVolume( front_stack, true ) &&
-            can_pickWeight( front_stack, true ) ) {
+            can_pick_volume( front_stack ) &&
+            can_pick_weight( front_stack, true ) ) {
             best_value = value( front_stack );
             to_steal = &front_stack;
         }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3392,12 +3392,12 @@ std::string give_item_to( npc &p, bool allow_use )
                           cur_weapon_value );
         }
     } else {//allow_use is false so try to carry instead
-        if( p.can_pickVolume( given ) && p.can_pickWeight( given ) ) {
+        if( p.can_pick_volume( given ) && p.can_pick_weight( given ) ) {
             reason = _( "Thanks, I'll carry that now." );
             taken = true;
             p.i_add( given );
         } else {
-            if( !p.can_pickVolume( given ) ) {
+            if( !p.can_pick_volume( given ) ) {
                 const units::volume free_space = p.volume_capacity() - p.volume_carried();
                 reason += "\n" + std::string( _( "I have no space to store it." ) ) + "\n";
                 if( free_space > 0_ml ) {
@@ -3407,7 +3407,7 @@ std::string give_item_to( npc &p, bool allow_use )
                     reason += _( "…or to store anything else for that matter." );
                 }
             }
-            if( !p.can_pickWeight( given ) ) {
+            if( !p.can_pick_weight( given ) ) {
                 reason += std::string( "\n" ) + _( "It is too heavy for me to carry." );
             }
         }

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -467,8 +467,8 @@ std::vector<cata::optional<size_t>> calculate_parents( const
 }
 
 struct parent_child_check_t {
-    bool parent_exists;
-    bool child_exists;
+    bool parent_exists = false;
+    bool child_exists = false;
 };
 
 struct unstacked_items {
@@ -488,7 +488,7 @@ std::vector<stacked_items> stack_for_pickup_ui( const
             std::pair<time_point, int> turn_and_drop = std::make_pair( token.turn, token.drop_number );
             parent_child_check[turn_and_drop].parent_exists = true;
         }
-        if( token.parent_number > 0 ) {
+        if( token.parent_number != token.drop_number && token.parent_number > 0 ) {
             std::pair<time_point, int> turn_and_parent = std::make_pair( token.turn, token.parent_number );
             parent_child_check[turn_and_parent].child_exists = true;
         }
@@ -505,7 +505,8 @@ std::vector<stacked_items> stack_for_pickup_ui( const
         }
 
         std::pair<time_point, int> turn_and_parent = std::make_pair( token.turn, token.parent_number );
-        if( token.parent_number > 0 && parent_child_check[turn_and_parent].parent_exists ) {
+        if( token.parent_number > 0 && token.parent_number != token.drop_number &&
+            parent_child_check[turn_and_parent].parent_exists ) {
             children_by_parent[turn_and_parent].unstacked_children.push_back( it );
         } else {
             children_by_parent[no_parent].unstacked_children.push_back( it );

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -479,7 +479,8 @@ struct unstacked_items {
 std::vector<stacked_items> stack_for_pickup_ui( const
         std::vector<item_stack::iterator> &unstacked )
 {
-    constexpr std::pair<time_point, int> no_parent = std::make_pair( time_point::before_time_starts, 0 );
+    const std::pair<time_point, int> no_parent = std::make_pair(
+                calendar::before_time_starts, 0 );
     std::map<std::pair<time_point, int>, parent_child_check_t> parent_child_check;
     // First, we need to check which parent-child groups exist
     for( item_stack::iterator it : unstacked ) {

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -444,8 +444,8 @@ bool do_pickup( std::vector<pick_drop_selection> &targets, bool autopickup )
     return !problem;
 }
 
-std::vector<cata::optional<size_t>> calculate_parents( const
-                                 std::vector<std::list<item_stack::iterator>> &stacked_here )
+static std::vector<cata::optional<size_t>> calculate_parents(
+        const std::vector<std::list<item_stack::iterator>> &stacked_here )
 {
     std::vector<cata::optional<size_t>> parents( stacked_here.size() );
     if( !stacked_here.empty() ) {

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -41,6 +41,7 @@
 #include "options.h"
 #include "output.h"
 #include "panels.h"
+#include "pickup_token.h"
 #include "player.h"
 #include "player_activity.h"
 #include "point.h"
@@ -396,7 +397,10 @@ static bool pick_one_up( pickup::pick_drop_selection &selection, bool &got_water
     return picked_up || !did_prompt;
 }
 
-bool pickup::do_pickup( std::vector<pick_drop_selection> &targets, bool autopickup )
+namespace pickup
+{
+
+bool do_pickup( std::vector<pick_drop_selection> &targets, bool autopickup )
 {
     bool got_water = false;
     Character &u = get_avatar();
@@ -440,9 +444,6 @@ bool pickup::do_pickup( std::vector<pick_drop_selection> &targets, bool autopick
     return !problem;
 }
 
-// For tests
-std::vector<cata::optional<size_t>> calculate_parents( const
-                                 std::vector<std::list<item_stack::iterator>> &stacked_here );
 std::vector<cata::optional<size_t>> calculate_parents( const
                                  std::vector<std::list<item_stack::iterator>> &stacked_here )
 {
@@ -475,14 +476,6 @@ struct unstacked_items {
     std::list<item_stack::iterator> unstacked_children;
 };
 
-struct stacked_items {
-    cata::optional<item_stack::iterator> parent;
-    std::vector<std::list<item_stack::iterator>> stacked_children;
-};
-
-// Non-static because tests
-std::vector<stacked_items> stack_for_pickup_ui( const
-        std::vector<item_stack::iterator> &unstacked );
 std::vector<stacked_items> stack_for_pickup_ui( const
         std::vector<item_stack::iterator> &unstacked )
 {
@@ -555,8 +548,6 @@ std::vector<stacked_items> stack_for_pickup_ui( const
     return restacked_with_parents;
 }
 
-// Non-static because tests
-std::vector<std::list<item_stack::iterator>> flatten( const std::vector<stacked_items> &stacked );
 std::vector<std::list<item_stack::iterator>> flatten( const std::vector<stacked_items> &stacked )
 {
     std::vector<std::list<item_stack::iterator>> flat;
@@ -570,6 +561,8 @@ std::vector<std::list<item_stack::iterator>> flatten( const std::vector<stacked_
 
     return flat;
 }
+
+} // namespace pickup
 
 // Pick up items at (pos).
 void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -479,7 +479,7 @@ struct unstacked_items {
 std::vector<stacked_items> stack_for_pickup_ui( const
         std::vector<item_stack::iterator> &unstacked )
 {
-    constexpr std::pair<time_point, int> no_parent = std::make_pair( time_point::from_turn( -1 ), 0 );
+    constexpr std::pair<time_point, int> no_parent = std::make_pair( time_point::before_time_starts, 0 );
     std::map<std::pair<time_point, int>, parent_child_check_t> parent_child_check;
     // First, we need to check which parent-child groups exist
     for( item_stack::iterator it : unstacked ) {

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -12,26 +12,10 @@ class JsonOut;
 class map;
 struct tripoint;
 
-// TODO: Move this!
-#include "item_location.h"
-#include "optional.h"
-
 namespace pickup
 {
 
-struct pick_drop_selection {
-    item_location target;
-    cata::optional<int> quantity;
-    std::vector<item_location> children;
-
-    void serialize( JsonOut &jsout ) const;
-    void deserialize( JsonIn &jin );
-};
-
-// TODO: This should get information on whether children are consecutive
-/** Finds possible parent-child relations in picked up items to save moves */
-std::vector<pick_drop_selection> optimize_pickup( const std::vector<item_location> &targets,
-        const std::vector<int> &quantities );
+struct pick_drop_selection;
 
 /**
  * Returns `false` if the player was presented a prompt and decided to cancel the pickup.
@@ -62,6 +46,6 @@ int cost_to_move_item( const Character &who, const item &it );
  * @param m map they are on
  */
 bool handle_spillable_contents( Character &c, item &it, map &m );
-} // namespace Pickup
+} // namespace pickup
 
 #endif // CATA_SRC_PICKUP_H

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -7,17 +7,37 @@
 class item;
 class item_location;
 class Character;
+class JsonIn;
+class JsonOut;
 class map;
 struct tripoint;
 
-namespace Pickup
+// TODO: Move this!
+#include "item_location.h"
+#include "optional.h"
+
+namespace pickup
 {
+
+struct pick_drop_selection {
+    item_location target;
+    cata::optional<int> quantity;
+    std::vector<item_location> children;
+
+    void serialize( JsonOut &jsout ) const;
+    void deserialize( JsonIn &jin );
+};
+
+// TODO: This should get information on whether children are consecutive
+/** Finds possible parent-child relations in picked up items to save moves */
+std::vector<pick_drop_selection> optimize_pickup( const std::vector<item_location> &targets,
+        const std::vector<int> &quantities );
+
 /**
  * Returns `false` if the player was presented a prompt and decided to cancel the pickup.
  * `true` in other cases.
  */
-bool do_pickup( std::vector<item_location> &targets, std::vector<int> &quantities,
-                bool autopickup );
+bool do_pickup( std::vector<pick_drop_selection> &targets, bool autopickup );
 bool query_thief();
 
 enum from_where : int {

--- a/src/pickup_token.h
+++ b/src/pickup_token.h
@@ -1,0 +1,64 @@
+#pragma once
+#ifndef CATA_SRC_PICKUP_TOKEN_H
+#define CATA_SRC_PICKUP_TOKEN_H
+
+#include <list>
+#include <vector>
+#include "item_location.h"
+#include "item_stack.h"
+#include "optional.h"
+
+class JsonIn;
+class JsonOut;
+
+using drop_location = std::pair<item_location, int>;
+using drop_locations = std::list<drop_location>;
+
+namespace pickup
+{
+
+/** Activity-associated item */
+struct act_item {
+    /// inventory item
+    item_location loc;
+    /// How many items need to be processed
+    int count;
+    /// Amount of moves that processing will consume
+    int consumed_moves;
+
+    act_item( const item_location &loc, int count, int consumed_moves )
+        : loc( loc ),
+          count( count ),
+          consumed_moves( consumed_moves ) {}
+};
+
+struct pick_drop_selection {
+    item_location target;
+    cata::optional<int> quantity;
+    std::vector<item_location> children;
+
+    void serialize( JsonOut &jsout ) const;
+    void deserialize( JsonIn &jin );
+};
+
+struct stacked_items {
+    cata::optional<item_stack::iterator> parent;
+    std::vector<std::list<item_stack::iterator>> stacked_children;
+};
+
+// TODO: This should get information on whether children are consecutive
+/** Finds possible parent-child relations in picked up items to save moves */
+std::vector<pick_drop_selection> optimize_pickup( const std::vector<item_location> &targets,
+        const std::vector<int> &quantities );
+std::list<act_item> reorder_for_dropping( Character &p, const drop_locations &drop );
+std::list<item> obtain_and_tokenize_items( player &p, std::list<act_item> &items );
+std::vector<item_location> extract_children( std::vector<item_location> &targets,
+        item_location &stack_top );
+std::vector<stacked_items> stack_for_pickup_ui( const
+        std::vector<item_stack::iterator> &unstacked );
+// TODO: This probably shouldn't return raw iterators
+std::vector<std::list<item_stack::iterator>> flatten( const std::vector<stacked_items> &stacked );
+
+} // namespace pickup
+
+#endif // CATA_SRC_PICKUP_TOKEN_H

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3055,9 +3055,9 @@ bool player::add_or_drop_with_msg( item &it, const bool unloading )
     it.charges = this->i_add_to_container( it, unloading );
     if( it.is_ammo() && it.charges == 0 ) {
         return true;
-    } else if( !this->can_pickVolume( it ) ) {
+    } else if( !this->can_pick_volume( it ) ) {
         put_into_vehicle_or_drop( *this, item_drop_reason::too_large, { it } );
-    } else if( !this->can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
+    } else if( !this->can_pick_weight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
         put_into_vehicle_or_drop( *this, item_drop_reason::too_heavy, { it } );
     } else {
         auto &ni = this->i_add( it );

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2022,7 +2022,7 @@ static bool query_consume_ownership( item &target, player &p )
     if( !target.is_owned_by( p, true ) ) {
         bool choice = true;
         if( p.get_value( "THIEF_MODE" ) == "THIEF_ASK" ) {
-            choice = Pickup::query_thief();
+            choice = pickup::query_thief();
         }
         if( p.get_value( "THIEF_MODE" ) == "THIEF_HONEST" || !choice ) {
             return false;
@@ -2129,7 +2129,7 @@ bool player::consume( item_location loc )
             }
         }
     } else if( inv_item ) {
-        if( Pickup::handle_spillable_contents( *this, target, g->m ) ) {
+        if( pickup::handle_spillable_contents( *this, target, g->m ) ) {
             i_rem( &target );
         }
         inv.restack( *this );

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <utility>
 
+#include "activity_actor.h"
 #include "activity_handlers.h"
 #include "activity_type.h"
 #include "avatar.h"
@@ -50,6 +51,10 @@ player_activity::player_activity( activity_id t, int turns, int Index, int pos,
 
 player_activity::player_activity( const activity_actor &actor ) : type( actor.get_type() ),
     actor( actor.clone() ), moves_total( 0 ), moves_left( 0 )
+{
+}
+
+player_activity::~player_activity()
 {
 }
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -54,9 +54,7 @@ player_activity::player_activity( const activity_actor &actor ) : type( actor.ge
 {
 }
 
-player_activity::~player_activity()
-{
-}
+player_activity::~player_activity() = default;
 
 void player_activity::migrate_item_position( Character &guy )
 {

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -19,6 +19,7 @@
 #include "point.h"
 #include "type_id.h"
 
+class activity_actor;
 class Character;
 class JsonIn;
 class JsonOut;
@@ -70,6 +71,7 @@ class player_activity
         // TODO: delete this constructor once migration to the activity_actor system is complete
         player_activity( activity_id, int turns = 0, int Index = -1, int pos = INT_MIN,
                          const std::string &name_in = "" );
+        ~player_activity();
         /**
          * Create a new activity with the given actor
          */

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -17,6 +17,7 @@
 #include "coordinate_conversions.h"
 #include "creature_tracker.h"
 #include "debug.h"
+#include "drop_token.h"
 #include "enum_conversions.h"
 #include "faction.h"
 #include "hash_utils.h"
@@ -106,6 +107,8 @@ void game::serialize( std::ostream &fout )
     json.member( "kill_tracker", *kill_tracker_ptr );
     json.member( "stats_tracker", *stats_tracker_ptr );
     json.member( "achievements_tracker", *achievements_tracker_ptr );
+
+    json.member( "token_provider", *token_provider_ptr );
 
     json.member( "player", u );
     Messages::serialize( json );
@@ -245,6 +248,7 @@ void game::unserialize( std::istream &fin )
         data.read( "player", u );
         data.read( "stats_tracker", *stats_tracker_ptr );
         data.read( "achievements_tracker", *achievements_tracker_ptr );
+        data.read( "token_provider", token_provider_ptr );
         Messages::deserialize( data );
 
     } catch( const JsonError &jsonerr ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -49,6 +49,7 @@
 #include "creature.h"
 #include "creature_tracker.h"
 #include "debug.h"
+#include "drop_token.h"
 #include "effect.h"
 #include "enum_conversions.h"
 #include "event.h"
@@ -2254,6 +2255,8 @@ void item::io( Archive &archive )
 
     static const cata::value_ptr<relic> null_relic_ptr = nullptr;
     archive.io( "relic_data", relic_data, null_relic_ptr );
+
+    archive.io( "drop_token", drop_token, decltype( drop_token )() );
 
     item_controller->migrate_item( orig, *this );
 

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2199,14 +2199,14 @@ void vehicle::interact_with( const tripoint &pos, int interact_part )
             return;
         }
         case GET_ITEMS_ON_GROUND: {
-            Pickup::pick_up( pos, 0, Pickup::from_ground );
+            pickup::pick_up( pos, 0, pickup::from_ground );
             return;
         }
         case GET_ITEMS: {
             if( from_vehicle ) {
-                Pickup::pick_up( pos, 0, Pickup::from_cargo );
+                pickup::pick_up( pos, 0, pickup::from_cargo );
             } else {
-                Pickup::pick_up( pos, 0, Pickup::from_ground );
+                pickup::pick_up( pos, 0, pickup::from_ground );
             }
             return;
         }

--- a/tests/drop_token_test.cpp
+++ b/tests/drop_token_test.cpp
@@ -1,0 +1,78 @@
+#include <algorithm>
+#include <climits>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "activity_handlers.h"
+#include "avatar.h"
+#include "calendar.h"
+#include "catch/catch.hpp"
+#include "drop_token.h"
+#include "item.h"
+#include "player_helpers.h"
+
+class inventory;
+struct act_item;
+
+std::list<act_item> reorder_for_dropping( Character &p, const drop_locations &drop );
+
+struct act_item {
+    /// inventory item
+    item_location loc;
+    /// How many items need to be processed
+    int count;
+    /// Amount of moves that processing will consume
+    int consumed_moves;
+
+    act_item( const item_location &loc, int count, int consumed_moves )
+        : loc( loc ),
+          count( count ),
+          consumed_moves( consumed_moves ) {}
+};
+
+TEST_CASE( "full backpack drop", "[activity][drop_token]" )
+{
+    const itype_id backpack_id = "backpack";
+    avatar dummy;
+    item an_item( "bottle_glass" );
+
+    GIVEN( "a character with a backpack full of items and no other containers" ) {
+        REQUIRE( dummy.wear_item( item( backpack_id ), false ) );
+        while( dummy.can_pickWeight( an_item, true ) && dummy.can_pickVolume( an_item ) ) {
+            dummy.i_add( an_item );
+        }
+
+        REQUIRE( dummy.worn.size() == 1 );
+        REQUIRE( dummy.inv.size() >= 1 );
+
+        WHEN( "he considers dropping items" ) {
+            drop_locations drop;
+            drop.push_back( drop_location( item_location( dummy, &dummy.worn.front() ), 1 ) );
+            std::list<act_item> drop_list = reorder_for_dropping( dummy, drop );
+            THEN( "he will try to drop all carried items" ) {
+                // TODO: Check that all items will be dropped. inv.size() doesn't work because stacks
+                AND_THEN( "all of them will have identical drop tokens, marking the backpack as parent" ) {
+                    item_drop_token first_token = *drop_list.front().loc->drop_token;
+                    for( const act_item &ait : drop_list ) {
+                        CHECK( *ait.loc->drop_token == first_token );
+                    }
+                }
+                AND_THEN( "the backpack will have non-zero drop cost, while all contents will have zero drop cost" ) {
+                    REQUIRE( drop_list.front().loc->typeId() == backpack_id );
+                    auto iter = drop_list.begin();
+                    CHECK( iter->consumed_moves > 0 );
+                    iter++;
+                    while( iter != drop_list.end() ) {
+                        CHECK( iter->consumed_moves == 0 );
+                        iter++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/drop_token_test.cpp
+++ b/tests/drop_token_test.cpp
@@ -274,14 +274,15 @@ TEST_CASE( "full backpack pickup", "[drop_token]" )
     dummy.worn.emplace_back( duffel_bag );
 
     map &here = get_map();
+    drop_token_provider &token_provider = drop_token::get_provider();
     GIVEN( "a backpack full of items lying on a ground tile" ) {
         item &parent = here.add_item( pos, backpack );
-        *parent.drop_token = drop_token::make_next();
+        *parent.drop_token = token_provider.make_next( calendar::turn );
         for( units::volume remaining_storage = backpack.get_storage();
              remaining_storage > an_item.volume();
              remaining_storage -= an_item.volume() ) {
             item &child = here.add_item( pos, an_item );
-            *child.drop_token = drop_token::make_next();
+            *child.drop_token = token_provider.make_next( calendar::turn );
             child.drop_token->parent_number = parent.drop_token->drop_number;
         }
 
@@ -355,15 +356,17 @@ TEST_CASE( "pickup_ui_stacking", "[activity][drop_token]" )
     item duffel_bag( "duffelbag" );
     const size_t per_backpack = backpack.get_total_capacity() / an_item.volume();
 
+    drop_token_provider &token_provider = drop_token::get_provider();
+
     GIVEN( "A mix of items on the ground, with some of them being in a backpack" ) {
         testing_stack the_stack;
         the_stack.insert( an_item );
         auto insert_parent_iter = the_stack.insert_with_return( backpack );
-        item_drop_token parent_token = drop_token::make_next();
+        item_drop_token parent_token = token_provider.make_next( calendar::turn );
         *( *insert_parent_iter ).drop_token = parent_token;
         for( size_t i = 0; i < per_backpack; i++ ) {
             auto child_iter = the_stack.insert_with_return( an_item );
-            *( *child_iter ).drop_token = drop_token::make_next();
+            *( *child_iter ).drop_token = token_provider.make_next( calendar::turn );
             ( *child_iter ).drop_token->parent_number = parent_token.drop_number;
         }
 
@@ -409,9 +412,9 @@ TEST_CASE( "pickup_ui_stacking", "[activity][drop_token]" )
     GIVEN( "Two backpacks with set tokens, but no contents" ) {
         testing_stack the_stack;
         auto first_backpack_iter = the_stack.insert_with_return( backpack );
-        *first_backpack_iter->drop_token = drop_token::make_next();
+        *first_backpack_iter->drop_token = token_provider.make_next( calendar::turn );
         auto second_backpack_iter = the_stack.insert_with_return( backpack );
-        *second_backpack_iter->drop_token = drop_token::make_next();
+        *second_backpack_iter->drop_token = token_provider.make_next( calendar::turn );
 
         std::vector<item_stack::iterator> unstacked = iterators_in_vector( the_stack );
 
@@ -427,17 +430,17 @@ TEST_CASE( "pickup_ui_stacking", "[activity][drop_token]" )
     GIVEN( "Multiple identical items with tokens with different turns and parents set, but with no parents on the item stack" ) {
         testing_stack the_stack;
 
-        item_drop_token first_parent_token = drop_token::make_next();
+        item_drop_token first_parent_token = token_provider.make_next( calendar::turn );
         for( size_t i = 0; i < per_backpack; i++ ) {
             auto child_iter = the_stack.insert_with_return( an_item );
-            *( *child_iter ).drop_token = drop_token::make_next();
+            *( *child_iter ).drop_token = token_provider.make_next( calendar::turn );
             ( *child_iter ).drop_token->parent_number = first_parent_token.drop_number;
         }
 
-        item_drop_token second_parent_token = drop_token::make_next();
+        item_drop_token second_parent_token = token_provider.make_next( calendar::turn );
         for( size_t i = 0; i < per_backpack; i++ ) {
             auto child_iter = the_stack.insert_with_return( an_item );
-            *( *child_iter ).drop_token = drop_token::make_next();
+            *( *child_iter ).drop_token = token_provider.make_next( calendar::turn );
             ( *child_iter ).drop_token->parent_number = second_parent_token.drop_number;
         }
 

--- a/tests/drop_token_test.cpp
+++ b/tests/drop_token_test.cpp
@@ -38,6 +38,7 @@ struct act_item {
 TEST_CASE( "full backpack drop", "[activity][drop_token]" )
 {
     const itype_id backpack_id = "backpack";
+    const itype_id duffel_id = "duffelbag";
     avatar dummy;
     item an_item( "bottle_glass" );
 
@@ -50,7 +51,7 @@ TEST_CASE( "full backpack drop", "[activity][drop_token]" )
         REQUIRE( dummy.worn.size() == 1 );
         REQUIRE( dummy.inv.size() >= 1 );
 
-        WHEN( "he considers dropping items" ) {
+        WHEN( "he considers dropping the backpack" ) {
             drop_locations drop;
             drop.push_back( drop_location( item_location( dummy, &dummy.worn.front() ), 1 ) );
             std::list<act_item> drop_list = reorder_for_dropping( dummy, drop );
@@ -71,6 +72,89 @@ TEST_CASE( "full backpack drop", "[activity][drop_token]" )
                         CHECK( iter->consumed_moves == 0 );
                         iter++;
                     }
+                }
+                AND_THEN( "total volume dropped will equal volume of backpack and all items in inventory" ) {
+                    units::volume total_dropped = std::accumulate( drop_list.begin(), drop_list.end(), 0_ml,
+                    []( units::volume acc, const act_item & ait ) {
+                        return acc + ait.loc->volume();
+                    } );
+                    units::volume inventory_volume = dummy.volume_carried();
+                    units::volume worn_volume = std::accumulate( dummy.worn.begin(), dummy.worn.end(), 0_ml,
+                    []( units::volume acc, const item & it ) {
+                        return acc + it.volume();
+                    } );
+                    CHECK( total_dropped == inventory_volume + worn_volume );
+                }
+            }
+        }
+    }
+
+    GIVEN( "a character with two duffel bags and two backpacks full of items and no other containers" ) {
+        REQUIRE( dummy.wear_item( item( duffel_id ), false ) );
+        REQUIRE( dummy.wear_item( item( duffel_id ), false ) );
+        REQUIRE( dummy.wear_item( item( backpack_id ), false ) );
+        REQUIRE( dummy.wear_item( item( backpack_id ), false ) );
+        while( dummy.can_pickWeight( an_item, true ) && dummy.can_pickVolume( an_item ) ) {
+            dummy.i_add( an_item );
+        }
+
+        REQUIRE( dummy.worn.size() == 4 );
+        REQUIRE( dummy.inv.size() >= 1 );
+
+        WHEN( "he considers dropping one duffel bag and one backpack" ) {
+            drop_locations drop;
+            auto first_duffel_iter = std::find_if( dummy.worn.begin(), dummy.worn.end(),
+            [&]( const item & it ) {
+                return it.typeId() == duffel_id;
+            } );
+            auto first_backpack_iter = std::find_if( dummy.worn.begin(), dummy.worn.end(),
+            [&]( const item & it ) {
+                return it.typeId() == backpack_id;
+            } );
+            REQUIRE( first_duffel_iter != dummy.worn.end() );
+            REQUIRE( first_backpack_iter != dummy.worn.end() );
+            drop.push_back( drop_location( item_location( dummy, &*first_duffel_iter ), 1 ) );
+            drop.push_back( drop_location( item_location( dummy, &*first_backpack_iter ), 1 ) );
+            std::list<act_item> drop_list = reorder_for_dropping( dummy, drop );
+            THEN( "he will try to drop some, but not all of the carried items" ) {
+                REQUIRE( drop_list.size() > 2 );
+
+                units::volume total_dropped = std::accumulate( drop_list.begin(), drop_list.end(), 0_ml,
+                []( units::volume acc, const act_item & ait ) {
+                    return acc + ait.loc->volume();
+                } );
+                units::volume inventory_volume = dummy.volume_carried();
+                units::volume worn_dropped_volume = first_duffel_iter->volume() + first_backpack_iter->volume();
+                CHECK( total_dropped - worn_dropped_volume < inventory_volume );
+
+                AND_THEN( "dropped duffel bag and backpack will have non-zero drop cost, while all contents will have zero drop cost" ) {
+                    auto drop_duffel_iter = std::find_if( drop_list.begin(), drop_list.end(),
+                    [&]( const act_item & ait ) {
+                        return ait.loc->typeId() == duffel_id;
+                    } );
+                    auto drop_backpack_iter = std::find_if( drop_list.begin(), drop_list.end(),
+                    [&]( const act_item & ait ) {
+                        return ait.loc->typeId() == backpack_id;
+                    } );
+                    REQUIRE( drop_duffel_iter != drop_list.end() );
+                    REQUIRE( drop_backpack_iter != drop_list.end() );
+                    for( auto iter = drop_list.begin(); iter != drop_list.end(); iter++ ) {
+                        if( iter == drop_duffel_iter || iter == drop_backpack_iter ) {
+                            CHECK( iter->consumed_moves > 0 );
+                        } else {
+                            CHECK( iter->consumed_moves == 0 );
+                        }
+                    }
+
+                    /*
+                    // TODO: Drop tokens are added after reordering, in drop phase
+                    AND_THEN("some, but not all of the contents will share a drop token with the duffel bag") {
+                        std::count_if(drop_list.begin(), drop_list.end(),
+                    [&]( const act_item & ait ) {
+                        return ait.loc->drop_token == drop_duffel_iter->loc->drop_token;
+                    } );
+                    }
+                    */
                 }
             }
         }

--- a/tests/drop_token_test.cpp
+++ b/tests/drop_token_test.cpp
@@ -37,13 +37,19 @@ struct act_item {
 
 TEST_CASE( "full backpack drop", "[activity][drop_token]" )
 {
-    const itype_id backpack_id = "backpack";
-    const itype_id duffel_id = "duffelbag";
     avatar dummy;
     item an_item( "bottle_glass" );
+    item backpack( "backpack" );
+    item duffel_bag( "duffelbag" );
+
+    // Filling item and container types can be freely changed, as long as they meet this:
+    REQUIRE( backpack.get_storage() % an_item.volume() == 0_ml );
+    REQUIRE( backpack.get_storage() / an_item.volume() > 1 );
+    REQUIRE( duffel_bag.get_storage() % an_item.volume() > 0_ml );
+    REQUIRE( duffel_bag.get_storage() / an_item.volume() > 1 );
 
     GIVEN( "a character with a backpack full of items and no other containers" ) {
-        REQUIRE( dummy.wear_item( item( backpack_id ), false ) );
+        REQUIRE( dummy.wear_item( backpack, false ) );
         while( dummy.can_pickWeight( an_item, true ) && dummy.can_pickVolume( an_item ) ) {
             dummy.i_add( an_item );
         }
@@ -64,7 +70,7 @@ TEST_CASE( "full backpack drop", "[activity][drop_token]" )
                     }
                 }
                 AND_THEN( "the backpack will have non-zero drop cost, while all contents will have zero drop cost" ) {
-                    REQUIRE( drop_list.front().loc->typeId() == backpack_id );
+                    REQUIRE( drop_list.front().loc->typeId() == backpack.typeId() );
                     auto iter = drop_list.begin();
                     CHECK( iter->consumed_moves > 0 );
                     iter++;
@@ -90,10 +96,10 @@ TEST_CASE( "full backpack drop", "[activity][drop_token]" )
     }
 
     GIVEN( "a character with two duffel bags and two backpacks full of items and no other containers" ) {
-        REQUIRE( dummy.wear_item( item( duffel_id ), false ) );
-        REQUIRE( dummy.wear_item( item( duffel_id ), false ) );
-        REQUIRE( dummy.wear_item( item( backpack_id ), false ) );
-        REQUIRE( dummy.wear_item( item( backpack_id ), false ) );
+        REQUIRE( dummy.wear_item( duffel_bag, false ) );
+        REQUIRE( dummy.wear_item( duffel_bag, false ) );
+        REQUIRE( dummy.wear_item( backpack, false ) );
+        REQUIRE( dummy.wear_item( backpack, false ) );
         while( dummy.can_pickWeight( an_item, true ) && dummy.can_pickVolume( an_item ) ) {
             dummy.i_add( an_item );
         }
@@ -105,11 +111,11 @@ TEST_CASE( "full backpack drop", "[activity][drop_token]" )
             drop_locations drop;
             auto first_duffel_iter = std::find_if( dummy.worn.begin(), dummy.worn.end(),
             [&]( const item & it ) {
-                return it.typeId() == duffel_id;
+                return it.typeId() == duffel_bag.typeId();
             } );
             auto first_backpack_iter = std::find_if( dummy.worn.begin(), dummy.worn.end(),
             [&]( const item & it ) {
-                return it.typeId() == backpack_id;
+                return it.typeId() == backpack.typeId();
             } );
             REQUIRE( first_duffel_iter != dummy.worn.end() );
             REQUIRE( first_backpack_iter != dummy.worn.end() );
@@ -117,7 +123,7 @@ TEST_CASE( "full backpack drop", "[activity][drop_token]" )
             drop.push_back( drop_location( item_location( dummy, &*first_backpack_iter ), 1 ) );
             std::list<act_item> drop_list = reorder_for_dropping( dummy, drop );
             THEN( "he will try to drop some, but not all of the carried items" ) {
-                REQUIRE( drop_list.size() > 2 );
+                REQUIRE( drop_list.size() > 4 );
 
                 units::volume total_dropped = std::accumulate( drop_list.begin(), drop_list.end(), 0_ml,
                 []( units::volume acc, const act_item & ait ) {
@@ -130,11 +136,11 @@ TEST_CASE( "full backpack drop", "[activity][drop_token]" )
                 AND_THEN( "dropped duffel bag and backpack will have non-zero drop cost, while all contents will have zero drop cost" ) {
                     auto drop_duffel_iter = std::find_if( drop_list.begin(), drop_list.end(),
                     [&]( const act_item & ait ) {
-                        return ait.loc->typeId() == duffel_id;
+                        return ait.loc->typeId() == duffel_bag.typeId();
                     } );
                     auto drop_backpack_iter = std::find_if( drop_list.begin(), drop_list.end(),
                     [&]( const act_item & ait ) {
-                        return ait.loc->typeId() == backpack_id;
+                        return ait.loc->typeId() == backpack.typeId();
                     } );
                     REQUIRE( drop_duffel_iter != drop_list.end() );
                     REQUIRE( drop_backpack_iter != drop_list.end() );
@@ -146,16 +152,74 @@ TEST_CASE( "full backpack drop", "[activity][drop_token]" )
                         }
                     }
 
-                    /*
-                    // TODO: Drop tokens are added after reordering, in drop phase
-                    AND_THEN("some, but not all of the contents will share a drop token with the duffel bag") {
-                        std::count_if(drop_list.begin(), drop_list.end(),
-                    [&]( const act_item & ait ) {
-                        return ait.loc->drop_token == drop_duffel_iter->loc->drop_token;
-                    } );
+                    AND_THEN( "both containers will be followed by enough zero-cost items to fill them" ) {
+                        const int expected_duffel_content_count = duffel_bag.get_total_capacity() / an_item.volume();
+                        const int expected_backpack_content_count = backpack.get_total_capacity() / an_item.volume();
+
+                        int actual_duffel_content_count = 0;
+                        for( auto iter = std::next( drop_duffel_iter ); iter != drop_list.end(); iter++ ) {
+                            if( iter->consumed_moves == 0 && iter->loc->typeId() == an_item.typeId() ) {
+                                actual_duffel_content_count++;
+                            } else {
+                                break;
+                            }
+                        }
+
+                        int actual_backpack_content_count = 0;
+                        for( auto iter = std::next( drop_backpack_iter ); iter != drop_list.end(); iter++ ) {
+                            if( iter->consumed_moves == 0 && iter->loc->typeId() == an_item.typeId() ) {
+                                actual_backpack_content_count++;
+                            } else {
+                                break;
+                            }
+                        }
+
+                        CHECK( actual_duffel_content_count == expected_duffel_content_count );
+                        // TODO: Check tokens! The last item should be uncontained
+                        CHECK( actual_backpack_content_count == expected_backpack_content_count + 1 );
+
+                        /*
+                        // TODO: Extract drop-tokening, then check tokens here
+                        AND_THEN( "one item will not fit in either container and so will have a different token" ) {
+                            const size_t actual_zero_cost_count = std::count_if( drop_list.begin(), drop_list.end(),
+                            [&]( const act_item & ait ) {
+                                return ait.consumed_moves == 0;
+                            } );
+                            // Two containers + one item outside them
+                            const size_t expected_zero_cost_count = drop_list.size() - 2 - 1;
+                            CHECK( actual_zero_cost_count == expected_zero_cost_count );
+                        }
+                        */
                     }
-                    */
                 }
+            }
+        }
+    }
+
+    GIVEN( "a character with two duffel bags full of items" ) {
+        REQUIRE( dummy.wear_item( duffel_bag, false ) );
+        REQUIRE( dummy.wear_item( duffel_bag, false ) );
+        while( dummy.can_pickWeight( an_item, true ) && dummy.can_pickVolume( an_item ) ) {
+            dummy.i_add( an_item );
+        }
+
+        WHEN( "he considers dropping only one of the bags, but all of the items" ) {
+            drop_locations drop;
+            drop.push_back( drop_location( item_location( dummy, &dummy.worn.front() ), 1 ) );
+            std::vector<item *> dump;
+            dummy.inv.dump( dump );
+            for( item *it : dump ) {
+                drop.push_back( drop_location( item_location( dummy, it ), 1 ) );
+            }
+
+            std::list<act_item> drop_list = reorder_for_dropping( dummy, drop );
+            THEN( "at most half of the non-bag items will have zero drop cost" ) {
+                const size_t actual_zero_cost = std::count_if( drop_list.begin(), drop_list.end(),
+                [&]( const act_item & ait ) {
+                    return ait.consumed_moves == 0;
+                } );
+                const size_t expected_zero_cost = ( drop_list.size() - 1 ) / 2;
+                CHECK( actual_zero_cost == expected_zero_cost );
             }
         }
     }

--- a/tests/drop_token_test.cpp
+++ b/tests/drop_token_test.cpp
@@ -24,14 +24,11 @@
 #include "units_mass.h"
 #include "units_volume.h"
 
-class inventory;
-struct act_item;
-
 class testing_stack : public item_stack
 {
     public:
         testing_stack() : item_stack( new cata::colony<item>() ) { }
-        ~testing_stack() {
+        ~testing_stack() override {
             delete( items );
         }
 

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -260,8 +260,9 @@ static void pick_up_from_feet( player &p, int id )
     REQUIRE( found );
 
     p.moves = 100;
-    p.assign_activity( player_activity( pickup_activity_actor( { item_location( map_cursor( p.pos() ), found ) }, { 0 },
-                                        p.pos() ) ) );
+    p.assign_activity( player_activity(
+    pickup_activity_actor( { { item_location( map_cursor( p.pos() ), found ), 0, {} } },
+    p.pos() ) ) );
     p.activity.do_turn( p );
 
     REQUIRE( items.size() == size_before - 1 );

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -87,8 +87,7 @@ void clear_character( player &dummy, bool debug_storage )
     dummy.reset_chargen_attributes();
     dummy.set_pain( 0 );
     dummy.reset_bonuses();
-    dummy.set_speed_base( 100 );
-    dummy.set_speed_bonus( 0 );
+    dummy.set_moves( -100 );
 
     // Restore all stamina and go to walk mode
     dummy.set_stamina( dummy.get_stamina_max() );
@@ -116,6 +115,8 @@ void clear_character( player &dummy, bool debug_storage )
 
     const tripoint spot( 60, 60, 0 );
     dummy.setpos( spot );
+
+    dummy.invalidate_crafting_inventory();
 }
 
 void clear_avatar()


### PR DESCRIPTION
Support for drop backpack->pick up backpack feature, without explicit inclusion of items in each other.

The idea is as follows:
* Dropped item gains a token
* The token is based on current turn and a value that is reset to 0 every turn and goes up with dropped items
* The token also has a "parent" number, which can link it to another token of an item dropped in the same turn
* When an item is about to be picked up, all items "above" (or "below", depending on menu) it are checked for parenthood. If they're children of this item, they're "in" it, so should be displayed with an indent and should be marked for pickup as well. If the parent+all children are picked up, it's one action, cheaper than it would be otherwise

This is for drops.
Having bags prefer some items when dropped or some items prefer some bags would be a separate thing.

In this PR I want to:
* [x] Implement the drop token generation and parent checks
* [x] When player drops a worn item container, mark up to its max volume in dropped items as its children, ensuring the container is dropped right before them
* [x] When picking a wearable container up, mark its children for pickup and if pickup if confirmed execute it in one action (per container+children)
* [x] Prevent stacking of containers with children and children with parents
* [x] Sort children after parents in UI
* [x] Fix parent-less items not stacking
* [x] Fix child-less parents not stacking
* [x] Save/load tokens on save/load game

Would be good to fix, but I won't fix in this PR:
* Fix count-by-charges items with separate parents (say, stack of flour too large to fit in one bag)

Out of scope of this PR are:
* How to mark items as belonging to containers for easier drops. In this PR, items will be dropped "in a dumb way", for simplicity of implementation.
* Wearing a container from the ground. In this PR, it will orphan the children.
* Time travel bugs causing some items to falsely become contained
* AIM preserving tokens rather than clearing them on pickup/move
* Packmule and disorganized affecting dropped containers. For now, un-equipped containers will be "normal sized".
* Wielded bag's effect on drop/pickup. At the moment, wielding during pickup will move items into inventory, most likely resulting in a spill due to overload.
* Previewing which items will be dropped when a worn bag is dropped. This would sure be useful, but the PR is too big.

EDIT: Death drops thing would require some extra work due to the way death drops are handled. I don't want horrible hacks, so for now it'll be just player drops (the main thing).