### PR TITLE
Fix bugs with vehicle-spawning scenarios/professions

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -643,6 +643,13 @@ bool game::start_game()
     }
     start_loc.prepare_map( omtstart );
 
+    // Place vehicles spawned by scenario or profession, has to be placed very early to avoid bugs.
+    if( u.starting_vehicle &&
+        !place_vehicle_nearby( u.starting_vehicle, omtstart.xy(), 0, 30,
+                               std::vector<std::string> {} ) ) {
+        debugmsg( "could not place starting vehicle" );
+    }
+
     if( scen->has_map_extra() ) {
         // Map extras can add monster spawn points and similar and should be done before the main
         // map is loaded.
@@ -762,12 +769,6 @@ bool game::start_game()
     }
     for( auto &e : u.inv_dump() ) {
         e->set_owner( g->u );
-    }
-    // Place vehicles spawned by scenario or profession.
-    if( u.starting_vehicle &&
-        !place_vehicle_nearby( u.starting_vehicle, u.global_omt_location().xy(), 1, 30,
-                               std::vector<std::string> {} ) ) {
-        debugmsg( "could not place starting vehicle" );
     }
     // Now that we're done handling coordinates, ensure the player's submap is in the center of the map
     update_map( u );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -763,6 +763,12 @@ bool game::start_game()
     for( auto &e : u.inv_dump() ) {
         e->set_owner( g->u );
     }
+    // Place vehicles spawned by scenario or profession.
+    if( u.starting_vehicle &&
+        !place_vehicle_nearby( u.starting_vehicle, u.global_omt_location().xy(), 1, 30,
+                               std::vector<std::string> {} ) ) {
+        debugmsg( "could not place starting vehicle" );
+    }
     // Now that we're done handling coordinates, ensure the player's submap is in the center of the map
     update_map( u );
     // Profession pets
@@ -773,11 +779,6 @@ bool game::start_game()
         } else {
             add_msg( m_debug, "cannot place starting pet, no space!" );
         }
-    }
-    if( u.starting_vehicle &&
-        !place_vehicle_nearby( u.starting_vehicle, u.global_omt_location().xy(), 1, 30,
-                               std::vector<std::string> {} ) ) {
-        debugmsg( "could not place starting vehicle" );
     }
     // Assign all of this scenario's missions to the player.
     for( const mission_type_id &m : scen->missions() ) {
@@ -826,6 +827,7 @@ vehicle *game::place_vehicle_nearby( const vproto_id &id, const point &origin, i
                 veh->sm_pos =  ms_to_sm_remain( abs_local );
                 veh->pos = abs_local.xy();
                 overmap_buffer.add_vehicle( veh );
+                veh->tracking_on = true;
                 target_map.save();
                 return veh;
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix two bugs with vehicles spawned by scenarios and professions"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Per discussion in https://github.com/cataclysmbnteam/Cataclysm-BN/issues/594 I tested two suggested code changes that turned out to be simple, and fixed both the main issues without any apparent problem.

And thanks to Olanti's advice, it can now spawn near the player if there is adequate space, so all three problems found in the issue are solved.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/594

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Moved the vehicle-placement section in `game::start_game` to occur before the `build_map_cache` and `update_map` bits Fixes spawned vehicle taking several seconds to apparently magic its way in out of thin air, and (together with setting it to allow a minimum radius of zero) fixes the issue of it always preferring to spawn the vehicle out of your start location.
2. Set the vehicle thus spawned to count as being tracked already, fixing the issue where a vehicle tracking indicator mysterious spawned but remained fixed at the location the vehicle spawned in.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Forgetting (again) to test out the proposed code changes I said I was going to test out when I had time.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested the game.
2. Spawned in the Ride of The Valkyries scenario confirmed the helicopter was already present as soon as I spawned.
3. Examined the vehicle, noting that the tracking option was now set to "remove tracking indicator" instead of giving the option to start tracking it.
4. Flew off in it, checked the map to confirm the vehicle tracking indicator had moved too.
5. Started a new game in a field, after fixing the last leftover bug, to confirm it can now spawn at my spawn location.
6. Started another new game in a forest afterward, to confirm it'll still spawn in the closest available field instead of bugging out if there isn't clear space at your position.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
