### PR TITLE
Fix permanent effects from spells require min_duration

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -392,12 +392,18 @@ static std::set<tripoint> spell_effect_area( const spell &sp, const tripoint &ta
 
 static void add_effect_to_target( const tripoint &target, const spell &sp )
 {
-    const int dur_moves = sp.duration();
-    const time_duration dur_td = 1_turns * dur_moves / 100;
-
     Creature *const critter = g->critter_at<Creature>( target );
     Character *const guy = g->critter_at<Character>( target );
     efftype_id spell_effect( sp.effect_data() );
+
+    // TODO: migrate duration from moves to time_duration
+    const int dur_turns = sp.duration() / 100;
+    // Ensure permanent effect has at last 1 second of duration,
+    // so it won't be instantly removed as expired.
+    time_duration dur_td = ( spell_effect->is_permanent() && dur_turns == 0 )
+                           ? 1_seconds
+                           : 1_turns * dur_turns;
+
     bool bodypart_effected = false;
 
     if( guy ) {


### PR DESCRIPTION
If `min_duration` is not specified in spells, it defaults to 0.
If duration of permanent effect is 0, it's removed during turn processing as expired.
However, requiring a permanent effect to have any kind of duration specified is somewhat counter-intuitive.

This change ensures permanent effects from spells get at least 1 second of duration when applied.

Alternatives: always use 1 second for permanent effects applied from spells? Enforce 1-second duration for all permanent effects? Don't remove permanent effects if their duration is 0? I imagine the latter may cause division-by-zero crashes, and the other 2 may restrict possible mechanics centered around effect duration (does it matter, if effects can have intensity anyway?)