### PR TITLE
Fix debugmsg on NPC inventory restack

### DIFF
--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -894,7 +894,7 @@ void player::sort_armor()
                     item &w = *witer;
                     if( invlet == w.invlet ) {
                         ++witer;
-                    } else if( invlet_to_position( invlet ) != INT_MIN ) {
+                    } else if( invlet_to_item( invlet ) != nullptr ) {
                         ++iiter;
                     } else {
                         inv.reassign_item( w, invlet );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2272,6 +2272,31 @@ std::list<item> Character::remove_worn_items_with( std::function<bool( item & )>
     return result;
 }
 
+item *Character::invlet_to_item( const int linvlet )
+{
+    // Invlets may come from curses, which may also return any kind of key codes, those being
+    // of type int and they can become valid, but different characters when casted to char.
+    // Example: KEY_NPAGE (returned when the player presses the page-down key) is 0x152,
+    // casted to char would yield 0x52, which happens to be 'R', a valid invlet.
+    if( linvlet > std::numeric_limits<char>::max() || linvlet < std::numeric_limits<char>::min() ) {
+        return nullptr;
+    }
+    const char invlet = static_cast<char>( linvlet );
+    if( is_npc() ) {
+        // This should be called only for UIs and avatar inventory management
+        debugmsg( "Called Character::invlet_to_item() on NPC (%s)", name );
+    }
+    item *invlet_item = nullptr;
+    visit_items( [&invlet, &invlet_item]( item * it ) {
+        if( it->invlet == invlet ) {
+            invlet_item = it;
+            return VisitResponse::ABORT;
+        }
+        return VisitResponse::NEXT;
+    } );
+    return invlet_item;
+}
+
 // Negative positions indicate weapon/clothing, 0 & positive indicate inventory
 const item &Character::i_at( int position ) const
 {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2292,7 +2292,9 @@ item *Character::invlet_to_item( const int linvlet )
             invlet_item = it;
             return VisitResponse::ABORT;
         }
-        return VisitResponse::NEXT;
+        // Visit top-level items only as UIs don't support nested items.
+        // Also, inventory restack logic depends on this.
+        return VisitResponse::SKIP;
     } );
     return invlet_item;
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2282,10 +2282,6 @@ item *Character::invlet_to_item( const int linvlet )
         return nullptr;
     }
     const char invlet = static_cast<char>( linvlet );
-    if( is_npc() ) {
-        // This should be called only for UIs and avatar inventory management
-        debugmsg( "Called Character::invlet_to_item() on NPC (%s)", name );
-    }
     item *invlet_item = nullptr;
     visit_items( [&invlet, &invlet_item]( item * it ) {
         if( it->invlet == invlet ) {

--- a/src/character.h
+++ b/src/character.h
@@ -1222,6 +1222,11 @@ class Character : public Creature, public visitable<Character>
          */
         std::list<item> remove_worn_items_with( std::function<bool( item & )> filter );
 
+        /** Return the item pointer of the item with given invlet, return nullptr if
+         * the player does not have such an item with that invlet. Don't use this on npcs.
+         * Only use the invlet in the user interface, otherwise always use the item position. */
+        item *invlet_to_item( int invlet );
+
         // Returns the item with a given inventory position.
         item &i_at( int position );
         const item &i_at( int position ) const;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1531,7 +1531,7 @@ void game_menus::inv::swap_letters( player &p )
         [ &p ]( const std::string::value_type & elem ) {
             if( p.inv.assigned_invlet.count( elem ) ) {
                 return c_yellow;
-            } else if( p.invlet_to_position( elem ) != INT_MIN ) {
+            } else if( p.invlet_to_item( elem ) != nullptr ) {
                 return c_white;
             } else {
                 return c_dark_gray;

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -262,7 +262,7 @@ char inventory::find_usable_cached_invlet( const std::string &item_type )
             continue;
         }
         // Check if anything is using this invlet.
-        if( g->u.invlet_to_position( invlet ) != INT_MIN ) {
+        if( g->u.invlet_to_item( invlet ) != nullptr ) {
             continue;
         }
         return invlet;
@@ -341,8 +341,9 @@ void inventory::restack( player &p )
         std::list<item> &stack = *iter;
         item &topmost = stack.front();
 
-        const int ipos = p.invlet_to_position( topmost.invlet );
-        if( !inv_chars.valid( topmost.invlet ) || ( ipos != INT_MIN && ipos != idx ) ) {
+        const item *invlet_item = p.invlet_to_item( topmost.invlet );
+        if( !inv_chars.valid( topmost.invlet ) || ( invlet_item != nullptr &&
+                position_by_item( invlet_item ) != idx ) ) {
             assign_empty_invlet( topmost, p );
             for( auto &stack_iter : stack ) {
                 stack_iter.invlet = topmost.invlet;
@@ -1105,7 +1106,7 @@ void inventory::update_invlet( item &newit, bool assign_invlet )
     if( newit.invlet ) {
         char tmp_invlet = newit.invlet;
         newit.invlet = '\0';
-        if( g->u.invlet_to_position( tmp_invlet ) == INT_MIN ) {
+        if( g->u.invlet_to_item( tmp_invlet ) == nullptr ) {
             newit.invlet = tmp_invlet;
         }
     }

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -244,7 +244,7 @@ bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool &offer
         }
     }
     if( newit.invlet != '\0' &&
-        u.invlet_to_position( newit.invlet ) != INT_MIN ) {
+        u.invlet_to_item( newit.invlet ) != nullptr ) {
         // Existing invlet is not re-usable, remove it and let the code in player.cpp/inventory.cpp
         // add a new invlet, otherwise keep the (usable) invlet.
         newit.invlet = '\0';

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1933,31 +1933,6 @@ item player::reduce_charges( item *it, int quantity )
     return result;
 }
 
-int player::invlet_to_position( const int linvlet ) const
-{
-    // Invlets may come from curses, which may also return any kind of key codes, those being
-    // of type int and they can become valid, but different characters when casted to char.
-    // Example: KEY_NPAGE (returned when the player presses the page-down key) is 0x152,
-    // casted to char would yield 0x52, which happens to be 'R', a valid invlet.
-    if( linvlet > std::numeric_limits<char>::max() || linvlet < std::numeric_limits<char>::min() ) {
-        return INT_MIN;
-    }
-    const char invlet = static_cast<char>( linvlet );
-    if( is_npc() ) {
-        debugmsg( "Called player::invlet_to_position on NPC (%s)", name );
-    }
-    if( weapon.invlet == invlet ) {
-        return -1;
-    }
-    auto iter = worn.begin();
-    for( size_t i = 0; i < worn.size(); i++, iter++ ) {
-        if( iter->invlet == invlet ) {
-            return worn_position_to_index( i );
-        }
-    }
-    return inv.invlet_to_position( invlet );
-}
-
 bool player::can_interface_armor() const
 {
     bool okay = std::any_of( my_bionics->begin(), my_bionics->end(),
@@ -3450,10 +3425,10 @@ void player::reassign_item( item &it, int invlet )
 {
     bool remove_old = true;
     if( invlet ) {
-        item &prev = i_at( invlet_to_position( invlet ) );
-        if( !prev.is_null() ) {
-            remove_old = it.typeId() != prev.typeId();
-            inv.reassign_item( prev, it.invlet, remove_old );
+        item *prev = invlet_to_item( invlet );
+        if( prev != nullptr ) {
+            remove_old = it.typeId() != prev->typeId();
+            inv.reassign_item( *prev, it.invlet, remove_old );
         }
     }
 

--- a/src/player.h
+++ b/src/player.h
@@ -534,10 +534,6 @@ class player : public Character
          * @param quantity How many charges to remove
          */
         item reduce_charges( item *it, int quantity );
-        /** Return the item position of the item with given invlet, return INT_MIN if
-         * the player does not have such an item with that invlet. Don't use this on npcs.
-         * Only use the invlet in the user interface, otherwise always use the item position. */
-        int invlet_to_position( int invlet ) const;
 
         /**
         * Check whether player has a bionic power armor interface.


### PR DESCRIPTION
#### Purpose of change
Fix #607.

#### Describe the solution
Remove the debugmsg as the rest of the code seems ok with NPCs having invlets.

#### Describe alternatives you've considered
Clear all invlets in NPC's inventory instead (as they don't use them anyway), but that breaks invlets in "select item to steal" menu.

#### Testing
There's no more debugmsg when selecting a book for NPC to read.