### PR TITLE
Port speedup for `materials::get_rotting()`

### DIFF
--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -359,6 +359,11 @@ class generic_factory
         virtual void finalize() {
             DynamicDataLoader::get_instance().load_deferred( deferred );
             abstracts.clear();
+
+            inc_version();
+            for( size_t i = 0; i < list.size(); i++ ) {
+                list[i].id.set_cid_version( static_cast<int>( i ), version );
+            }
         }
 
         /**
@@ -386,6 +391,7 @@ class generic_factory
          * Postcondition: `size() == 0`
          */
         void reset() {
+            inc_version();
             list.clear();
             map.clear();
         }

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -471,6 +471,38 @@ class generic_factory
             return obj( id ).id;
         }
         /**@}*/
+
+        /**
+         * Wrapper around generic_factory::version.
+         * Allows to have local caches that invalidate when corresponding generic factory invalidates.
+         * Note: when created using it's default constructor, Version is guaranteed to be invalid.
+        */
+        class Version
+        {
+                friend generic_factory<T>;
+            public:
+                Version() = default;
+            private:
+                Version( int64_t version ) : version( version ) {}
+                int64_t  version = -1;
+            public:
+                bool operator==( const Version &rhs ) const {
+                    return version == rhs.version;
+                }
+                bool operator!=( const Version &rhs ) const {
+                    return !( rhs == *this );
+                }
+        };
+
+        // current version of this generic_factory
+        Version get_version() {
+            return Version( version );
+        }
+
+        // checks whether given version is the same as current version of this generic_factory
+        bool is_valid( const Version &v ) {
+            return v.version == version;
+        }
 };
 
 /**

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -311,12 +311,20 @@ material_list materials::get_compactable()
 
 std::set<material_id> materials::get_rotting()
 {
-    material_list all = get_all();
-    std::set<material_id> rotting;
-    for( const material_type &m : all ) {
-        if( m.rotting() ) {
-            rotting.emplace( m.ident() );
+    static generic_factory<material_type>::Version version;
+    static std::set<material_id> rotting;
+
+    // freshly created version is guaranteed to be invalid
+    if( !material_data.is_valid( version ) ) {
+        material_list all = get_all();
+        rotting.clear();
+        for( const material_type &m : all ) {
+            if( m.rotting() ) {
+                rotting.emplace( m.ident() );
+            }
         }
+        version = material_data.get_version();
     }
+
     return rotting;
 }

--- a/tests/generic_factory_test.cpp
+++ b/tests/generic_factory_test.cpp
@@ -117,6 +117,32 @@ TEST_CASE( "generic_factory_common_null_ids", "[generic_factory]" )
     CHECK( field_type_str_id::NULL_ID().is_valid() );
 }
 
+TEST_CASE( "generic_factory_version_wrapper", "[generic_factory]" )
+{
+    generic_factory<test_obj> test_factory( "test_factory" );
+    generic_factory<test_obj>::Version v1;
+    generic_factory<test_obj>::Version v2;
+
+    CHECK_FALSE( test_factory.is_valid( v1 ) );
+    test_factory.reset();
+    CHECK_FALSE( test_factory.is_valid( v1 ) );
+
+    v1 = test_factory.get_version();
+
+    CHECK( test_factory.is_valid( v1 ) );
+    CHECK_FALSE( v1 == v2 );
+    CHECK( v1 != v2 );
+
+    v2 = v1;
+
+    CHECK( v1 == v2 );
+    CHECK_FALSE( v1 != v2 );
+
+    test_factory.reset();
+    CHECK_FALSE( test_factory.is_valid( v1 ) );
+    CHECK_FALSE( test_factory.is_valid( v2 ) );
+}
+
 TEST_CASE( "string_ids_comparison", "[generic_factory][string_id]" )
 {
     //  checks equality correctness for the following combinations of parameters:

--- a/tests/generic_factory_test.cpp
+++ b/tests/generic_factory_test.cpp
@@ -164,3 +164,65 @@ TEST_CASE( "string_ids_comparison", "[generic_factory][string_id]" )
         }
     }
 }
+
+// Benchmarks are skipped by default by using [.] tag
+TEST_CASE( "generic_factory_lookup_benchmark", "[.][generic_factory][benchmark]" )
+{
+    test_obj_id id_200( "id_200" );
+
+    generic_factory<test_obj> test_factory( "test_factory" );
+
+    for( int i = 0; i < 1000; ++i ) {
+        std::string id = "id_" + std::to_string( i );
+        std::string value = "value_" + std::to_string( i );
+        test_factory.insert( {test_obj_id( id ), value} );
+    }
+
+    BENCHMARK( "single lookup" ) {
+        return test_factory.obj( id_200 ).value;
+    };
+}
+
+TEST_CASE( "string_id_compare_benchmark", "[.][generic_factory][string_id][benchmark]" )
+{
+    std::string prefix;
+    SECTION( "short id" ) {
+    }
+    SECTION( "long id" ) {
+        prefix = "log_common_prefix_";
+    }
+
+    test_obj_id id_200( prefix + "id_200" );
+    test_obj_id id_200_( prefix + "id_200" );
+    test_obj_id id_300( prefix + "id_300" );
+
+    generic_factory<test_obj> test_factory( "test_factory" );
+
+    CHECK( id_200 == id_200_ );
+    BENCHMARK( "ids are equal, invalid version" ) {
+        return id_200 == id_200_;
+    };
+
+    CHECK_FALSE( id_200 == id_300 );
+    BENCHMARK( "ids are not equal, invalid version" ) {
+        return id_200 == id_300;
+    };
+
+    test_factory.insert( {test_obj_id( id_200 ), "value_200"} );
+    test_factory.insert( {test_obj_id( id_200_ ), "value_200_"} );
+    test_factory.insert( {test_obj_id( id_300 ), "value_300"} );
+    // make _version inside the ids valid
+    test_factory.is_valid( id_200 );
+    test_factory.is_valid( id_200_ );
+    test_factory.is_valid( id_300 );
+
+    CHECK( id_200 == id_200_ );
+    BENCHMARK( "ids are equal, valid version" ) {
+        return id_200 == id_200_;
+    };
+
+    CHECK_FALSE( id_200 == id_300 );
+    BENCHMARK( "ids are not equal, valid version" ) {
+        return id_200 == id_300;
+    };
+}


### PR DESCRIPTION
#### Purpose of change
Optimize rotting corpses

#### Describe the solution
Port CleverRaven#44544

#### Testing
In a test scenario (blind avatar waiting in a middle of a city) `materials::get_rotting()` went down from ≈12% to 0%.

#### Additional context
The next expensive calls in item processing are `get_heat_radiation()` with total of ≈22%.

![image](https://user-images.githubusercontent.com/60584843/122675447-26e09a80-d1e2-11eb-9de9-1ab66a000eb0.png)
