### PR TITLE
Re-add missing electric grids to shelters and mansions

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1110,7 +1110,7 @@
     "city_distance": [ 3, 10 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "URBAN" ]
+    "flags": [ "CLASSIC", "URBAN", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -1125,7 +1125,7 @@
     "city_distance": [ 3, 10 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "URBAN" ]
+    "flags": [ "CLASSIC", "URBAN", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -1140,7 +1140,7 @@
     "city_distance": [ 3, 10 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "URBAN" ]
+    "flags": [ "CLASSIC", "URBAN", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -1155,7 +1155,7 @@
     "city_distance": [ 3, 10 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "URBAN" ]
+    "flags": [ "CLASSIC", "URBAN", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -1170,7 +1170,7 @@
     "city_distance": [ 3, 10 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "URBAN" ]
+    "flags": [ "CLASSIC", "URBAN", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -1185,7 +1185,7 @@
     "city_distance": [ 3, 10 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "URBAN" ]
+    "flags": [ "CLASSIC", "URBAN", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -3688,7 +3688,7 @@
     "city_distance": [ 0, 10 ],
     "city_sizes": [ 6, -1 ],
     "occurrences": [ 85, 100 ],
-    "flags": [ "UNIQUE", "CLASSIC" ]
+    "flags": [ "UNIQUE", "CLASSIC", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -3736,7 +3736,7 @@
     "city_distance": [ 0, 10 ],
     "city_sizes": [ 6, -1 ],
     "occurrences": [ 75, 100 ],
-    "flags": [ "UNIQUE", "CLASSIC" ]
+    "flags": [ "UNIQUE", "CLASSIC", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -3782,7 +3782,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 15, 50 ],
     "occurrences": [ 60, 100 ],
-    "flags": [ "UNIQUE", "CLASSIC" ]
+    "flags": [ "UNIQUE", "CLASSIC", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -3828,7 +3828,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 15, 50 ],
     "occurrences": [ 35, 100 ],
-    "flags": [ "UNIQUE", "CLASSIC" ]
+    "flags": [ "UNIQUE", "CLASSIC", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -150,7 +150,7 @@
     "city_distance": [ 25, -1 ],
     "city_sizes": [ 0, 12 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC" ]
+    "flags": [ "CLASSIC", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -3346,7 +3346,7 @@
     "city_distance": [ 3, -1 ],
     "rotate": false,
     "occurrences": [ 30, 100 ],
-    "flags": [ "UNIQUE" ]
+    "flags": [ "UNIQUE", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Re-adds ELECTRIC_GRID flag accidentally removed from mansions and evac shelters, allow add grids to two more locations"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Quick and easy fix once it was noticed that https://github.com/cataclysmbnteam/Cataclysm-BN/pull/515 accidentally removed the `ELECTRIC_GRID` flag from the overmap specials they were used in.

Discussion in the BN discord led to giving grid support to two more locations that would be an easy and obvious fit for them, LMOE shelters and the Tacoma Ranch.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added the `ELECTRIC_GRID` back into all overmap specials that previously used them. That would be all variants of evac shelters, and all variants of mansions.
2. Added `ELECTRIC_GRID` to LMOE shelters and the ranch camp.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

~~Could add electric grid support to a few other locations. The ranch camp and LMOE shelters come to mind as most likely places to warrant them.~~ Implemented per discussion on the BN discord.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and linting errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

I'm now curious whether there's also a way to specify grid support for multitile city buildings, and/or if those use the same falg support that overmap specials do. Giving houses a working grid might be a bit overkill though.