### PR TITLE
Improve om notes manager

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -747,6 +747,20 @@
   },
   {
     "type": "keybinding",
+    "id": "CHANGE_SORT",
+    "category": "OVERMAP_NOTES",
+    "name": "Change sorting mode",
+    "bindings": [ { "input_method": "keyboard", "key": "S" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "CLEAR_FILTER",
+    "category": "OVERMAP_NOTES",
+    "name": "Clear filter",
+    "bindings": [ { "input_method": "keyboard", "key": "R" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "DELETE_NOTE",
     "category": "OVERMAP",
     "name": "Delete Note",

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -89,19 +89,23 @@ void color_manager::finalize()
     }
 }
 
-nc_color color_manager::name_to_color( const std::string &name ) const
+nc_color color_manager::name_to_color( const std::string &name,
+                                       const report_color_error color_error ) const
 {
-    const auto id = name_to_id( name );
-    auto &entry = color_array[id];
+    const color_id id = name_to_id( name, color_error );
+    const color_struct &entry = color_array[id];
 
     return entry.custom > 0 ? entry.custom : entry.color;
 }
 
-color_id color_manager::name_to_id( const std::string &name ) const
+color_id color_manager::name_to_id( const std::string &name,
+                                    const report_color_error color_error ) const
 {
     auto iter = name_map.find( name );
     if( iter == name_map.end() ) {
-        debugmsg( "couldn't parse color: %s", name );
+        if( color_error == report_color_error::yes ) {
+            debugmsg( "couldn't parse color: %s", name );
+        }
         return def_c_unset;
     }
 
@@ -545,7 +549,8 @@ nc_color cyan_background( const nc_color &c )
  * @param color The color to get, as a std::string.
  * @return The nc_color constant that matches the input.
  */
-nc_color color_from_string( const std::string &color )
+nc_color color_from_string( const std::string &color,
+                            const report_color_error color_error )
 {
     if( color.empty() ) {
         return c_unset;
@@ -561,12 +566,14 @@ nc_color color_from_string( const std::string &color )
         while( ( pos = new_color.find( i.second, pos ) ) != std::string::npos ) {
             new_color.replace( pos, i.second.length(), i.first );
             pos += i.first.length();
-            debugmsg( "Deprecated foreground color suffix was used: (%s) in (%s).  Please update mod that uses that.",
-                      i.second, color );
+            if( color_error == report_color_error::yes ) {
+                debugmsg( "Deprecated foreground color suffix was used: (%s) in (%s).  Please update mod that uses that.",
+                          i.second, color );
+            }
         }
     }
 
-    const nc_color col = all_colors.name_to_color( new_color );
+    const nc_color col = all_colors.name_to_color( new_color, color_error );
     if( col > 0 ) {
         return col;
     }
@@ -619,7 +626,8 @@ nc_color bgcolor_from_string( const std::string &color )
     return i_white;
 }
 
-color_tag_parse_result get_color_from_tag( const std::string &s )
+color_tag_parse_result get_color_from_tag( const std::string &s,
+        const report_color_error color_error )
 {
     if( s.empty() || s[0] != '<' ) {
         return { color_tag_parse_result::non_color_tag, {} };
@@ -635,7 +643,12 @@ color_tag_parse_result get_color_from_tag( const std::string &s )
         return { color_tag_parse_result::non_color_tag, {} };
     }
     std::string color_name = s.substr( 7, tag_close - 7 );
-    return { color_tag_parse_result::open_color_tag, color_from_string( color_name ) };
+    const nc_color color = color_from_string( color_name, color_error );
+    if( color != c_unset ) {
+        return { color_tag_parse_result::open_color_tag, color };
+    } else {
+        return { color_tag_parse_result::non_color_tag, color };
+    }
 }
 
 std::string get_tag_from_color( const nc_color &color )

--- a/src/color.h
+++ b/src/color.h
@@ -388,6 +388,10 @@ struct hash<nc_color> {
 };
 } // namespace std
 
+enum class report_color_error {
+    no, yes
+};
+
 class color_manager
 {
     private:
@@ -427,12 +431,14 @@ class color_manager
         nc_color get_random() const;
 
         color_id color_to_id( const nc_color &color ) const;
-        color_id name_to_id( const std::string &name ) const;
+        color_id name_to_id( const std::string &name,
+                             report_color_error color_error = report_color_error::yes ) const;
 
         std::string get_name( const nc_color &color ) const;
         std::string id_to_name( color_id id ) const;
 
-        nc_color name_to_color( const std::string &name ) const;
+        nc_color name_to_color( const std::string &name,
+                                report_color_error color_error = report_color_error::yes ) const;
 
         nc_color highlight_from_names( const std::string &name, const std::string &bg_name ) const;
 
@@ -492,10 +498,12 @@ nc_color yellow_background( const nc_color &c );
 nc_color magenta_background( const nc_color &c );
 nc_color cyan_background( const nc_color &c );
 
-nc_color color_from_string( const std::string &color );
+nc_color color_from_string( const std::string &color,
+                            report_color_error color_error = report_color_error::yes );
 std::string string_from_color( const nc_color &color );
 nc_color bgcolor_from_string( const std::string &color );
-color_tag_parse_result get_color_from_tag( const std::string &s );
+color_tag_parse_result get_color_from_tag( const std::string &s,
+        report_color_error color_error = report_color_error::yes );
 std::string get_tag_from_color( const nc_color &color );
 std::string colorize( const std::string &text, const nc_color &color );
 std::string colorize( const translation &text, const nc_color &color );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -414,7 +414,10 @@ void map_data_common_t::load_symbol( const JsonObject &jo )
     if( has_color && has_bgcolor ) {
         jo.throw_error( "Found both color and bgcolor, only one of these is allowed." );
     } else if( has_color ) {
-        load_season_array( jo, "color", color_, color_from_string );
+        load_season_array( jo, "color", color_, []( const std::string & str ) {
+            // has to use a lambda because of default params
+            return color_from_string( str );
+        } );
     } else if( has_bgcolor ) {
         load_season_array( jo, "bgcolor", color_, bgcolor_from_string );
     } else {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -161,9 +161,11 @@ std::string remove_color_tags( const std::string &s )
     return ret;
 }
 
-static void update_color_stack( std::stack<nc_color> &color_stack, const std::string &seg )
+static color_tag_parse_result::tag_type update_color_stack(
+    std::stack<nc_color> &color_stack, const std::string &seg,
+    const report_color_error color_error = report_color_error::yes )
 {
-    color_tag_parse_result tag = get_color_from_tag( seg );
+    color_tag_parse_result tag = get_color_from_tag( seg, color_error );
     switch( tag.type ) {
         case color_tag_parse_result::open_color_tag:
             color_stack.push( tag.color );
@@ -177,10 +179,12 @@ static void update_color_stack( std::stack<nc_color> &color_stack, const std::st
             // Do nothing
             break;
     }
+    return tag.type;
 }
 
 void print_colored_text( const catacurses::window &w, const point &p, nc_color &color,
-                         const nc_color &base_color, const std::string &text )
+                         const nc_color &base_color, const std::string &text,
+                         const report_color_error color_error )
 {
     if( p.y > -1 && p.x > -1 ) {
         wmove( w, p );
@@ -195,8 +199,11 @@ void print_colored_text( const catacurses::window &w, const point &p, nc_color &
         }
 
         if( seg[0] == '<' ) {
-            update_color_stack( color_stack, seg );
-            seg = rm_prefix( seg );
+            const color_tag_parse_result::tag_type type = update_color_stack(
+                        color_stack, seg, color_error );
+            if( type != color_tag_parse_result::non_color_tag ) {
+                seg = rm_prefix( seg );
+            }
         }
 
         color = color_stack.empty() ? base_color : color_stack.top();
@@ -204,11 +211,14 @@ void print_colored_text( const catacurses::window &w, const point &p, nc_color &
     }
 }
 
-void trim_and_print( const catacurses::window &w, const point &begin, int width,
-                     nc_color base_color, const std::string &text )
+void trim_and_print( const catacurses::window &w, const point &begin,
+                     const int width, const nc_color &base_color,
+                     const std::string &text,
+                     const report_color_error color_error )
 {
     std::string sText = trim_by_length( text, width );
-    print_colored_text( w, begin, base_color, base_color, sText );
+    nc_color dummy = base_color;
+    print_colored_text( w, begin, dummy, base_color, sText, color_error );
 }
 
 std::string trim_by_length( const std::string  &text, int width )
@@ -316,14 +326,18 @@ int fold_and_print_from( const catacurses::window &w, const point &begin, int wi
         // for each section, get the color, and print it
         std::vector<std::string>::iterator it;
         for( it = color_segments.begin(); it != color_segments.end(); ++it ) {
+            color_tag_parse_result::tag_type type = color_tag_parse_result::non_color_tag;
             if( !it->empty() && it->at( 0 ) == '<' ) {
-                update_color_stack( color_stack, *it );
+                type = update_color_stack( color_stack, *it );
             }
             if( line_num >= begin_line ) {
-                std::string l = rm_prefix( *it );
+                std::string l = *it;
+                if( type != color_tag_parse_result::non_color_tag ) {
+                    l = rm_prefix( l );
+                }
                 if( l != "--" ) { // -- is a separation line!
                     nc_color color = color_stack.empty() ? base_color : color_stack.top();
-                    wprintz( w, color, rm_prefix( *it ) );
+                    wprintz( w, color, l );
                 } else {
                     for( int i = 0; i < width; i++ ) {
                         wputch( w, c_dark_gray, LINE_OXOX );

--- a/src/output.h
+++ b/src/output.h
@@ -226,7 +226,8 @@ std::vector<std::string> foldstring( const std::string &str, int width, char spl
  * @param base_color Base color that is used outside of any color tag.
  **/
 void print_colored_text( const catacurses::window &w, const point &p, nc_color &cur_color,
-                         const nc_color &base_color, const std::string &text );
+                         const nc_color &base_color, const std::string &text,
+                         report_color_error color_error = report_color_error::yes );
 /**
  * Print word wrapped text (with @ref color_tags) into the window.
  *
@@ -310,14 +311,26 @@ inline int fold_and_print_from( const catacurses::window &w, const point &begin,
  * @param text Actual message to print
  */
 void trim_and_print( const catacurses::window &w, const point &begin, int width,
-                     nc_color base_color, const std::string &text );
+                     const nc_color &base_color, const std::string &text,
+                     report_color_error color_error = report_color_error::yes );
 std::string trim_by_length( const std::string &text, int width );
 template<typename ...Args>
 inline void trim_and_print( const catacurses::window &w, const point &begin,
-                            const int width, const nc_color base_color, const char *const mes, Args &&... args )
+                            const int width, const nc_color &base_color,
+                            const char *const mes, Args &&... args )
 {
-    return trim_and_print( w, begin, width, base_color, string_format( mes,
-                           std::forward<Args>( args )... ) );
+    return trim_and_print( w, begin, width, base_color,
+                           string_format( mes, std::forward<Args>( args )... ) );
+}
+template<typename ...Args>
+inline void trim_and_print( const catacurses::window &w, const point &begin,
+                            const int width, const nc_color &base_color,
+                            const report_color_error color_error,
+                            const char *const mes, Args &&... args )
+{
+    return trim_and_print( w, begin, width, base_color,
+                           string_format( mes, std::forward<Args>( args )... ),
+                           color_error );
 }
 void center_print( const catacurses::window &w, int y, const nc_color &FG,
                    const std::string &text );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1327,15 +1327,22 @@ bool overmap::is_marked_dangerous( const tripoint &p ) const
     return false;
 }
 
+const std::vector<om_note> &overmap::all_notes( int z ) const
+{
+    static const std::vector<om_note> fallback;
+
+    if( z < -OVERMAP_DEPTH || z > OVERMAP_HEIGHT ) {
+        return fallback;
+    }
+
+    return layer[z + OVERMAP_DEPTH].notes;
+}
+
 const std::string &overmap::note( const tripoint &p ) const
 {
     static const std::string fallback {};
 
-    if( p.z < -OVERMAP_DEPTH || p.z > OVERMAP_HEIGHT ) {
-        return fallback;
-    }
-
-    const auto &notes = layer[p.z + OVERMAP_DEPTH].notes;
+    const auto &notes = all_notes( p.z );
     const auto it = std::find_if( begin( notes ), end( notes ), [&]( const om_note & n ) {
         return n.p == p.xy();
     } );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1303,6 +1303,24 @@ bool overmap::has_note( const tripoint &p ) const
     return false;
 }
 
+cata::optional<int> overmap::has_note_with_danger_radius( const tripoint &p ) const
+{
+    if( p.z < -OVERMAP_DEPTH || p.z > OVERMAP_HEIGHT ) {
+        return cata::nullopt;
+    }
+
+    for( auto &i : layer[p.z + OVERMAP_DEPTH].notes ) {
+        if( i.p == p.xy() ) {
+            if( i.dangerous ) {
+                return i.danger_radius;
+            } else {
+                break;
+            }
+        }
+    }
+    return cata::nullopt;
+}
+
 bool overmap::is_marked_dangerous( const tripoint &p ) const
 {
     for( auto &i : layer[p.z + OVERMAP_DEPTH].notes ) {

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -267,6 +267,7 @@ class overmap
         bool is_explored( const tripoint &p ) const;
 
         bool has_note( const tripoint &p ) const;
+        cata::optional<int> has_note_with_danger_radius( const tripoint &p ) const;
         bool is_marked_dangerous( const tripoint &p ) const;
         const std::vector<om_note> &all_notes( int z ) const;
         const std::string &note( const tripoint &p ) const;

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -268,6 +268,7 @@ class overmap
 
         bool has_note( const tripoint &p ) const;
         bool is_marked_dangerous( const tripoint &p ) const;
+        const std::vector<om_note> &all_notes( int z ) const;
         const std::string &note( const tripoint &p ) const;
         void add_note( const tripoint &p, std::string message );
         void delete_note( const tripoint &p );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -257,7 +257,8 @@ static void update_note_preview( const std::string &note,
 
     werase( *w_preview_title );
     nc_color default_color = c_unset;
-    print_colored_text( *w_preview_title, point_zero, default_color, note_color, note_text );
+    print_colored_text( *w_preview_title, point_zero, default_color, note_color, note_text,
+                        report_color_error::no );
     int note_text_width = utf8_width( note_text );
     mvwputch( *w_preview_title, point( note_text_width, 0 ), c_white, LINE_XOXO );
     for( int i = 0; i < note_text_width; i++ ) {
@@ -501,6 +502,7 @@ static point draw_notes( const tripoint &origin )
     uilist nmenu;
     while( refresh ) {
         refresh = false;
+        nmenu.color_error( false );
         nmenu.init();
         nmenu.desc_enabled = true;
         nmenu.input_category = "OVERMAP_NOTES";
@@ -998,7 +1000,8 @@ void draw( const catacurses::window &w, const catacurses::window &wbar, const tr
             mvwputch( w, point( 1, i + 2 ), c_white, LINE_XOXO );
             mvwprintz( w, point( 2, i + 2 ), c_yellow, spacer );
             nc_color default_color = c_unset;
-            print_colored_text( w, point( 2, i + 2 ), default_color, pr.first, pr.second );
+            print_colored_text( w, point( 2, i + 2 ), default_color, pr.first, pr.second,
+                                report_color_error::no );
             mvwputch( w, point( maxlen + 2, i + 2 ), c_white, LINE_XOXO );
         }
         mvwputch( w, point( maxlen + 2, 1 ), c_white, LINE_OOXX );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -536,11 +536,11 @@ class map_notes_callback : public uilist_callback
         }
 };
 
-enum class SortMode : int {
-    Name,
-    Distance,
-    Symbol,
-    Num,
+enum class sort_mode_t : int {
+    name,
+    distance,
+    symbol,
+    num,
 };
 
 static bool sortfunc_dist( const note_cached &a, const note_cached &b )
@@ -568,6 +568,7 @@ static bool sortfunc_symbol( const note_cached &a, const note_cached &b )
         return sortfunc_name( a, b );
     } else {
         // Not using lexicographic comparator here because it's case-insensitive
+        // NOLINTNEXTLINE(cata-use-localized-sorting)
         return a.symbol < b.symbol;
     }
 }
@@ -580,7 +581,7 @@ static tripoint show_notes_manager( const tripoint &origin )
     uilist nmenu;
     std::string filter;
     tripoint selected = origin;
-    SortMode sort_mode = SortMode::Name;
+    sort_mode_t sort_mode = sort_mode_t::name;
 
     const tripoint p_player = g->u.global_omt_location();
 
@@ -624,15 +625,15 @@ static tripoint show_notes_manager( const tripoint &origin )
 
         const char *sort_str;
         switch( sort_mode ) {
-            case SortMode::Name:
+            case sort_mode_t::name:
                 sort_str = pgettext( "Sorted by:", "name" );
                 std::sort( notes.begin(), notes.end(), sortfunc_name );
                 break;
-            case SortMode::Distance:
+            case sort_mode_t::distance:
                 sort_str = pgettext( "Sorted by:", "distance" );
                 std::sort( notes.begin(), notes.end(), sortfunc_dist );
                 break;
-            case SortMode::Symbol:
+            case sort_mode_t::symbol:
                 sort_str = pgettext( "Sorted by:", "symbol" );
                 std::sort( notes.begin(), notes.end(), sortfunc_symbol );
                 break;
@@ -703,8 +704,8 @@ static tripoint show_notes_manager( const tripoint &origin )
         nmenu.query();
 
         if( nmenu.ret == UILIST_CHANGE_SORT ) {
-            sort_mode = static_cast<SortMode>(
-                            ( static_cast<int>( sort_mode ) + 1 ) % static_cast<int>( SortMode::Num )
+            sort_mode = static_cast<sort_mode_t>(
+                            ( static_cast<int>( sort_mode ) + 1 ) % static_cast<int>( sort_mode_t::num )
                         );
         }
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -551,7 +551,7 @@ static bool sortfunc_dist( const note_cached &a, const note_cached &b )
     } else {
         return a.dist_from_pl < b.dist_from_pl;
     }
-};
+}
 
 static bool sortfunc_name( const note_cached &a, const note_cached &b )
 {
@@ -560,7 +560,7 @@ static bool sortfunc_name( const note_cached &a, const note_cached &b )
     } else {
         return localized_compare( a.text_nocolor, b.text_nocolor );
     }
-};
+}
 
 static bool sortfunc_symbol( const note_cached &a, const note_cached &b )
 {
@@ -570,7 +570,7 @@ static bool sortfunc_symbol( const note_cached &a, const note_cached &b )
         // Not using lexicographic comparator here because it's case-insensitive
         return a.symbol < b.symbol;
     }
-};
+}
 
 static tripoint show_notes_manager( const tripoint &origin )
 {
@@ -653,7 +653,8 @@ static tripoint show_notes_manager( const tripoint &origin )
             tripoint tp_omt( note.p );
             const std::string direction_str = direction_name_short( direction_from( p_player, tp_omt ) );
             const tripoint sm_pos = omt_to_sm_copy( tp_omt );
-            const point p_om = omt_to_om_remain( tp_omt.xy() );
+            point p_omt = tp_omt.xy();
+            const point p_om = omt_to_om_remain( p_omt );
             const std::string location_desc = overmap_buffer.get_description_at( sm_pos );
 
             //~ "Dangerous" indicator for overmap note in note manager.
@@ -714,7 +715,7 @@ static tripoint show_notes_manager( const tripoint &origin )
             filter = nmenu.get_filter();
             if( nmenu.ret == UILIST_MAP_NOTE_EDITED || nmenu.ret == UILIST_CHANGE_SORT ) {
                 // Reselect same note
-                assert( nmenu.selected >= 0 && nmenu.selected < notes.size() );
+                assert( nmenu.selected >= 0 && nmenu.selected < static_cast<int>( notes.size() ) );
                 selected = notes[nmenu.selected].p;
             } else {
                 assert( nmenu.ret == UILIST_MAP_NOTE_DELETED );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -336,6 +336,14 @@ bool overmapbuffer::has_note( const tripoint &p )
     return false;
 }
 
+cata::optional<int> overmapbuffer::has_note_with_danger_radius( const tripoint &p )
+{
+    if( const overmap_with_local_coords om_loc = get_existing_om_global( p ) ) {
+        return om_loc.om->has_note_with_danger_radius( om_loc.local );
+    }
+    return cata::nullopt;
+}
+
 bool overmapbuffer::is_marked_dangerous( const tripoint &p )
 {
     if( const overmap_with_local_coords om_loc = get_existing_om_global( p ) ) {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1444,23 +1444,16 @@ overmapbuffer::t_notes_vector overmapbuffer::get_notes( int z, const std::string
     t_notes_vector result;
     for( auto &it : overmaps ) {
         const overmap &om = *it.second;
-        const int offset_x = om.pos().x * OMAPX;
-        const int offset_y = om.pos().y * OMAPY;
-        for( int i = 0; i < OMAPX; i++ ) {
-            for( int j = 0; j < OMAPY; j++ ) {
-                const std::string &note = om.note( { i, j, z } );
-                if( note.empty() ) {
-                    continue;
-                }
-                if( pattern != nullptr && lcmatch( note, *pattern ) ) {
-                    // pattern not found in note text
-                    continue;
-                }
-                result.push_back( t_point_with_note(
-                                      point( offset_x + i, offset_y + j ),
-                                      om.note( { i, j, z } )
-                                  ) );
+        const point offset( om.pos().x * OMAPX, om.pos().y * OMAPY );
+        const auto &all_om_notes = om.all_notes( z );
+        for( const om_note &note : all_om_notes ) {
+            if( pattern != nullptr && lcmatch( note.text, *pattern ) ) {
+                continue;
             }
+            result.push_back( t_point_with_note(
+                                  offset + note.p,
+                                  note.text
+                              ) );
         }
     }
     return result;

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -168,6 +168,11 @@ class overmapbuffer
          * Uses global overmap terrain coordinates.
          */
         bool has_note( const tripoint &p );
+        /**
+         * Check whether the tile has a note that's marked as dangerous.
+         * If such note exists, returns danger radius (may be 0).
+         */
+        cata::optional<int> has_note_with_danger_radius( const tripoint &p );
         bool is_marked_dangerous( const tripoint &p );
         const std::string &note( const tripoint &p );
         void add_note( const tripoint &, const std::string &message );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -92,6 +92,7 @@ std::unique_ptr<cata_tiles> tilecontext;
 static uint32_t lastupdate = 0;
 static uint32_t interval = 25;
 static bool needupdate = false;
+static bool need_invalidate_framebuffers = false;
 
 palette_array windowsPalette;
 
@@ -593,7 +594,8 @@ void reinitialize_framebuffer()
         for( int i = 0; i < new_height; i++ ) {
             terminal_framebuffer[i].chars.assign( new_width, cursecell( "" ) );
         }
-    } else {
+    } else if( need_invalidate_framebuffers ) {
+        need_invalidate_framebuffers = false;
         invalidate_framebuffer( oversized_framebuffer );
         invalidate_framebuffer( terminal_framebuffer );
     }
@@ -1326,6 +1328,7 @@ bool handle_resize( int w, int h )
         WindowHeight = h;
         TERMINAL_WIDTH = WindowWidth / fontwidth / scaling_factor;
         TERMINAL_HEIGHT = WindowHeight / fontheight / scaling_factor;
+        need_invalidate_framebuffers = true;
         catacurses::stdscr = catacurses::newwin( TERMINAL_HEIGHT, TERMINAL_WIDTH, point_zero );
         SetupRenderTarget();
         game_ui::init_ui();

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -593,6 +593,9 @@ void reinitialize_framebuffer()
         for( int i = 0; i < new_height; i++ ) {
             terminal_framebuffer[i].chars.assign( new_width, cursecell( "" ) );
         }
+    } else {
+        invalidate_framebuffer( oversized_framebuffer );
+        invalidate_framebuffer( terminal_framebuffer );
     }
 }
 

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -371,6 +371,7 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
         const std::string action = ctxt->handle_input();
         const input_event ev = ctxt->get_raw_input();
         ch = ev.type == CATA_INPUT_KEYBOARD ? ev.get_first_input() : 0;
+        _handled = true;
 
         if( callbacks[ch] ) {
             if( callbacks[ch]() ) {
@@ -378,10 +379,8 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
             }
         }
 
-        // This class only registers the ANY_INPUT action by default. If the
-        // client provides their own input_context with registered actions
-        // besides ANY_INPUT, ignore those so that the client may handle them.
-        if( action != "ANY_INPUT" ) {
+        if( _ignore_custom_actions && action != "ANY_INPUT" ) {
+            _handled = false;
             continue;
         }
 
@@ -405,15 +404,25 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
             }
             return _text;
         } else if( ch == KEY_UP ) {
-            if( _hist_use_uilist ) {
-                show_history( ret );
+            if( !_identifier.empty() ) {
+                if( _hist_use_uilist ) {
+                    show_history( ret );
+                } else {
+                    update_input_history( ret, true );
+                }
             } else {
-                update_input_history( ret, true );
+                _handled = false;
             }
-        } else if( ch == KEY_DOWN && !_hist_use_uilist ) {
-            update_input_history( ret, false );
+        } else if( ch == KEY_DOWN ) {
+            if( !_identifier.empty() ) {
+                if( !_hist_use_uilist ) {
+                    update_input_history( ret, false );
+                }
+            } else {
+                _handled = false;
+            }
         } else if( ch == KEY_DOWN || ch == KEY_NPAGE || ch == KEY_PPAGE || ch == KEY_BTAB || ch == 9 ) {
-            /* absolutely nothing */
+            _handled = false;
         } else if( ch == KEY_RIGHT ) {
             if( _position + 1 <= static_cast<int>( ret.size() ) ) {
                 _position++;
@@ -465,6 +474,8 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
         } else if( ev.edit.empty() ) {
             edit.erase( 0 );
             ctxt->set_edittext( edit.c_str() );
+        } else {
+            _handled = false;
         }
     } while( loop );
     _text = ret.str();

--- a/src/string_input_popup.h
+++ b/src/string_input_popup.h
@@ -60,6 +60,7 @@ class string_input_popup // NOLINT(cata-xy)
         int _max_length = -1;
         bool _only_digits = false;
         bool _hist_use_uilist = true;
+        bool _ignore_custom_actions = true;
         int _startx = 0;
         int _starty = 0;
         int _endx = 0;
@@ -83,6 +84,7 @@ class string_input_popup // NOLINT(cata-xy)
 
         bool _canceled = false;
         bool _confirmed = false;
+        bool _handled = false;
 
         void create_window();
         void create_context();
@@ -163,6 +165,16 @@ class string_input_popup // NOLINT(cata-xy)
          */
         string_input_popup &hist_use_uilist( bool value ) {
             _hist_use_uilist = value;
+            return *this;
+        }
+        /**
+         * If true and the custom input context returns an input action, the
+         * action is not handled at all and left to be handled by the caller.
+         * Otherwise the action is always handled as an input event to the popup.
+         * The caller can use @ref handled to check whether the last input is handled.
+         */
+        string_input_popup &ignore_custom_actions( const bool value ) {
+            _ignore_custom_actions = value;
             return *this;
         }
         /**
@@ -249,6 +261,13 @@ class string_input_popup // NOLINT(cata-xy)
          */
         bool confirmed() const {
             return _confirmed;
+        }
+        /**
+         * Returns false if the last input was unhandled. Useful to avoid handling
+         * input already handled by the popup itself.
+         */
+        bool handled() const {
+            return _handled;
         }
         /**
          * Edit values in place. This combines: calls to @ref text to set the

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -340,3 +340,19 @@ std::string &capitalize_letter( std::string &str, size_t n )
 
     return str;
 }
+
+std::string trim_whitespaces( const std::string &str )
+{
+    // Source: https://stackoverflow.com/a/1798170
+
+    const std::string whitespace = "\t ";
+    const auto strBegin = str.find_first_not_of( whitespace );
+    if( strBegin == std::string::npos ) {
+        return "";    // no content
+    }
+
+    const auto strEnd = str.find_last_not_of( whitespace );
+    const auto strRange = strEnd - strBegin + 1;
+
+    return str.substr( strBegin, strRange );
+}

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -345,6 +345,7 @@ std::string trim_whitespaces( const std::string &str )
 {
     // Source: https://stackoverflow.com/a/1798170
 
+    // NOLINTNEXTLINE(cata-text-style)
     const std::string whitespace = "\t ";
     const auto strBegin = str.find_first_not_of( whitespace );
     if( strBegin == std::string::npos ) {

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -347,13 +347,13 @@ std::string trim_whitespaces( const std::string &str )
 
     // NOLINTNEXTLINE(cata-text-style)
     const std::string whitespace = "\t ";
-    const auto strBegin = str.find_first_not_of( whitespace );
-    if( strBegin == std::string::npos ) {
+    const auto str_begin = str.find_first_not_of( whitespace );
+    if( str_begin == std::string::npos ) {
         return "";    // no content
     }
 
-    const auto strEnd = str.find_last_not_of( whitespace );
-    const auto strRange = strEnd - strBegin + 1;
+    const auto str_end = str.find_last_not_of( whitespace );
+    const auto str_range = str_end - str_begin + 1;
 
-    return str.substr( strBegin, strRange );
+    return str.substr( str_begin, str_range );
 }

--- a/src/string_utils.h
+++ b/src/string_utils.h
@@ -158,4 +158,9 @@ std::string replace_colors( std::string text );
  */
 std::string &capitalize_letter( std::string &str, size_t n = 0 );
 
+/**
+ * Remove leading and trailing whitespaces.
+ */
+std::string trim_whitespaces( const std::string &str );
+
 #endif // CATA_SRC_STRING_UTILS_H

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -265,6 +265,7 @@ void uilist::inputfilter()
     ctxt.register_action( "ANY_INPUT" );
     filter_popup = std::make_unique<string_input_popup>();
     filter_popup->context( ctxt ).text( filter )
+    .ignore_custom_actions( false )
     .max_length( 256 )
     .window( window, point( 4, w_height - 1 ), w_width - 4 );
     ime_sentry sentry;
@@ -273,7 +274,7 @@ void uilist::inputfilter()
         filter = filter_popup->query_string( false );
         if( !filter_popup->canceled() ) {
             const std::string action = ctxt.input_to_action( ctxt.get_raw_input() );
-            if( !scrollby( scroll_amount_from_action( action ) ) ) {
+            if( filter_popup->handled() || !scrollby( scroll_amount_from_action( action ) ) ) {
                 filterlist();
             }
         }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -308,15 +308,15 @@ void uilist::inputfilter()
 
 bool uilist::set_selected( int sel )
 {
-    if( sel < 0 || sel >= entries.size() ) {
+    if( sel < 0 || sel >= static_cast<int>( entries.size() ) ) {
         // Shortcut
         return false;
     }
 
-    for( int i = 0; i < fentries.size(); i++ ) {
+    for( size_t i = 0; i < fentries.size(); i++ ) {
         if( fentries[i] == sel ) {
             selected = sel;
-            fselected = i;
+            fselected = static_cast<int>( i );
             return true;
         }
     }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -129,6 +129,15 @@ uilist::~uilist()
     }
 }
 
+void uilist::color_error( const bool report )
+{
+    if( report ) {
+        _color_error = report_color_error::yes;
+    } else {
+        _color_error = report_color_error::no;
+    }
+}
+
 /*
  * Enables oneshot construction -> running -> exit
  */
@@ -576,7 +585,8 @@ void uilist::show()
     int estart = 1;
     if( !textformatted.empty() ) {
         for( int i = 0; i < text_lines; i++ ) {
-            trim_and_print( window, point( 2, 1 + i ), getmaxx( window ) - 4, text_color, textformatted[i] );
+            trim_and_print( window, point( 2, 1 + i ), getmaxx( window ) - 4,
+                            text_color, _color_error, "%s", textformatted[i] );
         }
 
         mvwputch( window, point( 0, text_lines + 1 ), border_color, LINE_XXXO );
@@ -626,13 +636,13 @@ void uilist::show()
                 const auto entry = utf8_wrapper( ei == selected ? remove_color_tags( entries[ ei ].txt ) :
                                                  entries[ ei ].txt );
                 trim_and_print( window, point( pad_left + 4, estart + si ),
-                                max_entry_len, co, "%s", entry.c_str() );
+                                max_entry_len, co, _color_error, "%s", entry.c_str() );
 
                 if( max_column_len && !entries[ ei ].ctxt.empty() ) {
                     const auto centry = utf8_wrapper( ei == selected ? remove_color_tags( entries[ ei ].ctxt ) :
                                                       entries[ ei ].ctxt );
                     trim_and_print( window, point( getmaxx( window ) - max_column_len - 2, estart + si ),
-                                    max_column_len, co, "%s", centry.c_str() );
+                                    max_column_len, co, _color_error, "%s", centry.str() );
                 }
             }
             mvwzstr menu_entry_extra_text = entries[ei].extratxt;

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -202,14 +202,12 @@ void uilist::init()
     max_entry_len = 0;
     max_column_len = 0;      // for calculating space for second column
 
+    _color_error = report_color_error::yes;
     hotkeys = DEFAULT_HOTKEYS;
     input_category = "UILIST";
     additional_actions.clear();
 }
 
-/**
- * repopulate filtered entries list (fentries) and set fselected accordingly
- */
 void uilist::filterlist()
 {
     bool filtering = ( this->filtering && !filter.empty() );
@@ -263,6 +261,18 @@ void uilist::filterlist()
     }
 }
 
+void uilist::clear_filter()
+{
+    filter.clear();
+    filterlist();
+}
+
+void uilist::set_filter( const std::string &fstr )
+{
+    filter = fstr;
+    filterlist();
+}
+
 void uilist::inputfilter()
 {
     input_context ctxt( input_category );
@@ -294,6 +304,24 @@ void uilist::inputfilter()
     }
 
     filter_popup.reset();
+}
+
+bool uilist::set_selected( int sel )
+{
+    if( sel < 0 || sel >= entries.size() ) {
+        // Shortcut
+        return false;
+    }
+
+    for( int i = 0; i < fentries.size(); i++ ) {
+        if( fentries[i] == sel ) {
+            selected = sel;
+            fselected = i;
+            return true;
+        }
+    }
+
+    return false;
 }
 
 /**

--- a/src/ui.h
+++ b/src/ui.h
@@ -198,6 +198,9 @@ class uilist // NOLINT(cata-xy)
 
         ~uilist();
 
+        // whether to report invalid color tag with debug message.
+        void color_error( bool report );
+
         void init();
         void setup();
         // initialize the window or reposition it after screen size change.
@@ -297,6 +300,7 @@ class uilist // NOLINT(cata-xy)
 
     private:
         std::string hotkeys;
+        report_color_error _color_error = report_color_error::yes;
 
     public:
         // Iternal states

--- a/src/ui.h
+++ b/src/ui.h
@@ -234,7 +234,7 @@ class uilist // NOLINT(cata-xy)
          * Get filtered list of entries.
          * Elements are indices for 'entries'.
          */
-        const std::vector<int> get_filtered() const {
+        const std::vector<int> &get_filtered() const {
             return fentries;
         }
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -208,7 +208,43 @@ class uilist // NOLINT(cata-xy)
         void show();
         bool scrollby( int scrollby );
         void query( bool loop = true, int timeout = -1 );
+
+        /**
+         * Repopulate filtered entries list (fentries) and set fselected accordingly.
+         */
         void filterlist();
+        /**
+         * Clear current filter string and repopulate filtered entries.
+         */
+        void clear_filter();
+        /**
+         * Override current filter string and repopulate filtered entries.
+         * Note that uilist has inbuilt "query for filter string and apply it" functionality,
+         * but this method can be used for creating uilists with some filter pre-applied.
+         */
+        void set_filter( const std::string &fstr );
+        /**
+         * Get current filter string.
+         */
+        const std::string &get_filter() const {
+            return filter;
+        }
+
+        /**
+         * Get filtered list of entries.
+         * Elements are indices for 'entries'.
+         */
+        const std::vector<int> get_filtered() const {
+            return fentries;
+        }
+
+        /**
+         * Move selection to given entry.
+         * @param sel Entry to select (index for 'entries').
+         * @returns 'false' if entry does not exist / is not available with current filter.
+         */
+        bool set_selected( int sel );
+
         void addentry( const std::string &str );
         void addentry( int r, bool e, int k, const std::string &str );
         // K is templated so it matches a `char` literal and a `int` value.

--- a/tests/cata_utility_test.cpp
+++ b/tests/cata_utility_test.cpp
@@ -145,11 +145,18 @@ TEST_CASE( "trim_whitespaces", "[utility]" )
     CHECK( trim_whitespaces( "  abc" ) == "abc" );
     CHECK( trim_whitespaces( "abc  " ) == "abc" );
     CHECK( trim_whitespaces( "  abc  " ) == "abc" );
+    // NOLINTNEXTLINE(cata-text-style)
     CHECK( trim_whitespaces( "  \t  \t  abc\t\t  \t\t\t  " ) == "abc" );
+    // NOLINTNEXTLINE(cata-text-style)
     CHECK( trim_whitespaces( "abc  \t   def" ) == "abc  \t   def" );
+    // NOLINTNEXTLINE(cata-text-style)
     CHECK( trim_whitespaces( "  abc  \t   def \t" ) == "abc  \t   def" );
+    // NOLINTNEXTLINE(readability-container-size-empty)
     CHECK( trim_whitespaces( "   " ) == "" );
+    // NOLINTNEXTLINE(readability-container-size-empty)
     CHECK( trim_whitespaces( " " ) == "" );
+    // NOLINTNEXTLINE(readability-container-size-empty, cata-text-style)
     CHECK( trim_whitespaces( "\t" ) == "" );
+    // NOLINTNEXTLINE(readability-container-size-empty)
     CHECK( trim_whitespaces( "" ) == "" );
 }

--- a/tests/cata_utility_test.cpp
+++ b/tests/cata_utility_test.cpp
@@ -138,3 +138,18 @@ TEST_CASE( "replace_first", "[utility]" )
         CHECK( text == it.expected );
     }
 }
+
+TEST_CASE( "trim_whitespaces", "[utility]" )
+{
+    CHECK( trim_whitespaces( "abc" ) == "abc" );
+    CHECK( trim_whitespaces( "  abc" ) == "abc" );
+    CHECK( trim_whitespaces( "abc  " ) == "abc" );
+    CHECK( trim_whitespaces( "  abc  " ) == "abc" );
+    CHECK( trim_whitespaces( "  \t  \t  abc\t\t  \t\t\t  " ) == "abc" );
+    CHECK( trim_whitespaces( "abc  \t   def" ) == "abc  \t   def" );
+    CHECK( trim_whitespaces( "  abc  \t   def \t" ) == "abc  \t   def" );
+    CHECK( trim_whitespaces( "   " ) == "" );
+    CHECK( trim_whitespaces( " " ) == "" );
+    CHECK( trim_whitespaces( "\t" ) == "" );
+    CHECK( trim_whitespaces( "" ) == "" );
+}


### PR DESCRIPTION
#### Purpose of change
Fix a couple bugs, add a couple QoL features. Closes #482.

#### Describe the solution
See commits.

New features:
* Show notes from all Z levels, show direction from `g->u`'s pos to that note
* Show note's danger radius in the list, or whether it is inside danger radius of some other note
* Allow sorting by name(default)/distance/symbol
* Retain sort order, filter and cursor position after editing / deleting a note
* Allow temporarily disabling 'Really delete note?' popup

Includes bugfixes ported from DDA:
https://github.com/CleverRaven/Cataclysm-DDA/pull/43220
https://github.com/CleverRaven/Cataclysm-DDA/pull/46768
https://github.com/CleverRaven/Cataclysm-DDA/pull/48190

#### Testing
Loading various worlds, adding/deleting notes with/without filter/specific sort order.

Along the way discovered that MIN_RANGE/MAX_RANGE marks that exist during camp mission destination selection show up in the list and make it pretty much unusable (https://github.com/CleverRaven/Cataclysm-DDA/issues/49394). It's quite minor, but would probably require a lot of code churn or maybe a refactor of om note handling, which is a bit out of scope of this PR.