### PR TITLE
Fix translation tests in CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(BACKTRACE    "Support for printing stack backtraces on crash"   "ON")
 option(LIBBACKTRACE "Print backtrace with libbacktrace."    "OFF")
 option(USE_HOME_DIR "Use user's home directory for save files."   "ON")
 option(LOCALIZE     "Support for language localizations. Also enable UTF support."   "ON")
-option(LANGUAGES    "Compile localization files for specified languages."   "")
+set(LANGUAGES "" CACHE STRING "Compile localization files for specified languages. List of language ids separated by semicolon. Set to 'all' or leave empty to compile all.")
 option(DYNAMIC_LINKING "Use dynamic linking. Or use static to remove MinGW dependency instead."   "ON")
 option(JSON_FORMAT  "Build JSON formatter" "OFF")
 option(CATA_CCACHE  "Try to find and build with ccache" "ON")
@@ -150,9 +150,7 @@ MESSAGE(STATUS "${PROJECT_NAME} build options --\n")
 
 # Preset variables
 IF(NOT LANGUAGES)
-    # English is included to workaround a libintl bug that affects performance
-    # on MinGW targets. See lang/CMakeList.txt for more information.
-    SET (LANGUAGES en de es_AR es_ES fr it_IT ja ko pt_BR ru zh_CN zh_TW)
+    SET(LANGUAGES all)
 ENDIF(NOT LANGUAGES)
 
 IF (GIT_BINARY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Main project build script
 cmake_minimum_required(VERSION 3.1.4)
 
-PROJECT(CataclysmDDA)
+PROJECT(CataclysmBN)
 
 SET(CMAKE_MODULE_PATH
     ${CMAKE_MODULE_PATH}
@@ -33,15 +33,16 @@ include(CTest)
 include(GetGitRevisionDescription)
 git_describe(GIT_VERSION)
 
-MESSAGE("\n * Cataclysm: Dark Days Ahead is a roguelike set in a post-apocalyptic world.")
+MESSAGE("\n * Cataclysm: Bright Nights is a roguelike set in a post-apocalyptic world.")
 MESSAGE("   _________            __                   .__                                ")
 MESSAGE("   \\_   ___ \\ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      ")
 MESSAGE("   /    \\  \\/ \\__  \\  \\   __\\\\__  \\  _/ ___\\ |  |  <   |  | /  ___/ /     \\     ")
 MESSAGE("   \\     \\____ / __ \\_ |  |   / __ \\_\\  \\___ |  |__ \\___  | \\___ \\ |  Y Y  \\    ")
 MESSAGE("    \\______  /\(____  / |__|  \(____  / \\___  >|____/ / ____|/____  >|__|_|  /    ")
 MESSAGE("           \\/      \\/             \\/      \\/        \\/          \\/       \\/     ")
-MESSAGE("                               --= Dark Days Ahead =--")
-MESSAGE("\n * https://cataclysmdda.org/\n")
+MESSAGE("                                --= Bright Nights =--")
+
+MESSAGE("\n * https://github.com/cataclysmbnteam/Cataclysm-BN\n")
 
 MESSAGE(STATUS "${PROJECT} build environment -- \n")
 

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -153,6 +153,7 @@ then
         analyze_files_in_random_order "$remaining_cpp_files"
     else
         # Regular build
+        make -j$num_jobs translations_compile
         make -j$num_jobs
         cd ..
         # Run regular tests
@@ -191,7 +192,7 @@ else
     else
         export BACKTRACE=1
     fi
-    make -j "$num_jobs" RELEASE=1 CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0
+    make -j "$num_jobs" RELEASE=1 CCACHE=1 CROSS="$CROSS_COMPILATION" LANGUAGES="all" LINTJSON=0
 
     export UBSAN_OPTIONS=print_stacktrace=1
     if [ "$TRAVIS_OS_NAME" == "osx" ] || [ "$OS" == "macos-10.15" ]

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -9,6 +9,21 @@ IF (NOT GETTEXT_FOUND)
     )
 ENDIF (NOT GETTEXT_FOUND)
 
+IF (LANGUAGES STREQUAL all)
+    set(LANGUAGES "")
+    file (GLOB PO_FILES
+      ${CMAKE_SOURCE_DIR}/lang/po/*.po
+    )
+    foreach (PO_FILE ${PO_FILES})
+      get_filename_component(LANG ${PO_FILE} NAME_WE)
+      list(APPEND LANGUAGES ${LANG})
+    endforeach ()
+    # Special case for English. See explanation below.
+    list(APPEND LANGUAGES en)
+    list(REMOVE_DUPLICATES LANGUAGES)
+    # End of special case
+ENDIF()
+
 foreach (LANG ${LANGUAGES})
     MESSAGE(STATUS "Add translation for ${LANG}: ${LANG}.po")
 endforeach ()

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -75,7 +75,7 @@ foreach (LANG ${LANGUAGES})
       PRE_BUILD
       COMMAND 
       ${GETTEXT_MSGFMT_EXECUTABLE} -f ${CMAKE_SOURCE_DIR}/lang/po/${LANG}.po
-             -o ${CMAKE_SOURCE_DIR}/lang/mo/${LANG}/LC_MESSAGES/cataclysm-dda.mo
+             -o ${CMAKE_SOURCE_DIR}/lang/mo/${LANG}/LC_MESSAGES/cataclysm-bn.mo
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
     IF(RELEASE)

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -14,39 +14,6 @@ foreach (LANG ${LANGUAGES})
 endforeach ()
 MESSAGE("\n")
 
-# Extract json strings
-
-add_custom_target (
-    extract_string
-    COMMAND python lang/extract_json_strings.py
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-
-# Generate cataclysm-bn.pot
-add_custom_target (
-    translations
-    COMMAND xgettext --default-domain="cataclysm-dda"
-                     --sort-by-file
-                     --add-comments="~"
-                     --output="${CMAKE_SOURCE_DIR}/lang/po/cataclysm-bn.pot"
-                     --keyword="_"
-                     --keyword="pgettext:1c,2"
-                     --keyword="vgettext:1,2"
-                     --keyword="vpgettext:1c,2,3"
-                     --keyword="translate_marker"
-                     --keyword="translate_marker_context:1c,2"
-                     --keyword="to_translation:1,1t"
-                     --keyword="to_translation:1c,2,2t"
-                     --keyword="pl_translation:1,2,2t"
-                     --keyword="pl_translation:1c,2,3,3t"
-                     --from-code="UTF-8"
-                     ${CMAKE_SOURCE_DIR}/src/*.cpp
-                     ${CMAKE_SOURCE_DIR}/src/*.h
-                     ${CMAKE_SOURCE_DIR}/lang/json/*.py
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    DEPENDS extract_string
-)
-
 add_custom_target (
     translations_prepare
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/src/language.cpp
+++ b/src/language.cpp
@@ -489,7 +489,7 @@ bool translations_exists_for_lang( const std::string &lang_id )
 #if defined(LOCALIZE)
     std::vector<std::string> opts = get_lang_path_substring( lang_id );
     for( const std::string &s : opts ) {
-        std::string path = "lang/mo/" + s + "/LC_MESSAGES/cataclysm-bn.mo";
+        std::string path = PATH_INFO::base_path() + "lang/mo/" + s + "/LC_MESSAGES/cataclysm-bn.mo";
         if( file_exist( path ) ) {
             return true;
         }


### PR DESCRIPTION
Closes #616.

Solution: get all files that match `lang/po/*.po` and build a list out of their names

Testing: Local tests with CMake confirm it generates a ninja build that compiles _all_ language files on `ninja translations_compile` invocation.

---

Closes #629.
* For `Make` builds, add `LANGUAGES="all"` (it was removed in https://github.com/CleverRaven/Cataclysm-DDA/pull/47077 for some reason, and that change slipped into BN during Travis->GA migration)
* For `CMake` builds, compile language files before running tests

Testing: Github Actions.