### PR TITLE
Fix controlled monsters

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -40,10 +40,16 @@
   },
   {
     "type": "effect_type",
-    "id": "controlled",
+    "id": "ai_controlled",
     "name": [ "Controlled Monster" ],
-    "desc": [ "AI tag for when monsters are being controlled by another.  This is a bug if you have it." ],
-    "permanent": true
+    "permanent": true,
+    "desc": [ "AI tag for when monsters are being controlled by another.  This is a bug if you have it." ]
+  },
+  {
+    "type": "effect_type",
+    "id": "ai_waiting",
+    "name": [ "Waiting Monster" ],
+    "desc": [ "AI tag for when monster passively waits in place.  This is a bug if you have it." ]
   },
   {
     "type": "effect_type",

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -99,8 +99,6 @@
 #include "vehicle.h"
 #include "vpart_position.h"
 
-static const efftype_id effect_sheared( "sheared" );
-
 static const activity_id ACT_ADV_INVENTORY( "ACT_ADV_INVENTORY" );
 static const activity_id ACT_AIM( "ACT_AIM" );
 static const activity_id ACT_ARMOR_LAYERS( "ACT_ARMOR_LAYERS" );
@@ -196,11 +194,12 @@ static const activity_id ACT_WAIT_WEATHER( "ACT_WAIT_WEATHER" );
 static const activity_id ACT_WASH( "ACT_WASH" );
 static const activity_id ACT_WEAR( "ACT_WEAR" );
 
+static const efftype_id effect_ai_waiting( "ai_waiting" );
 static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_blind( "blind" );
-static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_pet( "pet" );
+static const efftype_id effect_sheared( "sheared" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_tied( "tied" );
 static const efftype_id effect_under_op( "under_operation" );
@@ -3269,8 +3268,8 @@ void activity_handlers::find_mount_do_turn( player_activity *act, player *p )
         return;
     }
     if( rl_dist( guy.pos(), mon->pos() ) <= 1 ) {
-        if( mon->has_effect( effect_controlled ) ) {
-            mon->remove_effect( effect_controlled );
+        if( mon->has_effect( effect_ai_waiting ) ) {
+            mon->remove_effect( effect_ai_waiting );
         }
         if( p->can_mount( *mon ) ) {
             act->set_to_null();
@@ -3287,11 +3286,11 @@ void activity_handlers::find_mount_do_turn( player_activity *act, player *p )
         if( route.empty() ) {
             act->set_to_null();
             guy.revert_after_activity();
-            mon->remove_effect( effect_controlled );
+            mon->remove_effect( effect_ai_waiting );
             return;
         } else {
             p->activity = player_activity();
-            mon->add_effect( effect_controlled, 40_turns );
+            mon->add_effect( effect_ai_waiting, 40_turns );
             p->set_destination( route, player_activity( ACT_FIND_MOUNT ) );
         }
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -106,6 +106,7 @@ static const bionic_id bio_eye_optic( "bio_eye_optic" );
 static const bionic_id bio_watch( "bio_watch" );
 
 static const efftype_id effect_adrenaline( "adrenaline" );
+static const efftype_id effect_ai_waiting( "ai_waiting" );
 static const efftype_id effect_alarm_clock( "alarm_clock" );
 static const efftype_id effect_bandaged( "bandaged" );
 static const efftype_id effect_beartrap( "beartrap" );
@@ -117,7 +118,6 @@ static const efftype_id effect_bloated( "bloated" );
 static const efftype_id effect_boomered( "boomered" );
 static const efftype_id effect_cold( "cold" );
 static const efftype_id effect_contacts( "contacts" );
-static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_corroding( "corroding" );
 static const efftype_id effect_cough_suppress( "cough_suppress" );
 static const efftype_id effect_crushed( "crushed" );
@@ -1121,7 +1121,7 @@ void Character::forced_dismount()
         }
         mon->mounted_player_id = character_id();
         mon->remove_effect( effect_ridden );
-        mon->add_effect( effect_controlled, 5_turns );
+        mon->add_effect( effect_ai_waiting, 5_turns );
         mounted_creature = nullptr;
         mon->mounted_player = nullptr;
     }
@@ -1230,7 +1230,7 @@ void Character::dismount()
             g->u.grab( OBJECT_NONE );
         }
         critter->remove_effect( effect_ridden );
-        critter->add_effect( effect_controlled, 5_turns );
+        critter->add_effect( effect_ai_waiting, 5_turns );
         mounted_creature = nullptr;
         critter->mounted_player = nullptr;
         setpos( *pnt );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -195,11 +195,11 @@ static const species_id PLANT( "PLANT" );
 
 static const efftype_id effect_accumulated_mutagen( "accumulated_mutagen" );
 static const efftype_id effect_adrenaline_mycus( "adrenaline_mycus" );
+static const efftype_id effect_ai_controlled( "ai_controlled" );
 static const efftype_id effect_assisted( "assisted" );
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_contacts( "contacts" );
-static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_docile( "docile" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_drunk( "drunk" );
@@ -4325,12 +4325,9 @@ void game::monmove()
         while( critter.moves > 0 && !critter.is_dead() && !critter.has_effect( effect_ridden ) ) {
             critter.made_footstep = false;
             // Controlled critters don't make their own plans
-            if( !critter.has_effect( effect_controlled ) ) {
+            if( !critter.has_effect( effect_ai_controlled ) ) {
                 // Formulate a path to follow
                 critter.plan();
-            } else {
-                critter.moves = 0;
-                break;
             }
             critter.move(); // Move one square, possibly hit u
             critter.process_triggers();

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -80,12 +80,12 @@
 
 static const activity_id ACT_RELOAD( "ACT_RELOAD" );
 
+static const efftype_id effect_ai_controlled( "ai_controlled" );
 static const efftype_id effect_assisted( "assisted" );
 static const efftype_id effect_bite( "bite" );
 static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_boomered( "boomered" );
-static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_corroding( "corroding" );
 static const efftype_id effect_countdown( "countdown" );
 static const efftype_id effect_darkness( "darkness" );
@@ -2358,8 +2358,8 @@ bool mattack::callblobs( monster *z )
             post = nearby_points[ assigned_spot ];
         }
         ( *ally )->set_dest( post );
-        if( !( *ally )->has_effect( effect_controlled ) ) {
-            ( *ally )->add_effect( effect_controlled, 1_turns, num_bp );
+        if( !( *ally )->has_effect( effect_ai_controlled ) ) {
+            ( *ally )->add_effect( effect_ai_controlled, 1_turns, num_bp );
         }
     }
     // This is telepathy, doesn't take any moves.
@@ -2394,8 +2394,8 @@ bool mattack::jackson( monster *z )
             converted = true;
         }
         ( *ally )->set_dest( post );
-        if( !( *ally )->has_effect( effect_controlled ) ) {
-            ( *ally )->add_effect( effect_controlled, 1_turns, num_bp );
+        if( !( *ally )->has_effect( effect_ai_controlled ) ) {
+            ( *ally )->add_effect( effect_ai_controlled, 1_turns, num_bp );
         }
     }
     // Did we convert anybody?

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -53,9 +53,9 @@
 #include "value_ptr.h"
 #include "weighted_list.h"
 
+static const efftype_id effect_ai_controlled( "ai_controlled" );
 static const efftype_id effect_amigara( "amigara" );
 static const efftype_id effect_boomered( "boomered" );
-static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_darkness( "darkness" );
 static const efftype_id effect_glowing( "glowing" );
 static const efftype_id effect_no_ammo( "no_ammo" );
@@ -501,7 +501,7 @@ void mdeath::brainblob( monster &z )
 {
     for( monster &critter : g->all_monsters() ) {
         if( critter.type->in_species( species_BLOB ) && critter.type->id != mon_blob_brain ) {
-            critter.remove_effect( effect_controlled );
+            critter.remove_effect( effect_ai_controlled );
         }
     }
     blobsplit( z );
@@ -512,7 +512,7 @@ void mdeath::jackson( monster &z )
     for( monster &critter : g->all_monsters() ) {
         if( critter.type->id == mon_zombie_dancer ) {
             critter.poly( mon_zombie_hulk );
-            critter.remove_effect( effect_controlled );
+            critter.remove_effect( effect_ai_controlled );
         }
         if( g->u.sees( z ) ) {
             add_msg( m_warning, _( "The music stops!" ) );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -45,7 +45,7 @@ static const efftype_id effect_sheared( "sheared" );
 static const activity_id ACT_MILK( "ACT_MILK" );
 static const activity_id ACT_PLAY_WITH_PET( "ACT_PLAY_WITH_PET" );
 
-static const efftype_id effect_controlled( "controlled" );
+static const efftype_id effect_ai_waiting( "ai_waiting" );
 static const efftype_id effect_harnessed( "harnessed" );
 static const efftype_id effect_has_bag( "has_bag" );
 static const efftype_id effect_monster_armor( "monster_armor" );
@@ -459,7 +459,7 @@ bool Character::can_mount( const monster &critter ) const
         return false;
     }
     return ( critter.has_flag( MF_PET_MOUNTABLE ) && critter.friendly == -1 &&
-             !critter.has_effect( effect_controlled ) && !critter.has_effect( effect_ridden ) ) &&
+             !critter.has_effect( effect_ai_waiting ) && !critter.has_effect( effect_ridden ) ) &&
            ( ( critter.has_effect( effect_saddled ) && get_skill_level( skill_survival ) >= 1 ) ||
              get_skill_level( skill_survival ) >= 4 ) && ( critter.get_size() >= ( get_size() + 1 ) &&
                      get_weight() <= critter.get_weight() * critter.get_mountable_weight_ratio() );
@@ -605,7 +605,7 @@ bool monexamine::give_items_to( monster &z )
             to_move.insert( to_move.end(), itq );
         }
     }
-    z.add_effect( effect_controlled, 5_turns );
+    z.add_effect( effect_ai_waiting, 5_turns );
     g->u.drop( to_move, z.pos(), true );
 
     return false;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -74,9 +74,9 @@
 
 static const activity_id ACT_READ( "ACT_READ" );
 
+static const efftype_id effect_ai_waiting( "ai_waiting" );
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_contacts( "contacts" );
-static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_drunk( "drunk" );
 static const efftype_id effect_high( "high" );
 static const efftype_id effect_infection( "infection" );
@@ -2138,7 +2138,7 @@ void npc::npc_dismount()
         remove_item( weapon );
     }
     mounted_creature->remove_effect( effect_ridden );
-    mounted_creature->add_effect( effect_controlled, 5_turns );
+    mounted_creature->add_effect( effect_ai_waiting, 5_turns );
     mounted_creature = nullptr;
     setpos( *pnt );
     mod_moves( -100 );


### PR DESCRIPTION
#### Purpose of change
Fixes #633.
Fix dancer zombies not dancing.
Fix blobs freezing in place around brain blob.

#### Describe the solution
Split `controlled` effect into 2:
`ai_controlled` for use in Thriller's and brain blob's special attacks (makes creature follow predefined plan)
`ai_waiting` for horses (makes them stay still until effect expires)

#### Describe alternatives you've considered
Making `controlled` not permanent, but then after some digging I realized the effect was broken in 596d44984dc6a072f67c8b031228dc1f790beaa4 and repurposed to make horses stay in place. This PR reverts these changes, and implements a more careful solution.

#### Testing
Zombies dance, blobs swarm, horses can be repeatedly mounted.
Broken horses from existing saves become unbroken (game shows a couple debug messages, but they can be safely skipped).

#### Additional context
We should totally have dancers in vanilla.