### PR TITLE
Add initialization to misc class members

### DIFF
--- a/src/avatar.h
+++ b/src/avatar.h
@@ -220,7 +220,7 @@ class avatar : public player
 
     private:
         std::unique_ptr<map_memory> player_map_memory;
-        bool show_map_memory;
+        bool show_map_memory = true;
 
         friend class debug_menu::mission_debug;
         /**
@@ -239,12 +239,12 @@ class avatar : public player
         /**
          * The currently active mission, or null if no mission is currently in progress.
          */
-        mission *active_mission;
+        mission *active_mission = nullptr;
 
         // Items the player has identified.
         std::unordered_set<std::string> items_identified;
 
-        object_type grab_type;
+        object_type grab_type = OBJECT_NONE;
 
         // these are the stat upgrades from stats through kills
 
@@ -269,16 +269,17 @@ class avatar : public player
 avatar &get_avatar();
 
 struct points_left {
-    int stat_points;
-    int trait_points;
-    int skill_points;
+    int stat_points = 0;
+    int trait_points = 0;
+    int skill_points = 0;
 
     enum point_limit : int {
         FREEFORM = 0,
         ONE_POOL,
         MULTI_POOL,
         TRANSFER,
-    } limit;
+    };
+    point_limit limit = point_limit::FREEFORM;
 
     points_left();
     void init_from_options();

--- a/src/character.h
+++ b/src/character.h
@@ -281,7 +281,7 @@ class Character : public Creature, public visitable<Character>
         bool is_warm() const override;
         bool in_species( const species_id &spec ) const override;
         // Turned to false for simulating NPCs on distant missions so they don't drop all their gear in sight
-        bool death_drops;
+        bool death_drops = true;
         const std::string &symbol() const override;
 
         enum class comfort_level {
@@ -295,15 +295,15 @@ class Character : public Creature, public visitable<Character>
 
         // Character stats
         // TODO: Make those protected
-        int str_max;
-        int dex_max;
-        int int_max;
-        int per_max;
+        int str_max = 0;
+        int dex_max = 0;
+        int int_max = 0;
+        int per_max = 0;
 
-        int str_cur;
-        int dex_cur;
-        int int_cur;
-        int per_cur;
+        int str_cur = 0;
+        int dex_cur = 0;
+        int int_cur = 0;
+        int per_cur = 0;
 
         // The prevalence of getter, setter, and mutator functions here is partially
         // a result of the slow, piece-wise migration of the player class upwards into
@@ -617,8 +617,8 @@ class Character : public Creature, public visitable<Character>
         /** Returns true if the character is wearing something on the entered body_part, ignoring items with the ALLOWS_NATURAL_ATTACKS flag */
         bool natural_attack_restricted_on( const bodypart_id &bp ) const;
 
-        int blocks_left;
-        int dodges_left;
+        int blocks_left = 0;
+        int dodges_left = 0;
 
         double recoil = MAX_RECOIL;
 
@@ -1576,14 +1576,14 @@ class Character : public Creature, public visitable<Character>
 
         // --------------- Values ---------------
         std::string name;
-        bool male;
+        bool male = true;
 
         std::list<item> worn;
         std::array<int, num_hp_parts> damage_bandaged, damage_disinfected;
-        bool nv_cached;
+        bool nv_cached = false;
         // Means player sit inside vehicle on the tile he is now
-        bool in_vehicle;
-        bool hauling;
+        bool in_vehicle = false;
+        bool hauling = false;
 
         player_activity stashed_outbounds_activity;
         player_activity stashed_outbounds_backlog;
@@ -1594,20 +1594,20 @@ class Character : public Creature, public visitable<Character>
         itype_id last_item;
         item weapon;
 
-        int scent;
+        int scent = 0;
         pimpl<bionic_collection> my_bionics;
         pimpl<character_martial_arts> martial_arts_data;
 
         stomach_contents stomach;
         std::list<consumption_event> consumption_history;
 
-        int oxygen;
-        int tank_plut;
-        int reactor_plut;
-        int slow_rad;
+        int oxygen = 0;
+        int tank_plut = 0;
+        int reactor_plut = 0;
+        int slow_rad = 0;
 
-        int focus_pool;
-        int cash;
+        int focus_pool = 0;
+        int cash = 0;
         std::set<character_id> follower_ids;
         weak_ptr_fast<Creature> last_target;
         cata::optional<tripoint> last_target_pos;
@@ -1629,7 +1629,7 @@ class Character : public Creature, public visitable<Character>
 
         shared_ptr_fast<monster> mounted_creature;
         // for loading NPC mounts
-        int mounted_creature_id;
+        int mounted_creature_id = 0;
         // for vehicle work
         int activity_vehicle_part_index = -1;
 
@@ -2121,14 +2121,14 @@ class Character : public Creature, public visitable<Character>
         tripoint position;
 
         /** Bonuses to stats, calculated each turn */
-        int str_bonus;
-        int dex_bonus;
-        int per_bonus;
-        int int_bonus;
+        int str_bonus = 0;
+        int dex_bonus = 0;
+        int per_bonus = 0;
+        int int_bonus = 0;
 
         /** How healthy the character is. */
-        int healthy;
-        int healthy_mod;
+        int healthy = 0;
+        int healthy_mod = 0;
 
         /** age in years at character creation */
         int init_age = 25;
@@ -2140,7 +2140,7 @@ class Character : public Creature, public visitable<Character>
         trap_map known_traps;
         std::array<encumbrance_data, num_bp> encumbrance_cache;
         mutable std::map<std::string, double> cached_info;
-        bool bio_soporific_powered_at_last_sleep_check;
+        bool bio_soporific_powered_at_last_sleep_check = false;
         /** last time we checked for sleep */
         time_point last_sleep_check = calendar::turn_zero;
         /** warnings from a faction about bad behavior */
@@ -2171,7 +2171,7 @@ class Character : public Creature, public visitable<Character>
         std::bitset<NUM_VISION_MODES> vision_mode_cache;
         // "Raw" night vision range - just stats+mutations+items
         float nv_range = 0;
-        int sight_max;
+        int sight_max = 0;
 
         // turn the character expired, if calendar::before_time_starts it has not been set yet.
         // TODO: change into an optional<time_point>
@@ -2192,7 +2192,7 @@ class Character : public Creature, public visitable<Character>
         faction_id fac_id;
         faction *my_fac = nullptr;
 
-        character_movemode move_mode;
+        character_movemode move_mode = CMM_WALK;
         /** Current deficiency/excess quantity for each vitamin */
         std::map<vitamin_id, int> vitamin_levels;
 
@@ -2233,19 +2233,19 @@ class Character : public Creature, public visitable<Character>
         units::energy max_power_level;
 
         /** Needs (hunger, starvation, thirst, fatigue, etc.) */
-        int stored_calories;
+        int stored_calories = 0;
 
-        int thirst;
-        int stamina;
+        int thirst = 0;
+        int stamina = 0;
 
-        int fatigue;
-        int sleep_deprivation;
+        int fatigue = 0;
+        int sleep_deprivation = 0;
         bool check_encumbrance = true;
 
-        int stim;
-        int pkill;
+        int stim = 0;
+        int pkill = 0;
 
-        int radiation;
+        int radiation = 0;
 
         std::vector<tripoint> auto_move_route;
         // Used to make sure auto move is canceled if we stumble off course
@@ -2254,7 +2254,7 @@ class Character : public Creature, public visitable<Character>
 
         struct weighted_int_list<std::string> melee_miss_reasons;
 
-        int cached_moves;
+        int cached_moves = 0;
         tripoint cached_position;
         inventory cached_crafting_inventory;
 
@@ -2273,7 +2273,7 @@ class Character : public Creature, public visitable<Character>
         std::array<int, num_bp> drench_capacity;
 
         time_point next_climate_control_check;
-        bool last_climate_control_ret;
+        bool last_climate_control_ret = false;
 };
 
 Character &get_player_character();

--- a/src/creature.h
+++ b/src/creature.h
@@ -535,8 +535,8 @@ class Creature
         /** Returns a set of points we do not want to path through. */
         virtual std::set<tripoint> get_path_avoid() const = 0;
 
-        int moves;
-        bool underwater;
+        int moves = 0;
+        bool underwater = false;
         void draw( const catacurses::window &w, const point &origin, bool inverted ) const;
         void draw( const catacurses::window &w, const tripoint &origin, bool inverted ) const;
         /**
@@ -757,7 +757,7 @@ class Creature
         virtual bool is_symbol_highlighted() const;
 
     protected:
-        Creature *killer; // whoever killed us. this should be NULL unless we are dead
+        Creature *killer = nullptr; // whoever killed us. this should be NULL unless we are dead
         void set_killer( Creature *killer );
 
         /**
@@ -772,21 +772,21 @@ class Creature
         // used for innate bonuses like effects. weapon bonuses will be
         // handled separately
 
-        int num_blocks; // base number of blocks/dodges per turn
-        int num_dodges;
-        int num_blocks_bonus; // bonus ""
-        int num_dodges_bonus;
+        int num_blocks = 0; // base number of blocks/dodges per turn
+        int num_dodges = 0;
+        int num_blocks_bonus = 0; // bonus ""
+        int num_dodges_bonus = 0;
 
-        int armor_bash_bonus;
-        int armor_cut_bonus;
-        int speed_base; // only speed needs a base, the rest are assumed at 0 and calculated off skills
+        int armor_bash_bonus = 0;
+        int armor_cut_bonus = 0;
+        int speed_base = 0; // only speed needs a base, the rest are assumed at 0 and calculated off skills
 
-        int speed_bonus;
-        float dodge_bonus;
-        int block_bonus;
-        float hit_bonus;
+        int speed_bonus = 0;
+        float dodge_bonus = 0.0;
+        int block_bonus = 0;
+        float hit_bonus = 0.0;
 
-        bool fake;
+        bool fake = false;
         Creature();
         Creature( const Creature & ) = default;
         Creature( Creature && ) = default;
@@ -844,7 +844,7 @@ class Creature
         void load( const JsonObject &jsin );
 
     private:
-        int pain;
+        int pain = 0;
 };
 
 #endif // CATA_SRC_CREATURE_H

--- a/src/json.h
+++ b/src/json.h
@@ -828,7 +828,7 @@ class JsonObject
         std::map<std::string, int> positions;
         int start;
         int end_;
-        bool final_separator;
+        bool final_separator = false;
 #ifndef CATA_IN_TOOL
         mutable std::set<std::string> visited_members;
         mutable bool report_unvisited_members = true;

--- a/src/mission.h
+++ b/src/mission.h
@@ -140,7 +140,7 @@ struct mission_fail {
 struct mission_target_params {
     std::string overmap_terrain;
     ot_match_type overmap_terrain_match_type = ot_match_type::type;
-    mission *mission_pointer;
+    mission *mission_pointer = nullptr;
 
     bool origin_u = true;
     cata::optional<tripoint> offset;
@@ -300,21 +300,21 @@ class mission
         friend struct mission_start;
         friend class debug_menu::mission_debug;
 
-        const mission_type *type;
-        mission_status status;
+        const mission_type *type = nullptr;
+        mission_status status = mission_status::num_mission_status;
         // Cash/Favor value of completing this
-        unsigned int value;
+        unsigned int value = 0;
         // If there's a special reward for completing it
         npc_favor reward;
         // Unique ID number, used for referencing elsewhere
-        int uid;
+        int uid = 0;
         // Marked on the player's map. (INT_MIN, INT_MIN) for none,
         // global overmap terrain coordinates.
         tripoint target;
         // Item that needs to be found (or whatever)
         itype_id item_id;
         // The number of above items needed
-        int item_count;
+        int item_count = 0;
         // Destination type to be reached
         string_id<oter_type_t> target_id;
         // The type of NPC you are to recruit
@@ -326,16 +326,18 @@ class mission
         // Monster species that are to be killed
         species_id monster_species;
         // The number of monsters you need to kill
-        int monster_kill_goal;
+        int monster_kill_goal = 0;
         // The kill count you need to reach to complete mission
-        int kill_count_to_reach;
+        int kill_count_to_reach = 0;
         time_point deadline;
         // ID of a related npc
         character_id npc_id;
-        // IDs of the protagonist/antagonist factions
-        int good_fac_id, bad_fac_id;
+        // ID of the protagonist faction
+        int good_fac_id = 0;
+        // ID of antagonist faction
+        int bad_fac_id = 0;
         // How much have we completed?
-        int step;
+        int step = 0;
         // What mission do we get after this succeeds?
         mission_type_id follow_up;
         // The id of the player that has accepted this mission.

--- a/src/npc.h
+++ b/src/npc.h
@@ -239,19 +239,13 @@ struct npc_personality {
 };
 
 struct npc_opinion {
-    int trust;
-    int fear;
-    int value;
-    int anger;
-    int owed; // Positive when the npc owes the player. Negative if player owes them.
+    int trust = 0;
+    int fear = 0;
+    int value = 0;
+    int anger = 0;
+    int owed = 0; // Positive when the npc owes the player. Negative if player owes them.
 
-    npc_opinion() {
-        trust = 0;
-        fear  = 0;
-        value = 0;
-        anger = 0;
-        owed  = 0;
-    }
+    npc_opinion() = default;
 
     npc_opinion( int T, int F, int V, int A, int O ) :
         trust( T ), fear( F ), value( V ), anger( A ), owed( O ) {
@@ -367,7 +361,7 @@ enum class ally_rule {
 };
 
 struct ally_rule_data {
-    ally_rule rule;
+    ally_rule rule = ally_rule::DEFAULT;
     std::string rule_true_text;
     std::string rule_false_text;
 };
@@ -489,13 +483,13 @@ const std::unordered_map<std::string, ally_rule_data> ally_rule_strs = { {
 };
 
 struct npc_follower_rules {
-    combat_engagement engagement;
+    combat_engagement engagement = combat_engagement::NONE;
     aim_rule aim = aim_rule::WHEN_CONVENIENT;
     cbm_recharge_rule cbm_recharge = cbm_recharge_rule::CBM_RECHARGE_SOME;
     cbm_reserve_rule cbm_reserve = cbm_reserve_rule::CBM_RESERVE_SOME;
-    ally_rule flags;
-    ally_rule override_enable;
-    ally_rule overrides;
+    ally_rule flags = ally_rule::DEFAULT;
+    ally_rule override_enable = ally_rule::DEFAULT;
+    ally_rule overrides = ally_rule::DEFAULT;
 
     pimpl<auto_pickup::npc_settings> pickup_whitelist;
 
@@ -524,7 +518,7 @@ struct npc_follower_rules {
 struct dangerous_sound {
     tripoint abs_pos;
     sounds::sound_t type;
-    int volume;
+    int volume = 0;
 };
 
 const direction npc_threat_dir[8] = { direction::NORTHWEST, direction::NORTH, direction::NORTHEAST, direction::EAST,
@@ -1258,7 +1252,7 @@ class npc : public player
         cata::optional<tripoint> assigned_camp = cata::nullopt;
 
     private:
-        npc_attitude attitude; // What we want to do to the player
+        npc_attitude attitude = NPCATT_NULL; // What we want to do to the player
         npc_attitude previous_attitude = NPCATT_NULL;
         bool known_to_u = false; // Does the player know this NPC?
         /**
@@ -1294,7 +1288,7 @@ class npc : public player
          */
         tripoint global_square_location() const override;
         cata::optional<tripoint> last_player_seen_pos; // Where we last saw the player
-        int last_seen_player_turn; // Timeout to forgetting
+        int last_seen_player_turn = 0; // Timeout to forgetting
         tripoint wanted_item_pos; // The square containing an item we want
         tripoint guard_pos;  // These are the local coordinates that a guard will return to inside of their goal tripoint
         tripoint chair_pos = no_goal_point; // This is the spot the NPC wants to move to to sit and relax.
@@ -1305,16 +1299,16 @@ class npc : public player
          */
         tripoint goal;
         tripoint wander_pos = no_goal_point;
-        int wander_time;
+        int wander_time = 0;
         item *known_stolen_item = nullptr; // the item that the NPC wants the player to drop or barter for.
         /**
          * Location and index of the corpse we'd like to pulp (if any).
          */
         cata::optional<tripoint> pulp_location;
         time_point restock;
-        bool fetching_item;
-        bool has_new_items; // If true, we have something new and should re-equip
-        int  worst_item_value; // The value of our least-wanted item
+        bool fetching_item = false;
+        bool has_new_items = false; // If true, we have something new and should re-equip
+        int worst_item_value = 0; // The value of our least-wanted item
 
         std::vector<tripoint> path; // Our movement plans
 
@@ -1331,11 +1325,11 @@ class npc : public player
         npc_personality personality;
         npc_opinion op_of_u;
         npc_chatbin chatbin;
-        int patience; // Used when we expect the player to leave the area
+        int patience = 0; // Used when we expect the player to leave the area
         npc_follower_rules rules;
-        bool marked_for_death; // If true, we die as soon as we respawn!
-        bool hit_by_player;
-        bool hallucination; // If true, NPC is an hallucination
+        bool marked_for_death = false; // If true, we die as soon as we respawn!
+        bool hit_by_player = false;
+        bool hallucination = false; // If true, NPC is an hallucination
         std::vector<npc_need> needs;
         cata::optional<int> confident_range_cache;
         // Dummy point that indicates that the goal is invalid.
@@ -1382,7 +1376,7 @@ class npc : public player
         // the index of the bionics for the fake gun;
         int cbm_weapon_index = -1;
 
-        bool dead;  // If true, we need to be cleaned up
+        bool dead = false;  // If true, we need to be cleaned up
 
         bool sees_dangerous_field( const tripoint &p ) const;
         bool could_move_onto( const tripoint &p ) const;
@@ -1416,7 +1410,7 @@ class npc_template
             male,
             female
         };
-        gender gender_override;
+        gender gender_override = gender::random;
 
         static void load( const JsonObject &jsobj );
         static void reset();

--- a/src/player.h
+++ b/src/player.h
@@ -477,7 +477,7 @@ class player : public Character
 
         /** last time we checked for sleep */
         time_point last_sleep_check = calendar::turn_zero;
-        bool bio_soporific_powered_at_last_sleep_check;
+        bool bio_soporific_powered_at_last_sleep_check = false;
 
     public:
         /** Returns a value from 1.0 to 5.0 that acts as a multiplier
@@ -682,22 +682,22 @@ class player : public Character
         // ---------------VALUES-----------------
         tripoint view_offset;
         // Is currently in control of a vehicle
-        bool controlling_vehicle;
+        bool controlling_vehicle = false;
         // Relative direction of a grab, add to posx, posy to get the coordinates of the grabbed thing.
         tripoint grab_point;
-        int volume;
-        const profession *prof;
+        int volume = 0;
+        const profession *prof = nullptr;
 
-        bool random_start_location;
+        bool random_start_location = false;
         start_location_id start_location;
 
         weak_ptr_fast<Creature> last_target;
         cata::optional<tripoint> last_target_pos;
         // Save favorite ammo location
         item_location ammo_location;
-        int scent;
-        int cash;
-        int movecounter;
+        int scent = 0;
+        int cash = 0;
+        int movecounter = 0;
 
         bool manual_examine = false;
         vproto_id starting_vehicle;
@@ -708,7 +708,7 @@ class player : public Character
         pimpl<craft_command> last_craft;
 
         recipe_id lastrecipe;
-        int last_batch;
+        int last_batch = 0;
         itype_id lastconsumed;        //used in crafting.cpp and construction.cpp
 
         std::set<character_id> follower_ids;


### PR DESCRIPTION
#### Purpose of change
Make UBSan in CI happy

#### Describe the solution
Add initialization to misc members in `Creature` family and couple other classes.
Not all of this is necessary, but UBSan was tight-lipped on what fields exactly it didn't like, so I went with _all_ of them for the good measure.

#### Testing
All tests pass on local copy built with asan+ubsan
