### PR TITLE
Create individual folders for characters in graveyard

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -943,6 +943,33 @@ void game::create_starting_npcs()
                           tmp->getID() ) );
 }
 
+static std::string generate_memorial_filename( const std::string &char_name )
+{
+    // <name>-YYYY-MM-DD-HH-MM-SS.txt
+    //       123456789012345678901234 ~> 24 chars + a null
+    constexpr size_t suffix_len = 24 + 1;
+    constexpr size_t max_name_len = FILENAME_MAX - suffix_len;
+
+    const size_t name_len = char_name.size();
+    // Here -1 leaves space for the ~
+    const size_t truncated_name_len = ( name_len >= max_name_len ) ? ( max_name_len - 1 ) : name_len;
+
+    std::ostringstream memorial_file_path;
+
+    memorial_file_path << ensure_valid_file_name( char_name );
+
+    // Add a ~ if the player name was actually truncated.
+    memorial_file_path << ( ( truncated_name_len != name_len ) ? "~-" : "-" );
+
+    // Add a timestamp for uniqueness.
+    char buffer[suffix_len] {};
+    std::time_t t = std::time( nullptr );
+    std::strftime( buffer, suffix_len, "%Y-%m-%d-%H-%M-%S", std::localtime( &t ) );
+    memorial_file_path << buffer;
+
+    return memorial_file_path.str();
+}
+
 bool game::cleanup_at_end()
 {
     if( uquit == QUIT_DIED || uquit == QUIT_SUICIDE ) {
@@ -1142,8 +1169,9 @@ bool game::cleanup_at_end()
         const bool is_suicide = uquit == QUIT_SUICIDE;
         events().send<event_type::game_over>( is_suicide, sLastWords );
         // Struck the save_player_data here to forestall Weirdness
-        move_save_to_graveyard();
-        write_memorial_file( sLastWords );
+        std::string char_filename = generate_memorial_filename( u.name );
+        move_save_to_graveyard( char_filename );
+        write_memorial_file( char_filename, sLastWords );
         memorial().clear();
         std::vector<std::string> characters = list_active_characters();
         // remove current player from the active characters list, as they are dead
@@ -2641,14 +2669,19 @@ void game::win_screen()
     popup( msg );
 }
 
-void game::move_save_to_graveyard()
+void game::move_save_to_graveyard( const std::string &dirname )
 {
-    const std::string &save_dir      = get_world_base_save_path();
-    const std::string &graveyard_dir = PATH_INFO::graveyarddir();
-    const std::string &prefix        = base64_encode( u.name ) + ".";
+    const std::string save_dir           = get_world_base_save_path();
+    const std::string graveyard_dir      = PATH_INFO::graveyarddir() + "/";
+    const std::string graveyard_save_dir = graveyard_dir + dirname + "/";
+    const std::string prefix             = base64_encode( u.name ) + ".";
 
     if( !assure_dir_exist( graveyard_dir ) ) {
         debugmsg( "could not create graveyard path '%s'", graveyard_dir );
+    }
+
+    if( !assure_dir_exist( graveyard_save_dir ) ) {
+        debugmsg( "could not create graveyard path '%s'", graveyard_save_dir );
     }
 
     const auto save_files = get_files_from_path( prefix, save_dir );
@@ -2657,7 +2690,7 @@ void game::move_save_to_graveyard()
     }
 
     for( const auto &src_path : save_files ) {
-        const std::string dst_path = graveyard_dir +
+        const std::string dst_path = graveyard_save_dir +
                                      src_path.substr( src_path.rfind( '/' ), std::string::npos );
 
         if( rename_file( src_path, dst_path ) ) {
@@ -3013,7 +3046,7 @@ std::vector<std::string> game::list_active_characters()
  * state at the time the memorial was made (usually upon death) and
  * accomplishments in a human-readable format.
  */
-void game::write_memorial_file( std::string sLastWords )
+void game::write_memorial_file( const std::string &filename, std::string sLastWords )
 {
     const std::string &memorial_dir = PATH_INFO::memorialdir();
     const std::string &memorial_active_world_dir = memorial_dir +
@@ -3030,33 +3063,9 @@ void game::write_memorial_file( std::string sLastWords )
         return;
     }
 
-    // <name>-YYYY-MM-DD-HH-MM-SS.txt
-    //       123456789012345678901234 ~> 24 chars + a null
-    constexpr size_t suffix_len   = 24 + 1;
-    constexpr size_t max_name_len = FILENAME_MAX - suffix_len;
+    std::string path = memorial_active_world_dir + filename + ".txt";
 
-    const size_t name_len = u.name.size();
-    // Here -1 leaves space for the ~
-    const size_t truncated_name_len = ( name_len >= max_name_len ) ? ( max_name_len - 1 ) : name_len;
-
-    std::ostringstream memorial_file_path;
-    memorial_file_path << memorial_active_world_dir;
-
-    memorial_file_path << ensure_valid_file_name( u.name );
-
-    // Add a ~ if the player name was actually truncated.
-    memorial_file_path << ( ( truncated_name_len != name_len ) ? "~-" : "-" );
-
-    // Add a timestamp for uniqueness.
-    char buffer[suffix_len] {};
-    std::time_t t = std::time( nullptr );
-    std::strftime( buffer, suffix_len, "%Y-%m-%d-%H-%M-%S", std::localtime( &t ) );
-    memorial_file_path << buffer;
-
-    memorial_file_path << ".txt";
-
-    const std::string path_string = memorial_file_path.str();
-    write_to_file( memorial_file_path.str(), [&]( std::ostream & fout ) {
+    write_to_file( path, [&]( std::ostream & fout ) {
         memorial().write( fout, sLastWords );
     }, _( "player memorial" ) );
 }

--- a/src/game.h
+++ b/src/game.h
@@ -213,7 +213,7 @@ class game
 
         /** Returns a list of currently active character saves. */
         std::vector<std::string> list_active_characters();
-        void write_memorial_file( std::string sLastWords );
+        void write_memorial_file( const std::string &filename, std::string sLastWords );
         bool cleanup_at_end();
         void start_calendar();
         /** MAIN GAME LOOP. Returns true if game is over (death, saved, quit, etc.). */
@@ -955,7 +955,7 @@ class game
 
         Creature *is_hostile_within( int distance );
 
-        void move_save_to_graveyard();
+        void move_save_to_graveyard( const std::string &dirname );
         bool save_player_data();
         // ########################## DATA ################################
     private:


### PR DESCRIPTION
#### Purpose of change
Fixes #648, which occurs when character dies, but there is already a character with the same name in the graveyard.
This may happen when character duplicated due to a bug, or when player repeatedly tries and fails to survive in different worlds and gives their character same name on each attempt.

#### Describe the solution
Create per-character folders inside graveyard. The folders follow the memorial's naming scheme of name + timestamp, thus mitigating possible filename conflicts.

#### Testing
Delete graveyard folder, load a world, die. Character gets moved to a newly created subfolder inside newly created `graveyard` folder.
