### PR TITLE
Fix zone generation rotates zones on all z levels; clear zone manager on new game

### DIFF
--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1038,7 +1038,9 @@ void zone_manager::rotate_zones( map &target_map, const int turns )
         if( ( a_start.x <= z_start.x && a_start.y <= z_start.y ) &&
             ( a_end.x > z_start.x && a_end.y >= z_start.y ) &&
             ( a_start.x <= z_end.x && a_start.y <= z_end.y ) &&
-            ( a_end.x >= z_end.x && a_end.y >= z_end.y ) ) {
+            ( a_end.x >= z_end.x && a_end.y >= z_end.y ) &&
+            ( a_start.z == z_start.z )
+          ) {
             tripoint z_l_start3 = target_map.getlocal( z_start );
             tripoint z_l_end3 = target_map.getlocal( z_end );
             // don't rotate centered squares

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -122,6 +122,17 @@ zone_manager::zone_manager()
 
 }
 
+zone_manager &zone_manager::get_manager()
+{
+    static zone_manager manager;
+    return manager;
+}
+
+void zone_manager::reset_manager()
+{
+    get_manager() = zone_manager();
+}
+
 std::string zone_type::name() const
 {
     return _( name_ );

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -367,7 +367,6 @@ class zone_manager
         //Cache number of items already checked on each source tile when sorting
         std::unordered_map<tripoint, int> num_processed;
 
-    public:
         zone_manager();
         ~zone_manager() = default;
         zone_manager( zone_manager && ) = default;
@@ -375,10 +374,9 @@ class zone_manager
         zone_manager &operator=( zone_manager && ) = default;
         zone_manager &operator=( const zone_manager & ) = default;
 
-        static zone_manager &get_manager() {
-            static zone_manager manager;
-            return manager;
-        }
+    public:
+        static zone_manager &get_manager();
+        static void reset_manager();
 
         void add( const std::string &name, const zone_type_id &type, const faction_id &faction,
                   bool invert, bool enabled,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -660,6 +660,7 @@ void DynamicDataLoader::finalize_loaded_data( loading_ui &ui )
             { _( "Overmap specials" ), &overmap_specials::finalize },
             { _( "Overmap locations" ), &overmap_locations::finalize },
             { _( "Start locations" ), &start_locations::finalize_all },
+            { _( "Zone manager" ), &zone_manager::reset_manager },
             { _( "Vehicle prototypes" ), &vehicle_prototype::finalize },
             { _( "Mapgen weights" ), &calculate_mapgen_weights },
             {


### PR DESCRIPTION
#### Purpose of change
Fixes #635.
Fixes zones from one save appearing in different save if both have been loaded in single session and there was no zones file in the second save.

#### Describe the solution
1. In mapgen, restrict zone rotation to z-level being generated.
2. Reset zone manager during finalization (after zone types have been loaded, but before actual zones are loaded). 

#### Describe alternatives you've considered
Also fixing non-player zones (see https://github.com/CleverRaven/Cataclysm-DDA/issues/49755), but the more I looked into them the more I realized they may need a complete refactor. There is no "worldwide" zone handling; zones are handled on per-character basis, to the point that they can only be saved via Zone Manager UI.

For now, non-player zones in BN are considered unimplemented.

#### Testing
Save for testing: [zones-rotate-on-z-change.zip](https://github.com/cataclysmbnteam/Cataclysm-BN/files/6787764/zones-rotate-on-z-change.zip)
1. Load save
2. Enable submap grid overlay
3. Open Zone Manager, note that zones match colored chunks of floor
4. Descend and ascend.

With fix: zones are not affected
Without fix: zones have been rotated clockwise by 90 degrees around the center of overmap tile