### PR TITLE
Fix CTD when trying to ignite an item while having flamethrower in the inventory

### DIFF
--- a/data/json/items/classes/gun.json
+++ b/data/json/items/classes/gun.json
@@ -20,6 +20,7 @@
     "ammo_effects": [ "FLARE" ],
     "reload": 4,
     "flags": [ "FIRE_100", "NEVER_JAMS", "FIRESTARTER" ],
+    "use_action": { "type": "firestarter", "moves": 200 },
     "faults": [  ]
   },
   {

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -153,7 +153,8 @@
     "copy-from": "fake_item",
     "type": "TOOL",
     "name": { "str": "bionic firestarter" },
-    "flags": [ "FIRESTARTER" ]
+    "flags": [ "FIRESTARTER" ],
+    "use_action": { "type": "firestarter", "moves": 200 }
   },
   {
     "id": "migo_bio_gun",

--- a/data/json/items/gun/bio.json
+++ b/data/json/items/gun/bio.json
@@ -63,7 +63,8 @@
     "durability": 10,
     "loudness": 7,
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NEVER_JAMS", "TRADER_AVOID", "FIRESTARTER" ]
+    "flags": [ "NEVER_JAMS", "TRADER_AVOID", "FIRESTARTER" ],
+    "use_action": { "type": "firestarter", "moves": 200 }
   },
   {
     "id": "bio_lightning",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9281,6 +9281,10 @@ bool Character::has_fire( const int quantity ) const
         for( auto &i : firestarters ) {
             if( !i->type->can_have_charges() ) {
                 const use_function *usef = i->type->get_use( "firestarter" );
+                if( !usef ) {
+                    debugmsg( "failed to get use func 'firestarter' for item '%s'", i->typeId().c_str() );
+                    continue;
+                }
                 const firestarter_actor *actor = dynamic_cast<const firestarter_actor *>( usef->get_actor_ptr() );
                 if( actor->can_use( *this->as_character(), *i, false, tripoint_zero ).success() ) {
                     return true;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1118,6 +1118,12 @@ void Item_factory::check_definitions() const
             }
         }
 
+        if( type->has_flag( "FIRESTARTER" ) &&
+            !type->can_have_charges() &&
+            !type->get_use( "firestarter" ) ) {
+            msg += string_format( "has 'FIRESTARTER' flag, but neither can have charges nor defines 'firestarter' use func" );
+        }
+
         if( type->comestible ) {
             if( type->comestible->tool != "null" ) {
                 auto req_tool = find_template( type->comestible->tool );


### PR DESCRIPTION
#### Purpose of change
Fix CTD when trying to ignite an item while having flamethrower in the inventory.
This is caused by `Character::has_fire` assuming that chargeless items with `FIRESTARTER` flag also have `firestarter` iuse func (flamethrowers do not), and dereferencing a null pointer.

#### Describe the solution
Add a check that warns if `FIRESTARTER` item neither can have charges nor has the `firestarter` iuse.

#### Describe alternatives you've considered
Disallow using flamethrowers as lighters, but nothing else is good enough if one wants to have a smoke _with style_.

#### Testing
Game no longer crashes.

#### Additional context
Since flamethrowers are neither tools nor count-by-charges, using them to light a cig does not deplete fuel. I don't think that's a big deal since by the time the player gets a flamethrower they're most likely already in possession of (near-)limitless firestarting capabilities.