### PR TITLE
Fix false positive unvisited member warning if JSON file has mod_tileset entry and an entry of some other type

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -685,13 +685,14 @@ void tileset_loader::load( const std::string &tileset_id, const bool precheck )
         if( mod_config_json.test_array() ) {
             for( const JsonObject &mod_config : mod_config_json.get_array() ) {
                 if( mod_config.get_string( "type" ) == "mod_tileset" ) {
-                    mark_visited( mod_config );
                     if( num_in_file == mts.num_in_file() ) {
+                        mark_visited( mod_config );
                         load_internal( mod_config, tileset_root, img_path );
                         break;
                     }
                     num_in_file++;
                 }
+                mod_config.allow_omitted_members();
             }
         } else {
             JsonObject mod_config = mod_config_json.get_object();


### PR DESCRIPTION
#### Purpose of change
Fix false positive unvisited member warning if JSON file has mod_tileset entry and an entry of some other type.

#### Describe the solution
If entry is not of `mod_tileset` type, allow unvisited members, as their detection is handled by whatever code is actually responsible for loading that type.

#### Testing
Modified version of Aftershock for testing: [aftershock_with_misplaced_fields.zip](https://github.com/cataclysmbnteam/Cataclysm-BN/files/6797060/aftershock_with_misplaced_fields.zip)
Without fix: throws a dozen of 'unvisited member' warnings.
With fix: throws only 2 warnings, for genuinely misplaced fields `unvisited_1` and `unvisited_2`.