### PR TITLE
Enable backtraces in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,12 +62,14 @@ jobs:
         include:
           - name: Windows Tiles x64
             mxe: x86_64
+            mxe_apt: x86-64
             artifact: windows-tiles-x64
             os: ubuntu-latest
             ext: zip
             content: application/zip
           - name: Windows Tiles x32
             mxe: i686
+            mxe_apt: i686
             artifact: windows-tiles-x32
             os: ubuntu-latest
             ext: zip
@@ -140,7 +142,13 @@ jobs:
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
           sudo add-apt-repository "deb [arch=amd64] https://pkg.mxe.cc/repos/apt `lsb_release -sc` main"
           sudo apt update
-          sudo apt install mxe-{i686,x86-64}-w64-mingw32.static-{sdl2,sdl2-ttf,sdl2-image,sdl2-mixer,gettext}
+          sudo apt install mxe-${{ matrix.mxe_apt }}-w64-mingw32.static-{sdl2,sdl2-ttf,sdl2-image,sdl2-mixer,gettext}
+          curl -L -o libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz https://github.com/Qrox/libbacktrace/releases/download/2020-01-03/libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz
+          if ! shasum -a 256 -c ./build-scripts/libbacktrace-${{ matrix.mxe }}-w64-mingw32-sha256; then
+            echo "Checksum failed for libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz"
+            exit 1
+          fi
+          sudo tar -xzf libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz --exclude=LICENSE -C /usr/lib/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none'
         run: |
@@ -161,7 +169,7 @@ jobs:
           commit sha: ${{ github.sha }}
           commit url: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
           EOL
-          make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 bindist
+          make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all PCH=0 bindist
           mv cataclysmbn-unstable.tar.gz cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.tar.gz
       - name: Build CBN (windows)
         if: matrix.mxe != 'none'
@@ -174,7 +182,7 @@ jobs:
           commit sha: ${{ github.sha }}
           commit url: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
           EOL
-          make -j$((`nproc`+0)) CROSS="${PLATFORM}" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 bindist
+          make -j$((`nproc`+0)) CROSS="${PLATFORM}" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all PCH=0 bindist
           mv cataclysmbn-unstable.zip cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
       - name: Build CBN (osx)
         if: runner.os == 'macOS'
@@ -187,7 +195,7 @@ jobs:
           commit sha: ${{ github.sha }}
           commit url: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
           EOL
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 dmgdist
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all PCH=0 dmgdist
           mv CataclysmBN-unstable.dmg cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Set up JDK 8 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'


### PR DESCRIPTION
#### Purpose of change
Enable backtraces in release versions

#### Describe the solution
Remove `BACKTRACE=0`. For win build, also install mxe version of `libbacktrace` same way Travis used to:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/477b74802f798bb768df933f81e3a49061ec9216/build-scripts/requirements.sh#L66-L80

#### Testing
Ran the workflow in a fork, locally tested Win/Linux tiles releases produce `crash.log` when triggering crash via debug menu.
OSX release compiles, but I can't test further.
https://github.com/olanti-p/CataclysmExpBN/releases/tag/cbn-experimental-2021-07-12-1918
