### PR TITLE
Fix fuel tanks not depleted properly when engine is idling

### DIFF
--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -313,7 +313,7 @@ double vehicle_part::consume_energy( const itype_id &ftype, double energy_j )
         if( !charges_to_use ) {
             return 0.0;
         }
-        if( charges_to_use > fuel.charges ) {
+        if( charges_to_use >= fuel.charges ) {
             charges_to_use = fuel.charges;
             base.contents.clear_items();
         } else {


### PR DESCRIPTION
#### Purpose of change
Fix #612.
Cause: when amount consumed equals amount in the tank, the item that represents fuel is left with 0 charges, but is not removed from the tank. In case of e.g. a Portable Generator, consumption rate is 1 unit of gasoline per turn, so any amount of fuel ends up leaving invalid item.

#### Describe the solution
Fix condition

#### Testing
Repeated steps from the issue, observed absence of the bug.