### PR TITLE
Add astyle to CMake build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ SET(CMAKE_MODULE_PATH
     ${CMAKE_SOURCE_DIR}/CMakeModules
 )
 
+INCLUDE(AstyleFormatSource)
+
 SET(CMAKE_TLS_VERIFY ON)
 
 # Build options

--- a/CMakeModules/AstyleFormatSource.cmake
+++ b/CMakeModules/AstyleFormatSource.cmake
@@ -1,0 +1,19 @@
+#This file contains target 'format-source' which runs astyle to format source files to our code
+#style, if astyle was found, otherwise there will be reported warning message about not found astyle
+#executable
+#If Artistic style executable was found, it will be contained in ASTYLE_EXECUTABLE variable
+#and ASTYLE_FOUND variable will be set
+find_program(ASTYLE_EXECUTABLE astyle)
+if(ASTYLE_EXECUTABLE)
+    set(ASTYLE_OPTIONS_FILE ${CMAKE_SOURCE_DIR}/.astylerc)
+    set(ASTYLE_FOUND "true")
+    add_custom_target(format-source
+            COMMAND ${ASTYLE_EXECUTABLE}  --options=${ASTYLE_OPTIONS_FILE} -r ${CMAKE_SOURCE_DIR}/src/*.cpp,*.h
+            ${CMAKE_SOURCE_DIR}/tests/*.cpp,*.h
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            SOURCES ${ASTYLE_OPTIONS_FILE}
+            )
+else()
+    unset(ASTYLE_FOUND)
+    message("Artistic style executable was not found, so automatic code style formating will be unavailable")
+endif()


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Add astyle to CMake build process"

#### Purpose of change
Make astyle prettification automatic as part of the build process.

#### Describe the solution
Add a CMake module for astyle using the project's `.astylerc` and include it in CMakeLists.txt.
