### PR TITLE
Update default for how encumbrance scales for non-rigid items

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5442,7 +5442,7 @@ int item::get_encumber_when_containing(
                 debugmsg( "Non-rigid item (%s) without storage capacity.", tname() );
             }
         } else {
-            encumber += contents_volume / 250_ml;
+            encumber += contents_volume / 500_ml;
         }
     }
 

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -111,7 +111,7 @@ TEST_CASE( "item rigidity", "[item][iteminfo][rigidity]" )
             item( "test_waterskin" ), q,
             "--\n"
             "<color_c_white>Encumbrance</color>: <color_c_yellow>0</color>"
-            "  Encumbrance when full: <color_c_yellow>6</color>\n"
+            "  Encumbrance when full: <color_c_yellow>3</color>\n"
             "--\n"
             "* This item is <color_c_cyan>not rigid</color>."
             "  Its volume and encumbrance increase with contents.\n" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Scale default encumbrance for non-rigid items at 2 per liter held, instead of 4 per liter"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Per discussion in https://github.com/cataclysmbnteam/Cataclysm-BN/issues/669 it was suggested that I start with changing how the hardcode default affects the encumbrance of non-rigid items, at least when they lack a defined max_encumbrance. Turns out it's rather easier than I first thought to change the hardcode default scaling.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Changed `game::get_encumber_when_containing` to divide encumbrance penalty by 500 milliliters instead of 250 milliliters for non-gun items. Wearable guns has its own special-case modifier evidently designed to make bulky guns a bit less encumbering than even my planned modifier, so left it alone for now.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Setting explicit max_encumbrance for more non-rigid stuff, to make its usage more conistent, will likely be good long-term if non-rigid encumbrance isn't outright phased out over time per comment in the related issue. One minor advantage that'd come up is that setting an explicit max encumbrance allows one to pick *exact* encumbrance-per-liter ratios for different items, instead of a set encumbrance-per-liter rate that's skewed slightly by having base encumbrance added on top of it.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Debug spawned in a toolbelt.
3. Checked to confirm that listed max encumbrance was now 22 instead of 42.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

See musings in linked issue for possible further plans.