### PR TITLE
Update shotshell recipes to be more consistent

### DIFF
--- a/data/json/items/tool/handloading.json
+++ b/data/json/items/tool/handloading.json
@@ -17,8 +17,8 @@
   {
     "id": "press_dowel",
     "type": "TOOL",
-    "name": { "str": "makeshift shotshell 'press'", "str_pl": "makeshift shotshell 'presses'" },
-    "description": "This is a collection of items improvised for field reloading of shotshells.  A plank with a hole cut in the center, a medium-sized nail, and a whittled dowel are used to seat wads, decap primers, and reprime (carefully!) hulls.  Powder and shot are measured with a cut down fired shotshell.  The opposite side of the plank has been shaped to allow for roll crimping of the plastic hulls.  There's no provision for resizing, so reloaded hulls will fire best in the firearm they were fired from.",
+    "name": { "str": "makeshift shotshell press", "str_pl": "makeshift shotshell presses" },
+    "description": "This is a collection of items improvised for field reloading of shotshells.  A plank with a hole cut in the center, a medium-sized nail, and a selection of whittled dowels are used to seat wads, decap primers, and reprime (carefully!) hulls.  The opposite side of the plank has been shaped to allow for roll crimping of the plastic hulls.",
     "weight": "348 g",
     "volume": "250 ml",
     "price": 600,

--- a/data/json/recipes/ammo/40x46mm.json
+++ b/data/json/recipes/ammo/40x46mm.json
@@ -13,7 +13,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "shot_forming", 2 ], [ "ammo_bullet", 12 ] ],
-    "tools": [ [ [ "press", -1 ] ], [ [ "swage", -1 ] ] ],
+    "tools": [ [ [ "swage", -1 ] ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
@@ -37,7 +37,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "shot_forming", 2 ], [ "ammo_bullet", 12 ] ],
-    "tools": [ [ [ "press", -1 ] ], [ [ "swage", -1 ] ] ],
+    "tools": [ [ [ "swage", -1 ] ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
@@ -61,7 +61,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 12 ] ],
-    "tools": [ [ [ "press", -1 ] ], [ [ "swage", -1 ] ] ],
+    "tools": [ [ [ "swage", -1 ] ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
@@ -85,7 +85,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 12 ] ],
-    "tools": [ [ [ "press", -1 ] ], [ [ "swage", -1 ] ] ],
+    "tools": [ [ [ "swage", -1 ] ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],

--- a/data/json/recipes/ammo/40x53mm.json
+++ b/data/json/recipes/ammo/40x53mm.json
@@ -13,7 +13,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "shot_forming", 2 ], [ "ammo_bullet", 16 ] ],
-    "tools": [ [ [ "press", -1 ] ], [ [ "swage", -1 ] ] ],
+    "tools": [ [ [ "swage", -1 ] ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],
@@ -37,7 +37,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 16 ] ],
-    "tools": [ [ [ "press", -1 ] ], [ [ "swage", -1 ] ] ],
+    "tools": [ [ [ "swage", -1 ] ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [ [ "sheet_metal_small", 1 ] ],

--- a/data/json/recipes/ammo/shot.json
+++ b/data/json/recipes/ammo/shot.json
@@ -13,7 +13,6 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "shot_forming", 1 ], [ "ammo_bullet", 10 ], [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press", -1 ] ] ],
     "components": [ [ [ "gunpowder", 6 ], [ "gunpowder_pistol", 6 ], [ "gunpowder_shotgun", 6 ] ] ]
   },
   {
@@ -30,7 +29,6 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "shot_forming", 1 ], [ "ammo_bullet", 5 ], [ "ammo_410shot", 1 ] ],
-    "tools": [ [ [ "press", -1 ] ] ],
     "components": [ [ [ "gunpowder", 5 ], [ "gunpowder_pistol", 5 ], [ "gunpowder_shotgun", 5 ] ] ]
   },
   {
@@ -47,7 +45,6 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "shot_forming", 1 ], [ "ammo_bullet", 10 ], [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press", -1 ] ] ],
     "components": [ [ [ "gunpowder", 3 ], [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ] ]
   },
   {
@@ -63,7 +60,7 @@
     "book_learn": [ [ "recipe_bullets", 3 ], [ "manual_shotgun", 3 ] ],
     "charges": 1,
     "using": [ [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press", -1 ] ] ],
+    "tools": [ [ [ "press", -1 ], [ "press_dowel", -1 ] ] ],
     "components": [ [ [ "gunpowder", 3 ], [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "magnesium", 5 ] ] ]
   },
   {
@@ -80,7 +77,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press", -1 ] ] ],
+    "tools": [ [ [ "press", -1 ], [ "press_dowel", -1 ] ] ],
     "components": [ [ [ "gunpowder", 6 ], [ "gunpowder_pistol", 6 ], [ "gunpowder_shotgun", 6 ] ], [ [ "combatnail", 10 ] ] ]
   },
   {
@@ -96,7 +93,7 @@
     "book_learn": [ [ "recipe_bullets", 3 ], [ "manual_shotgun", 3 ] ],
     "charges": 1,
     "reversible": true,
-    "using": [ [ "bullet_forming", 1 ], [ "ammo_bullet", 20 ], [ "ammo_shot", 1 ] ],
+    "using": [ [ "shot_forming", 1 ], [ "ammo_bullet", 20 ], [ "ammo_shot", 1 ] ],
     "components": [ [ [ "gunpowder", 6 ], [ "gunpowder_pistol", 6 ], [ "gunpowder_shotgun", 6 ] ] ]
   },
   {
@@ -107,12 +104,11 @@
     "skill_used": "fabrication",
     "difficulty": 2,
     "skills_required": [ "gun", 1 ],
-    "time": "30 s",
+    "time": "2 m",
     "book_learn": [ [ "recipe_bullets", 2 ], [ "manual_shotgun", 2 ] ],
     "charges": 1,
     "reversible": true,
     "using": [ [ "shot_forming", 1 ], [ "ammo_bullet", 10 ], [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press", -1 ] ] ],
     "components": [ [ [ "chem_black_powder", 6 ] ] ]
   },
   {
@@ -123,13 +119,12 @@
     "skill_used": "fabrication",
     "difficulty": 2,
     "skills_required": [ "gun", 1 ],
-    "time": "20 s",
+    "time": "2 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_bullets", 1 ], [ "manual_shotgun", 1 ] ],
     "charges": 1,
     "reversible": true,
     "using": [ [ "shot_forming", 1 ], [ "ammo_bullet", 10 ], [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press", -1 ] ] ],
     "components": [ [ [ "chem_black_powder", 3 ] ] ]
   },
   {
@@ -140,13 +135,13 @@
     "skill_used": "fabrication",
     "difficulty": 2,
     "skills_required": [ "gun", 1 ],
-    "time": "20 s",
+    "time": "2 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_bullets", 3 ], [ "manual_shotgun", 3 ] ],
     "charges": 1,
     "reversible": true,
     "using": [ [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press", -1 ] ] ],
+    "tools": [ [ [ "press", -1 ], [ "press_dowel", -1 ] ] ],
     "components": [ [ [ "chem_black_powder", 3 ] ], [ [ "magnesium", 5 ] ] ]
   },
   {
@@ -157,13 +152,13 @@
     "skill_used": "fabrication",
     "difficulty": 2,
     "skills_required": [ "gun", 1 ],
-    "time": "20 s",
+    "time": "2 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_bullets", 4 ], [ "manual_shotgun", 4 ] ],
     "charges": 1,
     "reversible": true,
     "using": [ [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press", -1 ] ] ],
+    "tools": [ [ [ "press", -1 ], [ "press_dowel", -1 ] ] ],
     "components": [ [ [ "chem_black_powder", 6 ] ], [ [ "combatnail", 10 ] ] ]
   },
   {
@@ -174,57 +169,12 @@
     "skill_used": "fabrication",
     "difficulty": 3,
     "skills_required": [ "gun", 1 ],
-    "time": "20 s",
+    "time": "2 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_bullets", 3 ], [ "manual_shotgun", 3 ] ],
     "charges": 1,
     "reversible": true,
-    "using": [ [ "bullet_forming", 1 ], [ "ammo_bullet", 20 ], [ "ammo_shot", 1 ] ],
-    "components": [ [ [ "chem_black_powder", 6 ] ] ]
-  },
-  {
-    "result": "bp_shot_00",
-    "id_suffix": "with dowel",
-    "type": "recipe",
-    "copy-from": "bp_shot_00",
-    "book_learn": [ [ "survival_book", 1 ], [ "mag_survival", 1 ] ],
-    "time": "40 s",
-    "tools": [ [ [ "press_dowel", -1 ] ] ],
-    "components": [ [ [ "chem_black_powder", 6 ] ] ]
-  },
-  {
-    "result": "bp_shot_bird",
-    "id_suffix": "with dowel",
-    "type": "recipe",
-    "copy-from": "bp_shot_bird",
-    "book_learn": [ [ "survival_book", 1 ], [ "mag_survival", 1 ] ],
-    "time": "40 s",
-    "tools": [ [ [ "press_dowel", -1 ] ] ],
-    "components": [ [ [ "chem_black_powder", 3 ] ] ]
-  },
-  {
-    "result": "bp_shot_dragon",
-    "id_suffix": "with dowel",
-    "type": "recipe",
-    "copy-from": "bp_shot_dragon",
-    "book_learn": [ [ "survival_book", 1 ], [ "mag_survival", 1 ] ],
-    "time": "40 s",
-    "tools": [ [ [ "press_dowel", -1 ] ] ],
-    "components": [ [ [ "chem_black_powder", 3 ] ], [ [ "magnesium", 5 ] ] ]
-  },
-  {
-    "result": "bp_shot_slug",
-    "id_suffix": "with dowel",
-    "type": "recipe",
-    "copy-from": "bp_shot_slug",
-    "book_learn": [ [ "survival_book", 1 ], [ "mag_survival", 1 ] ],
-    "time": "40 s",
-    "using": [ [ "ammo_bullet", 20 ], [ "ammo_shot", 1 ] ],
-    "tools": [
-      [ [ "press_dowel", -1 ] ],
-      [ [ "pipe", -1 ], [ "cu_pipe", -1 ], [ "material_sand", -1 ], [ "material_soil", -1 ], [ "clay_lump", -1 ] ],
-      [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ]
-    ],
+    "using": [ [ "shot_forming", 1 ], [ "ammo_bullet", 20 ], [ "ammo_shot", 1 ] ],
     "components": [ [ [ "chem_black_powder", 6 ] ] ]
   },
   {
@@ -241,7 +191,7 @@
     "charges": 2,
     "reversible": true,
     "using": [ [ "ammo_shot", 2 ] ],
-    "tools": [ [ [ "press", -1 ] ] ],
+    "tools": [ [ [ "press", -1 ], [ "press_dowel", -1 ] ] ],
     "components": [
       [ [ "gunpowder", 12 ], [ "gunpowder_pistol", 12 ], [ "gunpowder_shotgun", 12 ] ],
       [
@@ -273,32 +223,7 @@
     "charges": 2,
     "reversible": true,
     "using": [ [ "ammo_shot", 2 ] ],
-    "tools": [ [ [ "press", -1 ] ] ],
-    "components": [
-      [ [ "chem_black_powder", 6 ] ],
-      [
-        [ "scrap", 1 ],
-        [ "nail", 10 ],
-        [ "bb", 20 ],
-        [ "solder_wire", 10 ],
-        [ "platinum_small", 4 ],
-        [ "gold_small", 4 ],
-        [ "bearing", 5 ],
-        [ "lead", 7 ],
-        [ "silver_small", 7 ],
-        [ "lead", 7 ],
-        [ "shrapnel", 4 ]
-      ]
-    ]
-  },
-  {
-    "result": "bp_shot_scrap",
-    "id_suffix": "with dowel",
-    "type": "recipe",
-    "copy-from": "bp_shot_scrap",
-    "book_learn": [ [ "survival_book", 1 ], [ "mag_survival", 1 ] ],
-    "time": 4000,
-    "tools": [ [ [ "press_dowel", -1 ] ] ],
+    "tools": [ [ [ "press", -1 ], [ "press_dowel", -1 ] ] ],
     "components": [
       [ [ "chem_black_powder", 6 ] ],
       [
@@ -329,7 +254,7 @@
     "book_learn": [ [ "recipe_bullets", 3 ], [ "manual_shotgun", 2 ], [ "pocket_survival", 2 ], [ "mag_survival", 2 ] ],
     "charges": 1,
     "using": [ [ "ammo_shot", 1 ] ],
-    "tools": [ [ [ "press", -1 ] ] ],
+    "tools": [ [ [ "press", -1 ], [ "press_dowel", -1 ] ] ],
     "components": [ [ [ "incendiary", 25 ] ] ]
   },
   {

--- a/data/json/recipes/recipe_obsolete.json
+++ b/data/json/recipes/recipe_obsolete.json
@@ -2524,5 +2524,35 @@
     "result": "bp_22_fmj",
     "type": "recipe",
     "obsolete": true
+  },
+  {
+    "type": "recipe",
+    "result": "bp_shot_00",
+    "id_suffix": "with dowel",
+    "obsolete": true
+  },
+  {
+    "type": "recipe",
+    "result": "bp_shot_bird",
+    "id_suffix": "with dowel",
+    "obsolete": true
+  },
+  {
+    "type": "recipe",
+    "result": "bp_shot_dragon",
+    "id_suffix": "with dowel",
+    "obsolete": true
+  },
+  {
+    "type": "recipe",
+    "result": "bp_shot_slug",
+    "id_suffix": "with dowel",
+    "obsolete": true
+  },
+  {
+    "type": "recipe",
+    "result": "bp_shot_scrap",
+    "id_suffix": "with dowel",
+    "obsolete": true
   }
 ]

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -8,19 +8,8 @@
   {
     "id": "shot_forming",
     "type": "requirement",
-    "//": "Forming of shot from raw materials",
-    "tools": [
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ], [ "iron_pot", -1 ], [ "pan", -1 ], [ "pot_makeshift", -1 ] ],
-      [ [ "water", 1 ], [ "water_clean", -1 ], [ "salt_water", -1 ], [ "water_sewage", -1 ] ],
-      [
-        [ "ceramic_mug", -1 ],
-        [ "ceramic_cup", -1 ],
-        [ "teapot", -1 ],
-        [ "clay_teapot", -1 ],
-        [ "can_food_unsealed", -1 ]
-      ],
-      [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ]
-    ]
+    "//": "Forming of shot from raw materials, allows use of makeshift press",
+    "tools": [ [ [ "press", -1 ], [ "press_dowel", -1 ] ], [ [ "fire", -1 ], [ "hotplate", 2 ], [ "toolset", 2 ] ] ]
   },
   {
     "id": "earthenware_firing",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Update shotshell handloading to be more consistent, make more use of makeshift press"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

While reviewing the recipe for handloading shotshells, I noticed how wildly inconsistent and bizare the tool requirements were. Standout problems with it were:
1. Recipes split up into variants that were almost identical aside from a tiny difference in time, presence/absence of batch mlutiplier, and use of the makeshift dowel press instead of a regular press. Otherwise still involved bullet casting.
2. Water requirement for bullet casting allows you to infinitely reuse clean water, salt water, or sewage, but set it so you had to use larger and larger amounts if using regular water.
3. The tools required for casting bullets are defined in a way that's not mod-friendly, doesn't make it clear what purpose the tools serve, and has some logical inconsistencies. Why makeshift pots but not regular pots, if only cast-iron pots are acceptable? And why not clay pots if clay crucibles are considered acceptable?
 3a. Likewise, the second tool requires a very narrow selection of sources for what's presumably either boiling quality or containing quality. Small tin cans but not medium cans, a teapot but none of the other valid pots that would surely be more robust, etc.
4. The makeshift dowel press was only being used for blackpowder loads, when mechanically changing the powder used would not affect whether the tools needed to load the rest of the shell differ.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Removed the extra tools needed for bullet-casting from the `shot_forming`, instead changing it to use the same tools as `bullet_forming`, except allowing the makeshift shotshell press as an explicit alternative to a standard hand press.
2. Updated recipes that use shot_forming accordingly, removing the explicit call to a hand press now that it's part of the crafting quality, and standardized shotshell recipes in general (excepting paper shotshells).
3. Updated 40mm grenade handloads to not call for a hand press explicitly, as even some that called for `bullet_forming` (which already calls for a hand press) also asked for a press separately.
4. Set time to make blackpowder shotshells the same as all the other shotshell handloads.
5. Obsoleted the separate dowel-using recipes.
6. Updated name and description of makeshift shotshell press. Removed unnecessary air-quotes around the word "press" in the item name. Removed extraneous reference to handloads from it only working with the gun it was made for, because that is not a detail implemented in-game. Also removed reference to a shotshell used as a measuring cup, because it's not present in the recipe and you don't need measuring tools for any other handloading recipe in the game. Also implied presence of more than one dowel due to potentially being used for .410 and 40mm shotshell recipes, the recipe's use of various sources of the dowel would allow making more than one.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

The casting requirements could be re-implemented in a future PR if desired, but would likely need some standardization and a better sense of what steps actually need to be simulated. If so it'd likely be part of a gradual overhaul implementing it in other recipes, which would be a fair bit of work.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Ported over recipe and requirement changes to build 7/5 1444, load-tested it, debugged in all recipes, took a look to confirm how the shotshell recipes looked.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Mechanic changes originated in: https://github.com/CleverRaven/Cataclysm-DDA/pull/34001

The apparent objective was to make casting ammo an explicit activity in the recipe instead of abstracted away by the presence of a heat source, but its current implementation would make non-improvised methods much harder to implement (i.e. it would require a single bullet mold tool to substitute for 2-3 separate tool entries, which isn't quite doable as-is).

It implies the objective was for it to see use elsewhere but it looks like it never got applied anywhere else, so it seems like it'd fall into the same category as BN's inheritance of the first part of the tailoring overhaul, as far as whether to choose between completing it in a more functional implementation vs axing it entirely.

Pinging @tenmillimaster for feedback and thoughts on whether it'd be desirable to try and re-implement their desired bullet-casting mechanics in BN, possibly using qualities or a more streamlined tool requirement that is easier to define valid substitutes for.