### PR TITLE
Allow match head powder for primer recipes

### DIFF
--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -82,7 +82,7 @@
     "tools": [ [ [ "swage", -1 ] ] ],
     "components": [
       [ [ "can_drink_unsealed", 2 ], [ "can_food_unsealed", 2 ], [ "canister_empty", 2 ], [ "scrap", 4 ] ],
-      [ [ "oxy_powder", 100 ], [ "chem_match_head_powder", 100 ] ]
+      [ [ "oxy_powder", 100 ] ]
     ]
   },
   {
@@ -99,7 +99,7 @@
     "tools": [ [ [ "swage", -1 ] ] ],
     "components": [
       [ [ "can_drink_unsealed", 2 ], [ "can_food_unsealed", 2 ], [ "canister_empty", 2 ], [ "scrap", 4 ] ],
-      [ [ "oxy_powder", 100 ], [ "chem_match_head_powder", 100 ] ]
+      [ [ "oxy_powder", 100 ] ]
     ]
   },
   {

--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -48,7 +48,7 @@
     "tools": [ [ [ "swage", -1 ] ] ],
     "components": [
       [ [ "can_drink_unsealed", 2 ], [ "can_food_unsealed", 2 ], [ "canister_empty", 2 ], [ "scrap", 4 ] ],
-      [ [ "oxy_powder", 100 ] ]
+      [ [ "oxy_powder", 100 ], [ "chem_match_head_powder", 100 ] ]
     ]
   },
   {
@@ -65,7 +65,7 @@
     "tools": [ [ [ "swage", -1 ] ] ],
     "components": [
       [ [ "can_drink_unsealed", 2 ], [ "can_food_unsealed", 2 ], [ "canister_empty", 2 ], [ "scrap", 4 ] ],
-      [ [ "oxy_powder", 100 ] ]
+      [ [ "oxy_powder", 100 ], [ "chem_match_head_powder", 100 ] ]
     ]
   },
   {
@@ -82,7 +82,7 @@
     "tools": [ [ [ "swage", -1 ] ] ],
     "components": [
       [ [ "can_drink_unsealed", 2 ], [ "can_food_unsealed", 2 ], [ "canister_empty", 2 ], [ "scrap", 4 ] ],
-      [ [ "oxy_powder", 100 ] ]
+      [ [ "oxy_powder", 100 ], [ "chem_match_head_powder", 100 ] ]
     ]
   },
   {
@@ -99,7 +99,7 @@
     "tools": [ [ [ "swage", -1 ] ] ],
     "components": [
       [ [ "can_drink_unsealed", 2 ], [ "can_food_unsealed", 2 ], [ "canister_empty", 2 ], [ "scrap", 4 ] ],
-      [ [ "oxy_powder", 100 ] ]
+      [ [ "oxy_powder", 100 ], [ "chem_match_head_powder", 100 ] ]
     ]
   },
   {
@@ -116,7 +116,7 @@
     "tools": [ [ [ "swage", -1 ] ] ],
     "components": [
       [ [ "can_drink_unsealed", 2 ], [ "can_food_unsealed", 2 ], [ "canister_empty", 2 ], [ "scrap", 4 ] ],
-      [ [ "oxy_powder", 100 ] ]
+      [ [ "oxy_powder", 100 ], [ "chem_match_head_powder", 100 ] ]
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Allow using match head powder as a source of impact-sensitive material for primer crafting"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A while back I recall there having been discussion of using match heads as an option for making primers. Rationale being, if you mix the main material from matchheads with that of the striker surface (or the entirity of the matchhead, in the case of strike-anywhere matches), you get an impact-sensitive material that people have successfully tested using for pistol primers.

First video example I was able to find, evidently a reupload of a video I'm going to guess was the source of this idea: https://www.youtube.com/watch?v=CQI2bvkE7ic

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Added match head powder to primer recipes as an alternative to oxidizer powder, at equal amounts by weight.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Having the added amount equal oxidizer powder by volume would use 125 match head powder instead (100 oxidizer powder is 125 ml due to a count of 200 per 200-ml stack, while match head powder uses 10-count stacks with 10 ml volume).
2. Removing the oxidizer powder as an option outright. It's not very realistic but oxy powder seems to be generic anyway, and probably still useful as an alternative in the absence of any recipes for fulminates or azides, currently absent among the myriad of grandfathered-from-DDA chemicals that don't have any use yet.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Tested file change for linting and syntax.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

I don't recall how far the proposal originally got, but I'm going to guess it probably ran into problems due to matchbooks being a tool, so it would've had to displace the oxidizer powder's use as a component entirely to work right. With match head powder now being an explicit material that can be crafted, it's feasible to implement this idea.

R.I.P. Grant Thompson, original maker of the video linked above.