### PR TITLE
Add bionics to zapper zombie

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -603,6 +603,27 @@
     ]
   },
   {
+    "id": "CBM_BASIC",
+    "type": "harvest",
+    "entries": [
+      {
+        "drop": "bio_power_storage",
+        "type": "bionic",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      {
+        "drop": "bionics_zapper",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "faults": [ "fault_bionic_salvaged" ]
+      },
+      { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
+      { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
+      { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 }
+    ]
+  },
+  {
     "id": "CBM_CIV",
     "type": "harvest",
     "entries": [

--- a/data/json/itemgroups/bionics.json
+++ b/data/json/itemgroups/bionics.json
@@ -352,15 +352,16 @@
     "type": "item_group",
     "id": "bionics_zapper",
     "subtype": "distribution",
-    "//": "Civilian-grade power generation and storage, used by zapper zombies.",
+    "//": "Limited selection of civilian-grade bionics, and a few of the lower-tier obscure bionics.",
     "items": [
-      [ "bio_power_storage", 10 ],
       [ "bio_fuel_cell_gasoline", 10 ],
-      [ "bio_batteries", 10 ],
-      [ "bio_metabolics", 10 ],
       [ "bio_ethanol", 10 ],
-      [ "bio_torsionratchet", 10 ],
-      [ "bio_cable", 10 ]
+      [ "bio_cable", 10 ],
+      [ "bio_evap", 10 ],
+      [ "bio_flashlight", 10 ],
+      [ "bio_geiger", 10 ],
+      [ "bio_meteorologist", 10 ],
+      [ "bio_purifier", 10 ]
     ]
   }
 ]

--- a/data/json/itemgroups/bionics.json
+++ b/data/json/itemgroups/bionics.json
@@ -347,5 +347,20 @@
       [ "bio_ods", 10 ],
       [ "bio_weight", 15 ]
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "bionics_zapper",
+    "subtype": "distribution",
+    "//": "Civilian-grade power generation and storage, used by zapper zombies.",
+    "items": [
+      [ "bio_power_storage", 10 ],
+      [ "bio_fuel_cell_gasoline", 10 ],
+      [ "bio_batteries", 10 ],
+      [ "bio_metabolics", 10 ],
+      [ "bio_ethanol", 10 ],
+      [ "bio_torsionratchet", 10 ],
+      [ "bio_cable", 10 ]
+    ]
   }
 ]

--- a/data/json/monsters/zed_electric.json
+++ b/data/json/monsters/zed_electric.json
@@ -150,7 +150,7 @@
     "melee_cut": 0,
     "dodge": 2,
     "luminance": 4,
-    "harvest": "zombie",
+    "harvest": "CBM_BASIC",
     "special_when_hit": [ "ZAPBACK", 100 ],
     "death_drops": "default_zombie_death_drops",
     "death_function": [ "NORMAL" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Have zapper zombies yield CBMs instead of relying on blob magic"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I mentioned pondering the idea of giving basic bionic spawns to zapper zombies, consistent with how BN is avoiding the "no bionics from zeds, they run on blob magic" development DDA is leaning towards, which was the reason why the original proposal of having zapper zombies yield CBMs was vetoed back when they were first added.

Per said conversation on the modder's discord, a suggestion came up to focus on power storage/generation, similar to broke cyborgs, thus making their yield useful while still encouraging the player to favor shocker zombies. Should be interesting for early-game characters wanting to break into the basics of bionics, and helps reinforce BN's retention of manmade CBMs as a contrast to the "CBMs are alien" lore DDA is drifting towards.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

* Changed zapper zombies to use a new `CBM_BASIC` harvest entry. Said entry is identical to `CBM_CIV` except for citing a different itemgroup for its bionic spawns to potentially cite.
* Added the `bionics_zapper` item group for the above harvest entry. Contents are similiar to `bionics_common` except for focusing siolwly on power storage and any power generation CBM present in said itemgroup.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adopting the "alien bionics" lore for BN and porting over https://github.com/CleverRaven/Cataclysm-DDA/pull/47451, not recommended as it makes shocker zombies just plain annoying rather than risk-reward, along with running contrary towards BN's general lean towards retaining sci-fi elements when doing so is more fun.
2. Letting zapper zombies use the exact same harvest entry as shocker zombies.
3. Leaving them as-is despite them evolving into bionic zeds currently.
4. One suggestion that came up in said discussion was something in the vein of a more zombie-tissue focus for CBMs harvested from zombies. Not sure what that'd entail, but one idea this brings to mind is the possibility of including exotic CBMs that do strange things and can only be harvested from undead. This could be flavored as the CBMs themselves being corrupted or mutated as a result of struggling to adapt to the changing physiology of the zed they're installed in, possibly as a new stab at the NCBM idea from https://github.com/CleverRaven/Cataclysm-DDA/pull/24745

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Ported over JSON changes to latest available build.
2. Load-tested, debugged skills up to 10, spawned in a hunting knife and scalpel.
3. Summoned multiple zapper zombies and killed them via debug.
4. Dissected to see what CBMs they yielded, got expected results.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR for zappy bois: https://github.com/CleverRaven/Cataclysm-DDA/pull/35951