### PR TITLE
[DinoMod] Duplicate entry caused CTD

### DIFF
--- a/data/mods/DinoMod/mutations/mutations.json
+++ b/data/mods/DinoMod/mutations/mutations.json
@@ -220,12 +220,6 @@
   },
   {
     "type": "mutation",
-    "id": "LIZ_EYE",
-    "copy-from": "LIZ_EYE",
-    "extend": { "category": [ "STEGO", "TYRANT" ] }
-  },
-  {
-    "type": "mutation",
     "id": "LIZ_IR",
     "copy-from": "LIZ_IR",
     "extend": { "category": [ "STEGO", "TYRANT" ] }


### PR DESCRIPTION


#### Summary


SUMMARY: Bugfixes "Duplicate mutation entry caused CTD"

#### Purpose of change

Fixes CTD


#### Describe the solution

deletes duplicate entry. Thanks to Cuddlebaby for finding the effect and cause. Based on https://github.com/CleverRaven/Cataclysm-DDA/pull/49919


#### Describe alternatives you've considered

Wait for a later rollup but this is time sensitive

#### Testing

NA

#### Additional context

Thanks to @Maleclypse for figuring this out