### PR TITLE
Add changelog to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.generate_env_vars.outputs.tag_name }}
           tag_prefix: ""
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v2
+      - run: git fetch origin tag ${{ steps.generate_env_vars.outputs.tag_name }} --no-tags
       - name: Build Changelog
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v2.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,17 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.generate_env_vars.outputs.tag_name }}
           tag_prefix: ""
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Build Changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v2.1.0
+        with:
+          configuration: "changelog.json"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -50,6 +61,7 @@ jobs:
           tag_name: ${{ steps.generate_env_vars.outputs.tag_name }}
           release_name: ${{ steps.generate_env_vars.outputs.release_name }}
           body: |
+            ${{ steps.build_changelog.outputs.changelog }}
             These are the outputs for the experimental build of commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
           draft: false
           prerelease: false

--- a/changelog.json
+++ b/changelog.json
@@ -1,0 +1,27 @@
+{
+  "categories": [
+    {
+      "title": "## 🚀 Features",
+      "labels": ["feature"]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": ["fix"]
+    }
+  ],
+  "ignore_labels": [
+    "ignore",
+    "wont-fix"
+  ],
+  "sort": "ASC",
+  "template": "${{CHANGELOG}}\n\n${{UNCATEGORIZED}}\n\n",
+  "pr_template": "- PR: #${{NUMBER}} **${{TITLE}}** by ${{AUTHOR}}",
+  "empty_template": "- no changes",
+
+  "max_tags_to_fetch": 200,
+  "max_pull_requests": 200,
+  "max_back_track_time_days": 365,
+  "tag_resolver": {
+    "method": "sort"
+  }
+}


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Add changelog to releases"

#### Purpose of change
Allow users to see the release changes without digging through PRs.

#### Describe the solution
Added a Github action to auto-create a changelog for releases. The downside is an additional 3 minutes to create a release due to having to fetch all refs from the repo. Could not get it to work without fetching all refs.

#### Describe alternatives you've considered
Simpler, faster alternatives are not feasible without using semantic version tagging.

#### Testing
Tested to be working properly on my fork.

#### Additional context
Screenshot of it working:
https://i.imgur.com/1R5wBCO.png