### PR TITLE
Very spammy test for asan

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -43,12 +43,6 @@ jobs:
             test-stage: 1
             title: GCC 9, Ubuntu, Curses
             native: linux64
-          - compiler: g++-7
-            os: ubuntu-latest
-            cmake: 1
-            tiles: 1
-            native: linux64
-            title: GCC 7, Ubuntu, Tiles, CMake
           - compiler: g++-8
             os: ubuntu-latest
             cmake: 0
@@ -63,12 +57,6 @@ jobs:
             sanitize: address,undefined
             native: linux64
             title: Clang 9, Ubuntu, Tiles, ASan, UBSan
-          - compiler: clang++
-            os: macos-10.15
-            cmake: 0
-            tiles: 1
-            native: osx
-            title: Clang 12, macOS 10.15, Tiles
     name: ${{ matrix.title }}
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -39,7 +39,8 @@ jobs:
           - compiler: g++-9
             os: ubuntu-latest
             cmake: 0
-            tiles: 0
+            tiles: 1
+            sound: 1
             test-stage: 1
             title: GCC 9, Ubuntu, Curses
             native: linux64
@@ -47,6 +48,7 @@ jobs:
             os: ubuntu-latest
             cmake: 0
             tiles: 1
+            sound: 0
             sanitize: address
             native: linux64
             title: GCC 8, Ubuntu, Tiles, ASan
@@ -54,6 +56,7 @@ jobs:
             os: ubuntu-latest
             cmake: 0
             tiles: 1
+            sound: 0
             sanitize: address,undefined
             native: linux64
             title: Clang 9, Ubuntu, Tiles, ASan, UBSan
@@ -64,7 +67,7 @@ jobs:
         COMPILER: ${{ matrix.compiler }}
         OS: ${{ matrix.os }}
         TILES: ${{ matrix.tiles }}
-        SOUND: ${{ matrix.tiles }}
+        SOUND: ${{ matrix.sound }}
         SANITIZE: ${{ matrix.sanitize }}
         TEST_STAGE: ${{ matrix.test-stage }}
         EXTRA_TEST_OPTS:

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -9,7 +9,7 @@ num_jobs=3
 function run_tests
 {
     # Just list the tests in lex order, so that if it crashes, we know what finished before it
-    $WINE "$@" -d yes --use-colour yes --order lex -s
+    $WINE "$@" -d yes --use-colour yes --order lex -s -l
     # The grep suppresses lines that begin with "0.0## s:", which are timing lines for tests with a very short duration.
     $WINE "$@" -d yes --use-colour yes --order lex -s --rng-seed time $EXTRA_TEST_OPTS 
 }

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -11,7 +11,7 @@ function run_tests
     # Just list the tests in lex order, so that if it crashes, we know what finished before it
     $WINE "$@" -d yes --use-colour yes --order lex -s -l || true
     # The grep suppresses lines that begin with "0.0## s:", which are timing lines for tests with a very short duration.
-    $WINE "$@" -d yes --use-colour yes --order lex -s --rng-seed time $EXTRA_TEST_OPTS 
+    $WINE "$@" -d yes --use-colour yes --order lex --rng-seed time $EXTRA_TEST_OPTS 
 }
 
 # We might need binaries installed via pip, so ensure that our personal bin dir is on the PATH

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -8,8 +8,10 @@ num_jobs=3
 
 function run_tests
 {
+    # Just list the tests in lex order, so that if it crashes, we know what finished before it
+    $WINE "$@" -d yes --use-colour yes --order lex -s
     # The grep suppresses lines that begin with "0.0## s:", which are timing lines for tests with a very short duration.
-    $WINE "$@" -d yes --use-colour yes --rng-seed time $EXTRA_TEST_OPTS | grep -Ev "^0\.0[0-9]{2} s:"
+    $WINE "$@" -d yes --use-colour yes --order lex -s --rng-seed time $EXTRA_TEST_OPTS 
 }
 
 # We might need binaries installed via pip, so ensure that our personal bin dir is on the PATH

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -9,7 +9,7 @@ num_jobs=3
 function run_tests
 {
     # Just list the tests in lex order, so that if it crashes, we know what finished before it
-    $WINE "$@" -d yes --use-colour yes --order lex -s -l
+    $WINE "$@" -d yes --use-colour yes --order lex -s -l || true
     # The grep suppresses lines that begin with "0.0## s:", which are timing lines for tests with a very short duration.
     $WINE "$@" -d yes --use-colour yes --order lex -s --rng-seed time $EXTRA_TEST_OPTS 
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1679,6 +1679,10 @@ void scrollingcombattext::add( const point &pos, direction p_oDir,
                                const std::string &p_sText2, const game_message_type p_gmt2,
                                const std::string &p_sType )
 {
+    // TODO: A non-hack
+    if( test_mode ) {
+        return;
+    }
     if( get_option<bool>( "ANIMATION_SCT" ) ) {
 
         int iCurStep = 0;

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1029,6 +1029,10 @@ void sfx::generate_melee_sound( const tripoint &source, const tripoint &target, 
                                 bool targ_mon,
                                 const std::string &material )
 {
+    // TODO: Handle it like messages.cpp
+    if( test_mode ) {
+        return;
+    }
     // If creating a new thread for each invocation is to much, we have to consider a thread
     // pool or maybe a single thread that works continuously, but that requires a queue or similar
     // to coordinate its work.

--- a/tests/catch/catch.hpp
+++ b/tests/catch/catch.hpp
@@ -13981,6 +13981,7 @@ namespace Catch {
     }
 
     void TestCase::invoke() const {
+        printf("Starting %s\n", name.c_str());
         test->invoke();
     }
 
@@ -14138,7 +14139,12 @@ namespace Catch {
     TestInvokerAsFunction::TestInvokerAsFunction( void(*testAsFunction)() ) noexcept : m_testAsFunction( testAsFunction ) {}
 
     void TestInvokerAsFunction::invoke() const {
+        printf("Before:\n");
+        int dummy = system("free");
         m_testAsFunction();
+        printf("After:\n");
+        dummy = system("free");
+        (void)dummy;
     }
 
     std::string extractClassName( StringRef const& classOrQualifiedMethodName ) {
@@ -17693,4 +17699,3 @@ using Catch::Detail::Approx;
 // end catch_reenable_warnings.h
 // end catch.hpp
 #endif // TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
-

--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -51,6 +51,7 @@ static double weapon_dps_trials( avatar &attacker, monster &defender, item &weap
             // Tally total damage and moves
             total_damage += std::max( 0, starting_hp - defender.get_hp() );
             total_moves += std::abs( attacker.get_moves() - before_moves );
+            system( "free" );
         }
     }
 

--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -9,6 +9,7 @@
 #include "melee.h"
 #include "monster.h"
 #include "player_helpers.h"
+#include "sounds.h"
 #include "ret_val.h"
 #include "type_id.h"
 
@@ -51,6 +52,10 @@ static double weapon_dps_trials( avatar &attacker, monster &defender, item &weap
             // Tally total damage and moves
             total_damage += std::max( 0, starting_hp - defender.get_hp() );
             total_moves += std::abs( attacker.get_moves() - before_moves );
+
+            // Every hit or miss enqueues a new sound
+            sounds::reset_sounds();
+
             int dummy = system( "free" );
             ( void )dummy;
         }

--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -56,6 +56,7 @@ static double weapon_dps_trials( avatar &attacker, monster &defender, item &weap
             // Every hit or miss enqueues a new sound
             sounds::reset_sounds();
 
+            printf( "Melee i=%d, j=%d\n", i, j );
             int dummy = system( "free" );
             ( void )dummy;
         }

--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -55,10 +55,6 @@ static double weapon_dps_trials( avatar &attacker, monster &defender, item &weap
 
             // Every hit or miss enqueues a new sound
             sounds::reset_sounds();
-
-            printf( "Melee i=%d, j=%d\n", i, j );
-            int dummy = system( "free" );
-            ( void )dummy;
         }
     }
 

--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -51,7 +51,8 @@ static double weapon_dps_trials( avatar &attacker, monster &defender, item &weap
             // Tally total damage and moves
             total_damage += std::max( 0, starting_hp - defender.get_hp() );
             total_moves += std::abs( attacker.get_moves() - before_moves );
-            system( "free" );
+            int dummy = system( "free" );
+            ( void )dummy;
         }
     }
 

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -73,6 +73,7 @@ void clear_character( player &dummy, bool debug_storage )
     // Clear stomach and then eat a nutritious meal to normalize stomach
     // contents (needs to happen before clear_morale).
     dummy.stomach.empty();
+    dummy.consumption_history.clear();
     item food( "debug_nutrition" );
     dummy.eat( food );
 

--- a/tests/stomach_contents_test.cpp
+++ b/tests/stomach_contents_test.cpp
@@ -143,7 +143,7 @@ TEST_CASE( "starve_test_hunger3", "[starve][slow]" )
 TEST_CASE( "all_nutrition_starve_test", "[!mayfail][starve][slow]" )
 {
     // change this bool when editing the test
-    const bool print_tests = false;
+    const bool print_tests = true;
     player &dummy = g->u;
     reset_time();
     clear_stomach( dummy );
@@ -155,6 +155,8 @@ TEST_CASE( "all_nutrition_starve_test", "[!mayfail][starve][slow]" )
     for( unsigned int day = 0; day <= 20; day++ ) {
         if( print_tests ) {
             cata_printf( "day %u: %d\n", day, dummy.get_stored_kcal() );
+            int dummy = system( "free" );
+            ( void )dummy;
         }
         pass_time( dummy, 1_days );
         dummy.set_thirst( 0 );

--- a/tests/stomach_contents_test.cpp
+++ b/tests/stomach_contents_test.cpp
@@ -143,7 +143,7 @@ TEST_CASE( "starve_test_hunger3", "[starve][slow]" )
 TEST_CASE( "all_nutrition_starve_test", "[!mayfail][starve][slow]" )
 {
     // change this bool when editing the test
-    const bool print_tests = true;
+    const bool print_tests = false;
     player &dummy = g->u;
     reset_time();
     clear_stomach( dummy );
@@ -155,8 +155,6 @@ TEST_CASE( "all_nutrition_starve_test", "[!mayfail][starve][slow]" )
     for( unsigned int day = 0; day <= 20; day++ ) {
         if( print_tests ) {
             cata_printf( "day %u: %d\n", day, dummy.get_stored_kcal() );
-            int dummy = system( "free" );
-            ( void )dummy;
         }
         pass_time( dummy, 1_days );
         dummy.set_thirst( 0 );


### PR DESCRIPTION
Brute force shotgun programming approach for now: list all tests, then do tests with `-s` flag, which prints successes.
Unfortunately there seems to be no option to make it print only test names, so it spam a whole lot and the test may fail due to console-induced slowdown.