### PR TITLE
Attempt at fixing ASan memory problem

### DIFF
--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -73,6 +73,7 @@ void clear_character( player &dummy, bool debug_storage )
     // Clear stomach and then eat a nutritious meal to normalize stomach
     // contents (needs to happen before clear_morale).
     dummy.stomach.empty();
+    dummy.consumption_history.clear();
     item food( "debug_nutrition" );
     dummy.eat( food );
 


### PR DESCRIPTION
`avatar::consumption_history` was not cleared in `clear_character`. Normally, it only clears with passage of time.
ASan probably made it consume much more memory than it ordinarily would.