### PR TITLE
Remove ledge trap from skylight

### DIFF
--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -304,12 +304,12 @@
     "looks_like": "t_linoleum_white",
     "color": "cyan",
     "move_cost": 2,
-    "trap": "tr_ledge",
     "flags": [ "TRANSPARENT", "NO_FLOOR", "INDOORS" ],
+    "deconstruct": { "ter_set": "t_open_air", "items": [ { "item": "glass_sheet", "count": 1 } ] },
     "bash": {
       "str_min": 3,
       "str_max": 6,
-      "sound": "glass braking!",
+      "sound": "glass breaking!",
       "sound_fail": "whack!",
       "ter_set": "t_open_air",
       "bash_below": true

--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -305,7 +305,6 @@
     "color": "cyan",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "NO_FLOOR", "INDOORS" ],
-    "deconstruct": { "ter_set": "t_open_air", "items": [ { "item": "glass_sheet", "count": 1 } ] },
     "bash": {
       "str_min": 3,
       "str_max": 6,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
Bugfixes: "Add deconstruct recipe to skylight & remove ledge trap"

<!-- This section should consist of exactly one line, formatted like this:


Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Fixes #685
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Added deconstruct recipe to the skylight (returning 1 sheet of glass) and removed the ledge trap flag so the tile is walkable and doesn't act like a hole. Also fixed a minor typo I noticed (braking > breaking).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Removing the bash_below tag does allow for smashing, but even with ter_set to t_open_air it changes the tile back to a roof. Adding functionality to punch holes in roofs felt out of scope and beyond my current abilities.. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled release build, checked various skylights for intended functionality
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
Presumably these are thick plate glass skylights and as such should allow a player to walk upon them, at least when the alternative is just plummeting through as if it did not exist. It still has NO_FLOOR and is missing FLAT so no building on top of them.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
