### PR TITLE
Port relative monster speed to look menu

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -639,21 +639,22 @@ static std::pair<std::string, nc_color> hp_description( int cur_hp, int max_hp )
     return std::make_pair( damage_info, col );
 }
 
-static std::pair<std::string, nc_color> speed_description( float mon_speed_rating, bool immobile = false )
+static std::pair<std::string, nc_color> speed_description( float mon_speed_rating,
+        bool immobile = false )
 {
     if( immobile ) {
         return std::make_pair( _( "It is immobile." ), c_green );
     }
 
     const std::array<std::tuple<float, nc_color, std::string>, 8> cases = {{
-        std::make_tuple( 1.40f, c_red, _( "It looks much faster than you." ) ),
-        std::make_tuple( 1.15f, c_light_red, _( "It looks faster than you." ) ),
-        std::make_tuple( 1.05f, c_yellow, _( "It looks slightly faster than you." ) ),
-        std::make_tuple( 0.90f, c_white, _( "It looks about as fast as you." ) ),
-        std::make_tuple( 0.80f, c_light_cyan, _( "It looks slightly slower than you." ) ),
-        std::make_tuple( 0.60f, c_cyan, _( "It looks slower than you." ) ),
-        std::make_tuple( 0.30f, c_light_green, _( "It looks much slower than you." ) ),
-        std::make_tuple( 0.00f, c_green, _( "It seems to be barely moving." ) )
+            std::make_tuple( 1.40f, c_red, _( "It looks much faster than you." ) ),
+            std::make_tuple( 1.15f, c_light_red, _( "It looks faster than you." ) ),
+            std::make_tuple( 1.05f, c_yellow, _( "It looks slightly faster than you." ) ),
+            std::make_tuple( 0.90f, c_white, _( "It looks about as fast as you." ) ),
+            std::make_tuple( 0.80f, c_light_cyan, _( "It looks slightly slower than you." ) ),
+            std::make_tuple( 0.60f, c_cyan, _( "It looks slower than you." ) ),
+            std::make_tuple( 0.30f, c_light_green, _( "It looks much slower than you." ) ),
+            std::make_tuple( 0.00f, c_green, _( "It seems to be barely moving." ) )
         }
     };
 
@@ -666,7 +667,7 @@ static std::pair<std::string, nc_color> speed_description( float mon_speed_ratin
     // determine tiles per turn (tpt)
     const float player_tpt = ply.get_speed() / player_runcost;
     const float ratio = player_tpt == 0 ?
-                            2.00f : mon_speed_rating / player_tpt;
+                        2.00f : mon_speed_rating / player_tpt;
 
     for( const std::tuple<float, nc_color, std::string> &speed_case : cases ) {
         if( ratio >= std::get<0>( speed_case ) ) {
@@ -753,8 +754,8 @@ std::string monster::extended_description() const
     ss += colorize( hp_bar.first, hp_bar.second ) + "\n";
 
     const std::pair<std::string, nc_color> speed_desc = speed_description(
-        speed_rating(),
-        has_flag( MF_IMMOBILE ) );
+                speed_rating(),
+                has_flag( MF_IMMOBILE ) );
     ss += colorize( speed_desc.first, speed_desc.second ) + "\n";
 
     ss += "--\n";
@@ -843,19 +844,19 @@ std::string monster::extended_description() const
 
         const time_duration current_time = calendar::turn - calendar::turn_zero;
         ss += string_format( _( "Current Time: Turn %1$d | Day: %2$d" ),
-            to_turns<int>( current_time ),
-            to_days<int>( current_time ) ) + "\n";
+                             to_turns<int>( current_time ),
+                             to_days<int>( current_time ) ) + "\n";
 
         ss += string_format( _( "Upgrade Time: %1$d (turns left: %2$d) %3$s" ),
-            upgrade_time,
-            to_turns<int>( time_duration::from_days( upgrade_time ) - current_time ),
-            can_upgrade() ? "" : _( "<color_red>(can't upgrade)</color>" ) ) + "\n";
+                             upgrade_time,
+                             to_turns<int>( time_duration::from_days( upgrade_time ) - current_time ),
+                             can_upgrade() ? "" : _( "<color_red>(can't upgrade)</color>" ) ) + "\n";
 
         if( baby_timer.has_value() ) {
             ss += string_format( _( "Reproduction time: %1$d (turns left: %2$d) %3$s" ),
-            to_turn<int>( baby_timer.value() ),
-            to_turn<int>( baby_timer.value() - current_time ),
-            reproduces ? "" : _( "<color_red>(cannot reproduce)</color>" ) ) + "\n";
+                                 to_turn<int>( baby_timer.value() ),
+                                 to_turn<int>( baby_timer.value() - current_time ),
+                                 reproduces ? "" : _( "<color_red>(cannot reproduce)</color>" ) ) + "\n";
         }
     }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -325,7 +325,7 @@ void monster::poly( const mtype_id &id )
     reproduces = type->reproduces;
 }
 
-bool monster::can_upgrade()
+bool monster::can_upgrade() const
 {
     return upgrades && get_option<float>( "MONSTER_UPGRADE_FACTOR" ) > 0.0;
 }
@@ -629,13 +629,53 @@ static std::pair<std::string, nc_color> hp_description( int cur_hp, int max_hp )
         damage_info = _( "It is nearly dead!" );
         col = c_red;
     }
-    /*
-    // This is unused code that allows the player to see the exact amount of monster HP, to be implemented later!
-    if( true ) ) {
-        damage_info = string_format( _( "It has %d/%d HP." ), cur_hp, max_hp );
-    }*/
+
+    // show exact monster HP if in debug mode
+    if( debug_mode ) {
+        damage_info += " ";
+        damage_info += string_format( _( "%1$d/%2$d HP" ), cur_hp, max_hp );
+    }
 
     return std::make_pair( damage_info, col );
+}
+
+static std::pair<std::string, nc_color> speed_description( float mon_speed_rating, bool immobile = false )
+{
+    if( immobile ) {
+        return std::make_pair( _( "It is immobile." ), c_green );
+    }
+
+    const std::array<std::tuple<float, nc_color, std::string>, 8> cases = {{
+        std::make_tuple( 1.40f, c_red, _( "It looks much faster than you." ) ),
+        std::make_tuple( 1.15f, c_light_red, _( "It looks faster than you." ) ),
+        std::make_tuple( 1.05f, c_yellow, _( "It looks slightly faster than you." ) ),
+        std::make_tuple( 0.90f, c_white, _( "It looks about as fast as you." ) ),
+        std::make_tuple( 0.80f, c_light_cyan, _( "It looks slightly slower than you." ) ),
+        std::make_tuple( 0.60f, c_cyan, _( "It looks slower than you." ) ),
+        std::make_tuple( 0.30f, c_light_green, _( "It looks much slower than you." ) ),
+        std::make_tuple( 0.00f, c_green, _( "It seems to be barely moving." ) )
+        }
+    };
+
+    const avatar &ply = get_avatar();
+    float player_runcost = ply.run_cost( 100 );
+    if( player_runcost == 0 ) {
+        player_runcost = 1.0f;
+    }
+
+    // determine tiles per turn (tpt)
+    const float player_tpt = ply.get_speed() / player_runcost;
+    const float ratio = player_tpt == 0 ?
+                            2.00f : mon_speed_rating / player_tpt;
+
+    for( const std::tuple<float, nc_color, std::string> &speed_case : cases ) {
+        if( ratio >= std::get<0>( speed_case ) ) {
+            return std::make_pair( std::get<2>( speed_case ), std::get<1>( speed_case ) );
+        }
+    }
+
+    debugmsg( "speed_description: no ratio value matched" );
+    return std::make_pair( _( "Unknown" ), c_white );
 }
 
 int monster::print_info( const catacurses::window &w, int vStart, int vLines, int column ) const
@@ -654,6 +694,9 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
     if( sees( g->u ) ) {
         mvwprintz( w, point( column, ++vStart ), c_yellow, _( "Aware of your presence!" ) );
     }
+
+    const auto speed_desc = speed_description( speed_rating(), has_flag( MF_IMMOBILE ) );
+    mvwprintz( w, point( column, ++vStart ), speed_desc.second, speed_desc.first );
 
     std::string effects = get_effect_status();
     if( !effects.empty() ) {
@@ -678,7 +721,7 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
 std::string monster::extended_description() const
 {
     std::string ss;
-    const auto att = get_attitude();
+    const std::pair<std::string, nc_color> att = get_attitude();
     std::string att_colored = colorize( att.first, att.second );
     std::string difficulty_str;
     if( debug_mode ) {
@@ -706,8 +749,13 @@ std::string monster::extended_description() const
     }
 
     ss += "--\n";
-    auto hp_bar = hp_description( hp, type->hp );
+    const std::pair<std::string, nc_color> hp_bar = hp_description( hp, type->hp );
     ss += colorize( hp_bar.first, hp_bar.second ) + "\n";
+
+    const std::pair<std::string, nc_color> speed_desc = speed_description(
+        speed_rating(),
+        has_flag( MF_IMMOBILE ) );
+    ss += colorize( speed_desc.first, speed_desc.second ) + "\n";
 
     ss += "--\n";
     ss += string_format( "<dark>%s</dark>", type->get_description() ) + "\n";
@@ -786,6 +834,30 @@ std::string monster::extended_description() const
     ss += string_format( _( "Deal average damage per second: <stat>%.1f</stat>" ),
                          g->u.weapon.effective_dps( g->u, *this ) );
     ss += "\n";
+
+    if( debug_mode ) {
+        ss += string_format( _( "Current Speed: %1$d" ), get_speed() ) + "\n";
+        ss += string_format( _( "Anger: %1$d" ), anger ) + "\n";
+        ss += string_format( _( "Friendly: %1$d" ), friendly ) + "\n";
+        ss += string_format( _( "Morale: %1$d" ), morale ) + "\n";
+
+        const time_duration current_time = calendar::turn - calendar::turn_zero;
+        ss += string_format( _( "Current Time: Turn %1$d | Day: %2$d" ),
+            to_turns<int>( current_time ),
+            to_days<int>( current_time ) ) + "\n";
+
+        ss += string_format( _( "Upgrade Time: %1$d (turns left: %2$d) %3$s" ),
+            upgrade_time,
+            to_turns<int>( time_duration::from_days( upgrade_time ) - current_time ),
+            can_upgrade() ? "" : _( "<color_red>(can't upgrade)</color>" ) ) + "\n";
+
+        if( baby_timer.has_value() ) {
+            ss += string_format( _( "Reproduction time: %1$d (turns left: %2$d) %3$s" ),
+            to_turn<int>( baby_timer.value() ),
+            to_turn<int>( baby_timer.value() - current_time ),
+            reproduces ? "" : _( "<color_red>(cannot reproduce)</color>" ) ) + "\n";
+        }
+    }
 
     return replace_colors( ss );
 }

--- a/src/monster.h
+++ b/src/monster.h
@@ -97,7 +97,7 @@ class monster : public Creature
         }
 
         void poly( const mtype_id &id );
-        bool can_upgrade();
+        bool can_upgrade() const;
         void hasten_upgrade();
         int get_upgrade_time() const;
         void allow_upgrade();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
Features: "Ports change to add relative monster speed to look menu and adds extra debug info to extended monster descriptions"
<!-- This section should consist of exactly one line, formatted like this:



Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Adds colour-coded monster speed relative to the player speed to the look menu, as well as advanced debug info to the extended description.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
With very minor changes, this PR implements:
https://github.com/CleverRaven/Cataclysm-DDA/pull/47153 `Add speed to monster descriptions`
https://github.com/CleverRaven/Cataclysm-DDA/pull/47252 `Change monster description speed colors`
https://github.com/CleverRaven/Cataclysm-DDA/pull/48481 `Adjust formula for monster speed descriptions`

I also implemented the changes from auto to proper function calls and making `monster::can_upgrade()` const as that just made sense.

All tables in this PR have been updated with the correct ratio calculation data.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Testing
Speed calculation is as follows:
```
Testing done with basic survivor:
Speed: 100
Base move cost: 103
Stamina: Full

Monster speed rating = monster speed / 100 (add 0.50 to the result if they have leap)
Player tiles per turn = player speed / movement cost
Speed ratio = monster speed rating / player tiles per turn
```

**General Monster Speed Rating to Ratio:**
| Speed Rating | Ratio |
| :-: | :-: |
| 3.00 | 3.09 |
2.95 | 3.04
2.90 | 2.99
2.85 | 2.94
2.80 | 2.89
2.75 | 2.84
2.70 | 2.78
2.65 | 2.73
2.60 | 2.68
2.55 | 2.63
2.50 | 2.58
2.45 | 2.53
2.40 | 2.47
2.35 | 2.42
2.30 | 2.37
2.25 | 2.32
2.20 | 2.27
2.15 | 2.22
2.10 | 2.16
2.05 | 2.11
2.00 | 2.06
1.95 | 2.01
1.90 | 1.96
1.85 | 1.91
1.80 | 1.86
1.75 | 1.80
1.70 | 1.75
1.65 | 1.70
1.60 | 1.65
1.55 | 1.60
1.50 | 1.55
1.45 | 1.49
1.40 | 1.44
1.35 | 1.39
1.30 | 1.34
1.25 | 1.29
1.20 | 1.24
1.15 | 1.19
1.10 | 1.13
1.05 | 1.08
1.00 | 1.03
0.95 | 0.98
0.90 | 0.93
0.85 | 0.88
0.80 | 0.82
0.75 | 0.77
0.70 | 0.72
0.65 | 0.67
0.60 | 0.62
0.55 | 0.57
0.50 | 0.52
0.45 | 0.46
0.40 | 0.41
0.35 | 0.36
0.30 | 0.31
0.25 | 0.26
0.20 | 0.21
0.15 | 0.15
0.10 | 0.10
0.05 | 0.05
0.00 | 0.00

**Monster Speed Table:** (tested all)
\* -> Monster has the leap ability (+0.5f to rating)
\* \* -> Monster has `IMMOBILE `flag

Monster | Mon Speed | Mon Speed Rating | Ratio | String
:-- | :-: | --: | --: | :--
Blood Sacrifice** | 200 | 2.00 | 2.06 | immobile
Crawling Zombie | 20 | 0.20 | 0.21 | barely moving
Lifting Mech | 50 | 0.50 | 0.52 | much slower
Zombie | 70 | 0.70 | 0.72 | slower
Sproglodyte* | 65 | 1.15 | 1.19 | faster
Chicken | 80 | 0.80 | 0.82 | slightly slower
Broken Cyborg | 90 | 0.90 | 0.93 | about as fast
Giant Locust* | 90 | 1.40 | 1.44 | much faster
Marloss Zealot | 100 | 1.00 | 1.03 | same speed
Grouse | 110 | 1.10 | 1.13 | slightly faster
Mi-go | 120 | 1.20 | 1.24 | faster
Pheasant | 130 | 1.30 | 1.34 | faster
Prototype Robot | 140 | 1.40 | 1.44 | much faster
Rabbit | 160 | 1.60 | 1.65 | much faster
Border Collie* | 200 | 2.50 | 2.58 | much faster
Bat | 230 | 2.30 | 2.37 | much faster
C-4 Hack | 250 | 2.50 | 2.58 | much faster
Deer | 300 | 3.00 | 3.09 | much faster

#### Additional context
I'm happy to take any and all feedback, especially since I'm not super great at C++. I left the thresholds in as-is from the other branch as they do seem pretty accurate, but they could probably stand to be tweaked further.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
