### PR TITLE
Update Windows compilation docs, fix couple issues with Visual Studio and MSYS builds

### DIFF
--- a/doc/COMPILING/COMPILING-CYGWIN.md
+++ b/doc/COMPILING/COMPILING-CYGWIN.md
@@ -39,7 +39,7 @@ Due to slow environment setup and execution of the resulting binary, compilation
 2. Install `apt-cyg` for easier package installation:
 
 ```bash
-wget rawgit.com/transcode-open/apt-cyg/master/apt-cyg -O /bin/apt-cyg
+wget https://raw.githubusercontent.com/transcode-open/apt-cyg/master/apt-cyg -O /bin/apt-cyg
 chmod 755 /bin/apt-cyg
 ```
 
@@ -66,12 +66,12 @@ cd Cataclysm-BN
 2. Compile:
 
 ```bash
-make CCACHE=1 RELEASE=1 CYGWIN=1 DYNAMIC_LINKING=1 SDL=1 TILES=1 SOUND=1 LOCALIZE=1 LANGUAGES=all LINTJSON=0 ASTYLE=0 BACKTRACE=0 RUNTESTS=0
+make -j$((`nproc`+0)) CCACHE=1 RELEASE=1 CYGWIN=1 DYNAMIC_LINKING=1 SDL=1 TILES=1 SOUND=1 LOCALIZE=1 LANGUAGES=all LINTJSON=0 ASTYLE=0 BACKTRACE=0 RUNTESTS=0
 ```
 
 You will receive warnings about unterminated character constants; they do not impact the compilation as far as this writer is aware.
 
-**Note**: This will compile release version with Sound and Tiles support and all localization languages, skipping checks and tests and using ccache for faster build. You can use other switches, but `Cygwin=1`, `DYNAMIC_LINKING=1` and probably `RELEASE=1` are required to compile without issues.
+**Note**: This will compile release version with Sound and Tiles support and all localization languages, skipping checks and tests and using ccache for faster build. You can use other switches, but `CYGWIN=1`, `DYNAMIC_LINKING=1` and `BACKTRACE=0` are required to compile without issues.
 
 ## Running:
 

--- a/doc/COMPILING/COMPILING-CYGWIN.md
+++ b/doc/COMPILING/COMPILING-CYGWIN.md
@@ -1,71 +1,89 @@
-# Compilation guide for 64 bit Windows (using CYGWIN)
+# Compilation guide for 64 bit Windows (using Cygwin)
 
-This guide contains steps required to allow compilation of Cataclysm-BN on Windows under CYGWIN.
+This guide contains instructions for compiling Cataclysm-DDA on Windows under Cygwin. **PLEASE NOTE:** These instructions *are not intended* to produce a redistributable copy of CDDA. Please download the official builds from the website or [cross-compile from Linux](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/COMPILING/COMPILING.md#cross-compile-to-windows-from-linux) if that is your intention.
 
-Steps from current guide were tested on Windows 10 (64 bit) and CYGWIN (64 bit), but should work for other versions of Windows and also CYGWIN (32 bit) if you download 32 bit version of all files.
+These instructions were written using 64-bit Windows 7 and the 64-bit version of Cygwin; the steps should be the same for other versions of Windows.
+
+Due to slow environment setup and execution of the resulting binary, compilation using MSYS2 is preferred.
 
 ## Prerequisites:
 
-* Computer with 64 bit version of modern Windows operating system installed (Windows 10, Windows 8.1 or Windows 7);
-* NTFS partition with ~10 Gb free space (~2 Gb for CYGWIN installation, ~3 Gb for repository and ~5 Gb for ccache);
-* 64 bit version of CYGWIN (installer can be downloaded from [CYGWIN homepage](https://cygwin.com/));
+* 64-bit version of Windows 7, 8, 8.1, or 10
+* NTFS partition with ~10 Gb free space (~2 Gb for Cygwin installation, ~3 Gb for repository and ~5 Gb for ccache)
+* 64-bit version of Cygwin
 
 ## Installation:
 
-1. Go to [CYGWIN homepage](https://cygwin.com/) and download 64 bit installer (e.g. [setup-x86_64.exe](https://cygwin.com/setup-x86_64.exe).
+1. Go to the [Cygwin homepage](https://cygwin.com/) and download the 64-bit installer (e.g. [setup-x86_64.exe](https://cygwin.com/setup-x86_64.exe)).
 
-2. Run downloaded file and install CYGWIN (click `Next` button, select instalation source (e.g. `Install from Internet`), click `Next` button, specify directory where CYGWIN 64 bit will be installed (e.g. `C:\cygwin64`), select whether to install for all users or just you, click `Next` button again, select local package directory (e.g. `C:\Distr\Cygwin`), click `Next` button, select Internet connection settings, click `Next` button again, choose a download site from the list of available download sites,  click `Next` button again).
+2. Run downloaded file and install Cygwin. Select `Install from Internet` and select the desired installation directory. It is suggested that you install into a dev-specific directory (e.g. `C:\dev\cygwin64`), but it's not strictly necessary. Install for all users.
 
-3. After CYGWIN installation is complete select following packages and press `Next` button to download and install them:
+3. Give the `\downloads\` folder as the local package directory (e.g. `C:\dev\cygwin64\downloads`).
 
-* `wget`.
+4. Use system proxy settings unless you know you have a reason not to.
 
-4. System will tell you it will install following packages (you will install everything else later):
+5. On the next screen, select any mirror you like.
 
-```
-...
-```
+6. Enter `wget` into the search box, expand the "Web" category and select the latest version in the drop-down (1.21.1-1 as of the time this guide was written).
 
-5. Check boxes to add shortcuts to Start Menu and/or Desktop, then press `Finish` button.
+7. Confirm that wget is shown in the following screen by scrolling to the bottom. This is the full list of packages that Cygwin will download and install.
+
+8. Retry any packages that throw errors.
+
+9. Check boxes to add shortcuts to Start Menu and/or Desktop, then press `Finish` button.
 
 ## Configuration:
 
-1. Install `apt-cyg` for easier package installation with:
+1. Launch the Cygwin64 terminal from your desktop.
+
+2. Install `apt-cyg` for easier package installation:
 
 ```bash
 wget rawgit.com/transcode-open/apt-cyg/master/apt-cyg -O /bin/apt-cyg
 chmod 755 /bin/apt-cyg
 ```
 
-2. Install packages required for compilation with:
+3. Install packages required for compilation:
 
 ```bash
-apt-cyg install git make astyle gcc-g++ libintl-devel libiconv-devel libSDL2_image-devel libSDL2_ttf-devel libSDL2_mixer-devel libncurses-devel xinit
+apt-cyg install astyle ccache gcc-g++ gettext-devel git libiconv-devel libintl-devel libSDL2_image-devel libSDL2_mixer-devel libSDL2_ttf-devel make xinit
 ```
+
+You will see messages saying packages are already installed, as well as Cygwin installing packages you didn't ask for; this is the result of Cygwin's package manager automatically resolving dependencies.
 
 ## Cloning and compilation:
 
-1. Clone Cataclysm-BN repository with following command line:
+1. Clone the Cataclysm-DDA repository with following command:
 
-**Note:** This will download whole BN repository. If you're just testing you should probably add `--depth=1`.
-
-```bash
-git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git
-cd Cataclysm-BN
-```
-
-2. Compile with following command line:
+**Note:** This will download the entire CDDA repository and all of its history (3GB). If you're just testing, you should probably add `--depth=1` (~350MB).
 
 ```bash
-make CCACHE=1 RELEASE=1 CYGWIN=1 DYNAMIC_LINKING=1 SDL=1 TILES=1 SOUND=1 LOCALIZE=1 LANGUAGES=all LINTJSON=0 ASTYLE=0 RUNTESTS=0
+cd /cygdrive/c/dev
+git clone https://github.com/CleverRaven/Cataclysm-DDA.git
+cd Cataclysm-DDA
 ```
 
-**Note**: This will compile release version with Sound and Tiles support and all localization languages, skipping checks and tests and using ccache for faster build. You can use other switches, but `CYGWIN=1`, `DYNAMIC_LINKING=1` and probably `RELEASE=1` are required to compile without issues.
+2. Compile:
+
+```bash
+make CCACHE=1 RELEASE=1 CYGWIN=1 DYNAMIC_LINKING=1 SDL=1 TILES=1 SOUND=1 LOCALIZE=1 LANGUAGES=all LINTJSON=0 ASTYLE=0 BACKTRACE=0 RUNTESTS=0
+```
+
+You will receive warnings about unterminated character constants; they do not impact the compilation as far as this writer is aware.
+
+**Note**: This will compile release version with Sound and Tiles support and all localization languages, skipping checks and tests and using ccache for faster build. You can use other switches, but `Cygwin=1`, `DYNAMIC_LINKING=1` and probably `RELEASE=1` are required to compile without issues.
 
 ## Running:
 
-1. Run from within CYGWIN XWin Server (found in Start Menu) with following command line:
+1. Execute the XWin Server from the Start menu.
+
+2. When the icons appear in the system tray, right-click the one that looks like a black C (X Applications Menu.)
+
+3. Point to System Tools, then click UXTerm.
 
 ```bash
+cd /cygdrive/c/dev/Cataclysm-DDA
 ./cataclysm-tiles
 ```
+
+There is no functionality for running Cygwin-compiled CDDA from outside of UXTerm.

--- a/doc/COMPILING/COMPILING-CYGWIN.md
+++ b/doc/COMPILING/COMPILING-CYGWIN.md
@@ -1,6 +1,6 @@
 # Compilation guide for 64 bit Windows (using Cygwin)
 
-This guide contains instructions for compiling Cataclysm-DDA on Windows under Cygwin. **PLEASE NOTE:** These instructions *are not intended* to produce a redistributable copy of CDDA. Please download the official builds from the website or [cross-compile from Linux](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/COMPILING/COMPILING.md#cross-compile-to-windows-from-linux) if that is your intention.
+This guide contains instructions for compiling Cataclysm-BN on Windows under Cygwin. **PLEASE NOTE:** These instructions *are not intended* to produce a redistributable copy of CBN. Please download the official builds from the website or [cross-compile from Linux](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/COMPILING/COMPILING.md#cross-compile-to-windows-from-linux) if that is your intention.
 
 These instructions were written using 64-bit Windows 7 and the 64-bit version of Cygwin; the steps should be the same for other versions of Windows.
 
@@ -53,14 +53,14 @@ You will see messages saying packages are already installed, as well as Cygwin i
 
 ## Cloning and compilation:
 
-1. Clone the Cataclysm-DDA repository with following command:
+1. Clone the Cataclysm-BN repository with following command:
 
-**Note:** This will download the entire CDDA repository and all of its history (3GB). If you're just testing, you should probably add `--depth=1` (~350MB).
+**Note:** This will download the entire CBN repository and all of its history (3GB). If you're just testing, you should probably add `--depth=1` (~350MB).
 
 ```bash
 cd /cygdrive/c/dev
-git clone https://github.com/CleverRaven/Cataclysm-DDA.git
-cd Cataclysm-DDA
+git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git
+cd Cataclysm-BN
 ```
 
 2. Compile:
@@ -82,8 +82,8 @@ You will receive warnings about unterminated character constants; they do not im
 3. Point to System Tools, then click UXTerm.
 
 ```bash
-cd /cygdrive/c/dev/Cataclysm-DDA
+cd /cygdrive/c/dev/Cataclysm-BN
 ./cataclysm-tiles
 ```
 
-There is no functionality for running Cygwin-compiled CDDA from outside of UXTerm.
+There is no functionality for running Cygwin-compiled CBN from outside of UXTerm.

--- a/doc/COMPILING/COMPILING-MSYS.md
+++ b/doc/COMPILING/COMPILING-MSYS.md
@@ -28,7 +28,7 @@ These instructions were written using 64-bit Windows 7 and the 64-bit version of
 pacman -Syyu
 ```
 
-2. MSYS will inform you of a cygheap base mismatch and inform you a forked process died unexpectedly; these errors appear to be due to the nature of `pacman`'s upgrades and *may be safely ignored.* You will be prompted to close the terminal window; do so, then re-start using the MSYS2 MinGW 64-bit menu item.
+2. MSYS may inform you of a cygheap base mismatch and inform you a forked process died unexpectedly; these errors appear to be due to the nature of `pacman`'s upgrades and *may be safely ignored.* You will be prompted to close the terminal window; do so, then re-start using the MSYS2 MinGW 64-bit menu item.
 
 3. Update remaining packages:
 
@@ -81,6 +81,7 @@ and
 ```bash
 cd /c/dev/
 git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git
+cd Cataclysm-BN
 ```
 
 **Note:** This will download the entire CBN repository and all of its history (3GB). If you're just testing, you should probably add `--depth=1` (~350MB).
@@ -88,13 +89,12 @@ git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git
 2. Compile with following command line:
 
 ```bash
-cd Cataclysm-BN
 make -j$((`nproc`+0)) CCACHE=1 RELEASE=1 MSYS2=1 DYNAMIC_LINKING=1 SDL=1 TILES=1 SOUND=1 LOCALIZE=1 LANGUAGES=all LINTJSON=0 ASTYLE=0 RUNTESTS=0
 ```
 
 You will receive warnings about unterminated character constants; they do not impact the compilation as far as this writer is aware.
 
-**Note**: This will compile a release version with Sound and Tiles support and all localization languages, skipping checks and tests, and using ccache for build acceleration. You can use other switches, but `MSYS2=1`, `DYNAMIC_LINKING=1` and probably `RELEASE=1` are required to compile without issues.
+**Note**: This will compile a release version with Sound and Tiles support and all localization languages, skipping checks and tests, and using ccache for build acceleration. You can use other switches, but `MSYS2=1` and `DYNAMIC_LINKING=1` are required to compile without issues.
 
 ## Running:
 

--- a/doc/COMPILING/COMPILING-MSYS.md
+++ b/doc/COMPILING/COMPILING-MSYS.md
@@ -1,6 +1,6 @@
 # Compilation guide for 64-bit Windows (using MSYS2)
 
-This guide contains instructions for compiling Cataclysm-DDA on Windows under MSYS2. **PLEASE NOTE:** These instructions *are not intended* to produce a redistributable copy of CDDA. Please download the official builds from the website or [cross-compile from Linux](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/COMPILING/COMPILING.md#cross-compile-to-windows-from-linux) if that is your intention.
+This guide contains instructions for compiling Cataclysm-BN on Windows under MSYS2. **PLEASE NOTE:** These instructions *are not intended* to produce a redistributable copy of CBN. Please download the official builds from the website or [cross-compile from Linux](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/COMPILING/COMPILING.md#cross-compile-to-windows-from-linux) if that is your intention.
 
 These instructions were written using 64-bit Windows 7 and the 64-bit version of MSYS2; the steps should be the same for other versions of Windows.
 
@@ -76,19 +76,19 @@ and
 
 ## Cloning and compilation:
 
-1. Open MSYS2 and clone the Cataclysm-DDA repository:
+1. Open MSYS2 and clone the Cataclysm-BN repository:
 
 ```bash
 cd /c/dev/
-git clone https://github.com/CleverRaven/Cataclysm-DDA.git ./Cataclysm-DDA
+git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git
 ```
 
-**Note:** This will download the entire CDDA repository and all of its history (3GB). If you're just testing, you should probably add `--depth=1` (~350MB).
+**Note:** This will download the entire CBN repository and all of its history (3GB). If you're just testing, you should probably add `--depth=1` (~350MB).
 
 2. Compile with following command line:
 
 ```bash
-cd Cataclysm-DDA
+cd Cataclysm-BN
 make -j$((`nproc`+0)) CCACHE=1 RELEASE=1 MSYS2=1 DYNAMIC_LINKING=1 SDL=1 TILES=1 SOUND=1 LOCALIZE=1 LANGUAGES=all LINTJSON=0 ASTYLE=0 RUNTESTS=0
 ```
 

--- a/doc/COMPILING/COMPILING-MSYS.md
+++ b/doc/COMPILING/COMPILING-MSYS.md
@@ -1,48 +1,50 @@
-# Compilation guide for 64 bit Windows (using MSYS2)
+# Compilation guide for 64-bit Windows (using MSYS2)
 
-This guide contains steps required to allow compilation of Cataclysm-BN on Windows under MSYS2.
+This guide contains instructions for compiling Cataclysm-DDA on Windows under MSYS2. **PLEASE NOTE:** These instructions *are not intended* to produce a redistributable copy of CDDA. Please download the official builds from the website or [cross-compile from Linux](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/COMPILING/COMPILING.md#cross-compile-to-windows-from-linux) if that is your intention.
 
-Steps from current guide were tested on Windows 10 (64 bit) and MSYS2 (64 bit), but should work for other versions of Windows and also MSYS2 (32 bit) if you download 32 bit version of all files.
+These instructions were written using 64-bit Windows 7 and the 64-bit version of MSYS2; the steps should be the same for other versions of Windows.
 
 ## Prerequisites:
 
-* Computer with 64 bit version of modern Windows operating system installed (Windows 10, Windows 8.1 or Windows 7);
-* NTFS partition with ~10 Gb free space (~2 Gb for MSYS2 installation, ~3 Gb for repository and ~5 Gb for ccache);
-* 64 bit version of MSYS2 (installer can be downloaded from [MSYS2 homepage](http://www.msys2.org/));
+* Windows 7, 8, 8.1, or 10
+* NTFS partition with ~10 Gb free space (~2 Gb for MSYS2 installation, ~3 Gb for repository and ~5 Gb for ccache)
+* 64-bit version of MSYS2
 
 **Note:** Windows XP is unsupported!
 
 ## Installation:
 
-1. Go to [MSYS2 homepage](http://www.msys2.org/) and download 64 bit installer (e.g. [msys2-x86_64-20180531.exe](http://repo.msys2.org/distrib/x86_64/msys2-x86_64-20180531.exe)).
+1. Go to the [MSYS2 homepage](http://www.msys2.org/) and download the installer.
 
-2. Run downloaded file and install MSYS2 (click `Next` button, specify directory where MSYS2 64 bit will be installed (e.g. `C:\msys64`), click `Next` button again, specify Start Menu folder name and click `Install` button).
+2. Run the installer. It is suggested that you install to a dev-specific folder (C:\dev\msys64\ or similar), but it's not strictly necessary.
 
-3. After MSYS2 installation is complete press `Next` button, tick `Run MSYS2 64 bit now` checkbox and press `Finish` button.
+3. After installation, run MSYS2 64bit now.
 
 ## Configuration:
 
-1. Update the package database and core system packages with:
+1. Update the package database and core system packages:
 
 ```bash
-pacman -Syu
+pacman -Syyu
 ```
 
-2. If asked close MSYS2 window and restart it from Start Menu or `C:\msys64\msys2_shell.cmd`.
+2. MSYS will inform you of a cygheap base mismatch and inform you a forked process died unexpectedly; these errors appear to be due to the nature of `pacman`'s upgrades and *may be safely ignored.* You will be prompted to close the terminal window; do so, then re-start using the MSYS2 MinGW 64-bit menu item.
 
-3. Update remaining packages with:
+3. Update remaining packages:
 
 ```bash
 pacman -Su
 ```
 
-4. Install packages required for compilation with:
+4. Install packages required for compilation:
 
 ```bash
-pacman -S git git-extras make mingw-w64-x86_64-{astyle,ccache,gcc,libmad,libwebp,ncurses,pkg-config,SDL2} mingw-w64-x86_64-SDL2_{image,mixer,ttf}
+pacman -S git make mingw-w64-x86_64-{astyle,ccache,gcc,libmad,libwebp,pkg-config,SDL2} mingw-w64-x86_64-SDL2_{image,mixer,ttf}
 ```
 
-5. Update paths in system-wide profile file (e.g. `C:\msys64\etc\profile`) as following:
+5. Close MSYS2.
+
+6. Update path variables in the system-wide profile file (e.g. `C:\dev\msys64\etc\profile`) as following:
 
 - find lines:
 
@@ -72,33 +74,34 @@ and
     PKG_CONFIG_PATH="/usr/lib/pkgconfig:/usr/share/pkgconfig:/lib/pkgconfig:/mingw64/lib/pkgconfig:/mingw64/share/pkgconfig"
 ```
 
-6. Restart MSYS2 to apply path changes.
-
 ## Cloning and compilation:
 
-1. Clone Cataclysm-BN repository with following command line:
-
-**Note:** This will download whole CBN repository. If you're just testing you should probably add `--depth=1`.
+1. Open MSYS2 and clone the Cataclysm-DDA repository:
 
 ```bash
-git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git
-cd Cataclysm-BN
+cd /c/dev/
+git clone https://github.com/CleverRaven/Cataclysm-DDA.git ./Cataclysm-DDA
 ```
+
+**Note:** This will download the entire CDDA repository and all of its history (3GB). If you're just testing, you should probably add `--depth=1` (~350MB).
 
 2. Compile with following command line:
 
 ```bash
-make CCACHE=1 RELEASE=1 MSYS2=1 DYNAMIC_LINKING=1 SDL=1 TILES=1 SOUND=1 LOCALIZE=1 LANGUAGES=all LINTJSON=0 ASTYLE=0 RUNTESTS=0
+cd Cataclysm-DDA
+make -j$((`nproc`+0)) CCACHE=1 RELEASE=1 MSYS2=1 DYNAMIC_LINKING=1 SDL=1 TILES=1 SOUND=1 LOCALIZE=1 LANGUAGES=all LINTJSON=0 ASTYLE=0 RUNTESTS=0
 ```
 
-**Note**: This will compile release version with Sound and Tiles support and all localization languages, skipping checks and tests and using ccache for faster build. You can use other switches, but `MSYS2=1`, `DYNAMIC_LINKING=1` and probably `RELEASE=1` are required to compile without issues.
+You will receive warnings about unterminated character constants; they do not impact the compilation as far as this writer is aware.
+
+**Note**: This will compile a release version with Sound and Tiles support and all localization languages, skipping checks and tests, and using ccache for build acceleration. You can use other switches, but `MSYS2=1`, `DYNAMIC_LINKING=1` and probably `RELEASE=1` are required to compile without issues.
 
 ## Running:
 
-1. Run from within MSYS2 with following command line:
+1. Run inside MSYS2 from Cataclysm's directory with the following command:
 
 ```bash
 ./cataclysm-tiles
 ```
 
-**Note:** If you want to run compiled executable from Explorer you will also need to update user or system `PATH` variable with path to MSYS2 runtime binaries (e.g. `C:\msys64\mingw64\bin`).
+**Note:** If you want to run the compiled executable outside of MSYS2, you will also need to update your user or system `PATH` variable with the path to MSYS2's runtime binaries (e.g. `C:\dev\msys64\mingw64\bin`).

--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -66,7 +66,7 @@ cd vcpkg
 
 1. Clone Cataclysm-BN repository with following command line:
 
-**Note:** This will download the entire CDDA repository; about three gigs of data. If you're just testing you should probably add `--depth=1`.
+**Note:** This will download the entire CBN repository; about three gigs of data. If you're just testing you should probably add `--depth=1`.
 
 ```cmd
 git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git

--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -91,7 +91,13 @@ Ensure that the Cataclysm project (`Cataclysm-vcpkg-static`) is the selected sta
 
 If you discover that after pressing the debug button in Visual Studio, Cataclysm just exits after launch with return code 1, that is because of the wrong working directory.
 
-When debugging, it is not strictly necessary to use a `Debug` build; `Release` builds run significantly faster, can still be run in the debugger, and most of the time will have most of the information you need.
+When debugging, it is not strictly necessary to use a `Debug` build.
+`Release` builds run significantly faster, can still be run in the debugger, and most of the time will have most of the information you need.
+If optimizations of `Release` build interfere with debugging, you can disable them on a file-by-file basis by adding
+```c++
+#pragma optimize("", off)
+```
+line at the top of the file.
 
 ### Running unit tests
 

--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -18,9 +18,13 @@ Steps from current guide were tested on Windows 10 (64 bit), Visual Studio 2019 
 
 1. Install `Visual Studio` (installer can be downloaded from [Visual Studio homepage](https://visualstudio.microsoft.com/)).
 
+- Select the "Desktop development with C++" and "Game development with C++" workloads.
+
 2. Install `Git for Windows` (installer can be downloaded from [Git homepage](https://git-scm.com/)).
 
-3. Install and configure `vcpkg` using instruction from [vcpkg homepage](https://github.com/Microsoft/vcpkg/blob/master/README.md#quick-start) with following command line:
+3. Install and configure `vcpkg`:
+
+***WARNING: It is important that, wherever you decide to clone this repo, the path does not include whitespace. That is, `C:/dev/vcpkg` is acceptable, but `C:/dev test/vcpkg` is not.***
 
 ```cmd
 git clone https://github.com/Microsoft/vcpkg.git
@@ -29,16 +33,24 @@ cd vcpkg
 .\vcpkg integrate install
 ```
 
-4. Install (or upgrade) neccessary packages with following command line:
+4. Install a necessary pre-requisite package:
 
-#### install 64 bit dependencies:
+#### Install YASM-tool:
+
+```cmd
+.\vcpkg --triplet x86-windows install yasm-tool yasm-tool-helper
+```
+
+5. Install the dependencies for your desired architecture.
+
+
+#### 64-bit dependencies:
 
 ```cmd
 .\vcpkg --triplet x64-windows-static install sdl2 sdl2-image sdl2-mixer[dynamic-load,libflac,mpg123,libmodplug,libvorbis] sdl2-ttf gettext
 ```
 
-
-#### install 32 bit dependencies:
+#### 32-bit dependencies:
 
 ```cmd
 .\vcpkg --triplet x86-windows-static install sdl2 sdl2-image sdl2-mixer[dynamic-load,libflac,mpg123,libmodplug,libvorbis] sdl2-ttf gettext
@@ -54,20 +66,22 @@ cd vcpkg
 
 1. Clone Cataclysm-BN repository with following command line:
 
-**Note:** This will download whole CBN repository. If you're just testing you should probably add `--depth=1`.
+**Note:** This will download the entire CDDA repository; about three gigs of data. If you're just testing you should probably add `--depth=1`.
 
 ```cmd
 git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 
-2. Open the provided solution (`msvc-full-features\Cataclysm-vcpkg-static.sln`) in `Visual Studio`, select configuration (`Release` or `Debug`) and platform (`x64` or `x86`) and build it.
+2. Open the provided solution (`msvc-full-features\Cataclysm-vcpkg-static.sln`) in `Visual Studio`.
 
-**Note**: This will compile release version with Sound, Tiles and Localization support (language files won't be automatically compiled).
+3. Open the `Build > Configuration Manager` menu and adjust `Active solution configuration` and `Active solution platform` to match your intended target.
 
-3. Building Cataclysm with Visual Studio is very simple. Just build it like a normal Visual C++ project. The process may takes a long period of time, so you'd better prepare a cup of coffee and some books in front of your computer :)
+This will configure Visual Studio to compile the release version, with support for Sound, Tiles, and Localization (note, however, that language files themselves are not automatically compiled; this will be done later).
 
-4. If you need localization support, execute the bash script `lang/compile_mo.sh` inside Git Bash GUI just like on a UNIX-like system. This will compile the language files that were not automatically compiled in step 2 above.
+4. Start the build process by selecting either `Build > Build Solution` or `Build > Build > 1 Cataclysm-vcpkg-static`. The process may take a long period of time, so you'd better prepare a cup of coffee and some books in front of your computer :)
+
+5. If you need localization support, execute the bash script `lang/compile_mo.sh` inside Git Bash GUI just like on a UNIX-like system. This will compile the language files that were not automatically compiled in step 2 above.
 
 Even if you do not need languages other than English, you may still want to execute `lang/compile_mo.sh en` or `lang/compile_mo.sh all` to compile the language file for English, in order to work-around a [libintl bug](https://savannah.gnu.org/bugs/index.php?58006) that is causing significant slow-down on Windows targets if a language file is not found.
 

--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -47,13 +47,13 @@ cd vcpkg
 #### 64-bit dependencies:
 
 ```cmd
-.\vcpkg --triplet x64-windows-static install sdl2 sdl2-image sdl2-mixer[dynamic-load,libflac,mpg123,libmodplug,libvorbis] sdl2-ttf gettext
+.\vcpkg --triplet x64-windows-static install sdl2 sdl2-image sdl2-mixer[libflac,mpg123,libmodplug,libvorbis] sdl2-ttf gettext
 ```
 
 #### 32-bit dependencies:
 
 ```cmd
-.\vcpkg --triplet x86-windows-static install sdl2 sdl2-image sdl2-mixer[dynamic-load,libflac,mpg123,libmodplug,libvorbis] sdl2-ttf gettext
+.\vcpkg --triplet x86-windows-static install sdl2 sdl2-image sdl2-mixer[libflac,mpg123,libmodplug,libvorbis] sdl2-ttf gettext
 ```
 
 #### upgrade all dependencies:

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -187,28 +187,44 @@ Run:
     make NATIVE=linux32
 
 ## Cross-compile to Windows from Linux
+To cross-compile to Windows from Linux, you will need [MXE](http://mxe.cc).
 
-To cross-compile to Windows from Linux, you will need MXE, which changes your `make` command slightly. These instructions were written from Ubuntu 20.04, but should be applicable to any Debian-based environment. Please adjust all package manager instructions to match your environment.
+These instructions were written for Ubuntu 20.04, but should be applicable to any Debian-based environment. Please adjust all package manager instructions to match your environment.
 
-Dependencies:
+MXE can be either installed from MXE apt repository (much faster) or compiled from source.
 
-  * [MXE](http://mxe.cc)
-  * [MXE Requirements](http://mxe.cc/#requirements)
+### Installing MXE from binary distribution
 
-Installation
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
+    sudo add-apt-repository "deb [arch=amd64] https://pkg.mxe.cc/repos/apt `lsb_release -sc` main"
+    sudo apt-get update
+    sudo apt-get install astyle bzip2 git make mxe-{i686,x86-64}-w64-mingw32.static-{sdl2,sdl2-ttf,sdl2-image,sdl2-mixer,gettext}
 
-<!-- astyle and lzip added to initial sudo apt install string to forestall complaints from MinGW and make -->
-<!-- ncurses removed from make MXE_TARGETS because we're not gonna be cross-compiling ncurses -->
+If you are not planning on building for both 32-bit and 64-bit, you might want to adjust the last apt-get invocation to install only `i686` or `x86-64` packages.
+
+Edit your `~/.profile` as follows:
+
+    export PLATFORM_32="/usr/lib/mxe/usr/bin/i686-w64-mingw32.static-"
+    export PLATFORM_64="/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.static-"
+
+This is to ensure that the variables for the `make` command will not get reset after a power cycle.
+
+### Installing MXE from source
+Install [MXE requirements](http://mxe.cc/#requirements) and build dependencies:
 
     sudo apt install astyle autoconf automake autopoint bash bison bzip2 cmake flex gettext git g++ gperf intltool libffi-dev libgdk-pixbuf2.0-dev libtool libltdl-dev libssl-dev libxml-parser-perl lzip make mingw-w64 openssl p7zip-full patch perl pkg-config python ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
-    mkdir -p ~/src/Cataclysm-BN
-    mkdir -p ~/src/mxe
+
+Clone MXE repo and build packages required for CBN:
+
+    mkdir -p ~/src
     cd ~/src
-    git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git ./Cataclysm-BN
-    git clone https://github.com/mxe/mxe.git ./mxe
+    git clone https://github.com/mxe/mxe.git
+    cd mxe
     make -j$((`nproc`+0)) MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' sdl2 sdl2_ttf sdl2_image sdl2_mixer gettext
 
-Building all these packages from MXE might take a while, even on a fast computer. Be patient; the `-j` flag will take advantage of all your processor cores. If you are not planning on building for both 32-bit and 64-bit, you might want to adjust your MXE_TARGETS.
+Building all these packages from MXE might take a while, even on a fast computer. Be patient; the `-j` flag will take advantage of all your processor cores.
+
+If you are not planning on building for both 32-bit and 64-bit, you might want to adjust your MXE_TARGETS.
 
 Edit your `~/.profile` as follows:
 
@@ -216,22 +232,12 @@ Edit your `~/.profile` as follows:
     export PLATFORM_64="~/src/mxe/usr/bin/x86_64-w64-mingw32.static-"
 
 This is to ensure that the variables for the `make` command will not get reset after a power cycle.
-
 ### Building (SDL)
-
-    cd ~/src/Cataclysm-BN
-
-***IMPORTANT:***
-
-The first time you set up your build environment, you must `touch VERSION.txt` to create a dummy file to avoid `make` complaining about not having a rule. You will need to add "VERSION.txt" to /.git/info/exclude in order to prevent your system from trying to `git push` this dummy file. Subsequent builds should not require `touch` again.
 
 Run one of the following commands based on your targeted environment:
 
     make -j$((`nproc`+0)) CROSS="${PLATFORM_32}" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 BACKTRACE=0 PCH=0 bindist
     make -j$((`nproc`+0)) CROSS="${PLATFORM_64}" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 BACKTRACE=0 PCH=0 bindist
-
-
-<!-- Building ncurses for Windows is a nonstarter, so the directions were removed. -->
 
 ## Cross-compile to Mac OS X from Linux
 

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -201,10 +201,10 @@ Installation
 <!-- ncurses removed from make MXE_TARGETS because we're not gonna be cross-compiling ncurses -->
 
     sudo apt install astyle autoconf automake autopoint bash bison bzip2 cmake flex gettext git g++ gperf intltool libffi-dev libgdk-pixbuf2.0-dev libtool libltdl-dev libssl-dev libxml-parser-perl lzip make mingw-w64 openssl p7zip-full patch perl pkg-config python ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
-    mkdir -p ~/src/Cataclysm-DDA
+    mkdir -p ~/src/Cataclysm-BN
     mkdir -p ~/src/mxe
     cd ~/src
-    git clone https://github.com/CleverRaven/Cataclysm-DDA.git ./Cataclysm-DDA
+    git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git ./Cataclysm-BN
     git clone https://github.com/mxe/mxe.git ./mxe
     make -j$((`nproc`+0)) MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' sdl2 sdl2_ttf sdl2_image sdl2_mixer gettext
 
@@ -219,7 +219,7 @@ This is to ensure that the variables for the `make` command will not get reset a
 
 ### Building (SDL)
 
-    cd ~/src/Cataclysm-DDA
+    cd ~/src/Cataclysm-BN
 
 ***IMPORTANT:***
 

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -188,45 +188,50 @@ Run:
 
 ## Cross-compile to Windows from Linux
 
-To cross-compile to Windows from Linux, you will need MXE. The main difference between the native build process and this one, is the use of the CROSS flag for make. The other make flags are still applicable.
-
-  * `CROSS=` - should be the full path to MXE g++ without the *g++* part at the end
+To cross-compile to Windows from Linux, you will need MXE, which changes your `make` command slightly. These instructions were written from Ubuntu 20.04, but should be applicable to any Debian-based environment. Please adjust all package manager instructions to match your environment.
 
 Dependencies:
 
   * [MXE](http://mxe.cc)
   * [MXE Requirements](http://mxe.cc/#requirements)
 
-Install:
+Installation
 
-    sudo apt-get install autoconf automake autopoint bash bison bzip2 cmake flex gettext git g++ gperf intltool libffi-dev libgdk-pixbuf2.0-dev libtool libltdl-dev libssl-dev libxml-parser-perl make openssl p7zip-full patch perl pkg-config python ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
+<!-- astyle and lzip added to initial sudo apt install string to forestall complaints from MinGW and make -->
+<!-- ncurses removed from make MXE_TARGETS because we're not gonna be cross-compiling ncurses -->
+
+    sudo apt install astyle autoconf automake autopoint bash bison bzip2 cmake flex gettext git g++ gperf intltool libffi-dev libgdk-pixbuf2.0-dev libtool libltdl-dev libssl-dev libxml-parser-perl lzip make mingw-w64 openssl p7zip-full patch perl pkg-config python ruby scons sed unzip wget xz-utils g++-multilib libc6-dev-i386 libtool-bin
+    mkdir -p ~/src/Cataclysm-DDA
     mkdir -p ~/src/mxe
-    git clone https://github.com/mxe/mxe.git ~/src/mxe
-    cd ~/src/mxe
-    make MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' sdl2 sdl2_ttf sdl2_image sdl2_mixer gettext ncurses
+    cd ~/src
+    git clone https://github.com/CleverRaven/Cataclysm-DDA.git ./Cataclysm-DDA
+    git clone https://github.com/mxe/mxe.git ./mxe
+    make -j$((`nproc`+0)) MXE_TARGETS='x86_64-w64-mingw32.static i686-w64-mingw32.static' sdl2 sdl2_ttf sdl2_image sdl2_mixer gettext
 
-If you are not on a Debian derivative (Linux Mint, Ubuntu, etc), you will have to use a different command than apt-get to install [the MXE requirements](http://mxe.cc/#requirements). Building all these packages from MXE might take a while even on a fast computer. Be patient. If you are not planning on building for both 32-bit and 64-bit, you might want to adjust your MXE_TARGETS.
+Building all these packages from MXE might take a while, even on a fast computer. Be patient; the `-j` flag will take advantage of all your processor cores. If you are not planning on building for both 32-bit and 64-bit, you might want to adjust your MXE_TARGETS.
+
+Edit your `~/.profile` as follows:
+
+    export PLATFORM_32="~/src/mxe/usr/bin/i686-w64-mingw32.static-"
+    export PLATFORM_64="~/src/mxe/usr/bin/x86_64-w64-mingw32.static-"
+
+This is to ensure that the variables for the `make` command will not get reset after a power cycle.
 
 ### Building (SDL)
 
-Run:
+    cd ~/src/Cataclysm-DDA
 
-    PLATFORM="i686-w64-mingw32.static"
-    make CROSS="~/src/mxe/usr/bin/${PLATFORM}-" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1
+***IMPORTANT:***
 
-Change PLATFORM to x86_64-w64-mingw32.static for a 64-bit Windows build.
+The first time you set up your build environment, you must `touch VERSION.txt` to create a dummy file to avoid `make` complaining about not having a rule. You will need to add "VERSION.txt" to /.git/info/exclude in order to prevent your system from trying to `git push` this dummy file. Subsequent builds should not require `touch` again.
 
-To create nice zip file with all the required resources for a trouble free copy on Windows use the bindist target like this:
+Run one of the following commands based on your targeted environment:
 
-    PLATFORM="i686-w64-mingw32.static"
-    make CROSS="~/src/mxe/usr/bin/${PLATFORM}-" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 bindist
+    make -j$((`nproc`+0)) CROSS="${PLATFORM_32}" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 BACKTRACE=0 PCH=0 bindist
+    make -j$((`nproc`+0)) CROSS="${PLATFORM_64}" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 BACKTRACE=0 PCH=0 bindist
 
-### Building (ncurses)
 
-Run:
-
-    PLATFORM="i686-w64-mingw32.static"
-    make CROSS="~/src/mxe/usr/bin/${PLATFORM}-" RELEASE=1 LOCALIZE=1
+<!-- Building ncurses for Windows is a nonstarter, so the directions were removed. -->
 
 ## Cross-compile to Mac OS X from Linux
 
@@ -573,11 +578,9 @@ Open Terminal's preferences, turn on "Use bright colors for bold text" in "Prefe
 
 # Windows
 
-## Building with Visual Studio
-
 See [COMPILING-VS-VCPKG.md](COMPILING-VS-VCPKG.md) for instructions on how to set up and use a build environment using Visual Studio on windows.
 
-This is probably the easiest solution for someone used to working with Visual Studio and similar IDEs.
+This is probably the easiest solution for someone used to working with Visual Studio and similar IDEs. -->
 
 ## Building with MSYS2
 

--- a/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
@@ -83,7 +83,7 @@
             <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
             <LinkStatus>true</LinkStatus>
             <AdditionalOptions>/LTCG:OFF %(AdditionalOptions)</AdditionalOptions>
-            <AdditionalDependencies>winmm.lib;imm32.lib;version.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+            <AdditionalDependencies>winmm.lib;imm32.lib;version.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;setupapi.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
         </Link>
         <PreBuildEvent>
             <Command>prebuild.cmd</Command>

--- a/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
@@ -81,7 +81,7 @@
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
       <LinkStatus>true</LinkStatus>
       <AdditionalOptions>/LTCG:OFF %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>winmm.lib;imm32.lib;version.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;imm32.lib;version.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;setupapi.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>prebuild.cmd</Command>

--- a/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
@@ -80,7 +80,7 @@
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
       <LinkStatus>true</LinkStatus>
       <AdditionalOptions>/LTCG:OFF %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>winmm.lib;imm32.lib;version.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;imm32.lib;version.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;setupapi.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>

--- a/msvc-full-features/JsonFormatter.vcxproj
+++ b/msvc-full-features/JsonFormatter.vcxproj
@@ -81,7 +81,7 @@
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
       <LinkStatus>true</LinkStatus>
       <AdditionalOptions>/LTCG:OFF %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>winmm.lib;imm32.lib;version.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;setupapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;imm32.lib;version.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;setupapi.lib;shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>prebuild.cmd</Command>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,7 @@
 class ui_adaptor;
 
 #if defined(TILES)
+#   define SDL_MAIN_HANDLED
 #   if defined(_MSC_VER) && defined(USE_VCPKG)
 #      include <SDL2/SDL_version.h>
 #      include <SDL2/SDL.h>


### PR DESCRIPTION
1. Fix #380
2. Fix sound not working in Visual Studio build
3. Update compilation instructions for Visual Studio, MSYS2, Cygwin and MXE
    (based on https://github.com/CleverRaven/Cataclysm-DDA/pull/46830)
4. Add instructions on how to install MXE via APT (which is much faster than compiling it from source)

#### Note 1
Existing Visual Studio environments shouldn't be affected in any way. To fix the sound, `sdl2_mixer` may need to be manually reinstalled.

For x64:
```
.\vcpkg --triplet x64-windows-static remove sdl2-mixer
.\vcpkg --triplet x64-windows-static install sdl2-mixer[libflac,mpg123,libmodplug,libvorbis]
```

Fox x32:
```
.\vcpkg --triplet x86-windows-static remove sdl2-mixer
.\vcpkg --triplet x86-windows-static install sdl2-mixer[libflac,mpg123,libmodplug,libvorbis]
```

#### Note 2
MSYS2 builds are pretty much unusable due to https://github.com/CleverRaven/Cataclysm-DDA/issues/50115.
@DeNarr mentioned on discord they had this problem, and I encountered it too during testing.

Workaround is to remove `Terminus` entries from `config/fonts.json`. I kept getting weird rendering artifacts with `unifont` afterwards, but that could've been caused by me using VM.
