### PR TITLE
Reenable 3+ engines for vehicles and rebalance required mechanics skill

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -727,23 +727,14 @@ bool veh_interact::update_part_requirements()
     std::string additional_requirements;
     bool lifting_or_jacking_required = false;
 
-    bool allow_more_eng = engines < 2 || g->u.has_trait( trait_DEBUG_HS );
-
     if( dif_eng > 0 ) {
-        if( !allow_more_eng || g->u.get_skill_level( skill_mechanics ) < dif_eng ) {
+        if( g->u.get_skill_level( skill_mechanics ) < dif_eng ) {
             ok = false;
         }
-        if( allow_more_eng ) {
-            //~ %1$s represents the internal color name which shouldn't be translated, %2$s is skill name, and %3$i is skill level
-            additional_requirements += string_format( _( "> %1$s%2$s %3$i</color> for extra engines." ),
-                                       status_color( g->u.get_skill_level( skill_mechanics ) >= dif_eng ),
-                                       skill_mechanics.obj().name(), dif_eng ) + "\n";
-        } else {
-            additional_requirements +=
-                _( "> <color_red>You cannot install any more engines on this vehicle.</color>" ) +
-                std::string( "\n" );
-        }
-
+        //~ %1$s represents the internal color name which shouldn't be translated, %2$s is skill name, and %3$i is skill level
+        additional_requirements += string_format( _( "> %1$s%2$s %3$i</color> for extra engines." ),
+                                   status_color( g->u.get_skill_level( skill_mechanics ) >= dif_eng ),
+                                   skill_mechanics.obj().name(), dif_eng ) + "\n";
     }
 
     if( dif_steering > 0 ) {
@@ -2005,22 +1996,8 @@ int veh_interact::part_at( const point &d )
  */
 bool veh_interact::can_potentially_install( const vpart_info &vpart )
 {
-    bool engine_reqs_met = true;
-    bool can_make = vpart.install_requirements().can_make_with_inventory( crafting_inv,
-                    is_crafting_component );
-    bool hammerspace = g->u.has_trait( trait_DEBUG_HS );
-
-    int engines = 0;
-    if( vpart.has_flag( VPFLAG_ENGINE ) && vpart.has_flag( "E_HIGHER_SKILL" ) ) {
-        for( const vpart_reference &vp : veh->get_avail_parts( "ENGINE" ) ) {
-            if( vp.has_feature( "E_HIGHER_SKILL" ) ) {
-                engines++;
-            }
-        }
-        engine_reqs_met = engines < 2;
-    }
-
-    return hammerspace || ( can_make && engine_reqs_met );
+    return g->u.has_trait( trait_DEBUG_HS ) ||
+           vpart.install_requirements().can_make_with_inventory( crafting_inv, is_crafting_component );
 }
 
 /**


### PR DESCRIPTION
#### Purpose of change
Closes #389

#### Describe the solution
Pre-disable values, for reference:
| # of engines | mechanics lvl |
|-|-|
1 | 0
2 | 8
3 | 12
4 | 14
| >=5 | 15

Rebalance was done on the following conditions:
* Installation cost of additional engine should be higher than installation cost of most difficult installed engine
* Installing more engines should progressively require more skill
* We can't go over lvl 10 with requirements and nobody liked limited engines, so let's allow _all_ the engines at lvl 10.

And based off the following numbers:
* `Under the hood` (raises to lvl 3) is described as "advanced mechanics manual", which is enough to install low-power combustion engines, but IMO should be _far_ from "explains how to install 2 engines".
* Repairing low-powered and installing medium-powered engines and motors requires lvl 4, so lvl 4 seems good as "confident with cars" skill level, but still not enough for 2nd engine.
* `Mechanical Mastery` (raises to lvl 6) is described as "advanced guide on mechanics", so it is not out of realm of possibility it might cover this topic, at least for simpler engines.
* `Internal Combustion Fundamentals` (raises to lvl 8) should _definitely_ unlock 2nd engine, maybe even 3rd if engines are simple enough.
* 7-8-9 is the required installation skill for turbines
* `lab journal-Curie` tops off skill at 10, and as high-end knowledge must allow installing multiple turbines

As a result, I came up with a formula that should allow more easily combine simple engines, but require higher skill for the more advanced ones.

New values, required mechanics lvl depends on highest mechanics lvl (hm) required for installation of current or any existing engine
| # of engines | lvl (hm <=3) | lvl (hm =4) | lvl (hm =5) | lvl (hm =6) | lvl (hm >=7) |
|-|-|-|-|-|-|
1 | 0 | 0 | 0 | 0 | 0
2 | 6 | 7 | 8 | 9 | 10
3 | 8 | 9 | 10 | 10 | 10
| >=4 | 10 | 10 | 10 | 10 | 10

Enabling additional engines gives diminishing power returns, which seems enough to me as balance against unlimited # of them
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/a62a8995d3ac5ad3b62d1f991fc56f244a06370a/src/vehicle.cpp#L3428
![image](https://user-images.githubusercontent.com/60584843/127399440-043e233b-c695-4cc0-ac98-8b344c6c259b.png)

#### Testing
At lvl 6, it's possible to install 1 gasoline V12, or 2 V-twin engines, or 2 gasoline V8s, or 2 large emotors.
At lvl 7, it's possible to install 1 diesel V12, or 2 V6s, or 2 diesel V8s, or 2 enhanced emotors.
At lvl 8, it's possible to install 3 gasoline V8s, or 3 V-twins, or 3 large emotors, or 2 super emotors.
At lvl 9, it's possible to install 2 gasoline V12s, or 3 diesel V8s.
At lvl 10, anything is possible (e.g. multiple turbines).

#### Alternatives
I tried to make multi-engine setup a bit more accessible, but 6 may be a bit too high/low?
