### PR TITLE
Potential fixes for ASan out of memory issue

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -40,6 +40,7 @@ jobs:
             os: ubuntu-latest
             cmake: 0
             tiles: 0
+            sound: 0
             test-stage: 1
             title: GCC 9, Ubuntu, Curses
             native: linux64
@@ -47,26 +48,30 @@ jobs:
             os: ubuntu-latest
             cmake: 1
             tiles: 1
+            sound: 1
             native: linux64
             title: GCC 7, Ubuntu, Tiles, CMake
           - compiler: g++-8
             os: ubuntu-latest
             cmake: 0
             tiles: 1
+            sound: 0
             sanitize: address
             native: linux64
-            title: GCC 8, Ubuntu, Tiles, ASan
+            title: GCC 8, Ubuntu, Tiles, NoSound, ASan
           - compiler: clang++-9
             os: ubuntu-latest
             cmake: 0
             tiles: 1
+            sound: 0
             sanitize: address,undefined
             native: linux64
-            title: Clang 9, Ubuntu, Tiles, ASan, UBSan
+            title: Clang 9, Ubuntu, Tiles, NoSound, ASan, UBSan
           - compiler: clang++
             os: macos-10.15
             cmake: 0
             tiles: 1
+            sound: 1
             native: osx
             title: Clang 12, macOS 10.15, Tiles
     name: ${{ matrix.title }}
@@ -76,7 +81,7 @@ jobs:
         COMPILER: ${{ matrix.compiler }}
         OS: ${{ matrix.os }}
         TILES: ${{ matrix.tiles }}
-        SOUND: ${{ matrix.tiles }}
+        SOUND: ${{ matrix.sound }}
         SANITIZE: ${{ matrix.sanitize }}
         TEST_STAGE: ${{ matrix.test-stage }}
         EXTRA_TEST_OPTS:

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1679,6 +1679,10 @@ void scrollingcombattext::add( const point &pos, direction p_oDir,
                                const std::string &p_sText2, const game_message_type p_gmt2,
                                const std::string &p_sType )
 {
+    // TODO: A non-hack
+    if( test_mode ) {
+        return;
+    }
     if( get_option<bool>( "ANIMATION_SCT" ) ) {
 
         int iCurStep = 0;

--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -9,6 +9,7 @@
 #include "melee.h"
 #include "monster.h"
 #include "player_helpers.h"
+#include "sounds.h"
 #include "ret_val.h"
 #include "type_id.h"
 
@@ -35,8 +36,7 @@ static double weapon_dps_trials( avatar &attacker, monster &defender, item &weap
             // Reset and re-wield weapon before each attack to prevent skill-up during trials
             clear_character( attacker );
             attacker.wield( weapon );
-            // Verify that wielding worked (and not e.g. using martial arts
-            // instead)
+            // Verify that wielding worked (and not e.g. using martial arts instead)
             REQUIRE( attacker.used_weapon().type == weapon.type );
 
             int before_moves = attacker.get_moves();
@@ -51,6 +51,10 @@ static double weapon_dps_trials( avatar &attacker, monster &defender, item &weap
             // Tally total damage and moves
             total_damage += std::max( 0, starting_hp - defender.get_hp() );
             total_moves += std::abs( attacker.get_moves() - before_moves );
+
+            // Every hit or miss enqueues a new sound
+            // Ideally, we'd have sound vector get cleared after every test, but it's not easy
+            sounds::reset_sounds();
         }
     }
 


### PR DESCRIPTION
* Disabled sounds on ASan/UBsan builds
* Prevented scrolling combat text from appearing in test builds
* Reset (in-game) sound list in dps test