### PR TITLE
Port over fix to martial arts arpen

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -925,6 +925,8 @@ class Character : public Creature, public visitable<Character>
         int mabuff_block_bonus() const;
         /** Returns the speed bonus from martial arts buffs */
         int mabuff_speed_bonus() const;
+        /** Returns the arpen bonus from martial arts buffs*/
+        int mabuff_arpen_bonus( damage_type type ) const;
         /** Returns the damage multiplier to given type from martial arts buffs */
         float mabuff_damage_mult( damage_type type ) const;
         /** Returns the flat damage bonus to given type from martial arts buffs, applied after the multiplier */

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -661,6 +661,10 @@ int ma_buff::block_bonus( const Character &u ) const
 {
     return bonuses.get_flat( u, affected_stat::BLOCK );
 }
+int ma_buff::arpen_bonus( const Character &u, damage_type dt ) const
+{
+    return bonuses.get_flat( u, affected_stat::ARMOR_PENETRATION, dt );
+}
 int ma_buff::speed_bonus( const Character &u ) const
 {
     return bonuses.get_flat( u, affected_stat::SPEED );
@@ -1114,6 +1118,14 @@ int Character::mabuff_speed_bonus() const
     int ret = 0;
     accumulate_ma_buff_effects( *effects, [&ret, this]( const ma_buff & b, const effect & d ) {
         ret += d.get_intensity() * b.speed_bonus( *this );
+    } );
+    return ret;
+}
+int Character::mabuff_arpen_bonus( damage_type type ) const
+{
+    int ret = 0;
+    accumulate_ma_buff_effects( *effects, [&ret, type, this]( const ma_buff & b, const effect & d ) {
+        ret += d.get_intensity() * b.arpen_bonus( *this, type );
     } );
     return ret;
 }

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -148,6 +148,7 @@ class ma_buff
         int dodge_bonus( const Character &u ) const;
         int speed_bonus( const Character &u ) const;
         int block_bonus( const Character &u ) const;
+        int arpen_bonus( const Character &u, damage_type dt ) const;
 
         // returns the armor bonus for various armor stats (equivalent to armor)
         int armor_bonus( const Character &guy, damage_type dt ) const;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -931,6 +931,8 @@ void Character::roll_bash_damage( bool crit, damage_instance &di, bool average,
     bash_mul *= mabuff_damage_mult( DT_BASH );
 
     float armor_mult = 1.0f;
+    int arpen = mabuff_arpen_bonus( DT_BASH );
+
     // Finally, extra critical effects
     if( crit ) {
         bash_mul *= 1.5f;
@@ -938,7 +940,7 @@ void Character::roll_bash_damage( bool crit, damage_instance &di, bool average,
         armor_mult = 0.5f;
     }
 
-    di.add_damage( DT_BASH, bash_dam, 0, armor_mult, bash_mul );
+    di.add_damage( DT_BASH, bash_dam, arpen, armor_mult, bash_mul );
 }
 
 void Character::roll_cut_damage( bool crit, damage_instance &di, bool average,
@@ -1003,6 +1005,8 @@ void Character::roll_cut_damage( bool crit, damage_instance &di, bool average,
         cut_mul *= 0.96 + 0.04 * cutting_skill;
     }
 
+    arpen += mabuff_arpen_bonus( DT_CUT );
+
     cut_mul *= mabuff_damage_mult( DT_CUT );
     if( crit ) {
         cut_mul *= 1.25f;
@@ -1066,7 +1070,7 @@ void Character::roll_stab_damage( bool crit, damage_instance &di, bool /*average
     } else {
         stab_mul = 0.86 + 0.06 * stabbing_skill;
     }
-
+    int arpen = mabuff_arpen_bonus( DT_STAB );
     stab_mul *= mabuff_damage_mult( DT_STAB );
     float armor_mult = 1.0f;
 
@@ -1077,7 +1081,7 @@ void Character::roll_stab_damage( bool crit, damage_instance &di, bool /*average
         armor_mult = 0.66f;
     }
 
-    di.add_damage( DT_STAB, stab_dam, 0, armor_mult, stab_mul );
+    di.add_damage( DT_STAB, stab_dam, arpen, armor_mult, stab_mul );
 }
 
 matec_id Character::pick_technique( Creature &t, const item &weap,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Port over fix to martial arts armor penetration"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

The issue with martial arts arpen was fixed in DDA, figured I'd port it over when I got a chance to.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/637

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Ported addition of a def for `mabuff_arpen_bonus` to character.h.
2. Ported `ma_buff::arpen_bonus` and `Character::mabuff_arpen_bonus` to martialarts.cpp.
3. Ported def for `arpen_bonus` to martialarts.h.
4. Ported changes to melee.cpp that make melee damage actually take arpen into account, converted to BN's older method of specifiying damage types.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Pestering someone else to do it.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Debugged in max skills and all martial arts.
3. Tested punching an armored zombie with brawling skill, and hitting them with an arming sword with medieval swordsmanship, observed that basically no damage was being dealt.
4. Quit, edited in a static buff to brawling giving 100 arpen to bash damage, and a static buff to medieval swordsmanship giving 100 arpen to cutting damage.
5. Repeated tests from steps 2-3, demolished armored zombies effortlessly.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/50132