### PR TITLE
Add noise from driven vehicle to displayed sound

### DIFF
--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -431,9 +431,16 @@ void sounds::process_sound_markers( player *p )
         }
 
         // Player volume meter includes all sounds from their tile and adjacent tiles
-        // TODO: Add noises from vehicle player is in.
         if( distance_to_sound <= 1 ) {
             p->volume = std::max( p->volume, heard_volume );
+        }
+
+        // Noises from vehicle player is in.
+        if( p->controlling_vehicle ) {
+            vehicle *veh = veh_pointer_or_null( get_map().veh_at( p->pos() ) );
+            const int noise = veh ? static_cast<int>( veh->vehicle_noise ) : 0;
+
+            p->volume = std::max( p->volume, noise );
         }
 
         // Secure the flag before wake_up() clears the effect


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Interface "Noise made by controlled vehicle added to sound indicator"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
While driving a vehicle, noises made by it should be displayed, but these can come from far enough position not to count as heard sound.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Sets `player.volume` appropriately using `vehicle.vehicle_noise`, already calculated by `vehicle::noise_and_smoke`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
`veh_pointer_or_null `shouldn't return `nullptr`, since only called when `p->controlling_vehicle` is `true`.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded test world, located vehicle, started engine, let go controls, walked to the back near muffler, from where the sound is coming.
Watched sound indicator rise, fall and rise again.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
Copied from origin PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/46544
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
