### PR TITLE
Add science tower lab start location 

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -191,7 +191,7 @@
     "description": "The scientists stopped their experiments on you abruptly, leaving you behind while they evacuated before lockdown.  Find a way to escape or starve to death.",
     "start_name": "Locked Lab",
     "professions": [ "unemployed", "mutant_patient", "mutant_volunteer", "labtech", "broken_cyborg" ],
-    "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale" ],
+    "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale", "sloc_tower_lab_finale", "sloc_tower_lab" ],
     "traits": [
       "ELFAEYES",
       "URSINE_EYE",
@@ -244,7 +244,7 @@
     "description": "You were deemed non-essential and made to stay behind during the lab evacuation.  Find a way to escape or starve to death.",
     "start_name": "Locked Lab",
     "professions": [ "labtech", "security", "medic" ],
-    "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale" ],
+    "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale", "sloc_tower_lab_finale", "sloc_tower_lab" ],
     "flags": [ "CHALLENGE", "CITY_START", "LONE_START" ]
   },
   {

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -248,13 +248,13 @@
   {
     "type": "start_location",
     "id": "sloc_tower_lab",
-    "name": "Tower lab",
+    "name": "Tower science lab",
     "terrain": [ "tower_lab_stairs" ]
   },
   {
     "type": "start_location",
     "id": "sloc_tower_lab_finale",
-    "name": "Top of the tower lab",
+    "name": "Top of the science tower lab",
     "terrain": [ "tower_lab_finale" ]
   },
   {

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -247,6 +247,18 @@
   },
   {
     "type": "start_location",
+    "id": "sloc_tower_lab",
+    "name": "Tower lab",
+    "terrain": [ "tower_lab_stairs" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_tower_lab_finale",
+    "name": "Top of the tower lab",
+    "terrain": [ "tower_lab_finale" ]
+  },
+  {
+    "type": "start_location",
     "id": "sloc_mall_loading_area",
     "name": "Mall (loading area)",
     "terrain": [ "mall_a_12" ]

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -248,13 +248,13 @@
   {
     "type": "start_location",
     "id": "sloc_tower_lab",
-    "name": "Tower science lab",
+    "name": "Science lab tower",
     "terrain": [ "tower_lab_stairs" ]
   },
   {
     "type": "start_location",
     "id": "sloc_tower_lab_finale",
-    "name": "Top of the science tower lab",
+    "name": "Top of the science lab tower",
     "terrain": [ "tower_lab_finale" ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
Features: Adds science lab tower starting location to lab escape challenges
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Lab Towers is the only type(barring microlabs) of labs that you can't spawn in as lab escape challenge. I find them pretty cool and they make nice starting and (probably) safe base if you can bear all the noise coming from first floor.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Added lab tower terrains to start_locations.json and added those locations to scenarios.json
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Not doing this PR
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Create a new character, select one of the escape lab challenge, select "Top of the science lab tower" or "Science lab tower" and spawn it.
Spawning at the top(finale room) gives an error message that it couldn't spawn me in but it went fine neverthless, the start_location.cpp mentions that it happens in exotic locations(read:deep of a science lab) for some reason.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
None
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
