### PR TITLE
Mechanical winch spawnig gate between walls fix #747

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -2146,6 +2146,30 @@
   },
   {
     "type": "terrain",
+    "id": "t_door_metal_locked_o",
+    "name": "open metal door",
+    "description": "A hanging metal gate. Typically used in conjunction with mechanical winch.  Probably shouldn't be underneath when it comes down.",
+    "symbol": "+",
+    "looks_like": "t_door_metal_lab_o",
+    "color": "cyan",
+    "move_cost": 1,
+    "roof": "t_flat_roof",
+    "flags": [ "TRANSPARENT", "FLAT", "CONNECT_TO_WALL", "BURROWABLE" ],
+    "bash": {
+      "str_min": 80,
+      "str_max": 250,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "ter_set": "t_null",
+      "items": [
+        { "item": "scrap", "count": [ 12, 24 ] },
+        { "item": "steel_plate", "prob": 75 },
+        { "item": "hinge", "count": [ 1, 3 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "t_door_metal_pickable",
     "name": "closed metal door",
     "description": "An extremely resilient door made of assorted steel, carved and pounded into shape.  This one has an extra keyhole, so it's likely locked.  You could probably pick the lock.",

--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -2148,7 +2148,7 @@
     "type": "terrain",
     "id": "t_door_metal_locked_o",
     "name": "open metal door",
-    "description": "A hanging metal gate. Typically used in conjunction with mechanical winch.  Probably shouldn't be underneath when it comes down.",
+    "description": "A hanging metal gate.  Typically used in conjunction with mechanical winch.  Probably shouldn't be underneath when it comes down.",
     "symbol": "+",
     "looks_like": "t_door_metal_lab_o",
     "color": "cyan",

--- a/data/json/gates.json
+++ b/data/json/gates.json
@@ -4,7 +4,7 @@
     "id": "t_gates_mech_control",
     "alias": [ "t_gates_control_concrete", "t_gates_control_brick" ],
     "door": "t_door_metal_locked",
-    "floor": "t_floor",
+    "floor": "t_door_metal_locked_o",
     "walls": [
       "t_wall",
       "t_wall_r",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

SUMMARY:bugfixes "Garage gate have now open variant to fix #747 issue."
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change

Garage gates were transforming into wooden floor thus Mechanical winch when constructed next to a specific walls with wooden floor between those walls could spawn metal garage door out of thin ~~air~~ floor. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution

I created opened variant for garage gates and swapped it with "t_floor" in the transformation code.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->



<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Works fine. If there are locations with "garage gate" that was open but possible for the player to operate trough Mechanical winch, it wont be there. Because they used floor as open variant for garage gates it will be just floor. At least there are barely any locations with "open" garage.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

On the pros side is also that me or SDG can make some nice sprite for open gate.
![](https://cdn.discordapp.com/attachments/830930402050703390/873372329743368192/unknown.png)
Also, why does the `t_mdoor_frame` etc leave roof tile as floor after destroying it? 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
