### PR TITLE
Update oxygen usage of acetylene recipe

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2452,7 +2452,7 @@
       [ "forge", 5 ],
       { "item": "weldtank", "charges": [ 0, 120 ], "prob": 10 },
       { "item": "tinyweldtank", "charges": [ 0, 30 ], "prob": 15 },
-      [ "oxygen", 15 ],
+      [ "oxygen_cylinder", 15 ],
       [ "coal_lump", 5 ],
       [ "material_limestone", 5 ]
     ]

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -929,23 +929,6 @@
   },
   {
     "type": "AMMO",
-    "id": "oxygen",
-    "category": "spare_parts",
-    "price": 12000,
-    "price_postapoc": 1000,
-    "//": "This seems like the larger medical tank, not an instant-use model with mask attached",
-    "name": { "str_sp": "oxygen" },
-    "symbol": "=",
-    "color": "light_gray",
-    "description": "A canister of oxygen.",
-    "material": "steel",
-    "volume": "2500 ml",
-    "weight": "1183 g",
-    "ammo_type": "oxygen",
-    "count": 10
-  },
-  {
-    "type": "AMMO",
     "id": "spiked_rocket",
     "price": 1000,
     "price_postapoc": 100,

--- a/data/json/items/ammo_types.json
+++ b/data/json/items/ammo_types.json
@@ -612,12 +612,6 @@
     "type": "ammunition_type"
   },
   {
-    "id": "oxygen",
-    "name": "oxygen",
-    "default": "oxygen",
-    "type": "ammunition_type"
-  },
-  {
     "type": "ammunition_type",
     "id": "300blk",
     "name": ".300 AAC Blackout",

--- a/data/json/items/obsolete.json
+++ b/data/json/items/obsolete.json
@@ -3268,5 +3268,28 @@
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "22_casing_new", 1 ] ], [ [ "gunpowder_pistol", 1 ] ] ],
     "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+  },
+  {
+    "type": "AMMO",
+    "id": "oxygen",
+    "category": "spare_parts",
+    "price": 12000,
+    "price_postapoc": 1000,
+    "//": "This seems like the larger medical tank, not an instant-use model with mask attached",
+    "name": { "str_sp": "oxygen" },
+    "symbol": "=",
+    "color": "light_gray",
+    "description": "A canister of oxygen.",
+    "material": "steel",
+    "volume": "2500 ml",
+    "weight": "1183 g",
+    "ammo_type": "oxygen",
+    "count": 10
+  },
+  {
+    "id": "oxygen",
+    "name": "oxygen",
+    "default": "oxygen",
+    "type": "ammunition_type"
   }
 ]

--- a/data/json/recipes/ammo/weldgas.json
+++ b/data/json/recipes/ammo/weldgas.json
@@ -10,7 +10,8 @@
     "charges": 120,
     "book_learn": [ [ "textbook_chemistry", 4 ], [ "textbook_gaswarfare", 5 ], [ "atomic_survival", 3 ] ],
     "qualities": [ { "id": "PRESSURIZATION", "level": 1 } ],
-    "components": [ [ [ "oxygen", 24 ] ], [ [ "acetylene", 96 ] ] ]
+    "tools": [ [ [ "smoxygen_tank", 3 ], [ "oxygen_tank", 3 ], [ "oxygen_cylinder", 25 ] ] ],
+    "components": [ [ [ "acetylene", 95 ] ] ]
   },
   {
     "result": "acetylene",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Make oxygen tanks usable for making oxy-ace, obsolete redundant oxygen item"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

As noticed during discussion of the industrial center PR, the type of oxygen item used for the oxy-acetlyene recipe was basically unobtainable, and seemed to have been added as an afterthought that ignored there already being three different sources of compressed oxygen in the game.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Updated the oxy-ace recipe to use charges of oxygen packs, tanks, and cylinders as tools instead of using raw oxygen as a component. The ratio was based off use of oxygen in Cata++ for makeshift thermal lances, as can be seen here: https://github.com/Noctifer-de-Mortem/nocts_cata_mod/blob/master/nocts_cata_mod_BN/Recipe/c_recipes.json#L1997
2. Amount of oxygen cylinder charges and acetylene used to make oxy-ace shifted to multiples of five.
3. Obsoleted the weird generic oxygen item and its ammotype, updated the sole spawn of it to spawn an oxygen cylinder instead.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

I was initially going to convert oxygen packs into a mask+regulator tool, to use varying sizes of oxygen tank as magazines, and converting the oxygen item into a gas loaded in the relevant magazines. I got all the way to the testing stage before finding out the hard way that the recipe wouldn't correctly see oxygen loaded in tanks that way.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Tested JSON changes for lint and syntax errors.
2. Copied JSON changes into today's build and load-tested.
3. Debugged in an oxygen pack, tank, and cylinder.
4. Debugged in all recipes, confirmed they all count as valid tools for oxy-ace recipe.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
