### PR TITLE
Add spawn_data for ammo and monster patrols

### DIFF
--- a/data/json/mapgen/outpost.json
+++ b/data/json/mapgen/outpost.json
@@ -94,14 +94,54 @@
       "place_fields": [ { "field": "fd_blood", "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 1, 12 ] } ],
       "toilets": { "&": {  } },
       "place_monster": [
-        { "monster": "mon_turret_medium", "x": 10, "y": 1 },
-        { "monster": "mon_turret_longrange", "x": 13, "y": 1 },
-        { "monster": "mon_turret_medium", "x": 1, "y": 10 },
-        { "monster": "mon_turret_longrange", "x": 1, "y": 13 },
-        { "monster": "mon_turret_medium", "x": 22, "y": 10 },
-        { "monster": "mon_turret_longrange", "x": 22, "y": 13 },
-        { "monster": "mon_turret_medium", "x": 10, "y": 22 },
-        { "monster": "mon_turret_longrange", "x": 13, "y": 22 },
+        {
+          "monster": "mon_turret_medium",
+          "x": 10,
+          "y": 1,
+          "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 60, 120 ] } ] }
+        },
+        {
+          "monster": "mon_turret_longrange",
+          "x": 13,
+          "y": 1,
+          "spawn_data": { "ammo": [ { "ammo_id": "762_51", "qty": [ 40, 80 ] } ] }
+        },
+        {
+          "monster": "mon_turret_medium",
+          "x": 1,
+          "y": 10,
+          "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 60, 120 ] } ] }
+        },
+        {
+          "monster": "mon_turret_longrange",
+          "x": 1,
+          "y": 13,
+          "spawn_data": { "ammo": [ { "ammo_id": "762_51", "qty": [ 40, 80 ] } ] }
+        },
+        {
+          "monster": "mon_turret_medium",
+          "x": 22,
+          "y": 10,
+          "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 60, 120 ] } ] }
+        },
+        {
+          "monster": "mon_turret_longrange",
+          "x": 22,
+          "y": 13,
+          "spawn_data": { "ammo": [ { "ammo_id": "762_51", "qty": [ 40, 80 ] } ] }
+        },
+        {
+          "monster": "mon_turret_medium",
+          "x": 10,
+          "y": 22,
+          "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 60, 120 ] } ] }
+        },
+        {
+          "monster": "mon_turret_longrange",
+          "x": 13,
+          "y": 22,
+          "spawn_data": { "ammo": [ { "ammo_id": "762_51", "qty": [ 40, 80 ] } ] }
+        },
         { "monster": "mon_turret_searchlight", "x": 1, "y": 1 },
         { "monster": "mon_turret_searchlight", "x": 22, "y": 22 },
         { "monster": "mon_turret_searchlight", "x": 1, "y": 22 },
@@ -220,14 +260,54 @@
       "place_fields": [ { "field": "fd_blood", "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 1, 12 ] } ],
       "toilets": { "&": {  } },
       "place_monster": [
-        { "monster": "mon_turret_medium", "x": 10, "y": 1 },
-        { "monster": "mon_turret_longrange", "x": 13, "y": 1 },
-        { "monster": "mon_turret_medium", "x": 1, "y": 10 },
-        { "monster": "mon_turret_longrange", "x": 1, "y": 13 },
-        { "monster": "mon_turret_medium", "x": 22, "y": 10 },
-        { "monster": "mon_turret_longrange", "x": 22, "y": 13 },
-        { "monster": "mon_turret_medium", "x": 10, "y": 22 },
-        { "monster": "mon_turret_longrange", "x": 13, "y": 22 },
+        {
+          "monster": "mon_turret_medium",
+          "x": 10,
+          "y": 1,
+          "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 60, 120 ] } ] }
+        },
+        {
+          "monster": "mon_turret_longrange",
+          "x": 13,
+          "y": 1,
+          "spawn_data": { "ammo": [ { "ammo_id": "762_51", "qty": [ 40, 80 ] } ] }
+        },
+        {
+          "monster": "mon_turret_medium",
+          "x": 1,
+          "y": 10,
+          "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 60, 120 ] } ] }
+        },
+        {
+          "monster": "mon_turret_longrange",
+          "x": 1,
+          "y": 13,
+          "spawn_data": { "ammo": [ { "ammo_id": "762_51", "qty": [ 40, 80 ] } ] }
+        },
+        {
+          "monster": "mon_turret_medium",
+          "x": 22,
+          "y": 10,
+          "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 60, 120 ] } ] }
+        },
+        {
+          "monster": "mon_turret_longrange",
+          "x": 22,
+          "y": 13,
+          "spawn_data": { "ammo": [ { "ammo_id": "762_51", "qty": [ 40, 80 ] } ] }
+        },
+        {
+          "monster": "mon_turret_medium",
+          "x": 10,
+          "y": 22,
+          "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 60, 120 ] } ] }
+        },
+        {
+          "monster": "mon_turret_longrange",
+          "x": 13,
+          "y": 22,
+          "spawn_data": { "ammo": [ { "ammo_id": "762_51", "qty": [ 40, 80 ] } ] }
+        },
         { "monster": "mon_turret_searchlight", "x": 1, "y": 1 },
         { "monster": "mon_turret_searchlight", "x": 22, "y": 22 },
         { "monster": "mon_turret_searchlight", "x": 1, "y": 22 },

--- a/data/json/monstergroups/robots.json
+++ b/data/json/monstergroups/robots.json
@@ -33,7 +33,14 @@
     "type": "monstergroup",
     "name": "GROUP_ROBOT_SECUBOT",
     "default": "mon_secubot",
-    "monsters": [ { "monster": "mon_secubot", "freq": 100, "cost_multiplier": 0 } ]
+    "monsters": [
+      {
+        "monster": "mon_secubot",
+        "freq": 100,
+        "cost_multiplier": 0,
+        "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": 30 } ] }
+      }
+    ]
   },
   {
     "type": "monstergroup",

--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -543,6 +543,7 @@ Value: `[ array of {objects} ]: [ { "monster": ... } ]`
 | friendly    | Set true to make the monster friendly. Default false.
 | name        | Extra name to display on the monster.
 | target      | Set to true to make this into mission target. Only works when the monster is spawned from a mission.
+| spawn_data  | An optional object that contains additional details for spawning the monster.
 
 Note that high spawn density game setting can cause extra monsters to spawn when `monster` is used. When `group` is used
 only one monster will spawn.
@@ -565,13 +566,38 @@ the monster at coordinate (10, 10) and also sets the monster as the target of th
 Example:
 ```json
 "place_monster": [
-    { "monster": "mon_secubot", "x": [ 7, 18 ], "y": [ 7, 18 ], "chance": 30, "repeat": [1, 3] }
+    { "monster": "mon_secubot", "x": [ 7, 18 ], "y": [ 7, 18 ], "chance": 30, "repeat": [1, 3], "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 20, 30 ] } ] } }
 ]
 ```
 
-This places "mon_secubot" at random coordinate (7-18, 7-18). The monster is placed with 30% probablity. The placement is
-repeated by random number of times `[1-3]`.
+This places "mon_secubot" at random coordinate (7-18, 7-18). The monster is placed with 30% probability. The placement is
+repeated by random number of times `[1-3]`. The monster will spawn with 20-30 5.56x45mm rounds.
 
+### "spawn_data" for monsters
+This optional object can have two fields:
+| Field       | Description
+| ---         | ---
+| ammo        | A list of objects, each of which has an `"ammo_id"` field and a `"qty"` list of two integers. The monster will spawn with items of "ammo_id", with at least the first number in the "qty" and no more than the second.
+| patrol      | A list of objects, each of which has an `"x"` field and a `"y"` field. Either value can be a range or a single number. The x,y co-ordinates define a patrol point as an relative mapsquare point offset from the (0, 0) local mapsquare of the overmap terrain tile that the monster spawns in. Patrol points are converted to absolute mapqaure tripoints inside the monster generator.
+
+Monsters with a patrol point list will move to each patrol point, in order, whenever they have no more pressing action to take on their turn. Upon reaching the last point in the patrol point list, the monster will continue on to the first point in the list.
+
+Example:
+```json
+"place_monster": [
+    { "monster": "mon_zombie", "x": 12, "y": 12, "spawn_data": { "patrol": [ { "x": 12, "y": 12 } ] } }
+]
+```
+
+This places a "mon_zombie" at (12, 12). The zombie can move freely to chase after enemies, but will always return to the (12, 12) position if it has nothing else to do.
+
+Example 2:
+```json
+"place_monster": [
+    { "monster": "mon_secubot", "x": 12, "y": 12, "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 20, 30 ] } ], "patrol": [ { "x": -23, "y": -23 }, { "x": 47, "y": -23 }, { "x": 47, "y": 47 },  { "x": 47, "y": -23 } ] } }
+]
+```
+This places a "mon_secubot" at (12,12). It will patrol the four outmost concerns of the diagonally adjacent overmap terrain tiles in a box pattern.
 
 ## Spawn specific items with a "place_item" array
 **optional** A list of *specific* things to add. WIP: Monsters and vehicles will be here too

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1835,12 +1835,10 @@ void debug()
 #endif
             break;
         case DEBUG_MAP_EXTRA: {
-            std::unordered_map<std::string, map_extra_pointer> FM = MapExtras::all_functions();
+            const std::vector<std::string> &mx_str = MapExtras::get_all_function_names();
             uilist mx_menu;
-            std::vector<std::string> mx_str;
-            for( auto &extra : FM ) {
-                mx_menu.addentry( -1, true, -1, extra.first );
-                mx_str.push_back( extra.first );
+            for( const std::string &extra : mx_str ) {
+                mx_menu.addentry( -1, true, -1, extra );
             }
             mx_menu.query();
             int mx_choice = mx_menu.ret;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -931,6 +931,8 @@ int place_monster_iuse::use( player &p, item &it, bool, const tripoint & ) const
                                  newmon.name() );
             amdef.second = ammo_item.charges;
         }
+    } else {
+        newmon.ammo = newmon.type->starting_ammo;
     }
     int skill_offset = 0;
     for( const skill_id &sk : skills ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7443,6 +7443,9 @@ void map::spawn_monsters_submap( const tripoint &gp, bool ignore_sight )
 
             const auto place_it = [&]( const tripoint & p ) {
                 monster *const placed = g->place_critter_at( make_shared_fast<monster>( tmp ), p );
+                if( !i.data.patrol_points_rel_ms.empty() ) {
+                    placed->set_patrol_route( i.data.patrol_points_rel_ms );
+                }
                 if( placed ) {
                     placed->on_load();
                 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7427,6 +7427,13 @@ void map::spawn_monsters_submap( const tripoint &gp, bool ignore_sight )
             if( i.friendly ) {
                 tmp.friendly = -1;
             }
+            if( !i.data.ammo.empty() ) {
+                for( std::pair<std::string, jmapgen_int> ap : i.data.ammo ) {
+                    tmp.ammo.emplace( itype_id( ap.first ), ap.second.get() );
+                }
+            } else {
+                tmp.ammo = tmp.type->starting_ammo;
+            }
 
             const auto valid_location = [&]( const tripoint & p ) {
                 // Checking for creatures via g is only meaningful if this is the main game map.

--- a/src/map.h
+++ b/src/map.h
@@ -30,6 +30,7 @@
 #include "line.h"
 #include "lru_cache.h"
 #include "mapdata.h"
+#include "mapgen.h"
 #include "memory_fast.h"
 #include "point.h"
 #include "shadowcasting.h"
@@ -1498,7 +1499,7 @@ class map
         void apply_faction_ownership( const point &p1, const point &p2, const faction_id &id );
         void add_spawn( const mtype_id &type, int count, const tripoint &p,
                         bool friendly = false, int faction_id = -1, int mission_id = -1,
-                        const std::string &name = "NONE" ) const;
+                        const std::string &name = "NONE", spawn_data data = spawn_data() ) const;
         void do_vehicle_caching( int z );
         // Note: in 3D mode, will actually build caches on ALL z-levels
         void build_map_cache( int zlev, bool skip_lightmap = false );

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -2910,6 +2910,12 @@ map_extra_pointer get_function( const std::string &name )
     return iter->second;
 }
 
+std::vector<std::string> all_function_names;
+std::vector<std::string> get_all_function_names()
+{
+    return all_function_names;
+}
+
 void apply_function( const string_id<map_extra> &id, map &m, const tripoint &abs_sub )
 {
     bool applied_successfully = false;
@@ -3065,6 +3071,7 @@ void map_extra::check() const
                 debugmsg( "invalid map extra function (%s) defined for map extra (%s)", generator_id, id.str() );
                 break;
             }
+            MapExtras::all_function_names.push_back( generator_id );
             break;
         }
         case map_extra_method::mapgen: {
@@ -3077,6 +3084,7 @@ void map_extra::check() const
                           id.str() );
                 break;
             }
+            MapExtras::all_function_names.push_back( generator_id );
             break;
         }
         case map_extra_method::null:

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -67,6 +67,7 @@ using FunctionMap = std::unordered_map<std::string, map_extra_pointer>;
 
 map_extra_pointer get_function( const std::string &name );
 FunctionMap all_functions();
+std::vector<std::string> get_all_function_names();
 
 void apply_function( const string_id<map_extra> &id, map &m, const tripoint &abs_sub );
 void apply_function( const std::string &id, map &m, const tripoint &abs_sub );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1254,7 +1254,8 @@ class jmapgen_monster : public jmapgen_piece
             chance( jsi, "chance", 100, 100 )
             , pack_size( jsi, "pack_size", 1, 1 )
             , one_or_none( jsi.get_bool( "one_or_none",
-                                         !( jsi.has_member( "repeat" ) || jsi.has_member( "pack_size" ) ) ) )
+                                         !( jsi.has_member( "repeat" ) || 
+                                            jsi.has_member( "pack_size" ) ) ) )
             , friendly( jsi.get_bool( "friendly", false ) )
             , name( jsi.get_string( "name", "NONE" ) )
             , target( jsi.get_bool( "target", false ) ) {
@@ -1295,7 +1296,16 @@ class jmapgen_monster : public jmapgen_piece
                 if( sd.has_array( "ammo" ) ) {
                     const JsonArray &ammos = sd.get_array( "ammo" );
                     for( const JsonObject &adata : ammos ) {
-                        data.ammo.emplace( adata.get_string( "ammo_id" ), jmapgen_int( adata, "qty" ) );
+                        data.ammo.emplace( itype_id( adata.get_string( "ammo_id" ) ), 
+                                           jmapgen_int( adata, "qty" ) );
+                    }
+                }
+                if( sd.has_array( "patrol" ) ) {
+                    const JsonArray &patrol_pts = sd.get_array( "patrol" );
+                    for( const JsonObject p_pt : patrol_pts ) {
+                        jmapgen_int ptx = jmapgen_int( p_pt, "x" );
+                        jmapgen_int pty = jmapgen_int( p_pt, "y" );
+                        data.patrol_points_rel_ms.push_back( point( ptx.get(), pty.get() ) );
                     }
                 }
             }
@@ -1304,7 +1314,8 @@ class jmapgen_monster : public jmapgen_piece
 
             int raw_odds = chance.get();
 
-            // Handle spawn density: Increase odds, but don't let the odds of absence go below half the odds at density 1.
+            // Handle spawn density: Increase odds, but don't let the odds of absence go below 
+            // half the odds at density 1.
             // Instead, apply a multipler to the number of monsters for really high densities.
             // For example, a 50% chance at spawn density 4 becomes a 75% chance of ~2.7 monsters.
             int odds_after_density = raw_odds * get_option<float>( "SPAWN_DENSITY" );
@@ -1322,10 +1333,12 @@ class jmapgen_monster : public jmapgen_piece
 
             int spawn_count = roll_remainder( density_multiplier );
 
-            if( one_or_none ) { // don't let high spawn density alone cause more than 1 to spawn.
+            // don't let high spawn density cause more than 1 to spawn.
+            if( one_or_none ) {
                 spawn_count = std::min( spawn_count, 1 );
             }
-            if( raw_odds == 100 ) { // don't spawn less than 1 if odds were 100%, even with low spawn density.
+            // don't spawn less than 1 if odds were 100%, even with low spawn density.
+            if( raw_odds == 100 ) { 
                 spawn_count = std::max( spawn_count, 1 );
             } else {
                 if( !x_in_y( odds_after_density, 100 ) ) {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1254,7 +1254,7 @@ class jmapgen_monster : public jmapgen_piece
             chance( jsi, "chance", 100, 100 )
             , pack_size( jsi, "pack_size", 1, 1 )
             , one_or_none( jsi.get_bool( "one_or_none",
-                                         !( jsi.has_member( "repeat" ) || 
+                                         !( jsi.has_member( "repeat" ) ||
                                             jsi.has_member( "pack_size" ) ) ) )
             , friendly( jsi.get_bool( "friendly", false ) )
             , name( jsi.get_string( "name", "NONE" ) )
@@ -1296,7 +1296,7 @@ class jmapgen_monster : public jmapgen_piece
                 if( sd.has_array( "ammo" ) ) {
                     const JsonArray &ammos = sd.get_array( "ammo" );
                     for( const JsonObject &adata : ammos ) {
-                        data.ammo.emplace( itype_id( adata.get_string( "ammo_id" ) ), 
+                        data.ammo.emplace( itype_id( adata.get_string( "ammo_id" ) ),
                                            jmapgen_int( adata, "qty" ) );
                     }
                 }
@@ -1314,7 +1314,7 @@ class jmapgen_monster : public jmapgen_piece
 
             int raw_odds = chance.get();
 
-            // Handle spawn density: Increase odds, but don't let the odds of absence go below 
+            // Handle spawn density: Increase odds, but don't let the odds of absence go below
             // half the odds at density 1.
             // Instead, apply a multipler to the number of monsters for really high densities.
             // For example, a 50% chance at spawn density 4 becomes a 75% chance of ~2.7 monsters.
@@ -1338,7 +1338,7 @@ class jmapgen_monster : public jmapgen_piece
                 spawn_count = std::min( spawn_count, 1 );
             }
             // don't spawn less than 1 if odds were 100%, even with low spawn density.
-            if( raw_odds == 100 ) { 
+            if( raw_odds == 100 ) {
                 spawn_count = std::max( spawn_count, 1 );
             } else {
                 if( !x_in_y( odds_after_density, 100 ) ) {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1249,6 +1249,7 @@ class jmapgen_monster : public jmapgen_piece
         bool friendly;
         std::string name;
         bool target;
+        struct spawn_data data;
         jmapgen_monster( const JsonObject &jsi ) :
             chance( jsi, "chance", 100, 100 )
             , pack_size( jsi, "pack_size", 1, 1 )
@@ -1288,6 +1289,16 @@ class jmapgen_monster : public jmapgen_piece
                 }
                 ids.add( id, 100 );
             }
+
+            if( jsi.has_object( "spawn_data" ) ) {
+                const JsonObject &sd = jsi.get_object( "spawn_data" );
+                if( sd.has_array( "ammo" ) ) {
+                    const JsonArray &ammos = sd.get_array( "ammo" );
+                    for( const JsonObject &adata : ammos ) {
+                        data.ammo.emplace( adata.get_string( "ammo_id" ), jmapgen_int( adata, "qty" ) );
+                    }
+                }
+            }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
 
@@ -1326,11 +1337,11 @@ class jmapgen_monster : public jmapgen_piece
                 MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup( m_id );
                 dat.m.add_spawn( spawn_details.name, spawn_count * pack_size.get(),
                 { x.get(), y.get(), dat.m.get_abs_sub().z },
-                friendly, -1, mission_id, name );
+                friendly, -1, mission_id, name, data );
             } else {
                 dat.m.add_spawn( *( ids.pick() ), spawn_count * pack_size.get(),
                 { x.get(), y.get(), dat.m.get_abs_sub().z },
-                friendly, -1, mission_id, name );
+                friendly, -1, mission_id, name, data );
             }
         }
 };
@@ -2858,11 +2869,11 @@ void jmapgen_objects::apply( mapgendata &dat, const point &offset ) const
         return;
     }
 
-    for( auto &obj : objects ) {
-        auto where = obj.first;
+    for( const jmapgen_obj &obj : objects ) {
+        jmapgen_place where = obj.first;
         where.offset( -offset );
 
-        const auto &what = *obj.second;
+        const jmapgen_piece &what = *obj.second;
         // The user will only specify repeat once in JSON, but it may get loaded both
         // into the what and where in some cases--we just need the greater value of the two.
         const int repeat = std::max( where.repeat.get(), what.repeat.get() );
@@ -5717,8 +5728,14 @@ void map::place_spawns( const mongroup_id &group, const int chance,
         // Pick a monster type
         MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup( group, &num );
 
+        const MonsterGroup &mg = group.obj();
+        auto mon_selected = std::find_if( mg.monsters.begin(), mg.monsters.end(),
+        [spawn_details]( const MonsterGroupEntry & mon ) {
+            return mon.name == spawn_details.name;
+        } );
+
         add_spawn( spawn_details.name, spawn_details.pack_size, { x, y, abs_sub.z },
-                   friendly, -1, mission_id, name );
+                   friendly, -1, mission_id, name, mon_selected->data );
     }
 }
 
@@ -5863,7 +5880,7 @@ std::vector<item *> map::put_items_from_loc( const item_group_id &loc, const tri
 }
 
 void map::add_spawn( const mtype_id &type, int count, const tripoint &p, bool friendly,
-                     int faction_id, int mission_id, const std::string &name ) const
+                     int faction_id, int mission_id, const std::string &name, spawn_data data ) const
 {
     if( p.x < 0 || p.x >= SEEX * my_MAPSIZE || p.y < 0 || p.y >= SEEY * my_MAPSIZE ) {
         debugmsg( "Bad add_spawn(%s, %d, %d, %d)", type.c_str(), count, p.x, p.y );
@@ -5880,7 +5897,7 @@ void map::add_spawn( const mtype_id &type, int count, const tripoint &p, bool fr
     if( MonsterGroupManager::monster_is_blacklisted( type ) ) {
         return;
     }
-    spawn_point tmp( type, count, offset, faction_id, mission_id, friendly, name );
+    spawn_point tmp( type, count, offset, faction_id, mission_id, friendly, name, data );
     place_on_submap->spawns.push_back( tmp );
 }
 

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -129,8 +129,7 @@ struct jmapgen_setmap {
 
 struct spawn_data {
     std::map<std::string, jmapgen_int> ammo;
-
-    spawn_data() : ammo() {};
+    std::vector<point> patrol_points_rel_ms;
 };
 
 /**

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -127,6 +127,12 @@ struct jmapgen_setmap {
     bool has_vehicle_collision( mapgendata &dat, const point &offset ) const;
 };
 
+struct spawn_data {
+    std::map<std::string, jmapgen_int> ammo;
+
+    spawn_data() : ammo() {};
+};
+
 /**
  * Basic mapgen object. It is supposed to place or do something on a specific square on the map.
  * Inherit from this class and implement the @ref apply function.

--- a/src/mattack_actors.h
+++ b/src/mattack_actors.h
@@ -147,7 +147,7 @@ class gun_actor : public mattack_actor
         /** Specify weapon mode to use at different engagement distances */
         std::map<std::pair<int, int>, gun_mode_id> ranges;
 
-        int max_ammo = INT_MAX; /** limited also by monster starting_ammo */
+        int max_ammo = INT_MAX; /** limited also by monster starting ammo */
 
         /** Description of the attack being run */
         std::string description;
@@ -155,7 +155,7 @@ class gun_actor : public mattack_actor
         /** Message to display (if any) for failures to fire excluding lack of ammo */
         std::string failure_msg;
 
-        /** Sound (if any) when either starting_ammo depleted or max_ammo reached */
+        /** Sound (if any) when either ammo depleted or max_ammo reached */
         std::string no_ammo_sound;
 
         /** Number of moves required for each attack */

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -634,8 +634,8 @@ void mdeath::broken( monster &z )
     g->m.add_item_or_charges( z.pos(), broken_mon );
 
     if( z.type->has_flag( MF_DROPS_AMMO ) ) {
-        for( const std::pair<const std::string, int> &ammo_entry : z.type->starting_ammo ) {
-            if( z.ammo[ammo_entry.first] > 0 ) {
+        for( const std::pair<const itype_id, int> &ammo_entry : z.ammo ) {
+            if( ammo_entry.second > 0 ) {
                 bool spawned = false;
                 for( const std::pair<const std::string, mtype_special_attack> &attack : z.type->special_attacks ) {
                     if( attack.second->id == "gun" ) {
@@ -650,7 +650,7 @@ void mdeath::broken( monster &z )
                         const bool uses_mags = !gun.magazine_compatible().empty();
                         if( same_ammo && uses_mags ) {
                             std::vector<item> mags;
-                            int ammo_count = z.ammo[ammo_entry.first];
+                            int ammo_count = ammo_entry.second;
                             while( ammo_count > 0 ) {
                                 item mag = item( gun.type->magazine_default.find( item( ammo_entry.first ).ammo_type() )->second );
                                 mag.ammo_set( ammo_entry.first,
@@ -665,7 +665,7 @@ void mdeath::broken( monster &z )
                     }
                 }
                 if( !spawned ) {
-                    g->m.spawn_item( z.pos(), ammo_entry.first, z.ammo[ammo_entry.first], 1,
+                    g->m.spawn_item( z.pos(), ammo_entry.first, ammo_entry.second, 1,
                                      calendar::turn );
                 }
             }

--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -369,8 +369,18 @@ void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
             if( mon.has_member( "ends" ) ) {
                 ends = tdfactor * mon.get_int( "ends" ) * ( mon_upgrade_factor > 0 ? mon_upgrade_factor : 1 );
             }
-            MonsterGroupEntry new_mon_group = MonsterGroupEntry( name, freq, cost, pack_min, pack_max, starts,
-                                              ends );
+            spawn_data data;
+            if( mon.has_object( "spawn_data" ) ) {
+                const JsonObject &sd = mon.get_object( "spawn_data" );
+                if( sd.has_array( "ammo" ) ) {
+                    const JsonArray &ammos = sd.get_array( "ammo" );
+                    for( const JsonObject &adata : ammos ) {
+                        data.ammo.emplace( adata.get_string( "ammo_id" ), jmapgen_int( adata, "qty" ) );
+                    }
+                }
+            }
+            MonsterGroupEntry new_mon_group = MonsterGroupEntry( name, freq, cost, pack_min, pack_max, data,
+                                              starts, ends );
             if( mon.has_member( "conditions" ) ) {
                 for( const std::string line : mon.get_array( "conditions" ) ) {
                     new_mon_group.conditions.push_back( line );

--- a/src/mongroup.h
+++ b/src/mongroup.h
@@ -9,6 +9,7 @@
 
 #include "calendar.h"
 #include "io_tags.h"
+#include "mapgen.h"
 #include "monster.h"
 #include "point.h"
 #include "type_id.h"
@@ -29,6 +30,7 @@ struct MonsterGroupEntry {
     int cost_multiplier;
     int pack_minimum;
     int pack_maximum;
+    spawn_data data;
     std::vector<std::string> conditions;
     time_duration starts;
     time_duration ends;
@@ -36,13 +38,15 @@ struct MonsterGroupEntry {
         return ends <= 0_turns;
     }
 
-    MonsterGroupEntry( const mtype_id &id, int new_freq, int new_cost,
-                       int new_pack_min, int new_pack_max, const time_duration &new_starts, const time_duration &new_ends )
+    MonsterGroupEntry( const mtype_id &id, int new_freq, int new_cost, int new_pack_min,
+                       int new_pack_max, spawn_data new_data, const time_duration &new_starts,
+                       const time_duration &new_ends )
         : name( id )
         , frequency( new_freq )
         , cost_multiplier( new_cost )
         , pack_minimum( new_pack_min )
         , pack_maximum( new_pack_max )
+        , data( new_data )
         , starts( new_starts )
         , ends( new_ends ) {
     }
@@ -63,7 +67,7 @@ struct MonsterGroupResult {
 struct MonsterGroup {
     mongroup_id name;
     mtype_id defaultMonster;
-    FreqDef  monsters;
+    FreqDef monsters;
     bool IsMonsterInGroup( const mtype_id &id ) const;
     bool is_animal = false;
     // replaces this group after a period of

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -201,7 +201,6 @@ monster::monster( const mtype_id &id ) : monster()
     anger = type->agro;
     morale = type->morale;
     faction = type->default_faction;
-    ammo = type->starting_ammo;
     upgrades = type->upgrades && ( type->half_life || type->age_grow );
     reproduces = type->reproduces && type->baby_timer && !monster::has_flag( MF_NO_BREED );
     if( monster::has_flag( MF_AQUATIC ) ) {
@@ -2060,24 +2059,6 @@ int monster::shortest_special_cooldown() const
         countdown = std::min( countdown, local_attack_data.cooldown );
     }
     return countdown;
-}
-
-void monster::normalize_ammo( const int old_ammo )
-{
-    int total_ammo = 0;
-    // Sum up the ammo entries to get a ratio.
-    for( const auto &ammo_entry : type->starting_ammo ) {
-        total_ammo += ammo_entry.second;
-    }
-    if( total_ammo == 0 ) {
-        // Should never happen, but protect us from a div/0 if it does.
-        return;
-    }
-    // Previous code gave robots 100 rounds of ammo.
-    // This reassigns whatever is left from that in the appropriate proportions.
-    for( const auto &ammo_entry : type->starting_ammo ) {
-        ammo[ammo_entry.first] = old_ammo * ammo_entry.second / ( 100 * total_ammo );
-    }
 }
 
 void monster::explode()

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -9,6 +9,7 @@
 #include "avatar.h"
 #include "character.h"
 #include "coordinate_conversions.h"
+#include "coordinates.h"
 #include "cursesdef.h"
 #include "debug.h"
 #include "effect.h"
@@ -963,6 +964,16 @@ bool monster::made_of( phase_id p ) const
 void monster::set_goal( const tripoint &p )
 {
     goal = p;
+}
+
+void monster::set_patrol_route( const std::vector<point> &patrol_pts_rel_ms )
+{
+    map &here = get_map();
+    tripoint base_abs_ms( real_coords( here.getabs( pos().xy() ) ).begin_om_pos(), posz() );
+    for( const point &patrol_pt : patrol_pts_rel_ms ) {
+        patrol_route_abs_ms.push_back( base_abs_ms + patrol_pt );
+    }
+    next_patrol_point = 0;
 }
 
 void monster::shift( const point &sm_shift )

--- a/src/monster.h
+++ b/src/monster.h
@@ -556,7 +556,7 @@ class monster : public Creature
         /** patrol points for monsters that can pathfind and have a patrol route! **/
         std::vector<tripoint> patrol_route_abs_ms;
         int next_patrol_point = -1;
-        
+
         std::bitset<NUM_MEFF> effect_cache;
         cata::optional<time_duration> summon_time_limit = cata::nullopt;
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -168,6 +168,7 @@ class monster : public Creature
         // Movement
         void shift( const point &sm_shift ); // Shifts the monster to the appropriate submap
         void set_goal( const tripoint &p );
+        void set_patrol_route( const std::vector<point> &patrol_pts_rel_ms );
         // Updates current pos AND our plans
         bool wander(); // Returns true if we have no plans
 
@@ -552,6 +553,10 @@ class monster : public Creature
         monster_horde_attraction horde_attraction;
         /** Found path. Note: Not used by monsters that don't pathfind! **/
         std::vector<tripoint> path;
+        /** patrol points for monsters that can pathfind and have a patrol route! **/
+        std::vector<tripoint> patrol_route_abs_ms;
+        int next_patrol_point = -1;
+        
         std::bitset<NUM_MEFF> effect_cache;
         cata::optional<time_duration> summon_time_limit = cata::nullopt;
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -542,8 +542,6 @@ class monster : public Creature
         tripoint goal;
         tripoint position;
         bool dead;
-        /** Legacy loading logic for monsters that are packing ammo. **/
-        void normalize_ammo( int old_ammo );
         /** Normal upgrades **/
         int next_upgrade_time();
         bool upgrades;

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -177,7 +177,7 @@ enum m_flag : int {
     MF_LOUDMOVES,           // This monster makes move noises as if ~2 sizes louder, even if flying.
     MF_CAN_OPEN_DOORS,      // This monster can open doors.
     MF_STUN_IMMUNE,         // This monster is immune to the stun effect
-    MF_DROPS_AMMO,          // This monster drops ammo. Check to make sure starting_ammo paramter is present for this monster type!
+    MF_DROPS_AMMO,          // This monster drops ammo. Should not be set for monsters that use pseudo ammo.
     MF_MAX                  // Sets the length of the flags - obviously must be LAST
 };
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1971,20 +1971,7 @@ void monster::load( const JsonObject &data )
     data.read( "corpse_components", corpse_components );
     data.read( "dragged_foe_id", dragged_foe_id );
 
-    if( data.has_int( "ammo" ) && !type->starting_ammo.empty() ) {
-        // Legacy loading for ammo.
-        normalize_ammo( data.get_int( "ammo" ) );
-    } else {
-        data.read( "ammo", ammo );
-        // legacy loading for milkable creatures, fix mismatch.
-        if( has_flag( MF_MILKABLE ) && !type->starting_ammo.empty() && !ammo.empty() &&
-            type->starting_ammo.begin()->first != ammo.begin()->first ) {
-            const std::string old_type = ammo.begin()->first;
-            const int old_value = ammo.begin()->second;
-            ammo[type->starting_ammo.begin()->first] = old_value;
-            ammo.erase( old_type );
-        }
-    }
+    data.read( "ammo", ammo );
 
     faction = mfaction_str_id( data.get_string( "faction", "" ) );
     if( !data.read( "last_updated", last_updated ) ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1858,6 +1858,10 @@ void monster::load( const JsonObject &data )
     if( data.read( "wandz", wander_pos.z ) ) {
         wander_pos.z = position.z;
     }
+    if( data.has_int( "next_patrol_point" ) ) {
+        data.read( "next_patrol_point", next_patrol_point );
+        data.read( "patrol_route", patrol_route_abs_ms );
+    }
     if( data.has_object( "tied_item" ) ) {
         JsonIn *tied_item_json = data.get_raw( "tied_item" );
         item newitem;
@@ -2005,6 +2009,10 @@ void monster::store( JsonOut &json ) const
     json.member( "wandy", wander_pos.y );
     json.member( "wandz", wander_pos.z );
     json.member( "wandf", wandf );
+    if( !patrol_route_abs_ms.empty() ) {
+        json.member( "patrol_route", patrol_route_abs_ms );
+        json.member( "next_patrol_point", next_patrol_point );
+    }
     json.member( "hp", hp );
     json.member( "special_attacks", special_attacks );
     json.member( "friendly", friendly );

--- a/src/submap.h
+++ b/src/submap.h
@@ -19,9 +19,10 @@
 #include "field.h"
 #include "game_constants.h"
 #include "item.h"
-#include "type_id.h"
+#include "mapgen.h"
 #include "point.h"
 #include "poly_serialized.h"
+#include "type_id.h"
 
 class JsonIn;
 class JsonOut;
@@ -40,11 +41,12 @@ struct spawn_point {
     int mission_id;
     bool friendly;
     std::string name;
+    spawn_data data;
     spawn_point( const mtype_id &T = mtype_id::NULL_ID(), int C = 0, point P = point_zero,
                  int FAC = -1, int MIS = -1, bool F = false,
-                 const std::string &N = "NONE" ) :
+                 const std::string &N = "NONE", spawn_data SD = spawn_data() ) :
         pos( P ), count( C ), type( T ), faction_id( FAC ),
-        mission_id( MIS ), friendly( F ), name( N ) {}
+        mission_id( MIS ), friendly( F ), name( N ), data( SD ) {}
 };
 
 template<int sx, int sy>


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
[Features] "Adds spawn_data which allows for setting monster ammo and patrol routes on spawn from JSON."
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Creates extensible spawn_data framework for monsters, which currently allows setting patrol routes and initial ammo. 

This will allow for more interesting monster behaviour and better control over ammo spawns. As with the original PRs I included the change to add all map extras (including JSON only - ie: dermatik nests) to the debug spawn menu, mostly as this is very handy for testing. No real balance changes were made here outside of mild turret ammo tweaking in military outposts as a proof-of-concept.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Ports:
https://github.com/CleverRaven/Cataclysm-DDA/pull/40516 `define monster starting ammo in mapgen`
https://github.com/CleverRaven/Cataclysm-DDA/pull/48155 `monsters on patrol` 
https://github.com/CleverRaven/Cataclysm-DDA/pull/48136 `put all map extras in the debug menu`

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Testing
_Ammo Testing_
- [x] Spawned monsters with newly defined ammo data and verified type & amounts.
- [x] Spawned monsters without defined ammo, work as expected
- [x] All other monsters including player spawned continue to function, special attacks work

_Patrols/Debug Menu Testing_
- [x] Spawned monsters (manhacks) with defined patrol pattern using a temporary debug map extra on a 10x10 patrol, works as expected. Monsters dodge obstacles on route, attack enemies if spotted, and resume patrol once done.
- [x] Spawned monsters in increasingly larger patrol patterns to observe
- [x] Monsters with no defined patrols continue to function as expected

The GIF in the original monster patrol PR is a true representation of how this looks if you'd like to see it in action before compiling.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
I am very inexperienced with C++ so I welcome feedback. Largely I'm porting changes as-is with tweaks to fit the BN codebase better, and I'm very much learning as I go. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
