### PR TITLE
Fix Jittery trait hunger condition

### DIFF
--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -320,7 +320,7 @@ void Character::suffer_while_awake( const int current_stim )
     if( has_trait( trait_JITTERY ) && !has_effect( effect_shakes ) ) {
         if( current_stim > 50 && one_in( to_turns<int>( 30_minutes ) - ( current_stim * 6 ) ) ) {
             add_effect( effect_shakes, 30_minutes + 1_turns * current_stim );
-        } else if( ( get_hunger() > 80 || get_kcal_percent() < 1.0f ) && get_hunger() > 0 &&
+        } else if( (static_cast<float>(max_stored_calories()-get_stored_kcal()))/bmr() > 1.0f && get_hunger() > 0 &&
                    one_in( to_turns<int>( 50_minutes ) - ( get_hunger() * 6 ) ) ) {
             add_effect( effect_shakes, 40_minutes );
         }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix Jittery trait hunger condition"

#### Purpose of change

Jittery trait was set to trigger when stored calories where below 100% of max, so the trait could trigger even at "Sated" hunger. Now set to trigger only when hunger state is at "Very Hungry" or below. Partially addresses issue #349.

#### Describe the solution

Hunger now only triggers Jittery when player's stored calories are at least 1 day's worth below max calories, similar to what triggers the "Very Hungry" hunger description in get_hunger_description().

#### Describe alternatives you've considered

Changing the trait description to match its actual behavior.

#### Testing

Create new character with Jittery as only trait. Set stored calories to max with debug menu. Wait for a few hours, no shakes triggered. Set stored calories low enough to change to "Very Hungry". Wait a few hours, shakes are observed constantly. Set calories high enough to change to "Hungry" and stay there for a few hours. Wait a few hours, no new shakes are triggered.

#### Additional context

None.