### PR TITLE
Left and right variants Hd_Doors and Hatches

### DIFF
--- a/data/json/vehicleparts/doors.json
+++ b/data/json/vehicleparts/doors.json
@@ -315,5 +315,55 @@
     "id": "door_rear",
     "symbol": "B",
     "type": "vehicle_part"
+  },
+  {
+    "copy-from": "hddoor_abstract",
+    "id": "hddoor_left",
+    "symbol": "L",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "hddoor_abstract",
+    "id": "hddoor_right",
+    "symbol": "R",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "hddoor_opaque_abstract",
+    "id": "hddoor_opaque_left",
+    "symbol": "L",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "hddoor_opaque_abstract",
+    "id": "hddoor_opaque_right",
+    "symbol": "R",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "hdhatch_abstract",
+    "id": "hdhatch_left",
+    "symbol": "L",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "hdhatch_abstract",
+    "id": "hdhatch_right",
+    "symbol": "R",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "hdhatch_opaque_abstract",
+    "id": "hdhatch_opaque_left",
+    "symbol": "L",
+    "looks_like": "hdhatch_left",
+    "type": "vehicle_part"
+  },
+  {
+    "copy-from": "hdhatch_opaque_abstract",
+    "id": "hdhatch_opaque_right",
+    "symbol": "R",
+    "looks_like": "hdhatch_right",
+    "type": "vehicle_part"
   }
 ]


### PR DESCRIPTION
#### Summary

Summary: Features "Created Left and right variants Hd_Doors and Hatches to make it possible to use new UDP sprites."

#### Purpose of change

![](https://cdn.discordapp.com/attachments/718342626733981699/874861536781410344/Sprite-0001.gif)

#### Describe the solution

Created entries that already existed in UDP json because DDA use them.

#### Testing
Some vehicles might need slight fixes, like this humvee there using front/rear variant instead of left/right variants.

https://user-images.githubusercontent.com/37194372/128952923-b679705e-a659-46e9-9735-923bb0f60055.mp4


#### Credit for the new pretty door sprites goes to

### RockTheShoulder 


