### PR TITLE
[CR]Remove hunger in favor of just calories

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -176,7 +176,7 @@ void dig_channel_activity_actor::finish( player_activity &act, Character &who )
                                   calendar::turn ) );
     }
 
-    who.mod_hunger( 5 );
+    who.mod_stored_kcal( -40 );
     who.mod_thirst( 5 );
     who.mod_fatigue( 10 );
     who.add_msg_if_player( m_good, _( "You finish digging up %s." ),

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -993,27 +993,29 @@ bool avatar_action::eat_here( avatar &you )
 {
     if( ( you.has_active_mutation( trait_RUMINANT ) || you.has_active_mutation( trait_GRAZER ) ) &&
         ( g->m.ter( you.pos() ) == t_underbrush || g->m.ter( you.pos() ) == t_shrub ) ) {
-        if( you.get_hunger() < 20 ) {
+        item food( "underbrush", calendar::turn, 1 );
+        if( you.get_stored_kcal() > you.max_stored_calories() -
+            food.get_comestible()->default_nutrition.kcal ) {
             add_msg( _( "You're too full to eat the leaves from the %s." ), g->m.ter( you.pos() )->name() );
             return true;
         } else {
             you.moves -= 400;
             g->m.ter_set( you.pos(), t_grass );
             add_msg( _( "You eat the underbrush." ) );
-            item food( "underbrush", calendar::turn, 1 );
             you.eat( food );
             return true;
         }
     }
     if( you.has_active_mutation( trait_GRAZER ) && ( g->m.ter( you.pos() ) == t_grass ||
             g->m.ter( you.pos() ) == t_grass_long || g->m.ter( you.pos() ) == t_grass_tall ) ) {
-        if( you.get_hunger() < 8 ) {
+        item food( item( "grass", calendar::turn, 1 ) );
+        if( you.get_stored_kcal() > you.max_stored_calories() -
+            food.get_comestible()->default_nutrition.kcal ) {
             add_msg( _( "You're too full to graze." ) );
             return true;
         } else {
             you.moves -= 400;
             add_msg( _( "You eat the grass." ) );
-            item food( item( "grass", calendar::turn, 1 ) );
             you.eat( food );
             if( g->m.ter( you.pos() ) == t_grass_tall ) {
                 g->m.ter_set( you.pos(), t_grass_long );

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -994,7 +994,7 @@ bool avatar_action::eat_here( avatar &you )
     if( ( you.has_active_mutation( trait_RUMINANT ) || you.has_active_mutation( trait_GRAZER ) ) &&
         ( g->m.ter( you.pos() ) == t_underbrush || g->m.ter( you.pos() ) == t_shrub ) ) {
         item food( "underbrush", calendar::turn, 1 );
-        if( you.get_stored_kcal() > you.max_stored_calories() -
+        if( you.get_stored_kcal() > you.max_stored_kcal() -
             food.get_comestible()->default_nutrition.kcal ) {
             add_msg( _( "You're too full to eat the leaves from the %s." ), g->m.ter( you.pos() )->name() );
             return true;
@@ -1009,7 +1009,7 @@ bool avatar_action::eat_here( avatar &you )
     if( you.has_active_mutation( trait_GRAZER ) && ( g->m.ter( you.pos() ) == t_grass ||
             g->m.ter( you.pos() ) == t_grass_long || g->m.ter( you.pos() ) == t_grass_tall ) ) {
         item food( item( "grass", calendar::turn, 1 ) );
-        if( you.get_stored_kcal() > you.max_stored_calories() -
+        if( you.get_stored_kcal() > you.max_stored_kcal() -
             food.get_comestible()->default_nutrition.kcal ) {
             add_msg( _( "You're too full to graze." ) );
             return true;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1081,7 +1081,7 @@ bool Character::burn_fuel( int b, bool start )
             int current_fuel_stock;
             if( is_metabolism_powered ) {
                 current_fuel_stock = std::max( 0.0f, get_stored_kcal() - 0.8f *
-                                               get_healthy_kcal() );
+                                               max_stored_calories() );
             } else if( is_perpetual_fuel ) {
                 current_fuel_stock = 1;
             } else if( is_cable_powered ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1081,7 +1081,7 @@ bool Character::burn_fuel( int b, bool start )
             int current_fuel_stock;
             if( is_metabolism_powered ) {
                 current_fuel_stock = std::max( 0.0f, get_stored_kcal() - 0.8f *
-                                               max_stored_calories() );
+                                               max_stored_kcal() );
             } else if( is_perpetual_fuel ) {
                 current_fuel_stock = 1;
             } else if( is_cable_powered ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -503,7 +503,7 @@ void Character::mod_stat( const std::string &stat, float modifier )
     } else if( stat == "kcal" ) {
         mod_stored_kcal( modifier );
     } else if( stat == "hunger" ) {
-        mod_stored_kcal( -8 * modifier );
+        mod_stored_kcal( -10 * modifier );
     } else {
         Creature::mod_stat( stat, modifier );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -398,7 +398,7 @@ Character::Character() :
     set_anatomy( anatomy_id("human_anatomy") );
     update_type_of_scent( true );
     pkill = 0;
-    stored_calories = max_stored_calories() - 100;
+    stored_calories = max_stored_kcal() - 100;
     initialize_stomach_contents();
     healed_total = { { 0, 0, 0, 0, 0, 0 } };
 
@@ -4129,22 +4129,22 @@ void Character::mod_stored_nutr( int nnutr )
 void Character::set_stored_kcal( int kcal )
 {
     if( stored_calories != kcal ) {
-        stored_calories = std::min( kcal, max_stored_calories() );
+        stored_calories = std::min( kcal, max_stored_kcal() );
 
-        if( kcal > max_stored_calories() && has_trait( trait_EATHEALTH ) ) {
-            healall( roll_remainder( ( kcal - max_stored_calories() ) / 50.0f ) );
+        if( kcal > max_stored_kcal() && has_trait( trait_EATHEALTH ) ) {
+            healall( roll_remainder( ( kcal - max_stored_kcal() ) / 50.0f ) );
         }
     }
 }
 
-int Character::max_stored_calories() const
+int Character::max_stored_kcal() const
 {
     return 2500 * 7;
 }
 
 float Character::get_kcal_percent() const
 {
-    return static_cast<float>( get_stored_kcal() ) / static_cast<float>( max_stored_calories() );
+    return static_cast<float>( get_stored_kcal() ) / static_cast<float>( max_stored_kcal() );
 }
 
 int Character::get_thirst() const
@@ -4184,7 +4184,7 @@ std::pair<std::string, nc_color> Character::get_thirst_description() const
 std::pair<std::string, nc_color> Character::get_hunger_description() const
 {
     int total_kcal = stored_calories + stomach.get_calories();
-    int max_kcal = max_stored_calories();
+    int max_kcal = max_stored_kcal();
     float days_left = static_cast<float>( total_kcal ) / bmr();
     float days_max = static_cast<float>( max_kcal ) / bmr();
     std::string hunger_string;
@@ -4584,7 +4584,7 @@ void Character::update_stomach( const time_point &from, const time_point &to )
 
     if( npc_no_food ) {
         set_thirst( static_cast<int>( thirst_levels::hydrated ) );
-        set_stored_kcal( max_stored_calories() );
+        set_stored_kcal( max_stored_kcal() );
     }
 
     // Mycus and Metabolic Rehydration makes thirst unnecessary
@@ -4719,9 +4719,6 @@ needs_rates Character::calc_needs_rates() const
 
     needs_rates rates;
     rates.hunger = metabolic_rate();
-
-    // TODO: this is where calculating basal metabolic rate, in kcal per day would go
-    rates.kcal = 2500.0;
 
     add_msg_if_player( m_debug, "Metabolic rate: %.2f", rates.hunger );
 
@@ -8851,7 +8848,7 @@ void Character::fall_asleep()
         }
     }
     if( has_active_mutation( trait_HIBERNATE ) ) {
-        if( get_stored_kcal() > max_stored_calories() - bmr() / 4 &&
+        if( get_stored_kcal() > max_stored_kcal() - bmr() / 4 &&
             get_thirst() < thirst_levels::thirsty ) {
             if( is_avatar() ) {
                 g->memorial().add( pgettext( "memorial_male", "Entered hibernation." ),

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -500,8 +500,10 @@ void Character::mod_stat( const std::string &stat, float modifier )
         mod_int_bonus( modifier );
     } else if( stat == "healthy" ) {
         mod_healthy( modifier );
+    } else if( stat == "kcal" ) {
+        mod_stored_kcal( modifier );
     } else if( stat == "hunger" ) {
-        mod_hunger( modifier );
+        mod_stored_kcal( -8 * modifier );
     } else {
         Creature::mod_stat( stat, modifier );
     }
@@ -4140,33 +4142,9 @@ int Character::max_stored_calories() const
     return 2500 * 7;
 }
 
-int Character::get_healthy_kcal() const
-{
-    return max_stored_calories();
-}
-
 float Character::get_kcal_percent() const
 {
     return static_cast<float>( get_stored_kcal() ) / static_cast<float>( max_stored_calories() );
-}
-
-float Character::get_hunger() const
-{
-    return ( max_stored_calories() - get_stored_kcal() ) / ( 2500.0f / ( 12 * 24 ) );
-}
-
-void Character::mod_hunger( float nhunger )
-{
-    set_hunger( get_hunger() + nhunger );
-}
-
-void Character::set_hunger( float nhunger )
-{
-    if( get_hunger() != nhunger ) {
-        int hunger_in_kcal = nhunger * ( 2500.0f / ( 12 * 24 ) );
-        int new_kcal = max_stored_calories() - hunger_in_kcal;
-        set_stored_kcal( new_kcal );
-    }
 }
 
 int Character::get_thirst() const
@@ -4606,7 +4584,7 @@ void Character::update_stomach( const time_point &from, const time_point &to )
 
     if( npc_no_food ) {
         set_thirst( static_cast<int>( thirst_levels::hydrated ) );
-        set_stored_kcal( get_healthy_kcal() );
+        set_stored_kcal( max_stored_calories() );
     }
 
     // Mycus and Metabolic Rehydration makes thirst unnecessary
@@ -8734,7 +8712,7 @@ void Character::check_and_recover_morale()
         }
     }
 
-    test_morale.on_stat_change( "hunger", get_hunger() );
+    test_morale.on_stat_change( "kcal", get_stored_kcal() );
     test_morale.on_stat_change( "thirst", get_thirst() );
     test_morale.on_stat_change( "fatigue", get_fatigue() );
     test_morale.on_stat_change( "pain", get_pain() );

--- a/src/character.h
+++ b/src/character.h
@@ -361,7 +361,7 @@ class Character : public Creature, public visitable<Character>
         int get_stored_kcal() const;
         // Maximum stored calories, excluding stomach.
         // If more would be digested, it is instead wasted.
-        int max_stored_calories() const;
+        int max_stored_kcal() const;
         float get_kcal_percent() const;
         int get_thirst() const;
         std::pair<std::string, nc_color> get_thirst_description() const;

--- a/src/character.h
+++ b/src/character.h
@@ -359,12 +359,10 @@ class Character : public Creature, public visitable<Character>
 
         /** Getter for need values exclusive to characters */
         int get_stored_kcal() const;
-        int get_healthy_kcal() const;
         // Maximum stored calories, excluding stomach.
         // If more would be digested, it is instead wasted.
         int max_stored_calories() const;
         float get_kcal_percent() const;
-        float get_hunger() const;
         int get_thirst() const;
         std::pair<std::string, nc_color> get_thirst_description() const;
         std::pair<std::string, nc_color> get_hunger_description() const;
@@ -377,14 +375,12 @@ class Character : public Creature, public visitable<Character>
         /** Modifiers for need values exclusive to characters */
         virtual void mod_stored_kcal( int nkcal );
         virtual void mod_stored_nutr( int nnutr );
-        virtual void mod_hunger( float nhunger );
         virtual void mod_thirst( int nthirst );
         virtual void mod_fatigue( int nfatigue );
         virtual void mod_sleep_deprivation( int nsleep_deprivation );
 
         /** Setters for need values exclusive to characters */
         virtual void set_stored_kcal( int kcal );
-        virtual void set_hunger( float nhunger );
         virtual void set_thirst( int nthirst );
         virtual void set_fatigue( int nfatigue );
         virtual void set_sleep_deprivation( int nsleep_deprivation );

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -365,8 +365,9 @@ void conditional_t<T>::set_need( const JsonObject &jo, const std::string &member
         if( is_npc ) {
             actor = dynamic_cast<player *>( d.beta );
         }
+        int effective_hunger = ( actor->max_stored_calories() - actor->get_stored_kcal() ) / 10;
         return ( actor->get_fatigue() > amount && need == "fatigue" ) ||
-               ( actor->get_hunger() > amount && need == "hunger" ) ||
+               ( effective_hunger > amount && need == "hunger" ) ||
                ( actor->get_thirst() > amount && need == "thirst" );
     };
 }

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -365,7 +365,7 @@ void conditional_t<T>::set_need( const JsonObject &jo, const std::string &member
         if( is_npc ) {
             actor = dynamic_cast<player *>( d.beta );
         }
-        int effective_hunger = ( actor->max_stored_calories() - actor->get_stored_kcal() ) / 10;
+        int effective_hunger = ( actor->max_stored_kcal() - actor->get_stored_kcal() ) / 10;
         return ( actor->get_fatigue() > amount && need == "fatigue" ) ||
                ( effective_hunger > amount && need == "hunger" ) ||
                ( actor->get_thirst() > amount && need == "thirst" );

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -777,7 +777,7 @@ ret_val<edible_rating> Character::will_eat( const item &food, bool interactive )
     if( !food.has_infinite_charges() &&
         ( ( food_kcal > 0 &&
             get_stored_kcal() + stomach.get_calories() + food_kcal
-            > max_stored_calories() ) ||
+            > max_stored_kcal() ) ||
           ( comest->quench > 0 && get_thirst() < comest->quench ) ) ) {
         add_consequence( _( "You're full already and the excess food will be wasted." ),
                          edible_rating::too_full );
@@ -1192,7 +1192,7 @@ bool Character::consume_effects( item &food )
     // Moved here and changed a bit - it was too complex
     // Incredibly minor stuff like this shouldn't require complexity
     if( !is_npc() && has_trait( trait_SLIMESPAWNER ) &&
-        max_stored_calories() < get_stored_kcal() + 4000 && get_thirst() < thirst_levels::slaked ) {
+        max_stored_kcal() < get_stored_kcal() + 4000 && get_thirst() < thirst_levels::slaked ) {
         add_msg_if_player( m_mixed,
                            _( "You feel as though you're going to split open!  In a good way?" ) );
         mod_pain( 5 );
@@ -1220,7 +1220,7 @@ bool Character::consume_effects( item &food )
     }
 
     int excess_kcal = get_stored_kcal() + stomach.get_calories() + ingested.nutr.kcal -
-                      max_stored_calories();
+                      max_stored_kcal();
     int excess_quench = -( get_thirst() - comest.quench );
     stomach.ingest( ingested );
     mod_thirst( -contained_food.type->comestible->quench );

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -599,28 +599,9 @@ float Character::metabolic_rate_base() const
     return std::max( 0.0f, with_mut + ench_bonus );
 }
 
-// TODO: Make this less chaotic to let NPC retroactive catch up work here
-// TODO: Involve body heat (cold -> higher metabolism, unless cold-blooded)
-// TODO: Involve stamina (maybe not here?)
 float Character::metabolic_rate() const
 {
-    // First value is effective hunger, second is nutrition multiplier
-    // Note: Values do not match hungry/v.hungry/famished/starving,
-    // because effective hunger is affected by speed (which drops when hungry)
-    static const std::vector<std::pair<float, float>> thresholds = {{
-            { 300.0f, 1.0f },
-            { 2000.0f, 0.8f },
-            { 5000.0f, 0.6f },
-            { 8000.0f, 0.5f }
-        }
-    };
-
-    // Penalize fast survivors
-    // TODO: Have cold temperature increase, not decrease, metabolism
-    const float effective_hunger = get_hunger() * 100.0f / std::max( 50, get_speed() );
-    const float modifier = multi_lerp( thresholds, effective_hunger );
-
-    return modifier * metabolic_rate_base();
+    return metabolic_rate_base();
 }
 
 morale_type Character::allergy_type( const item &food ) const
@@ -1221,7 +1202,7 @@ bool Character::consume_effects( item &food )
                 slime->friendly = -1;
             }
         }
-        mod_hunger( 40 );
+        mod_stored_kcal( -400 );
         mod_thirst( 40 );
         //~ slimespawns have *small voices* which may be the Nice equivalent
         //~ of the Rat King's ALL CAPS invective.  Probably shared-brain telepathy.

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -826,12 +826,11 @@ void character_edit_menu()
         break;
         case D_NEEDS: {
             uilist smenu;
-            smenu.addentry( 0, true, 'h', "%s: %.1f", _( "Hunger" ), p.get_hunger() );
-            smenu.addentry( 1, true, 's', "%s: %d", _( "Stored kCal" ), p.get_stored_kcal() );
-            smenu.addentry( 2, true, 't', "%s: %d", _( "Thirst" ), p.get_thirst() );
-            smenu.addentry( 3, true, 'f', "%s: %d", _( "Fatigue" ), p.get_fatigue() );
-            smenu.addentry( 4, true, 'd', "%s: %d", _( "Sleep Deprivation" ), p.get_sleep_deprivation() );
-            smenu.addentry( 5, true, 'a', _( "Reset all basic needs" ) );
+            smenu.addentry( 0, true, 's', "%s: %d", _( "Stored kCal" ), p.get_stored_kcal() );
+            smenu.addentry( 1, true, 't', "%s: %d", _( "Thirst" ), p.get_thirst() );
+            smenu.addentry( 2, true, 'f', "%s: %d", _( "Fatigue" ), p.get_fatigue() );
+            smenu.addentry( 3, true, 'd', "%s: %d", _( "Sleep Deprivation" ), p.get_sleep_deprivation() );
+            smenu.addentry( 4, true, 'a', _( "Reset all basic needs" ) );
 
             const auto &vits = vitamin::all();
             for( const auto &v : vits ) {
@@ -842,42 +841,35 @@ void character_edit_menu()
             int value;
             switch( smenu.ret ) {
                 case 0:
-                    if( query_int( value, _( "Set hunger to?  Currently: %d" ), p.get_hunger() ) ) {
-                        p.set_hunger( value );
-                    }
-                    break;
-
-                case 1:
                     if( query_int( value, _( "Set stored kCal to?  Currently: %d" ), p.get_stored_kcal() ) ) {
                         p.set_stored_kcal( value );
                     }
                     break;
 
-                case 2:
+                case 1:
                     if( query_int( value, _( "Set thirst to?  Currently: %d" ), p.get_thirst() ) ) {
                         p.set_thirst( value );
                     }
                     break;
 
-                case 3:
+                case 2:
                     if( query_int( value, _( "Set fatigue to?  Currently: %d" ), p.get_fatigue() ) ) {
                         p.set_fatigue( value );
                     }
                     break;
 
-                case 4:
+                case 3:
                     if( query_int( value, _( "Set sleep deprivation to?  Currently: %d" ),
                                    p.get_sleep_deprivation() ) ) {
                         p.set_sleep_deprivation( value );
                     }
                     break;
-                case 5:
+                case 4:
                     p.initialize_stomach_contents();
-                    p.set_hunger( 0 );
                     p.set_thirst( 0 );
                     p.set_fatigue( 0 );
                     p.set_sleep_deprivation( 0 );
-                    p.set_stored_kcal( p.get_healthy_kcal() );
+                    p.set_stored_kcal( p.max_stored_calories() );
                     break;
                 default:
                     if( smenu.ret >= 6 && smenu.ret < static_cast<int>( vits.size() + 6 ) ) {
@@ -1335,9 +1327,9 @@ void debug()
             std::string stom =
                 _( "Stomach Contents: kCal: %d" );
             add_msg( m_info, stom.c_str(), u.stomach.get_calories() );
-            stom = _( "Hunger: %0.1f, Thirst: %d, kCal: %d / %d" );
-            add_msg( m_info, stom.c_str(), u.get_hunger(), u.get_thirst(), u.get_stored_kcal(),
-                     u.get_healthy_kcal() );
+            stom = _( "Thirst: %d, kCal: %d / %d" );
+            add_msg( m_info, stom.c_str(), u.get_thirst(), u.get_stored_kcal(),
+                     u.max_stored_calories() );
             add_msg( m_info, _( "Body Mass Index: %.0f\nBasal Metabolic Rate: %i" ), u.bmi(), u.bmr() );
             if( get_option<bool>( "STATS_THROUGH_KILLS" ) ) {
                 add_msg( m_info, _( "Kill xp: %d" ), u.kill_xp() );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -869,7 +869,7 @@ void character_edit_menu()
                     p.set_thirst( 0 );
                     p.set_fatigue( 0 );
                     p.set_sleep_deprivation( 0 );
-                    p.set_stored_kcal( p.max_stored_calories() );
+                    p.set_stored_kcal( p.max_stored_kcal() );
                     break;
                 default:
                     if( smenu.ret >= 6 && smenu.ret < static_cast<int>( vits.size() + 6 ) ) {
@@ -1329,7 +1329,7 @@ void debug()
             add_msg( m_info, stom.c_str(), u.stomach.get_calories() );
             stom = _( "Thirst: %d, kCal: %d / %d" );
             add_msg( m_info, stom.c_str(), u.get_thirst(), u.get_stored_kcal(),
-                     u.max_stored_calories() );
+                     u.max_stored_kcal() );
             add_msg( m_info, _( "Body Mass Index: %.0f\nBasal Metabolic Rate: %i" ), u.bmi(), u.bmr() );
             if( get_option<bool>( "STATS_THROUGH_KILLS" ) ) {
                 add_msg( m_info, _( "Kill xp: %d" ), u.kill_xp() );

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -77,7 +77,7 @@ void weed_msg( player &p )
                 // Simpsons
                 p.add_msg_if_player(
                     _( "Could Jesus microwave a burrito so hot, that he himself couldn't eat it?" ) );
-                p.mod_hunger( 2 );
+                p.mod_stored_kcal( -20 );
                 return;
             case 2:
                 if( smarts > 8 ) {
@@ -183,7 +183,7 @@ void weed_msg( player &p )
             case 1:
                 // Real Life
                 p.add_msg_if_player( _( "Man, a cheeseburger sounds SO awesome right now." ) );
-                p.mod_hunger( 4 );
+                p.mod_stored_kcal( -40 );
                 if( p.has_trait( trait_VEGETARIAN ) ) {
                     p.add_msg_if_player( _( "Eh… maybe not." ) );
                 } else if( p.has_trait( trait_LACTOSE ) ) {

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2550,7 +2550,6 @@ void basecamp::finish_return( npc &comp, const bool fixed_time, const std::strin
     validate_assignees();
 
     camp_food_supply( -need_food );
-    comp.mod_hunger( -avail_food );
     comp.mod_stored_kcal( avail_food );
     if( has_water() ) {
         comp.set_thirst( 0 );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11722,7 +11722,7 @@ void game::process_artifact( item &it, player &p )
 
             case AEP_HUNGER:
                 if( one_in( 100 ) ) {
-                    p.mod_hunger( 1 );
+                    p.mod_stored_kcal( -10 );
                 }
                 break;
 

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -135,7 +135,7 @@ void defense_game::per_turn()
         g->u.set_thirst( 0 );
     }
     if( !hunger ) {
-        g->u.set_stored_kcal( g->u.max_stored_calories() );
+        g->u.set_stored_kcal( g->u.max_stored_kcal() );
     }
     if( !sleep ) {
         g->u.set_fatigue( 0 );

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -135,7 +135,7 @@ void defense_game::per_turn()
         g->u.set_thirst( 0 );
     }
     if( !hunger ) {
-        g->u.set_hunger( 0 );
+        g->u.set_stored_kcal( g->u.max_stored_calories() );
     }
     if( !sleep ) {
         g->u.set_fatigue( 0 );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1038,7 +1038,7 @@ static void sleep()
     }
     if( u.has_alarm_clock() ) {
         /* Reuse menu to ask player whether they want to set an alarm. */
-        bool can_hibernate = u.get_hunger() < -60 && u.has_active_mutation( trait_HIBERNATE );
+        bool can_hibernate = u.get_kcal_percent() > 0.95 && u.has_active_mutation( trait_HIBERNATE );
 
         as_m.reset();
         as_m.text = can_hibernate ?

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1677,7 +1677,7 @@ static bool can_drink_nectar( const player &p, const item &nectar )
 {
     return ( p.has_active_mutation( trait_PROBOSCIS )  ||
              p.has_active_mutation( trait_BEAK_HUM ) ) &&
-           ( ( p.max_stored_calories() - p.get_stored_kcal() ) <
+           ( ( p.max_stored_kcal() - p.get_stored_kcal() ) <
              nectar.get_comestible()->default_nutrition.kcal ) &&
            ( !( p.wearing_something_on( bodypart_id( "mouth" ) ) ) );
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1242,7 +1242,7 @@ static void marloss_common( player &p, item &it, const trait_id &current_color )
             }
         }
 
-        p.set_stored_kcal( p.max_stored_calories() );
+        p.set_stored_kcal( p.max_stored_kcal() );
         spawn_spores( p );
         return;
     }
@@ -1281,7 +1281,7 @@ static void marloss_common( player &p, item &it, const trait_id &current_color )
         }
     } else if( effect == 7 ) {
         p.add_msg_if_player( m_good, _( "It is delicious, and very filling!" ) );
-        p.set_stored_kcal( p.max_stored_calories() );
+        p.set_stored_kcal( p.max_stored_kcal() );
     } else if( effect == 8 ) {
         p.add_msg_if_player( m_bad, _( "You take one bite, and immediately vomit!" ) );
         p.vomit();

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -426,7 +426,7 @@ static int alcohol( player &p, const item &it, const int strength )
                    36_seconds, 1_minutes, 1_minutes ) * p.str_max );
         // Metabolizing the booze improves the nutritional value;
         // might not be healthy, and still causes Thirst problems, though
-        p.mod_hunger( -( std::abs( it.get_comestible() ? it.type->comestible->stim : 0 ) ) );
+        p.mod_stored_kcal( 10 * ( std::abs( it.get_comestible() ? it.type->comestible->stim : 0 ) ) );
         // Metabolizing it cancels out the depressant
         p.mod_stim( std::abs( it.get_comestible() ? it.get_comestible()->stim : 0 ) );
     } else if( p.has_trait( trait_TOLERANCE ) ) {
@@ -479,7 +479,7 @@ int iuse::smoking( player *p, item *it, bool, const tripoint & )
     if( it->typeId() == "cig" ) {
         cig = item( "cig_lit", calendar::turn );
         cig.item_counter = to_turns<int>( 4_minutes );
-        p->mod_hunger( -3 );
+        p->mod_stored_kcal( 30 );
         p->mod_thirst( 2 );
     } else if( it->typeId() == "handrolled_cig" ) {
         // This transforms the hand-rolled into a normal cig, which isn't exactly
@@ -487,16 +487,16 @@ int iuse::smoking( player *p, item *it, bool, const tripoint & )
         cig = item( "cig_lit", calendar::turn );
         cig.item_counter = to_turns<int>( 4_minutes );
         p->mod_thirst( 2 );
-        p->mod_hunger( -3 );
+        p->mod_stored_kcal( 30 );
     } else if( it->typeId() == "cigar" ) {
         cig = item( "cigar_lit", calendar::turn );
         cig.item_counter = to_turns<int>( 12_minutes );
         p->mod_thirst( 3 );
-        p->mod_hunger( -4 );
+        p->mod_stored_kcal( 40 );
     } else if( it->typeId() == "joint" ) {
         cig = item( "joint_lit", calendar::turn );
         cig.item_counter = to_turns<int>( 4_minutes );
-        p->mod_hunger( 4 );
+        p->mod_stored_kcal( -40 );
         p->mod_thirst( 6 );
         if( p->get_painkiller() < 5 ) {
             p->set_painkiller( ( p->get_painkiller() + 3 ) * 2 );
@@ -546,7 +546,7 @@ int iuse::ecig( player *p, item *it, bool, const tripoint & )
     }
 
     p->mod_thirst( 1 );
-    p->mod_hunger( -1 );
+    p->mod_stored_kcal( 10 );
     p->add_effect( effect_cig, 10_minutes );
     if( p->get_effect_dur( effect_cig ) > 10_minutes * ( p->addiction_level(
                 add_type::CIG ) + 1 ) ) {
@@ -746,7 +746,7 @@ int iuse::weed_cake( player *p, item *it, bool, const tripoint & )
     if( p->has_trait( trait_LIGHTWEIGHT ) ) {
         duration = 15_minutes;
     }
-    p->mod_hunger( 2 );
+    p->mod_stored_kcal( -20 );
     p->mod_thirst( 6 );
     if( p->get_painkiller() < 5 ) {
         p->set_painkiller( ( p->get_painkiller() + 3 ) * 2 );
@@ -770,7 +770,7 @@ int iuse::coke( player *p, item *it, bool, const tripoint & )
     if( p->has_trait( trait_LIGHTWEIGHT ) ) {
         duration += 2_minutes;
     }
-    p->mod_hunger( -8 );
+    p->mod_stored_kcal( 100 );
     p->add_effect( effect_high, duration );
     return it->type->charges_to_use();
 }
@@ -805,7 +805,7 @@ int iuse::meth( player *p, item *it, bool, const tripoint & )
         /** @EFFECT_STR_MAX >4 experiences less hunger benefit from meth */
         int hungerpen = ( p->str_max < 5 ? 35 : 40 - ( 2 * p->str_max ) );
         if( hungerpen > 0 ) {
-            p->mod_hunger( -hungerpen );
+            p->mod_stored_kcal( 10 * hungerpen );
         }
         p->add_effect( effect_meth, duration );
     }
@@ -1008,7 +1008,7 @@ int iuse::blech( player *p, item *it, bool, const tripoint & )
         p->add_msg_if_player( m_bad, _( "Blech, that tastes gross!" ) );
         //reverse the harmful values of drinking this acid.
         double multiplier = -1;
-        p->mod_hunger( -p->nutrition_for( *it ) * multiplier );
+        p->mod_stored_kcal( 10 * p->nutrition_for( *it ) * multiplier );
         p->mod_thirst( -it->get_comestible()->quench * multiplier + 20 );
         p->mod_healthy_mod( it->get_comestible()->healthy * multiplier,
                             it->get_comestible()->healthy * multiplier );
@@ -1052,7 +1052,7 @@ int iuse::plantblech( player *p, item *it, bool, const tripoint &pos )
         }
 
         //reverses the harmful values of drinking fertilizer
-        p->mod_hunger( p->nutrition_for( *it ) * multiplier );
+        p->mod_stored_kcal( -10 * p->nutrition_for( *it ) * multiplier );
         p->mod_thirst( -it->get_comestible()->quench * multiplier );
         p->mod_healthy_mod( it->get_comestible()->healthy * multiplier,
                             it->get_comestible()->healthy * multiplier );
@@ -1242,7 +1242,7 @@ static void marloss_common( player &p, item &it, const trait_id &current_color )
             }
         }
 
-        p.set_hunger( -10 );
+        p.set_stored_kcal( p.max_stored_calories() );
         spawn_spores( p );
         return;
     }
@@ -1281,7 +1281,7 @@ static void marloss_common( player &p, item &it, const trait_id &current_color )
         }
     } else if( effect == 7 ) {
         p.add_msg_if_player( m_good, _( "It is delicious, and very filling!" ) );
-        p.set_hunger( 0 );
+        p.set_stored_kcal( p.max_stored_calories() );
     } else if( effect == 8 ) {
         p.add_msg_if_player( m_bad, _( "You take one bite, and immediately vomit!" ) );
         p.vomit();

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4462,7 +4462,7 @@ int mutagen_iv_actor::use( player &p, item &it, bool, const tripoint & ) const
         p.mod_pain( m_category.iv_pain  * rng( 1, 5 ) );
     }
 
-    p.mod_hunger( m_category.iv_hunger * mut_count );
+    p.mod_stored_kcal( -10 * m_category.iv_hunger * mut_count );
     p.mod_thirst( m_category.iv_thirst * mut_count );
     p.mod_fatigue( m_category.iv_fatigue * mut_count );
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1496,7 +1496,7 @@ void npc::decide_needs()
     }
 
     needrank[need_weapon] = weapon_value( weapon );
-    needrank[need_food] = 15.0f - ( max_stored_calories() - get_stored_kcal() ) / 10.0f;
+    needrank[need_food] = 15.0f - ( max_stored_kcal() - get_stored_kcal() ) / 10.0f;
     needrank[need_drink] = 15 - get_thirst();
     invslice slice = inv.slice();
     for( auto &i : slice ) {
@@ -1756,9 +1756,9 @@ int npc::value( const item &it, int market_price ) const
         if( nutrition_for( it ) > 0 || it.get_comestible()->quench > 0 ) {
             comestval++;
         }
-        if( max_stored_calories() - get_stored_kcal() > 500 ) {
+        if( max_stored_kcal() - get_stored_kcal() > 500 ) {
             comestval += ( nutrition_for( it ) +
-                           ( max_stored_calories() - get_stored_kcal() - 500 ) / 10 ) / 6;
+                           ( max_stored_kcal() - get_stored_kcal() - 500 ) / 10 ) / 6;
         }
         if( get_thirst() > thirst_levels::thirsty ) {
             comestval += ( it.get_comestible()->quench + get_thirst() - thirst_levels::thirsty ) / 4;
@@ -2809,7 +2809,7 @@ void npc::process_turn()
                          std::max( 0, -op_of_u.value ) +
                          std::max( 0, op_of_u.fear );
         // Being barely hungry and thirsty, not in pain and not wounded means good care
-        int state_penalty = ( max_stored_calories() - get_stored_kcal() ) / 10 + get_thirst()
+        int state_penalty = ( max_stored_kcal() - get_stored_kcal() ) / 10 + get_thirst()
                             + ( 100 - hp_percentage() ) + get_pain();
         if( x_in_y( trust_chance, 240 + 10 * op_penalty + state_penalty ) ) {
             op_of_u.trust++;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1496,7 +1496,7 @@ void npc::decide_needs()
     }
 
     needrank[need_weapon] = weapon_value( weapon );
-    needrank[need_food] = 15 - ( max_stored_calories() - get_stored_kcal() ) / 10;
+    needrank[need_food] = 15.0f - ( max_stored_calories() - get_stored_kcal() ) / 10.0f;
     needrank[need_drink] = 15 - get_thirst();
     invslice slice = inv.slice();
     for( auto &i : slice ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3835,7 +3835,7 @@ bool npc::consume_food()
 {
     float best_weight = 0.0f;
     int index = -1;
-    int want_hunger = std::max<int>( 0, ( max_stored_calories() - get_stored_kcal() ) / 8.6f );
+    int want_hunger = std::max<int>( 0, ( max_stored_calories() - get_stored_kcal() ) / 10 );
     int want_quench = std::max( 0, get_thirst() );
     invslice slice = inv.slice();
     for( size_t i = 0; i < slice.size(); i++ ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1836,7 +1836,7 @@ npc_action npc::address_needs( float danger )
 
     // Extreme thirst or hunger, bypass safety check.
     if( get_thirst() > thirst_levels::dehydrated ||
-        get_stored_kcal() + stomach.get_calories() < max_stored_calories() * 0.75 ) {
+        get_stored_kcal() + stomach.get_calories() < max_stored_kcal() * 0.75 ) {
         if( consume_food_from_camp() ) {
             return npc_noop;
         }
@@ -1856,7 +1856,7 @@ npc_action npc::address_needs( float danger )
     }
 
     if( one_in( 3 ) && ( get_thirst() > thirst_levels::thirsty ||
-                         get_stored_kcal() + stomach.get_calories() < max_stored_calories() * 0.95 ) ) {
+                         get_stored_kcal() + stomach.get_calories() < max_stored_kcal() * 0.95 ) ) {
         if( consume_food_from_camp() ) {
             return npc_noop;
         }
@@ -3819,7 +3819,7 @@ bool npc::consume_food_from_camp()
         return true;
     }
     faction *yours = g->u.get_faction();
-    int camp_kcals = std::min( std::max( 0, 19 * max_stored_calories() / 20 - get_stored_kcal() -
+    int camp_kcals = std::min( std::max( 0, 19 * max_stored_kcal() / 20 - get_stored_kcal() -
                                          stomach.get_calories() ), yours->food_supply );
     if( camp_kcals > 0 ) {
         complain_about( "camp_food_thanks", 1_hours, "<camp_food_thanks>", false );
@@ -3835,7 +3835,7 @@ bool npc::consume_food()
 {
     float best_weight = 0.0f;
     int index = -1;
-    int want_hunger = std::max<int>( 0, ( max_stored_calories() - get_stored_kcal() ) / 10 );
+    int want_hunger = std::max<int>( 0, ( max_stored_kcal() - get_stored_kcal() ) / 10 );
     int want_quench = std::max( 0, get_thirst() );
     invslice slice = inv.slice();
     for( size_t i = 0; i < slice.size(); i++ ) {
@@ -3853,7 +3853,7 @@ bool npc::consume_food()
     if( index == -1 ) {
         if( !is_player_ally() ) {
             // TODO: Remove this and let player "exploit" hungry NPCs
-            set_stored_kcal( max_stored_calories() );
+            set_stored_kcal( max_stored_kcal() );
             set_thirst( 0 );
         }
         return false;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1836,7 +1836,7 @@ npc_action npc::address_needs( float danger )
 
     // Extreme thirst or hunger, bypass safety check.
     if( get_thirst() > thirst_levels::dehydrated ||
-        get_stored_kcal() + stomach.get_calories() < get_healthy_kcal() * 0.75 ) {
+        get_stored_kcal() + stomach.get_calories() < max_stored_calories() * 0.75 ) {
         if( consume_food_from_camp() ) {
             return npc_noop;
         }
@@ -1856,7 +1856,7 @@ npc_action npc::address_needs( float danger )
     }
 
     if( one_in( 3 ) && ( get_thirst() > thirst_levels::thirsty ||
-                         get_stored_kcal() + stomach.get_calories() < get_healthy_kcal() * 0.95 ) ) {
+                         get_stored_kcal() + stomach.get_calories() < max_stored_calories() * 0.95 ) ) {
         if( consume_food_from_camp() ) {
             return npc_noop;
         }
@@ -3819,11 +3819,10 @@ bool npc::consume_food_from_camp()
         return true;
     }
     faction *yours = g->u.get_faction();
-    int camp_kcals = std::min( std::max( 0, 19 * get_healthy_kcal() / 20 - get_stored_kcal() -
+    int camp_kcals = std::min( std::max( 0, 19 * max_stored_calories() / 20 - get_stored_kcal() -
                                          stomach.get_calories() ), yours->food_supply );
     if( camp_kcals > 0 ) {
         complain_about( "camp_food_thanks", 1_hours, "<camp_food_thanks>", false );
-        mod_hunger( -camp_kcals );
         mod_stored_kcal( camp_kcals );
         yours->food_supply -= camp_kcals;
         return true;
@@ -3836,7 +3835,7 @@ bool npc::consume_food()
 {
     float best_weight = 0.0f;
     int index = -1;
-    int want_hunger = std::max<int>( 0, get_hunger() );
+    int want_hunger = std::max<int>( 0, ( max_stored_calories() - get_stored_kcal() ) / 8.6f );
     int want_quench = std::max( 0, get_thirst() );
     invslice slice = inv.slice();
     for( size_t i = 0; i < slice.size(); i++ ) {
@@ -3854,7 +3853,7 @@ bool npc::consume_food()
     if( index == -1 ) {
         if( !is_player_ally() ) {
             // TODO: Remove this and let player "exploit" hungry NPCs
-            set_hunger( 0 );
+            set_stored_kcal( max_stored_calories() );
             set_thirst( 0 );
         }
         return false;
@@ -4485,9 +4484,9 @@ bool npc::complain()
 
     // Hunger every 3-6 hours
     // Since NPCs can't starve to death, respect the rules
-    if( get_hunger() > 160 &&
+    if( get_kcal_percent() < 0.9 &&
         complain_about( hunger_string, std::max( 3_hours,
-                        time_duration::from_minutes( 60 * 8 - get_hunger() ) ), _( "<hungry>" ) ) ) {
+                        time_duration::from_minutes( get_kcal_percent() * 60 * 7 ) ), _( "<hungry>" ) ) ) {
         return true;
     }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1096,8 +1096,10 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
             } else {
                 info += _( "\nThirsty" );
             }
-            if( p->get_hunger() < 100 ) {
-                time_duration hunger_at = 5_minutes * ( 100 - p->get_hunger() ) / rates.hunger;
+            if( p->max_stored_calories() - p->get_stored_kcal() > 500 ) {
+                time_duration hunger_at = 5_minutes
+                                          * ( 500 - p->max_stored_calories() + p->get_stored_kcal() )
+                                          / rates.kcal;
                 if( hunger_at > 1_hours ) {
                     info += _( "\nWill need food in " ) + to_string_approx( hunger_at );
                 }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1096,10 +1096,10 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
             } else {
                 info += _( "\nThirsty" );
             }
-            if( p->max_stored_calories() - p->get_stored_kcal() > 500 ) {
+            if( p->max_stored_kcal() - p->get_stored_kcal() > 500 ) {
                 time_duration hunger_at = 5_minutes
-                                          * ( 500 - p->max_stored_calories() + p->get_stored_kcal() )
-                                          / rates.kcal;
+                                          * ( 500 - p->max_stored_kcal() + p->get_stored_kcal() )
+                                          / p->bmr();
                 if( hunger_at > 1_hours ) {
                     info += _( "\nWill need food in " ) + to_string_approx( hunger_at );
                 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1481,7 +1481,7 @@ void player::process_one_effect( effect &it, bool is_new )
     if( val != 0 ) {
         mod = 1;
         if( is_new || it.activated( calendar::turn, "HUNGER", val, reduced, mod ) ) {
-            mod_stored_kcal( -10 * bound_mod_to_vals( ( max_stored_calories() - get_stored_kcal() ) / 10,
+            mod_stored_kcal( -10 * bound_mod_to_vals( ( max_stored_kcal() - get_stored_kcal() ) / 10,
                              val, it.get_max_val( "HUNGER", reduced ), it.get_min_val( "HUNGER", reduced ) ) );
         }
     }
@@ -4370,7 +4370,7 @@ void player::environmental_revert_effect()
     morale->clear();
 
     set_all_parts_hp_to_max();
-    set_stored_kcal( max_stored_calories() );
+    set_stored_kcal( max_stored_kcal() );
     set_thirst( 0 );
     set_fatigue( 0 );
     set_healthy( 0 );

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1481,8 +1481,8 @@ void player::process_one_effect( effect &it, bool is_new )
     if( val != 0 ) {
         mod = 1;
         if( is_new || it.activated( calendar::turn, "HUNGER", val, reduced, mod ) ) {
-            mod_hunger( bound_mod_to_vals( get_hunger(), val, it.get_max_val( "HUNGER", reduced ),
-                                           it.get_min_val( "HUNGER", reduced ) ) );
+            mod_stored_kcal( -10 * bound_mod_to_vals( ( max_stored_calories() - get_stored_kcal() ) / 10,
+                             val, it.get_max_val( "HUNGER", reduced ), it.get_min_val( "HUNGER", reduced ) ) );
         }
     }
 
@@ -4370,7 +4370,7 @@ void player::environmental_revert_effect()
     morale->clear();
 
     set_all_parts_hp_to_max();
-    set_hunger( 0 );
+    set_stored_kcal( max_stored_calories() );
     set_thirst( 0 );
     set_fatigue( 0 );
     set_healthy( 0 );

--- a/src/player.h
+++ b/src/player.h
@@ -94,7 +94,6 @@ struct needs_rates {
     float hunger = 0.0f;
     float fatigue = 0.0f;
     float recovery = 0.0f;
-    float kcal = 0.0f;
 };
 
 class player : public Character

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -167,7 +167,7 @@ static void eff_fun_fungus( player &u, effect &it )
 
                 const int awfulness = rng( 0, 10 );
                 u.moves = -200;
-                u.mod_hunger( awfulness );
+                u.mod_stored_kcal( -10 * awfulness );
                 u.mod_thirst( awfulness );
                 u.apply_damage( nullptr, bodypart_id( "torso" ), 1 );
             }
@@ -251,7 +251,7 @@ static void eff_fun_hallu( player &u, effect &it )
     } else if( dur > peakTime && dur < comeupTime ) {
         if( u.stomach.get_calories() > 0 && ( one_in( 1200 ) || x_in_y( u.vomit_mod(), 300 ) ) ) {
             u.add_msg_if_player( m_bad, _( "You feel sick to your stomach." ) );
-            u.mod_hunger( -2 );
+            u.mod_stored_kcal( 20 );
             if( one_in( 6 ) ) {
                 u.vomit();
             }
@@ -1064,8 +1064,8 @@ void player::hardcoded_effects( effect &it )
             if( has_trait( trait_CHLOROMORPH ) ) {
                 // Hunger and thirst fall before your Chloromorphic physiology!
                 if( g->natural_light_level( posz() ) >= 12 && compatible_weather_types ) {
-                    if( get_hunger() >= -30 ) {
-                        mod_hunger( -5 );
+                    if( get_stored_kcal() < max_stored_calories() - 50 ) {
+                        mod_stored_kcal( 50 );
                     }
                     if( get_thirst() >= thirst_levels::turgid ) {
                         mod_thirst( -5 );

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -432,7 +432,7 @@ static void eff_fun_frostbite( player &u, effect &it )
 
 static void eff_fun_bloated( player &u, effect &it )
 {
-    if( u.get_stored_kcal() > u.max_stored_calories() || u.get_thirst() < 0 ) {
+    if( u.get_stored_kcal() > u.max_stored_kcal() || u.get_thirst() < 0 ) {
         it.set_duration( 5_minutes );
     }
 }
@@ -1064,7 +1064,7 @@ void player::hardcoded_effects( effect &it )
             if( has_trait( trait_CHLOROMORPH ) ) {
                 // Hunger and thirst fall before your Chloromorphic physiology!
                 if( g->natural_light_level( posz() ) >= 12 && compatible_weather_types ) {
-                    if( get_stored_kcal() < max_stored_calories() - 50 ) {
+                    if( get_stored_kcal() < max_stored_kcal() - 50 ) {
                         mod_stored_kcal( 50 );
                     }
                     if( get_thirst() >= thirst_levels::turgid ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -320,8 +320,8 @@ void Character::suffer_while_awake( const int current_stim )
     if( has_trait( trait_JITTERY ) && !has_effect( effect_shakes ) ) {
         if( current_stim > 50 && one_in( to_turns<int>( 30_minutes ) - ( current_stim * 6 ) ) ) {
             add_effect( effect_shakes, 30_minutes + 1_turns * current_stim );
-        } else if( ( get_hunger() > 80 || get_kcal_percent() < 1.0f ) && get_hunger() > 0 &&
-                   one_in( to_turns<int>( 50_minutes ) - ( get_hunger() * 6 ) ) ) {
+        } else if( ( get_kcal_percent() < 0.95f ) &&
+                   one_turn_in( 60_minutes - 1_seconds * ( max_stored_calories() - get_stored_kcal() ) ) ) {
             add_effect( effect_shakes, 40_minutes );
         }
     }
@@ -383,7 +383,7 @@ void Character::suffer_from_chemimbalance()
         } else {
             add_msg_if_player( m_good, _( "You suddenly feel a little full." ) );
         }
-        mod_hunger( hungadd );
+        mod_stored_kcal( -10 * hungadd );
     }
     if( one_turn_in( 6_hours ) ) {
         add_msg_if_player( m_bad, _( "You suddenly feel thirsty." ) );
@@ -734,9 +734,7 @@ void Character::suffer_in_sunlight()
     }
 
     if( x_in_y( sunlight_nutrition, 12000 ) ) {
-        mod_hunger( -1 );
-        // photosynthesis absorbs kcal directly
-        mod_stored_nutr( -1 );
+        mod_stored_kcal( 10 );
         stomach.ate();
     }
 
@@ -1590,7 +1588,7 @@ void Character::mend( int rate_multiplier )
     // Very hungry starts lowering the chance
     // square rooting the value makes the numbers drop off faster when below 1
     healing_factor *= std::sqrt( static_cast<float>( get_stored_kcal() ) / static_cast<float>
-                                 ( get_healthy_kcal() ) );
+                                 ( max_stored_calories() ) );
     // Similar for thirst - starts at very thirsty, drops to 0 at parched
     healing_factor *= 1.0f - clamp( 1.0f * ( get_thirst() - thirst_levels::very_thirsty ) /
                                     +thirst_levels::parched, 0.0f, 1.0f );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -321,7 +321,7 @@ void Character::suffer_while_awake( const int current_stim )
         if( current_stim > 50 && one_in( to_turns<int>( 30_minutes ) - ( current_stim * 6 ) ) ) {
             add_effect( effect_shakes, 30_minutes + 1_turns * current_stim );
         } else if( ( get_kcal_percent() < 0.95f ) &&
-                   one_turn_in( 60_minutes - 1_seconds * ( max_stored_calories() - get_stored_kcal() ) ) ) {
+                   one_turn_in( 60_minutes - 1_seconds * ( max_stored_kcal() - get_stored_kcal() ) ) ) {
             add_effect( effect_shakes, 40_minutes );
         }
     }
@@ -1588,7 +1588,7 @@ void Character::mend( int rate_multiplier )
     // Very hungry starts lowering the chance
     // square rooting the value makes the numbers drop off faster when below 1
     healing_factor *= std::sqrt( static_cast<float>( get_stored_kcal() ) / static_cast<float>
-                                 ( max_stored_calories() ) );
+                                 ( max_stored_kcal() ) );
     // Similar for thirst - starts at very thirsty, drops to 0 at parched
     healing_factor *= 1.0f - clamp( 1.0f * ( get_thirst() - thirst_levels::very_thirsty ) /
                                     +thirst_levels::parched, 0.0f, 1.0f );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4516,7 +4516,7 @@ void vehicle::consume_fuel( int load, const int t_seconds, bool skip_electric )
             mod -= std::max( eff_load / 5, 5 );
         }
         if( one_in( 1000 / load ) && one_in( 10 ) ) {
-            g->u.mod_hunger( 1 );
+            g->u.mod_stored_kcal( -10 );
             g->u.mod_thirst( 1 );
             g->u.mod_fatigue( 1 );
         }

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -70,7 +70,7 @@ static avatar get_sanitized_player()
     ret.set_body();
     ret.recalc_hp();
 
-    // Set these insanely high so can_eat doesn't return TOO_FULL
+    // Set these to starving/parched so can_eat doesn't return TOO_FULL
     ret.set_stored_kcal( 100 );
     ret.set_thirst( 10000 );
     return ret;

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -71,7 +71,7 @@ static avatar get_sanitized_player()
     ret.recalc_hp();
 
     // Set these insanely high so can_eat doesn't return TOO_FULL
-    ret.set_hunger( 10000 );
+    ret.set_stored_kcal( 100 );
     ret.set_thirst( 10000 );
     return ret;
 }

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -51,7 +51,7 @@ static npc &create_test_talker()
     for( const trait_id &tr : model_npc->get_mutations() ) {
         model_npc->unset_mutation( tr );
     }
-    model_npc->set_stored_kcal( model_npc->max_stored_calories() );
+    model_npc->set_stored_kcal( model_npc->max_stored_kcal() );
     model_npc->set_thirst( 0 );
     model_npc->set_fatigue( 0 );
     model_npc->remove_effect( efftype_id( "sleep" ) );

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -51,7 +51,7 @@ static npc &create_test_talker()
     for( const trait_id &tr : model_npc->get_mutations() ) {
         model_npc->unset_mutation( tr );
     }
-    model_npc->set_hunger( 0 );
+    model_npc->set_stored_kcal( model_npc->max_stored_calories() );
     model_npc->set_thirst( 0 );
     model_npc->set_fatigue( 0 );
     model_npc->remove_effect( efftype_id( "sleep" ) );

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -44,7 +44,7 @@ static void test_needs( const npc &who, const numeric_interval<int> &kcal_lost,
                         const numeric_interval<int> &thirst,
                         const numeric_interval<int> &fatigue )
 {
-    int kcal_below_max = who.max_stored_calories() - who.get_stored_kcal();
+    int kcal_below_max = who.max_stored_kcal() - who.get_stored_kcal();
     CHECK( kcal_below_max <= kcal_lost.max );
     CHECK( kcal_below_max >= kcal_lost.min );
     CHECK( who.get_thirst() <= thirst.max );
@@ -61,7 +61,7 @@ static npc create_model()
     for( const trait_id &tr : model_npc.get_mutations() ) {
         model_npc.unset_mutation( tr );
     }
-    model_npc.set_stored_kcal( model_npc.max_stored_calories() );
+    model_npc.set_stored_kcal( model_npc.max_stored_kcal() );
     model_npc.set_thirst( 0 );
     model_npc.set_fatigue( 0 );
     model_npc.remove_effect( efftype_id( "sleep" ) );
@@ -148,7 +148,7 @@ TEST_CASE( "on_load-similar-to-per-turn", "[.]" )
         }
 
         const int margin = 2;
-        const numeric_interval<int> hunger( iterated_npc.max_stored_calories() -
+        const numeric_interval<int> hunger( iterated_npc.max_stored_kcal() -
                                             iterated_npc.get_stored_kcal(), margin, margin );
         const numeric_interval<int> thirst( iterated_npc.get_thirst(), margin, margin );
         const numeric_interval<int> fatigue( iterated_npc.get_fatigue(), margin, margin );
@@ -167,7 +167,7 @@ TEST_CASE( "on_load-similar-to-per-turn", "[.]" )
         }
 
         const int margin = 10;
-        const numeric_interval<int> hunger( iterated_npc.max_stored_calories() -
+        const numeric_interval<int> hunger( iterated_npc.max_stored_kcal() -
                                             iterated_npc.get_stored_kcal(), margin, margin );
         const numeric_interval<int> thirst( iterated_npc.get_thirst(), margin, margin );
         const numeric_interval<int> fatigue( iterated_npc.get_fatigue(), margin, margin );

--- a/tests/stomach_contents_test.cpp
+++ b/tests/stomach_contents_test.cpp
@@ -21,7 +21,7 @@ static void reset_time()
 {
     calendar::turn = calendar::start_of_cataclysm;
     player &p = g->u;
-    p.set_stored_kcal( p.max_stored_calories() );
+    p.set_stored_kcal( p.max_stored_kcal() );
     clear_avatar();
 }
 
@@ -53,7 +53,7 @@ static void print_stomach_contents( player &p, const bool print )
         return;
     }
     cata_printf( "stomach: %d player: %d/%d\n", p.stomach.get_calories(),
-                 p.get_stored_kcal(), p.max_stored_calories() );
+                 p.get_stored_kcal(), p.max_stored_kcal() );
     cata_printf( "metabolic rate: %.2f\n", p.metabolic_rate() );
 }
 
@@ -170,7 +170,7 @@ TEST_CASE( "all_nutrition_starve_test", "[!mayfail][starve][slow]" )
         print_stomach_contents( dummy, print_tests );
         cata_printf( "\n" );
     }
-    CHECK( dummy.get_stored_kcal() < dummy.max_stored_calories() );
+    CHECK( dummy.get_stored_kcal() < dummy.max_stored_kcal() );
     // We need to account for a day's worth of error since we're passing a day at a time and we are
     // close to 0 which is the max value for some vitamins
     CHECK( dummy.vitamin_get( vitamin_id( "vitA" ) ) >= -100 );
@@ -216,7 +216,7 @@ TEST_CASE( "Stomach calories become stored calories after less than 1 day", "[st
     player &dummy = g->u;
     reset_time();
     clear_stomach( dummy );
-    int kcal_before = dummy.max_stored_calories() - dummy.bmr();
+    int kcal_before = dummy.max_stored_kcal() - dummy.bmr();
     dummy.set_stored_kcal( kcal_before );
     dummy.stomach.mod_calories( 1000 );
 
@@ -254,7 +254,7 @@ TEST_CASE( "Eating above max kcal causes bloating", "[stomach]" )
     player &dummy = g->u;
     reset_time();
     clear_stomach( dummy );
-    dummy.set_stored_kcal( dummy.max_stored_calories() - 10 );
+    dummy.set_stored_kcal( dummy.max_stored_kcal() - 10 );
     item food( "protein_drink", calendar::start_of_cataclysm, 10 );
     REQUIRE( dummy.compute_effective_nutrients( food ).kcal > 0 );
     WHEN( "Character consumes calories above max" ) {
@@ -269,7 +269,7 @@ TEST_CASE( "Eating above max kcal causes bloating", "[stomach]" )
             CHECK( dummy.has_effect( effect_bloated ) );
         }
         THEN( "They are no longer above max calories" ) {
-            CHECK( dummy.get_stored_kcal() < dummy.max_stored_calories() );
+            CHECK( dummy.get_stored_kcal() < dummy.max_stored_kcal() );
         }
     }
 

--- a/tests/stomach_contents_test.cpp
+++ b/tests/stomach_contents_test.cpp
@@ -21,8 +21,7 @@ static void reset_time()
 {
     calendar::turn = calendar::start_of_cataclysm;
     player &p = g->u;
-    p.set_stored_kcal( p.get_healthy_kcal() );
-    p.set_hunger( 0 );
+    p.set_stored_kcal( p.max_stored_calories() );
     clear_avatar();
 }
 
@@ -53,8 +52,8 @@ static void print_stomach_contents( player &p, const bool print )
     if( !print ) {
         return;
     }
-    cata_printf( "stomach: %d player: %d/%d hunger: %0.1f\n", p.stomach.get_calories(),
-                 p.get_stored_kcal(), p.get_healthy_kcal(), p.get_hunger() );
+    cata_printf( "stomach: %d player: %d/%d\n", p.stomach.get_calories(),
+                 p.get_stored_kcal(), p.max_stored_calories() );
     cata_printf( "metabolic rate: %.2f\n", p.metabolic_rate() );
 }
 
@@ -171,7 +170,7 @@ TEST_CASE( "all_nutrition_starve_test", "[!mayfail][starve][slow]" )
         print_stomach_contents( dummy, print_tests );
         cata_printf( "\n" );
     }
-    CHECK( dummy.get_stored_kcal() < dummy.get_healthy_kcal() );
+    CHECK( dummy.get_stored_kcal() < dummy.max_stored_calories() );
     // We need to account for a day's worth of error since we're passing a day at a time and we are
     // close to 0 which is the max value for some vitamins
     CHECK( dummy.vitamin_get( vitamin_id( "vitA" ) ) >= -100 );
@@ -255,7 +254,7 @@ TEST_CASE( "Eating above max kcal causes bloating", "[stomach]" )
     player &dummy = g->u;
     reset_time();
     clear_stomach( dummy );
-    dummy.set_stored_kcal( dummy.max_stored_calories() );
+    dummy.set_stored_kcal( dummy.max_stored_calories() - 10 );
     item food( "protein_drink", calendar::start_of_cataclysm, 10 );
     REQUIRE( dummy.compute_effective_nutrients( food ).kcal > 0 );
     WHEN( "Character consumes calories above max" ) {
@@ -270,7 +269,7 @@ TEST_CASE( "Eating above max kcal causes bloating", "[stomach]" )
             CHECK( dummy.has_effect( effect_bloated ) );
         }
         THEN( "They are no longer above max calories" ) {
-            CHECK( dummy.get_hunger() >= 0 );
+            CHECK( dummy.get_stored_kcal() < dummy.max_stored_calories() );
         }
     }
 


### PR DESCRIPTION
Remove the `get/set/mod`+`_hunger` functions in `Character`.
They were just wrappers around kcal anyway.

I'm not sure if I didn't scramble any of the replacement values (signs, math), hence [CR].
For values where it doesn't matter, I used something from 5 to 10 (kcal per hunger).
For ones where it does, I used 10.

The actual value for closest conversion is ~8.6. This corresponds to 2500 kcal per day.

I'm not sure if I should change effects here or leave them with conversions for now.