### PR TITLE
Misc fixes for vehicle efficiency, fuel usage estimate and vehicle UI

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -12,7 +12,7 @@
     "flags": [ "TRADER_AVOID" ],
     "material": "iron",
     "effects": [ "COOKOFF" ],
-    "volume": "250 ml",
+    "volume": "100 ml",
     "//": "Setting battery volume to 0 causes weirdness in vehicle tests.  Please don't do that.",
     "ammo_type": "battery",
     "count": 100,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -580,7 +580,7 @@ item &item::ammo_set( const itype_id &ammo, int qty )
     // check ammo is valid for the item
     const itype *atype = item_controller->find_template( ammo );
     if( !atype->ammo || !ammo_types().count( atype->ammo->type ) ) {
-        debugmsg( "Tried to set invalid ammo of %s for %s", atype->nname( qty ), tname() );
+        debugmsg( "Tried to set invalid ammo %s[%d] for %s", atype->get_id(), qty, typeId() );
         return *this;
     }
 
@@ -601,8 +601,8 @@ item &item::ammo_set( const itype_id &ammo, int qty )
         if( !magazine_current() ) {
             const itype *mag = find_type( magazine_default() );
             if( !mag->magazine ) {
-                debugmsg( "Tried to set ammo of %s without suitable magazine for %s",
-                          atype->nname( qty ), tname() );
+                debugmsg( "Tried to set ammo %s[%d] without suitable magazine for %s",
+                          atype->get_id(), qty, typeId() );
                 return *this;
             }
 
@@ -612,7 +612,7 @@ item &item::ammo_set( const itype_id &ammo, int qty )
                 auto iter = type->magazines.find( atype->ammo->type );
                 if( iter == type->magazines.end() ) {
                     debugmsg( "%s doesn't have a magazine for %s",
-                              tname(), ammo );
+                              typeId(), ammo );
                     return *this;
                 }
                 std::vector<itype_id> opts( iter->second.begin(), iter->second.end() );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -733,6 +733,10 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
     }
     if( has_flag( "TURRET" ) ) {
         class::item base( item );
+        if( base.ammo_required() && !base.ammo_remaining() ) {
+            itype_id default_ammo = base.magazine_current() ? base.common_ammo_default() : base.ammo_default();
+            base.ammo_set( default_ammo );
+        }
         long_descrip += string_format( _( "\nRange: %1$5d     Damage: %2$5.0f" ),
                                        base.gun_range( true ),
                                        base.gun_damage().total_damage() );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3373,30 +3373,13 @@ int vehicle::consumption_per_hour( const itype_id &ftype, int fuel_rate_w ) cons
     if( fuel_rate_w == 0 || fuel.has_flag( "PERPETUAL" ) || !engine_on ) {
         return 0;
     }
-    // consume this fuel type's share of alternator load for 3600 seconds
-    int amount_pct = 3600 * alternator_load / 1000;
 
-    // calculate fuel consumption for the lower of safe speed or 70 mph
-    // or 0 if the vehicle is idling
-    if( is_moving() ) {
-        int target_v = std::min( safe_velocity(), 70 * 100 );
-        int vslowdown = slowdown( target_v );
-        // add 3600 seconds worth of fuel consumption for the engine
-        // HACK: engines consume 1 second worth of fuel per turn, even though a turn is 6 seconds
-        if( vslowdown > 0 ) {
-            int accel = acceleration( true, target_v );
-            if( accel == 0 ) {
-                // FIXME: Long-term plan is to change the fuel consumption
-                // computation entirely; for now just warn if this would
-                // otherwise have been division-by-zero
-                debugmsg( "Vehicle unexpectedly has zero acceleration" );
-            } else {
-                amount_pct += 600 * vslowdown / accel;
-            }
-        }
-    }
-    int energy_j_per_mL = fuel.fuel_energy() * 1000;
-    return -amount_pct * fuel_rate_w / energy_j_per_mL;
+    float j_per_turn = fuel_rate_w;
+    float j_per_second = j_per_turn / to_seconds<float>( time_duration::from_turns( 1 ) );
+    float kj_per_hour = j_per_second * 3.6f;
+    float kj_per_mL = fuel.fuel_energy();
+
+    return kj_per_hour / kj_per_mL;
 }
 
 int vehicle::total_power_w( const bool fueled, const bool safe ) const

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -441,14 +441,18 @@ void vehicle::print_fuel_indicator( const catacurses::window &win, const point &
                 tank_color = c_light_red;
                 tank_goal = _( "empty" );
             }
+
+            // promote to double so esimate doesn't overflow for high fuel values
+            // 3600 * tank_use overflows signed 32 bit when tank_use is over ~596523
+            double turns = to_turns<double>( 60_minutes );
+            time_duration estimate = time_duration::from_turns( turns * tank_use / std::abs( rate ) );
+
             if( debug_mode ) {
                 wprintz( win, tank_color, _( ", %d %s(%4.2f%%)/hour, %s until %s" ),
-                         rate, units, 100.0 * rate  / cap,
-                         to_string_clipped( 60_minutes * tank_use / std::abs( rate ) ), tank_goal );
+                         rate, units, 100.0 * rate  / cap, to_string_clipped( estimate ), tank_goal );
             } else {
                 wprintz( win, tank_color, _( ", %3.1f%% / hour, %s until %s" ),
-                         100.0 * rate  / cap,
-                         to_string_clipped( 60_minutes * tank_use / std::abs( rate ) ), tank_goal );
+                         100.0 * rate  / cap, to_string_clipped( estimate ), tank_goal );
             }
         }
     }

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -417,7 +417,7 @@ void vehicle::print_fuel_indicator( const catacurses::window &win, const point &
         int rate = 0;
         std::string units;
         if( fuel_data != fuel_usages.end() ) {
-            rate = consumption_per_hour( fuel_type, fuel_data->second );
+            rate = -consumption_per_hour( fuel_type, fuel_data->second );
             units = _( "mL" );
         }
         if( fuel_type == itype_id( "battery" ) ) {
@@ -441,6 +441,14 @@ void vehicle::print_fuel_indicator( const catacurses::window &win, const point &
                 tank_color = c_light_red;
                 tank_goal = _( "empty" );
             }
+
+            item fitem( fuel_type );
+            int charges_per_L = fitem.charges_per_volume( 1_liter );
+            if( charges_per_L == 0 || charges_per_L == item::INFINITE_CHARGES ) {
+                return;
+            }
+            float charges_per_mL = charges_per_L / 1000.0f;
+            tank_use = tank_use / charges_per_mL;
 
             // promote to double so esimate doesn't overflow for high fuel values
             // 3600 * tank_use overflows signed 32 bit when tank_use is over ~596523

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -198,7 +198,7 @@ void vehicle::thrust( int thd, int z )
         load = ( thrusting ? 1000 : 0 );
     }
     // rotorcraft need to spend 15% of load to hover, 30% to change z
-    if( is_rotorcraft() && is_flying_in_air() ) {
+    if( is_rotorcraft() && ( z > 0 || is_flying_in_air() ) ) {
         load = std::max( load, z > 0 ? 300 : 150 );
         thrusting = true;
     }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -166,43 +166,41 @@ void vehicle::thrust( int thd, int z )
         }
         return;
     }
-    int max_vel = traction * max_velocity();
-
-    // Get braking power
-    int brk = std::max( 1000, std::abs( max_vel ) * 3 / 10 );
-
+    const int max_vel = traction * max_velocity();
+    // maximum braking is 20 mph/s, assumes high friction tires
+    const int max_brake = 20 * 100;
     //pos or neg if accelerator or brake
-    int vel_inc = ( ( thrusting ) ? accel : brk ) * thd;
+    int vel_inc = ( accel + ( thrusting ? 0 : max_brake ) ) * thd;
     // Reverse is only 60% acceleration, unless an electric motor is in use
     if( thd == -1 && thrusting && !has_engine_type( fuel_type_battery, true ) ) {
         vel_inc = .6 * vel_inc;
     }
 
-    //find power ratio used of engines max
+    //find ratio of used acceleration to maximum available, returned in tenths of a percent
+    //so 1000 = 100% and 453 = 45.3%
     int load;
     // Keep exact cruise control speed
     if( cruise_on && accel != 0 ) {
         int effective_cruise = std::min( cruise_velocity, max_vel );
         if( thd > 0 ) {
             vel_inc = std::min( vel_inc, effective_cruise - velocity );
-            //find power ratio used of engines max
-            load = 1000 * std::max( 0, vel_inc ) / std::max( ( thrusting ? accel : brk ), 1 );
         } else {
             vel_inc = std::max( vel_inc, effective_cruise - velocity );
-            load = 1000 * std::min( 0, vel_inc ) / std::max( ( thrusting ? accel : brk ), 1 );
         }
-        if( z != 0 ) {
-            // @TODO : actual engine strain / load for going up a z-level.
-            load = 1;
-            thrusting = true;
+        if( thrusting ) {
+            load = 1000 * std::abs( vel_inc ) / accel;
+        } else {
+            // brakes provide 20 mph/s of slowdown and the rest is engine braking
+            // TODO: braking depends on wheels, traction, driver skill
+            load = 1000 * std::max( 0, std::abs( vel_inc ) - max_brake ) / accel;
         }
     } else {
-        if( z != 0 ) {
-            load = 1;
-            thrusting = true;
-        } else {
-            load = ( thrusting ? 1000 : 0 );
-        }
+        load = ( thrusting ? 1000 : 0 );
+    }
+    // rotorcraft need to spend 15% of load to hover, 30% to change z
+    if( is_rotorcraft() && is_flying_in_air() ) {
+        load = std::max( load, z > 0 ? 300 : 150 );
+        thrusting = true;
     }
 
     // only consume resources if engine accelerating

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -315,19 +315,25 @@ static int avg_from_stat( const efficiency_stat &st )
     return ugly_integer - ugly_integer % precision;
 }
 
-static void print_test_strings( const std::string &type )
+static int print_test_strings( const std::string &type, bool in_reverse = false )
 {
     int expected_mass = 0;
-    int v1 = avg_from_stat( find_inner( type, expected_mass, "t_pavement", -1, false, false ) );
+    int v1 = avg_from_stat( find_inner( type, expected_mass, "t_pavement", -1, false, false,
+                                        in_reverse ) );
     int expm = expected_mass;
-    int v2 = avg_from_stat( find_inner( type, expected_mass, "t_dirt", -1, false, false ) );
-    int v3 = avg_from_stat( find_inner( type, expected_mass, "t_pavement", 5, false, false ) );
-    int v4 = avg_from_stat( find_inner( type, expected_mass, "t_dirt", 5, false, false ) );
+    int v2 = avg_from_stat( find_inner( type, expected_mass, "t_dirt", -1, false, false,
+                                        in_reverse ) );
+    int v3 = avg_from_stat( find_inner( type, expected_mass, "t_pavement", 5, false, false,
+                                        in_reverse ) );
+    int v4 = avg_from_stat( find_inner( type, expected_mass, "t_dirt", 5, false, false,
+                                        in_reverse ) );
 
     cata_printf(
-        "    test_vehicle( \"%s\", %d; %d, %d, %d, %d );\n",
-        type, expm, v1, v2, v3, v4
+        "    test_vehicle( \"%s\", %d, %d, %d, %d, %d%s );\n",
+        type, expm, v1, v2, v3, v4, in_reverse ? ", 0, 0, true" : ""
     );
+
+    return v1;
 }
 
 static void test_vehicle(
@@ -408,7 +414,7 @@ TEST_CASE( "make_vehicle_efficiency_case", "[.]" )
         const int in_forward = print_test_strings( veh );
         forward_distance[ veh ] = in_forward;
     }
-    printf( "// in reverse\n" );
+    printf( "\n    // in reverse\n" );
     for( const std::string &veh : vehs_to_test ) {
         const int in_reverse = print_test_strings( veh, true );
         CHECK( in_reverse < ( acceptable * forward_distance[ veh ] ) );
@@ -421,41 +427,42 @@ TEST_CASE( "make_vehicle_efficiency_case", "[.]" )
 // Fix test for electric vehicles
 TEST_CASE( "vehicle_efficiency", "[vehicle] [engine]" )
 {
-    test_vehicle( "beetle", 816469, 431300, 338700, 95610, 68060 );
-    test_vehicle( "car", 1120618, 617500, 388600, 52730, 25170 );
-    test_vehicle( "car_sports", 1155014, 352600, 267600, 36820, 22360 );
-    test_vehicle( "electric_car", 1047135, 355300, 201600, 22400, 10780 );
-    test_vehicle( "suv", 1320286, 1163000, 630000, 85540, 31840 );
-    test_vehicle( "motorcycle", 163085, 120300, 100900, 63320, 50810 );
+    test_vehicle( "beetle", 815669, 431300, 338700, 95610, 68060 );
+    test_vehicle( "car", 1120618, 617500, 386100, 52730, 25170 );
+    test_vehicle( "car_sports", 1154214, 352600, 267600, 36790, 22350 );
+    test_vehicle( "electric_car", 1126087, 346600, 181500, 20480, 8492 );
+    test_vehicle( "suv", 1320286, 1163000, 630000, 85540, 30810 );
+    test_vehicle( "motorcycle", 163085, 120300, 99920, 63320, 50810 );
     test_vehicle( "quad_bike", 265345, 116100, 116100, 46770, 46770 );
-    test_vehicle( "scooter", 55941, 235900, 235900, 174700, 174700 );
+    test_vehicle( "scooter", 62587, 228800, 216400, 170200, 161900 );
     test_vehicle( "superbike", 242085, 109800, 65300, 41780, 24070 );
-    test_vehicle( "ambulance", 1839299, 623000, 511100, 78160, 58670 );
-    test_vehicle( "fire_engine", 2628611, 1885000, 1566000, 335800, 259200 );
-    test_vehicle( "fire_truck", 6314603, 410700, 83850, 19470, 4461 );
-    test_vehicle( "truck_swat", 5959334, 682900, 131900, 29610, 7604 );
-    test_vehicle( "tractor_plow", 723658, 681200, 681200, 132700, 132700 );
+    test_vehicle( "ambulance", 1839299, 613400, 504700, 77700, 58290 );
+    test_vehicle( "fire_engine", 2628611, 1885000, 1558000, 334700, 257000 );
+    test_vehicle( "fire_truck", 6314603, 410700, 83850, 19080, 4063 );
+    test_vehicle( "truck_swat", 5959334, 682900, 131700, 29610, 7604 );
+    test_vehicle( "tractor_plow", 723658, 681200, 681200, 132400, 132400 );
     test_vehicle( "apc", 5801619, 1626000, 1119000, 130800, 85590 );
-    test_vehicle( "humvee", 5503345, 767900, 306900, 25620, 9171 );
+    test_vehicle( "humvee", 5503245, 767900, 306900, 25620, 9171 );
     test_vehicle( "road_roller", 8829220, 602500, 147100, 22760, 6925 );
     test_vehicle( "golf_cart", 444630, 96000, 69390, 35490, 14200 );
+
     // in reverse
-    test_vehicle( "beetle", 816469, 58970, 58870, 44560, 43060, 0, 0, true );
-    test_vehicle( "car", 1120618, 76060, 76060, 44230, 24920, 0, 0, true );
-    test_vehicle( "car_sports", 1155014, 353200, 268000, 35220, 19540, 0, 0, true );
-    test_vehicle( "electric_car", 1047135, 356400, 202300, 22450, 10810, 0, 0, true );
-    test_vehicle( "suv", 1320286, 112000, 111700, 66880, 31640, 0, 0, true );
+    test_vehicle( "beetle", 815669, 58970, 58870, 44560, 43060, 0, 0, true );
+    test_vehicle( "car", 1120618, 76060, 76060, 44230, 24870, 0, 0, true );
+    test_vehicle( "car_sports", 1154214, 353200, 268000, 35200, 19540, 0, 0, true );
+    test_vehicle( "electric_car", 1126087, 347700, 182100, 20520, 8516, 0, 0, true );
+    test_vehicle( "suv", 1320286, 112000, 111800, 66880, 31670, 0, 0, true );
     test_vehicle( "motorcycle", 163085, 19980, 19030, 15490, 14890, 0, 0, true );
     test_vehicle( "quad_bike", 265345, 19650, 19650, 15440, 15440, 0, 0, true );
-    test_vehicle( "scooter", 55941, 58790, 58790, 46320, 46320, 0, 0, true );
-    test_vehicle( "superbike", 242085, 18320, 10570, 13100, 8497, 0, 0, true );
-    test_vehicle( "ambulance", 1839299, 58510, 57740, 42480, 39080, 0, 0, true );
-    test_vehicle( "fire_engine", 2628611, 258000, 257600, 181200, 173500, 0, 0, true );
-    test_vehicle( "fire_truck", 6314603, 58440, 58720, 18920, 4480, 0, 0, true );
+    test_vehicle( "scooter", 62587, 59160, 59160, 46320, 46320, 0, 0, true );
+    test_vehicle( "superbike", 242085, 18320, 10570, 13070, 8497, 0, 0, true );
+    test_vehicle( "ambulance", 1839299, 58460, 57780, 42480, 39130, 0, 0, true );
+    test_vehicle( "fire_engine", 2628611, 258000, 257800, 179800, 173300, 0, 0, true );
+    test_vehicle( "fire_truck", 6314603, 58480, 58640, 18600, 4471, 0, 0, true );
     test_vehicle( "truck_swat", 5959334, 129300, 130100, 29350, 7668, 0, 0, true );
-    test_vehicle( "tractor_plow", 723658, 72490, 72490, 53700, 53700, 0, 0, true );
+    test_vehicle( "tractor_plow", 723658, 72240, 72240, 53610, 53610, 0, 0, true );
     test_vehicle( "apc", 5801619, 381500, 382100, 123600, 82000, 0, 0, true );
-    test_vehicle( "humvee", 5503345, 89940, 89940, 25780, 9086, 0, 0, true );
+    test_vehicle( "humvee", 5503245, 89940, 89940, 25780, 9086, 0, 0, true );
     test_vehicle( "road_roller", 8829220, 97490, 97690, 22880, 6606, 0, 0, true );
     test_vehicle( "golf_cart", 444630, 96150, 28800, 35560, 11150, 0, 0, true );
 }

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -164,7 +164,8 @@ const int cycle_limit = 100;
 static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
                             const ter_id &terrain,
                             const int reset_velocity_turn, const int target_distance,
-                            const bool smooth_stops = false, const bool test_mass = true )
+                            const bool smooth_stops = false, const bool test_mass = true,
+                            const bool in_reverse = false )
 {
     int min_dist = target_distance * 0.99;
     int max_dist = target_distance * 1.01;
@@ -207,7 +208,8 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
     veh.tags.insert( "IN_CONTROL_OVERRIDE" );
     veh.engine_on = true;
 
-    const int target_velocity = std::min( 70 * 100, veh.safe_ground_velocity( false ) );
+    const int sign = in_reverse ? -1 : 1;
+    const int target_velocity = sign * std::min( 50 * 100, veh.safe_ground_velocity( false ) );
     veh.cruise_velocity = target_velocity;
     // If we aren't testing repeated cold starts, start the vehicle at cruising velocity.
     // Otherwise changing the amount of fuel in the tank perturbs the test results.
@@ -265,12 +267,12 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
 
 static efficiency_stat find_inner(
     const std::string &type, int &expected_mass, const std::string &terrain, const int delay,
-    const bool smooth, const bool test_mass = false )
+    const bool smooth, const bool test_mass = false, const bool in_reverse = false )
 {
     efficiency_stat efficiency;
     for( int i = 0; i < 10; i++ ) {
         efficiency.add( test_efficiency( vproto_id( type ), expected_mass, ter_id( terrain ),
-                                         delay, -1, smooth, test_mass ) );
+                                         delay, -1, smooth, test_mass, in_reverse ) );
     }
     return efficiency;
 }
@@ -332,33 +334,35 @@ static void test_vehicle(
     std::string type, int expected_mass,
     const int pavement_target, const int dirt_target,
     const int pavement_target_w_stops, const int dirt_target_w_stops,
-    const int pavement_target_smooth_stops = 0, const int dirt_target_smooth_stops = 0 )
+    const int pavement_target_smooth_stops = 0, const int dirt_target_smooth_stops = 0,
+    const bool in_reverse = false )
 {
     SECTION( type + " on pavement" ) {
         test_efficiency( vproto_id( type ), expected_mass, ter_id( "t_pavement" ), -1,
-                         pavement_target );
+                         pavement_target, false, true, in_reverse );
     }
     SECTION( type + " on dirt" ) {
-        test_efficiency( vproto_id( type ), expected_mass, ter_id( "t_dirt" ), -1, dirt_target );
+        test_efficiency( vproto_id( type ), expected_mass, ter_id( "t_dirt" ), -1,
+                         dirt_target, false, true, in_reverse );
     }
     SECTION( type + " on pavement, full stop every 5 turns" ) {
         test_efficiency( vproto_id( type ), expected_mass, ter_id( "t_pavement" ), 5,
-                         pavement_target_w_stops );
+                         pavement_target_w_stops, false, true, in_reverse );
     }
     SECTION( type + " on dirt, full stop every 5 turns" ) {
         test_efficiency( vproto_id( type ), expected_mass, ter_id( "t_dirt" ), 5,
-                         dirt_target_w_stops );
+                         dirt_target_w_stops, false, true, in_reverse );
     }
     if( pavement_target_smooth_stops > 0 ) {
         SECTION( type + " on pavement, alternating 5 turns of acceleration and 5 turns of decceleration" ) {
             test_efficiency( vproto_id( type ), expected_mass, ter_id( "t_pavement" ), 5,
-                             pavement_target_smooth_stops, true );
+                             pavement_target_smooth_stops, true, true, in_reverse );
         }
     }
     if( dirt_target_smooth_stops > 0 ) {
         SECTION( type + " on dirt, alternating 5 turns of acceleration and 5 turns of decceleration" ) {
             test_efficiency( vproto_id( type ), expected_mass, ter_id( "t_dirt" ), 5,
-                             dirt_target_smooth_stops, true );
+                             dirt_target_smooth_stops, true, true, in_reverse );
         }
     }
 }
@@ -398,8 +402,16 @@ TEST_CASE( "vehicle_find_efficiency", "[.]" )
 /** This is even less of a test. It generates C++ lines for the actual test below */
 TEST_CASE( "make_vehicle_efficiency_case", "[.]" )
 {
+    const float acceptable = 1.25;
+    std::map<std::string, int> forward_distance;
     for( const std::string &veh : vehs_to_test ) {
-        print_test_strings( veh );
+        const int in_forward = print_test_strings( veh );
+        forward_distance[ veh ] = in_forward;
+    }
+    printf( "// in reverse\n" );
+    for( const std::string &veh : vehs_to_test ) {
+        const int in_reverse = print_test_strings( veh, true );
+        CHECK( in_reverse < ( acceptable * forward_distance[ veh ] ) );
     }
 }
 
@@ -409,22 +421,41 @@ TEST_CASE( "make_vehicle_efficiency_case", "[.]" )
 // Fix test for electric vehicles
 TEST_CASE( "vehicle_efficiency", "[vehicle] [engine]" )
 {
-    test_vehicle( "beetle", 815669, 277800, 211800, 70490, 53160 );
-    test_vehicle( "car", 1120618, 473700, 277500, 45440, 25170 );
-    test_vehicle( "car_sports", 1154214, 360300, 260700, 36450, 20770 );
-    test_vehicle( "electric_car", 1126087, 213400, 116100, 16900, 8492 );
-    test_vehicle( "suv", 1320286, 902100, 451700, 67740, 30810 );
-    test_vehicle( "motorcycle", 163085, 74030, 61180, 46200, 38100 );
-    test_vehicle( "quad_bike", 265345, 73170, 73170, 34300, 34300 );
-    test_vehicle( "scooter", 62587, 228800, 216400, 170200, 161900 );
-    test_vehicle( "superbike", 242085, 68580, 45170, 33670, 21220 );
-    test_vehicle( "ambulance", 1839299, 404800, 323500, 62240, 43840 );
-    test_vehicle( "fire_engine", 2628611, 1136000, 924100, 242300, 209600 );
-    test_vehicle( "fire_truck", 6314603, 288800, 180900, 19080, 4063 );
-    test_vehicle( "truck_swat", 5959334, 483800, 322700, 29610, 7604 );
-    test_vehicle( "tractor_plow", 723658, 482400, 482400, 113900, 113900 );
-    test_vehicle( "apc", 5801619, 1069000, 922400, 130800, 85590 );
-    test_vehicle( "humvee", 5503245, 574300, 325900, 25620, 9171 );
-    test_vehicle( "road_roller", 8829220, 357200, 380200, 22760, 6925 );
-    test_vehicle( "golf_cart", 444630, 52460, 105500, 27250, 14200 );
+    test_vehicle( "beetle", 816469, 431300, 338700, 95610, 68060 );
+    test_vehicle( "car", 1120618, 617500, 388600, 52730, 25170 );
+    test_vehicle( "car_sports", 1155014, 352600, 267600, 36820, 22360 );
+    test_vehicle( "electric_car", 1047135, 355300, 201600, 22400, 10780 );
+    test_vehicle( "suv", 1320286, 1163000, 630000, 85540, 31840 );
+    test_vehicle( "motorcycle", 163085, 120300, 100900, 63320, 50810 );
+    test_vehicle( "quad_bike", 265345, 116100, 116100, 46770, 46770 );
+    test_vehicle( "scooter", 55941, 235900, 235900, 174700, 174700 );
+    test_vehicle( "superbike", 242085, 109800, 65300, 41780, 24070 );
+    test_vehicle( "ambulance", 1839299, 623000, 511100, 78160, 58670 );
+    test_vehicle( "fire_engine", 2628611, 1885000, 1566000, 335800, 259200 );
+    test_vehicle( "fire_truck", 6314603, 410700, 83850, 19470, 4461 );
+    test_vehicle( "truck_swat", 5959334, 682900, 131900, 29610, 7604 );
+    test_vehicle( "tractor_plow", 723658, 681200, 681200, 132700, 132700 );
+    test_vehicle( "apc", 5801619, 1626000, 1119000, 130800, 85590 );
+    test_vehicle( "humvee", 5503345, 767900, 306900, 25620, 9171 );
+    test_vehicle( "road_roller", 8829220, 602500, 147100, 22760, 6925 );
+    test_vehicle( "golf_cart", 444630, 96000, 69390, 35490, 14200 );
+    // in reverse
+    test_vehicle( "beetle", 816469, 58970, 58870, 44560, 43060, 0, 0, true );
+    test_vehicle( "car", 1120618, 76060, 76060, 44230, 24920, 0, 0, true );
+    test_vehicle( "car_sports", 1155014, 353200, 268000, 35220, 19540, 0, 0, true );
+    test_vehicle( "electric_car", 1047135, 356400, 202300, 22450, 10810, 0, 0, true );
+    test_vehicle( "suv", 1320286, 112000, 111700, 66880, 31640, 0, 0, true );
+    test_vehicle( "motorcycle", 163085, 19980, 19030, 15490, 14890, 0, 0, true );
+    test_vehicle( "quad_bike", 265345, 19650, 19650, 15440, 15440, 0, 0, true );
+    test_vehicle( "scooter", 55941, 58790, 58790, 46320, 46320, 0, 0, true );
+    test_vehicle( "superbike", 242085, 18320, 10570, 13100, 8497, 0, 0, true );
+    test_vehicle( "ambulance", 1839299, 58510, 57740, 42480, 39080, 0, 0, true );
+    test_vehicle( "fire_engine", 2628611, 258000, 257600, 181200, 173500, 0, 0, true );
+    test_vehicle( "fire_truck", 6314603, 58440, 58720, 18920, 4480, 0, 0, true );
+    test_vehicle( "truck_swat", 5959334, 129300, 130100, 29350, 7668, 0, 0, true );
+    test_vehicle( "tractor_plow", 723658, 72490, 72490, 53700, 53700, 0, 0, true );
+    test_vehicle( "apc", 5801619, 381500, 382100, 123600, 82000, 0, 0, true );
+    test_vehicle( "humvee", 5503345, 89940, 89940, 25780, 9086, 0, 0, true );
+    test_vehicle( "road_roller", 8829220, 97490, 97690, 22880, 6606, 0, 0, true );
+    test_vehicle( "golf_cart", 444630, 96150, 28800, 35560, 11150, 0, 0, true );
 }

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -396,7 +396,7 @@ TEST_CASE( "vehicle_find_efficiency", "[.]" )
 }
 
 /** This is even less of a test. It generates C++ lines for the actual test below */
-TEST_CASE( "vehicle_make_efficiency_case", "[.]" )
+TEST_CASE( "make_vehicle_efficiency_case", "[.]" )
 {
     for( const std::string &veh : vehs_to_test ) {
         print_test_strings( veh );

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -430,7 +430,7 @@ TEST_CASE( "vehicle_efficiency", "[vehicle] [engine]" )
     test_vehicle( "beetle", 815669, 431300, 338700, 95610, 68060 );
     test_vehicle( "car", 1120618, 617500, 386100, 52730, 25170 );
     test_vehicle( "car_sports", 1154214, 352600, 267600, 36790, 22350 );
-    test_vehicle( "electric_car", 1126087, 346600, 181500, 20480, 8492 );
+    test_vehicle( "electric_car", 1126087, 132700, 72290, 8160, 3390 );
     test_vehicle( "suv", 1320286, 1163000, 630000, 85540, 30810 );
     test_vehicle( "motorcycle", 163085, 120300, 99920, 63320, 50810 );
     test_vehicle( "quad_bike", 265345, 116100, 116100, 46770, 46770 );
@@ -444,13 +444,13 @@ TEST_CASE( "vehicle_efficiency", "[vehicle] [engine]" )
     test_vehicle( "apc", 5801619, 1626000, 1119000, 130800, 85590 );
     test_vehicle( "humvee", 5503245, 767900, 306900, 25620, 9171 );
     test_vehicle( "road_roller", 8829220, 602500, 147100, 22760, 6925 );
-    test_vehicle( "golf_cart", 444630, 96000, 69390, 35490, 14200 );
+    test_vehicle( "golf_cart", 444630, 37080, 27460, 14080, 5671 );
 
     // in reverse
     test_vehicle( "beetle", 815669, 58970, 58870, 44560, 43060, 0, 0, true );
     test_vehicle( "car", 1120618, 76060, 76060, 44230, 24870, 0, 0, true );
     test_vehicle( "car_sports", 1154214, 353200, 268000, 35200, 19540, 0, 0, true );
-    test_vehicle( "electric_car", 1126087, 347700, 182100, 20520, 8516, 0, 0, true );
+    test_vehicle( "electric_car", 1126087, 133100, 72520, 8140, 3390, 0, 0, true );
     test_vehicle( "suv", 1320286, 112000, 111800, 66880, 31670, 0, 0, true );
     test_vehicle( "motorcycle", 163085, 19980, 19030, 15490, 14890, 0, 0, true );
     test_vehicle( "quad_bike", 265345, 19650, 19650, 15440, 15440, 0, 0, true );
@@ -464,5 +464,5 @@ TEST_CASE( "vehicle_efficiency", "[vehicle] [engine]" )
     test_vehicle( "apc", 5801619, 381500, 382100, 123600, 82000, 0, 0, true );
     test_vehicle( "humvee", 5503245, 89940, 89940, 25780, 9086, 0, 0, true );
     test_vehicle( "road_roller", 8829220, 97490, 97690, 22880, 6606, 0, 0, true );
-    test_vehicle( "golf_cart", 444630, 96150, 28800, 35560, 11150, 0, 0, true );
+    test_vehicle( "golf_cart", 444630, 37140, 11510, 14110, 4440, 0, 0, true );
 }


### PR DESCRIPTION
#### Purpose of change
Fix fuel usage estimate in vehicle UI.
Fix turret damage estimate in vehicle UI.
Fix moving in reverse does not consume fuel for acceleration.
Fix emotors consider 1 battery charge as 2.5kJ worth of energy, not 1kJ as the rest of the code does.

#### Describe the solution
For fuel estimate, fix calculations in `vehicle::consumption_per_hour()`. I'm not sure what it was calculating before (some legacy value?), but now it calculates fuel consumption in millilitres based on joules consumed this turn. Also, display code assumed that returned value was in charges, which broke display for non-1-millilitre-per-charge fuels -- added proper conversion for that.

For battery energy density, "energy" field of fuel islot is per-millilitre, so make 1 charge of battery be 1mL.

Other fixes were ported from DDA:
https://github.com/CleverRaven/Cataclysm-DDA/pull/44005
https://github.com/CleverRaven/Cataclysm-DDA/pull/43037
https://github.com/CleverRaven/Cataclysm-DDA/pull/42626 + https://github.com/CleverRaven/Cataclysm-DDA/pull/45111

#### Describe alternatives you've considered
An elaborate fuel tracker that gives estimates by extrapolating consumption over the last N turns. That turned out kinda meh.

Convert "energy" back to per-charge, but that's a bit more involved and may screw with balancing in unofficial mods.

#### Testing
Cars no longer promise years of continuous operation.

Checked that estimated time matches actual time in the following scenarios:
1. Idling car 
2. Idling portable generator
3. Helicopter at top speed with cruise control enabled
4. Car at steady speed with cc
5. Amphibious truck on water at steady spead with cc
6. Solar car at steady speed with cc
7. Recharging stationary solar car

Estimate does not count in fuel consumption from direct control (ascending/descending helicopters, driving without cruise control), but I'm not sure whether it should. It also uses averaged solar panel energy output, not actual once-each-60-seconds output, so at low charge levels and tiny consumption rates it gets a bit incorrect.

#### Additional context
Some other fuels may also need energy density fix?
