### PR TITLE
Port DDA fix for Clang 12 complaint on Mac

### DIFF
--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -1,4 +1,5 @@
 #include "crash.h"
+#include "sdl_wrappers.h"
 
 #if defined(BACKTRACE)
 
@@ -11,14 +12,6 @@
 #include <sstream>
 #include <string>
 #include <typeinfo>
-
-#if defined(TILES)
-#   if defined(_MSC_VER) && defined(USE_VCPKG)
-#       include <SDL2/SDL.h>
-#   else
-#       include <SDL.h>
-#   endif
-#endif
 
 #if defined(_WIN32)
 #if 1 // HACK: Hack to prevent reordering of #include "platform_win.h" by IWYU

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -39,6 +39,7 @@
 #include "output.h"
 #include "path_info.h"
 #include "point.h"
+#include "sdl_wrappers.h"
 #include "string_utils.h"
 #include "translations.h"
 #include "type_id.h"
@@ -66,14 +67,6 @@
 #       include <unistd.h>
 #   endif
 #endif
-
-#if defined(TILES)
-#   if defined(_MSC_VER) && defined(USE_VCPKG)
-#       include <SDL2/SDL.h>
-#   else
-#       include <SDL.h>
-#   endif
-#endif // TILES
 
 #if defined(__ANDROID__)
 // used by android_version() function for __system_property_get().

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -6,17 +6,10 @@
 #include "cached_options.h"
 #include "color.h"
 #include "output.h"
+#include "sdl_wrappers.h"
 #include "translations.h"
 #include "ui.h"
 #include "ui_manager.h"
-
-#if defined(TILES)
-#   if defined(_MSC_VER) && defined(USE_VCPKG)
-#       include <SDL2/SDL.h>
-#   else
-#       include <SDL.h>
-#   endif
-#endif // TILES
 
 loading_ui::loading_ui( bool display )
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@
 #include "output.h"
 #include "path_info.h"
 #include "rng.h"
+#include "sdl_wrappers.h"
 #include "type_id.h"
 
 class ui_adaptor;
@@ -47,10 +48,8 @@ class ui_adaptor;
 #   define SDL_MAIN_HANDLED
 #   if defined(_MSC_VER) && defined(USE_VCPKG)
 #      include <SDL2/SDL_version.h>
-#      include <SDL2/SDL.h>
 #   else
 #      include <SDL_version.h>
-#      include <SDL.h>
 #   endif
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,13 +39,13 @@
 #include "output.h"
 #include "path_info.h"
 #include "rng.h"
-#include "sdl_wrappers.h"
 #include "type_id.h"
 
 class ui_adaptor;
 
 #if defined(TILES)
 #   define SDL_MAIN_HANDLED
+#   include "sdl_wrappers.h"
 #   if defined(_MSC_VER) && defined(USE_VCPKG)
 #      include <SDL2/SDL_version.h>
 #   else

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -24,6 +24,7 @@
 #include "player_activity.h"
 #include "pldata.h"
 #include "rng.h"
+#include "sdl_wrappers.h"
 #include "sounds.h"
 #include "stomach.h"
 #include "string_formatter.h"
@@ -31,15 +32,6 @@
 #include "translations.h"
 #include "weather.h"
 #include "vitamin.h"
-
-#if defined(TILES)
-#   if defined(_MSC_VER) && defined(USE_VCPKG)
-#       include <SDL2/SDL.h>
-#   else
-#       include <SDL.h>
-#   endif
-#endif // TILES
-
 #include <algorithm>
 #include <functional>
 

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -9,15 +9,8 @@
 #include "ime.h"
 #include "input.h"
 #include "output.h"
+#include "sdl_wrappers.h"
 #include "ui_manager.h"
-
-#if defined(TILES)
-#   if defined(_MSC_VER) && defined(USE_VCPKG)
-#       include <SDL2/SDL.h>
-#   else
-#       include <SDL.h>
-#   endif
-#endif // TILES
 
 query_popup::query_popup()
     : cur( 0 ), default_text_color( c_white ), anykey( false ), cancel( false ), ontop( false ),

--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -2,6 +2,8 @@
 #ifndef CATA_SRC_SDL_WRAPPERS_H
 #define CATA_SRC_SDL_WRAPPERS_H
 
+#if defined(TILES)
+
 // IWYU pragma: begin_exports
 #if defined(_MSC_VER) && defined(USE_VCPKG)
 #   include <SDL2/SDL.h>
@@ -139,5 +141,7 @@ inline bool operator!=( const SDL_Rect &lhs, const SDL_Rect &rhs )
 }
 
 /**@}*/
+
+#endif // if defined(TILES)
 
 #endif // CATA_SRC_SDL_WRAPPERS_H

--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -8,7 +8,10 @@
 #   include <SDL2/SDL_image.h>
 #   include <SDL2/SDL_ttf.h>
 #else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #   include <SDL.h>
+#pragma GCC diagnostic pop
 #   include <SDL_image.h>
 #   include <SDL_ttf.h>
 #endif


### PR DESCRIPTION
Closes #787

Clang 12 needs to be specifically informed not to use `-Wold-style-cast` when including `SDL.h`.
Changed all inclusions of `SDL.h` to inclusions of `sdl_wrappers.h`.
Unlike in DDA, which wraps inclusion of wrappers in `if defined(TILES)`, I decided to wrap the contents of the file instead, to cut down on boilerplate. I hope this won't cause problems.

I decided to port things manually because the file has a longer history in DDA.

Author of the fix itself is Kevin