### PR TITLE
Bump ubuntu version to 18 on clang-tidy

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     env:
         CMAKE: 1
         CLANG: clang++-8


### PR DESCRIPTION
Ubuntu 16 will be discontinued on Github Actions soon.