### PR TITLE
Fix 3D bresenham for `abs(dx) == abs(dz)` and `abs(dy) == abs(dz)` cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.d
 *.dll
 *.exe
+*.exp
 *.o
 *.tmp
 *.zip

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -23,7 +23,7 @@ void bresenham( const point &p1, const point &p2, int t,
     const int sx = ( d.x == 0 ) ? 0 : sgn( d.x );
     const int sy = ( d.y == 0 ) ? 0 : sgn( d.y );
     // Absolute values of slopes x2 to avoid rounding errors.
-    const point a = abs( d ) * 2;
+    const point a = d.abs() * 2;
 
     point cur = p1;
 
@@ -264,7 +264,7 @@ float rl_dist_exact( const tripoint &loc1, const tripoint &loc2 )
 
 int manhattan_dist( const point &loc1, const point &loc2 )
 {
-    const point d = abs( loc1 - loc2 );
+    const point d = ( loc1 - loc2 ).abs();
     return d.x + d.y;
 }
 

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -20,8 +20,7 @@ void bresenham( const point &p1, const point &p2, int t,
     // The slope components.
     const point d = p2 - p1;
     // Signs of slope values.
-    const int sx = ( d.x == 0 ) ? 0 : sgn( d.x );
-    const int sy = ( d.y == 0 ) ? 0 : sgn( d.y );
+    const point s( ( d.x == 0 ) ? 0 : sgn( d.x ), ( d.y == 0 ) ? 0 : sgn( d.y ) );
     // Absolute values of slopes x2 to avoid rounding errors.
     const point a = d.abs() * 2;
 
@@ -29,8 +28,8 @@ void bresenham( const point &p1, const point &p2, int t,
 
     if( a.x == a.y ) {
         while( cur.x != p2.x ) {
-            cur.y += sy;
-            cur.x += sx;
+            cur.y += s.y;
+            cur.x += s.x;
             if( !interact( cur ) ) {
                 break;
             }
@@ -38,10 +37,10 @@ void bresenham( const point &p1, const point &p2, int t,
     } else if( a.x > a.y ) {
         while( cur.x != p2.x ) {
             if( t > 0 ) {
-                cur.y += sy;
+                cur.y += s.y;
                 t -= a.x;
             }
-            cur.x += sx;
+            cur.x += s.x;
             t += a.y;
             if( !interact( cur ) ) {
                 break;
@@ -50,10 +49,10 @@ void bresenham( const point &p1, const point &p2, int t,
     } else {
         while( cur.y != p2.y ) {
             if( t > 0 ) {
-                cur.x += sx;
+                cur.x += s.x;
                 t -= a.y;
             }
-            cur.y += sy;
+            cur.y += s.y;
             t += a.x;
             if( !interact( cur ) ) {
                 break;
@@ -66,37 +65,32 @@ void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
                 const std::function<bool( const tripoint & )> &interact )
 {
     // The slope components.
-    const int dx = loc2.x - loc1.x;
-    const int dy = loc2.y - loc1.y;
-    const int dz = loc2.z - loc1.z;
+    const tripoint d( -loc1 + loc2 );
     // The signs of the slopes.
-    const int sx = ( dx == 0 ? 0 : sgn( dx ) );
-    const int sy = ( dy == 0 ? 0 : sgn( dy ) );
-    const int sz = ( dz == 0 ? 0 : sgn( dz ) );
+    const tripoint s( ( d.x == 0 ? 0 : sgn( d.x ) ), ( d.y == 0 ? 0 : sgn( d.y ) ),
+                      ( d.z == 0 ? 0 : sgn( d.z ) ) );
     // Absolute values of slope components, x2 to avoid rounding errors.
-    const int ax = std::abs( dx ) * 2;
-    const int ay = std::abs( dy ) * 2;
-    const int az = std::abs( dz ) * 2;
+    const tripoint a( std::abs( d.x ) * 2, std::abs( d.y ) * 2, std::abs( d.z ) * 2 );
 
     tripoint cur( loc1 );
 
-    if( az == 0 ) {
-        if( ax == ay ) {
+    if( a.z == 0 ) {
+        if( a.x == a.y ) {
             while( cur.x != loc2.x ) {
-                cur.y += sy;
-                cur.x += sx;
+                cur.y += s.y;
+                cur.x += s.x;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
-        } else if( ax > ay ) {
+        } else if( a.x > a.y ) {
             while( cur.x != loc2.x ) {
                 if( t > 0 ) {
-                    cur.y += sy;
-                    t -= ax;
+                    cur.y += s.y;
+                    t -= a.x;
                 }
-                cur.x += sx;
-                t += ay;
+                cur.x += s.x;
+                t += a.y;
                 if( !interact( cur ) ) {
                     break;
                 }
@@ -104,95 +98,95 @@ void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
         } else {
             while( cur.y != loc2.y ) {
                 if( t > 0 ) {
-                    cur.x += sx;
-                    t -= ay;
+                    cur.x += s.x;
+                    t -= a.y;
                 }
-                cur.y += sy;
-                t += ax;
+                cur.y += s.y;
+                t += a.x;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
         }
     } else {
-        if( ax == ay && ay == az ) {
+        if( a.x == a.y && a.y == a.z ) {
             while( cur.x != loc2.x ) {
-                cur.z += sz;
-                cur.y += sy;
-                cur.x += sx;
+                cur.z += s.z;
+                cur.y += s.y;
+                cur.x += s.x;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
-        } else if( ( az > ax ) && ( az > ay ) ) {
+        } else if( ( a.z > a.x ) && ( a.z > a.y ) ) {
             while( cur.z != loc2.z ) {
                 if( t > 0 ) {
-                    cur.x += sx;
-                    t -= az;
+                    cur.x += s.x;
+                    t -= a.z;
                 }
                 if( t2 > 0 ) {
-                    cur.y += sy;
-                    t2 -= az;
+                    cur.y += s.y;
+                    t2 -= a.z;
                 }
-                cur.z += sz;
-                t += ax;
-                t2 += ay;
+                cur.z += s.z;
+                t += a.x;
+                t2 += a.y;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
-        } else if( ax == ay ) {
+        } else if( a.x == a.y ) {
             while( cur.x != loc2.x ) {
                 if( t > 0 ) {
-                    cur.z += sz;
-                    t -= ax;
+                    cur.z += s.z;
+                    t -= a.x;
                 }
-                cur.y += sy;
-                cur.x += sx;
-                t += az;
+                cur.y += s.y;
+                cur.x += s.x;
+                t += a.z;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
-        } else if( ax == az ) {
+        } else if( a.x == a.z ) {
             while( cur.x != loc2.x ) {
                 if( t > 0 ) {
-                    cur.y += sy;
-                    t -= ax;
+                    cur.y += s.y;
+                    t -= a.x;
                 }
-                cur.z += sz;
-                cur.x += sx;
-                t += ax;
+                cur.z += s.z;
+                cur.x += s.x;
+                t += a.x;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
-        } else if( ay == az ) {
+        } else if( a.y == a.z ) {
             while( cur.y != loc2.y ) {
                 if( t > 0 ) {
-                    cur.x += sx;
-                    t -= az;
+                    cur.x += s.x;
+                    t -= a.z;
                 }
-                cur.y += sy;
-                cur.z += sz;
-                t += az;
+                cur.y += s.y;
+                cur.z += s.z;
+                t += a.z;
                 if( !interact( cur ) ) {
                     break;
                 }
             }
-        } else if( ax > ay ) {
+        } else if( a.x > a.y ) {
             while( cur.x != loc2.x ) {
                 if( t > 0 ) {
-                    cur.y += sy;
-                    t -= ax;
+                    cur.y += s.y;
+                    t -= a.x;
                 }
                 if( t2 > 0 ) {
-                    cur.z += sz;
-                    t2 -= ax;
+                    cur.z += s.z;
+                    t2 -= a.x;
                 }
-                cur.x += sx;
-                t += ay;
-                t2 += az;
+                cur.x += s.x;
+                t += a.y;
+                t2 += a.z;
                 if( !interact( cur ) ) {
                     break;
                 }
@@ -200,16 +194,16 @@ void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
         } else { //dy > dx >= dz
             while( cur.y != loc2.y ) {
                 if( t > 0 ) {
-                    cur.x += sx;
-                    t -= ay;
+                    cur.x += s.x;
+                    t -= a.y;
                 }
                 if( t2 > 0 ) {
-                    cur.z += sz;
-                    t2 -= ay;
+                    cur.z += s.z;
+                    t2 -= a.y;
                 }
-                cur.y += sy;
-                t += ax;
-                t2 += az;
+                cur.y += s.y;
+                t += a.x;
+                t2 += a.z;
                 if( !interact( cur ) ) {
                     break;
                 }
@@ -507,35 +501,32 @@ std::string direction_suffix( const tripoint &p, const tripoint &q )
 std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &to )
 {
     std::vector<tripoint> adjacent_closer_squares;
-    const int dx = to.x - from.x;
-    const int dy = to.y - from.y;
-    const int dz = to.z - from.z;
-    const int ax = std::abs( dx );
-    const int ay = std::abs( dy );
-    if( dz != 0 ) {
-        adjacent_closer_squares.push_back( from + tripoint( sgn( dx ), sgn( dy ), sgn( dz ) ) );
+    const tripoint d( -from + to );
+    const point a( std::abs( d.x ), std::abs( d.y ) );
+    if( d.z != 0 ) {
+        adjacent_closer_squares.push_back( from + tripoint( sgn( d.x ), sgn( d.y ), sgn( d.z ) ) );
     }
-    if( ax > ay ) {
+    if( a.x > a.y ) {
         // X dominant.
-        adjacent_closer_squares.push_back( from + point( sgn( dx ), 0 ) );
-        adjacent_closer_squares.push_back( from + point( sgn( dx ), 1 ) );
-        adjacent_closer_squares.push_back( from + point( sgn( dx ), -1 ) );
-        if( dy != 0 ) {
-            adjacent_closer_squares.push_back( from + point( 0, sgn( dy ) ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x ), 0 ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x ), 1 ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x ), -1 ) );
+        if( d.y != 0 ) {
+            adjacent_closer_squares.push_back( from + point( 0, sgn( d.y ) ) );
         }
-    } else if( ax < ay ) {
+    } else if( a.x < a.y ) {
         // Y dominant.
-        adjacent_closer_squares.push_back( from + point( 0, sgn( dy ) ) );
-        adjacent_closer_squares.push_back( from + point( 1, sgn( dy ) ) );
-        adjacent_closer_squares.push_back( from + point( -1, sgn( dy ) ) );
-        if( dx != 0 ) {
-            adjacent_closer_squares.push_back( from + point( sgn( dx ), 0 ) );
+        adjacent_closer_squares.push_back( from + point( 0, sgn( d.y ) ) );
+        adjacent_closer_squares.push_back( from + point( 1, sgn( d.y ) ) );
+        adjacent_closer_squares.push_back( from + point( -1, sgn( d.y ) ) );
+        if( d.x != 0 ) {
+            adjacent_closer_squares.push_back( from + point( sgn( d.x ), 0 ) );
         }
-    } else if( dx != 0 ) {
+    } else if( d.x != 0 ) {
         // Pure diagonal.
-        adjacent_closer_squares.push_back( from + point( sgn( dx ), sgn( dy ) ) );
-        adjacent_closer_squares.push_back( from + point( sgn( dx ), 0 ) );
-        adjacent_closer_squares.push_back( from + point( 0, sgn( dy ) ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x ), sgn( d.y ) ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x ), 0 ) );
+        adjacent_closer_squares.push_back( from + point( 0, sgn( d.y ) ) );
     }
 
     return adjacent_closer_squares;

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -135,6 +135,40 @@ void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
                     break;
                 }
             }
+        } else if( ( a.x > a.y ) && ( a.x > a.z ) ) {
+            while( cur.x != loc2.x ) {
+                if( t > 0 ) {
+                    cur.y += s.y;
+                    t -= a.x;
+                }
+                if( t2 > 0 ) {
+                    cur.z += s.z;
+                    t2 -= a.x;
+                }
+                cur.x += s.x;
+                t += a.y;
+                t2 += a.z;
+                if( !interact( cur ) ) {
+                    break;
+                }
+            }
+        } else if( ( a.y > a.z ) && ( a.y > a.x ) ) {
+            while( cur.y != loc2.y ) {
+                if( t > 0 ) {
+                    cur.z += s.z;
+                    t -= a.y;
+                }
+                if( t2 > 0 ) {
+                    cur.x += s.x;
+                    t2 -= a.y;
+                }
+                cur.y += s.y;
+                t += a.z;
+                t2 += a.x;
+                if( !interact( cur ) ) {
+                    break;
+                }
+            }
         } else if( a.x == a.y ) {
             while( cur.x != loc2.x ) {
                 if( t > 0 ) {

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -156,7 +156,7 @@ void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
                 }
                 cur.z += s.z;
                 cur.x += s.x;
-                t += a.x;
+                t += a.y;
                 if( !interact( cur ) ) {
                     break;
                 }
@@ -169,7 +169,7 @@ void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
                 }
                 cur.y += s.y;
                 cur.z += s.z;
-                t += a.z;
+                t += a.x;
                 if( !interact( cur ) ) {
                     break;
                 }

--- a/src/line.h
+++ b/src/line.h
@@ -162,12 +162,12 @@ inline float trig_dist( const point &loc1, const point &loc2 )
 // Roguelike distance; maximum of dX and dY
 inline int square_dist( const tripoint &loc1, const tripoint &loc2 )
 {
-    const tripoint d = abs( loc1 - loc2 );
+    const tripoint d = ( loc1 - loc2 ).abs();
     return std::max( { d.x, d.y, d.z } );
 }
 inline int square_dist( const point &loc1, const point &loc2 )
 {
-    const point d = abs( loc1 - loc2 );
+    const point d = ( loc1 - loc2 ).abs();
     return std::max( d.x, d.y );
 }
 
@@ -224,7 +224,7 @@ inline FastDistanceApproximation trig_dist_fast( const tripoint &loc1, const tri
 }
 inline FastDistanceApproximation square_dist_fast( const tripoint &loc1, const tripoint &loc2 )
 {
-    const tripoint d = abs( loc1 - loc2 );
+    const tripoint d = ( loc1 - loc2 ).abs();
     return std::max( { d.x, d.y, d.z } );
 }
 inline FastDistanceApproximation rl_dist_fast( const tripoint &loc1, const tripoint &loc2 )

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -231,7 +231,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
     // Clockwise Perpendicular of Delta vector
     const point delta_perp( -delta.y, delta.x );
 
-    const point abs_delta = abs( delta );
+    const point abs_delta = delta.abs();
     // Primary axis of delta vector
     const point axis_delta = abs_delta.x > abs_delta.y ? point( delta.x, 0 ) : point( 0, delta.y );
     // Clockwise Perpendicular of axis vector

--- a/src/point.h
+++ b/src/point.h
@@ -72,6 +72,12 @@ struct point {
         return point( x / rhs, y / rhs );
     }
 
+#ifndef CATA_NO_STL
+    inline point abs() const {
+        return point( std::abs( x ), std::abs( y ) );
+    }
+#endif
+
     /**
      * Rotate point clockwise @param turns times, 90 degrees per turn,
      * around the center of a rectangle with the dimensions specified
@@ -177,6 +183,12 @@ struct tripoint {
         z -= rhs.z;
         return *this;
     }
+
+#ifndef CATA_NO_STL
+    inline tripoint abs() const {
+        return tripoint( std::abs( x ), std::abs( y ), std::abs( z ) );
+    }
+#endif
 
     constexpr point xy() const {
         return point( x, y );
@@ -320,16 +332,6 @@ std::vector<tripoint> closest_tripoints_first( const tripoint &center, int min_d
 
 std::vector<point> closest_points_first( const point &center, int max_dist );
 std::vector<point> closest_points_first( const point &center, int min_dist, int max_dist );
-
-inline point abs( const point &p )
-{
-    return point( std::abs( p.x ), std::abs( p.y ) );
-}
-
-inline tripoint abs( const tripoint &p )
-{
-    return tripoint( std::abs( p.x ), std::abs( p.y ), std::abs( p.z ) );
-}
 
 static constexpr tripoint tripoint_min { INT_MIN, INT_MIN, INT_MIN };
 static constexpr tripoint tripoint_max{ INT_MAX, INT_MAX, INT_MAX };

--- a/src/tileray.cpp
+++ b/src/tileray.cpp
@@ -25,7 +25,7 @@ tileray::tileray( int adir ): direction( adir )
 void tileray::init( const point &ad )
 {
     delta = ad;
-    abs_d = abs( delta );
+    abs_d = delta.abs();
     if( delta == point_zero ) {
         direction = 0;
     } else {
@@ -48,7 +48,7 @@ void tileray::init( int adir )
     float direction_radians = static_cast<float>( direction ) * M_PI / 180.0;
     rl_vec2d delta_f( std::cos( direction_radians ), std::sin( direction_radians ) );
     delta = ( delta_f * 100 ).as_point();
-    abs_d = abs( delta );
+    abs_d = delta.abs();
     steps = 0;
     infinite = true;
 }

--- a/tests/line_test.cpp
+++ b/tests/line_test.cpp
@@ -17,61 +17,57 @@
 static std::vector <point> canonical_line_to( const point &p1, const point &p2, int t )
 {
     std::vector<point> ret;
-    const int dx = p2.x - p1.x;
-    const int dy = p2.y - p1.y;
-    const int ax = std::abs( dx ) << 1;
-    const int ay = std::abs( dy ) << 1;
-    int sx = SGN( dx );
-    int sy = SGN( dy );
-    if( dy == 0 ) {
-        sy = 0;
+    const point d( -p1 + p2 );
+    const point a( std::abs( d.x ) << 1, std::abs( d.y ) << 1 );
+    point s( SGN( d.x ), SGN( d.y ) );
+    if( d.y == 0 ) {
+        s.y = 0;
     }
-    if( dx == 0 ) {
-        sx = 0;
+    if( d.x == 0 ) {
+        s.x = 0;
     }
     point cur;
     cur.x = p1.x;
     cur.y = p1.y;
 
-    int xmin = std::min( p1.x, p2.x );
-    int ymin = std::min( p1.y, p2.y );
+    point min( std::min( p1.x, p2.x ), std::min( p1.y, p2.y ) );
     int xmax = std::max( p1.x, p2.x );
     int ymax = std::max( p1.y, p2.y );
 
-    xmin -= std::abs( dx );
-    ymin -= std::abs( dy );
-    xmax += std::abs( dx );
-    ymax += std::abs( dy );
+    min.x -= std::abs( d.x );
+    min.y -= std::abs( d.y );
+    xmax += std::abs( d.x );
+    ymax += std::abs( d.y );
 
-    if( ax == ay ) {
+    if( a.x == a.y ) {
         do {
-            cur.y += sy;
-            cur.x += sx;
+            cur.y += s.y;
+            cur.x += s.x;
             ret.push_back( cur );
         } while( ( cur.x != p2.x || cur.y != p2.y ) &&
-                 ( cur.x >= xmin && cur.x <= xmax && cur.y >= ymin && cur.y <= ymax ) );
-    } else if( ax > ay ) {
+                 ( cur.x >= min.x && cur.x <= xmax && cur.y >= min.y && cur.y <= ymax ) );
+    } else if( a.x > a.y ) {
         do {
             if( t > 0 ) {
-                cur.y += sy;
-                t -= ax;
+                cur.y += s.y;
+                t -= a.x;
             }
-            cur.x += sx;
-            t += ay;
+            cur.x += s.x;
+            t += a.y;
             ret.push_back( cur );
         } while( ( cur.x != p2.x || cur.y != p2.y ) &&
-                 ( cur.x >= xmin && cur.x <= xmax && cur.y >= ymin && cur.y <= ymax ) );
+                 ( cur.x >= min.x && cur.x <= xmax && cur.y >= min.y && cur.y <= ymax ) );
     } else {
         do {
             if( t > 0 ) {
-                cur.x += sx;
-                t -= ay;
+                cur.x += s.x;
+                t -= a.y;
             }
-            cur.y += sy;
-            t += ax;
+            cur.y += s.y;
+            t += a.x;
             ret.push_back( cur );
         } while( ( cur.x != p2.x || cur.y != p2.y ) &&
-                 ( cur.x >= xmin && cur.x <= xmax && cur.y >= ymin && cur.y <= ymax ) );
+                 ( cur.x >= min.x && cur.x <= xmax && cur.y >= min.y && cur.y <= ymax ) );
     }
     return ret;
 }
@@ -361,35 +357,35 @@ static void line_to_comparison( const int iterations )
     REQUIRE( trig_dist( point_zero, point_east ) == 1 );
 
     for( int i = 0; i < RANDOM_TEST_NUM; ++i ) {
-        const int x1 = rng( -COORDINATE_RANGE, COORDINATE_RANGE );
-        const int y1 = rng( -COORDINATE_RANGE, COORDINATE_RANGE );
-        const int x2 = rng( -COORDINATE_RANGE, COORDINATE_RANGE );
-        const int y2 = rng( -COORDINATE_RANGE, COORDINATE_RANGE );
+        const point p1( rng( -COORDINATE_RANGE, COORDINATE_RANGE ), rng( -COORDINATE_RANGE,
+                        COORDINATE_RANGE ) );
+        const point p2( rng( -COORDINATE_RANGE, COORDINATE_RANGE ), rng( -COORDINATE_RANGE,
+                        COORDINATE_RANGE ) );
         int t1 = 0;
         int t2 = 0;
-        REQUIRE( line_to( point( x1, y1 ), point( x2, y2 ), t1 ) == canonical_line_to( point( x1, y1 ),
-                 point( x2, y2 ),
+        REQUIRE( line_to( p1, p2, t1 ) == canonical_line_to( p1,
+                 p2,
                  t2 ) );
     }
 
     {
-        const int x1 = rng( -COORDINATE_RANGE, COORDINATE_RANGE );
-        const int y1 = rng( -COORDINATE_RANGE, COORDINATE_RANGE );
-        const int x2 = rng( -COORDINATE_RANGE, COORDINATE_RANGE );
-        const int y2 = rng( -COORDINATE_RANGE, COORDINATE_RANGE );
+        const point p12( rng( -COORDINATE_RANGE, COORDINATE_RANGE ), rng( -COORDINATE_RANGE,
+                         COORDINATE_RANGE ) );
+        const point p22( rng( -COORDINATE_RANGE, COORDINATE_RANGE ), rng( -COORDINATE_RANGE,
+                         COORDINATE_RANGE ) );
         const int t1 = 0;
         const int t2 = 0;
         int count1 = 0;
         const auto start1 = std::chrono::high_resolution_clock::now();
         while( count1 < iterations ) {
-            line_to( point( x1, y1 ), point( x2, y2 ), t1 );
+            line_to( p12, p22, t1 );
             count1++;
         }
         const auto end1 = std::chrono::high_resolution_clock::now();
         int count2 = 0;
         const auto start2 = std::chrono::high_resolution_clock::now();
         while( count2 < iterations ) {
-            canonical_line_to( point( x1, y1 ), point( x2, y2 ), t2 );
+            canonical_line_to( p12, p22, t2 );
             count2++;
         }
         const auto end2 = std::chrono::high_resolution_clock::now();
@@ -413,10 +409,9 @@ TEST_CASE( "line_to_boundaries", "[line]" )
 {
     for( int i = -60; i < 60; ++i ) {
         for( int j = -60; j < 60; ++j ) {
-            const int ax = std::abs( i ) * 2;
-            const int ay = std::abs( j ) * 2;
-            const int dominant = std::max( ax, ay );
-            const int minor = std::min( ax, ay );
+            const point a( std::abs( i ) * 2, std::abs( j ) * 2 );
+            const int dominant = std::max( a.x, a.y );
+            const int minor = std::min( a.x, a.y );
             const int ideal_start_offset = minor - ( dominant / 2 );
             // get the sign of the start offset.
             const int st( ( ideal_start_offset > 0 ) - ( ideal_start_offset < 0 ) );

--- a/tests/line_test.cpp
+++ b/tests/line_test.cpp
@@ -105,7 +105,7 @@ static bool check_bresenham_far( const tripoint &source, const tripoint &destina
         return false;
     }
     // ...and have proper length; ...
-    if( generated_path.size() != length ) {
+    if( generated_path.size() != static_cast<size_t>( length ) ) {
         FAIL_CHECK( "line has invalid length" );
         return false;
     }


### PR DESCRIPTION
Includes some refactors cherry-picked from commits https://github.com/CleverRaven/Cataclysm-DDA/commit/6d444b891e9be260c8adb955cfe55595d74e8faa and https://github.com/CleverRaven/Cataclysm-DDA/commit/78cb7c199a7f6c30b76642d399dbf7c25de068e3 and a fix cherry-picked from https://github.com/CleverRaven/Cataclysm-DDA/pull/41470.

The missing cases added by me are just copies of the following snippet with axes switched, so I'm not sure whether they properly use `t` and `t2`.
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/99ce588f21dc6d60cd3f7835e1f0d9eb0a0c6e7f/src/line.cpp#L127-L143