### PR TITLE
Vehicles can't go trough open garage gate fix 

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -2152,9 +2152,9 @@
     "symbol": "+",
     "looks_like": "t_door_metal_lab_o",
     "color": "cyan",
-    "move_cost": 1,
+    "move_cost": 2,
     "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "FLAT", "CONNECT_TO_WALL", "BURROWABLE" ],
+    "flags": [ "TRANSPARENT", "FLAT", "CONNECT_TO_WALL", "SUPPORTS_ROOF", "ROAD", "INDOORS", "BURROWABLE" ],
     "bash": {
       "str_min": 80,
       "str_max": 250,


### PR DESCRIPTION
Move_cost changed to 2 to allow vehicles passage and added flags to support roof.

I forgot to test the most important feature of gate last time.
![obraz](https://user-images.githubusercontent.com/37194372/130311421-fb2deb09-7b04-49aa-8737-c18bb2ff3b40.png)
