### PR TITLE
Removed or replaced 1cyl_combustion_small with not small

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -1321,7 +1321,6 @@
       [ "v6_combustion", 10 ],
       [ "v6_diesel", 10 ],
       [ "v8_combustion", 10 ],
-      [ "1cyl_combustion_small", 10 ],
       [ "steam_triple_small", 1 ],
       [ "steam_triple_medium", 1 ],
       [ "steam_watts_small", 1 ],

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -395,7 +395,6 @@
       [ "steam_triple_small", 1 ],
       [ "steam_triple_medium", 1 ],
       [ "steam_watts_small", 1 ],
-      [ "1cyl_combustion_small", 10 ],
       [ "vehicle_controls", 3 ],
       [ "horn_car", 10 ],
       [ "horn_big", 8 ],

--- a/data/json/items/vehicle/engine.json
+++ b/data/json/items/vehicle/engine.json
@@ -74,19 +74,6 @@
     "faults": [ "fault_engine_starter" ]
   },
   {
-    "id": "1cyl_combustion_small",
-    "copy-from": "engine_gasoline",
-    "type": "ENGINE",
-    "name": { "str": "small 1-cylinder engine" },
-    "description": "A small single-cylinder 2-stroke combustion engine.",
-    "weight": "10000 g",
-    "volume": "750 ml",
-    "price": 6000,
-    "price_postapoc": 750,
-    "displacement": 20,
-    "faults": [  ]
-  },
-  {
     "id": "i4_combustion",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",

--- a/data/json/recipes/recipe_electronics.json
+++ b/data/json/recipes/recipe_electronics.json
@@ -89,7 +89,7 @@
       [ [ "metal_tank_little", 1 ] ],
       [ [ "scrap", 2 ] ],
       [ [ "cable", 4 ] ],
-      [ [ "1cyl_combustion_small", 1 ] ]
+      [ [ "1cyl_combustion", 1 ] ]
     ]
   },
   {

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -320,7 +320,7 @@
     "book_learn": [ [ "book_icef", 3 ], [ "textbook_mechanics", 3 ], [ "textbook_carpentry", 3 ] ],
     "using": [ [ "welding_standard", 10 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
-    "components": [ [ [ "1cyl_combustion_small", 1 ] ], [ [ "metal_tank_little", 1 ] ], [ [ "chain", 1 ] ], [ [ "scrap", 3 ] ] ]
+    "components": [ [ [ "1cyl_combustion", 1 ] ], [ [ "metal_tank_little", 1 ] ], [ [ "chain", 1 ] ], [ [ "scrap", 3 ] ] ]
   },
   {
     "result": "masonrysaw_off",
@@ -348,7 +348,7 @@
     ],
     "components": [
       [ [ "circsaw_off", 1 ] ],
-      [ [ "1cyl_combustion_small", 1 ] ],
+      [ [ "1cyl_combustion", 1 ] ],
       [ [ "metal_tank_little", 1 ] ],
       [ [ "steel_chunk", 6 ], [ "steel_lump", 2 ] ]
     ]
@@ -2591,7 +2591,7 @@
     "using": [ [ "welding_standard", 10 ] ],
     "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "components": [
-      [ [ "1cyl_combustion", 1 ], [ "1cyl_combustion_small", 1 ] ],
+      [ [ "1cyl_combustion", 1 ] ],
       [ [ "metal_tank_little", 1 ] ],
       [ [ "rebar", 2 ], [ "steel_chunk", 4 ] ],
       [ [ "scrap", 3 ] ]

--- a/data/json/uncraft/vehicle/engines.json
+++ b/data/json/uncraft/vehicle/engines.json
@@ -41,26 +41,6 @@
   },
   {
     "type": "uncraft",
-    "result": "1cyl_combustion_small",
-    "skill_used": "mechanics",
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
-    "difficulty": 4,
-    "time": "40 m",
-    "components": [
-      [ [ "drivebelt", 2 ] ],
-      [ [ "filter_air", 1 ] ],
-      [ [ "filter_liquid", 1 ] ],
-      [ [ "motor_small", 1 ] ],
-      [ [ "well_pump", 2 ] ],
-      [ [ "power_supply", 1 ] ],
-      [ [ "cable", 40 ] ],
-      [ [ "engine_block_tiny", 1 ] ],
-      [ [ "metal_tank_little", 1 ] ],
-      [ [ "motor_oil", 650 ] ]
-    ]
-  },
-  {
-    "type": "uncraft",
     "result": "i4_combustion",
     "skill_used": "mechanics",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],

--- a/data/json/vehicleparts/combustion.json
+++ b/data/json/vehicleparts/combustion.json
@@ -157,31 +157,6 @@
     "damage_reduction": { "all": 40 }
   },
   {
-    "id": "engine_1cyl_small",
-    "copy-from": "gasoline_engine",
-    "type": "vehicle_part",
-    "item": "1cyl_combustion_small",
-    "//": "5 HP lawnmower engine - a big pusher or small walk-behind",
-    "fuel_type": "gasoline",
-    "durability": 120,
-    "epower": 0,
-    "power": 3728,
-    "energy_consumption": 9320,
-    "folded_volume": 3,
-    "breaks_into": [
-      { "item": "steel_lump", "count": [ 2, 4 ] },
-      { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "count": [ 2, 4 ] }
-    ],
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "vehicle_bolt", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_bolt", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
-    },
-    "extend": { "flags": [ "FOLDABLE" ] },
-    "damage_reduction": { "all": 40 }
-  },
-  {
     "id": "engine_inline4",
     "copy-from": "gasoline_engine",
     "type": "vehicle_part",


### PR DESCRIPTION

#### Purpose of change

Remove 1cyl_combustion_small from the game. It was available only trough deconstruction of trimmer and chainsaw. Some recipes required that engine which source was totally inadvertent. Now all these recipes require just `1cyl_combustion`.


#### Describe alternatives you've considered

should i put that engine in obsolete or something?
#### Testing

i will soon hopefully


