### PR TITLE
Readd extended description key hint to look around menu

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6814,19 +6814,24 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
 
             center_print( w_info, 0, c_white, string_format( _( "< <color_green>Look Around</color> >" ) ) );
 
+            std::string extended_descr_text = string_format( _( "%s - %s" ),
+                                              ctxt.get_desc( "EXTENDED_DESCRIPTION" ),
+                                              ctxt.get_action_name( "EXTENDED_DESCRIPTION" ) );
             std::string fast_scroll_text = string_format( _( "%s - %s" ),
                                            ctxt.get_desc( "TOGGLE_FAST_SCROLL" ),
                                            ctxt.get_action_name( "TOGGLE_FAST_SCROLL" ) );
             std::string pixel_minimap_text = string_format( _( "%s - %s" ),
                                              ctxt.get_desc( "toggle_pixel_minimap" ),
                                              ctxt.get_action_name( "toggle_pixel_minimap" ) );
+
+            center_print( w_info, getmaxy( w_info ) - 2, c_light_gray, extended_descr_text );
             mvwprintz( w_info, point( 1, getmaxy( w_info ) - 1 ), fast_scroll ? c_light_green : c_green,
                        fast_scroll_text );
             right_print( w_info, getmaxy( w_info ) - 1, 1, pixel_minimap_option ? c_light_green : c_green,
                          pixel_minimap_text );
 
             int first_line = 1;
-            const int last_line = getmaxy( w_info ) - 2;
+            const int last_line = getmaxy( w_info ) - 3;
             pre_print_all_tile_info( lp, w_info, first_line, last_line, cache );
 
             wnoutrefresh( w_info );


### PR DESCRIPTION
It was there in 0.D, but then was removed for seemingly no reason.
With electric grids in game, there should be a more obvious way to access furniture/terrain descriptions as they may contain hints or explanations.

![image](https://user-images.githubusercontent.com/60584843/130649882-14f1e23b-74fc-42c2-a7ad-8f01800e9a29.png)