### PR TITLE
Fix debug hammerspace and weird charge display for tool component selection

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -237,6 +237,33 @@
     "magazine_well": 1
   },
   {
+    "id": "test_battery_tool",
+    "type": "TOOL",
+    "name": "TEST tool that uses batteries.",
+    "description": "It can't be used, yet it is an invaluable implement in mysterious test recipes.",
+    "weight": "1000 g",
+    "volume": "5000 ml",
+    "price": 1000,
+    "material": "iron",
+    "symbol": ",",
+    "color": "light_gray",
+    "ammo": "battery",
+    "magazines": [
+      [
+        "battery",
+        [
+          "light_minus_battery_cell",
+          "light_battery_cell",
+          "light_plus_battery_cell",
+          "light_atomic_battery_cell",
+          "light_minus_atomic_battery_cell",
+          "light_minus_disposable_cell",
+          "light_disposable_cell"
+        ]
+      ]
+    ]
+  },
+  {
     "id": "test_jack_small",
     "type": "TOOL",
     "name": "TEST scissor jack",

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -14,6 +14,7 @@
 #include "clzones.h"
 #include "color.h"
 #include "coordinate_conversions.h"
+#include "crafting.h"
 #include "debug.h"
 #include "faction_camp.h"
 #include "flat_set.h"
@@ -731,9 +732,10 @@ bool basecamp_action_components::choose_components()
     }
     // this may consume pseudo-resources from fake items
     for( const auto &it : req->get_tools() ) {
+        const Character *player_with_inventory = base_.by_radio ? nullptr : &get_avatar();
         comp_selection<tool_comp> ts =
-            g->u.select_tool_component( it, batch_size_, base_._inv, DEFAULT_HOTKEYS, true,
-                                        !base_.by_radio );
+            crafting::select_tool_component( it, batch_size_, base_._inv,
+                                             player_with_inventory, true );
         if( ts.use_from == cancel ) {
             return false;
         }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1158,7 +1158,7 @@ void construct::done_grave( const tripoint &p )
     g->m.destroy_furn( p, true );
 }
 
-static vpart_id vpart_from_item( const std::string &item_id )
+static vpart_id vpart_from_item( const itype_id &item_id )
 {
     for( const auto &e : vpart_info::all() ) {
         const vpart_info &vp = e.second;
@@ -1190,18 +1190,26 @@ void construct::done_vehicle( const tripoint &p )
         name = _( "Car" );
     }
 
-    vehicle *veh = g->m.add_vehicle( vproto_id( "none" ), p, 270, 0, 0 );
+    map &m = get_map();
+    avatar &u = get_avatar();
+
+    vehicle *veh = m.add_vehicle( vproto_id( "none" ), p, 270, 0, 0 );
 
     if( !veh ) {
         debugmsg( "error constructing vehicle" );
         return;
     }
     veh->name = name;
-    veh->install_part( point_zero, vpart_from_item( g->u.lastconsumed ) );
+    if( u.has_trait( trait_DEBUG_HS ) ) {
+        // TODO: Allow DEBUG_HS to consume items that don't exist
+        veh->install_part( point_zero, vpart_id( "frame_vertical_2" ) );
+    } else {
+        veh->install_part( point_zero, vpart_from_item( u.lastconsumed ) );
+    }
 
     // Update the vehicle cache immediately,
     // or the vehicle will be invisible for the first couple of turns.
-    g->m.add_vehicle_to_cache( veh );
+    m.add_vehicle_to_cache( veh );
 }
 
 void construct::done_deconstruct( const tripoint &p )

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -146,7 +146,7 @@ void craft_command::execute( const tripoint &new_loc )
         item_selections.clear();
         const auto filter = rec->get_component_filter( flags );
         const requirement_data *needs = rec->deduped_requirements().select_alternative(
-                                            *crafter, filter, batch_size, craft_flags::start_only );
+                                            *crafter, filter, batch_size, cost_adjustment::start_only );
         if( !needs ) {
             return;
         }
@@ -162,10 +162,10 @@ void craft_command::execute( const tripoint &new_loc )
 
         tool_selections.clear();
         for( const auto &it : needs->get_tools() ) {
-            comp_selection<tool_comp> ts = crafter->select_tool_component(
-            it, batch_size, map_inv, DEFAULT_HOTKEYS, true, true, []( int charges ) {
-                return charges / 20 + charges % 20;
-            } );
+            comp_selection<tool_comp> ts = crafting::select_tool_component(
+                                               it, batch_size, map_inv, crafter, true,
+                                               DEFAULT_HOTKEYS,
+                                               cost_adjustment::start_only );
             if( ts.use_from == cancel ) {
                 return;
             }

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -226,7 +226,9 @@ item craft_command::create_in_progress_craft()
     std::list<item> used;
     std::vector<item_comp> comps_used;
     if( crafter->has_trait( trait_DEBUG_HS ) ) {
-        return item( rec, batch_size, used, comps_used );
+        item new_craft( rec, batch_size, used, comps_used );
+        new_craft.set_tools_to_continue( true );
+        return new_craft;
     }
 
     if( empty() ) {

--- a/src/craft_command.h
+++ b/src/craft_command.h
@@ -39,6 +39,11 @@ struct enum_traits<usage> {
 */
 template<typename CompType = component>
 struct comp_selection {
+    comp_selection() = default;
+    comp_selection( usage use_from, const CompType &comp = CompType() )
+        : use_from( use_from ), comp( comp )
+    {}
+    comp_selection( const comp_selection & ) = default;
     /** Tells us where the selected component should be used from. */
     usage use_from = use_from_none;
     CompType comp;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -711,11 +711,11 @@ static item_location set_item_inventory( player &p, item &newit )
     return set_item_map_or_vehicle( p, p.pos(), newit );
 }
 
-void player::start_craft( craft_command &command, const tripoint & )
+item_location player::start_craft( craft_command &command, const tripoint & )
 {
     if( command.empty() ) {
         debugmsg( "Attempted to start craft with empty command" );
-        return;
+        return item_location();
     }
 
     item craft = command.create_in_progress_craft();
@@ -752,6 +752,7 @@ void player::start_craft( craft_command &command, const tripoint & )
         pgettext( "in progress craft", "You start working on the %s." ),
         pgettext( "in progress craft", "<npcname> starts working on the %s." ),
         craft.tname() );
+    return craft_in_world;
 }
 
 void player::craft_skill_gain( const item &craft, const int &multiplier )
@@ -1143,6 +1144,9 @@ bool player::can_continue_craft( item &craft )
     if( !craft.is_craft() ) {
         debugmsg( "complete_craft() called on non-craft '%s.'  Aborting.", craft.tname() );
         return false;
+    }
+    if( has_trait( trait_DEBUG_HS ) ) {
+        return true;
     }
 
     const recipe &rec = craft.get_making();
@@ -1666,6 +1670,9 @@ bool player::craft_consume_tools( item &craft, int mulitplier, bool start_craft 
     if( !craft.is_craft() ) {
         debugmsg( "craft_consume_tools() called on non-craft '%s.' Aborting.", craft.tname() );
         return false;
+    }
+    if( has_trait( trait_DEBUG_HS ) ) {
+        return true;
     }
 
     const auto calc_charges = [&craft, &start_craft, &mulitplier]( int charges ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -537,7 +537,7 @@ bool player::can_start_craft( const recipe *rec, recipe_filter_flags flags, int 
 
     const inventory &inv = crafting_inventory();
     return rec->deduped_requirements().can_make_with_inventory(
-               inv, rec->get_component_filter( flags ), batch_size, craft_flags::start_only );
+               inv, rec->get_component_filter( flags ), batch_size, cost_adjustment::start_only );
 }
 
 const inventory &Character::crafting_inventory( bool clear_path )
@@ -771,6 +771,7 @@ void player::craft_skill_gain( const item &craft, const int &multiplier )
         // Normalize experience gain to crafting time, giving a bonus for longer crafting
         const double batch_mult = batch_size + base_time_to_craft( making, batch_size ) / 30000.0;
         // This is called after every 5% crafting progress, so divide by 20
+        // TODO: Don't multiply, instead divide the crafting time into more "learn bits"
         const int base_practice = roll_remainder( ( making.difficulty * 15 + 10 ) * batch_mult /
                                   20.0 ) * multiplier;
         const int skill_cap = static_cast<int>( making.difficulty * 1.25 );
@@ -1242,10 +1243,9 @@ bool player::can_continue_craft( item &craft )
 
         std::vector<comp_selection<tool_comp>> new_tool_selections;
         for( const std::vector<tool_comp> &alternatives : tool_reqs ) {
-            comp_selection<tool_comp> selection = select_tool_component( alternatives, batch_size,
-            map_inv, DEFAULT_HOTKEYS, true, true, []( int charges ) {
-                return charges / 20;
-            } );
+            comp_selection<tool_comp> selection =
+                crafting::select_tool_component( alternatives, batch_size, map_inv, this, true, DEFAULT_HOTKEYS,
+                                                 cost_adjustment::continue_only );
             if( selection.use_from == cancel ) {
                 return false;
             }
@@ -1549,121 +1549,174 @@ std::list<item> player::consume_items( const std::vector<item_comp> &components,
                           filter );
 }
 
-comp_selection<tool_comp>
-player::select_tool_component( const std::vector<tool_comp> &tools, int batch, inventory &map_inv,
-                               const std::string &hotkeys, bool can_cancel, bool player_inv,
-                               const std::function<int( int )> charges_required_modifier )
+struct avail_tool_comp {
+    avail_tool_comp( comp_selection<tool_comp> comp, int charges, int ideal )
+        : comp( comp ), charges( charges ), ideal( ideal )
+    {}
+    avail_tool_comp( const avail_tool_comp & ) = default;
+
+    comp_selection<tool_comp> comp;
+    int charges;
+    int ideal;
+};
+
+namespace crafting
 {
 
-    comp_selection<tool_comp> selected;
+std::vector<avail_tool_comp>
+find_tool_component( const Character *player_with_inv, const std::vector<tool_comp> &tools,
+                     int batch,
+                     const inventory &map_inv, cost_adjustment charge_mod )
+{
+    std::vector<avail_tool_comp> available_tools;
 
     auto calc_charges = [&]( const tool_comp & t ) {
-        const int full_craft_charges = item::find_type( t.type )->charge_factor() * t.count * batch;
-        const int modified_charges = charges_required_modifier( full_craft_charges );
-        return std::max( modified_charges, 1 );
+        const int full_craft_charges = std::max( 1, t.count * batch );
+        switch( charge_mod ) {
+            case cost_adjustment::none:
+                return std::make_pair( full_craft_charges, full_craft_charges );
+            case cost_adjustment::start_only:
+                return std::make_pair( full_craft_charges / 20 + full_craft_charges % 20, full_craft_charges );
+            case cost_adjustment::continue_only:
+                return std::make_pair( std::max( 1, full_craft_charges / 20 ), full_craft_charges );
+        }
+
+        debugmsg( "Invalid tool_charge_mod" );
+        return std::make_pair( INT_MAX, INT_MAX );
     };
 
     bool found_nocharge = false;
-    std::vector<tool_comp> player_has;
-    std::vector<tool_comp> map_has;
     // Use charges of any tools that require charges used
     for( auto it = tools.begin(); it != tools.end() && !found_nocharge; ++it ) {
         itype_id type = it->type;
         if( it->count > 0 ) {
-            const int count = calc_charges( *it );
-            if( player_inv ) {
-                if( has_charges( type, count ) ) {
-                    player_has.push_back( *it );
+            const std::pair<int, int> &expected_count = calc_charges( *it );
+            const int count = expected_count.first;
+            const int ideal = expected_count.second;
+            if( player_with_inv ) {
+                if( player_with_inv->has_charges( type, count ) ) {
+                    int total_charges = player_with_inv->charges_of( type );
+                    comp_selection<tool_comp> sel( use_from_player, *it );
+                    available_tools.emplace_back( sel, total_charges, ideal );
                 }
             }
             if( map_inv.has_charges( type, count ) ) {
-                map_has.push_back( *it );
+                int total_charges = map_inv.charges_of( type );
+                comp_selection<tool_comp> sel( use_from_map, *it );
+                available_tools.emplace_back( sel, total_charges, ideal );
             }
-        } else if( ( player_inv && has_amount( type, 1 ) ) || map_inv.has_tools( type, 1 ) ) {
-            selected.comp = *it;
-            found_nocharge = true;
-        }
-    }
-    if( found_nocharge ) {
-        selected.use_from = use_from_none;
-        return selected;    // Default to using a tool that doesn't require charges
-    }
-
-    if( player_has.size() + map_has.size() == 1 ) {
-        if( map_has.empty() ) {
-            selected.use_from = use_from_player;
-            selected.comp = player_has[0];
-        } else {
-            selected.use_from = use_from_map;
-            selected.comp = map_has[0];
-        }
-    } else if( is_npc() ) {
-        if( !player_has.empty() ) {
-            selected.use_from = use_from_player;
-            selected.comp = player_has[0];
-        } else if( !map_has.empty() ) {
-            selected.use_from = use_from_map;
-            selected.comp = map_has[0];
-        } else {
-            selected.use_from = use_from_none;
-            return selected;
-        }
-    } else { // Variety of options, list them and pick one
-        // Populate the list
-        uilist tmenu( hotkeys );
-        for( auto &map_ha : map_has ) {
-            if( item::find_type( map_ha.type )->maximum_charges() > 1 ) {
-                const int charge_count = calc_charges( map_ha );
-                std::string tmpStr = string_format( _( "%s (%d/%d charges nearby)" ),
-                                                    item::nname( map_ha.type ), charge_count,
-                                                    map_inv.charges_of( map_ha.type ) );
-                tmenu.addentry( tmpStr );
-            } else {
-                std::string tmpStr = item::nname( map_ha.type ) + _( " (nearby)" );
-                tmenu.addentry( tmpStr );
-            }
-        }
-        for( auto &player_ha : player_has ) {
-            if( item::find_type( player_ha.type )->maximum_charges() > 1 ) {
-                const int charge_count = calc_charges( player_ha );
-                std::string tmpStr = string_format( _( "%s (%d/%d charges on person)" ),
-                                                    item::nname( player_ha.type ), charge_count,
-                                                    charges_of( player_ha.type ) );
-                tmenu.addentry( tmpStr );
-            } else {
-                tmenu.addentry( item::nname( player_ha.type ) );
-            }
-        }
-
-        if( tmenu.entries.empty() ) {  // This SHOULD only happen if cooking with a fire,
-            selected.use_from = use_from_none;
-            return selected;    // and the fire goes out.
-        }
-
-        tmenu.allow_cancel = can_cancel;
-
-        // Get selection via a popup menu
-        tmenu.title = _( "Use which tool?" );
-        tmenu.query();
-
-        if( tmenu.ret < 0 || static_cast<size_t>( tmenu.ret ) >= map_has.size() + player_has.size() ) {
-            selected.use_from = cancel;
-            return selected;
-        }
-
-        size_t uselection = static_cast<size_t>( tmenu.ret );
-        if( uselection < map_has.size() ) {
-            selected.use_from = use_from_map;
-            selected.comp = map_has[uselection];
-        } else {
-            uselection -= map_has.size();
-            selected.use_from = use_from_player;
-            selected.comp = player_has[uselection];
+        } else if( ( player_with_inv && player_with_inv->has_amount( type, 1 ) )
+                   || map_inv.has_tools( type, 1 ) ) {
+            comp_selection<tool_comp> sel( use_from_none, *it );
+            available_tools.emplace_back( sel, 0, 0 );
         }
     }
 
-    return selected;
+    std::sort( available_tools.begin(), available_tools.end(),
+    []( const avail_tool_comp & lhs, const avail_tool_comp & rhs ) {
+        if( lhs.comp.use_from == use_from_none && rhs.comp.use_from != use_from_none ) {
+            return true;
+        }
+        if( rhs.comp.use_from == use_from_none ) {
+            return false;
+        }
+        if( lhs.charges >= lhs.ideal && rhs.charges < rhs.ideal ) {
+            return true;
+        }
+        if( lhs.charges < lhs.ideal && rhs.charges >= rhs.ideal ) {
+            return false;
+        }
+        // We want "bigger" tools first because those are likely to be vehicle mounted
+        return static_cast<float>( lhs.ideal ) / lhs.charges > static_cast<float>
+               ( rhs.ideal ) / rhs.charges;
+    } );
+    return available_tools;
 }
+
+comp_selection<tool_comp>
+query_tool_selection( const std::vector<avail_tool_comp> &available_tools,
+                      const std::string &hotkeys, bool can_cancel, bool is_npc )
+{
+    if( available_tools.empty() ) {
+        // This SHOULD only happen if cooking with a fire,
+        // and the fire goes out.
+        return comp_selection<tool_comp>( use_from_none );
+    }
+    if( available_tools.front().comp.use_from == use_from_none ) {
+        // Default to using a tool that doesn't require charges
+        return available_tools.front().comp;
+    }
+    if( available_tools.size() == 1 ) {
+        return available_tools.front().comp;
+    }
+    if( is_npc ) {
+        auto iter = std::find_if( available_tools.begin(), available_tools.end(),
+        []( const avail_tool_comp & tool ) {
+            return tool.comp.use_from == use_from_player;
+        } );
+        if( iter != available_tools.end() ) {
+            return iter->comp;
+        }
+        return available_tools.front().comp;
+    }
+
+    // Variety of options, list them and pick one
+    // Populate the list
+    uilist tmenu( hotkeys );
+    for( const avail_tool_comp &tool : available_tools ) {
+        const itype_id &comp_type = tool.comp.comp.type;
+        if( tool.ideal > 1 ) {
+            const char *format = tool.comp.use_from == use_from_map
+                                 ? _( "%s (%d/%d charges nearby)" )
+                                 : _( "%s (%d/%d charges on person)" );
+            std::string str = string_format( format,
+                                             item::nname( comp_type ), tool.ideal,
+                                             tool.charges );
+            tmenu.addentry( str );
+        } else {
+            std::string str = tool.comp.use_from == use_from_map
+                              ? item::nname( comp_type ) + _( " (nearby)" )
+                              : item::nname( comp_type );
+            tmenu.addentry( str );
+        }
+    }
+
+    tmenu.allow_cancel = can_cancel;
+
+    // Get selection via a popup menu
+    tmenu.title = _( "Use which tool?" );
+    tmenu.query();
+
+    if( tmenu.ret < 0 || static_cast<size_t>( tmenu.ret ) >= available_tools.size() ) {
+        return comp_selection<tool_comp>( cancel );
+    }
+
+    return available_tools.at( static_cast<size_t>( tmenu.ret ) ).comp;
+}
+
+comp_selection<tool_comp>
+select_tool_component( const std::vector<tool_comp> &tools, int batch, const inventory &map_inv,
+                       const Character *player_with_inv,
+                       bool can_cancel,
+                       const std::string &hotkeys,
+                       cost_adjustment adjustment )
+{
+    std::vector<avail_tool_comp> options = find_tool_component( player_with_inv, tools, batch, map_inv,
+                                           adjustment );
+    bool is_npc = player_with_inv ? player_with_inv->is_npc() : false;
+    return query_tool_selection( options, hotkeys, can_cancel, is_npc );
+}
+
+comp_selection<tool_comp>
+select_tool_component( const std::vector<tool_comp> &tools, int batch, const inventory &map_inv,
+                       const Character *player_with_inv,
+                       bool can_cancel )
+{
+    return select_tool_component( tools, batch, map_inv, player_with_inv, can_cancel, DEFAULT_HOTKEYS,
+                                  cost_adjustment::none );
+}
+
+} // namespace crafting
 
 bool player::craft_consume_tools( item &craft, int mulitplier, bool start_craft )
 {
@@ -1674,28 +1727,27 @@ bool player::craft_consume_tools( item &craft, int mulitplier, bool start_craft 
     if( has_trait( trait_DEBUG_HS ) ) {
         return true;
     }
+    if( start_craft && mulitplier > 1 ) {
+        debugmsg( "start_craft is true, but multiplier is %d > 1", mulitplier );
+        return false;
+    }
 
     const auto calc_charges = [&craft, &start_craft, &mulitplier]( int charges ) {
         int ret = charges;
 
-        if( ret <= 0 ) {
+        if( charges <= 0 ) {
             return ret;
         }
 
         // Account for batch size
-        ret *= craft.charges;
+        int full_cost = charges * craft.charges;
 
-        // Only for the next 5% progress
-        ret /= 20;
-
-        // In case more than 5% progress was accomplished in one turn
-        ret *= mulitplier;
-
-        // If just starting consume the remainder as well
         if( start_craft ) {
-            ret += ( charges * craft.charges ) % 20;
+            return crafting::charges_for_starting( full_cost );
+        } else {
+            // In case more than 5% progress was accomplished in one turn
+            return crafting::charges_for_continuing( full_cost ) * mulitplier;
         }
-        return ret;
     };
 
     // First check if we still have our cached selections
@@ -1788,7 +1840,8 @@ void player::consume_tools( const std::vector<tool_comp> &tools, int batch,
 {
     inventory map_inv;
     map_inv.form_from_map( pos(), PICKUP_RANGE, this );
-    consume_tools( select_tool_component( tools, batch, map_inv, hotkeys ), batch );
+    consume_tools( crafting::select_tool_component( tools, batch, map_inv, this, false, hotkeys,
+                   cost_adjustment::none ), batch );
 }
 
 ret_val<bool> player::can_disassemble( const item &obj, const inventory &inv ) const
@@ -2368,6 +2421,19 @@ std::set<itype_id> get_books_for_recipe( const recipe *r )
         return pr.first;
     } );
     return book_ids;
+}
+
+int charges_for_complete( int full_charges )
+{
+    return full_charges;
+}
+int charges_for_starting( int full_charges )
+{
+    return full_charges / 20 + full_charges % 20;
+}
+int charges_for_continuing( int full_charges )
+{
+    return full_charges / 20;
 }
 
 } // namespace crafting

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1824,8 +1824,7 @@ void player::consume_tools( map &m, const comp_selection<tool_comp> &tool, int b
         return;
     }
 
-    const itype *tmp = item::find_type( tool.comp.type );
-    int quantity = tool.comp.count * batch * tmp->charge_factor();
+    int quantity = tool.comp.count * batch;
     if( tool.use_from & use_from_player ) {
         use_charges( tool.comp.type, quantity );
     }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1564,7 +1564,7 @@ struct avail_tool_comp {
 namespace crafting
 {
 
-std::vector<avail_tool_comp>
+static std::vector<avail_tool_comp>
 find_tool_component( const Character *player_with_inv, const std::vector<tool_comp> &tools,
                      int batch,
                      const inventory &map_inv, cost_adjustment charge_mod )
@@ -1637,7 +1637,7 @@ find_tool_component( const Character *player_with_inv, const std::vector<tool_co
     return available_tools;
 }
 
-comp_selection<tool_comp>
+static comp_selection<tool_comp>
 query_tool_selection( const std::vector<avail_tool_comp> &available_tools,
                       const std::string &hotkeys, bool can_cancel, bool is_npc )
 {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1219,7 +1219,8 @@ bool player::can_continue_craft( item &craft )
                 if( adjusted_alternative.count > 0 ) {
                     adjusted_alternative.count *= batch_size;
                     // Only for the next 5% progress
-                    adjusted_alternative.count = std::max( adjusted_alternative.count / 20, 1 );
+                    adjusted_alternative.count = std::max(
+                                                     crafting::charges_for_continuing( adjusted_alternative.count ), 1 );
                 }
                 adjusted_alternatives.push_back( adjusted_alternative );
             }
@@ -1574,11 +1575,14 @@ find_tool_component( const Character *player_with_inv, const std::vector<tool_co
         const int full_craft_charges = std::max( 1, t.count * batch );
         switch( charge_mod ) {
             case cost_adjustment::none:
-                return std::make_pair( full_craft_charges, full_craft_charges );
+                return std::make_pair( charges_for_complete( full_craft_charges ),
+                                       charges_for_complete( full_craft_charges ) );
             case cost_adjustment::start_only:
-                return std::make_pair( full_craft_charges / 20 + full_craft_charges % 20, full_craft_charges );
+                return std::make_pair( charges_for_starting( full_craft_charges ),
+                                       charges_for_complete( full_craft_charges ) );
             case cost_adjustment::continue_only:
-                return std::make_pair( std::max( 1, full_craft_charges / 20 ), full_craft_charges );
+                return std::make_pair( charges_for_continuing( full_craft_charges ),
+                                       charges_for_complete( full_craft_charges ) );
         }
 
         debugmsg( "Invalid tool_charge_mod" );

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -72,7 +72,7 @@ int charges_for_starting( int full_charges );
 int charges_for_continuing( int full_charges );
 
 /**
- * Returns selected tool component that matches one on the expected ones.
+ * Returns selected tool component that matches one of the expected ones.
  * @param tools tools to match
  * @param batch size of batch to craft, multiplier on expected charges
  * @param map_inv map inventory to select from

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -79,7 +79,6 @@ int charges_for_continuing( int full_charges );
  * @param player_with_inv if not null, character who provides additional inventory
  * @param hotkeys hotkeys available to the menu
  * @param can_cancel can the selection be aborted with no result
- * @param pick_first select like an npc - pick first result matched, preferring ones on player
  * @param adjustment affects required charges, see @ref cost_adjustment
  */
 comp_selection<tool_comp>

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -4,6 +4,7 @@
 
 #include <list>
 #include <set>
+#include <vector>
 #include "point.h"
 
 class Character;
@@ -11,13 +12,11 @@ class inventory;
 class item;
 class player;
 class recipe;
+struct tool_comp;
 
 using itype_id = std::string;
 
-enum class craft_flags : int {
-    none = 0,
-    start_only = 1, // Only require 5% (plus remainder) of tool charges
-};
+enum class cost_adjustment : int;
 
 enum class bench_type : int {
     ground = 0,
@@ -26,11 +25,6 @@ enum class bench_type : int {
     vehicle
 };
 
-inline constexpr craft_flags operator&( craft_flags l, craft_flags r )
-{
-    return static_cast<craft_flags>( static_cast<unsigned>( l ) & static_cast<unsigned>( r ) );
-}
-
 struct bench_location {
     explicit bench_location( bench_type type, tripoint position )
         : type( type ), position( position )
@@ -38,6 +32,9 @@ struct bench_location {
     bench_type type;
     tripoint position;
 };
+
+template<typename Type>
+struct comp_selection;
 
 // removes any (removable) ammo from the item and stores it in the
 // players inventory.
@@ -69,6 +66,33 @@ std::set<itype_id> get_books_for_recipe( const Character &c, const inventory &cr
  * Returns the set of book types that provide the given recipe.
  */
 std::set<itype_id> get_books_for_recipe( const recipe *r );
+
+int charges_for_complete( int full_charges );
+int charges_for_starting( int full_charges );
+int charges_for_continuing( int full_charges );
+
+/**
+ * Returns selected tool component that matches one on the expected ones.
+ * @param tools tools to match
+ * @param batch size of batch to craft, multiplier on expected charges
+ * @param map_inv map inventory to select from
+ * @param player_with_inv if not null, character who provides additional inventory
+ * @param hotkeys hotkeys available to the menu
+ * @param can_cancel can the selection be aborted with no result
+ * @param pick_first select like an npc - pick first result matched, preferring ones on player
+ * @param adjustment affects required charges, see @ref cost_adjustment
+ */
+comp_selection<tool_comp>
+select_tool_component( const std::vector<tool_comp> &tools, int batch, const inventory &map_inv,
+                       const Character *player_with_inv,
+                       bool can_cancel,
+                       const std::string &hotkeys,
+                       cost_adjustment adjustment );
+
+comp_selection<tool_comp>
+select_tool_component( const std::vector<tool_comp> &tools, int batch, const inventory &map_inv,
+                       const Character *player_with_inv,
+                       bool can_cancel = false );
 
 } // namespace crafting
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -247,13 +247,13 @@ const recipe *select_crafting_recipe( int &batch_size )
             auto no_rotten_filter = r->get_component_filter( recipe_filter_flags::no_rotten );
             const deduped_requirement_data &req = r->deduped_requirements();
             could_craft_if_knew = req.can_make_with_inventory(
-                                      inv, all_items_filter, batch_size, craft_flags::start_only );
+                                      inv, all_items_filter, batch_size, cost_adjustment::start_only );
             can_craft = known && could_craft_if_knew;
             can_craft_non_rotten = req.can_make_with_inventory(
-                                       inv, no_rotten_filter, batch_size, craft_flags::start_only );
+                                       inv, no_rotten_filter, batch_size, cost_adjustment::start_only );
             const requirement_data &simple_req = r->simple_requirements();
             apparently_craftable = simple_req.can_make_with_inventory(
-                                       inv, all_items_filter, batch_size, craft_flags::start_only );
+                                       inv, all_items_filter, batch_size, cost_adjustment::start_only );
         }
         bool can_craft;
         bool can_craft_non_rotten;

--- a/src/player.h
+++ b/src/player.h
@@ -606,7 +606,7 @@ class player : public Character
         void make_craft( const recipe_id &id, int batch_size, const tripoint &loc = tripoint_zero );
         void make_all_craft( const recipe_id &id, int batch_size, const tripoint &loc = tripoint_zero );
         /** consume components and create an active, in progress craft containing them */
-        void start_craft( craft_command &command, const tripoint &loc );
+        item_location start_craft( craft_command &command, const tripoint &loc );
         /**
          * Calculate a value representing the success of the player at crafting the given recipe,
          * taking player skill, recipe difficulty, npc helpers, and player mutations into account.

--- a/src/player.h
+++ b/src/player.h
@@ -79,7 +79,6 @@ template<>
 struct ret_val<edible_rating>::default_failure : public
     std::integral_constant<edible_rating, edible_rating::inedible> {};
 
-
 struct stat_mod {
     int strength = 0;
     int dexterity = 0;
@@ -662,13 +661,6 @@ class player : public Character
                                        const tripoint &origin = tripoint_zero, int radius = PICKUP_RANGE );
         std::list<item> consume_items( const std::vector<item_comp> &components, int batch = 1,
                                        const std::function<bool( const item & )> &filter = return_true<item> );
-        comp_selection<tool_comp>
-        select_tool_component( const std::vector<tool_comp> &tools, int batch, inventory &map_inv,
-                               const std::string &hotkeys = DEFAULT_HOTKEYS,
-                               bool can_cancel = false, bool player_inv = true,
-        std::function<int( int )> charges_required_modifier = []( int i ) {
-            return i;
-        } );
         /** Consume tools for the next multiplier * 5% progress of the craft */
         bool craft_consume_tools( item &craft, int mulitplier, bool start_craft );
         void consume_tools( const comp_selection<tool_comp> &tool, int batch );

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -544,7 +544,10 @@ void requirement_data::finalize()
             for( auto &comp : list ) {
                 const std::list<itype_id> replacements = item_controller->subtype_replacement( comp.type );
                 for( const itype_id &replacing_type : replacements ) {
-                    const int charge_factor = item::find_type( replacing_type )->charge_factor();
+                    // One of the replacements is the type itself
+                    const int charge_factor = replacing_type != comp.type
+                                              ? item::find_type( replacing_type )->charge_factor()
+                                              : 1;
                     new_list.emplace_back( replacing_type, charge_factor * comp.count );
                 }
             }

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -2,15 +2,12 @@
 #ifndef CATA_SRC_REQUIREMENTS_H
 #define CATA_SRC_REQUIREMENTS_H
 
-#include <functional>
 #include <list>
 #include <map>
 #include <string>
 #include <tuple>
-#include <utility>
 #include <vector>
 
-#include "crafting.h"
 #include "translations.h"
 #include "type_id.h"
 
@@ -37,6 +34,14 @@ enum class component_type : int {
     ITEM,
     TOOL,
     QUALITY,
+};
+
+enum class cost_adjustment : int {
+    none = 0,
+    // Only require 5% (plus remainder) of tool charges
+    start_only,
+    // Only require 5% of tool charges
+    continue_only
 };
 
 struct quality {
@@ -92,7 +97,7 @@ struct tool_comp : public component {
     void load( const JsonValue &value );
     void dump( JsonOut &jsout ) const;
     bool has( const inventory &crafting_inv, const std::function<bool( const item & )> &filter,
-              int batch = 1, craft_flags = craft_flags::none,
+              int batch = 1, cost_adjustment = cost_adjustment::none,
               std::function<void( int )> visitor = std::function<void( int )>() ) const;
     std::string to_string( int batch = 1, int avail = 0 ) const;
     nc_color get_color( bool has_one, const inventory &crafting_inv,
@@ -110,7 +115,7 @@ struct item_comp : public component {
     void load( const JsonValue &value );
     void dump( JsonOut &jsout ) const;
     bool has( const inventory &crafting_inv, const std::function<bool( const item & )> &filter,
-              int batch = 1, craft_flags = craft_flags::none,
+              int batch = 1, cost_adjustment = cost_adjustment::none,
               std::function<void( int )> visitor = std::function<void( int )>() ) const;
     std::string to_string( int batch = 1, int avail = 0 ) const;
     nc_color get_color( bool has_one, const inventory &crafting_inv,
@@ -149,7 +154,7 @@ struct quality_requirement {
     void load( const JsonValue &value );
     void dump( JsonOut &jsout ) const;
     bool has( const inventory &crafting_inv, const std::function<bool( const item & )> &filter,
-              int = 0, craft_flags = craft_flags::none,
+              int = 0, cost_adjustment = cost_adjustment::none,
               std::function<void( int )> visitor = std::function<void( int )>() ) const;
     std::string to_string( int batch = 1, int avail = 0 ) const;
     void check_consistency( const std::string &display_name ) const;
@@ -315,7 +320,7 @@ struct requirement_data {
          */
         bool can_make_with_inventory( const inventory &crafting_inv,
                                       const std::function<bool( const item & )> &filter, int batch = 1,
-                                      craft_flags = craft_flags::none ) const;
+                                      cost_adjustment = cost_adjustment::none ) const;
 
         /** @param filter see @ref can_make_with_inventory */
         std::vector<std::string> get_folded_components_list( int width, nc_color col,
@@ -381,7 +386,7 @@ struct requirement_data {
         static bool has_comps(
             const inventory &crafting_inv, const std::vector< std::vector<T> > &vec,
             const std::function<bool( const item & )> &filter, int batch = 1,
-            craft_flags = craft_flags::none );
+            cost_adjustment = cost_adjustment::none );
 
         template<typename T>
         std::vector<std::string> get_folded_list( int width, const inventory &crafting_inv,
@@ -435,19 +440,19 @@ class deduped_requirement_data
 
         std::vector<const requirement_data *> feasible_alternatives(
             const inventory &crafting_inv, const std::function<bool( const item & )> &filter,
-            int batch = 1, craft_flags = craft_flags::none ) const;
+            int batch = 1, cost_adjustment = static_cast<cost_adjustment>( 0 ) ) const;
 
         const requirement_data *select_alternative(
             player &, const std::function<bool( const item & )> &filter, int batch = 1,
-            craft_flags = craft_flags::none ) const;
+            cost_adjustment = static_cast<cost_adjustment>( 0 ) ) const;
 
         const requirement_data *select_alternative(
             player &, const inventory &, const std::function<bool( const item & )> &filter,
-            int batch = 1, craft_flags = craft_flags::none ) const;
+            int batch = 1, cost_adjustment = static_cast<cost_adjustment>( 0 ) ) const;
 
         bool can_make_with_inventory(
             const inventory &crafting_inv, const std::function<bool( const item & )> &filter,
-            int batch = 1, craft_flags = craft_flags::none ) const;
+            int batch = 1, cost_adjustment = static_cast<cost_adjustment>( 0 ) ) const;
 
         bool is_too_complex() const {
             return is_too_complex_;

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -11,6 +11,7 @@
 
 #include "calendar.h"
 #include "craft_command.h"
+#include "crafting.h"
 #include "map.h"
 #include "player.h"
 #include "veh_type.h"
@@ -138,7 +139,7 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who_c )
     }
 
     for( const auto &e : reqs.get_tools() ) {
-        who.consume_tools( who.select_tool_component( e, 1, map_inv ), 1 );
+        who.consume_tools( crafting::select_tool_component( e, 1, map_inv, &who ), 1 );
     }
 
     who.invalidate_crafting_inventory();

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -709,4 +709,20 @@ TEST_CASE( "tool selection ui", "[crafting][ui]" )
             CHECK( result.use_from == use_from_none );
         }
     }
+
+    GIVEN( "Two compatible tools in map inventory, one with enough charges for entire craft and one with half" ) {
+        tool_comp too_little( itype_id( "test_soldering_iron" ), 200 );
+        tool_comp enough( itype_id( "test_battery_tool" ), 100 );
+        tools = {too_little, enough};
+        map_inv.add_item( item( too_little.type, calendar::start_of_cataclysm, 100 ) );
+        map_inv.add_item( item( enough.type, calendar::start_of_cataclysm, 100 ) );
+
+        comp_selection<tool_comp> result = crafting::select_tool_component( tools, 1, map_inv,
+                                           &dummy, false,
+                                           DEFAULT_HOTKEYS, cost_adjustment::none );
+
+        THEN( "The tool with enough charges is selected" ) {
+            CHECK( result.comp.type == enough.type );
+        }
+    }
 }

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -638,36 +638,6 @@ TEST_CASE( "oven electric grid", "[crafting][overmap][grids][slow]" )
     }
 }
 
-template < size_t i, typename ... Args>
-std::enable_if_t < ( i == sizeof...( Args ) - 1 ) >
-stream_tuple( const std::tuple<Args...> &t, std::ostream &stream )
-{
-    stream << std::get < i > ( t );
-}
-
-template < size_t i, typename ... Args >
-std::enable_if_t < ( i < sizeof...( Args ) - 1 ) >
-stream_tuple( const std::tuple<Args...> &t, std::ostream &stream )
-{
-    stream << std::get < i > ( t ) << ", ";
-    stream_tuple < i + 1 > ( t, stream );
-}
-
-template<typename ... Args>
-void operator<<( std::ostream &stream, const std::tuple<Args...> &t )
-{
-    stream << "[";
-    stream_tuple <0> ( t, stream );
-    stream << "]";
-}
-
-TEST_CASE( "tuple streaming", "[crafting][ui]" )
-{
-    std::stringstream ss;
-    ss << std::make_tuple( 1, 2, "abc", 3.0f );
-    CHECK( ss.str() == "[1, 2, abc, 3]" );
-}
-
 TEST_CASE( "tool selection ui", "[crafting][ui]" )
 {
     npc dummy;


### PR DESCRIPTION
Hammerspace no longer cancels crafting as soon as it is started.

When selecting tool components, the following changes are visible:
* Actual cost of use is shown, rather than one just for starting the craft (in case of crafting)
* Tools with magazines show charges properly
* Sorting prefers tools with enough charge over tools carried by player

Also code side changes:
* `requirements.h` no longer includes `crafting.h`
* `select_tool_components` is no longer a `player` method, but a regular function in `crafting` namespace
* Renamed `crafting_flags`, changed from flags (`AND`ed `bitset`-but-not-really) to just regular `enum class`, now handles whether the menu displays full costs, starting costs or continue costs
* Added basic tests for tool selection and hammerspace crafting