### PR TITLE
Helicopter rotors collide only with huge creatures

### DIFF
--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -545,7 +545,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         if( ovp && ( &ovp->vehicle() == this ) && get_pet( ovp->part_index() ) ) {
             return ret;
         }
-        //Rotors only collide with huge creatures.
+        //Rotors only collide with huge creatures
         if( part_info( part ).rotor_diameter() > 0 && critter->get_size() != MS_HUGE ) {
             return ret;
         }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -545,7 +545,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         if( ovp && ( &ovp->vehicle() == this ) && get_pet( ovp->part_index() ) ) {
             return ret;
         }
-        //Rotors only collide with huge creatures
+        // Rotors only collide with huge creatures
         if( part_info( part ).rotor_diameter() > 0 && critter->get_size() != MS_HUGE ) {
             return ret;
         }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -545,6 +545,10 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         if( ovp && ( &ovp->vehicle() == this ) && get_pet( ovp->part_index() ) ) {
             return ret;
         }
+        //Rotors only collide with huge creatures.
+        if (part_info(part).rotor_diameter() > 0 && critter->get_size() != MS_HUGE) {
+            return ret;
+        }
         // we just ran into a fish, so move it out of the way
         if( g->m.has_flag( "SWIMMABLE", critter->pos() ) ) {
             tripoint end_pos = critter->pos();

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -546,7 +546,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
             return ret;
         }
         //Rotors only collide with huge creatures.
-        if (part_info(part).rotor_diameter() > 0 && critter->get_size() != MS_HUGE) {
+        if( part_info( part ).rotor_diameter() > 0 && critter->get_size() != MS_HUGE ) {
             return ret;
         }
         // we just ran into a fish, so move it out of the way


### PR DESCRIPTION
Helicopter rotors collide only with huge creatures

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Features "Helicopter rotors collide only with huge creatures"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: Features "Helicopter rotors collide only with huge creatures]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
It is very easy to lose helicopter rotors to random zombie due collision with rotors. At the same time logically normal creature should not collide with helicopters blades since blades is placed  quite high.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Only huge creatres can collide with helicopter blades.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Spawn helicopter
2) Spawn zombies with variuos sizes.
3) Make sure that helicopter blades collides only with huge zombies, like hulks, but do not collide with normal or smaller zombies.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
Maybe it is better simply to prevent collidng rotors with all creatures?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
