### PR TITLE
Add Boxing to Self-Defense Classes trait

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -577,9 +577,9 @@
     "id": "MARTIAL_ARTS2",
     "name": { "str": "Self-Defense Classes" },
     "points": 2,
-    "description": "You have taken some self-defense classes at a nearby gym.  You start with your choice of Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
+    "description": "You have taken some self-defense classes at a nearby gym.  You start with your choice of Boxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
     "starting_trait": true,
-    "initial_ma_styles": [ "style_krav_maga", "style_muay_thai", "style_ninjutsu", "style_capoeira", "style_zui_quan", "style_wingchun" ],
+    "initial_ma_styles": [ "style_boxing", "style_krav_maga", "style_muay_thai", "style_ninjutsu", "style_capoeira", "style_zui_quan", "style_wingchun" ],
     "valid": false
   },
   {

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -572,16 +572,16 @@
     "initial_ma_styles": [ "style_karate", "style_judo", "style_aikido", "style_tai_chi", "style_taekwondo", "style_pankration" ],
     "valid": false
   },
-  {
-    "type": "mutation",
-    "id": "MARTIAL_ARTS2",
-    "name": { "str": "Self-Defense Classes" },
-    "points": 2,
-    "description": "You have taken some self-defense classes at a nearby gym.  You start with your choice of Boxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
-    "starting_trait": true,
-    "initial_ma_styles": [ "style_boxing", "style_krav_maga", "style_muay_thai", "style_ninjutsu", "style_capoeira", "style_zui_quan", "style_wingchun" ],
-    "valid": false
-  },
+   {
+ 	"type": "mutation",
+ 	"id": "MARTIAL_ARTS2",
+ 	"name": { "str": "Self-Defense Classes" },
+ 	"points": 2,
+ 	"description": "You have taken some self-defense classes at a nearby gym. You start with your choice of Boxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
+ 	"starting_trait": true,
+ 	"initial_ma_styles": [ "style_boxing", "style_krav_maga", "style_muay_thai", "style_ninjutsu", "style_capoeira", "style_zui_quan", "style_wingchun" ],
+ 	"valid": false
+ },
   {
     "type": "mutation",
     "id": "MARTIAL_ARTS3",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -21,10 +21,10 @@
     "cost": 1,
     "time": 810000,
     "hunger": true,
-    "encumbrance_covered": [ [ "HEAD", 5 ] ],
+    "encumbrance_covered": [ [ "head", 5 ] ],
     "changes_to": [ "BIOLUM2" ],
     "category": [ "ELFA", "INSECT", "FISH" ],
-    "lumination": [ [ "HEAD", 8 ] ]
+    "lumination": [ [ "head", 8 ] ]
   },
   {
     "type": "mutation",
@@ -36,10 +36,10 @@
     "cost": 1,
     "time": 405000,
     "hunger": true,
-    "encumbrance_covered": [ [ "HEAD", 5 ] ],
+    "encumbrance_covered": [ [ "head", 5 ] ],
     "prereqs": [ "BIOLUM1" ],
     "category": [ "ELFA", "INSECT", "FISH" ],
-    "lumination": [ [ "HEAD", 20 ] ]
+    "lumination": [ [ "head", 20 ] ]
   },
   {
     "type": "mutation",
@@ -74,16 +74,16 @@
     "starting_trait": true,
     "valid": false,
     "wet_protection": [
-      { "part": "HEAD", "neutral": 6 },
-      { "part": "LEG_L", "neutral": 8 },
-      { "part": "LEG_R", "neutral": 8 },
-      { "part": "FOOT_L", "neutral": 2 },
-      { "part": "FOOT_R", "neutral": 2 },
-      { "part": "ARM_L", "neutral": 8 },
-      { "part": "ARM_R", "neutral": 8 },
-      { "part": "HAND_L", "neutral": 12 },
-      { "part": "HAND_R", "neutral": 12 },
-      { "part": "TORSO", "neutral": 10 }
+      { "part": "head", "neutral": 6 },
+      { "part": "leg_l", "neutral": 8 },
+      { "part": "leg_r", "neutral": 8 },
+      { "part": "foot_l", "neutral": 2 },
+      { "part": "foot_r", "neutral": 2 },
+      { "part": "arm_l", "neutral": 8 },
+      { "part": "arm_r", "neutral": 8 },
+      { "part": "hand_l", "neutral": 12 },
+      { "part": "hand_r", "neutral": 12 },
+      { "part": "torso", "neutral": 10 }
     ]
   },
   {
@@ -244,7 +244,7 @@
     "name": { "str": "Tough Feet" },
     "points": 1,
     "description": "The bottoms of your feet are tough and you are accustomed to going barefoot.  You receive no movement penalty for not wearing shoes, and your feet are more resistant to damage.",
-    "armor": [ { "parts": [ "FOOT_L", "FOOT_R" ], "physical": 2, "acid": 2 } ],
+    "armor": [ { "parts": [ "foot_l", "foot_r" ], "physical": 2, "acid": 2 } ],
     "starting_trait": true,
     "valid": false
   },
@@ -572,26 +572,24 @@
     "initial_ma_styles": [ "style_karate", "style_judo", "style_aikido", "style_tai_chi", "style_taekwondo", "style_pankration" ],
     "valid": false
   },
- {
-  "type": "mutation",
-  "id": "MARTIAL_ARTS2",
-  "name": {
-    "str": "Self-Defense Classes"
+  {
+    "type": "mutation",
+    "id": "MARTIAL_ARTS2",
+    "name": { "str": "Self-Defense Classes" },
+    "points": 2,
+    "description": "You have taken some self-defense classes at a nearby gym.  You start with your choice of Boxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
+    "starting_trait": true,
+    "initial_ma_styles": [
+      "style_boxing",
+      "style_krav_maga",
+      "style_muay_thai",
+      "style_ninjutsu",
+      "style_capoeira",
+      "style_zui_quan",
+      "style_wingchun"
+    ],
+    "valid": false
   },
-  "points": 2,
-  "description": "You have taken some self-defense classes at a nearby gym.  You start with your choice of Boxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
-  "starting_trait": true,
-  "initial_ma_styles": [
-    "style_boxing",
-    "style_krav_maga",
-    "style_muay_thai",
-    "style_ninjutsu",
-    "style_capoeira",
-    "style_zui_quan",
-    "style_wingchun"
-  ],
-  "valid": false
-},
   {
     "type": "mutation",
     "id": "MARTIAL_ARTS3",
@@ -1503,7 +1501,7 @@
         "attack_text_u": "You sink your fangs into %s",
         "attack_text_npc": "%1$s sinks their fangs into %2$s",
         "blocker_mutations": [ "MUZZLE", "MUZZLE_LONG", "MUZZLE_RAT" ],
-        "body_part": "MOUTH",
+        "body_part": "mouth",
         "chance": 20,
         "base_damage": { "damage_type": "stab", "amount": 20 }
       },
@@ -1511,7 +1509,7 @@
         "attack_text_u": "You sink your fangs into %s",
         "attack_text_npc": "%1$s sinks their fangs into %2$s",
         "required_mutations": [ "MUZZLE" ],
-        "body_part": "MOUTH",
+        "body_part": "mouth",
         "chance": 18,
         "base_damage": { "damage_type": "stab", "amount": 20 }
       },
@@ -1519,7 +1517,7 @@
         "attack_text_u": "You sink your fangs into %s",
         "attack_text_npc": "%1$s sinks their fangs into %2$s",
         "required_mutations": [ "MUZZLE_LONG" ],
-        "body_part": "MOUTH",
+        "body_part": "mouth",
         "chance": 15,
         "base_damage": { "damage_type": "stab", "amount": 20 }
       },
@@ -1527,7 +1525,7 @@
         "attack_text_u": "You sink your fangs into %s",
         "attack_text_npc": "%1$s sinks their fangs into %2$s",
         "required_mutations": [ "MUZZLE_RAT" ],
-        "body_part": "MOUTH",
+        "body_part": "mouth",
         "chance": 19,
         "base_damage": { "damage_type": "stab", "amount": 20 }
       }
@@ -1548,7 +1546,7 @@
     "attacks": {
       "attack_text_u": "You bite into %s with your ratlike incisors",
       "attack_text_npc": "%1$s bites %2$s with their ratlike incisors",
-      "body_part": "MOUTH",
+      "body_part": "mouth",
       "chance": 18,
       "base_damage": [ { "damage_type": "cut", "amount": 3 }, { "damage_type": "bash", "amount": 3 } ]
     }
@@ -1563,7 +1561,7 @@
     "description": "You have a set of clear lenses which lower over your eyes while underwater, allowing you to see as though you were wearing goggles.  Slightly decreases wet penalties.",
     "prereqs": [ "EYEBULGE" ],
     "category": [ "LIZARD", "FISH" ],
-    "wet_protection": [ { "part": "EYES", "neutral": 1 } ]
+    "wet_protection": [ { "part": "eyes", "neutral": 1 } ]
   },
   {
     "type": "mutation",
@@ -1575,7 +1573,7 @@
     "description": "You've grown a set of gills in your neck, allowing you to breathe underwater.  Slightly increases wet benefits.",
     "category": [ "FISH" ],
     "cancels": [ "GILLS_CEPH" ],
-    "wet_protection": [ { "part": "HEAD", "good": 1 } ]
+    "wet_protection": [ { "part": "head", "good": 1 } ]
   },
   {
     "type": "mutation",
@@ -1587,7 +1585,7 @@
     "description": "You've grown a set of gills, running from your neck up behind your ears.  They allow you to breathe underwater and slightly increase wet benefits.",
     "category": [ "CEPHALOPOD" ],
     "cancels": [ "GILLS" ],
-    "wet_protection": [ { "part": "HEAD", "good": 1 } ]
+    "wet_protection": [ { "part": "head", "good": 1 } ]
   },
   {
     "type": "mutation",
@@ -1605,16 +1603,16 @@
     "leads_to": [ "M_DEFENDER" ],
     "changes_to": [ "M_SKIN2" ],
     "wet_protection": [
-      { "part": "HEAD", "ignored": 6 },
-      { "part": "LEG_L", "ignored": 20 },
-      { "part": "LEG_R", "ignored": 20 },
-      { "part": "FOOT_L", "ignored": 6 },
-      { "part": "FOOT_R", "ignored": 6 },
-      { "part": "ARM_L", "ignored": 18 },
-      { "part": "ARM_R", "ignored": 18 },
-      { "part": "HAND_L", "ignored": 4 },
-      { "part": "HAND_R", "ignored": 4 },
-      { "part": "TORSO", "ignored": 40 }
+      { "part": "head", "ignored": 6 },
+      { "part": "leg_l", "ignored": 20 },
+      { "part": "leg_r", "ignored": 20 },
+      { "part": "foot_l", "ignored": 6 },
+      { "part": "foot_r", "ignored": 6 },
+      { "part": "arm_l", "ignored": 18 },
+      { "part": "arm_r", "ignored": 18 },
+      { "part": "hand_l", "ignored": 4 },
+      { "part": "hand_r", "ignored": 4 },
+      { "part": "torso", "ignored": 40 }
     ],
     "armor": [ { "parts": "ALL", "cut": 1, "bash": 2 } ]
   },
@@ -1634,16 +1632,16 @@
     "threshreq": [ "THRESH_MYCUS" ],
     "changes_to": [ "M_SKIN3" ],
     "wet_protection": [
-      { "part": "HEAD", "ignored": 9 },
-      { "part": "LEG_L", "ignored": 30 },
-      { "part": "LEG_R", "ignored": 30 },
-      { "part": "FOOT_L", "ignored": 9 },
-      { "part": "FOOT_R", "ignored": 9 },
-      { "part": "ARM_L", "ignored": 24 },
-      { "part": "ARM_R", "ignored": 24 },
-      { "part": "HAND_L", "ignored": 6 },
-      { "part": "HAND_R", "ignored": 6 },
-      { "part": "TORSO", "ignored": 60 }
+      { "part": "head", "ignored": 9 },
+      { "part": "leg_l", "ignored": 30 },
+      { "part": "leg_r", "ignored": 30 },
+      { "part": "foot_l", "ignored": 9 },
+      { "part": "foot_r", "ignored": 9 },
+      { "part": "arm_l", "ignored": 24 },
+      { "part": "arm_r", "ignored": 24 },
+      { "part": "hand_l", "ignored": 6 },
+      { "part": "hand_r", "ignored": 6 },
+      { "part": "torso", "ignored": 60 }
     ],
     "armor": [ { "parts": "ALL", "cut": 2, "bash": 3 } ],
     "speed_modifier": 0.8
@@ -1662,16 +1660,16 @@
     "prereqs": [ "M_SKIN2" ],
     "threshreq": [ "THRESH_MYCUS" ],
     "wet_protection": [
-      { "part": "HEAD", "ignored": 9 },
-      { "part": "LEG_L", "ignored": 30 },
-      { "part": "LEG_R", "ignored": 30 },
-      { "part": "FOOT_L", "ignored": 9 },
-      { "part": "FOOT_R", "ignored": 9 },
-      { "part": "ARM_L", "ignored": 24 },
-      { "part": "ARM_R", "ignored": 24 },
-      { "part": "HAND_L", "ignored": 6 },
-      { "part": "HAND_R", "ignored": 6 },
-      { "part": "TORSO", "ignored": 60 }
+      { "part": "head", "ignored": 9 },
+      { "part": "leg_l", "ignored": 30 },
+      { "part": "leg_r", "ignored": 30 },
+      { "part": "foot_l", "ignored": 9 },
+      { "part": "foot_r", "ignored": 9 },
+      { "part": "arm_l", "ignored": 24 },
+      { "part": "arm_r", "ignored": 24 },
+      { "part": "hand_l", "ignored": 6 },
+      { "part": "hand_r", "ignored": 6 },
+      { "part": "torso", "ignored": 60 }
     ],
     "armor": [ { "parts": "ALL", "cut": 3, "bash": 5 } ],
     "speed_modifier": 0.8
@@ -1690,16 +1688,16 @@
     "changes_to": [ "THICK_SCALES", "SLEEK_SCALES" ],
     "movecost_swim_modifier": 0.9,
     "wet_protection": [
-      { "part": "HEAD", "ignored": 3 },
-      { "part": "LEG_L", "ignored": 10 },
-      { "part": "LEG_R", "ignored": 10 },
-      { "part": "FOOT_L", "ignored": 3 },
-      { "part": "FOOT_R", "ignored": 3 },
-      { "part": "ARM_L", "ignored": 9 },
-      { "part": "ARM_R", "ignored": 9 },
-      { "part": "HAND_L", "ignored": 2 },
-      { "part": "HAND_R", "ignored": 2 },
-      { "part": "TORSO", "ignored": 20 }
+      { "part": "head", "ignored": 3 },
+      { "part": "leg_l", "ignored": 10 },
+      { "part": "leg_r", "ignored": 10 },
+      { "part": "foot_l", "ignored": 3 },
+      { "part": "foot_r", "ignored": 3 },
+      { "part": "arm_l", "ignored": 9 },
+      { "part": "arm_r", "ignored": 9 },
+      { "part": "hand_l", "ignored": 2 },
+      { "part": "hand_r", "ignored": 2 },
+      { "part": "torso", "ignored": 20 }
     ],
     "armor": [ { "parts": "ALL", "physical": 3 } ]
   },
@@ -1717,16 +1715,16 @@
     "threshreq": [ "THRESH_LIZARD" ],
     "category": [ "LIZARD" ],
     "wet_protection": [
-      { "part": "HEAD", "ignored": 5 },
-      { "part": "LEG_L", "ignored": 16 },
-      { "part": "LEG_R", "ignored": 16 },
-      { "part": "FOOT_L", "ignored": 5 },
-      { "part": "FOOT_R", "ignored": 5 },
-      { "part": "ARM_L", "ignored": 14 },
-      { "part": "ARM_R", "ignored": 14 },
-      { "part": "HAND_L", "ignored": 4 },
-      { "part": "HAND_R", "ignored": 4 },
-      { "part": "TORSO", "ignored": 30 }
+      { "part": "head", "ignored": 5 },
+      { "part": "leg_l", "ignored": 16 },
+      { "part": "leg_r", "ignored": 16 },
+      { "part": "foot_l", "ignored": 5 },
+      { "part": "foot_r", "ignored": 5 },
+      { "part": "arm_l", "ignored": 14 },
+      { "part": "arm_r", "ignored": 14 },
+      { "part": "hand_l", "ignored": 4 },
+      { "part": "hand_r", "ignored": 4 },
+      { "part": "torso", "ignored": 30 }
     ],
     "armor": [ { "parts": "ALL", "physical": 10 } ],
     "passive_mods": { "dex_mod": -2 }
@@ -1744,16 +1742,16 @@
     "category": [ "FISH" ],
     "movecost_swim_modifier": 0.75,
     "wet_protection": [
-      { "part": "HEAD", "good": 7 },
-      { "part": "LEG_L", "good": 21 },
-      { "part": "LEG_R", "good": 21 },
-      { "part": "FOOT_L", "good": 6 },
-      { "part": "FOOT_R", "good": 6 },
-      { "part": "ARM_L", "good": 19 },
-      { "part": "ARM_R", "good": 19 },
-      { "part": "HAND_L", "good": 5 },
-      { "part": "HAND_R", "good": 5 },
-      { "part": "TORSO", "good": 40 }
+      { "part": "head", "good": 7 },
+      { "part": "leg_l", "good": 21 },
+      { "part": "leg_r", "good": 21 },
+      { "part": "foot_l", "good": 6 },
+      { "part": "foot_r", "good": 6 },
+      { "part": "arm_l", "good": 19 },
+      { "part": "arm_r", "good": 19 },
+      { "part": "hand_l", "good": 5 },
+      { "part": "hand_r", "good": 5 },
+      { "part": "torso", "good": 40 }
     ],
     "armor": [ { "parts": "ALL", "physical": 2 } ]
   },
@@ -1900,16 +1898,16 @@
     "changes_to": [ "CHITIN2", "CHITIN_FUR" ],
     "category": [ "SPIDER" ],
     "wet_protection": [
-      { "part": "HEAD", "ignored": 1 },
-      { "part": "LEG_L", "ignored": 5 },
-      { "part": "LEG_R", "ignored": 5 },
-      { "part": "FOOT_L", "ignored": 1 },
-      { "part": "FOOT_R", "ignored": 1 },
-      { "part": "ARM_L", "ignored": 4 },
-      { "part": "ARM_R", "ignored": 4 },
-      { "part": "HAND_L", "ignored": 1 },
-      { "part": "HAND_R", "ignored": 1 },
-      { "part": "TORSO", "ignored": 10 }
+      { "part": "head", "ignored": 1 },
+      { "part": "leg_l", "ignored": 5 },
+      { "part": "leg_r", "ignored": 5 },
+      { "part": "foot_l", "ignored": 1 },
+      { "part": "foot_r", "ignored": 1 },
+      { "part": "arm_l", "ignored": 4 },
+      { "part": "arm_r", "ignored": 4 },
+      { "part": "hand_l", "ignored": 1 },
+      { "part": "hand_r", "ignored": 1 },
+      { "part": "torso", "ignored": 10 }
     ],
     "armor": [ { "parts": "ALL", "physical": 5 } ]
   },
@@ -1928,16 +1926,16 @@
     "changes_to": [ "CHITIN3" ],
     "category": [ "INSECT" ],
     "wet_protection": [
-      { "part": "HEAD", "ignored": 2 },
-      { "part": "LEG_L", "ignored": 9 },
-      { "part": "LEG_R", "ignored": 9 },
-      { "part": "FOOT_L", "ignored": 2 },
-      { "part": "FOOT_R", "ignored": 2 },
-      { "part": "ARM_L", "ignored": 8 },
-      { "part": "ARM_R", "ignored": 8 },
-      { "part": "HAND_L", "ignored": 2 },
-      { "part": "HAND_R", "ignored": 2 },
-      { "part": "TORSO", "ignored": 18 }
+      { "part": "head", "ignored": 2 },
+      { "part": "leg_l", "ignored": 9 },
+      { "part": "leg_r", "ignored": 9 },
+      { "part": "foot_l", "ignored": 2 },
+      { "part": "foot_r", "ignored": 2 },
+      { "part": "arm_l", "ignored": 8 },
+      { "part": "arm_r", "ignored": 8 },
+      { "part": "hand_l", "ignored": 2 },
+      { "part": "hand_r", "ignored": 2 },
+      { "part": "torso", "ignored": 18 }
     ],
     "armor": [ { "parts": "ALL", "physical": 8 } ],
     "passive_mods": { "dex_mod": -1 }
@@ -1956,30 +1954,30 @@
     "category": [ "SPIDER" ],
     "changes_to": [ "CHITIN_FUR3" ],
     "wet_protection": [
-      { "part": "HEAD", "ignored": 4 },
-      { "part": "LEG_L", "ignored": 14 },
-      { "part": "LEG_R", "ignored": 14 },
-      { "part": "FOOT_L", "ignored": 4 },
-      { "part": "FOOT_R", "ignored": 4 },
-      { "part": "ARM_L", "ignored": 12 },
-      { "part": "ARM_R", "ignored": 12 },
-      { "part": "HAND_L", "ignored": 3 },
-      { "part": "HAND_R", "ignored": 3 },
-      { "part": "TORSO", "ignored": 26 }
+      { "part": "head", "ignored": 4 },
+      { "part": "leg_l", "ignored": 14 },
+      { "part": "leg_r", "ignored": 14 },
+      { "part": "foot_l", "ignored": 4 },
+      { "part": "foot_r", "ignored": 4 },
+      { "part": "arm_l", "ignored": 12 },
+      { "part": "arm_r", "ignored": 12 },
+      { "part": "hand_l", "ignored": 3 },
+      { "part": "hand_r", "ignored": 3 },
+      { "part": "torso", "ignored": 26 }
     ],
     "encumbrance_always": [
-      [ "TORSO", 10 ],
-      [ "HEAD", 10 ],
-      [ "ARM_L", 10 ],
-      [ "ARM_R", 10 ],
-      [ "HAND_L", 10 ],
-      [ "HAND_R", 10 ],
-      [ "LEG_L", 10 ],
-      [ "LEG_R", 10 ],
-      [ "FOOT_L", 10 ],
-      [ "FOOT_R", 10 ]
+      [ "torso", 10 ],
+      [ "head", 10 ],
+      [ "arm_l", 10 ],
+      [ "arm_r", 10 ],
+      [ "hand_l", 10 ],
+      [ "hand_r", 10 ],
+      [ "leg_l", 10 ],
+      [ "leg_r", 10 ],
+      [ "foot_l", 10 ],
+      [ "foot_r", 10 ]
     ],
-    "restricts_gear": [ "HEAD" ],
+    "restricts_gear": [ "head" ],
     "armor": [ { "parts": "ALL", "physical": 12 } ],
     "passive_mods": { "dex_mod": -1 }
   },
@@ -2026,22 +2024,22 @@
     "bodytemp_sleep": 75,
     "description": "Your exoskeleton has hardened considerably--restricting movement, granted--and boasts a fine coat of hairs that put feline whiskers to shame.",
     "encumbrance_always": [
-      [ "TORSO", 10 ],
-      [ "HEAD", 10 ],
-      [ "ARM_L", 10 ],
-      [ "ARM_R", 10 ],
-      [ "HAND_L", 10 ],
-      [ "HAND_R", 10 ],
-      [ "LEG_L", 10 ],
-      [ "LEG_R", 10 ],
-      [ "FOOT_L", 10 ],
-      [ "FOOT_R", 10 ]
+      [ "torso", 10 ],
+      [ "head", 10 ],
+      [ "arm_l", 10 ],
+      [ "arm_r", 10 ],
+      [ "hand_l", 10 ],
+      [ "hand_r", 10 ],
+      [ "leg_l", 10 ],
+      [ "leg_r", 10 ],
+      [ "foot_l", 10 ],
+      [ "foot_r", 10 ]
     ],
     "types": [ "SKIN" ],
     "prereqs": [ "CHITIN_FUR2", "CHITIN3" ],
     "threshreq": [ "THRESH_SPIDER" ],
     "category": [ "SPIDER" ],
-    "restricts_gear": [ "HEAD" ],
+    "restricts_gear": [ "head" ],
     "armor": [ { "parts": "ALL", "physical": 10, "bash": 15 } ],
     "passive_mods": { "dex_mod": -1 }
   },
@@ -2104,16 +2102,16 @@
     "leads_to": [ "THORNS", "LEAVES" ],
     "category": [ "PLANT", "ELFA" ],
     "wet_protection": [
-      { "part": "HEAD", "neutral": 4 },
-      { "part": "LEG_L", "neutral": 5 },
-      { "part": "LEG_R", "neutral": 5 },
-      { "part": "FOOT_L", "neutral": 1 },
-      { "part": "FOOT_R", "neutral": 1 },
-      { "part": "ARM_L", "neutral": 4 },
-      { "part": "ARM_R", "neutral": 4 },
-      { "part": "HAND_L", "neutral": 1 },
-      { "part": "HAND_R", "neutral": 1 },
-      { "part": "TORSO", "neutral": 10 }
+      { "part": "head", "neutral": 4 },
+      { "part": "leg_l", "neutral": 5 },
+      { "part": "leg_r", "neutral": 5 },
+      { "part": "foot_l", "neutral": 1 },
+      { "part": "foot_r", "neutral": 1 },
+      { "part": "arm_l", "neutral": 4 },
+      { "part": "arm_r", "neutral": 4 },
+      { "part": "hand_l", "neutral": 1 },
+      { "part": "hand_r", "neutral": 1 },
+      { "part": "torso", "neutral": 10 }
     ],
     "armor": [ { "parts": "ALL", "cut": 2, "stab": 2 } ],
     "thirst_modifier": -0.2
@@ -2130,16 +2128,16 @@
     "prereqs": [ "PLANTSKIN" ],
     "category": [ "PLANT" ],
     "wet_protection": [
-      { "part": "HEAD", "ignored": 5 },
-      { "part": "LEG_L", "ignored": 16 },
-      { "part": "LEG_R", "ignored": 16 },
-      { "part": "FOOT_L", "ignored": 5 },
-      { "part": "FOOT_R", "ignored": 5 },
-      { "part": "ARM_L", "ignored": 14 },
-      { "part": "ARM_R", "ignored": 14 },
-      { "part": "HAND_L", "ignored": 4 },
-      { "part": "HAND_R", "ignored": 4 },
-      { "part": "TORSO", "ignored": 30 }
+      { "part": "head", "ignored": 5 },
+      { "part": "leg_l", "ignored": 16 },
+      { "part": "leg_r", "ignored": 16 },
+      { "part": "foot_l", "ignored": 5 },
+      { "part": "foot_r", "ignored": 5 },
+      { "part": "arm_l", "ignored": 14 },
+      { "part": "arm_r", "ignored": 14 },
+      { "part": "hand_l", "ignored": 4 },
+      { "part": "hand_r", "ignored": 4 },
+      { "part": "torso", "ignored": 30 }
     ],
     "armor": [ { "parts": "ALL", "cut": 5, "stab": 5, "heat": 1 } ]
   },
@@ -2166,7 +2164,7 @@
     "prereqs": [ "PLANTSKIN", "BARK" ],
     "changes_to": [ "LEAVES2" ],
     "category": [ "PLANT", "ELFA" ],
-    "wet_protection": [ { "part": "HEAD", "ignored": 1 } ]
+    "wet_protection": [ { "part": "head", "ignored": 1 } ]
   },
   {
     "type": "mutation",
@@ -2181,8 +2179,8 @@
     "threshreq": [ "THRESH_PLANT" ],
     "changes_to": [ "LEAVES3" ],
     "category": [ "PLANT" ],
-    "wet_protection": [ { "part": "HEAD", "ignored": 4 }, { "part": "ARM_L", "ignored": 5 }, { "part": "ARM_R", "ignored": 5 } ],
-    "encumbrance_covered": [ [ "ARM_L", 5 ], [ "ARM_R", 5 ] ]
+    "wet_protection": [ { "part": "head", "ignored": 4 }, { "part": "arm_l", "ignored": 5 }, { "part": "arm_r", "ignored": 5 } ],
+    "encumbrance_covered": [ [ "arm_l", 5 ], [ "arm_r", 5 ] ]
   },
   {
     "type": "mutation",
@@ -2196,8 +2194,8 @@
     "prereqs2": [ "TRANSPIRATION" ],
     "threshreq": [ "THRESH_PLANT" ],
     "category": [ "PLANT" ],
-    "wet_protection": [ { "part": "HEAD", "ignored": 5 }, { "part": "ARM_L", "ignored": 8 }, { "part": "ARM_R", "ignored": 8 } ],
-    "encumbrance_covered": [ [ "ARM_L", 10 ], [ "ARM_R", 10 ] ]
+    "wet_protection": [ { "part": "head", "ignored": 5 }, { "part": "arm_l", "ignored": 8 }, { "part": "arm_r", "ignored": 8 } ],
+    "encumbrance_covered": [ [ "arm_l", 10 ], [ "arm_r", 10 ] ]
   },
   {
     "type": "mutation",
@@ -2420,7 +2418,7 @@
     "ugliness": 4,
     "mixed_effect": true,
     "description": "Your upper tentacles have grown large, hook-barbed rakes on the ends.  They're quite vicious, but really aren't suited for fine manipulation.",
-    "encumbrance_always": [ [ "HAND_L", 20 ], [ "HAND_R", 20 ] ],
+    "encumbrance_always": [ [ "hand_l", 20 ], [ "hand_r", 20 ] ],
     "prereqs": [ "ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8" ],
     "threshreq": [ "THRESH_CEPHALOPOD" ],
     "category": [ "CEPHALOPOD" ]
@@ -2447,7 +2445,7 @@
     "butchering_quality": 10,
     "flags": [ "UNARMED_BONUS" ],
     "mixed_effect": true,
-    "restricts_gear": [ "HAND_L", "HAND_R" ],
+    "restricts_gear": [ "hand_l", "hand_r" ],
     "destroys_gear": true,
     "description": "Your index fingers have grown into huge talons.  After a bit of practice, you find that this does not affect your dexterity, but allows for a deadly unarmed attack.  They also prevent wearing gloves.",
     "types": [ "CLAWS" ],
@@ -2594,7 +2592,7 @@
     "description": "The skin on your hands is a mucous membrane and produces a thick, acrid slime.  Attacks using your hand will cause minor cutting damage.  Slightly increases wet benefits.",
     "prereqs": [ "SLIMY" ],
     "category": [ "SLIME" ],
-    "wet_protection": [ { "part": "HAND_L", "good": 5 }, { "part": "HAND_R", "good": 5 } ]
+    "wet_protection": [ { "part": "hand_l", "good": 5 }, { "part": "hand_r", "good": 5 } ]
   },
   {
     "type": "mutation",
@@ -2662,7 +2660,7 @@
     "points": 1,
     "visibility": 1,
     "description": "The bottoms of your feet are strongly padded.  You receive no movement penalty for not wearing shoes, and even receive a 10% bonus when moving barefoot.",
-    "types": [ "LEGS" ],
+    "types": [ "legs" ],
     "category": [ "BEAST", "URSINE", "FELINE", "LUPINE" ]
   },
   {
@@ -2674,9 +2672,9 @@
     "ugliness": 2,
     "mixed_effect": true,
     "description": "You have grown large, curved, and wickedly sharp talons in place of your big toes.  Fortunately, they don't get in the way of your movement.  Unfortunately, they do prevent wearing footgear.",
-    "types": [ "LEGS" ],
+    "types": [ "legs" ],
     "category": [ "RAPTOR" ],
-    "restricts_gear": [ "FOOT_L", "FOOT_R" ],
+    "restricts_gear": [ "foot_l", "foot_r" ],
     "destroys_gear": true,
     "attacks": {
       "attack_text_u": "You slash %s with a talon",
@@ -2695,12 +2693,12 @@
     "ugliness": 2,
     "mixed_effect": true,
     "description": "Your feet have fused into hooves.  This allows kicking attacks to do much more damage, provides natural armor, and removes the need to wear shoes; however, you cannot wear shoes of any kind.  Reduces wet effects.",
-    "types": [ "LEGS" ],
+    "types": [ "legs" ],
     "category": [ "CATTLE", "CHIMERA" ],
-    "wet_protection": [ { "part": "FOOT_L", "neutral": 10 }, { "part": "FOOT_R", "neutral": 10 } ],
-    "restricts_gear": [ "FOOT_L", "FOOT_R" ],
+    "wet_protection": [ { "part": "foot_l", "neutral": 10 }, { "part": "foot_r", "neutral": 10 } ],
+    "restricts_gear": [ "foot_l", "foot_r" ],
     "destroys_gear": true,
-    "armor": [ { "parts": [ "FOOT_L", "FOOT_R" ], "physical": 10 } ],
+    "armor": [ { "parts": [ "foot_l", "foot_r" ], "physical": 10 } ],
     "attacks": {
       "attack_text_u": "You kick %s with your hooves",
       "attack_text_npc": "%1$s kicks %2$s with their hooves",
@@ -2856,13 +2854,13 @@
     "prereqs": [ "FANGS" ],
     "threshreq": [ "THRESH_FELINE", "THRESH_CHIMERA" ],
     "category": [ "FELINE", "CHIMERA" ],
-    "restricts_gear": [ "MOUTH" ],
+    "restricts_gear": [ "mouth" ],
     "destroys_gear": true,
     "social_modifiers": { "intimidate": 15 },
     "attacks": {
       "attack_text_u": "You tear into %s with your saber teeth",
       "attack_text_npc": "%1$s tears into %2$s with their saber teeth",
-      "body_part": "MOUTH",
+      "body_part": "mouth",
       "chance": 20,
       "base_damage": { "damage_type": "stab", "amount": 25 },
       "strength_damage": { "damage_type": "stab", "amount": 1 }
@@ -2890,7 +2888,7 @@
     "ugliness": 1,
     "description": "You have a pair of small horns on your head.  They allow you to make a weak piercing headbutt attack.",
     "types": [ "HORNS" ],
-    "prereqs": [ "HEADBUMPS" ],
+    "prereqs": [ "headBUMPS" ],
     "changes_to": [ "HORNS_CURLED", "HORNS_POINTED", "ANTLERS" ],
     "category": [ "CATTLE" ],
     "attacks": {
@@ -2912,7 +2910,7 @@
     "types": [ "HORNS" ],
     "prereqs": [ "HORNS" ],
     "category": [ "CHIMERA" ],
-    "restricts_gear": [ "HEAD" ],
+    "restricts_gear": [ "head" ],
     "attacks": {
       "attack_text_u": "You headbutt %s with your curled horns",
       "attack_text_npc": "%1$s headbutts %2$s with their curled horns",
@@ -2932,7 +2930,7 @@
     "description": "You have a pair of long, pointed horns, like those of an antelope.  They allow you to make a strong piercing headbutt attack, but prevent wearing headwear that is not made of fabric.",
     "types": [ "HORNS" ],
     "prereqs": [ "HORNS" ],
-    "restricts_gear": [ "HEAD" ],
+    "restricts_gear": [ "head" ],
     "allow_soft_gear": true,
     "attacks": {
       "attack_text_u": "You stab %s with your pointed horns",
@@ -2953,7 +2951,7 @@
     "description": "You have a huge rack of antlers, like those of a moose.  They allow you to make a weak headbutt attack, but prevent wearing headwear that is not made of fabric.",
     "types": [ "HORNS" ],
     "prereqs": [ "HORNS" ],
-    "restricts_gear": [ "HEAD" ],
+    "restricts_gear": [ "head" ],
     "allow_soft_gear": true,
     "attacks": {
       "attack_text_u": "You butt %s with your antlers",
@@ -2972,11 +2970,11 @@
     "ugliness": 4,
     "description": "You have a pair of antennae.  They allow you to detect the presence of monsters up to a few tiles away, even if you can't see or hear them, but prevent wearing headwear that is not made of fabric.",
     "types": [ "HORNS" ],
-    "prereqs": [ "HEADBUMPS" ],
+    "prereqs": [ "headBUMPS" ],
     "category": [ "INSECT" ],
     "active": true,
     "starts_active": true,
-    "restricts_gear": [ "HEAD" ],
+    "restricts_gear": [ "head" ],
     "allow_soft_gear": true
   },
   {
@@ -3013,9 +3011,9 @@
     "types": [ "TAIL" ],
     "prereqs": [ "TAIL_STUB" ],
     "category": [ "FISH" ],
-    "wet_protection": [ { "part": "LEG_L", "good": 3 }, { "part": "LEG_R", "good": 3 } ],
+    "wet_protection": [ { "part": "leg_l", "good": 3 }, { "part": "leg_r", "good": 3 } ],
     "movecost_swim_modifier": 0.75,
-    "restricts_gear": [ "LEG_L", "LEG_R" ],
+    "restricts_gear": [ "leg_l", "leg_r" ],
     "allow_soft_gear": true
   },
   {
@@ -3030,7 +3028,7 @@
     "prereqs": [ "TAIL_STUB" ],
     "changes_to": [ "TAIL_FLUFFY", "TAIL_STING", "TAIL_CLUB", "TAIL_CATTLE", "TAIL_RAT" ],
     "category": [ "FELINE" ],
-    "restricts_gear": [ "LEG_L", "LEG_R" ],
+    "restricts_gear": [ "leg_l", "leg_r" ],
     "allow_soft_gear": true,
     "dodge_modifier": 2
   },
@@ -3045,7 +3043,7 @@
     "types": [ "TAIL" ],
     "prereqs": [ "TAIL_LONG" ],
     "category": [ "CATTLE" ],
-    "restricts_gear": [ "LEG_L", "LEG_R" ],
+    "restricts_gear": [ "leg_l", "leg_r" ],
     "allow_soft_gear": true,
     "dodge_modifier": 1
   },
@@ -3060,7 +3058,7 @@
     "types": [ "TAIL" ],
     "prereqs": [ "TAIL_LONG", "TAIL_STUB" ],
     "category": [ "RAT", "MOUSE" ],
-    "restricts_gear": [ "LEG_L", "LEG_R" ],
+    "restricts_gear": [ "leg_l", "leg_r" ],
     "allow_soft_gear": true,
     "dodge_modifier": 2
   },
@@ -3076,7 +3074,7 @@
     "prereqs": [ "TAIL_STUB" ],
     "changes_to": [ "TAIL_CLUB" ],
     "category": [ "LIZARD" ],
-    "restricts_gear": [ "LEG_L", "LEG_R" ],
+    "restricts_gear": [ "leg_l", "leg_r" ],
     "allow_soft_gear": true,
     "attacks": {
       "attack_text_u": "You whap %s with your tail",
@@ -3097,7 +3095,7 @@
     "types": [ "TAIL" ],
     "prereqs": [ "TAIL_STUB" ],
     "category": [ "RAPTOR" ],
-    "restricts_gear": [ "LEG_L", "LEG_R" ],
+    "restricts_gear": [ "leg_l", "leg_r" ],
     "allow_soft_gear": true,
     "dodge_modifier": 3
   },
@@ -3111,7 +3109,7 @@
     "types": [ "TAIL" ],
     "prereqs": [ "TAIL_LONG" ],
     "category": [ "BEAST", "LUPINE" ],
-    "restricts_gear": [ "LEG_L", "LEG_R" ],
+    "restricts_gear": [ "leg_l", "leg_r" ],
     "allow_soft_gear": true,
     "social_modifiers": { "lie": -20, "persuade": 10 },
     "dodge_modifier": 4
@@ -3126,7 +3124,7 @@
     "description": "You have a long tail that ends in a vicious stinger.  It does not improve your balance at all, but allows for a powerful piercing attack.  Prevents wearing non-fabric pants.",
     "types": [ "TAIL" ],
     "prereqs": [ "TAIL_LONG" ],
-    "restricts_gear": [ "LEG_L", "LEG_R" ],
+    "restricts_gear": [ "leg_l", "leg_r" ],
     "allow_soft_gear": true,
     "attacks": {
       "attack_text_u": "You sting %s with your tail",
@@ -3146,7 +3144,7 @@
     "types": [ "TAIL" ],
     "prereqs": [ "TAIL_THICK" ],
     "category": [ "CHIMERA" ],
-    "restricts_gear": [ "LEG_L", "LEG_R" ],
+    "restricts_gear": [ "leg_l", "leg_r" ],
     "allow_soft_gear": true,
     "attacks": {
       "attack_text_u": "You club %s with your tail",
@@ -3443,16 +3441,16 @@
   },
   {
     "type": "mutation",
-    "id": "MOUTH_TENTACLES",
+    "id": "mouth_TENTACLES",
     "name": { "str": "Mouth Tentacles" },
     "points": 1,
     "visibility": 8,
     "ugliness": 5,
     "description": "A set of tentacles surrounds your mouth.  They allow you to eat twice as fast.  Slightly decreases wet penalties.",
-    "prereqs": [ "MOUTH_FLAPS" ],
+    "prereqs": [ "mouth_FLAPS" ],
     "cancels": [ "MANDIBLES" ],
     "category": [ "CEPHALOPOD" ],
-    "wet_protection": [ { "part": "MOUTH", "neutral": 4 } ]
+    "wet_protection": [ { "part": "mouth", "neutral": 4 } ]
   },
   {
     "type": "mutation",
@@ -3465,18 +3463,18 @@
     "mixed_effect": true,
     "description": "A set of insect-like mandibles have grown around your mouth.  They allow you to eat faster and provide a slicing unarmed attack, but prevent wearing mouthwear.  Slightly reduces wet effects.",
     "types": [ "TEETH", "MUZZLE" ],
-    "prereqs": [ "MOUTH_FLAPS" ],
+    "prereqs": [ "mouth_FLAPS" ],
     "changes_to": [ "FANGS_SPIDER" ],
-    "cancels": [ "MOUTH_TENTACLES" ],
+    "cancels": [ "mouth_TENTACLES" ],
     "category": [ "INSECT", "SPIDER" ],
-    "wet_protection": [ { "part": "MOUTH", "ignored": 100 } ],
-    "restricts_gear": [ "MOUTH" ],
+    "wet_protection": [ { "part": "mouth", "ignored": 100 } ],
+    "restricts_gear": [ "mouth" ],
     "destroys_gear": true,
     "attacks": {
       "attack_text_u": "You bite %s with your fangs",
       "attack_text_npc": "%1$s bites %2$s with their fangs",
       "blocker_mutations": [ "FANGS_SPIDER" ],
-      "body_part": "MOUTH",
+      "body_part": "mouth",
       "chance": 15,
       "base_damage": { "damage_type": "cut", "amount": 12 }
     }
@@ -3490,17 +3488,17 @@
     "ugliness": 6,
     "description": "Your mandibles have developed extensible fangs, allowing you to bite quickly or ensure your venom goes home, as desired.",
     "types": [ "TEETH", "MUZZLE" ],
-    "cancels": [ "MOUTH_TENTACLES" ],
+    "cancels": [ "mouth_TENTACLES" ],
     "prereqs": [ "MANDIBLES" ],
     "prereqs2": [ "POISONOUS", "POISONOUS2" ],
     "threshreq": [ "THRESH_SPIDER" ],
     "category": [ "SPIDER" ],
-    "wet_protection": [ { "part": "MOUTH", "ignored": 100 } ],
+    "wet_protection": [ { "part": "mouth", "ignored": 100 } ],
     "attacks": {
       "attack_text_u": "You bite %s with your fangs",
       "attack_text_npc": "%1$s bites %2$s with their fangs",
       "blocker_mutations": [ "MANDIBLES" ],
-      "body_part": "MOUTH",
+      "body_part": "mouth",
       "chance": 15,
       "base_damage": { "damage_type": "stab", "amount": 22 }
     }
@@ -3688,7 +3686,7 @@
     "visibility": 1,
     "ugliness": 1,
     "mixed_effect": true,
-    "encumbrance_always": [ [ "TORSO", 10 ], [ "ARM_L", 10 ], [ "ARM_R", 10 ] ],
+    "encumbrance_always": [ [ "torso", 10 ], [ "arm_l", 10 ], [ "arm_r", 10 ] ],
     "description": "You have grown noticeably taller and broader.  Much of it is useful muscle mass (Strength +2), but you find it throws off your balance and you get in your own way (+10 torso and arm encumbrance).",
     "prereqs": [ "STR_UP", "STR_UP_2", "STR_UP_3", "STR_UP_4" ],
     "cancels": [ "SMALL", "SMALL2" ],
@@ -3731,7 +3729,7 @@
     "passive_mods": { "str_mod": 4 },
     "hp_adjustment": -6,
     "fatigue_modifier": 0.15,
-    "restricts_gear": [ "TORSO", "LEG_L", "LEG_R", "ARM_L", "ARM_R", "HAND_L", "HAND_R", "HEAD", "FOOT_L", "FOOT_R" ],
+    "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
     "destroys_gear": true,
     "weight_capacity_modifier": 1.1
   },
@@ -3751,7 +3749,7 @@
     "leads_to": [ "MUT_TOUGH" ],
     "category": [ "URSINE", "CATTLE" ],
     "passive_mods": { "str_mod": 4 },
-    "restricts_gear": [ "TORSO", "LEG_L", "LEG_R", "ARM_L", "ARM_R", "HAND_L", "HAND_R", "HEAD", "FOOT_L", "FOOT_R" ],
+    "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
     "destroys_gear": true,
     "weight_capacity_modifier": 1.1
   },
@@ -4111,7 +4109,7 @@
   },
   {
     "type": "mutation",
-    "id": "HEADBUMPS",
+    "id": "headBUMPS",
     "name": { "str": "Head Bumps" },
     "points": 0,
     "visibility": 3,
@@ -4127,7 +4125,7 @@
     "visibility": 7,
     "ugliness": 4,
     "description": "You have a flattened nose and thin slits for nostrils, giving you a lizard-like appearance.  This makes breathing slightly difficult and increases mouth encumbrance by 10.",
-    "encumbrance_always": [ [ "MOUTH", 10 ] ],
+    "encumbrance_always": [ [ "mouth", 10 ] ],
     "category": [ "LIZARD", "CEPHALOPOD", "RAPTOR" ]
   },
   {
@@ -4153,14 +4151,14 @@
   },
   {
     "type": "mutation",
-    "id": "MOUTH_FLAPS",
+    "id": "mouth_FLAPS",
     "name": { "str": "Mouth Flaps" },
     "points": -1,
     "visibility": 7,
     "ugliness": 6,
     "description": "Skin tabs and odd flaps of skin surround your mouth.  They don't affect your eating, but are unpleasant to look at.",
     "category": [ "CHIMERA" ],
-    "leads_to": [ "MOUTH_TENTACLES", "MANDIBLES" ]
+    "leads_to": [ "mouth_TENTACLES", "MANDIBLES" ]
   },
   {
     "type": "mutation",
@@ -4194,12 +4192,12 @@
     "description": "You have a very large and very beautiful pair of brightly-colored wings.  They can't lift you, and they make balancing tricky, but they certainly catch air and attention!",
     "valid": false,
     "purifiable": false,
-    "encumbrance_always": [ [ "TORSO", 10 ] ],
+    "encumbrance_always": [ [ "torso", 10 ] ],
     "types": [ "WINGS" ],
     "prereqs": [ "WINGS_STUB" ],
     "threshreq": [ "THRESH_INSECT" ],
     "category": [ "INSECT" ],
-    "restricts_gear": [ "TORSO" ],
+    "restricts_gear": [ "torso" ],
     "social_modifiers": { "lie": 15, "persuade": 5, "intimidate": -20 },
     "dodge_modifier": -4,
     "movecost_modifier": 0.9
@@ -4337,7 +4335,7 @@
     "types": [ "MUZZLE" ],
     "prereqs": [ "SNOUT" ],
     "category": [ "CATTLE" ],
-    "restricts_gear": [ "MOUTH" ],
+    "restricts_gear": [ "mouth" ],
     "social_modifiers": { "intimidate": 15 }
   },
   {
@@ -4352,13 +4350,13 @@
     "types": [ "MUZZLE" ],
     "prereqs": [ "SNOUT" ],
     "category": [ "BEAST", "LUPINE" ],
-    "restricts_gear": [ "MOUTH" ],
+    "restricts_gear": [ "mouth" ],
     "social_modifiers": { "intimidate": 6 },
     "attacks": {
       "attack_text_u": "You nip at %s",
       "attack_text_npc": "%1$s nips and harries %2$s",
       "blocker_mutations": [ "FANGS" ],
-      "body_part": "MOUTH",
+      "body_part": "mouth",
       "chance": 18,
       "base_damage": { "damage_type": "cut", "amount": 4 }
     }
@@ -4375,12 +4373,12 @@
     "types": [ "MUZZLE" ],
     "prereqs": [ "SNOUT" ],
     "category": [ "URSINE" ],
-    "restricts_gear": [ "MOUTH" ],
+    "restricts_gear": [ "mouth" ],
     "attacks": {
       "attack_text_u": "You bite %s",
       "attack_text_npc": "%1$s bites %2$s",
       "blocker_mutations": [ "FANGS" ],
-      "body_part": "MOUTH",
+      "body_part": "mouth",
       "chance": 20,
       "base_damage": { "damage_type": "cut", "amount": 5 }
     }
@@ -4396,7 +4394,7 @@
     "types": [ "MUZZLE" ],
     "prereqs": [ "SNOUT" ],
     "category": [ "RAT" ],
-    "restricts_gear": [ "MOUTH" ]
+    "restricts_gear": [ "mouth" ]
   },
   {
     "type": "mutation",
@@ -4410,13 +4408,13 @@
     "types": [ "MUZZLE" ],
     "prereqs": [ "SNOUT" ],
     "category": [ "LIZARD" ],
-    "restricts_gear": [ "MOUTH" ],
+    "restricts_gear": [ "mouth" ],
     "social_modifiers": { "intimidate": 20 },
     "attacks": {
       "attack_text_u": "You bite a chunk out of %s",
       "attack_text_npc": "%1$s bites a chunk out of %2$s",
       "blocker_mutations": [ "FANGS" ],
-      "body_part": "MOUTH",
+      "body_part": "mouth",
       "chance": 18,
       "base_damage": { "damage_type": "stab", "amount": 18 }
     }
@@ -4432,12 +4430,12 @@
     "valid": false,
     "purifiable": false,
     "types": [ "TEETH", "MUZZLE" ],
-    "cancels": [ "MOUTH_TENTACLES" ],
+    "cancels": [ "mouth_TENTACLES" ],
     "prereqs": [ "EYEBULGE", "COMPOUND_EYES" ],
     "threshreq": [ "THRESH_INSECT" ],
     "category": [ "INSECT" ],
     "active": true,
-    "restricts_gear": [ "MOUTH" ]
+    "restricts_gear": [ "mouth" ]
   },
   {
     "type": "mutation",
@@ -4697,8 +4695,8 @@
     "cancels": [ "ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8" ],
     "description": "Your hands and feet are heavily webbed, reducing your Dexterity by 1 and causing problems with gloves.  However, you can swim much faster.  Slightly decreases wet penalties.",
     "category": [ "LIZARD", "FISH", "SLIME" ],
-    "wet_protection": [ { "part": "HAND_L", "good": 3 }, { "part": "HAND_R", "good": 3 } ],
-    "encumbrance_covered": [ [ "HAND_L", 50 ], [ "HAND_R", 50 ] ],
+    "wet_protection": [ { "part": "hand_l", "good": 3 }, { "part": "hand_r", "good": 3 } ],
+    "encumbrance_covered": [ [ "hand_l", 50 ], [ "hand_r", 50 ] ],
     "passive_mods": { "dex_mod": -1 }
   },
   {
@@ -4710,10 +4708,10 @@
     "ugliness": 2,
     "mixed_effect": true,
     "description": "Your hands have fused into quasi-paws.  Fine manipulation is a challenge: permanent hand encumbrance of 10, difficulty with delicate craftwork, and your gloves don't fit.  But they handle water better.",
-    "encumbrance_always": [ [ "HAND_L", 10 ], [ "HAND_R", 10 ] ],
-    "restricts_gear": [ "HAND_L", "HAND_R" ],
+    "encumbrance_always": [ [ "hand_l", 10 ], [ "hand_r", 10 ] ],
+    "restricts_gear": [ "hand_l", "hand_r" ],
     "craft_skill_bonus": [ [ "electronics", -2 ], [ "tailor", -2 ], [ "mechanics", -2 ] ],
-    "types": [ "HANDS" ],
+    "types": [ "hands" ],
     "prereqs": [ "CLAWS", "CLAWS_RETRACT", "CLAWS_RAT" ],
     "cancels": [ "TALONS" ],
     "changes_to": [ "PAWS_LARGE" ],
@@ -4739,9 +4737,9 @@
       [ "cooking", -2 ],
       [ "survival", -2 ]
     ],
-    "encumbrance_always": [ [ "HAND_L", 20 ], [ "HAND_R", 20 ] ],
-    "restricts_gear": [ "HAND_L", "HAND_R" ],
-    "types": [ "HANDS" ],
+    "encumbrance_always": [ [ "hand_l", 20 ], [ "hand_r", 20 ] ],
+    "restricts_gear": [ "hand_l", "hand_r" ],
+    "types": [ "hands" ],
     "prereqs": [ "PAWS" ],
     "cancels": [ "TALONS" ],
     "category": [ "BEAST", "URSINE" ]
@@ -4758,13 +4756,13 @@
     "types": [ "TEETH", "MUZZLE" ],
     "changes_to": [ "BEAK_HUM", "BEAK_PECK" ],
     "category": [ "BIRD", "CEPHALOPOD" ],
-    "wet_protection": [ { "part": "MOUTH", "ignored": 1 } ],
-    "restricts_gear": [ "MOUTH" ],
+    "wet_protection": [ { "part": "mouth", "ignored": 1 } ],
+    "restricts_gear": [ "mouth" ],
     "destroys_gear": true,
     "attacks": {
       "attack_text_u": "You peck %s",
       "attack_text_npc": "%1$s pecks %2$s",
-      "body_part": "MOUTH",
+      "body_part": "mouth",
       "chance": 15,
       "base_damage": { "damage_type": "stab", "amount": 15 }
     }
@@ -4780,18 +4778,18 @@
     "valid": false,
     "purifiable": false,
     "types": [ "TEETH", "MUZZLE" ],
-    "cancels": [ "MOUTH_TENTACLES" ],
+    "cancels": [ "mouth_TENTACLES" ],
     "prereqs": [ "BEAK" ],
     "threshreq": [ "THRESH_BIRD" ],
     "category": [ "BIRD" ],
-    "wet_protection": [ { "part": "MOUTH", "ignored": 2 } ],
-    "restricts_gear": [ "MOUTH" ],
+    "wet_protection": [ { "part": "mouth", "ignored": 2 } ],
+    "restricts_gear": [ "mouth" ],
     "destroys_gear": true,
     "attacks": [
       {
         "attack_text_u": "You jackhammer into %s with your beak",
         "attack_text_npc": "%1$s jackhammer into %2$s with their beak",
-        "body_part": "MOUTH",
+        "body_part": "mouth",
         "chance": 15,
         "hardcoded_effect": true
       }
@@ -4808,13 +4806,13 @@
     "valid": false,
     "purifiable": false,
     "types": [ "TEETH", "MUZZLE" ],
-    "cancels": [ "MOUTH_TENTACLES" ],
+    "cancels": [ "mouth_TENTACLES" ],
     "prereqs": [ "BEAK" ],
     "threshreq": [ "THRESH_BIRD" ],
     "category": [ "BIRD" ],
-    "wet_protection": [ { "part": "MOUTH", "ignored": 2 } ],
+    "wet_protection": [ { "part": "mouth", "ignored": 2 } ],
     "active": true,
-    "restricts_gear": [ "MOUTH" ],
+    "restricts_gear": [ "mouth" ],
     "destroys_gear": true
   },
   {
@@ -4879,16 +4877,16 @@
     "changes_to": [ "VISCOUS" ],
     "category": [ "FISH", "SLIME", "TROGLOBITE", "CEPHALOPOD" ],
     "wet_protection": [
-      { "part": "HEAD", "neutral": 3, "good": 4 },
-      { "part": "LEG_L", "neutral": 7, "good": 14 },
-      { "part": "LEG_R", "neutral": 7, "good": 14 },
-      { "part": "FOOT_L", "neutral": 2, "good": 4 },
-      { "part": "FOOT_R", "neutral": 2, "good": 4 },
-      { "part": "ARM_L", "neutral": 7, "good": 12 },
-      { "part": "ARM_R", "neutral": 7, "good": 12 },
-      { "part": "HAND_L", "neutral": 2, "good": 3 },
-      { "part": "HAND_R", "neutral": 2, "good": 3 },
-      { "part": "TORSO", "neutral": 14, "good": 26 }
+      { "part": "head", "neutral": 3, "good": 4 },
+      { "part": "leg_l", "neutral": 7, "good": 14 },
+      { "part": "leg_r", "neutral": 7, "good": 14 },
+      { "part": "foot_l", "neutral": 2, "good": 4 },
+      { "part": "foot_r", "neutral": 2, "good": 4 },
+      { "part": "arm_l", "neutral": 7, "good": 12 },
+      { "part": "arm_r", "neutral": 7, "good": 12 },
+      { "part": "hand_l", "neutral": 2, "good": 3 },
+      { "part": "hand_r", "neutral": 2, "good": 3 },
+      { "part": "torso", "neutral": 14, "good": 26 }
     ]
   },
   {
@@ -4904,16 +4902,16 @@
     "threshreq": [ "THRESH_SLIME" ],
     "category": [ "SLIME" ],
     "wet_protection": [
-      { "part": "HEAD", "neutral": 4, "good": 5 },
-      { "part": "LEG_L", "neutral": 8, "good": 15 },
-      { "part": "LEG_R", "neutral": 8, "good": 15 },
-      { "part": "FOOT_L", "neutral": 3, "good": 5 },
-      { "part": "FOOT_R", "neutral": 3, "good": 5 },
-      { "part": "ARM_L", "neutral": 8, "good": 14 },
-      { "part": "ARM_R", "neutral": 8, "good": 14 },
-      { "part": "HAND_L", "neutral": 3, "good": 4 },
-      { "part": "HAND_R", "neutral": 3, "good": 4 },
-      { "part": "TORSO", "neutral": 15, "good": 27 }
+      { "part": "head", "neutral": 4, "good": 5 },
+      { "part": "leg_l", "neutral": 8, "good": 15 },
+      { "part": "leg_r", "neutral": 8, "good": 15 },
+      { "part": "foot_l", "neutral": 3, "good": 5 },
+      { "part": "foot_r", "neutral": 3, "good": 5 },
+      { "part": "arm_l", "neutral": 8, "good": 14 },
+      { "part": "arm_r", "neutral": 8, "good": 14 },
+      { "part": "hand_l", "neutral": 3, "good": 4 },
+      { "part": "hand_r", "neutral": 3, "good": 4 },
+      { "part": "torso", "neutral": 15, "good": 27 }
     ],
     "armor": [ { "parts": "ALL", "acid": 2 } ]
   },
@@ -5028,7 +5026,7 @@
     "prereqs": [ "PLANTSKIN", "BARK" ],
     "changes_to": [ "VINES2" ],
     "category": [ "PLANT" ],
-    "encumbrance_always": [ [ "TORSO", 10 ] ]
+    "encumbrance_always": [ [ "torso", 10 ] ]
   },
   {
     "type": "mutation",
@@ -5051,7 +5049,7 @@
         "hardcoded_effect": true
       }
     ],
-    "encumbrance_always": [ [ "TORSO", 10 ] ]
+    "encumbrance_always": [ [ "torso", 10 ] ]
   },
   {
     "type": "mutation",
@@ -5104,7 +5102,7 @@
     "changes_to": [ "ROOTS2" ],
     "cancels": [ "LEG_TENTACLES", "HOOVES" ],
     "category": [ "PLANT" ],
-    "encumbrance_covered": [ [ "FOOT_L", 10 ], [ "FOOT_R", 10 ] ]
+    "encumbrance_covered": [ [ "foot_l", 10 ], [ "foot_r", 10 ] ]
   },
   {
     "type": "mutation",
@@ -5117,12 +5115,12 @@
       "//~": "The idea is that you, for lack of a better term, plant yourself.  Crafting and digging don't count because they presume a certain amount of movement during the task.  The handheld game does count.",
       "str": "It's about time you started developing a root system.  When reading, fishing, waiting, or otherwise being stationary for a while on diggable terrain, you'll extract nutrients and water from the soil."
     },
-    "types": [ "LEGS" ],
+    "types": [ "legs" ],
     "prereqs": [ "ROOTS1" ],
     "threshreq": [ "THRESH_PLANT" ],
     "changes_to": [ "ROOTS3" ],
     "category": [ "PLANT" ],
-    "encumbrance_covered": [ [ "FOOT_L", 10 ], [ "FOOT_R", 10 ] ]
+    "encumbrance_covered": [ [ "foot_l", 10 ], [ "foot_r", 10 ] ]
   },
   {
     "type": "mutation",
@@ -5132,12 +5130,12 @@
     "visibility": 5,
     "ugliness": 5,
     "description": "You find it difficult not to sink roots when able.  You extract nutrients and water whenever on diggable terrain, but move more slowly.",
-    "types": [ "LEGS" ],
+    "types": [ "legs" ],
     "prereqs": [ "ROOTS2" ],
     "prereqs2": [ "SAPROPHAGE" ],
     "threshreq": [ "THRESH_PLANT" ],
     "category": [ "PLANT" ],
-    "encumbrance_covered": [ [ "FOOT_L", 10 ], [ "FOOT_R", 10 ] ]
+    "encumbrance_covered": [ [ "foot_l", 10 ], [ "foot_r", 10 ] ]
   },
   {
     "type": "mutation",
@@ -5149,14 +5147,14 @@
     "description": "Every inch of your skin is packed with chlorophyll and you have strong roots.  Sleeping on diggable soil will satisfy any hunger or thirst you might have.",
     "valid": false,
     "purifiable": false,
-    "types": [ "LEGS" ],
+    "types": [ "legs" ],
     "prereqs": [ "ROOTS2", "ROOTS3" ],
     "prereqs2": [ "SAPROPHAGE" ],
     "threshreq": [ "THRESH_PLANT" ],
     "cancels": [ "SMELLY", "SMELLY2" ],
     "category": [ "PLANT" ],
     "scent_type": "sc_flower",
-    "encumbrance_covered": [ [ "FOOT_L", 10 ], [ "FOOT_R", 10 ] ]
+    "encumbrance_covered": [ [ "foot_l", 10 ], [ "foot_r", 10 ] ]
   },
   {
     "type": "mutation",
@@ -5296,13 +5294,13 @@
     "description": "Your arms have grown vibrantly colored feathers.  They effectively waterproof your arms and take the edge off hits, but really get in the way.  They're simply too small to help you in the air.",
     "category": [ "RAPTOR" ],
     "wet_protection": [
-      { "part": "ARM_L", "neutral": 50 },
-      { "part": "ARM_R", "neutral": 50 },
-      { "part": "HAND_L", "neutral": 10 },
-      { "part": "HAND_R", "neutral": 10 }
+      { "part": "arm_l", "neutral": 50 },
+      { "part": "arm_r", "neutral": 50 },
+      { "part": "hand_l", "neutral": 10 },
+      { "part": "hand_r", "neutral": 10 }
     ],
-    "encumbrance_always": [ [ "ARM_L", 20 ], [ "ARM_R", 20 ] ],
-    "armor": [ { "parts": [ "ARM_L", "ARM_R" ], "bash": 1 } ]
+    "encumbrance_always": [ [ "arm_l", 20 ], [ "arm_r", 20 ] ],
+    "armor": [ { "parts": [ "arm_l", "arm_r" ], "bash": 1 } ]
   },
   {
     "type": "mutation",
@@ -5313,14 +5311,14 @@
     "ugliness": 5,
     "description": "You've *finally* sprouted a pair of arms from your midsection.  They flail more-or-less uncontrollably, making you feel rather larval.",
     "purifiable": false,
-    "encumbrance_always": [ [ "ARM_L", 30 ], [ "ARM_R", 30 ] ],
-    "types": [ "HANDS" ],
+    "encumbrance_always": [ [ "arm_l", 30 ], [ "arm_r", 30 ] ],
+    "types": [ "hands" ],
     "changes_to": [ "INSECT_ARMS_OK", "ARACHNID_ARMS" ],
     "prereqs": [ "CHITIN", "CHITIN2", "CHITIN3", "CHITIN_FUR2", "CHITIN_FUR3" ],
     "prereqs2": [ "ANTENNAE" ],
     "threshreq": [ "THRESH_INSECT", "THRESH_SPIDER" ],
     "category": [ "INSECT", "SPIDER" ],
-    "restricts_gear": [ "TORSO" ],
+    "restricts_gear": [ "torso" ],
     "passive_mods": { "dex_mod": -2 }
   },
   {
@@ -5333,7 +5331,7 @@
     "description": "It's good having all your arms.  Though they're too thin to block or punch, you can fold them inside human-shaped gear if need be.",
     "valid": false,
     "purifiable": false,
-    "types": [ "HANDS" ],
+    "types": [ "hands" ],
     "prereqs": [ "INSECT_ARMS" ],
     "prereqs2": [ "ANTENNAE" ],
     "threshreq": [ "THRESH_INSECT" ],
@@ -5349,14 +5347,14 @@
     "description": "There's the last two limbs you were expecting.  Unfortunately you still can't coordinate them, so you're getting in your own way.  A lot.",
     "valid": false,
     "purifiable": false,
-    "encumbrance_always": [ [ "ARM_L", 40 ], [ "ARM_R", 40 ] ],
-    "types": [ "HANDS" ],
+    "encumbrance_always": [ [ "arm_l", 40 ], [ "arm_r", 40 ] ],
+    "types": [ "hands" ],
     "changes_to": [ "ARACHNID_ARMS_OK" ],
     "prereqs": [ "INSECT_ARMS" ],
     "prereqs2": [ "CHITIN3", "CHITIN_FUR2", "CHITIN_FUR3" ],
     "threshreq": [ "THRESH_SPIDER" ],
     "category": [ "SPIDER" ],
-    "restricts_gear": [ "TORSO" ],
+    "restricts_gear": [ "torso" ],
     "passive_mods": { "dex_mod": -4 }
   },
   {
@@ -5369,7 +5367,7 @@
     "description": "You have four handsome limbs, and then those mutant 'hand' and 'foot' things.  They probably aren't worth concealing.",
     "valid": false,
     "purifiable": false,
-    "types": [ "HANDS" ],
+    "types": [ "hands" ],
     "prereqs": [ "ARACHNID_ARMS" ],
     "prereqs2": [ "POISONOUS", "POISONOUS2", "WEB_RAPPEL" ],
     "threshreq": [ "THRESH_SPIDER" ],
@@ -5384,17 +5382,17 @@
     "ugliness": 4,
     "mixed_effect": true,
     "description": "Your arms have transformed into tentacles, resulting in a bonus of 1 to Dexterity, permanent hand encumbrance of 30, and inability to wear gloves.  Somewhat decreases wet penalties.",
-    "encumbrance_always": [ [ "HAND_L", 30 ], [ "HAND_R", 30 ] ],
-    "restricts_gear": [ "HAND_L", "HAND_R" ],
-    "types": [ "HANDS" ],
+    "encumbrance_always": [ [ "hand_l", 30 ], [ "hand_r", 30 ] ],
+    "restricts_gear": [ "hand_l", "hand_r" ],
+    "types": [ "hands" ],
     "leads_to": [ "CLAWS_TENTACLE" ],
     "changes_to": [ "ARM_TENTACLES_4" ],
     "cancels": [ "NAILS", "CLAWS", "TALONS", "WEBBED" ],
     "wet_protection": [
-      { "part": "ARM_L", "neutral": 19 },
-      { "part": "ARM_R", "neutral": 19 },
-      { "part": "HAND_L", "neutral": 5 },
-      { "part": "HAND_R", "neutral": 5 }
+      { "part": "arm_l", "neutral": 19 },
+      { "part": "arm_r", "neutral": 19 },
+      { "part": "hand_l", "neutral": 5 },
+      { "part": "hand_r", "neutral": 5 }
     ],
     "attacks": [
       {
@@ -5422,17 +5420,17 @@
     "visibility": 8,
     "ugliness": 5,
     "description": "Your arms have transformed into four tentacles, resulting in a bonus of 1 to Dexterity, permanent hand encumbrance of 30, and inability to wear gloves.  You can make up to 3 extra attacks with them.  Somewhat decreases wet penalties.",
-    "encumbrance_always": [ [ "HAND_L", 30 ], [ "HAND_R", 30 ] ],
-    "restricts_gear": [ "HAND_L", "HAND_R" ],
-    "types": [ "HANDS" ],
+    "encumbrance_always": [ [ "hand_l", 30 ], [ "hand_r", 30 ] ],
+    "restricts_gear": [ "hand_l", "hand_r" ],
+    "types": [ "hands" ],
     "prereqs": [ "ARM_TENTACLES" ],
     "leads_to": [ "CLAWS_TENTACLE" ],
     "changes_to": [ "ARM_TENTACLES_8" ],
     "wet_protection": [
-      { "part": "ARM_L", "neutral": 19 },
-      { "part": "ARM_R", "neutral": 19 },
-      { "part": "HAND_L", "neutral": 5 },
-      { "part": "HAND_R", "neutral": 5 }
+      { "part": "arm_l", "neutral": 19 },
+      { "part": "arm_r", "neutral": 19 },
+      { "part": "hand_l", "neutral": 5 },
+      { "part": "hand_r", "neutral": 5 }
     ],
     "attacks": [
       {
@@ -5460,17 +5458,17 @@
     "visibility": 9,
     "ugliness": 6,
     "description": "Your arms have transformed into eight tentacles, resulting in a bonus of 1 to Dexterity, permanent hand encumbrance of 30, and inability to wear gloves.  You can make up to 7 extra attacks with them.  Somewhat decreases wet penalties.",
-    "encumbrance_always": [ [ "HAND_L", 30 ], [ "HAND_R", 30 ] ],
-    "restricts_gear": [ "HAND_L", "HAND_R" ],
-    "types": [ "HANDS" ],
+    "encumbrance_always": [ [ "hand_l", 30 ], [ "hand_r", 30 ] ],
+    "restricts_gear": [ "hand_l", "hand_r" ],
+    "types": [ "hands" ],
     "prereqs": [ "ARM_TENTACLES_4" ],
     "leads_to": [ "CLAWS_TENTACLE" ],
     "category": [ "CEPHALOPOD" ],
     "wet_protection": [
-      { "part": "ARM_L", "neutral": 19 },
-      { "part": "ARM_R", "neutral": 19 },
-      { "part": "HAND_L", "neutral": 5 },
-      { "part": "HAND_R", "neutral": 5 }
+      { "part": "arm_l", "neutral": 19 },
+      { "part": "arm_r", "neutral": 19 },
+      { "part": "hand_l", "neutral": 5 },
+      { "part": "hand_r", "neutral": 5 }
     ],
     "attacks": [
       {
@@ -5502,10 +5500,10 @@
     "cancels": [ "CHITIN3" ],
     "changes_to": [ "SHELL2" ],
     "category": [ "CEPHALOPOD" ],
-    "wet_protection": [ { "part": "TORSO", "ignored": 26 } ],
-    "restricts_gear": [ "TORSO" ],
+    "wet_protection": [ { "part": "torso", "ignored": 26 } ],
+    "restricts_gear": [ "torso" ],
     "destroys_gear": true,
-    "armor": [ { "parts": "TORSO", "bash": 6, "cut": 14 } ]
+    "armor": [ { "parts": "torso", "bash": 6, "cut": 14 } ]
   },
   {
     "type": "mutation",
@@ -5518,15 +5516,15 @@
     "bodytemp_sleep": 200,
     "mixed_effect": true,
     "description": "Your protective shell has grown large enough to accommodate--if need be--your whole body.  Activate to pull your head and limbs into your shell, trading mobility and vision for warmth and shelter.",
-    "encumbrance_always": [ [ "TORSO", 10 ] ],
+    "encumbrance_always": [ [ "torso", 10 ] ],
     "prereqs": [ "SHELL" ],
     "threshreq": [ "THRESH_CEPHALOPOD" ],
     "category": [ "CEPHALOPOD" ],
-    "wet_protection": [ { "part": "TORSO", "ignored": 26 } ],
+    "wet_protection": [ { "part": "torso", "ignored": 26 } ],
     "active": true,
-    "restricts_gear": [ "TORSO" ],
+    "restricts_gear": [ "torso" ],
     "destroys_gear": true,
-    "armor": [ { "parts": "TORSO", "bash": 9, "cut": 17 } ]
+    "armor": [ { "parts": "torso", "bash": 9, "cut": 17 } ]
   },
   {
     "type": "mutation",
@@ -5537,18 +5535,18 @@
     "ugliness": 4,
     "mixed_effect": true,
     "description": "Your legs have transformed into six tentacles.  This decreases your speed on land by 20%, makes your movement silent, increases your swimming speed, and reduces wet penalties.",
-    "types": [ "LEGS" ],
+    "types": [ "legs" ],
     "leads_to": [ "LEG_TENT_BRACE" ],
     "movecost_swim_modifier": 0.85,
     "cancels": [ "LIGHTSTEP", "CLUMSY" ],
     "category": [ "CEPHALOPOD" ],
     "wet_protection": [
-      { "part": "LEG_L", "neutral": 21 },
-      { "part": "LEG_R", "neutral": 21 },
-      { "part": "FOOT_L", "neutral": 6 },
-      { "part": "FOOT_R", "neutral": 6 }
+      { "part": "leg_l", "neutral": 21 },
+      { "part": "leg_r", "neutral": 21 },
+      { "part": "foot_l", "neutral": 6 },
+      { "part": "foot_r", "neutral": 6 }
     ],
-    "restricts_gear": [ "FOOT_L", "FOOT_R" ],
+    "restricts_gear": [ "foot_l", "foot_r" ],
     "movecost_modifier": 1.2,
     "noise_modifier": 0.0
   },
@@ -5847,7 +5845,7 @@
     "description": "Like a true fish, your eyes lack eyelids, and are are instead covered by a translucent, protective membrane that blocks irritants and water, and provides minor armor.  It also allows you to sleep with your eyes open!  Activate to cause the approach of hostile creatures to wake you up.",
     "category": [ "FISH" ],
     "threshreq": [ "THRESH_FISH" ],
-    "armor": [ { "parts": "EYES", "cut": 3, "bash": 1 } ],
+    "armor": [ { "parts": "eyes", "cut": 3, "bash": 1 } ],
     "active": true
   },
   {
@@ -5905,7 +5903,7 @@
     "attacks": {
       "attack_text_u": "You tear into %s with your teeth",
       "attack_text_npc": "%1$s tears into %2$s with their teeth",
-      "body_part": "MOUTH",
+      "body_part": "mouth",
       "blocker_mutations": [ "MUZZLE", "MUZZLE_LONG", "MUZZLE_RAT" ],
       "chance": 20,
       "base_damage": { "damage_type": "stab", "amount": 25 }

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -572,16 +572,26 @@
     "initial_ma_styles": [ "style_karate", "style_judo", "style_aikido", "style_tai_chi", "style_taekwondo", "style_pankration" ],
     "valid": false
   },
-   {
- 	"type": "mutation",
- 	"id": "MARTIAL_ARTS2",
- 	"name": { "str": "Self-Defense Classes" },
- 	"points": 2,
- 	"description": "You have taken some self-defense classes at a nearby gym. You start with your choice of Boxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
- 	"starting_trait": true,
- 	"initial_ma_styles": [ "style_boxing", "style_krav_maga", "style_muay_thai", "style_ninjutsu", "style_capoeira", "style_zui_quan", "style_wingchun" ],
- 	"valid": false
- },
+ {
+  "type": "mutation",
+  "id": "MARTIAL_ARTS2",
+  "name": {
+    "str": "Self-Defense Classes"
+  },
+  "points": 2,
+  "description": "You have taken some self-defense classes at a nearby gym.  You start with your choice of Boxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
+  "starting_trait": true,
+  "initial_ma_styles": [
+    "style_boxing",
+    "style_krav_maga",
+    "style_muay_thai",
+    "style_ninjutsu",
+    "style_capoeira",
+    "style_zui_quan",
+    "style_wingchun"
+  ],
+  "valid": false
+},
   {
     "type": "mutation",
     "id": "MARTIAL_ARTS3",


### PR DESCRIPTION


SUMMARY: Content "Add Boxing to Self-Defense Classes trait"


#### Purpose of change

Recreates #50243  for BN. Basically, Boxing can't be selected at character generation save by two separate professions (one of which is only in the later versions of Magiclysm). As I could literally go up the street and enroll in a boxing gym, this doesn't make a lot of sense and it's less fun to boot.


#### Describe the solution

As in the original PR, add the style to the Self-Defense Classes trait.

#### Describe alternatives you've considered

Make Boxing a separate trait, which might make sense anyway as a lot of MMA folks do boxing as part of their discipline to say nothing of kung-fu stylists.

#### Testing

Edited trait, made new character, chose Self-Defense Classes. Boxing was available as an option. Selected, entered game world, Boxing worked as expected. Died horribly to Shocker Zombie, also expected.

#### Additional context

I've been considering doing this for a while, but seeing someone else did it mainline inspired me to put it up.
