### PR TITLE
Show gender on NPC

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6354,7 +6354,7 @@ std::string Character::extended_description() const
         // <bad>This is me, <player_name>.</bad>
         ss += string_format( _( "This is you - %s." ), name );
     } else {
-        ss += string_format( _( "This is %s, %s" ), name, male ? _( "male" ) : _( "female" ));
+        ss += string_format( _( "This is %s, %s" ), name, male ? _( "male" ) : _( "female" ) );
     }
 
     ss += "\n--\n";

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6357,6 +6357,9 @@ std::string Character::extended_description() const
         ss += string_format( _( "This is %s." ), name );
     }
 
+    ss += "\n";
+    ss += male ? _( "Male" ) : _( "Female" );
+    ss += ".";
     ss += "\n--\n";
 
     const std::vector<bodypart_id> &bps = get_all_body_parts( true );
@@ -9863,6 +9866,8 @@ std::vector<std::string> Character::short_description_parts() const
 {
     std::vector<std::string> result;
 
+    std::string gender = male ? _( "Male" ) : _( "Female" );
+    result.push_back( _( "Gender: " ) + gender );
     if( is_armed() ) {
         result.push_back( _( "Wielding: " ) + weapon.tname() );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6354,12 +6354,9 @@ std::string Character::extended_description() const
         // <bad>This is me, <player_name>.</bad>
         ss += string_format( _( "This is you - %s." ), name );
     } else {
-        ss += string_format( _( "This is %s." ), name );
+        ss += string_format( _( "This is %s, %s" ), name, male ? _( "male" ) : _( "female" ));
     }
 
-    ss += "\n";
-    ss += male ? _( "Male" ) : _( "Female" );
-    ss += ".";
     ss += "\n--\n";
 
     const std::vector<bodypart_id> &bps = get_all_body_parts( true );
@@ -9866,8 +9863,8 @@ std::vector<std::string> Character::short_description_parts() const
 {
     std::vector<std::string> result;
 
-    std::string gender = male ? _( "Male" ) : _( "Female" );
-    result.push_back( _( "Gender: " ) + gender );
+    std::string gender = male ? _( "male" ) : _( "female" );
+    result.push_back( name +  ", "  + gender );
     if( is_armed() ) {
         result.push_back( _( "Wielding: " ) + weapon.tname() );
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2230,10 +2230,6 @@ int npc::print_info( const catacurses::window &w, int line, int vLines, int colu
     // w is also 48 characters wide - 2 characters for border = 46 characters for us
     mvwprintz( w, point( column, line++ ), c_white, _( "NPC: " ) );
     wprintz( w, basic_symbol_color(), name );
-    wprintz( w, c_white, " | " );
-    const auto gender_str = male ? _( "Male" ) : _( "Female" );
-    const auto c_color = male ? c_light_blue : c_pink;
-    wprintz( w, c_color, gender_str );
 
     if( sees( g->u ) ) {
         mvwprintz( w, point( column, line++ ), c_yellow, _( "Aware of your presence!" ) );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2234,7 +2234,6 @@ int npc::print_info( const catacurses::window &w, int line, int vLines, int colu
     const auto gender_str = male ? _( "Male" ) : _( "Female" );
     const auto c_color = male ? c_light_blue : c_pink;
     wprintz( w, c_color, gender_str );
-    //mvwprintz(w, point(column, line++), c_color, gender_str);
 
     if( sees( g->u ) ) {
         mvwprintz( w, point( column, line++ ), c_yellow, _( "Aware of your presence!" ) );
@@ -2280,9 +2279,7 @@ int npc::print_info( const catacurses::window &w, int line, int vLines, int colu
         const std::string mutations = _( "Traits: " ) + trait_str;
         enumerate_print( mutations, c_green );
     }
-    //const auto gender_str = male ? _("Male") : _("Female");
-    //const auto color = male ? c_light_blue : c_pink;
-    //enumerate_print(gender_str, color);
+
     return line;
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2230,6 +2230,11 @@ int npc::print_info( const catacurses::window &w, int line, int vLines, int colu
     // w is also 48 characters wide - 2 characters for border = 46 characters for us
     mvwprintz( w, point( column, line++ ), c_white, _( "NPC: " ) );
     wprintz( w, basic_symbol_color(), name );
+    wprintz( w, c_white, " | " );
+    const auto gender_str = male ? _( "Male" ) : _( "Female" );
+    const auto c_color = male ? c_light_blue : c_pink;
+    wprintz( w, c_color, gender_str );
+    //mvwprintz(w, point(column, line++), c_color, gender_str);
 
     if( sees( g->u ) ) {
         mvwprintz( w, point( column, line++ ), c_yellow, _( "Aware of your presence!" ) );
@@ -2275,7 +2280,9 @@ int npc::print_info( const catacurses::window &w, int line, int vLines, int colu
         const std::string mutations = _( "Traits: " ) + trait_str;
         enumerate_print( mutations, c_green );
     }
-
+    //const auto gender_str = male ? _("Male") : _("Female");
+    //const auto color = male ? c_light_blue : c_pink;
+    //enumerate_print(gender_str, color);
     return line;
 }
 


### PR DESCRIPTION
Show gender on NPC

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Interface "Show gender on NPC"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
NPC has genders ingame just like player. However there are no way to see it except using tileset. But some players may not use tilesets- for them it may be not possible to determine gender at all (probably by name, but name may be confusing or by clothes but it is not that easy notice).
At the same time showing gender can be usefull for roleplay reasons and for game world perception.
Also it may be usefull for modders.
Long time ago:
https://github.com/CleverRaven/Cataclysm-DDA/pull/31390
> shard in the Discord asked me to do this.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Restore and improve:
https://github.com/CleverRaven/Cataclysm-DDA/pull/31390
(It was reverted here: https://github.com/CleverRaven/Cataclysm-DDA/pull/31395 for some reason)
Now player can see NPC gender just like to its own.
* in extra examine screen (by pressing e while looking on npc),
* inside dialog menu via Shift+L.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Spawn NPC.
2) Check if gender is visible on examine screen, extended examine screen and inside dialog by pressing Shift+L.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
Armor/mutations/androgyny meaning that its difficult to tell gender at a glance,
though in 90% of cases, id probably be possible.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
