### PR TITLE
Make the stone and copper axe a more vialble tool and make log to planks a fabrication based skill, not survival

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -64,9 +64,9 @@
     "id": "constr_chop_trunk",
     "description": "Chop Tree Trunk Into Planks",
     "category": "FARM_WOOD",
-    "required_skills": [ [ "survival", 2 ] ],
+    "required_skills": [ [ "fabrication", 2 ] ],
     "time": "60 m",
-    "qualities": [ [ { "id": "AXE", "level": 2 }, { "id": "SAW_W", "level": 1 } ] ],
+    "qualities": [ [ { "id": "AXE", "level": 3 }, { "id": "SAW_W", "level": 1 } ] ],
     "pre_terrain": "t_trunk",
     "post_terrain": "t_dirt",
     "post_special": "done_trunk_plank"

--- a/data/json/items/tool/firefighting.json
+++ b/data/json/items/tool/firefighting.json
@@ -18,7 +18,7 @@
     "cutting": 8,
     "to_hit": -1,
     "flags": [ "DURABLE_MELEE", "BELT_CLIP", "NONCONDUCTIVE", "SHEATH_AXE" ],
-    "qualities": [ [ "AXE", 2 ], [ "CUT", 1 ], [ "PRY", 2 ], [ "BUTCHER", 16 ] ]
+    "qualities": [ [ "AXE", 3 ], [ "CUT", 1 ], [ "PRY", 2 ], [ "BUTCHER", 16 ] ]
   },
   {
     "id": "extinguisher",
@@ -54,7 +54,7 @@
     "symbol": "/",
     "color": "light_gray",
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
-    "qualities": [ [ "AXE", 2 ], [ "PRY", 3 ], [ "BUTCHER", -30 ] ],
+    "qualities": [ [ "AXE", 3 ], [ "PRY", 3 ], [ "BUTCHER", -30 ] ],
     "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "BELT_CLIP", "SHEATH_AXE" ],
     "use_action": "CROWBAR"
   },

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -14,7 +14,7 @@
     "material": [ "wood", "steel" ],
     "symbol": "/",
     "color": "light_gray",
-    "qualities": [ [ "AXE", 2 ], [ "BUTCHER", -36 ] ],
+    "qualities": [ [ "AXE", 3 ], [ "BUTCHER", -36 ] ],
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
     "flags": [ "NONCONDUCTIVE", "SHEATH_AXE" ]
   },
@@ -115,7 +115,7 @@
     "material": [ "wood", "copper" ],
     "symbol": "/",
     "color": "brown",
-    "qualities": [ [ "AXE", 1 ], [ "BUTCHER", -44 ] ],
+    "qualities": [ [ "AXE", 2 ], [ "BUTCHER", -44 ] ],
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
     "flags": [ "NONCONDUCTIVE", "SHEATH_AXE" ]
   },
@@ -137,7 +137,7 @@
     "to_hit": -2,
     "flags": [ "DURABLE_MELEE", "BELT_CLIP", "NONCONDUCTIVE", "SHEATH_AXE" ],
     "category": "weapons",
-    "qualities": [ [ "AXE", 2 ], [ "CUT", 1 ], [ "HAMMER", 2 ], [ "HAMMER_FINE", 1 ], [ "BUTCHER", 16 ] ]
+    "qualities": [ [ "AXE", 3 ], [ "CUT", 1 ], [ "HAMMER", 2 ], [ "HAMMER_FINE", 1 ], [ "BUTCHER", 16 ] ]
   },
   {
     "id": "elec_chainsaw_off",
@@ -237,7 +237,7 @@
     "name": { "str": "stone axe" },
     "description": "This is a stone with a narrow edge affixed to a stick.  It can chop wood, but requires much more effort than a modern axe.",
     "weight": "3154 g",
-    "volume": "3500 ml",
+    "volume": "2500 ml",
     "price": 0,
     "price_postapoc": 50,
     "bashing": 9,
@@ -246,7 +246,7 @@
     "material": [ "wood", "stone" ],
     "symbol": "/",
     "color": "light_gray",
-    "qualities": [ [ "AXE", 1 ], [ "BUTCHER", -70 ], [ "HAMMER", 1 ] ],
+    "qualities": [ [ "AXE", 2 ], [ "BUTCHER", -70 ], [ "HAMMER", 2 ] ],
     "flags": [ "BELT_CLIP", "SHEATH_AXE" ]
   },
   {

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -117,7 +117,7 @@
     "type": "tool_quality",
     "id": "AXE",
     "name": { "str": "tree cutting" },
-    "usages": [ [ 1, [ "CHOP_TREE", "CHOP_LOGS" ] ], [ 2, [ "LUMBER" ] ] ]
+    "usages": [ [ 1, [ "CHOP_TREE", "CHOP_LOGS" ] ], [ 3, [ "LUMBER" ] ] ]
   },
   {
     "type": "tool_quality",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Balance "Change axe quality of stone and copper axe"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Stone axe is in every way inferior to the stone hand axe or metal hand axe. It deals less damage, has the same axe and hammering quality, need more skill to make, more material and takes up more space. This commit is trying to make it a more viable tool to use. Same with the copper axe.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Raising axe quality of all 2s to 3s. Raising stone axe axe quality to 2
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
removing the tool from crafting. Since it has absolutly no advantage to the hand axes.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
![image](https://user-images.githubusercontent.com/33199510/131639492-f7fcd30b-66e7-4366-a997-7f3123cbed65.png)
a stone wood axe can be a very good and accurate tool, even to make planks out of logs.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
