### PR TITLE
Make arm/leg components of armor sets consistent with rest of set

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -278,6 +278,6 @@
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "BELTED", "OUTER", "WATER_FRIENDLY" ]
+    "flags": [ "STURDY", "BELTED", "WATER_FRIENDLY" ]
   }
 ]

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -97,7 +97,7 @@
     "color": "brown",
     "covers": [ "ARMS" ],
     "coverage": 90,
-    "encumbrance": 10,
+    "encumbrance": 20,
     "warmth": 25,
     "material_thickness": 4,
     "valid_mods": [ "steel_padded" ],

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -44,7 +44,7 @@
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ]
+    "flags": [ "STURDY", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ]
   },
   {
     "id": "armguard_acidchitin",
@@ -101,7 +101,7 @@
     "warmth": 25,
     "material_thickness": 4,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "STURDY", "BELTED", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ]
+    "flags": [ "STURDY", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ]
   },
   {
     "id": "armguard_lightplate",
@@ -123,7 +123,7 @@
     "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "BELTED", "STURDY", "BLOCK_WHILE_WORN" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY", "BLOCK_WHILE_WORN" ]
   },
   {
     "id": "armguard_metal",
@@ -278,6 +278,6 @@
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "STURDY", "BELTED", "WATER_FRIENDLY" ]
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY" ]
   }
 ]

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -101,7 +101,7 @@
     "warmth": 25,
     "material_thickness": 4,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "STURDY", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ]
+    "flags": [ "VARSIZE", "STURDY", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ]
   },
   {
     "id": "armguard_lightplate",
@@ -278,6 +278,6 @@
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY" ]
+    "flags": [ "STRAPPED", "OUTER", "WATER_FRIENDLY" ]
   }
 ]

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -278,6 +278,6 @@
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "STRAPPED", "OUTER", "WATER_FRIENDLY" ]
+    "flags": [ "BELTED", "OUTER", "WATER_FRIENDLY" ]
   }
 ]

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -198,7 +198,7 @@
     "encumbrance": 20,
     "warmth": 20,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "BELTED", "STURDY" ]
+    "flags": [ "VARSIZE", "OUTER", "STURDY" ]
   },
   {
     "id": "legguard_metal",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix arm and leg guards that are part of an armor set having wildly different properties"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I noticed while fumbling to get leather armor produced that leather arm guards, intended to be worn with leather body armor, and being used together to craft the plated and boiled armor sets, didn't behave the same as leather body armor. It was on the strapped layer instead of normal, and wasn't variable in size.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Set leather arm guards to have VARSIZE, increased encumbrance to 20, and removed `STRAPPED` flag. Now consistent with leather body armor.
2. Removed `STRAPPED` flag from chitin and acidchitin arm guards, to be consistent with the body armor item.
3. Replaced `STRAPPED` with `OUTER` for plate arm and leg guards, to be consistent with cuirass and with assembled plate armor.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Removing `BLOCK_WHILE_WORN` as well, seems acceptable to have it on. For leather arm guards it's a trade off between upgrading your armor vs. retaining the freedom to block with the arm guards, and chitin arm guards don't have any upgraded merged sets where it'd lose the flag. Steel arm guards losing the `BLOCK_WHILE_WORN` on being crafted into plate armor, with no advantage to make up for it, is the only real oddity resulting from that.
2. Could update the bone armor too but could also save it for any future revival of it from the depths of obsolescence.
3. Briefly pondered applying similar updates to vambraces but they aren't part of a set, meaning it's reasonable for them to be a standalone arm guard item.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Ported JSON changes over to check for syntax errors, ran affected files through linter.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
