### PR TITLE
Remove Gravel

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4281,5 +4281,17 @@
     "pre_note": "Must be between brick or (reinforced)concrete walls to function, and at least one wall must have an adjacent mechanical winch.",
     "pre_special": "check_empty",
     "post_terrain": "t_door_metal_locked"
+  },
+  {
+    "type": "construction",
+    "id": "constr_remove_gravel",
+    "description": "Remove gravel and replace with dirt",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "60 m",
+    "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
+    "byproducts": [ { "item": "pebble", "count": [ 6, 10 ] } ],
+    "pre_terrain": "t_railroad_rubble",
+    "post_terrain": "t_dirt"
   }
 ]


### PR DESCRIPTION
#### Summary
SUMMARY: Features "Make removing gravel possible"

#### Purpose of change
Since we can place gravel but can't remove it, this should do the trick. I wasn't sure if we should keep 100% of the ingredients when building gravel floors, but rather a bit lower (some may get destroyed or were washed away, etc.).
Reason for it is: you can't build fences etc. over gravel.

#### Describe the solution
Add a construction method of removing gravel from groundtiles.

#### Testing
While I "remove gravel", some stone faced dude appeared and played the accordion next to me.