### PR TITLE
Increase effect of prying quality on prying difficulty, door damage chance

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2389,14 +2389,14 @@ int iuse::crowbar( player *p, item *it, bool, const tripoint &pos )
         new_type = t_door_o;
         pry_quality = 2;
         noisy = true;
-        difficulty = 6;
+        difficulty = 8;
     } else if( type == t_door_locked_peep ) {
         succ_action = _( "You pry open the door." );
         fail_action = _( "You pry, but cannot pry open the door." );
         new_type = t_door_o_peep;
         pry_quality = 2;
         noisy = true;
-        difficulty = 6;
+        difficulty = 8;
     } else if( type == t_door_c ) {
         p->add_msg_if_player( m_info, _( "You notice the door is unlocked, so you simply open it." ) );
         g->m.ter_set( pnt, t_door_o );
@@ -2425,14 +2425,14 @@ int iuse::crowbar( player *p, item *it, bool, const tripoint &pos )
         fail_action = _( "You pry, but the coffin remains closed." );
         pry_quality = 2;
         noisy = true;
-        difficulty = 5;
+        difficulty = 7;
     } else if( type == t_window_domestic || type == t_curtains || type == t_window_no_curtains ) {
         succ_action = _( "You pry open the window." );
         fail_action = _( "You pry, but cannot pry open the window." );
         new_type = ( type == t_window_no_curtains ) ? t_window_no_curtains_open : t_window_open;
         pry_quality = 2;
         noisy = true;
-        difficulty = 6;
+        difficulty = 8;
     } else {
         return 0;
     }
@@ -2451,8 +2451,14 @@ int iuse::crowbar( player *p, item *it, bool, const tripoint &pos )
         return 0;
     }
 
-    // For every level of PRY over the requirement, remove n from the difficulty (so -2 with a PRY 4 tool)
-    difficulty -= ( pry_level - pry_quality );
+    // For every level of PRY over the requirement, remove n from the difficulty.
+    // If pry_quality is 2 or higher, multiply effect of pre_level by 3.
+    // So a tool with PRY 4 gives -6 when used on a door, but only -2 on a manhole cover.
+    if( pry_quality > 1 ) {
+        difficulty -= ( ( pry_level - pry_quality ) * 3 );
+    } else {
+        difficulty -= ( pry_level - pry_quality );
+    }
 
     /** @EFFECT_STR speeds up crowbar prying attempts */
     p->mod_moves( -std::max( 20, difficulty * 20 - p->str_cur * 5 ) );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -322,9 +322,10 @@ bool plant_data::load( const JsonObject &jsobj, const std::string &member )
     return true;
 }
 
-pry_result::pry_result() : pry_quality( 1 ), pry_bonus_mult( 1 ),
+pry_result::pry_result() : pry_quality( -1 ), pry_bonus_mult( 1 ),
     difficulty( 1 ), noise( 0 ),
     alarm( false ), breakable( false ),
+    pry_drop_group( "EMPTY_GROUP" ), break_drop_group( "EMPTY_GROUP" ),
     breakage_ter_type( ter_str_id::NULL_ID() ), breakage_furn_type( furn_str_id::NULL_ID() ),
     new_ter_type( ter_str_id::NULL_ID() ), new_furn_type( furn_str_id::NULL_ID() ) {}
 
@@ -336,7 +337,7 @@ bool pry_result::load( const JsonObject &jsobj, const std::string &member,
     }
 
     JsonObject j = jsobj.get_object( member );
-    pry_quality = j.get_int( "pry_quality", 1 );
+    pry_quality = j.get_int( "pry_quality", -1 );
     pry_bonus_mult = j.get_int( "pry_bonus_mult", 1 );
     difficulty = j.get_int( "difficulty", 1 );
 
@@ -355,6 +356,18 @@ bool pry_result::load( const JsonObject &jsobj, const std::string &member,
             new_ter_type = ter_str_id( j.get_string( "new_ter_type" ) );
             breakage_ter_type = ter_str_id( j.get_string( "breakage_ter_type" ) );
             break;
+    }
+
+    if( j.has_member( "pry_items" ) ) {
+        pry_items = item_group::load_item_group( j.get_member( "pry_items" ), "collection" );
+    } else {
+        pry_items = item_group_id( "EMPTY_GROUP" );
+    }
+
+    if( j.has_member( "break_items" ) ) {
+        break_items = item_group::load_item_group( j.get_member( "break_items" ), "collection" );
+    } else {
+        break_items = item_group_id( "EMPTY_GROUP" );
     }
 
     return true;

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -322,6 +322,44 @@ bool plant_data::load( const JsonObject &jsobj, const std::string &member )
     return true;
 }
 
+pry_result::pry_result() : pry_quality( 1 ), pry_bonus_mult( 1 ),
+    difficulty( 1 ), noise( 0 ),
+    alarm( false ), breakable( false ),
+    breakage_ter_type( ter_str_id::NULL_ID() ), breakage_furn_type( furn_str_id::NULL_ID() ),
+    new_ter_type( ter_str_id::NULL_ID() ), new_furn_type( furn_str_id::NULL_ID() ) {}
+
+bool pry_result::load( const JsonObject &jsobj, const std::string &member,
+                          map_object_type obj_type )
+{
+    if( !jsobj.has_object( member ) ) {
+        return false;
+    }
+
+    JsonObject j = jsobj.get_object( member );
+    pry_quality = j.get_int( "pry_quality", 1 );
+    pry_bonus_mult = j.get_int( "pry_bonus_mult", 1 );
+    difficulty = j.get_int( "difficulty", 1 );
+
+    noise = j.get_int( "noise", 0 );
+    sound = to_translation( "crunch!" );
+    sound_break = to_translation( "crack!" );
+    j.read( "sound", sound );
+    j.read( "sound_break", sound_break );
+
+    switch( obj_type ) {
+        case pry_result::furniture:
+            new_furn_type = furn_str_id( j.get_string( "new_furn_type", "f_null" ) );
+            breakage_furn_type = furn_str_id( j.get_string( "breakage_furn_type", "f_null" ) );
+            break;
+        case pry_result::terrain:
+            new_ter_type = ter_str_id( j.get_string( "new_ter_type" ) );
+            breakage_ter_type = ter_str_id( j.get_string( "breakage_ter_type" ) );
+            break;
+    }
+
+    return true;
+}
+
 furn_t null_furniture_t()
 {
     furn_t new_furniture;

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -112,17 +112,22 @@ struct pry_result {
     int difficulty;
     // How much noise a successful prying attempt creates, if any
     int noise;
-    // Does a successful pry attempt cause noise?
+    // Does a successful pry attempt potentially sound an alarm?
     bool alarm;
     // Does a failed pry attempt risk breaking it instead?
     bool breakable;
     // What terrain or furniture it will turn into if you break it
     ter_id breakage_ter_type;
     furn_id breakage_furn_type;
+    // sound message made on success ('You hear a "smash!"')
+    translation sound;
+    // sound message made on breakage, if breakable is true
+    translation sound_break;
     // Messages for succeeding or failing pry attempt, and breakage
     std::string success_message;
     std::string fail_message;
     std::string breakage_message;
+    pry_result();
     enum map_object_type {
         furniture = 0,
         terrain

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -119,6 +119,9 @@ struct pry_result {
     // What terrain or furniture it will turn into if you break it
     ter_id breakage_ter_type;
     furn_id breakage_furn_type;
+    // item group of items that are dropped on success or breakage
+    item_group_id pry_items;
+    item_group_id break_items;
     // sound message made on success ('You hear a "smash!"')
     translation sound;
     // sound message made on breakage, if breakable is true

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -100,6 +100,36 @@ struct lockpicking_open_result {
     std::string open_message;
 };
 
+struct pry_result {
+    // What terrain or furniture it will turn into when pried open
+    ter_id new_ter_type;
+    furn_id new_furn_type;
+    // Minimum prying quality required to pry open
+    int pry_quality;
+    // Multiplier for how much of an advantage is gained from using a better tool than the minimum
+    int pry_bonus_mult;
+    // Difficulty value used for roll
+    int difficulty;
+    // How much noise a successful prying attempt creates, if any
+    int noise;
+    // Does a successful pry attempt cause noise?
+    bool alarm;
+    // Does a failed pry attempt risk breaking it instead?
+    bool breakable;
+    // What terrain or furniture it will turn into if you break it
+    ter_id breakage_ter_type;
+    furn_id breakage_furn_type;
+    // Messages for succeeding or failing pry attempt, and breakage
+    std::string success_message;
+    std::string fail_message;
+    std::string breakage_message;
+    enum map_object_type {
+        furniture = 0,
+        terrain
+    };
+    bool load( const JsonObject &jsobj, const std::string &member, map_object_type obj_type );
+};
+
 /*
  * List of known flags, used in both terrain.json and furniture.json.
  * TRANSPARENT - Players and monsters can see through/past it. Also sets ter_t.transparent


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->


SUMMARY: Balance "Increase how prying quality affects success rate and time taken to pry terrain, allow prying failure to damage doors"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Per discussion in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/835, it was suggested that the effect of prying quality have more of an impact, noting that there was very little advantage to using a crowbar over a claw bar, and that this was an obstacle to balancing makeshift crowbars so that they can be allowed to open doors again.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed base difficulty for most prying targets from 6 to 8, and that of coffins from 5 to 7.
2. Implemented an if/else tweak so that, if the minimum prying required is 2 or higher, the existing bonus for having higher prying than the minimum is tripled. Since that bonus could get much higher with prying of 1 as the requirement, the exception was added so that waving a halligan bar at a crate won't give it negative difficulty.
3. Time taken to use a crowbar was found to very very short even under non-ideal conditions, leading to a rebalance of how move cost scales with difficulty and strength.
4. It was proposed that there could be a chance of breaking doors on a failed prying attempt, like how you can break windows.

Tables summarizing net impact of this will be below.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. It might be feasible to balance targets with minimum difficulty of 1 to work with 2x quality bonus instead of retaining the 1x multiplier, but it would require increasing the base difficulty for those to a degree as well. Seems like it'd be harder to balance out to work well since there's more room to expand.
2. Windows having the same difficulty as doors seems odd, could be nudged down a point.
3. Likewise, sealed coffins seem like they should be prying 1 tier, since if I recall the coffin construction implies you're nailing them shut, not locking them.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested code changes.
2. Debugged in a multitude of locked doors, waved an escalating series of crowbars at them to contain game doesn't explode.
3. Ran through Astyle to make sure code formatting fit the standard.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Separate from but related to PR linked to above, making the balance impact of un-nerfing makeshift crowbars have less of an effect on the desirability of normal crowbars.

This should quantify the actual odds of a successful pry, before and after the changes, in a selection of contexts: https://anydice.com/program/2418a
And this is used to calculate the risk of damaging a door on a failed pry, which has effectively half the difficulty roll of windows: https://anydice.com/program/241dc

Against locked doors specifically:

Context | Success Chance Before | Success Chance After
------------ | ------------- | -------------
Prying 2, Strength 8 | 72.62% (Difficulty: 6) | 46.98% (Difficulty: 8)
Prying 3, Strength 8 | 84.29% (Difficulty: 5) | 84.29% (Difficulty: 5)
Prying 4, Strength 8 | 92.80% (Difficulty: 4)  | 99.51% (Difficulty: 2)
Prying 2, Strength 20 | 99.08% (Difficulty: 6) | 97.17% (Difficulty: 8)
Prying 3, Strength 20 | 99.55% (Difficulty: 5) | 99.55% (Difficulty: 5)
Prying 4, Strength 20 | 99.81% (Difficulty: 4) | 99.99% (Difficulty: 2)

For risk of breaking doors:

Context | Breakage Chance, Mechanics 0 | Breakage Chance, Mechanics 5 | Breakage Chance, Mechanics 10
------------ | ------------- | ------------- | -------------
Pry 2, Str 8 (Diff 8) | 45.8% | 9.96% | 2.94%
Pry 3, Str 8 (Diff 5) | 18.75% | 1.15% | 0.29%
Pry 4, Str 8 (Diff 2) | 1.95%  | 0% | 0%
Pry 2, Str 20 (Diff 8) | 8.31% | 1.62% | 0.48%
Pry 3, Str 20 (Diff 5) | 3% | 0.18% | 0.05%
Pry 4, Str 20 (Diff 2) | 0.31% | 0% | 0%

Time taken per pry attempt:

Context | Time Taken Before | Time Taken After
------------ | ------------- | -------------
Prying 2, Strength 8 | 0.8 sec (Difficulty: 6) | 3.2 sec (Difficulty: 8)
Prying 3, Strength 8 | 0.6 sec (Difficulty: 5) | 2.2 sec (Difficulty: 5)
Prying 4, Strength 8 | 0.4 sec (Difficulty: 4)  | 1.2 sec (Difficulty: 2)
Prying 2, Strength 20 | 0.2 sec (Difficulty: 6) | 2 sec (Difficulty: 8)
Prying 3, Strength 20 | 0.2 sec (Difficulty: 5) | 1 sec (Difficulty: 5)
Prying 4, Strength 20 | 0.2 sec (Difficulty: 4) | 0.2 sec (Difficulty: 2)