### PR TITLE
Persist perfered aiming mode

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -951,13 +951,6 @@
   },
   {
     "type": "keybinding",
-    "id": "SWITCH_AIM",
-    "category": "TARGET",
-    "name": "Switch Aiming Mode",
-    "bindings": [ { "input_method": "keyboard", "key": "m" } ]
-  },
-  {
-    "type": "keybinding",
     "id": "SWITCH_AMMO",
     "category": "TARGET",
     "name": "Switch ammo",

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -193,6 +193,8 @@ class avatar : public player
         faction *get_faction() const override;
         // Set in npc::talk_to_you for use in further NPC interactions
         bool dialogue_by_radio = false;
+        // Preferred aim mode - ranged.cpp aim mode defaults to this if possible
+        std::string preferred_aiming_mode;
 
         void set_movement_mode( character_movemode mode ) override;
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2793,6 +2793,7 @@ void target_ui::action_switch_mode()
                 menu.entries.back().text_color = c_light_green;
             }
         }
+	}
     ensure_ranged_gun_mode();
     update_ammo_range_from_gun_mode();
     on_range_ammo_changed();

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2831,7 +2831,7 @@ void target_ui::action_switch_mode()
         const std::map<gun_mode_id, gun_mode> all_gun_modes = relevant->gun_all_modes();
         int skip = menu.ret - firing_modes_range.first;
         for( std::pair<gun_mode_id, gun_mode> it : all_gun_modes ) {
-            if( it.second.flags.count( "REACH_ATTACK" ) ) {
+            if( it.second.melee() ) {
                 continue;
             }
             if( skip-- == 0 ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2128,14 +2128,6 @@ target_handler::trajectory target_ui::run()
                 loop_exit_code = ExitCode::Reload;
                 break;
             }
-        } else if( action == "SWITCH_AIM" ) {
-            if( status != Status::Good ) {
-                continue;
-            }
-            aim_mode++;
-            if( aim_mode == aim_types.end() ) {
-                aim_mode = aim_types.begin();
-            }
         } else if( action == "FIRE" ) {
             if( status != Status::Good ) {
                 continue;
@@ -2275,7 +2267,6 @@ void target_ui::init_window_and_input()
     }
     if( mode == TargetMode::Fire ) {
         ctxt.register_action( "AIM" );
-        ctxt.register_action( "SWITCH_AIM" );
 
         aim_types = you->get_aim_types( *relevant );
         for( aim_type &type : aim_types ) {
@@ -2284,6 +2275,11 @@ void target_ui::init_window_and_input()
             }
         }
         aim_mode = aim_types.begin();
+        for( auto it = aim_types.begin(); it != aim_types.end(); ++it ) {
+            if( you->preferred_aiming_mode == it->action ) {
+                aim_mode = it; // default to persisted mode if possible
+            }
+        }
     }
     if( mode == TargetMode::Turrets ) {
         ctxt.register_action( "TOGGLE_TURRET_LINES" );
@@ -2777,11 +2773,81 @@ void target_ui::apply_aim_turning_penalty()
 
 void target_ui::action_switch_mode()
 {
-    relevant->gun_cycle_mode();
+    uilist menu;
+    menu.settext( _( "Select preferences" ) );
+    const std::pair<int, int> aim_modes_range = std::make_pair( 0, 100 );
+    const std::pair<int, int> firing_modes_range = std::make_pair( 100, 200 );
+
+    if( !aim_types.empty() ) {
+        menu.addentry( -1, false, 0, "  " + std::string( _( "Default aiming mode" ) ) );
+        menu.entries.back().force_color = true;
+        menu.entries.back().text_color = c_cyan;
+
+        for( auto it = aim_types.begin(); it != aim_types.end(); ++it ) {
+            const bool is_active_aim_mode = aim_mode == it;
+            const std::string text = ( it->name.empty() ? _( "Immediate" ) : it->name ) +
+                                     ( is_active_aim_mode ? _( " (active)" ) : "" );
+            menu.addentry( aim_modes_range.first + std::distance( aim_types.begin(), it ),
+                           true, MENU_AUTOASSIGN, text );
+            if( is_active_aim_mode ) {
+                menu.entries.back().text_color = c_light_green;
+            }
+        }
     ensure_ranged_gun_mode();
     update_ammo_range_from_gun_mode();
     on_range_ammo_changed();
 }
+
+    const std::map<gun_mode_id, gun_mode> gun_modes = relevant->gun_all_modes();
+    if( !gun_modes.empty() ) {
+        menu.addentry( -1, false, 0, "  " + std::string( _( "Firing mode" ) ) );
+        menu.entries.back().force_color = true;
+        menu.entries.back().text_color = c_cyan;
+
+        for( auto it = gun_modes.begin(); it != gun_modes.end(); ++it ) {
+            if( it->second.flags.count( "REACH_ATTACK" ) ) {
+                continue;
+            }
+            const bool active_gun_mode = relevant->gun_get_mode_id() == it->first;
+
+            // If gun mode is from a gunmod use gunmod's name, pay attention to the "->" on tname
+            std::string text = ( it->second.target == relevant )
+                               ? it->second.tname()
+                               : it->second->tname() + " (" + std::to_string( it->second.qty ) + ")";
+
+            text += ( active_gun_mode ? _( " (active)" ) : "" );
+
+            menu.entries.emplace_back( firing_modes_range.first + std::distance( gun_modes.begin(), it ),
+                                       true, MENU_AUTOASSIGN, text );
+            if( active_gun_mode ) {
+                menu.entries.back().text_color = c_light_green;
+                if( menu.selected == 0 ) {
+                    menu.selected = menu.entries.size() - 1;
+                }
+            }
+        }
+    }
+
+    menu.query();
+    if( menu.ret >= firing_modes_range.first && menu.ret < firing_modes_range.second ) {
+        // gun mode select
+        const std::map<gun_mode_id, gun_mode> all_gun_modes = relevant->gun_all_modes();
+        int skip = menu.ret - firing_modes_range.first;
+        for( std::pair<gun_mode_id, gun_mode> it : all_gun_modes ) {
+            if( it.second.flags.count( "REACH_ATTACK" ) ) {
+                continue;
+            }
+            if( skip-- == 0 ) {
+                relevant->gun_set_mode( it.first );
+                break;
+            }
+        }
+    } else if( menu.ret >= aim_modes_range.first && menu.ret < aim_modes_range.second ) {
+        // aiming mode select
+        aim_mode = aim_types.begin();
+        std::advance( aim_mode, menu.ret - aim_modes_range.first );
+        you->preferred_aiming_mode = aim_mode->action;
+    } // else - just refresh
 
 void target_ui::ensure_ranged_gun_mode()
 {
@@ -3109,11 +3175,8 @@ void target_ui::draw_controls_list( int text_y )
 
         std::string aim = string_format( _( "[%c] to steady your aim.  (10 moves)" ),
                                          bound_key( "AIM" ) );
-        std::string sw_aim = string_format( _( "[%c] to switch aiming modes." ),
-                                            bound_key( "SWITCH_AIM" ) );
 
         lines.push_back( { 2, colored( col_fire, aim ) } );
-        lines.push_back( { 1, colored( col_fire, sw_aim ) } );
         lines.push_back( { 4, colored( col_fire, aim_and_fire ) } );
     }
     if( mode == TargetMode::Fire || mode == TargetMode::TurretManual ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2794,7 +2794,7 @@ void target_ui::action_switch_mode()
             }
         }
 	}
-	
+
     const std::map<gun_mode_id, gun_mode> gun_modes = relevant->gun_all_modes();
     if( !gun_modes.empty() ) {
         menu.addentry( -1, false, 0, "  " + std::string( _( "Firing mode" ) ) );
@@ -2850,9 +2850,6 @@ void target_ui::action_switch_mode()
     update_ammo_range_from_gun_mode();
     on_range_ammo_changed();
 }
-
-
- 
 
 void target_ui::ensure_ranged_gun_mode()
 {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2802,7 +2802,7 @@ void target_ui::action_switch_mode()
         menu.entries.back().text_color = c_cyan;
 
         for( auto it = gun_modes.begin(); it != gun_modes.end(); ++it ) {
-            if( it->second.flags.count( "REACH_ATTACK" ) ) {
+            if( it->second.melee() ) {
                 continue;
             }
             const bool active_gun_mode = relevant->gun_get_mode_id() == it->first;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2793,7 +2793,7 @@ void target_ui::action_switch_mode()
                 menu.entries.back().text_color = c_light_green;
             }
         }
-	}
+    }
 
     const std::map<gun_mode_id, gun_mode> gun_modes = relevant->gun_all_modes();
     if( !gun_modes.empty() ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2794,11 +2794,7 @@ void target_ui::action_switch_mode()
             }
         }
 	}
-    ensure_ranged_gun_mode();
-    update_ammo_range_from_gun_mode();
-    on_range_ammo_changed();
-}
-
+	
     const std::map<gun_mode_id, gun_mode> gun_modes = relevant->gun_all_modes();
     if( !gun_modes.empty() ) {
         menu.addentry( -1, false, 0, "  " + std::string( _( "Firing mode" ) ) );
@@ -2849,6 +2845,14 @@ void target_ui::action_switch_mode()
         std::advance( aim_mode, menu.ret - aim_modes_range.first );
         you->preferred_aiming_mode = aim_mode->action;
     } // else - just refresh
+
+    ensure_ranged_gun_mode();
+    update_ammo_range_from_gun_mode();
+    on_range_ammo_changed();
+}
+
+
+ 
 
 void target_ui::ensure_ranged_gun_mode()
 {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2814,8 +2814,8 @@ void target_ui::action_switch_mode()
 
             text += ( active_gun_mode ? _( " (active)" ) : "" );
 
-            menu.entries.emplace_back( firing_modes_range.first + std::distance( gun_modes.begin(), it ),
-                                       true, MENU_AUTOASSIGN, text );
+            int retv = firing_modes_range.first + std::distance( gun_modes.begin(), it );
+            menu.entries.emplace_back( retv, true, MENU_AUTOASSIGN, text );
             if( active_gun_mode ) {
                 menu.entries.back().text_color = c_light_green;
                 if( menu.selected == 0 ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1141,7 +1141,7 @@ void avatar::load( const JsonObject &data )
         JsonIn *jip = data.get_raw( "invcache" );
         inv.json_load_invcache( *jip );
     }
-	
+
     data.read( "preferred_aiming_mode", preferred_aiming_mode );
 }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -994,6 +994,8 @@ void avatar::store( JsonOut &json ) const
 
     json.member( "invcache" );
     inv.json_save_invcache( json );
+
+    json.member( "preferred_aiming_mode", preferred_aiming_mode );
 }
 
 void avatar::deserialize( JsonIn &jsin )
@@ -1139,6 +1141,8 @@ void avatar::load( const JsonObject &data )
         JsonIn *jip = data.get_raw( "invcache" );
         inv.json_load_invcache( *jip );
     }
+	
+    data.read( "preferred_aiming_mode", preferred_aiming_mode );
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Interface "Persist preferred aiming mode"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Cherry pick of https://github.com/CleverRaven/Cataclysm-DDA/pull/44775. A extremly handy way of aiming without changing modes all over again.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Copy and pasting
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Chaos tried, and he got it to work!
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
It does throw this message on compiling tho...
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29910\include\xmemory(696,103): warning C4244: 'argument': conversion from '_Ty' to 'int', possible loss of data
1>        with
1>        [
1>            _Ty=__int64
1>        ] (compiling source file ..\src\ranged.cpp)
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29910\include\vector(694): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,__int64,bool,const int&,std::string&>(_Alloc &,_Objty *const ,__int64 &&,bool &&,const int &,std::string &)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<uilist_entry>,
1>            _Ty=uilist_entry,
1>            _Objty=uilist_entry
1>        ] (compiling source file ..\src\ranged.cpp)
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29910\include\vector(694): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,__int64,bool,const int&,std::string&>(_Alloc &,_Objty *const ,__int64 &&,bool &&,const int &,std::string &)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<uilist_entry>,
1>            _Ty=uilist_entry,
1>            _Objty=uilist_entry
1>        ] (compiling source file ..\src\ranged.cpp)
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29910\include\vector(712): message : see reference to function template instantiation 'void std::vector<uilist_entry,std::allocator<uilist_entry>>::_Emplace_back_with_unused_capacity<_Ty,bool,const int&,std::string&>(_Ty &&,bool &&,const int &,std::string &)' being compiled
1>        with
1>        [
1>            _Ty=__int64
1>        ] (compiling source file ..\src\ranged.cpp)
1>C:\Users\Vincent\Downloads\Cataclysm-BN-firemode\Cataclysm-BN-firemode\src\ranged.cpp(2818): message : see reference to function template instantiation 'void std::vector<uilist_entry,std::allocator<uilist_entry>>::emplace_back<__int64,bool,const int&,std::string&>(__int64 &&,bool &&,const int &,std::string &)' being compiled

don't ask me what it means or how to fix it. lol

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
![image](https://user-images.githubusercontent.com/33199510/131934628-37a51964-5593-4d47-b8ce-9aafde031696.png)
