### PR TITLE
Expose mana cap reduction from bionic power to external option

### DIFF
--- a/data/json/game_balance.json
+++ b/data/json/game_balance.json
@@ -208,5 +208,12 @@
     "info": "Makes mutation more balanced and interesting.",
     "stype": "bool",
     "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "BP_REDUCES_MANA_CAP",
+    "info": "If true, mana cap will be reduced by 1 for each kJ of stored bionic power.",
+    "stype": "bool",
+    "value": false
   }
 ]

--- a/data/mods/Magiclysm/modinfo.json
+++ b/data/mods/Magiclysm/modinfo.json
@@ -15,5 +15,11 @@
     "name": "spellcraft",
     "display_category": "display_ranged",
     "description": "Your skill in the arcane.  Represents magic theory and all that entails.  A higher skill increases how quickly you can learn spells, and decreases their spell failure chance.  You learn this skill by studying books or spells."
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "BP_REDUCES_MANA_CAP",
+    "stype": "bool",
+    "value": true
   }
 ]

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -36,6 +36,7 @@
 #include "monster.h"
 #include "mtype.h"
 #include "mutation.h"
+#include "options.h"
 #include "output.h"
 #include "pldata.h"
 #include "point.h"
@@ -1430,7 +1431,9 @@ int known_magic::max_mana( const Character &guy ) const
     float mut_add = guy.mutation_value( "mana_modifier" );
     int natural_cap = std::max( 0.0f, ( ( mana_base + int_bonus ) * mut_mul ) + mut_add );
 
-    int bp_penalty = units::to_kilojoule( guy.get_power_level() );
+    int bp_penalty = get_option<bool>( "BP_REDUCES_MANA_CAP" )
+                     ? units::to_kilojoule( guy.get_power_level() )
+                     : 0;
     int ench_bonus = guy.bonus_from_enchantments( natural_cap, enchant_vals::mod::MANA_CAP, true );
 
     return std::max( 0, natural_cap - bp_penalty + ench_bonus );


### PR DESCRIPTION
And enable it by default for Magiclysm.

Should allow to more easily combine magic with bionics if a mod (or user) wants to.

Mana is updated every 3 minutes, so this does not affect performance.