### PR TITLE
Fix up mixed smokeless powder recipe, make better use of sieves

### DIFF
--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -842,6 +842,7 @@
   },
   {
     "id": "sieve_primitive",
+    "sub": "sieve_steel",
     "type": "GENERIC",
     "category": "tools",
     "name": { "str": "wicker sieve" },

--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -21,8 +21,9 @@
     "difficulty": 1,
     "time": "15 s",
     "charges": 1,
+    "autolearn": [ [ "fabrication", 4 ] ],
     "book_learn": [ [ "pocket_firearms", 3 ], [ "manual_gun", 2 ], [ "recipe_bullets", 1 ], [ "textbook_anarch", 0 ] ],
-    "tools": [ [ [ "mortar_pestle", -1 ] ], [ [ "sieve_steel", -1 ] ] ],
+    "tools": [ [ [ "rock_quern", -1 ], [ "clay_quern", -1 ], [ "mortar_pestle", -1 ] ], [ [ "sieve_steel", -1 ] ] ],
     "components": [
       [
         [ "gunpowder_shotgun", 1 ],

--- a/data/json/recipes/food/canned.json
+++ b/data/json/recipes/food/canned.json
@@ -1346,7 +1346,7 @@
     "book_learn": [ [ "preserving_juice", 2 ] ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "COOK", "level": 3 }, { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "jar_glass", 1 ] ], [ [ "irradiated_apple", 4 ], [ "apple", 4 ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ]
   },
   {
@@ -1364,7 +1364,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "COOK", "level": 3 } ],
-    "tools": [ [ [ "surface_heat", 10, "LIST" ] ], [ [ "can_sealer", -1 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 10, "LIST" ] ], [ [ "can_sealer", -1 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "can_medium_unsealed", 1 ] ], [ [ "scrap", 1 ] ], [ [ "irradiated_apple", 4 ], [ "apple", 4 ] ] ]
   },
   {
@@ -1383,7 +1383,7 @@
     "book_learn": [ [ "preserving_juice", 2 ] ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "COOK", "level": 3 }, { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [
       [ [ "jar_3l_glass", 1 ] ],
       [ [ "irradiated_apple", 24 ], [ "apple", 24 ] ],
@@ -1406,7 +1406,7 @@
     "book_learn": [ [ "preserving_juice", 2 ] ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "COOK", "level": 3 }, { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "jar_glass", 1 ] ], [ [ "irradiated_orange", 4 ], [ "orange", 4 ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ]
   },
   {
@@ -1424,7 +1424,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "COOK", "level": 3 } ],
-    "tools": [ [ [ "surface_heat", 10, "LIST" ] ], [ [ "can_sealer", -1 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 10, "LIST" ] ], [ [ "can_sealer", -1 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "can_medium_unsealed", 1 ] ], [ [ "scrap", 1 ] ], [ [ "irradiated_orange", 4 ], [ "orange", 4 ] ] ]
   },
   {
@@ -1443,7 +1443,7 @@
     "book_learn": [ [ "preserving_juice", 2 ] ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "COOK", "level": 3 }, { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [
       [ [ "jar_3l_glass", 1 ] ],
       [ [ "irradiated_orange", 24 ], [ "orange", 24 ] ],
@@ -1466,7 +1466,7 @@
     "book_learn": [ [ "preserving_juice", 2 ] ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "COOK", "level": 3 }, { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [
       [ [ "jar_glass", 1 ] ],
       [ [ "irradiated_cranberries", 6 ], [ "cranberries", 6 ] ],
@@ -1488,7 +1488,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "COOK", "level": 3 } ],
-    "tools": [ [ [ "surface_heat", 10, "LIST" ] ], [ [ "can_sealer", -1 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 10, "LIST" ] ], [ [ "can_sealer", -1 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "can_medium_unsealed", 1 ] ], [ [ "scrap", 1 ] ], [ [ "irradiated_cranberries", 6 ], [ "cranberries", 6 ] ] ]
   },
   {
@@ -1507,7 +1507,7 @@
     "book_learn": [ [ "preserving_juice", 2 ] ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "COOK", "level": 3 }, { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [
       [ [ "jar_3l_glass", 1 ] ],
       [ [ "irradiated_cranberries", 36 ], [ "cranberries", 36 ] ],
@@ -1530,7 +1530,7 @@
     "book_learn": [ [ "preserving_juice", 2 ] ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "COOK", "level": 3 }, { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "jar_glass", 1 ] ], [ [ "sweet_fruit", 2, "LIST" ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ]
   },
   {
@@ -1548,7 +1548,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "HAMMER", "level": 1 }, { "id": "COOK", "level": 3 } ],
-    "tools": [ [ [ "surface_heat", 10, "LIST" ] ], [ [ "can_sealer", -1 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 10, "LIST" ] ], [ [ "can_sealer", -1 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "can_medium_unsealed", 1 ] ], [ [ "scrap", 1 ] ], [ [ "sweet_fruit", 2, "LIST" ] ] ]
   },
   {
@@ -1567,7 +1567,7 @@
     "book_learn": [ [ "preserving_juice", 2 ] ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "COOK", "level": 3 }, { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 200, "LIST" ] ], [ [ "pot_canning", -1 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "jar_3l_glass", 1 ] ], [ [ "sweet_fruit", 12, "LIST" ] ], [ [ "water", 10 ], [ "water_clean", 10 ] ] ]
   }
 ]

--- a/data/json/recipes/food/dairy_products.json
+++ b/data/json/recipes/food/dairy_products.json
@@ -51,7 +51,7 @@
     "time": "30 m",
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "BOIL", "level": 1 }, { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "water_boiling_heat", 2, "LIST" ] ], [ [ "sieve_steel", -1 ], [ "sieve_primitive", -1 ], [ "rag", -1 ] ] ],
+    "tools": [ [ [ "water_boiling_heat", 2, "LIST" ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "raw_butter", 1 ], [ "butter", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -550,7 +550,7 @@
     "book_learn": [ [ "cookbook_sushi", 3 ], [ "cookbook_eatyrway", 4 ] ],
     "time": "45 m",
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "rag", -1 ] ], [ [ "surface_heat", 10, "LIST" ] ] ],
+    "tools": [ [ [ "sieve_steel", -1 ], [ "rag", -1 ] ], [ [ "surface_heat", 10, "LIST" ] ] ],
     "batch_time_factors": [ 50, 2 ],
     "components": [ [ [ "soy_milk", 5 ] ], [ [ "water_clean", 1 ] ], [ [ "lemon", 1 ], [ "vinegar", 1 ] ] ]
   },
@@ -1581,7 +1581,7 @@
     "difficulty": 1,
     "time": "15 m",
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "rag", -1 ] ], [ [ "mortar_pestle", -1 ] ] ],
+    "tools": [ [ [ "sieve_steel", -1 ], [ "rag", -1 ] ], [ [ "mortar_pestle", -1 ] ] ],
     "autolearn": true,
     "batch_time_factors": [ 30, 1 ],
     "components": [ [ [ "almond", 2 ] ], [ [ "water_clean", 3 ] ] ]
@@ -1597,7 +1597,7 @@
     "difficulty": 1,
     "time": "9 m",
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "food_processor", 20 ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "food_processor", 20 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "autolearn": true,
     "batch_time_factors": [ 80, 1 ],
     "components": [ [ [ "almond", 2 ] ], [ [ "water_clean", 3 ] ] ]
@@ -1611,7 +1611,7 @@
     "difficulty": 1,
     "time": "13 m",
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "food_processor", 20 ] ], [ [ "rag", -1 ] ], [ [ "surface_heat", 10, "LIST" ] ] ],
+    "tools": [ [ [ "food_processor", 20 ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ], [ [ "surface_heat", 10, "LIST" ] ] ],
     "autolearn": true,
     "batch_time_factors": [ 25, 2 ],
     "components": [ [ [ "soybean", 2 ] ], [ [ "water_clean", 2 ] ] ]
@@ -1664,7 +1664,7 @@
     "time": "15 m",
     "book_learn": [ [ "manual_sealing", 1 ] ],
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "CUT", "level": 1 } ],
-    "tools": [ [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "coconut", 2 ] ], [ [ "water_clean", 2 ] ] ]
   },
   {
@@ -1721,7 +1721,7 @@
     "time": "5 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "irradiated_orange", 2 ], [ "orange", 2 ] ] ]
   },
   {
@@ -1735,7 +1735,7 @@
     "time": "5 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "cranberries", 3 ], [ "irradiated_cranberries", 3 ] ], [ [ "water_clean", 1 ] ] ]
   },
   {
@@ -1749,7 +1749,7 @@
     "time": "7 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "irradiated_apple", 2 ], [ "apple", 2 ] ] ]
   },
   {
@@ -2048,7 +2048,7 @@
       { "id": "BOIL", "level": 2 },
       { "id": "CONTAIN", "level": 1 }
     ],
-    "tools": [ [ [ "surface_heat", 4, "LIST" ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 4, "LIST" ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "milk_curdled", 2 ] ], [ [ "salt_water", 1 ], [ "saline", 1 ], [ "salt", 1 ], [ "seasoning_salt", 1 ] ] ]
   },
   {
@@ -2301,7 +2301,7 @@
     "autolearn": true,
     "batch_time_factors": [ 60, 3 ],
     "qualities": [ { "id": "BOIL", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 12, "LIST" ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 12, "LIST" ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "maple_sap", 40 ] ] ]
   },
   {
@@ -4983,7 +4983,7 @@
     "time": "3 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "sweet_fruit", 1, "LIST" ] ], [ [ "water_clean", 1 ] ] ]
   },
   {
@@ -4998,7 +4998,7 @@
     "time": "5 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "sweet_fruit", 2, "LIST" ] ] ]
   },
   {
@@ -5536,7 +5536,7 @@
     "time": "10 m",
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "tools": [ [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "honeycomb", 1 ] ] ]
   },
   {
@@ -5552,7 +5552,7 @@
     "batch_time_factors": [ 80, 4 ],
     "autolearn": true,
     "qualities": [ { "id": "BOIL", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 5, "LIST" ] ], [ [ "rag", -1 ] ] ],
+    "tools": [ [ [ "surface_heat", 5, "LIST" ] ], [ [ "sieve_steel", -1 ], [ "rag", -1 ] ] ],
     "components": [ [ [ "water", 1 ], [ "water_clean", 1 ] ], [ [ "honey_glassed", 5 ] ] ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Make sieves more useful and make mixed smokeless gunpowder less hassle to make"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

On noticing that mixed gunpowder was still booklearn-only, despite now being made from existing powders blended together and crushed fine instead of being made by chemistry, I started looking into the production chain for it and realizing there were multiple improvements that could be made. The need to use a sieve especially seemed strange, and rather than just scrap it for pointless realism I decided to salvage the concept to make sieves actually have some gameplay utility.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Set wicker sieve to count as a substitute tool for steel sieve. For most, likely all, purposes the innawoods variant will likely be fine-grained enough for the task at hand, plus this improves usability.
2. Expanded what food recipes allowed sieves. Ghee was already set to allow sieves as an alternative to rags, and this was previously the only use for wicker sieves. Instead set it so the other food items that allow rags can use sieves, which makes sieves useful since they can potentially be more accessible than rags (the innawoods version moreso than the mesh version).
3. Removed now-surplus call to a wicker sieve from recipe for ghee, now that the tool counts as a substitute for steel sieve.
4. Set mixed gunpowder recipe to autolearn at fabrication 4, and to allow querns as an alternative to mortar and pestle. Level chosen as 1 level above highest booklearn.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making grinding and sieving a requirement for crafting blackpowder as well, possibly other similar powder recipes.
2. Making blackpowder recipe autolearn at a given cooking skill level. Consistency with how mixed gunpowder's autolearn was set would lead to blackpowder autolearning at cooking 7.
3. Removing the need to mortar and sieve outright, presumably obsoleting sieves as a consequence. As noted above, sieves do have some use with these changes, especially innawoods where getting even one rag can be a hassle, so sieves can still be useful.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
