### PR TITLE
Fix branch in automatic translation pulling

### DIFF
--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: upload
           fetch-depth: 0
       - name: "Get current date"
         uses: 1466587594/get-current-time@v2


### PR DESCRIPTION
As in title. BN currently has builds executed on `upload` branch, which is the de-facto master.