### PR TITLE
Fix a couple cases of UB

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -950,7 +950,7 @@ VehicleList map::get_vehicles( const tripoint &start, const tripoint &end )
 
 optional_vpart_position map::veh_at( const tripoint &p ) const
 {
-    if( !const_cast<map *>( this )->get_cache( p.z ).veh_in_active_range || !inbounds( p ) ) {
+    if( !inbounds( p ) || !const_cast<map *>( this )->get_cache( p.z ).veh_in_active_range ) {
         return optional_vpart_position( cata::nullopt );
     }
 

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -124,16 +124,29 @@ bool vertical_move_destination( const map &m, tripoint &t )
         return false;
     }
 
-    constexpr int omtileszx = SEEX * 2;
-    constexpr int omtileszy = SEEY * 2;
     real_coords rc( m.getabs( t.xy() ) );
-    const point omtile_align_start(
-        m.getlocal( rc.begin_om_pos() )
-    );
+
+    // Align to OMT boundaries
+    point start = m.getlocal( rc.begin_om_pos() );
+    point end = start + point( SEEX * 2, SEEY * 2 );
+
+    // Exclude submaps not loaded into bubble
+    if( start.x < 0 ) {
+        start.x = 0;
+    }
+    if( start.y < 0 ) {
+        start.y = 0;
+    }
+    if( end.x >= MAPSIZE_X ) {
+        end.x = MAPSIZE_X - 1;
+    }
+    if( end.y >= MAPSIZE_Y ) {
+        end.y = MAPSIZE_Y - 1;
+    }
 
     const auto &pf_cache = m.get_pathfinding_cache_ref( t.z );
-    for( int x = omtile_align_start.x; x < omtile_align_start.x + omtileszx; x++ ) {
-        for( int y = omtile_align_start.y; y < omtile_align_start.y + omtileszy; y++ ) {
+    for( int x = start.x; x < end.x; x++ ) {
+        for( int y = start.y; y < end.y; y++ ) {
             if( pf_cache.special[x][y] & PF_UPDOWN ) {
                 const tripoint p( x, y, t.z );
                 if( m.has_flag( flag, p ) ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1061,9 +1061,15 @@ bool vehicle::check_heli_ascend( player &p )
     }
     for( const tripoint &pt : get_points( true ) ) {
         tripoint above( pt.xy(), pt.z + 1 );
-        const optional_vpart_position ovp = g->m.veh_at( above );
-        if( g->m.has_flag_ter_or_furn( TFLAG_INDOORS, pt ) || g->m.impassable_ter_furn( above ) || ovp ||
-            g->critter_at( above ) ) {
+        if( !g->m.inbounds_z( above.z ) ) {
+            p.add_msg_if_player( m_bad, _( "It would be unsafe to try and ascend further." ) );
+            return false;
+        }
+        if( g->m.has_flag_ter_or_furn( TFLAG_INDOORS, pt )
+            || g->m.impassable_ter_furn( above )
+            || g->m.veh_at( above )
+            || g->critter_at( above )
+          ) {
             p.add_msg_if_player( m_bad,
                                  _( "It would be unsafe to try and ascend when there are obstacles above you." ) );
             return false;


### PR DESCRIPTION
Fix UB when trying to ascend with a helicopter beyond map boundaries.
* Fixed boundary check in `veh_at`
* Added a separate flavor message when trying to ascend too high, as there should be no obstacles in the sky

---

Fix UB when NPC tries to path over stairs in a partially-loaded OMT.
This may happen when player character approaches a location that has both NPCs and monsters, and z levels are enabled, so NPC might try to investigate sound on different z level while OMT is only partially inside reality bubble.
[crash.log](https://github.com/cataclysmbnteam/Cataclysm-BN/files/7115993/npc-finds-stairs-ub.log)

Reproduction steps:
1. Add a check that x or y are outside array bounds, add it right before `if( pf_cache.special[x][y] & PF_UPDOWN )`
2. Start new game in shelter with an NPC
3. Teleport to the edge of reality bubble, so that only part of the shelter (with NPC) would still be loaded
4. Debug spawn mi-go in the basement
5. Wait a bit, observe that check has been triggered

Solution: restrict iteration to the submaps that are part of `g->m`.