### PR TITLE
Force stereo when opening audio device

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -94,12 +94,32 @@ bool init_sound()
     int audio_rate = 44100;
     Uint16 audio_format = AUDIO_S16;
     int audio_channels = 2;
-    int audio_buffers = 2048;
+    int chunksize = 2048;
+    // Autodetect device
+    const char *audio_device = nullptr;
+    // We only care about sample format and number of channels.
+    // SDL will be allowed to choose a different frequency if it needs to.
+    int flags = SDL_AUDIO_ALLOW_FREQUENCY_CHANGE;
 
     // We should only need to init once
     if( !sound_init_success ) {
-        // Mix_OpenAudio returns non-zero if something went wrong trying to open the device
-        if( !Mix_OpenAudio( audio_rate, audio_format, audio_channels, audio_buffers ) ) {
+        const char *driver = SDL_GetCurrentAudioDriver();
+        DebugLog( DL::Info, DC::Main ) << "Active audio driver: " << driver;
+
+        int open_code = Mix_OpenAudioDevice( audio_rate, audio_format, audio_channels,
+                                             chunksize, audio_device, flags );
+        if( open_code == 0 ) {
+            int dev_rate = 0;
+            Uint16 dev_format = 0;
+            int dev_channels = 0;
+            if( Mix_QuerySpec( &dev_rate, &dev_format, &dev_channels ) ) {
+                DebugLog( DL::Info, DC::Main )
+                        << string_format( "Opened mixer with specs: %d Hz, %d channel(s), format %#x",
+                                          dev_rate, dev_channels, dev_format );
+            } else {
+                DebugLog( DL::Warn, DC::SDL ) << "Mix_QuerySpec failed: " << Mix_GetError();
+            }
+
             Mix_AllocateChannels( 128 );
             Mix_ReserveChannels( static_cast<int>( sfx::channel::MAX_CHANNEL ) );
 


### PR DESCRIPTION
#### Purpose of change
Fixes "metallic" pitch-shifted sounds (e.g. walking) on some sound cards.
Fixes #410.

#### Describe the solution
I had to deep dive SDL2 again, and in the process noticed that `Mix_OpenAudio()` by default allows SDL2 to choose any number of sound channels. For some sound devices, this number may be higher than 2 (e.g. 4 or 6).

When sound is to be played, it is first loaded via SDL2, which converts it into the mixer's format. If played sound must be pitch-shifted, it is then passed to Cata's `do_pitch_shift()` which assumes there are always 2 channels, and in case there are _not_ 2 channels - scrambles the sound and turns it "metallic".

You can reproduce "metallic" effect on system with any sound card by changing `int audio_channels` to 6 and then launching the game with `SDL_AUDIODRIVER=disk` environment variable. SDL2 will create a raw file in game's directory and use it as output device that matches desired specs, and afterwards the file can be imported into Audacity (16-bit PCM, LE, 6 channels, 44100) and replayed to get exactly this:
https://user-images.githubusercontent.com/74045419/112876475-48654500-9111-11eb-8fd4-b57b76d8c415.mp4

Solution is to use `Mix_OpenAudioDevice()`, which allows specifying what specs the device _must_ match, and force device to be stereo.

#### Describe alternatives you've considered
Fixing `do_pitch_shift()` for non-stereo, but I doubt surround sound is something a roguelike needs to support. Also, less channels == less RAM consumed by each sound sample.

#### Testing
I don't have the hardware myself, but @EirenexTheDragon confirmed this patch fixes sounds in BN.