### PR TITLE
fixes a runtime when picking mutated poppies and fixes some mutants being unable to eat nectar

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1690,7 +1690,7 @@ static bool can_drink_nectar( const player &p, const item &nectar )
 {
     return ( p.has_active_mutation( trait_PROBOSCIS )  ||
              p.has_active_mutation( trait_BEAK_HUM ) ) &&
-           ( ( p.max_stored_kcal() - p.get_stored_kcal() ) <
+           ( ( p.max_stored_kcal() - p.get_stored_kcal() ) >
              nectar.get_comestible()->default_nutrition.kcal ) &&
            ( !( p.wearing_something_on( bodypart_id( "mouth" ) ) ) );
 }
@@ -1740,7 +1740,7 @@ void iexamine::flower_poppy( player &p, const tripoint &examp )
     }
     // TODO: Get rid of this section and move it to eating
     // Two y/n prompts is just too much
-    item poppy( "poppy_nectar", calendar::turn, 1 );
+    item poppy( "nectar", calendar::turn, 1 );
     if( can_drink_nectar( p, poppy ) ) {
         if( !query_yn( _( "You feel woozy as you explore the %s. Drink?" ),
                        g->m.furnname( examp ) ) ) {


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Mutants with the Proboscis or Hummingbird Beak mutations can correctly suck nectar out of flowers again."

#### Purpose of change

Right now, the game throws a runtime every time the player tries to pick a mutated poppy. This is because it tries to fetch a certain type of item (`poppy_nectar`) whose definition doesn't actually exist, causing the error. This PR fixes that by making it fetch the normal nectar item instead.

There's also an issue in the math allowing certain mutants to actually drink the nectar the flower provides; it checks if the player's max stored calories minus their current calories is *less than* the nectar provided by the flower, which means they'll only actually be able to drink the nectar when they're nearly dead from starvation.

#### Describe the solution

* Mutated poppies' `iexamine` function now fetches the normal `nectar` item instead.
* I've flipped the operator when checking relative calories for mutants, which lets them drink the nectar correctly as long as their calorie store isn't almost completely filled.

#### Describe alternatives you've considered

I had thought about making a separate item for poppy nectar, but I felt that for a PR purely fixing bugs, it was out of scope.

#### Testing

I mutated myself to have a hummingbird beak in-game, and then consumed nectar from both a dahlia flower and a mutated poppy flower. I had several debug messages to walk through each step of the logic and discovered that the calorie issue was indeed the problem preventing them from eating.

#### Additional context

N/A