### PR TITLE
Trade ui: add amount to trade hint

### DIFF
--- a/src/npctrade.h
+++ b/src/npctrade.h
@@ -79,7 +79,7 @@ class trading_window
         units::volume volume_left;
         units::mass weight_left;
 
-        int get_var_trade( const item &it, int total_count );
+        int get_var_trade( const item &it, int total_count, int amount_hint );
         bool npc_will_accept_trade( const npc &np ) const;
         int calc_npc_owes_you( const npc &np ) const;
 };


### PR DESCRIPTION
Add a hint in trading UI on how much it would take to settle the deal.

This should make trading UI a bit less awful, and free the player from mental gymnastics of dividing by 2.5
![image](https://user-images.githubusercontent.com/60584843/132074589-6c6c278e-13fb-45fd-bd26-1122c58f9a97.png)
![image](https://user-images.githubusercontent.com/60584843/132074622-3c51d27b-3049-44bb-9593-3c7c1910cce6.png)

The `You'll need to offer X to settle the deal` hint may show amount higher than available amount, but this is intended.