### PR TITLE
Make candy ice cream less unhealthy 

### DIFF
--- a/data/json/items/comestibles/frozen.json
+++ b/data/json/items/comestibles/frozen.json
@@ -97,7 +97,7 @@
     "name": { "str": "candy ice cream", "str_pl": "candy ice cream scoops" },
     "description": "Ice cream with bits of chocolate, caramel, or other flavoring mixed in.",
     "fun": 20,
-    "healthy": -1,
+    "healthy": -2,
     "price": 300,
     "price_postapoc": 300,
     "calories": 330,

--- a/data/json/items/comestibles/frozen.json
+++ b/data/json/items/comestibles/frozen.json
@@ -97,7 +97,7 @@
     "name": { "str": "candy ice cream", "str_pl": "candy ice cream scoops" },
     "description": "Ice cream with bits of chocolate, caramel, or other flavoring mixed in.",
     "fun": 20,
-    "healthy": -3,
+    "healthy": -1,
     "price": 300,
     "price_postapoc": 300,
     "calories": 330,


### PR DESCRIPTION

#### Summary

SUMMARY: [Balance] "Make candy ice cream less unhealthy"

#### Purpose of change

Currently it's ridiculously easy to tank health using candy ice cream. With -3 health, it is equivalent to tainted fat and less healthy than fertilizer or sewage water (both -2), among other examples. As candy ice cream is far less bad for you then the above, this makes no sense from a balance perspective.

#### Describe the solution

Change the health modifier of candy ice cream from -3 to -1.

#### Describe alternatives you've considered

If -2 is more appropriate than -1, I'm willing to change that.

Revamp the entire health system (as eating candy and ice cream separately will also have a modifier of -3). But I'm not good enough at coding for that. This PR is more of a band-aid fix than anything.

#### Testing

None needed 

#### Additional context
