### PR TITLE
Flag fixes for wooden stairs and privacy gates

### DIFF
--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -834,7 +834,7 @@
     "color": "brown",
     "looks_like": "t_fencegate_o",
     "move_cost": 1,
-    "flags": [ "FLAMMABLE_ASH", "FLAT", "ROAD", "BURROWABLE" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "FLAT", "ROAD", "BURROWABLE" ],
     "connects_to": "WOODFENCE",
     "close": "t_privacy_fencegate_c",
     "deconstruct": {

--- a/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
+++ b/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
@@ -7,7 +7,7 @@
     "symbol": ">",
     "color": "light_red",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "GOES_DOWN", "PLACE_ITEM" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "GOES_DOWN", "INDOORS", "PLACE_ITEM" ],
     "bash": {
       "str_min": 10,
       "str_max": 70,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix two terrains lacking expected flags"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Noticed that there was an open gate I couldn't see through, and quickly found it was missing the `TRANSPARENT` flag. Along the way @SzQ1 also mentioned apparently some behavior problems caused by wooden downstairs not having `INDOORS` like normal stairs, so good timing I guess.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Gave open split rail privacy fence gates `TRANSPARENT` like all other open gates have, including the other type of split rail gate. Doesn't give much privacy when it's open, after all.
2. Gave wooden downstairs `INDOORS` per SzQ's request as they're evidently busy and just recently did some stairs tweaks. Consistent with normal stairs, I'm not exactly sure what behavior it causes problems with and whether trying to build them outside might cause a different issue.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

They actually suggested both `INDOORS` and `SUPPORTS_ROOF` but regular downstairs only have indoors, presumably since both have specific effects on constructing roofs.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked file changes for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
