### PR TITLE
Prevent monsters from upgrading into blacklisted forms.

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -356,6 +356,10 @@ void monster::try_upgrade( bool pin_time )
         }
 
         if( type->upgrade_into ) {
+            //If we upgrade into a blacklisted monster, treat it as though we are non-upgradeable
+            if( MonsterGroupManager::monster_is_blacklisted( type->upgrade_into ) ) {
+                return;
+            }
             poly( type->upgrade_into );
         } else {
             const mtype_id &new_type = MonsterGroupManager::GetRandomMonsterFromGroup( type->upgrade_group );


### PR DESCRIPTION
#### Summary
Bugfixes: "Added a check to prevent monster upgrades from circumventing blacklists."

#### Purpose of change
Previously, if a monster had a specific upgraded form defined (for example, SWAT zombies specifically upgrade into kevlar zombies), the game would allow the monster to evolve into its upgraded form even if the upgraded form was blacklisted. This issue did not affect monsters that upgrade using _groups_, such as the zombie soldier.

This could result in situations where monsters such as Kevlar Hulks would show up in worlds where they had been blacklisted.

#### Describe the solution
I added an if statement to `monster::try_upgrade`, inside the branch that handles upgrading to a specifically defined monster. It now checks if the upgrade target is blacklisted, and if so, returns as it would if there were no upgrades available.

#### Describe alternatives you've considered
I thought about setting `upgrade_into` to null, but that seemed like a more convoluted solution.

#### Testing
First, I created a world with `classic_zombies` enabled. I then repeated the following procedure first without, then with the fix:
1. Spawn 10 SWAT zombies, and 10 soldier zombies in a basement.
2.  Advance time by 5 years
3. Leave and come back so that the zombies are loaded and unloaded from the reality bubble

Without the fix, most of the SWAT zombies turned into kevlar hulks, and the soldiers turned into various upgraded forms. 

With the fix, the SWAT zombies remained swat zombies, though a few of the soldiers did upgrade (this is because soldier zombies have the `CLASSIC` category and some of their evolved forms `copy_from` the soldier zombie definition). This is exactly what should have happened with the fix in place.

#### Additional context
![Upside down kevlar hulk is very real, and can hurt you.](https://user-images.githubusercontent.com/30204365/133142136-8c88887f-8f1e-4d7e-9eb2-1deb6294e704.png) 
Upside-down kevlar hulk is very real, and _can_ hurt you. 
(This happens on all my compiled builds, I don't know why)

