### PR TITLE
No crash on Android when USB device is plugged in

### DIFF
--- a/android/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
+++ b/android/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
@@ -53,7 +53,12 @@ class HIDDeviceUSB implements HIDDevice {
     public String getSerialNumber() {
         String result = null;
         if (Build.VERSION.SDK_INT >= 21) {
-            result = mDevice.getSerialNumber();
+            try {
+                result = mDevice.getSerialNumber();
+            }
+            catch (SecurityException exception) {
+                //Log.w(TAG, "App permissions mean we cannot get serial number for device " + getDeviceName() + " message: " + exception.getMessage());
+            }
         }
         if (result == null) {
             result = "";


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Possibly get rid of crashes on Android when USB device is plugged in.

#### Describe the solution

Catch SecurityException in SDL getSerialNumber