### PR TITLE
Fix drop & stash activities cannot be interrupted

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -474,6 +474,13 @@ drop_activity_actor::drop_activity_actor( Character &ch, const drop_locations &i
     this->items = pickup::reorder_for_dropping( ch, items );
 }
 
+void drop_activity_actor::start( player_activity &act, Character & )
+{
+    // Set moves_left to value other than zero to indicate ongoing activity
+    act.moves_total = 1;
+    act.moves_left = 1;
+}
+
 void drop_activity_actor::serialize( JsonOut &jsout ) const
 {
     jsout.start_object();
@@ -882,6 +889,13 @@ stash_activity_actor::stash_activity_actor( Character &ch, const drop_locations 
         const tripoint &relpos ) : relpos( relpos )
 {
     this->items = pickup::reorder_for_dropping( ch, items );
+}
+
+void stash_activity_actor::start( player_activity &act, Character & )
+{
+    // Set moves_left to value other than zero to indicate ongoing activity
+    act.moves_total = 1;
+    act.moves_left = 1;
 }
 
 void stash_activity_actor::serialize( JsonOut &jsout ) const

--- a/src/activity_actor.h
+++ b/src/activity_actor.h
@@ -306,7 +306,7 @@ class drop_activity_actor : public activity_actor
             return activity_id( "ACT_DROP" );
         }
 
-        void start( player_activity &, Character & ) override {};
+        void start( player_activity &, Character & ) override;
         void do_turn( player_activity &, Character &who ) override;
         void finish( player_activity &, Character & ) override {};
 
@@ -480,7 +480,7 @@ class stash_activity_actor : public activity_actor
             return activity_id( "ACT_STASH" );
         }
 
-        void start( player_activity &, Character & ) override {};
+        void start( player_activity &, Character & ) override;
         void do_turn( player_activity &, Character &who ) override;
         void finish( player_activity &, Character & ) override {};
 


### PR DESCRIPTION
Fixes regression after #885 (see https://github.com/cataclysmbnteam/Cataclysm-BN/pull/885#issuecomment-920298776 for context).