### PR TITLE
Misc fixes for activity interrupt prompt

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -885,6 +885,7 @@ class game
         // Routine loop functions, approximately in order of execution
         void monmove();          // Monster movement
         void overmap_npc_move(); // NPC overmap movement
+        void process_voluntary_act_interrupt(); // Process
         void process_activity(); // Processes and enacts the player's activity
         void handle_key_blocking_activity(); // Abort reading etc.
         void open_consume_item_menu(); // Custom menu for consuming specific group of items


### PR DESCRIPTION
1. Redraw terrain view when querying to stop activity
2. Move interrupt checks from '.' key and from monster being too close to before activity is executed, so if the player confirms interrupt, they'll still have all their moves before it's the monsters' turn to act.
3. Fix text in auto-move interrupt confirmation prompt.