### PR TITLE
Port rectangle refactor + a couple more `point`-related refactors

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -548,8 +548,8 @@ int advanced_inventory::print_header( advanced_inventory_pane &pane, aim_locatio
         mvwprintz( window, p, bcolor, "%c", bracket[0] );
         wprintz( window, kcolor, "%s", in_vehicle && sel != AIM_DRAGGED ? "V" : key );
         wprintz( window, bcolor, "%c", bracket[1] );
-        if( x < min_x ) {
-            min_x = x;
+        if( p.x < min_x ) {
+            min_x = p.x;
         }
     }
     return min_x;

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -544,9 +544,8 @@ int advanced_inventory::print_header( advanced_inventory_pane &pane, aim_locatio
         }
 
         const std::string key = get_location_key( static_cast<aim_location>( i ) );
-        const int x = squares[i].hscreen.x + ofs;
-        const int y = squares[i].hscreen.y;
-        mvwprintz( window, point( x, y ), bcolor, "%c", bracket[0] );
+        const point p( squares[i].hscreen + point( ofs, 0 ) );
+        mvwprintz( window, p, bcolor, "%c", bracket[0] );
         wprintz( window, kcolor, "%s", in_vehicle && sel != AIM_DRAGGED ? "V" : key );
         wprintz( window, bcolor, "%c", bracket[1] );
         if( x < min_x ) {
@@ -1593,9 +1592,8 @@ void query_destination_callback::draw_squares( const uilist *menu )
         bool canputitems = menu->entries[i - 1].enabled && square.canputitems();
         nc_color bcolor = canputitems ? sel == loc ? h_white : c_light_gray : c_dark_gray;
         nc_color kcolor = canputitems ? sel == loc ? h_white : c_light_gray : c_dark_gray;
-        const int x = square.hscreen.x + ofs;
-        const int y = square.hscreen.y + 5;
-        mvwprintz( menu->window, point( x, y ), bcolor, "%c", bracket[0] );
+        const point p( square.hscreen + point( ofs, 5 ) );
+        mvwprintz( menu->window, p, bcolor, "%c", bracket[0] );
         wprintz( menu->window, kcolor, "%s", key );
         wprintz( menu->window, bcolor, "%c", bracket[1] );
     }

--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -460,8 +460,7 @@ void player::sort_armor()
 
     int win_h = 0;
     int win_w = 0;
-    int win_x = 0;
-    int win_y = 0;
+    point win;
 
     int cont_h   = 0;
     int left_w   = 0;
@@ -501,22 +500,22 @@ void player::sort_armor()
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
         win_h = std::min( TERMY, std::max( { FULL_SCREEN_HEIGHT, req_right_h, req_mid_h } ) );
         win_w = FULL_SCREEN_WIDTH + ( TERMX - FULL_SCREEN_WIDTH ) * 3 / 4;
-        win_x = TERMX / 2 - win_w / 2;
-        win_y = TERMY / 2 - win_h / 2;
+        win.x = TERMX / 2 - win_w / 2;
+        win.y = TERMY / 2 - win_h / 2;
         cont_h = win_h - 4;
         left_w = ( win_w - 4 ) / 3;
         right_w = left_w;
         middle_w = ( win_w - 4 ) - left_w - right_w;
         leftListLines = rightListLines = cont_h - 2;
-        w_sort_armor = catacurses::newwin( win_h, win_w, point( win_x, win_y ) );
-        w_sort_cat = catacurses::newwin( 1, win_w - 4, point( win_x + 2, win_y + 1 ) );
-        w_sort_left = catacurses::newwin( cont_h, left_w, point( win_x + 1, win_y + 3 ) );
+        w_sort_armor = catacurses::newwin( win_h, win_w, win );
+        w_sort_cat = catacurses::newwin( 1, win_w - 4, win + point( 2, 1 ) );
+        w_sort_left = catacurses::newwin( cont_h, left_w, win + point( 1, 3 ) );
         w_sort_middle = catacurses::newwin( cont_h - num_bp - 1, middle_w,
-                                            point( win_x + left_w + 2, win_y + 3 ) );
+                                            win + point( 2 + left_w, 3 ) );
         w_sort_right = catacurses::newwin( cont_h, right_w,
-                                           point( win_x + left_w + middle_w + 3, win_y + 3 ) );
+                                           win + point( 3 + left_w + middle_w, 3 ) );
         w_encumb = catacurses::newwin( num_bp + 1, middle_w,
-                                       point( win_x + left_w + 2, win_y + 3 + cont_h - num_bp - 1 ) );
+                                       win + point( 2 + left_w, -1 + 3 + cont_h - num_bp ) );
         ui.position_from_window( w_sort_armor );
     } );
     ui.mark_resize();

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -183,17 +183,17 @@ void auto_note_manager_gui::show()
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
         iContentHeight = FULL_SCREEN_HEIGHT - 2 - iHeaderHeight;
 
-        const int iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-        const int iOffsetY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
+        const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
 
         w_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                       point( iOffsetX, iOffsetY ) );
+                                       iOffset );
 
         w_header = catacurses::newwin( iHeaderHeight, FULL_SCREEN_WIDTH - 2,
-                                       point( 1 + iOffsetX, 1 + iOffsetY ) );
+                                       iOffset + point_south_east );
 
         w = catacurses::newwin( iContentHeight, FULL_SCREEN_WIDTH - 2,
-                                point( 1 + iOffsetX, iHeaderHeight + 1 + iOffsetY ) );
+                                iOffset + point( 1, iHeaderHeight + 1 ) );
 
         ui.position_from_window( w_border );
     } );

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -59,15 +59,15 @@ void user_interface::show()
 
     const auto init_windows = [&]( ui_adaptor & ui ) {
         iContentHeight = FULL_SCREEN_HEIGHT - 2 - iHeaderHeight;
-        const int iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-        const int iOffsetY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
+        const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
 
         w_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                       point( iOffsetX, iOffsetY ) );
+                                       iOffset );
         w_header = catacurses::newwin( iHeaderHeight, FULL_SCREEN_WIDTH - 2,
-                                       point( 1 + iOffsetX, 1 + iOffsetY ) );
+                                       iOffset + point_south_east );
         w = catacurses::newwin( iContentHeight, FULL_SCREEN_WIDTH - 2,
-                                point( 1 + iOffsetX, iHeaderHeight + 1 + iOffsetY ) );
+                                iOffset + point( 1, iHeaderHeight + 1 ) );
 
         ui.position_from_window( w_border );
     };
@@ -284,11 +284,11 @@ void user_interface::show()
                 ui_adaptor help_ui;
                 catacurses::window w_help;
                 const auto init_help_window = [&]( ui_adaptor & help_ui ) {
-                    const int iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-                    const int iOffsetY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
+                    const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                                         TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
                     w_help = catacurses::newwin( FULL_SCREEN_HEIGHT / 2 + 2,
                                                  FULL_SCREEN_WIDTH * 3 / 4,
-                                                 point( iOffsetX + 19 / 2, 7 + iOffsetY + FULL_SCREEN_HEIGHT / 2 / 2 ) );
+                                                 iOffset + point( 19 / 2, 7 + FULL_SCREEN_HEIGHT / 2 / 2 ) );
                     help_ui.position_from_window( w_help );
                 };
                 init_help_window( help_ui );
@@ -439,17 +439,17 @@ void rule::test_pattern() const
     ui_adaptor ui;
 
     const auto init_windows = [&]( ui_adaptor & ui ) {
-        const int iOffsetX = 15 + ( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0 );
-        const int iOffsetY = 5 + ( TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 :
-                                   0 );
+        const point iOffset( 15 + ( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0 ),
+                             5 + ( TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 :
+                                   0 ) );
         iContentHeight = FULL_SCREEN_HEIGHT - 8;
         iContentWidth = FULL_SCREEN_WIDTH - 30;
 
         w_test_rule_border = catacurses::newwin( iContentHeight + 2, iContentWidth,
-                             point( iOffsetX, iOffsetY ) );
+                             iOffset );
         w_test_rule_content = catacurses::newwin( iContentHeight,
                               iContentWidth - 2,
-                              point( 1 + iOffsetX, 1 + iOffsetY ) );
+                              iOffset + point_south_east );
 
         ui.position_from_window( w_test_rule_border );
     };

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -134,16 +134,15 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     }
 
     // If the player is *attempting to* move on the X axis, update facing direction of their sprite to match.
-    int new_dx = dest_loc.x - you.posx();
-    int new_dy = dest_loc.y - you.posy();
+    point new_d( dest_loc.xy() + point( -you.posx(), -you.posy() ) );
 
     if( !tile_iso ) {
-        if( new_dx > 0 ) {
+        if( new_d.x > 0 ) {
             you.facing = FD_RIGHT;
             if( is_riding ) {
                 you.mounted_creature->facing = FD_RIGHT;
             }
-        } else if( new_dx < 0 ) {
+        } else if( new_d.x < 0 ) {
             you.facing = FD_LEFT;
             if( is_riding ) {
                 you.mounted_creature->facing = FD_LEFT;
@@ -180,14 +179,14 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         // y: left-up key       =>  __ -y       FD_LEFT
         // down key             =>  -x +y       ______
         //
-        if( new_dx >= 0 && new_dy >= 0 ) {
+        if( new_d.x >= 0 && new_d.y >= 0 ) {
             you.facing = FD_RIGHT;
             if( is_riding ) {
                 auto mons = you.mounted_creature.get();
                 mons->facing = FD_RIGHT;
             }
         }
-        if( new_dy <= 0 && new_dx <= 0 ) {
+        if( new_d.y <= 0 && new_d.x <= 0 ) {
             you.facing = FD_LEFT;
             if( is_riding ) {
                 auto mons = you.mounted_creature.get();

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -81,7 +81,7 @@ extern const std::map<point, direction_data> all_directions;
 
 point direction_from_id( const std::string &id );
 
-const point base_dir = point_zero;
+const point base_dir;
 const std::string prefix = "faction_base_";
 const std::string id = "FACTION_CAMP";
 const int prefix_len = 13;

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -572,30 +572,28 @@ void player::power_bionics()
                                      TITLE_HEIGHT + TITLE_TAB_HEIGHT +
                                      static_cast<int>( my_bionics->size() ) + 2 ) );
         WIDTH = FULL_SCREEN_WIDTH + ( TERMX - FULL_SCREEN_WIDTH ) / 2;
-        const int START_X = ( TERMX - WIDTH ) / 2;
-        const int START_Y = ( TERMY - HEIGHT ) / 2;
+        const point START( ( TERMX - WIDTH ) / 2, ( TERMY - HEIGHT ) / 2 );
         //wBio is the entire bionic window
-        wBio = catacurses::newwin( HEIGHT, WIDTH, point( START_X, START_Y ) );
+        wBio = catacurses::newwin( HEIGHT, WIDTH, START );
 
         LIST_HEIGHT = HEIGHT - TITLE_HEIGHT - TITLE_TAB_HEIGHT - 2;
 
         const int DESCRIPTION_WIDTH = WIDTH - 2 - 40;
-        const int DESCRIPTION_START_Y = START_Y + TITLE_HEIGHT + TITLE_TAB_HEIGHT + 1;
-        const int DESCRIPTION_START_X = START_X + 1 + 40;
+        const int DESCRIPTION_START_Y = START.y + TITLE_HEIGHT + TITLE_TAB_HEIGHT + 1;
+        const int DESCRIPTION_START_X = START.x + 1 + 40;
         //w_description is the description panel that is controlled with ! key
         w_description = catacurses::newwin( LIST_HEIGHT, DESCRIPTION_WIDTH,
                                             point( DESCRIPTION_START_X, DESCRIPTION_START_Y ) );
 
         // Title window
-        const int TITLE_START_Y = START_Y + 1;
+        const int TITLE_START_Y = START.y + 1;
         const int HEADER_LINE_Y = TITLE_HEIGHT + TITLE_TAB_HEIGHT;
-        w_title = catacurses::newwin( TITLE_HEIGHT, WIDTH - 2, point( START_X + 1,
-                                      START_Y ) );
+        w_title = catacurses::newwin( TITLE_HEIGHT, WIDTH - 2, START + point_east );
 
         const int TAB_START_Y = TITLE_START_Y + 3;
         //w_tabs is the tab bar for passive and active bionic groups
         w_tabs = catacurses::newwin( TITLE_TAB_HEIGHT, WIDTH,
-                                     point( START_X, TAB_START_Y ) );
+                                     point( START.x, TAB_START_Y ) );
 
         // offset for display: bionic with index i is drawn at y=list_start_y+i
         // drawing the bionics starts with bionic[scroll_position]

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -448,54 +448,46 @@ class time_point
             return point.turn_;
         }
 
+        friend constexpr inline bool operator<( const time_point &lhs, const time_point &rhs ) {
+            return to_turn<int>( lhs ) < to_turn<int>( rhs );
+        }
+        friend constexpr inline bool operator<=( const time_point &lhs, const time_point &rhs ) {
+            return to_turn<int>( lhs ) <= to_turn<int>( rhs );
+        }
+        friend constexpr inline bool operator>( const time_point &lhs, const time_point &rhs ) {
+            return to_turn<int>( lhs ) > to_turn<int>( rhs );
+        }
+        friend constexpr inline bool operator>=( const time_point &lhs, const time_point &rhs ) {
+            return to_turn<int>( lhs ) >= to_turn<int>( rhs );
+        }
+        friend constexpr inline bool operator==( const time_point &lhs, const time_point &rhs ) {
+            return to_turn<int>( lhs ) == to_turn<int>( rhs );
+        }
+        friend constexpr inline bool operator!=( const time_point &lhs, const time_point &rhs ) {
+            return to_turn<int>( lhs ) != to_turn<int>( rhs );
+        }
+
+        friend constexpr inline time_duration operator-(
+            const time_point &lhs, const time_point &rhs ) {
+            return time_duration::from_turns( to_turn<int>( lhs ) - to_turn<int>( rhs ) );
+        }
+        friend constexpr inline time_point operator+(
+            const time_point &lhs, const time_duration &rhs ) {
+            return time_point::from_turn( to_turn<int>( lhs ) + to_turns<int>( rhs ) );
+        }
+        friend time_point inline &operator+=( time_point &lhs, const time_duration &rhs ) {
+            return lhs = time_point::from_turn( to_turn<int>( lhs ) + to_turns<int>( rhs ) );
+        }
+        friend constexpr inline time_point operator-(
+            const time_point &lhs, const time_duration &rhs ) {
+            return time_point::from_turn( to_turn<int>( lhs ) - to_turns<int>( rhs ) );
+        }
+        friend time_point inline &operator-=( time_point &lhs, const time_duration &rhs ) {
+            return lhs = time_point::from_turn( to_turn<int>( lhs ) - to_turns<int>( rhs ) );
+        }
+
         // TODO: implement minutes_of_hour and so on and use it.
 };
-
-constexpr inline bool operator<( const time_point &lhs, const time_point &rhs )
-{
-    return to_turn<int>( lhs ) < to_turn<int>( rhs );
-}
-constexpr inline bool operator<=( const time_point &lhs, const time_point &rhs )
-{
-    return to_turn<int>( lhs ) <= to_turn<int>( rhs );
-}
-constexpr inline bool operator>( const time_point &lhs, const time_point &rhs )
-{
-    return to_turn<int>( lhs ) > to_turn<int>( rhs );
-}
-constexpr inline bool operator>=( const time_point &lhs, const time_point &rhs )
-{
-    return to_turn<int>( lhs ) >= to_turn<int>( rhs );
-}
-constexpr inline bool operator==( const time_point &lhs, const time_point &rhs )
-{
-    return to_turn<int>( lhs ) == to_turn<int>( rhs );
-}
-constexpr inline bool operator!=( const time_point &lhs, const time_point &rhs )
-{
-    return to_turn<int>( lhs ) != to_turn<int>( rhs );
-}
-
-constexpr inline time_duration operator-( const time_point &lhs, const time_point &rhs )
-{
-    return time_duration::from_turns( to_turn<int>( lhs ) - to_turn<int>( rhs ) );
-}
-constexpr inline time_point operator+( const time_point &lhs, const time_duration &rhs )
-{
-    return time_point::from_turn( to_turn<int>( lhs ) + to_turns<int>( rhs ) );
-}
-time_point inline &operator+=( time_point &lhs, const time_duration &rhs )
-{
-    return lhs = time_point::from_turn( to_turn<int>( lhs ) + to_turns<int>( rhs ) );
-}
-constexpr inline time_point operator-( const time_point &lhs, const time_duration &rhs )
-{
-    return time_point::from_turn( to_turn<int>( lhs ) - to_turns<int>( rhs ) );
-}
-time_point inline &operator-=( time_point &lhs, const time_duration &rhs )
-{
-    return lhs = time_point::from_turn( to_turn<int>( lhs ) - to_turns<int>( rhs ) );
-}
 
 inline time_duration time_past_midnight( const time_point &p )
 {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1158,8 +1158,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                                  std::min( o.y, min_visible_y )
                              );
     const point max_mm_reg = point(
-                                 std::max( sx + o.x, max_visible_x ),
-                                 std::max( sy + o.y, max_visible_y )
+                                 std::max( s.x + o.x, max_visible_x ),
+                                 std::max( s.y + o.y, max_visible_y )
                              );
     g->u.prepare_map_memory_region(
         g->m.getabs( tripoint( min_mm_reg, center.z ) ),

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1450,7 +1450,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     //Memorize everything the character just saw even if it wasn't displayed.
     for( int mem_y = min_visible_y; mem_y <= max_visible_y; mem_y++ ) {
         for( int mem_x = min_visible_x; mem_x <= max_visible_x; mem_x++ ) {
-            rectangle already_drawn( point( min_col, min_row ), point( max_col, max_row ) );
+            half_open_rectangle already_drawn( point( min_col, min_row ),
+                                               point( max_col, max_row ) );
             if( iso_mode ) {
                 // calculate the screen position according to the drawing code above (division rounded down):
 
@@ -1461,7 +1462,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 // \/
                 const int col = mem_y + mem_x + sx / 2 - o.y - o.x;
                 const int row = mem_y - mem_x + sy / 2 - o.y + o.x;
-                if( already_drawn.contains_half_open( point( col, row ) ) ) {
+                if( already_drawn.contains( point( col, row ) ) ) {
                     continue;
                 }
             } else {
@@ -1473,7 +1474,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 // \/
                 // col = mem_x - o.x
                 // row = mem_y - o.y
-                if( already_drawn.contains_half_open( point( mem_x, mem_y ) - o ) ) {
+                if( already_drawn.contains( point( mem_x, mem_y ) - o ) ) {
                     continue;
                 }
             }
@@ -1810,9 +1811,9 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
     // check to make sure that we are drawing within a valid area
     // [0->width|height / tile_width|height]
 
-    rectangle screen_bounds( o, o + point( screentile_width, screentile_height ) );
+    half_open_rectangle screen_bounds( o, o + point( screentile_width, screentile_height ) );
     if( !tile_iso &&
-        !screen_bounds.contains_half_open( pos.xy() ) ) {
+        !screen_bounds.contains( pos.xy() ) ) {
         return false;
     }
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1569,10 +1569,10 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         bool zlevs = g->m.has_zlevels();
         int mapsize = g->m.getmapsize();
         tripoint mappos = g->m.get_abs_sub();
-        rectangle maprect( mappos.xy(), mappos.xy() + point( mapsize, mapsize ) );
+        half_open_rectangle maprect( mappos.xy(), mappos.xy() + point( mapsize, mapsize ) );
 
         const auto is_map = [mappos, zlevs, maprect]( const tripoint & p ) {
-            if( !maprect.contains_half_open( p.xy() ) ) {
+            if( !maprect.contains( p.xy() ) ) {
                 return false;
             }
             if( zlevs ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1071,7 +1071,7 @@ void tileset_loader::load_tile_spritelists( const JsonObject &entry,
 }
 
 struct tile_render_info {
-    const tripoint pos;
+    const tripoint pos{};
     // accumulator for 3d tallness of sprites rendered here so far;
     int height_3d = 0;
     lit_level ll;
@@ -1121,9 +1121,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         geometry->rect( renderer, clipRect, SDL_Color() );
     }
 
-    int sx = 0;
-    int sy = 0;
-    get_window_tile_counts( width, height, sx, sy );
+    point s;
+    get_window_tile_counts( width, height, s.x, s.y );
 
     init_light();
     map &here = get_map();
@@ -1139,9 +1138,9 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     screentile_height = divide_round_up( height, tile_height );
 
     const int min_col = 0;
-    const int max_col = sx;
+    const int max_col = s.x;
     const int min_row = 0;
-    const int max_row = sy;
+    const int max_row = s.y;
 
     //limit the render area to maximum view range (121x121 square centered on player)
     const int min_visible_x = g->u.posx() % SEEX;
@@ -1226,11 +1225,11 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             if( iso_mode ) {
                 //in isometric, rows and columns represent a checkerboard screen space, and we place
                 //the appropriate tile in valid squares by getting position relative to the screen center.
-                if( modulo( row - sy / 2, 2 ) != modulo( col - sx / 2, 2 ) ) {
+                if( modulo( row - s.y / 2, 2 ) != modulo( col - s.x / 2, 2 ) ) {
                     continue;
                 }
-                temp_x = divide_round_down( col - row - sx / 2 + sy / 2, 2 ) + o.x;
-                temp_y = divide_round_down( row + col - sy / 2 - sx / 2, 2 ) + o.y;
+                temp_x = divide_round_down( col - row - s.x / 2 + s.y / 2, 2 ) + o.x;
+                temp_y = divide_round_down( row + col - s.y / 2 - s.x / 2, 2 ) + o.y;
             } else {
                 temp_x = col + o.x;
                 temp_y = row + o.y;
@@ -1460,8 +1459,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 // ( col - sx / 2 ) % 2 = ( row - sy / 2 ) % 2
                 // ||
                 // \/
-                const int col = mem_y + mem_x + sx / 2 - o.y - o.x;
-                const int row = mem_y - mem_x + sy / 2 - o.y + o.x;
+                const int col = mem_y + mem_x + s.x / 2 - o.y - o.x;
+                const int row = mem_y - mem_x + s.y / 2 - o.y + o.x;
                 if( already_drawn.contains( point( col, row ) ) ) {
                     continue;
                 }
@@ -2376,22 +2375,21 @@ bool cata_tiles::draw_terrain_below( const tripoint &p, const lit_level, int &,
         belowRect.w = ( belowRect.w * 3 ) / 4;
     }
     // translate from player-relative to screen relative tile position
-    int screen_x = 0;
-    int screen_y = 0;
+    point screen;
     if( tile_iso ) {
-        screen_x = ( ( pbelow.x - o.x ) - ( o.y - pbelow.y ) + screentile_width - 2 ) * tile_width / 2 +
+        screen.x = ( ( pbelow.x - o.x ) - ( o.y - pbelow.y ) + screentile_width - 2 ) * tile_width / 2 +
                    op.x;
         // y uses tile_width because width is definitive for iso tiles
         // tile footprints are half as tall as wide, arbitrarily tall
-        screen_y = ( ( pbelow.y - o.y ) - ( pbelow.x - o.x ) - 4 ) * tile_width / 4 +
+        screen.y = ( ( pbelow.y - o.y ) - ( pbelow.x - o.x ) - 4 ) * tile_width / 4 +
                    screentile_height * tile_height / 2 + // TODO: more obvious centering math
                    op.y;
     } else {
-        screen_x = ( pbelow.x - o.x ) * tile_width + op.x;
-        screen_y = ( pbelow.y - o.y ) * tile_height + op.y;
+        screen.x = ( pbelow.x - o.x ) * tile_width + op.x;
+        screen.y = ( pbelow.y - o.y ) * tile_height + op.y;
     }
-    belowRect.x = screen_x + ( tile_width - belowRect.w ) / 2;
-    belowRect.y = screen_y + ( tile_height - belowRect.h ) / 2;
+    belowRect.x = screen.x + ( tile_width - belowRect.w ) / 2;
+    belowRect.y = screen.y + ( tile_height - belowRect.h ) / 2;
     if( tile_iso ) {
         belowRect.y += tile_height / 8;
     }
@@ -3522,8 +3520,7 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
     const bool use_font = get_option<bool>( "ANIMATION_SCT_USE_FONT" );
 
     for( auto iter = SCT.vSCT.begin(); iter != SCT.vSCT.end(); ++iter ) {
-        const int iDX = iter->getPosX();
-        const int iDY = iter->getPosY();
+        const point iD( iter->getPosX(), iter->getPosY() );
         const int full_text_length = utf8_width( iter->getText() );
 
         int iOffsetX = 0;
@@ -3541,7 +3538,7 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
                 const int direction_offset = ( -direction_XY( direction ).x + 1 ) * full_text_length / 2;
 
                 overlay_strings.emplace(
-                    player_to_screen( point( iDX + direction_offset, iDY ) ),
+                    player_to_screen( iD + point( direction_offset, 0 ) ),
                     formatted_text( sText, FG, direction ) );
             } else {
                 for( auto &it : sText ) {
@@ -3549,7 +3546,7 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
 
                     if( tileset_ptr->find_tile_type( generic_id ) ) {
                         draw_from_id_string( generic_id, C_NONE, empty_string,
-                        { iDX + iOffsetX, iDY + iOffsetY, g->u.pos().z }, 0, 0, LL_LIT, false );
+                                             iD + tripoint( iOffsetX, iOffsetY, g->u.pos().z ), 0, 0, LL_LIT, false );
                     }
 
                     if( tile_iso ) {
@@ -3760,21 +3757,20 @@ void cata_tiles::do_tile_loading_report()
 
 point cata_tiles::player_to_screen( const point &p ) const
 {
-    int screen_x = 0;
-    int screen_y = 0;
+    point screen;
     if( tile_iso ) {
-        screen_x = ( ( p.x - o.x ) - ( o.y - p.y ) + screentile_width - 2 ) * tile_width / 2 +
+        screen.x = ( ( p.x - o.x ) - ( o.y - p.y ) + screentile_width - 2 ) * tile_width / 2 +
                    op.x;
         // y uses tile_width because width is definitive for iso tiles
         // tile footprints are half as tall as wide, arbitrarily tall
-        screen_y = ( ( p.y - o.y ) - ( p.x - o.x ) - 4 ) * tile_width / 4 +
+        screen.y = ( ( p.y - o.y ) - ( p.x - o.x ) - 4 ) * tile_width / 4 +
                    screentile_height * tile_height / 2 + // TODO: more obvious centering math
                    op.y;
     } else {
-        screen_x = ( p.x - o.x ) * tile_width + op.x;
-        screen_y = ( p.y - o.y ) * tile_height + op.y;
+        screen.x = ( p.x - o.x ) * tile_width + op.x;
+        screen.y = ( p.y - o.y ) * tile_height + op.y;
     }
-    return {screen_x, screen_y};
+    return {screen};
 }
 
 template<typename Iter, typename Func>

--- a/src/cellular_automata.h
+++ b/src/cellular_automata.h
@@ -23,15 +23,14 @@ inline int neighbor_count( const std::vector<std::vector<int>> &cells, const poi
     int neighbors = 0;
     for( int ni = -1; ni <= 1; ni++ ) {
         for( int nj = -1; nj <= 1; nj++ ) {
-            const int nx = p.x + ni;
-            const int ny = p.y + nj;
+            const point n( p + point( ni, nj ) );
 
             // These neighbors are outside the bounds, so they can't contribute.
-            if( nx < 0 || nx >= size.x || ny < 0 || ny >= size.y ) {
+            if( n.x < 0 || n.x >= size.x || n.y < 0 || n.y >= size.y ) {
                 continue;
             }
 
-            neighbors += cells[nx][ny];
+            neighbors += cells[n.x][n.y];
         }
     }
     // Because we included ourself in the loop above, subtract ourselves back out.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9806,8 +9806,7 @@ void Character::place_corpse( const tripoint &om_target )
 {
     tinymap bay;
     bay.load( tripoint( om_target.x * 2, om_target.y * 2, om_target.z ), false );
-    int finX = rng( 1, SEEX * 2 - 2 );
-    int finY = rng( 1, SEEX * 2 - 2 );
+    point fin( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEX * 2 - 2 ) );
     // This makes no sense at all. It may find a random tile without furniture, but
     // if the first try to find one fails, it will go through all tiles of the map
     // and essentially select the last one that has no furniture.
@@ -9815,11 +9814,11 @@ void Character::place_corpse( const tripoint &om_target )
     // Q: Why not grep a random point out of all the possible points (e.g. via random_entry)?
     // Q: Why use furn_str_id instead of f_null?
     // TODO: fix it, see above.
-    if( bay.furn( point( finX, finY ) ) != furn_str_id( "f_null" ) ) {
+    if( bay.furn( fin ) != furn_str_id( "f_null" ) ) {
         for( const tripoint &p : bay.points_on_zlevel() ) {
             if( bay.furn( p ) == furn_str_id( "f_null" ) ) {
-                finX = p.x;
-                finY = p.y;
+                fin.x = p.x;
+                fin.y = p.y;
             }
         }
     }
@@ -9827,7 +9826,7 @@ void Character::place_corpse( const tripoint &om_target )
     std::vector<item *> tmp = inv_dump();
     item body = item::make_corpse( mtype_id::NULL_ID(), calendar::turn, name );
     for( auto itm : tmp ) {
-        bay.add_item_or_charges( point( finX, finY ), *itm );
+        bay.add_item_or_charges( fin, *itm );
     }
     for( const bionic &bio : *my_bionics ) {
         if( item::type_is_defined( bio.id.str() ) ) {
@@ -9843,7 +9842,7 @@ void Character::place_corpse( const tripoint &om_target )
     for( int i = 0; i < storage_modules.second; ++i ) {
         body.put_in( item( "bio_power_storage_mkII" ) );
     }
-    bay.add_item_or_charges( point( finX, finY ), body );
+    bay.add_item_or_charges( fin, body );
 }
 
 bool Character::sees_with_infrared( const Creature &critter ) const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9806,7 +9806,7 @@ void Character::place_corpse( const tripoint &om_target )
 {
     tinymap bay;
     bay.load( tripoint( om_target.x * 2, om_target.y * 2, om_target.z ), false );
-    point fin( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEX * 2 - 2 ) );
+    point fin{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEX * 2 - 2 ) };
     // This makes no sense at all. It may find a random tile without furniture, but
     // if the first try to find one fails, it will go through all tiles of the map
     // and essentially select the last one that has no furniture.

--- a/src/character_id.h
+++ b/src/character_id.h
@@ -31,28 +31,24 @@ class character_id
 
         void serialize( JsonOut & ) const;
         void deserialize( JsonIn & );
+
+        friend inline bool operator==( character_id l, character_id r ) {
+            return l.get_value() == r.get_value();
+        }
+
+        friend inline bool operator!=( character_id l, character_id r ) {
+            return l.get_value() != r.get_value();
+        }
+
+        friend inline bool operator<( character_id l, character_id r ) {
+            return l.get_value() < r.get_value();
+        }
+
+        friend inline std::ostream &operator<<( std::ostream &o, character_id id ) {
+            return o << id.get_value();
+        }
     private:
         int value;
 };
-
-inline bool operator==( character_id l, character_id r )
-{
-    return l.get_value() == r.get_value();
-}
-
-inline bool operator!=( character_id l, character_id r )
-{
-    return l.get_value() != r.get_value();
-}
-
-inline bool operator<( character_id l, character_id r )
-{
-    return l.get_value() < r.get_value();
-}
-
-inline std::ostream &operator<<( std::ostream &o, character_id id )
-{
-    return o << id.get_value();
-}
 
 #endif // CATA_SRC_CHARACTER_ID_H

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -735,8 +735,7 @@ void color_manager::show_gui()
     const int iHeaderHeight = 4;
     int iContentHeight = 0;
 
-    int iOffsetX = 0;
-    int iOffsetY = 0;
+    point iOffset;
 
     std::vector<int> vLines;
     vLines.push_back( -1 );
@@ -756,15 +755,15 @@ void color_manager::show_gui()
     const auto init_windows = [&]( ui_adaptor & ui ) {
         iContentHeight = FULL_SCREEN_HEIGHT - 2 - iHeaderHeight;
 
-        iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-        iOffsetY = calc_offset_y();
+        iOffset.x = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
+        iOffset.y = calc_offset_y();
 
         w_colors_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                              point( iOffsetX, iOffsetY ) );
+                                              iOffset );
         w_colors_header = catacurses::newwin( iHeaderHeight, FULL_SCREEN_WIDTH - 2,
-                                              point( 1 + iOffsetX, 1 + iOffsetY ) );
+                                              iOffset + point_south_east );
         w_colors = catacurses::newwin( iContentHeight, FULL_SCREEN_WIDTH - 2,
-                                       point( 1 + iOffsetX, iHeaderHeight + 1 + iOffsetY ) );
+                                       iOffset + point( 1, iHeaderHeight + 1 ) );
 
         ui.position_from_window( w_colors_border );
     };

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -74,9 +74,8 @@ static catacurses::window init_window()
 {
     const int width = FULL_SCREEN_WIDTH;
     const int height = FULL_SCREEN_HEIGHT;
-    const int x = std::max( 0, ( TERMX - width ) / 2 );
-    const int y = std::max( 0, ( TERMY - height ) / 2 );
-    return catacurses::newwin( height, width, point( x, y ) );
+    const point p( std::max( 0, ( TERMX - width ) / 2 ), std::max( 0, ( TERMY - height ) / 2 ) );
+    return catacurses::newwin( height, width, p );
 }
 
 computer_session::computer_session( computer &comp ) : comp( comp ),
@@ -91,9 +90,8 @@ void computer_session::use()
     ui.on_screen_resize( [this]( ui_adaptor & ui ) {
         const int width = getmaxx( win );
         const int height = getmaxy( win );
-        const int x = std::max( 0, ( TERMX - width ) / 2 );
-        const int y = std::max( 0, ( TERMY - height ) / 2 );
-        win = catacurses::newwin( height, width, point( x, y ) );
+        const point p( std::max( 0, ( TERMX - width ) / 2 ), std::max( 0, ( TERMY - height ) / 2 ) );
+        win = catacurses::newwin( height, width, p );
         ui.position_from_window( win );
     } );
     ui.mark_resize();

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -4,6 +4,7 @@
 
 #include <cstdlib>
 
+#include "coordinate_conversions.h"
 #include "enums.h"
 #include "game_constants.h"
 #include "point.h"
@@ -39,17 +40,16 @@ struct real_coords {
     }
 
     void fromabs( const point &abs ) {
-        const int normx = std::abs( abs.x );
-        const int normy = std::abs( abs.y );
+        const point norm( std::abs( abs.x ), std::abs( abs.y ) );
         abs_pos = abs;
 
         if( abs.x < 0 ) {
             abs_sub.x = ( abs.x - SEEX + 1 ) / SEEX;
-            sub_pos.x = SEEX - 1 - ( ( normx - 1 ) % SEEX );
+            sub_pos.x = SEEX - 1 - ( ( norm.x - 1 ) % SEEX );
             abs_om.x = ( abs_sub.x - subs_in_om_n ) / subs_in_om;
-            om_sub.x = subs_in_om_n - ( ( ( normx - 1 ) / SEEX ) % subs_in_om );
+            om_sub.x = subs_in_om_n - ( ( ( norm.x - 1 ) / SEEX ) % subs_in_om );
         } else {
-            abs_sub.x = normx / SEEX;
+            abs_sub.x = norm.x / SEEX;
             sub_pos.x = abs.x % SEEX;
             abs_om.x = abs_sub.x / subs_in_om;
             om_sub.x = abs_sub.x % subs_in_om;
@@ -58,11 +58,11 @@ struct real_coords {
 
         if( abs.y < 0 ) {
             abs_sub.y = ( abs.y - SEEY + 1 ) / SEEY;
-            sub_pos.y = SEEY - 1 - ( ( normy - 1 ) % SEEY );
+            sub_pos.y = SEEY - 1 - ( ( norm.y - 1 ) % SEEY );
             abs_om.y = ( abs_sub.y - subs_in_om_n ) / subs_in_om;
-            om_sub.y = subs_in_om_n - ( ( ( normy - 1 ) / SEEY ) % subs_in_om );
+            om_sub.y = subs_in_om_n - ( ( ( norm.y - 1 ) / SEEY ) % subs_in_om );
         } else {
-            abs_sub.y = normy / SEEY;
+            abs_sub.y = norm.y / SEEY;
             sub_pos.y = abs.y % SEEY;
             abs_om.y = abs_sub.y / subs_in_om;
             om_sub.y = abs_sub.y % subs_in_om;
@@ -72,9 +72,8 @@ struct real_coords {
 
     // specifically for the subjective position returned by overmap::draw
     void fromomap( const point &rel_om, const point &rel_om_pos ) {
-        const int ax = rel_om.x * OMAPX + rel_om_pos.x;
-        const int ay = rel_om.y * OMAPY + rel_om_pos.y;
-        fromabs( point( ax * SEEX * 2, ay * SEEY * 2 ) );
+        const point a = om_to_omt_copy( rel_om ) + rel_om_pos;
+        fromabs( omt_to_ms_copy( a ) );
     }
 
     // helper functions to return abs_pos of submap/overmap tile/overmap's start

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -221,11 +221,10 @@ const recipe *select_crafting_recipe( int &batch_size )
         if( isWide ) {
             item_info_width = width - FULL_SCREEN_WIDTH - 2;
             const int item_info_height = dataHeight - 3;
-            const int item_info_x = wStart + width - item_info_width;
-            const int item_info_y = headHeight + subHeadHeight;
+            const point item_info( wStart + width - item_info_width, headHeight + subHeadHeight );
 
             w_iteminfo = catacurses::newwin( item_info_height, item_info_width,
-                                             point( item_info_x, item_info_y ) );
+                                             item_info );
         } else {
             item_info_width = 0;
             w_iteminfo = {};

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1690,14 +1690,13 @@ void Creature::draw( const catacurses::window &w, const tripoint &origin, bool i
         return;
     }
 
-    int draw_x = getmaxx( w ) / 2 + posx() - origin.x;
-    int draw_y = getmaxy( w ) / 2 + posy() - origin.y;
+    point draw( -origin.xy() + point( getmaxx( w ) / 2 + posx(), getmaxy( w ) / 2 + posy() ) );
     if( inverted ) {
-        mvwputch_inv( w, point( draw_x, draw_y ), basic_symbol_color(), symbol() );
+        mvwputch_inv( w, draw, basic_symbol_color(), symbol() );
     } else if( is_symbol_highlighted() ) {
-        mvwputch_hi( w, point( draw_x, draw_y ), basic_symbol_color(), symbol() );
+        mvwputch_hi( w, draw, basic_symbol_color(), symbol() );
     } else {
-        mvwputch( w, point( draw_x, draw_y ), symbol_color(), symbol() );
+        mvwputch( w, draw, symbol_color(), symbol() );
     }
 }
 

--- a/src/distribution_grid.cpp
+++ b/src/distribution_grid.cpp
@@ -213,7 +213,7 @@ void distribution_grid_tracker::on_changed( const tripoint &p )
     tripoint sm_pos = ms_to_sm_copy( p );
     // TODO: If not in bounds, just drop the grid, rebuild lazily
     if( parent_distribution_grids.count( sm_pos ) > 0 ||
-        bounds.contains_half_open( sm_pos.xy() ) ) {
+        bounds.contains( sm_pos.xy() ) ) {
         // TODO: Don't rebuild, update
         make_distribution_grid_at( sm_pos );
     }
@@ -267,7 +267,7 @@ void distribution_grid_tracker::update( time_point to )
     }
 }
 
-void distribution_grid_tracker::load( rectangle area )
+void distribution_grid_tracker::load( half_open_rectangle area )
 {
     bounds = area;
     // TODO: Don't reload everything when not needed
@@ -276,6 +276,7 @@ void distribution_grid_tracker::load( rectangle area )
 
 void distribution_grid_tracker::load( const map &m )
 {
-    load( rectangle( m.get_abs_sub().xy(),
-                     m.get_abs_sub().xy() + point( m.getmapsize(), m.getmapsize() ) ) );
+    point p_min = m.get_abs_sub().xy();
+    point p_max = p_min + point( m.getmapsize(), m.getmapsize() );
+    load( half_open_rectangle( p_min, p_max ) );
 }

--- a/src/distribution_grid.h
+++ b/src/distribution_grid.h
@@ -74,7 +74,7 @@ class distribution_grid_tracker
         /**
          * In submap coords, to mirror @ref map
          */
-        rectangle bounds;
+        half_open_rectangle bounds;
 
         mapbuffer &mb;
 
@@ -100,7 +100,7 @@ class distribution_grid_tracker
         /**
          * Loads grids in an area given by submap coords.
          */
-        void load( rectangle area );
+        void load( half_open_rectangle area );
         /**
          * Loads grids in the same area as a given map.
          */

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -58,7 +58,7 @@
 static constexpr tripoint editmap_boundary_min( 0, 0, -OVERMAP_DEPTH );
 static constexpr tripoint editmap_boundary_max( MAPSIZE_X, MAPSIZE_Y, OVERMAP_HEIGHT + 1 );
 
-static constexpr box editmap_boundaries( editmap_boundary_min, editmap_boundary_max );
+static constexpr half_open_box editmap_boundaries( editmap_boundary_min, editmap_boundary_max );
 
 static const ter_id undefined_ter_id( -1 );
 
@@ -1517,7 +1517,7 @@ void editmap::recalc_target( shapetype shape )
             int radius = rl_dist( origin, target );
             for( const tripoint &p : g->m.points_in_radius( origin, radius ) ) {
                 if( rl_dist( p, origin ) <= radius ) {
-                    if( editmap_boundaries.contains_half_open( p ) ) {
+                    if( editmap_boundaries.contains( p ) ) {
                         target_list.push_back( p );
                     }
                 }
@@ -1548,7 +1548,7 @@ void editmap::recalc_target( shapetype shape )
                 for( int y = sy; y <= ey; y++ ) {
                     if( shape == editmap_rect_filled || x == sx || x == ex || y == sy || y == ey ) {
                         const tripoint p( x, y, z );
-                        if( editmap_boundaries.contains_half_open( p ) ) {
+                        if( editmap_boundaries.contains( p ) ) {
                             target_list.push_back( p );
                         }
                     }
@@ -2005,8 +2005,8 @@ void editmap::mapgen_retarget()
         if( const cata::optional<tripoint> vec = ctxt.get_direction( action ) ) {
             point vec_ms = omt_to_ms_copy( vec->xy() );
             tripoint ptarget = target + vec_ms;
-            if( editmap_boundaries.contains_half_open( ptarget ) &&
-                editmap_boundaries.contains_half_open( ptarget + point( SEEX, SEEY ) ) ) {
+            if( editmap_boundaries.contains( ptarget ) &&
+                editmap_boundaries.contains( ptarget + point( SEEX, SEEY ) ) ) {
                 target = ptarget;
 
                 target_list.clear();

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -671,11 +671,11 @@ void faction_manager::display() const
 
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        const int term_x = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
-        const int term_y = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
+        const point term( TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0,
+                          TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0 );
 
         w_missions = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                         point( term_y, term_x ) );
+                                         point( term.y, term.x ) );
 
         entries_per_page = FULL_SCREEN_HEIGHT - 4;
 

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1640,11 +1640,11 @@ void basecamp::worker_assignment_ui()
 
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        const int term_x = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
-        const int term_y = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
+        const point term( TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0,
+                          TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0 );
 
         w_followers = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                          point( term_y, term_x ) );
+                                          point( term.y, term.x ) );
         entries_per_page = FULL_SCREEN_HEIGHT - 4;
 
         ui.position_from_window( w_followers );
@@ -1737,11 +1737,11 @@ void basecamp::job_assignment_ui()
 
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        const int term_x = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
-        const int term_y = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
+        const point term( TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0,
+                          TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0 );
 
         w_jobs = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                     point( term_y, term_x ) );
+                                     point( term.y, term.x ) );
 
         entries_per_page = FULL_SCREEN_HEIGHT - 4;
 
@@ -3222,9 +3222,8 @@ int om_cutdown_trees( const tripoint &omt_tgt, int chance, bool estimate, bool f
                 continue;
             }
             // get a random number that is either 1 or -1
-            int dir_x = 3 * ( 2 * rng( 0, 1 ) - 1 ) + rng( -1, 1 );
-            int dir_y = 3 * rng( -1, 1 ) + rng( -1, 1 );
-            tripoint to = p + tripoint( dir_x, dir_y, omt_tgt.z );
+            point dir( 3 * ( 2 * rng( 0, 1 ) - 1 ) + rng( -1, 1 ), 3 * rng( -1, 1 ) + rng( -1, 1 ) );
+            tripoint to = p + tripoint( dir, omt_tgt.z );
             std::vector<tripoint> tree = line_to( p, to, rng( 1, 8 ) );
             for( auto &elem : tree ) {
                 target_bay.destroy( elem );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3221,10 +3221,12 @@ int om_cutdown_trees( const tripoint &omt_tgt, int chance, bool estimate, bool f
             if( estimate ) {
                 continue;
             }
-            // get a random number that is either 1 or -1
-            point dir( 3 * ( 2 * rng( 0, 1 ) - 1 ) + rng( -1, 1 ), 3 * rng( -1, 1 ) + rng( -1, 1 ) );
-            tripoint to = p + tripoint( dir, omt_tgt.z );
-            std::vector<tripoint> tree = line_to( p, to, rng( 1, 8 ) );
+            tripoint delta{
+                3 * ( 2 * rng( 0, 1 ) - 1 ) + rng( -1, 1 ),
+                3 * rng( -1, 1 ) + rng( -1, 1 ),
+                omt_tgt.z
+            };
+            std::vector<tripoint> tree = line_to( p, p + delta, rng( 1, 8 ) );
             for( auto &elem : tree ) {
                 target_bay.destroy( elem );
                 target_bay.ter_set( elem, t_trunk );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3886,7 +3886,7 @@ std::unordered_set<tripoint> game::get_fishable_locations( int distance, const t
     const tripoint fishing_boundary_min( fish_pos + point( -distance, -distance ) );
     const tripoint fishing_boundary_max( fish_pos + point( distance, distance ) );
 
-    const box fishing_boundaries( fishing_boundary_min, fishing_boundary_max );
+    const inclusive_box fishing_boundaries( fishing_boundary_min, fishing_boundary_max );
 
     const auto get_fishable_terrain = [&]( tripoint starting_point,
     std::unordered_set<tripoint> &fishable_terrain ) {
@@ -3902,7 +3902,7 @@ std::unordered_set<tripoint> game::get_fishable_locations( int distance, const t
             }
 
             // This point is out of bounds, so bail.
-            if( !fishing_boundaries.contains_inclusive( current_point ) ) {
+            if( !fishing_boundaries.contains( current_point ) ) {
                 continue;
             }
 
@@ -10944,10 +10944,10 @@ point game::update_map( int &x, int &y )
 
     // this handles loading/unloading submaps that have scrolled on or off the viewport
     // NOLINTNEXTLINE(cata-use-named-point-constants)
-    rectangle size_1( point( -1, -1 ), point( 1, 1 ) );
+    inclusive_rectangle size_1( point( -1, -1 ), point( 1, 1 ) );
     point remaining_shift = shift;
     while( remaining_shift != point_zero ) {
-        point this_shift = clamp_inclusive( remaining_shift, size_1 );
+        point this_shift = clamp( remaining_shift, size_1 );
         m.shift( this_shift );
         remaining_shift -= this_shift;
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2276,25 +2276,24 @@ std::pair<tripoint, tripoint> game::mouse_edge_scrolling( input_context &ctxt, c
     }
     const input_event event = ctxt.get_raw_input();
     if( event.type == CATA_INPUT_MOUSE ) {
-        const int threshold_x = projected_window_width() / 100;
-        const int threshold_y = projected_window_height() / 100;
-        if( event.mouse_pos.x <= threshold_x ) {
+        const point threshold( projected_window_width() / 100, projected_window_height() / 100 );
+        if( event.mouse_pos.x <= threshold.x ) {
             ret.first.x -= speed;
             if( iso ) {
                 ret.first.y -= speed;
             }
-        } else if( event.mouse_pos.x >= projected_window_width() - threshold_x ) {
+        } else if( event.mouse_pos.x >= projected_window_width() - threshold.x ) {
             ret.first.x += speed;
             if( iso ) {
                 ret.first.y += speed;
             }
         }
-        if( event.mouse_pos.y <= threshold_y ) {
+        if( event.mouse_pos.y <= threshold.y ) {
             ret.first.y -= speed;
             if( iso ) {
                 ret.first.x += speed;
             }
-        } else if( event.mouse_pos.y >= projected_window_height() - threshold_y ) {
+        } else if( event.mouse_pos.y >= projected_window_height() - threshold.y ) {
             ret.first.y += speed;
             if( iso ) {
                 ret.first.x -= speed;
@@ -3124,7 +3123,7 @@ void game::display_faction_epilogues()
 }
 
 struct npc_dist_to_player {
-    const tripoint ppos;
+    const tripoint ppos{};
     npc_dist_to_player() : ppos( g->u.global_omt_location() ) { }
     // Operator overload required to leverage sort API.
     bool operator()( const shared_ptr_fast<npc> &a,
@@ -3331,8 +3330,8 @@ static shared_ptr_fast<game::draw_callback_t> create_zone_callback(
             }
         }
         if( zone_blink && zone_start && zone_end ) {
-            const int offset_x = ( g->u.posx() + g->u.view_offset.x ) - getmaxx( g->w_terrain ) / 2;
-            const int offset_y = ( g->u.posy() + g->u.view_offset.y ) - getmaxy( g->w_terrain ) / 2;
+            const point offset2( g->u.view_offset.xy() + point( g->u.posx() - getmaxx( g->w_terrain ) / 2,
+                                 g->u.posy() - getmaxy( g->w_terrain ) / 2 ) );
 
             tripoint offset;
 #if defined(TILES)
@@ -3340,7 +3339,7 @@ static shared_ptr_fast<game::draw_callback_t> create_zone_callback(
                 offset = tripoint_zero; //TILES
             } else {
 #endif
-                offset = tripoint( offset_x, offset_y, 0 ); //CURSES
+                offset = tripoint( offset2, 0 ); //CURSES
 #if defined(TILES)
             }
 #endif
@@ -3566,17 +3565,15 @@ void game::draw_minimap()
     draw_border( w_minimap );
 
     const tripoint curs = u.global_omt_location();
-    const int cursx = curs.x;
-    const int cursy = curs.y;
+    const point curs2( curs.xy() );
     const tripoint targ = u.get_active_mission_target();
     bool drew_mission = targ == overmap::invalid_tripoint;
 
     for( int i = -2; i <= 2; i++ ) {
         for( int j = -2; j <= 2; j++ ) {
-            const int omx = cursx + i;
-            const int omy = cursy + j;
+            const point om( curs2 + point( i, j ) );
             nc_color ter_color;
-            tripoint omp( omx, omy, get_levz() );
+            tripoint omp( om, get_levz() );
             std::string ter_sym;
             const bool seen = overmap_buffer.seen( omp );
             const bool vehicle_here = overmap_buffer.has_vehicle( omp );
@@ -3702,11 +3699,11 @@ void game::draw_minimap()
 
     // Print arrow to mission if we have one!
     if( !drew_mission ) {
-        double slope = ( cursx != targ.x ) ? static_cast<double>( targ.y - cursy ) / static_cast<double>
-                       ( targ.x - cursx ) : 4;
+        double slope = ( curs2.x != targ.x ) ? static_cast<double>( targ.y - curs2.y ) / static_cast<double>
+                       ( targ.x - curs2.x ) : 4;
 
-        if( cursx == targ.x || std::fabs( slope ) > 3.5 ) { // Vertical slope
-            if( targ.y > cursy ) {
+        if( curs2.x == targ.x || std::fabs( slope ) > 3.5 ) { // Vertical slope
+            if( targ.y > curs2.y ) {
                 mvwputch( w_minimap, point( 3, 6 ), c_red, "*" );
             } else {
                 mvwputch( w_minimap, point( 3, 0 ), c_red, "*" );
@@ -3715,8 +3712,8 @@ void game::draw_minimap()
             int arrowx = -1;
             int arrowy = -1;
             if( std::fabs( slope ) >= 1. ) { // y diff is bigger!
-                arrowy = ( targ.y > cursy ? 6 : 0 );
-                arrowx = static_cast<int>( 3 + 3 * ( targ.y > cursy ? slope : ( 0 - slope ) ) );
+                arrowy = ( targ.y > curs2.y ? 6 : 0 );
+                arrowx = static_cast<int>( 3 + 3 * ( targ.y > curs2.y ? slope : ( 0 - slope ) ) );
                 if( arrowx < 0 ) {
                     arrowx = 0;
                 }
@@ -3724,8 +3721,8 @@ void game::draw_minimap()
                     arrowx = 6;
                 }
             } else {
-                arrowx = ( targ.x > cursx ? 6 : 0 );
-                arrowy = static_cast<int>( 3 + 3 * ( targ.x > cursx ? slope : ( 0 - slope ) ) );
+                arrowx = ( targ.x > curs2.x ? 6 : 0 );
+                arrowy = static_cast<int>( 3 + 3 * ( targ.x > curs2.x ? slope : ( 0 - slope ) ) );
                 if( arrowy < 0 ) {
                     arrowy = 0;
                 }
@@ -3750,8 +3747,8 @@ void game::draw_minimap()
             if( i > -3 && i < 3 && j > -3 && j < 3 ) {
                 continue; // only do hordes on the border, skip inner map
             }
-            const int omx = cursx + i;
-            const int omy = cursy + j;
+            const int omx = curs2.x + i;
+            const int omy = curs2.y + j;
             tripoint omp( omx, omy, get_levz() );
             if( overmap_buffer.get_horde_size( omp ) >= HORDE_VISIBILITY_SIZE ) {
                 const tripoint cur_pos {
@@ -5201,17 +5198,16 @@ bool game::forced_door_closing( const tripoint &p, const ter_id &door_type, int 
     const int &x = p.x;
     const int &y = p.y;
     const std::string &door_name = door_type.obj().name();
-    int kbx = x; // Used when player/monsters are knocked back
-    int kby = y; // and when moving items out of the way
+    point kb( x, y ); // and when moving items out of the way
     const auto valid_location = [&]( const tripoint & p ) {
         return g->is_empty( p );
     };
     if( const cata::optional<tripoint> pos = random_point( m.points_in_radius( p, 2 ),
             valid_location ) ) {
-        kbx = -pos->x + x + x;
-        kby = -pos->y + y + y;
+        kb.x = -pos->x + x + x;
+        kb.y = -pos->y + y + y;
     }
-    const tripoint kbp( kbx, kby, p.z );
+    const tripoint kbp( kb, p.z );
     if( kbp == p ) {
         // can't pushback any creatures anywhere, that means the door can't close.
         return false;
@@ -7099,8 +7095,7 @@ static void centerlistview( const tripoint &active_item_position, int ui_width )
             u.view_offset.x = active_item_position.x;
             u.view_offset.y = active_item_position.y;
         } else {
-            int xpos = POSX + active_item_position.x;
-            int ypos = POSY + active_item_position.y;
+            point pos( active_item_position.xy() + point( POSX, POSY ) );
 
             // item/monster list UI is on the right, so get the difference between its width
             // and the width of the sidebar on the right (if any)
@@ -7114,18 +7109,18 @@ static void centerlistview( const tripoint &active_item_position, int ui_width )
             to_map_font_dim_width( right_offset );
             int terrain_width = TERRAIN_WINDOW_WIDTH - right_offset;
 
-            if( xpos < 0 ) {
-                u.view_offset.x = xpos;
-            } else if( xpos >= terrain_width ) {
-                u.view_offset.x = xpos - ( terrain_width - 1 );
+            if( pos.x < 0 ) {
+                u.view_offset.x = pos.x;
+            } else if( pos.x >= terrain_width ) {
+                u.view_offset.x = pos.x - ( terrain_width - 1 );
             } else {
                 u.view_offset.x = 0;
             }
 
-            if( ypos < 0 ) {
-                u.view_offset.y = ypos;
-            } else if( ypos >= TERRAIN_WINDOW_HEIGHT ) {
-                u.view_offset.y = ypos - ( TERRAIN_WINDOW_HEIGHT - 1 );
+            if( pos.y < 0 ) {
+                u.view_offset.y = pos.y;
+            } else if( pos.y >= TERRAIN_WINDOW_HEIGHT ) {
+                u.view_offset.y = pos.y - ( TERRAIN_WINDOW_HEIGHT - 1 );
             } else {
                 u.view_offset.y = 0;
             }
@@ -7252,12 +7247,11 @@ void game::reset_item_list_state( const catacurses::window &window, int height, 
     int usedwidth = letters;
     const int gap_spaces = ( width - usedwidth ) / gaps;
     usedwidth += gap_spaces * gaps;
-    int xpos = gap_spaces + ( width - usedwidth ) / 2;
-    const int ypos = TERMY - height - 1;
+    point pos( gap_spaces + ( width - usedwidth ) / 2, TERMY - height - 1 );
 
     for( int i = 0; i < n; i++ ) {
-        xpos += shortcut_print( window, point( xpos, ypos ), c_white, c_light_green,
-                                tokens[i] ) + gap_spaces;
+        pos.x += shortcut_print( window, pos, c_white, c_light_green,
+                                 tokens[i] ) + gap_spaces;
     }
 }
 
@@ -9773,8 +9767,7 @@ bool game::phasing_move( const tripoint &dest_loc )
     tripoint dest = dest_loc;
     // tile is impassable
     int tunneldist = 0;
-    const int dx = sgn( dest.x - u.posx() );
-    const int dy = sgn( dest.y - u.posy() );
+    const point d( sgn( dest.x - u.posx() ), sgn( dest.y - u.posy() ) );
     while( m.impassable( dest ) ||
            ( critter_at( dest ) != nullptr && tunneldist > 0 ) ) {
         //add 1 to tunnel distance for each impassable tile in the line
@@ -9798,8 +9791,8 @@ bool game::phasing_move( const tripoint &dest_loc )
             return false;
         }
 
-        dest.x += dx;
-        dest.y += dy;
+        dest.x += d.x;
+        dest.y += d.y;
     }
 
     if( tunneldist != 0 ) {
@@ -10666,7 +10659,7 @@ void game::start_hauling( const tripoint &pos )
     // Whether the destination is inside a vehicle (not supported)
     const bool to_vehicle = false;
     // Destination relative to the player
-    const tripoint relative_destination = tripoint_zero;
+    const tripoint relative_destination{};
 
     u.assign_activity( player_activity( move_items_activity_actor(
                                             target_items,
@@ -10905,9 +10898,8 @@ void game::vertical_notes( int z_before, int z_after )
 
 point game::update_map( player &p )
 {
-    int x = p.posx();
-    int y = p.posy();
-    return update_map( x, y );
+    point p2( p.posx(), p.posy() );
+    return update_map( p2.x, p2.y );
 }
 
 point game::update_map( int &x, int &y )
@@ -11109,11 +11101,10 @@ void game::update_stair_monsters()
 
     // Attempt to spawn zombies.
     for( size_t i = 0; i < coming_to_stairs.size(); i++ ) {
-        int mposx = stairx[si];
-        int mposy = stairy[si];
+        point mpos( stairx[si], stairy[si] );
         monster &critter = coming_to_stairs[i];
         const tripoint dest {
-            mposx, mposy, g->get_levz()
+            mpos, g->get_levz()
         };
 
         // We might be not be visible.
@@ -11172,8 +11163,7 @@ void game::update_stair_monsters()
             continue;
         } else if( u.pos() == dest ) {
             // Monster attempts to push player of stairs
-            int pushx = -1;
-            int pushy = -1;
+            point push( point_north_west );
             int tries = 0;
 
             // the critter is now right on top of you and will attack unless
@@ -11184,12 +11174,11 @@ void game::update_stair_monsters()
             critter.spawn( dest );
             while( tries < creature_push_attempts ) {
                 tries++;
-                pushx = rng( -1, 1 );
-                pushy = rng( -1, 1 );
-                int iposx = mposx + pushx;
-                int iposy = mposy + pushy;
-                tripoint pos( iposx, iposy, get_levz() );
-                if( ( pushx != 0 || pushy != 0 ) && !critter_at( pos ) &&
+                push.x = rng( -1, 1 );
+                push.y = rng( -1, 1 );
+                point ipos( mpos + push );
+                tripoint pos( ipos, get_levz() );
+                if( ( push.x != 0 || push.y != 0 ) && !critter_at( pos ) &&
                     critter.can_move_to( pos ) ) {
                     bool resiststhrow = ( u.is_throw_immune() ) ||
                                         ( u.has_trait( trait_LEG_TENT_BRACE ) );
@@ -11218,8 +11207,8 @@ void game::update_stair_monsters()
                         msg = _( "The %s pushed you back!" );
                     }
                     add_msg( m_warning, msg.c_str(), critter.name() );
-                    u.setx( u.posx() + pushx );
-                    u.sety( u.posy() + pushy );
+                    u.setx( u.posx() + push.x );
+                    u.sety( u.posy() + push.y );
                     return;
                 }
             }
@@ -11240,20 +11229,18 @@ void game::update_stair_monsters()
             const int creature_throw_resist = 4;
 
             int tries = 0;
-            int pushx = 0;
-            int pushy = 0;
+            point push2;
             while( tries < creature_push_attempts ) {
                 tries++;
-                pushx = rng( -1, 1 );
-                pushy = rng( -1, 1 );
-                int iposx = mposx + pushx;
-                int iposy = mposy + pushy;
-                tripoint pos( iposx, iposy, get_levz() );
-                if( ( pushx == 0 && pushy == 0 ) || ( ( iposx == u.posx() ) && ( iposy == u.posy() ) ) ) {
+                push2.x = rng( -1, 1 );
+                push2.y = rng( -1, 1 );
+                point ipos2( mpos + push2 );
+                tripoint pos( ipos2, get_levz() );
+                if( ( push2.x == 0 && push2.y == 0 ) || ( ( ipos2.x == u.posx() ) && ( ipos2.y == u.posy() ) ) ) {
                     continue;
                 }
                 if( !critter_at( pos ) && other.can_move_to( pos ) ) {
-                    other.setpos( tripoint( iposx, iposy, get_levz() ) );
+                    other.setpos( tripoint( ipos2, get_levz() ) );
                     other.moves -= 50;
                     std::string msg;
                     if( one_in( creature_throw_resist ) ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5198,7 +5198,8 @@ bool game::forced_door_closing( const tripoint &p, const ter_id &door_type, int 
     const int &x = p.x;
     const int &y = p.y;
     const std::string &door_name = door_type.obj().name();
-    point kb( x, y ); // and when moving items out of the way
+    // sed when player/monsters are knocked back and when moving items out of the way
+    point kb( x, y );
     const auto valid_location = [&]( const tripoint & p ) {
         return g->is_empty( p );
     };

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -879,9 +879,9 @@ void defense_game::caravan()
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
         const int width = FULL_SCREEN_WIDTH;
         const int height = FULL_SCREEN_HEIGHT;
-        const int offsetx = std::max( 0, TERMX - FULL_SCREEN_WIDTH ) / 2;
-        const int offsety = std::max( 0, TERMY - FULL_SCREEN_HEIGHT ) / 2;
-        w = catacurses::newwin( height, width, point( offsetx, offsety ) );
+        const point offset( std::max( 0, TERMX - FULL_SCREEN_WIDTH ) / 2, std::max( 0,
+                            TERMY - FULL_SCREEN_HEIGHT ) / 2 );
+        w = catacurses::newwin( height, width, offset );
         ui.position_from_window( w );
     } );
     ui.mark_resize();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -273,7 +273,7 @@ input_context game::get_player_input( std::string &action )
                 wPrint.vdrops.clear();
 
                 for( int i = 0; i < dropCount; i++ ) {
-                    const point iRand( rng( iStart.x, iEnd.x - 1 ), rng( iStart.y, iEnd.y - 1 ) );
+                    const point iRand{ rng( iStart.x, iEnd.x - 1 ), rng( iStart.y, iEnd.y - 1 ) };
                     const point map( iRand + offset );
 
                     const tripoint mapp( map, u.posz() );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -199,43 +199,42 @@ input_context game::get_player_input( std::string &action )
 
     if( get_option<bool>( "ANIMATIONS" ) ) {
         const int TOTAL_VIEW = MAX_VIEW_DISTANCE * 2 + 1;
-        int iStartX = ( TERRAIN_WINDOW_WIDTH > TOTAL_VIEW ) ? ( TERRAIN_WINDOW_WIDTH - TOTAL_VIEW ) / 2 : 0;
-        int iStartY = ( TERRAIN_WINDOW_HEIGHT > TOTAL_VIEW ) ? ( TERRAIN_WINDOW_HEIGHT - TOTAL_VIEW ) / 2 :
-                      0;
-        int iEndX = ( TERRAIN_WINDOW_WIDTH > TOTAL_VIEW ) ? TERRAIN_WINDOW_WIDTH -
+        point iStart( ( TERRAIN_WINDOW_WIDTH > TOTAL_VIEW ) ? ( TERRAIN_WINDOW_WIDTH - TOTAL_VIEW ) / 2 : 0,
+                      ( TERRAIN_WINDOW_HEIGHT > TOTAL_VIEW ) ? ( TERRAIN_WINDOW_HEIGHT - TOTAL_VIEW ) / 2 :
+                      0 );
+        point iEnd( ( TERRAIN_WINDOW_WIDTH > TOTAL_VIEW ) ? TERRAIN_WINDOW_WIDTH -
                     ( TERRAIN_WINDOW_WIDTH - TOTAL_VIEW ) /
                     2 :
-                    TERRAIN_WINDOW_WIDTH;
-        int iEndY = ( TERRAIN_WINDOW_HEIGHT > TOTAL_VIEW ) ? TERRAIN_WINDOW_HEIGHT -
+                    TERRAIN_WINDOW_WIDTH, ( TERRAIN_WINDOW_HEIGHT > TOTAL_VIEW ) ? TERRAIN_WINDOW_HEIGHT -
                     ( TERRAIN_WINDOW_HEIGHT - TOTAL_VIEW ) /
-                    2 : TERRAIN_WINDOW_HEIGHT;
+                    2 : TERRAIN_WINDOW_HEIGHT );
 
         if( fullscreen ) {
-            iStartX = 0;
-            iStartY = 0;
-            iEndX = TERMX;
-            iEndY = TERMY;
+            iStart.x = 0;
+            iStart.y = 0;
+            iEnd.x = TERMX;
+            iEnd.y = TERMY;
         }
 
         //x% of the Viewport, only shown on visible areas
         const auto weather_info = get_weather_animation( weather.weather );
-        int offset_x = u.posx() + u.view_offset.x - getmaxx( w_terrain ) / 2;
-        int offset_y = u.posy() + u.view_offset.y - getmaxy( w_terrain ) / 2;
+        point offset( u.view_offset.xy() + point( -getmaxx( w_terrain ) / 2 + u.posx(),
+                      -getmaxy( w_terrain ) / 2 + u.posy() ) );
 
 #if defined(TILES)
         if( tile_iso && use_tiles ) {
-            iStartX = 0;
-            iStartY = 0;
-            iEndX = MAPSIZE_X;
-            iEndY = MAPSIZE_Y;
-            offset_x = 0;
-            offset_y = 0;
+            iStart.x = 0;
+            iStart.y = 0;
+            iEnd.x = MAPSIZE_X;
+            iEnd.y = MAPSIZE_Y;
+            offset.x = 0;
+            offset.y = 0;
         }
 #endif //TILES
 
         // TODO: Move the weather calculations out of here.
         const bool bWeatherEffect = ( weather_info.glyph != '?' );
-        const int dropCount = static_cast<int>( iEndX * iEndY * weather_info.factor );
+        const int dropCount = static_cast<int>( iEnd.x * iEnd.y * weather_info.factor );
 
         weather_printable wPrint;
         wPrint.colGlyph = weather_info.color;
@@ -274,19 +273,17 @@ input_context game::get_player_input( std::string &action )
                 wPrint.vdrops.clear();
 
                 for( int i = 0; i < dropCount; i++ ) {
-                    const int iRandX = rng( iStartX, iEndX - 1 );
-                    const int iRandY = rng( iStartY, iEndY - 1 );
-                    const int mapx = iRandX + offset_x;
-                    const int mapy = iRandY + offset_y;
+                    const point iRand( rng( iStart.x, iEnd.x - 1 ), rng( iStart.y, iEnd.y - 1 ) );
+                    const point map( iRand + offset );
 
-                    const tripoint mapp( mapx, mapy, u.posz() );
+                    const tripoint mapp( map, u.posz() );
 
                     const lit_level lighting = visibility_cache[mapp.x][mapp.y];
 
                     if( m.is_outside( mapp ) && m.get_visibility( lighting, cache ) == VIS_CLEAR &&
                         !critter_at( mapp, true ) ) {
                         // Suppress if a critter is there
-                        wPrint.vdrops.emplace_back( std::make_pair( iRandX, iRandY ) );
+                        wPrint.vdrops.emplace_back( std::make_pair( iRand.x, iRand.y ) );
                     }
                 }
             }
@@ -374,12 +371,10 @@ inline static void rcdrive( const point &d )
         u.add_msg_if_player( m_warning, _( "No radio car connected." ) );
         return;
     }
-    int cx = 0;
-    int cy = 0;
-    int cz = 0;
-    car_location_string >> cx >> cy >> cz;
+    tripoint c;
+    car_location_string >> c.x >> c.y >> c.z;
 
-    auto rc_pairs = m.get_rc_items( tripoint( cx, cy, cz ) );
+    auto rc_pairs = m.get_rc_items( c );
     auto rc_pair = rc_pairs.begin();
     for( ; rc_pair != rc_pairs.end(); ++rc_pair ) {
         if( rc_pair->second->typeId() == "radio_car_on" && rc_pair->second->active ) {
@@ -393,14 +388,14 @@ inline static void rcdrive( const point &d )
     }
     item *rc_car = rc_pair->second;
 
-    tripoint dest( cx + d.x, cy + d.y, cz );
+    tripoint dest( c + d );
     if( m.impassable( dest ) || !m.can_put_items_ter_furn( dest ) ||
         m.has_furn( dest ) ) {
         sounds::sound( dest, 7, sounds::sound_t::combat,
                        _( "sound of a collision with an obstacle." ), true, "misc", "rc_car_hits_obstacle" );
         return;
     } else if( !m.add_item_or_charges( dest, *rc_car ).is_null() ) {
-        tripoint src( cx, cy, cz );
+        tripoint src( c );
         //~ Sound of moving a remote controlled car
         sounds::sound( src, 6, sounds::sound_t::movement, _( "zzz…" ), true, "misc", "rc_car_drives" );
         u.moves -= 50;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -637,8 +637,8 @@ void iexamine::vending( player &p, const tripoint &examp )
 
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        const int padding_x  = std::max( 0, TERMX - FULL_SCREEN_WIDTH ) / 4;
-        const int padding_y  = std::max( 0, TERMY - FULL_SCREEN_HEIGHT ) / 6;
+        const point padding( std::max( 0, TERMX - FULL_SCREEN_WIDTH ) / 4, std::max( 0,
+                             TERMY - FULL_SCREEN_HEIGHT ) / 6 );
         const int window_h   = FULL_SCREEN_HEIGHT + std::max( 0, TERMY - FULL_SCREEN_HEIGHT ) * 2 / 3;
         const int window_w   = FULL_SCREEN_WIDTH + std::max( 0, TERMX - FULL_SCREEN_WIDTH ) / 2;
         w_items_w  = window_w / 2;
@@ -649,11 +649,11 @@ void iexamine::vending( player &p, const tripoint &examp )
         lines_below = list_lines / 2 + list_lines % 2; // lines below the selector
 
         w = catacurses::newwin( window_h, w_items_w,
-                                point( padding_x, padding_y ) );
+                                padding );
         w_item_info = catacurses::newwin( window_h, w_info_w,
-                                          point( padding_x + w_items_w, padding_y ) );
+                                          padding + point( w_items_w, 0 ) );
 
-        ui.position( point( padding_x, padding_y ), point( window_w, window_h ) );
+        ui.position( padding, point( window_w, window_h ) );
     } );
     ui.mark_resize();
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1338,8 +1338,8 @@ cata::optional<tripoint> input_context::get_coordinates( const catacurses::windo
     const point view_size( getmaxx( capture_win ), getmaxy( capture_win ) );
     const point win_min( getbegx( capture_win ),
                          getbegy( capture_win ) );
-    const rectangle win_bounds( win_min, win_min + view_size );
-    if( !win_bounds.contains_half_open( coordinate ) ) {
+    const half_open_rectangle win_bounds( win_min, win_min + view_size );
+    if( !win_bounds.contains( coordinate ) ) {
         return cata::nullopt;
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8924,8 +8924,7 @@ cata::optional<tripoint> item::get_cable_target( Character *p, const tripoint &p
         }
     }
 
-    tripoint source2( get_var( "source_x", 0 ), get_var( "source_y", 0 ), get_var( "source_z", 0 ) );
-    tripoint source( source2 );
+    tripoint source( get_var( "source_x", 0 ), get_var( "source_y", 0 ), get_var( "source_z", 0 ) );
 
     return g->m.getlocal( source );
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8924,10 +8924,8 @@ cata::optional<tripoint> item::get_cable_target( Character *p, const tripoint &p
         }
     }
 
-    int source_x = get_var( "source_x", 0 );
-    int source_y = get_var( "source_y", 0 );
-    int source_z = get_var( "source_z", 0 );
-    tripoint source( source_x, source_y, source_z );
+    tripoint source2( get_var( "source_x", 0 ), get_var( "source_y", 0 ), get_var( "source_z", 0 ) );
+    tripoint source( source2 );
 
     return g->m.getlocal( source );
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5163,30 +5163,29 @@ int iuse::artifact( player *p, item *it, bool, const tripoint & )
                                "thunder_near" );
                 int num_bolts = rng( 2, 4 );
                 for( int j = 0; j < num_bolts; j++ ) {
-                    int xdir = 0;
-                    int ydir = 0;
-                    while( xdir == 0 && ydir == 0 ) {
-                        xdir = rng( -1, 1 );
-                        ydir = rng( -1, 1 );
+                    point dir;
+                    while( dir.x == 0 && dir.y == 0 ) {
+                        dir.x = rng( -1, 1 );
+                        dir.y = rng( -1, 1 );
                     }
                     int dist = rng( 4, 12 );
-                    int boltx = p->posx(), bolty = p->posy();
+                    point bolt( p->posx(), p->posy() );
                     for( int n = 0; n < dist; n++ ) {
-                        boltx += xdir;
-                        bolty += ydir;
-                        g->m.add_field( {boltx, bolty, p->posz()}, fd_electricity, rng( 2, 3 ) );
+                        bolt.x += dir.x;
+                        bolt.y += dir.y;
+                        g->m.add_field( {bolt, p->posz()}, fd_electricity, rng( 2, 3 ) );
                         if( one_in( 4 ) ) {
-                            if( xdir == 0 ) {
-                                xdir = rng( 0, 1 ) * 2 - 1;
+                            if( dir.x == 0 ) {
+                                dir.x = rng( 0, 1 ) * 2 - 1;
                             } else {
-                                xdir = 0;
+                                dir.x = 0;
                             }
                         }
                         if( one_in( 4 ) ) {
-                            if( ydir == 0 ) {
-                                ydir = rng( 0, 1 ) * 2 - 1;
+                            if( dir.y == 0 ) {
+                                dir.y = rng( 0, 1 ) * 2 - 1;
                             } else {
-                                ydir = 0;
+                                dir.y = 0;
                             }
                         }
                     }
@@ -5233,8 +5232,8 @@ int iuse::artifact( player *p, item *it, bool, const tripoint & )
 
             case AEA_FATIGUE: {
                 p->add_msg_if_player( m_warning, _( "The fabric of space seems to decay." ) );
-                int x = rng( p->posx() - 3, p->posx() + 3 ), y = rng( p->posy() - 3, p->posy() + 3 );
-                g->m.add_field( {x, y, p->posz()}, fd_fatigue, rng( 1, 2 ) );
+                point p2( rng( p->posx() - 3, p->posx() + 3 ), rng( p->posy() - 3, p->posy() + 3 ) );
+                g->m.add_field( {p2, p->posz()}, fd_fatigue, rng( 1, 2 ) );
             }
             break;
 
@@ -7774,11 +7773,10 @@ int iuse::ehandcuffs( player *p, item *it, bool t, const tripoint &pos )
                            "environment", "police_siren" );
         }
 
-        const int x = it->get_var( "HANDCUFFS_X", 0 );
-        const int y = it->get_var( "HANDCUFFS_Y", 0 );
+        const point p2( it->get_var( "HANDCUFFS_X", 0 ), it->get_var( "HANDCUFFS_Y", 0 ) );
 
-        if( ( it->ammo_remaining() > it->type->maximum_charges() - 1000 ) && ( x != pos.x ||
-                y != pos.y ) ) {
+        if( ( it->ammo_remaining() > it->type->maximum_charges() - 1000 ) && ( p2.x != pos.x ||
+                p2.y != pos.y ) ) {
 
             if( p->has_item( *it ) && p->weapon.typeId() == "e_handcuffs" ) {
 
@@ -8218,8 +8216,7 @@ int iuse::remoteveh( player *p, item *it, bool t, const tripoint &pos )
         return 0;
     }
 
-    int px = g->u.view_offset.x;
-    int py = g->u.view_offset.y;
+    point p2( g->u.view_offset.xy() );
 
     vehicle *veh = pickveh( pos, choice == 0 );
 
@@ -8253,8 +8250,8 @@ int iuse::remoteveh( player *p, item *it, bool t, const tripoint &pos )
         }
     }
 
-    g->u.view_offset.x = px;
-    g->u.view_offset.y = py;
+    g->u.view_offset.x = p2.x;
+    g->u.view_offset.y = p2.y;
     return it->type->charges_to_use();
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5232,7 +5232,7 @@ int iuse::artifact( player *p, item *it, bool, const tripoint & )
 
             case AEA_FATIGUE: {
                 p->add_msg_if_player( m_warning, _( "The fabric of space seems to decay." ) );
-                point p2( rng( p->posx() - 3, p->posx() + 3 ), rng( p->posy() - 3, p->posy() + 3 ) );
+                point p2{ rng( p->posx() - 3, p->posx() + 3 ), rng( p->posy() - 3, p->posy() + 3 ) };
                 g->m.add_field( {p2, p->posz()}, fd_fatigue, rng( 1, 2 ) );
             }
             break;

--- a/src/iuse_software_kitten.cpp
+++ b/src/iuse_software_kitten.cpp
@@ -456,8 +456,8 @@ void robot_finds_kitten::process_input()
                     check.x++;
                 }
 
-                constexpr rectangle bounds( point( 0, 3 ), point( rfkCOLS, rfkLINES ) );
-                if( !bounds.contains_half_open( check ) ) {
+                constexpr half_open_rectangle bounds( point( 0, 3 ), point( rfkCOLS, rfkLINES ) );
+                if( !bounds.contains( check ) ) {
                     /* Can't move past edge */
                 } else if( rfkscreen[check.x][check.y] != EMPTY ) {
                     switch( rfkscreen[check.x][check.y] ) {

--- a/src/iuse_software_lightson.cpp
+++ b/src/iuse_software_lightson.cpp
@@ -133,10 +133,10 @@ int lightson_game::start_game()
 
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        const int iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-        const int iOffsetY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
-        w_border = catacurses::newwin( w_height, FULL_SCREEN_WIDTH, point( iOffsetX, iOffsetY ) );
-        w = catacurses::newwin( w_height - 6, FULL_SCREEN_WIDTH - 2, point( iOffsetX + 1, iOffsetY + 1 ) );
+        const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
+        w_border = catacurses::newwin( w_height, FULL_SCREEN_WIDTH, iOffset );
+        w = catacurses::newwin( w_height - 6, FULL_SCREEN_WIDTH - 2, iOffset + point_south_east );
         ui.position_from_window( w_border );
     } );
     ui.mark_resize();

--- a/src/iuse_software_minesweeper.cpp
+++ b/src/iuse_software_minesweeper.cpp
@@ -137,13 +137,13 @@ int minesweeper_game::start_game()
 
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        const int iCenterX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-        const int iCenterY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
+        const point iCenter( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
 
         w_minesweeper_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                               point( iCenterX, iCenterY ) );
+                               iCenter );
         w_minesweeper = catacurses::newwin( FULL_SCREEN_HEIGHT - 2, FULL_SCREEN_WIDTH - 2,
-                                            point( iCenterX + 1, iCenterY + 1 ) );
+                                            iCenter + point_south_east );
         max = point( FULL_SCREEN_WIDTH - 4, FULL_SCREEN_HEIGHT - 4 );
         ui.position_from_window( w_minesweeper_border );
     } );

--- a/src/iuse_software_snake.cpp
+++ b/src/iuse_software_snake.cpp
@@ -92,11 +92,11 @@ int snake_game::start_game()
     catacurses::window w_snake;
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        const int iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-        const int iOffsetY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
+        const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
 
         w_snake = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                      point( iOffsetX, iOffsetY ) );
+                                      iOffset );
 
         ui.position_from_window( w_snake );
     } );

--- a/src/iuse_software_sokoban.cpp
+++ b/src/iuse_software_sokoban.cpp
@@ -163,8 +163,8 @@ int sokoban_game::get_wall_connection( const point &i )
 
 void sokoban_game::draw_level( const catacurses::window &w_sokoban )
 {
-    const int iOffsetX = ( FULL_SCREEN_WIDTH - 2 - mLevelInfo[iCurrentLevel]["MaxLevelX"] ) / 2;
-    const int iOffsetY = ( FULL_SCREEN_HEIGHT - 2 - mLevelInfo[iCurrentLevel]["MaxLevelY"] ) / 2;
+    const point iOffset( ( FULL_SCREEN_WIDTH - 2 - mLevelInfo[iCurrentLevel]["MaxLevelX"] ) / 2,
+                         ( FULL_SCREEN_HEIGHT - 2 - mLevelInfo[iCurrentLevel]["MaxLevelY"] ) / 2 );
 
     for( auto &elem : mLevel ) {
         for( std::map<int, std::string>::iterator iterX = elem.second.begin();
@@ -172,7 +172,7 @@ void sokoban_game::draw_level( const catacurses::window &w_sokoban )
             std::string sTile = iterX->second;
 
             if( sTile == "#" ) {
-                mvwputch( w_sokoban, point( iOffsetX + iterX->first, iOffsetY + elem.first ),
+                mvwputch( w_sokoban, iOffset + point( iterX->first, elem.first ),
                           c_white, get_wall_connection( point( iterX->first, elem.first ) ) );
 
             } else {
@@ -194,7 +194,7 @@ void sokoban_game::draw_level( const catacurses::window &w_sokoban )
                     sTile = "@";
                 }
 
-                mvwprintz( w_sokoban, point( iOffsetX + iterX->first, iOffsetY + elem.first ), cCol, sTile );
+                mvwprintz( w_sokoban, iOffset + point( iterX->first, elem.first ), cCol, sTile );
             }
         }
     }
@@ -224,10 +224,10 @@ int sokoban_game::start_game()
     catacurses::window w_sokoban;
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ) {
-        const int iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-        const int iOffsetY = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
+        const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
         w_sokoban = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                        point( iOffsetX, iOffsetY ) );
+                                        iOffset );
         ui.position_from_window( w_sokoban );
     } );
     ui.mark_resize();

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -49,7 +49,7 @@ static constexpr int LIGHTMAP_CACHE_Y = MAPSIZE_Y;
 static constexpr point lightmap_boundary_min( point_zero );
 static constexpr point lightmap_boundary_max( LIGHTMAP_CACHE_X, LIGHTMAP_CACHE_Y );
 
-const rectangle lightmap_boundaries( lightmap_boundary_min, lightmap_boundary_max );
+const half_open_rectangle lightmap_boundaries( lightmap_boundary_min, lightmap_boundary_max );
 
 std::string four_quadrants::to_string() const
 {
@@ -421,7 +421,7 @@ void map::generate_lightmap( const int zlev )
                         // Apply light sources for external/internal divide
                         for( int i = 0; i < 4; ++i ) {
                             point neighbour = p.xy() + point( dir_x[i], dir_y[i] );
-                            if( lightmap_boundaries.contains_half_open( neighbour )
+                            if( lightmap_boundaries.contains( neighbour )
                                 && outside_cache[neighbour.x][neighbour.y]
                               ) {
                                 if( light_transparency( p ) > LIGHT_TRANSPARENCY_SOLID ) {
@@ -665,7 +665,7 @@ map::apparent_light_info map::apparent_light_helper( const level_cache &map_cach
         for( const offset_and_quadrants &oq : adjacent_offsets ) {
             const point neighbour = p.xy() + oq.offset;
 
-            if( !lightmap_boundaries.contains_half_open( neighbour ) ) {
+            if( !lightmap_boundaries.contains( neighbour ) ) {
                 continue;
             }
             if( is_opaque( neighbour ) ) {
@@ -1566,7 +1566,7 @@ void map::apply_light_ray( bool lit[LIGHTMAP_CACHE_X][LIGHTMAP_CACHE_Y],
             t += ay;
 
             // TODO: clamp coordinates to map bounds before this method is called.
-            if( lightmap_boundaries.contains_half_open( point( x, y ) ) ) {
+            if( lightmap_boundaries.contains( point( x, y ) ) ) {
                 float current_transparency = transparency_cache[x][y];
                 bool is_opaque = ( current_transparency == LIGHT_TRANSPARENCY_SOLID );
                 if( !lit[x][y] ) {
@@ -1598,7 +1598,7 @@ void map::apply_light_ray( bool lit[LIGHTMAP_CACHE_X][LIGHTMAP_CACHE_Y],
             y += dy;
             t += ax;
 
-            if( lightmap_boundaries.contains_half_open( point( x, y ) ) ) {
+            if( lightmap_boundaries.contains( point( x, y ) ) ) {
                 float current_transparency = transparency_cache[x][y];
                 bool is_opaque = ( current_transparency == LIGHT_TRANSPARENCY_SOLID );
                 if( !lit[x][y] ) {

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -46,7 +46,7 @@ static const efftype_id effect_onfire( "onfire" );
 static constexpr int LIGHTMAP_CACHE_X = MAPSIZE_X;
 static constexpr int LIGHTMAP_CACHE_Y = MAPSIZE_Y;
 
-static constexpr point lightmap_boundary_min( point_zero );
+static constexpr point lightmap_boundary_min{};
 static constexpr point lightmap_boundary_max( LIGHTMAP_CACHE_X, LIGHTMAP_CACHE_Y );
 
 const half_open_rectangle lightmap_boundaries( lightmap_boundary_min, lightmap_boundary_max );
@@ -1098,32 +1098,31 @@ void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
         delta.x = -distance + std::max( static_cast<int>( std::ceil( away * ( -distance - 0.5f ) ) ), 0 );
 
         for( ; delta.x <= 0; delta.x++ ) {
-            int currentX = offset.x + delta.x * xx + delta.y * xy;
-            int currentY = offset.y + delta.x * yx + delta.y * yy;
+            point current( offset.x + delta.x * xx + delta.y * xy, offset.y + delta.x * yx + delta.y * yy );
             float trailingEdge = ( delta.x - 0.5f ) / ( delta.y + 0.5f );
             float leadingEdge = ( delta.x + 0.5f ) / ( delta.y - 0.5f );
 
-            if( !( currentX >= 0 && currentY >= 0 && currentX < MAPSIZE_X &&
-                   currentY < MAPSIZE_Y ) /* || start < leadingEdge */ ) {
+            if( !( current.x >= 0 && current.y >= 0 && current.x < MAPSIZE_X &&
+                   current.y < MAPSIZE_Y ) /* || start < leadingEdge */ ) {
                 continue;
             } else if( end > trailingEdge ) {
                 break;
             }
             if( !started_row ) {
                 started_row = true;
-                current_transparency = input_array[ currentX ][ currentY ];
+                current_transparency = input_array[ current.x ][ current.y ];
             }
 
             const int dist = rl_dist( tripoint_zero, delta ) + offsetDistance;
             last_intensity = calc( numerator, cumulative_transparency, dist );
 
-            T new_transparency = input_array[ currentX ][ currentY ];
+            T new_transparency = input_array[ current.x ][ current.y ];
 
             if( check( new_transparency, last_intensity ) ) {
-                update_output( output_cache[currentX][currentY], last_intensity,
+                update_output( output_cache[current.x][current.y], last_intensity,
                                quadrant::default_ );
             } else {
-                update_output( output_cache[currentX][currentY], last_intensity, quad );
+                update_output( output_cache[current.x][current.y], last_intensity, quad );
             }
 
             if( new_transparency == current_transparency ) {
@@ -1359,13 +1358,12 @@ void map::apply_light_source( const tripoint &p, float luminance )
     float ( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.transparency_cache;
     float ( &light_source_buffer )[MAPSIZE_X][MAPSIZE_Y] = cache.light_source_buffer;
 
-    const int x = p.x;
-    const int y = p.y;
+    const point p2( p.xy() );
 
     if( inbounds( p ) ) {
         const float min_light = std::max( static_cast<float>( LL_LOW ), luminance );
-        lm[x][y] = elementwise_max( lm[x][y], min_light );
-        sm[x][y] = std::max( sm[x][y], luminance );
+        lm[p2.x][p2.y] = elementwise_max( lm[p2.x][p2.y], min_light );
+        sm[p2.x][p2.y] = std::max( sm[p2.x][p2.y], luminance );
     }
     if( luminance <= LL_LOW ) {
         return;
@@ -1390,52 +1388,51 @@ void map::apply_light_source( const tripoint &p, float luminance )
            sy
     */
     const int peer_inbounds = LIGHTMAP_CACHE_X - 1;
-    bool north = ( y != 0 && light_source_buffer[x][y - 1] < luminance );
-    bool south = ( y != peer_inbounds && light_source_buffer[x][y + 1] < luminance );
-    bool east = ( x != peer_inbounds && light_source_buffer[x + 1][y] < luminance );
-    bool west = ( x != 0 && light_source_buffer[x - 1][y] < luminance );
+    bool north = ( p2.y != 0 && light_source_buffer[p2.x][p2.y - 1] < luminance );
+    bool south = ( p2.y != peer_inbounds && light_source_buffer[p2.x][p2.y + 1] < luminance );
+    bool east = ( p2.x != peer_inbounds && light_source_buffer[p2.x + 1][p2.y] < luminance );
+    bool west = ( p2.x != 0 && light_source_buffer[p2.x - 1][p2.y] < luminance );
 
     if( north ) {
         castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
         castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
     }
 
     if( east ) {
         castLight < 0, -1, 1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
         castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
     }
 
     if( south ) {
         castLight<1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency>(
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
         castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
     }
 
     if( west ) {
         castLight<0, 1, 1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency>(
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
         castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
     }
 }
 
 void map::apply_directional_light( const tripoint &p, int direction, float luminance )
 {
-    const int x = p.x;
-    const int y = p.y;
+    const point p2( p.xy() );
 
     auto &cache = get_cache( p.z );
     four_quadrants( &lm )[MAPSIZE_X][MAPSIZE_Y] = cache.lm;
@@ -1444,31 +1441,31 @@ void map::apply_directional_light( const tripoint &p, int direction, float lumin
     if( direction == 90 ) {
         castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
         castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
     } else if( direction == 0 ) {
         castLight < 0, -1, 1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
         castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
     } else if( direction == 270 ) {
         castLight<1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency>(
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
         castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
     } else if( direction == 180 ) {
         castLight<0, 1, 1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency>(
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
         castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, point( x, y ), 0, luminance );
+                      lm, transparency_cache, p2, 0, luminance );
     }
 }
 
@@ -1532,14 +1529,11 @@ void map::apply_light_arc( const tripoint &p, int angle, float luminance, int wi
 void map::apply_light_ray( bool lit[LIGHTMAP_CACHE_X][LIGHTMAP_CACHE_Y],
                            const tripoint &s, const tripoint &e, float luminance )
 {
-    int ax = std::abs( e.x - s.x ) * 2;
-    int ay = std::abs( e.y - s.y ) * 2;
-    int dx = ( s.x < e.x ) ? 1 : -1;
-    int dy = ( s.y < e.y ) ? 1 : -1;
-    int x = s.x;
-    int y = s.y;
+    point a( std::abs( e.x - s.x ) * 2, std::abs( e.y - s.y ) * 2 );
+    point d( ( s.x < e.x ) ? 1 : -1, ( s.y < e.y ) ? 1 : -1 );
+    point p( s.xy() );
 
-    quadrant quad = quadrant_from_x_y( dx, dy );
+    quadrant quad = quadrant_from_x_y( d.x, d.y );
 
     // TODO: Invert that z comparison when it's sane
     if( s.z != e.z || ( s.x == e.x && s.y == e.y ) ) {
@@ -1554,27 +1548,27 @@ void map::apply_light_ray( bool lit[LIGHTMAP_CACHE_X][LIGHTMAP_CACHE_Y],
     const float scaling_factor = static_cast<float>( rl_dist( s, e ) ) /
                                  static_cast<float>( square_dist( s, e ) );
     // TODO: [lightmap] Pull out the common code here rather than duplication
-    if( ax > ay ) {
-        int t = ay - ( ax / 2 );
+    if( a.x > a.y ) {
+        int t = a.y - ( a.x / 2 );
         do {
             if( t >= 0 ) {
-                y += dy;
-                t -= ax;
+                p.y += d.y;
+                t -= a.x;
             }
 
-            x += dx;
-            t += ay;
+            p.x += d.x;
+            t += a.y;
 
             // TODO: clamp coordinates to map bounds before this method is called.
-            if( lightmap_boundaries.contains( point( x, y ) ) ) {
-                float current_transparency = transparency_cache[x][y];
+            if( lightmap_boundaries.contains( p ) ) {
+                float current_transparency = transparency_cache[p.x][p.y];
                 bool is_opaque = ( current_transparency == LIGHT_TRANSPARENCY_SOLID );
-                if( !lit[x][y] ) {
+                if( !lit[p.x][p.y] ) {
                     // Multiple rays will pass through the same squares so we need to record that
-                    lit[x][y] = true;
+                    lit[p.x][p.y] = true;
                     float lm_val = luminance / ( fastexp( transparency * distance ) * distance );
                     quadrant q = is_opaque ? quad : quadrant::default_;
-                    lm[x][y][q] = std::max( lm[x][y][q], lm_val );
+                    lm[p.x][p.y][q] = std::max( lm[p.x][p.y][q], lm_val );
                 }
                 if( is_opaque ) {
                     break;
@@ -1586,27 +1580,27 @@ void map::apply_light_ray( bool lit[LIGHTMAP_CACHE_X][LIGHTMAP_CACHE_Y],
             }
 
             distance += scaling_factor;
-        } while( !( x == e.x && y == e.y ) );
+        } while( !( p.x == e.x && p.y == e.y ) );
     } else {
-        int t = ax - ( ay / 2 );
+        int t = a.x - ( a.y / 2 );
         do {
             if( t >= 0 ) {
-                x += dx;
-                t -= ay;
+                p.x += d.x;
+                t -= a.y;
             }
 
-            y += dy;
-            t += ax;
+            p.y += d.y;
+            t += a.x;
 
-            if( lightmap_boundaries.contains( point( x, y ) ) ) {
-                float current_transparency = transparency_cache[x][y];
+            if( lightmap_boundaries.contains( p ) ) {
+                float current_transparency = transparency_cache[p.x][p.y];
                 bool is_opaque = ( current_transparency == LIGHT_TRANSPARENCY_SOLID );
-                if( !lit[x][y] ) {
+                if( !lit[p.x][p.y] ) {
                     // Multiple rays will pass through the same squares so we need to record that
-                    lit[x][y] = true;
+                    lit[p.x][p.y] = true;
                     float lm_val = luminance / ( fastexp( transparency * distance ) * distance );
                     quadrant q = is_opaque ? quad : quadrant::default_;
-                    lm[x][y][q] = std::max( lm[x][y][q], lm_val );
+                    lm[p.x][p.y][q] = std::max( lm[p.x][p.y][q], lm_val );
                 }
                 if( is_opaque ) {
                     break;
@@ -1618,6 +1612,6 @@ void map::apply_light_ray( bool lit[LIGHTMAP_CACHE_X][LIGHTMAP_CACHE_Y],
             }
 
             distance += scaling_factor;
-        } while( !( x == e.x && y == e.y ) );
+        } while( !( p.x == e.x && p.y == e.y ) );
     }
 }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -1012,14 +1012,13 @@ bool main_menu::load_character_tab( bool transfer )
 
     ui_adaptor ui;
     ui.on_redraw( [&]( const ui_adaptor & ) {
-        const int offset_x = transfer ? 25 : 15;
-        const int offset_y = transfer ? -1 : 0;
+        const point offset( transfer ? 25 : 15, transfer ? -1 : 0 );
 
         print_menu( w_open, transfer ? 3 : 2, menu_offset );
 
         if( layer == 2 && sel1 == 2 ) {
             if( all_worldnames.empty() ) {
-                mvwprintz( w_open, menu_offset + point( offset_x + extra_w / 2, -2 ),
+                mvwprintz( w_open, menu_offset + point( offset.x + extra_w / 2, -2 ),
                            c_red, "%s", _( "No Worlds found!" ) );
             } else {
                 for( int i = 0; i < static_cast<int>( all_worldnames.size() ); ++i ) {
@@ -1034,7 +1033,7 @@ bool main_menu::load_character_tab( bool transfer )
                         color1 = c_white;
                         color2 = h_white;
                     }
-                    mvwprintz( w_open, point( offset_x + menu_offset.x + extra_w / 2, line + offset_y ),
+                    mvwprintz( w_open, offset + point( extra_w / 2 + menu_offset.x, line ),
                                ( sel2 == i ? color2 : color1 ), "%s (%d)",
                                world_name, savegames_count );
                 }
@@ -1045,18 +1044,18 @@ bool main_menu::load_character_tab( bool transfer )
 
             const std::string &wn = all_worldnames[sel2];
 
-            mvwprintz( w_open, menu_offset + point( offset_x + extra_w / 2, -2 - sel2 + offset_y ), h_white,
+            mvwprintz( w_open, menu_offset + offset + point( extra_w / 2, -2 - sel2 ), h_white,
                        "%s", wn );
 
             if( savegames.empty() ) {
-                mvwprintz( w_open, menu_offset + point( 40 + extra_w / 2, -2 - sel2 + offset_y ),
+                mvwprintz( w_open, menu_offset + point( 40 + extra_w / 2, -2 - sel2 + offset.y ),
                            c_red, "%s", _( "No save games found!" ) );
             } else {
                 int line = menu_offset.y - 2;
 
                 for( const auto &savename : savegames ) {
                     const bool selected = sel3 + line == menu_offset.y - 2;
-                    mvwprintz( w_open, point( 40 + menu_offset.x + extra_w / 2, line-- + offset_y ),
+                    mvwprintz( w_open, point( 40 + menu_offset.x + extra_w / 2, line-- + offset.y ),
                                selected ? h_white : c_white,
                                "%s", savename.player_name() );
                 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4510,8 +4510,8 @@ std::vector<tripoint> map::check_submap_active_item_consistency()
     }
     for( const tripoint &p : submaps_with_active_items ) {
         tripoint rel = p - abs_sub.xy();
-        rectangle map( point_zero, point( MAPSIZE, MAPSIZE ) );
-        if( !map.contains_half_open( rel.xy() ) ) {
+        half_open_rectangle map( point_zero, point( MAPSIZE, MAPSIZE ) );
+        if( !map.contains( rel.xy() ) ) {
             result.push_back( p );
         }
     }
@@ -7509,9 +7509,9 @@ bool map::inbounds( const tripoint &p ) const
     static constexpr tripoint map_boundary_min( 0, 0, -OVERMAP_DEPTH );
     static constexpr tripoint map_boundary_max( MAPSIZE_Y, MAPSIZE_X, OVERMAP_HEIGHT + 1 );
 
-    static constexpr box map_boundaries( map_boundary_min, map_boundary_max );
+    static constexpr half_open_box map_boundaries( map_boundary_min, map_boundary_max );
 
-    return map_boundaries.contains_half_open( p );
+    return map_boundaries.contains( p );
 }
 
 bool tinymap::inbounds( const tripoint &p ) const
@@ -7519,9 +7519,9 @@ bool tinymap::inbounds( const tripoint &p ) const
     constexpr tripoint map_boundary_min( 0, 0, -OVERMAP_DEPTH );
     constexpr tripoint map_boundary_max( SEEY * 2, SEEX * 2, OVERMAP_HEIGHT + 1 );
 
-    constexpr box map_boundaries( map_boundary_min, map_boundary_max );
+    constexpr half_open_box map_boundaries( map_boundary_min, map_boundary_max );
 
-    return map_boundaries.contains_half_open( p );
+    return map_boundaries.contains( p );
 }
 
 // set up a map just long enough scribble on it
@@ -7728,7 +7728,7 @@ void map::build_obstacle_cache( const tripoint &start, const tripoint &end,
         }
     }
     VehicleList vehs = get_vehicles( start, end );
-    const box bounds( start, end );
+    const inclusive_box bounds( start, end );
     // Cache all the vehicle stuff in one loop
     for( auto &v : vehs ) {
         for( const vpart_reference &vp : v.v->get_all_parts() ) {
@@ -7736,7 +7736,7 @@ void map::build_obstacle_cache( const tripoint &start, const tripoint &end,
             if( p.z != start.z ) {
                 break;
             }
-            if( !bounds.contains_inclusive( p ) ) {
+            if( !bounds.contains( p ) ) {
                 continue;
             }
 
@@ -8197,7 +8197,7 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
 
     function_over( tripoint( min, abs_sub.z ), tripoint( max, abs_sub.z ), fill_values );
 
-    const rectangle local_bounds( min, max );
+    const inclusive_rectangle local_bounds( min, max );
 
     // Now vehicles
 
@@ -8206,7 +8206,7 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
         vehicle &veh = *( wrapped_veh.v );
         for( const vpart_reference &vp : veh.get_any_parts( VPFLAG_OBSTACLE ) ) {
             const tripoint part_pos = vp.pos();
-            if( local_bounds.contains_inclusive( part_pos.xy() ) ) {
+            if( local_bounds.contains( part_pos.xy() ) ) {
                 reduces_scent[part_pos.x][part_pos.y] = true;
             }
         }
@@ -8218,7 +8218,7 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
             }
 
             const tripoint part_pos = vp.pos();
-            if( local_bounds.contains_inclusive( part_pos.xy() ) ) {
+            if( local_bounds.contains( part_pos.xy() ) ) {
                 reduces_scent[part_pos.x][part_pos.y] = true;
             }
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2487,43 +2487,41 @@ bool map::is_outside( const tripoint &p ) const
 bool map::is_last_ter_wall( const bool no_furn, const point &p,
                             const point &max, const direction dir ) const
 {
-    int xmov = 0;
-    int ymov = 0;
+    point mov;
     switch( dir ) {
         case direction::NORTH:
-            ymov = -1;
+            mov.y = -1;
             break;
         case direction::SOUTH:
-            ymov = 1;
+            mov.y = 1;
             break;
         case direction::WEST:
-            xmov = -1;
+            mov.x = -1;
             break;
         case direction::EAST:
-            xmov = 1;
+            mov.x = 1;
             break;
         default:
             break;
     }
-    int x2 = p.x;
-    int y2 = p.y;
+    point p2( p );
     bool result = true;
     bool loop = true;
-    while( ( loop ) && ( ( dir == direction::NORTH && y2 >= 0 ) ||
-                         ( dir == direction::SOUTH && y2 < max.y ) ||
-                         ( dir == direction::WEST  && x2 >= 0 ) ||
-                         ( dir == direction::EAST  && x2 < max.x ) ) ) {
-        if( no_furn && has_furn( point( x2, y2 ) ) ) {
+    while( ( loop ) && ( ( dir == direction::NORTH && p2.y >= 0 ) ||
+                         ( dir == direction::SOUTH && p2.y < max.y ) ||
+                         ( dir == direction::WEST  && p2.x >= 0 ) ||
+                         ( dir == direction::EAST  && p2.x < max.x ) ) ) {
+        if( no_furn && has_furn( p2 ) ) {
             loop = false;
             result = false;
-        } else if( !has_flag_ter( "FLAT", point( x2, y2 ) ) ) {
+        } else if( !has_flag_ter( "FLAT", p2 ) ) {
             loop = false;
-            if( !has_flag_ter( "WALL", point( x2, y2 ) ) ) {
+            if( !has_flag_ter( "WALL", p2 ) ) {
                 result = false;
             }
         }
-        x2 += xmov;
-        y2 += ymov;
+        p2.x += mov.x;
+        p2.y += mov.y;
     }
     return result;
 }
@@ -3028,10 +3026,9 @@ static bool furn_is_supported( const map &m, const tripoint &p )
     const signed char cy[4] = { -1,  0, 1, 0};
 
     for( int i = 0; i < 4; i++ ) {
-        const int adj_x = p.x + cx[i];
-        const int adj_y = p.y + cy[i];
-        if( m.has_furn( tripoint( adj_x, adj_y, p.z ) ) &&
-            m.furn( tripoint( adj_x, adj_y, p.z ) ).obj().has_flag( "BLOCKSDOOR" ) ) {
+        const point adj( p.xy() + point( cx[i], cy[i] ) );
+        if( m.has_furn( tripoint( adj, p.z ) ) &&
+            m.furn( tripoint( adj, p.z ) ).obj().has_flag( "BLOCKSDOOR" ) ) {
             return true;
         }
     }
@@ -5482,10 +5479,9 @@ computer *map::computer_at( const tripoint &p )
 bool map::point_within_camp( const tripoint &point_check ) const
 {
     const tripoint omt_check = ms_to_omt_copy( point_check );
-    const int x = omt_check.x;
-    const int y = omt_check.y;
-    for( int x2 = x - 2; x2 < x + 2; x2++ ) {
-        for( int y2 = y - 2; y2 < y + 2; y2++ ) {
+    const point p( omt_check.xy() );
+    for( int x2 = p.x - 2; x2 < p.x + 2; x2++ ) {
+        for( int y2 = p.y - 2; y2 < p.y + 2; y2++ ) {
             if( cata::optional<basecamp *> bcp = overmap_buffer.find_camp( point( x2, y2 ) ) ) {
                 return ( *bcp )->camp_omt_pos().z == point_check.z;
             }
@@ -6133,9 +6129,8 @@ int map::obstacle_coverage( const tripoint &loc1, const tripoint &loc2 ) const
     if( furn( loc2 ).obj().id || ( move_cost( loc2 ) > 2 && !has_flag_ter( TFLAG_FLAT, loc2 ) ) ) {
         return 0;
     }
-    const int ax = std::abs( loc1.x - loc2.x ) * 2;
-    const int ay = std::abs( loc1.y - loc2.y ) * 2;
-    int offset = std::min( ax, ay ) - ( std::max( ax, ay ) / 2 );
+    const point a( std::abs( loc1.x - loc2.x ) * 2, std::abs( loc1.y - loc2.y ) * 2 );
+    int offset = std::min( a.x, a.y ) - ( std::max( a.x, a.y ) / 2 );
     tripoint obstaclepos;
     bresenham( loc2, loc1, offset, 0, [&obstaclepos]( const tripoint & new_point ) {
         // Only adjacent tile between you and enemy is checked for cover.
@@ -6176,12 +6171,10 @@ std::vector<tripoint> map::find_clear_path( const tripoint &source,
         const tripoint &destination ) const
 {
     // TODO: Push this junk down into the Bresenham method, it's already doing it.
-    const int dx = destination.x - source.x;
-    const int dy = destination.y - source.y;
-    const int ax = std::abs( dx ) * 2;
-    const int ay = std::abs( dy ) * 2;
-    const int dominant = std::max( ax, ay );
-    const int minor = std::min( ax, ay );
+    const point d( destination.xy() - source.xy() );
+    const point a( std::abs( d.x ) * 2, std::abs( d.y ) * 2 );
+    const int dominant = std::max( a.x, a.y );
+    const int minor = std::min( a.x, a.y );
     // This seems to be the method for finding the ideal start value for the error value.
     const int ideal_start_offset = minor - dominant / 2;
     const int start_sign = ( ideal_start_offset > 0 ) - ( ideal_start_offset < 0 );
@@ -6249,13 +6242,11 @@ void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tri
         };
         // *INDENT-ON*
 
-        int ex = elem.ndx % grid_dim;
-        int ey = elem.ndx / grid_dim;
+        point e( elem.ndx % grid_dim, elem.ndx / grid_dim );
         for( int i = 0; i < 8; ++i ) {
-            int nx = ex + ox[i];
-            int ny = ey + oy[i];
+            point n( e + point( ox[i], oy[i] ) );
 
-            int ndx = nx + ny * grid_dim;
+            int ndx = n.x + n.y * grid_dim;
             neighbors[i] = { new_cost, ndx };
         }
     };
@@ -7815,9 +7806,8 @@ void map::do_vehicle_caching( int z )
     for( vehicle *v : ch.vehicle_list ) {
         for( const vpart_reference &vp : v->get_all_parts() ) {
             const size_t part = vp.part_index();
-            int px = v->global_pos3().x + vp.part().precalc[0].x;
-            int py = v->global_pos3().y + vp.part().precalc[0].y;
-            const point p( px, py );
+            point p2( v->global_pos3().xy() + vp.part().precalc[0] );
+            const point p( p2 );
             if( !inbounds( p ) ) {
                 continue;
             }
@@ -7828,18 +7818,18 @@ void map::do_vehicle_caching( int z )
             if( vehicle_is_opaque ) {
                 int dpart = v->part_with_feature( part, VPFLAG_OPENABLE, true );
                 if( dpart < 0 || !v->parts[dpart].open ) {
-                    transparency_cache[px][py] = LIGHT_TRANSPARENCY_SOLID;
+                    transparency_cache[p2.x][p2.y] = LIGHT_TRANSPARENCY_SOLID;
                 } else {
                     vehicle_is_opaque = false;
                 }
             }
 
             if( vehicle_is_opaque || vp.is_inside() ) {
-                outside_cache[px][py] = false;
+                outside_cache[p2.x][p2.y] = false;
             }
 
             if( vp.has_feature( VPFLAG_BOARDABLE ) && !vp.part().is_broken() ) {
-                floor_cache[px][py] = true;
+                floor_cache[p2.x][p2.y] = true;
             }
 
             if( process_floor_above && ( vp.has_feature( VPFLAG_OPAQUE ) || vp.has_feature( VPFLAG_ROOF ) ) ) {
@@ -8116,38 +8106,34 @@ void map::function_over( const tripoint &start, const tripoint &end, Functor fun
 {
     // start and end are just two points, end can be "before" start
     // Also clip the area to map area
-    const int minx = std::max( std::min( start.x, end.x ), 0 );
-    const int miny = std::max( std::min( start.y, end.y ), 0 );
-    const int minz = std::max( std::min( start.z, end.z ), -OVERMAP_DEPTH );
-    const int maxx = std::min( std::max( start.x, end.x ), SEEX * my_MAPSIZE - 1 );
-    const int maxy = std::min( std::max( start.y, end.y ), SEEY * my_MAPSIZE - 1 );
-    const int maxz = std::min( std::max( start.z, end.z ), OVERMAP_HEIGHT );
+    const tripoint min( std::max( std::min( start.x, end.x ), 0 ), std::max( std::min( start.y, end.y ),
+                        0 ), std::max( std::min( start.z, end.z ), -OVERMAP_DEPTH ) );
+    const tripoint max( std::min( std::max( start.x, end.x ), SEEX * my_MAPSIZE - 1 ),
+                        std::min( std::max( start.y, end.y ), SEEY * my_MAPSIZE - 1 ), std::min( std::max( start.z, end.z ),
+                                OVERMAP_HEIGHT ) );
 
     // Submaps that contain the bounding points
-    const int min_smx = minx / SEEX;
-    const int min_smy = miny / SEEY;
-    const int max_smx = maxx / SEEX;
-    const int max_smy = maxy / SEEY;
+    const point min_sm( min.x / SEEX, min.y / SEEY );
+    const point max_sm( max.x / SEEX, max.y / SEEY );
     // Z outermost, because submaps are flat
     tripoint gp;
     int &z = gp.z;
     int &smx = gp.x;
     int &smy = gp.y;
-    for( z = minz; z <= maxz; z++ ) {
-        for( smx = min_smx; smx <= max_smx; smx++ ) {
-            for( smy = min_smy; smy <= max_smy; smy++ ) {
+    for( z = min.z; z <= max.z; z++ ) {
+        for( smx = min_sm.x; smx <= max_sm.x; smx++ ) {
+            for( smy = min_sm.y; smy <= max_sm.y; smy++ ) {
                 submap const *cur_submap = get_submap_at_grid( { smx, smy, z } );
                 // Bounds on the submap coordinates
-                const int sm_minx = smx > min_smx ? 0 : minx % SEEX;
-                const int sm_miny = smy > min_smy ? 0 : miny % SEEY;
-                const int sm_maxx = smx < max_smx ? SEEX - 1 : maxx % SEEX;
-                const int sm_maxy = smy < max_smy ? SEEY - 1 : maxy % SEEY;
+                const point sm_min( smx > min_sm.x ? 0 : min.x % SEEX, smy > min_sm.y ? 0 : min.y % SEEY );
+                const point sm_max( smx < max_sm.x ? SEEX - 1 : max.x % SEEX,
+                                    smy < max_sm.y ? SEEY - 1 : max.y % SEEY );
 
                 point lp;
                 int &sx = lp.x;
                 int &sy = lp.y;
-                for( sx = sm_minx; sx <= sm_maxx; ++sx ) {
-                    for( sy = sm_miny; sy <= sm_maxy; ++sy ) {
+                for( sx = sm_min.x; sx <= sm_max.x; ++sx ) {
+                    for( sy = sm_min.y; sy <= sm_max.y; ++sy ) {
                         const iteration_state rval = fun( gp, cur_submap, lp );
                         if( rval != ITER_CONTINUE ) {
                             switch( rval ) {
@@ -8178,18 +8164,17 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
     auto block = TFLAG_NO_SCENT;
     auto fill_values = [&]( const tripoint & gp, const submap * sm, const point & lp ) {
         // We need to generate the x/y coordinates, because we can't get them "for free"
-        const int x = gp.x * SEEX + lp.x;
-        const int y = gp.y * SEEY + lp.y;
+        const point p = lp + sm_to_ms_copy( gp.xy() );
         if( sm->get_ter( lp ).obj().has_flag( block ) ) {
-            blocks_scent[x][y] = true;
-            reduces_scent[x][y] = false;
+            blocks_scent[p.x][p.y] = true;
+            reduces_scent[p.x][p.y] = false;
         } else if( sm->get_ter( lp ).obj().has_flag( reduce ) ||
                    sm->get_furn( lp ).obj().has_flag( reduce ) ) {
-            blocks_scent[x][y] = false;
-            reduces_scent[x][y] = true;
+            blocks_scent[p.x][p.y] = false;
+            reduces_scent[p.x][p.y] = true;
         } else {
-            blocks_scent[x][y] = false;
-            reduces_scent[x][y] = false;
+            blocks_scent[p.x][p.y] = false;
+            reduces_scent[p.x][p.y] = false;
         }
 
         return ITER_CONTINUE;
@@ -8227,24 +8212,22 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
 
 tripoint_range map::points_in_rectangle( const tripoint &from, const tripoint &to ) const
 {
-    const int minx = std::max( 0, std::min( from.x, to.x ) );
-    const int miny = std::max( 0, std::min( from.y, to.y ) );
-    const int minz = std::max( -OVERMAP_DEPTH, std::min( from.z, to.z ) );
-    const int maxx = std::min( SEEX * my_MAPSIZE - 1, std::max( from.x, to.x ) );
-    const int maxy = std::min( SEEX * my_MAPSIZE - 1, std::max( from.y, to.y ) );
-    const int maxz = std::min( OVERMAP_HEIGHT, std::max( from.z, to.z ) );
-    return tripoint_range( tripoint( minx, miny, minz ), tripoint( maxx, maxy, maxz ) );
+    const tripoint min( std::max( 0, std::min( from.x, to.x ) ), std::max( 0, std::min( from.y,
+                        to.y ) ), std::max( -OVERMAP_DEPTH, std::min( from.z, to.z ) ) );
+    const tripoint max( std::min( SEEX * my_MAPSIZE - 1, std::max( from.x, to.x ) ),
+                        std::min( SEEX * my_MAPSIZE - 1, std::max( from.y, to.y ) ), std::min( OVERMAP_HEIGHT,
+                                std::max( from.z, to.z ) ) );
+    return tripoint_range( min, max );
 }
 
 tripoint_range map::points_in_radius( const tripoint &center, size_t radius, size_t radiusz ) const
 {
-    const int minx = std::max<int>( 0, center.x - radius );
-    const int miny = std::max<int>( 0, center.y - radius );
-    const int minz = clamp<int>( center.z - radiusz, -OVERMAP_DEPTH, OVERMAP_HEIGHT );
-    const int maxx = std::min<int>( SEEX * my_MAPSIZE - 1, center.x + radius );
-    const int maxy = std::min<int>( SEEX * my_MAPSIZE - 1, center.y + radius );
-    const int maxz = clamp<int>( center.z + radiusz, -OVERMAP_DEPTH, OVERMAP_HEIGHT );
-    return tripoint_range( tripoint( minx, miny, minz ), tripoint( maxx, maxy, maxz ) );
+    const tripoint min( std::max<int>( 0, center.x - radius ), std::max<int>( 0, center.y - radius ),
+                        clamp<int>( center.z - radiusz, -OVERMAP_DEPTH, OVERMAP_HEIGHT ) );
+    const tripoint max( std::min<int>( SEEX * my_MAPSIZE - 1, center.x + radius ),
+                        std::min<int>( SEEX * my_MAPSIZE - 1, center.y + radius ), clamp<int>( center.z + radiusz,
+                                -OVERMAP_DEPTH, OVERMAP_HEIGHT ) );
+    return tripoint_range( min, max );
 }
 
 tripoint_range map::points_on_zlevel( const int z ) const

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5717,12 +5717,12 @@ void map::draw( const catacurses::window &w, const tripoint &center )
     }
 
     // Memorize off-screen tiles
-    rectangle display( offs.xy(), offs.xy() + point( wnd_w, wnd_h ) );
+    half_open_rectangle display( offs.xy(), offs.xy() + point( wnd_w, wnd_h ) );
     drawsq_params mm_params = drawsq_params().memorize( true ).output( false );
     for( int y = 0; y < MAPSIZE_Y; y++ ) {
         for( int x = 0; x < MAPSIZE_X; x++ ) {
             const tripoint p( x, y, center.z );
-            if( display.contains_half_open( p.xy() ) ) {
+            if( display.contains( p.xy() ) ) {
                 // Have been memorized during display loop
                 continue;
             }
@@ -6518,13 +6518,13 @@ template void
 shift_bitset_cache<MAPSIZE, 1>( std::bitset<MAPSIZE *MAPSIZE> &cache, const point &s );
 
 static inline void shift_tripoint_set( std::set<tripoint> &set, const point &offset,
-                                       const rectangle &boundaries )
+                                       const half_open_rectangle &boundaries )
 {
     std::set<tripoint> old_set = std::move( set );
     set.clear();
     for( const tripoint &pt : old_set ) {
         tripoint new_pt = pt + offset;
-        if( boundaries.contains_half_open( new_pt.xy() ) ) {
+        if( boundaries.contains( new_pt.xy() ) ) {
             set.insert( new_pt );
         }
     }
@@ -6532,13 +6532,13 @@ static inline void shift_tripoint_set( std::set<tripoint> &set, const point &off
 
 template <typename T>
 static inline void shift_tripoint_map( std::map<tripoint, T> &map, const point &offset,
-                                       const rectangle &boundaries )
+                                       const half_open_rectangle &boundaries )
 {
     std::map<tripoint, T> old_map = std::move( map );
     map.clear();
     for( const std::pair<tripoint, T> &pr : old_map ) {
         tripoint new_pt = pr.first + offset;
-        if( boundaries.contains_half_open( new_pt.xy() ) ) {
+        if( boundaries.contains( new_pt.xy() ) ) {
             map.emplace( new_pt, pr.second );
         }
     }
@@ -6579,7 +6579,7 @@ void map::shift( const point &sp )
         }
     }
 
-    constexpr rectangle boundaries_2d = rectangle( point_zero, point( MAPSIZE_Y, MAPSIZE_X ) );
+    constexpr half_open_rectangle boundaries_2d( point_zero, point( MAPSIZE_Y, MAPSIZE_X ) );
     const point shift_offset_pt( -sp.x * SEEX, -sp.y * SEEY );
 
     // Shift the map sx submaps to the right and sy submaps down.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7833,7 +7833,7 @@ void map::do_vehicle_caching( int z )
             }
 
             if( process_floor_above && ( vp.has_feature( VPFLAG_OPAQUE ) || vp.has_feature( VPFLAG_ROOF ) ) ) {
-                get_cache( z + 1 ).floor_cache[px][py] = true;
+                get_cache( z + 1 ).floor_cache[p.x][p.y] = true;
             }
         }
     }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -229,22 +229,20 @@ static bool mx_house_wasp( map &m, const tripoint &loc )
     }
     const int num_pods = rng( 8, 12 );
     for( int i = 0; i < num_pods; i++ ) {
-        const int podx = rng( 1, SEEX * 2 - 2 );
-        const int pody = rng( 1, SEEY * 2 - 2 );
-        int nonx = 0;
-        int nony = 0;
-        while( nonx == 0 && nony == 0 ) {
-            nonx = rng( -1, 1 );
-            nony = rng( -1, 1 );
+        const point pod( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) );
+        point non;
+        while( non.x == 0 && non.y == 0 ) {
+            non.x = rng( -1, 1 );
+            non.y = rng( -1, 1 );
         }
         for( int x = -1; x <= 1; x++ ) {
             for( int y = -1; y <= 1; y++ ) {
-                if( ( x != nonx || y != nony ) && ( x != 0 || y != 0 ) ) {
-                    m.ter_set( point( podx + x, pody + y ), t_paper );
+                if( ( x != non.x || y != non.y ) && ( x != 0 || y != 0 ) ) {
+                    m.ter_set( pod + point( x, y ), t_paper );
                 }
             }
         }
-        m.add_spawn( mon_wasp, 1, tripoint( podx, pody, loc.z ) );
+        m.add_spawn( mon_wasp, 1, tripoint( pod, loc.z ) );
     }
     m.place_items( item_group_id( "rare" ), 70, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ), false,
                    calendar::start_of_cataclysm );
@@ -290,8 +288,7 @@ static bool mx_house_spider( map &m, const tripoint &loc )
 
 static bool mx_helicopter( map &m, const tripoint &abs_sub )
 {
-    int cx = rng( 6, SEEX * 2 - 7 );
-    int cy = rng( 6, SEEY * 2 - 7 );
+    point c( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ) );
 
     for( int x = 0; x < SEEX * 2; x++ ) {
         for( int y = 0; y < SEEY * 2; y++ ) {
@@ -299,14 +296,14 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
                 m.ter( tripoint( x, y, abs_sub.z ) )->has_flag( TFLAG_DIGGABLE ) ) {
                 m.ter_set( tripoint( x, y, abs_sub.z ), t_dirtmound );
             } else {
-                if( x >= cx - dice( 1, 5 ) && x <= cx + dice( 1, 5 ) && y >= cy - dice( 1, 5 ) &&
-                    y <= cy + dice( 1, 5 ) ) {
+                if( x >= c.x - dice( 1, 5 ) && x <= c.x + dice( 1, 5 ) && y >= c.y - dice( 1, 5 ) &&
+                    y <= c.y + dice( 1, 5 ) ) {
                     if( one_in( 7 ) && m.ter( tripoint( x, y, abs_sub.z ) )->has_flag( TFLAG_DIGGABLE ) ) {
                         m.ter_set( tripoint( x, y, abs_sub.z ), t_dirtmound );
                     }
                 }
-                if( x >= cx - dice( 1, 6 ) && x <= cx + dice( 1, 6 ) && y >= cy - dice( 1, 6 ) &&
-                    y <= cy + dice( 1, 6 ) ) {
+                if( x >= c.x - dice( 1, 6 ) && x <= c.x + dice( 1, 6 ) && y >= c.y - dice( 1, 6 ) &&
+                    y <= c.y + dice( 1, 6 ) ) {
                     if( !one_in( 5 ) ) {
                         m.make_rubble( tripoint( x,  y, abs_sub.z ), f_wreckage, true );
                         if( m.ter( tripoint( x, y, abs_sub.z ) )->has_flag( TFLAG_DIGGABLE ) ) {
@@ -319,8 +316,8 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
                         }
                     }
 
-                } else if( one_in( 4 + ( std::abs( x - cx ) + ( std::abs( y -
-                                         cy ) ) ) ) ) { // 1 in 10 chance of being wreckage anyway
+                } else if( one_in( 4 + ( std::abs( x - c.x ) + ( std::abs( y -
+                                         c.y ) ) ) ) ) { // 1 in 10 chance of being wreckage anyway
                     m.make_rubble( tripoint( x,  y, abs_sub.z ), f_wreckage, true );
                     if( !one_in( 3 ) ) {
                         if( m.ter( tripoint( x, y, abs_sub.z ) )->has_flag( TFLAG_DIGGABLE ) ) {
@@ -358,8 +355,8 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
     int y_max = SEEY * 2 - bbox.p2.y - 1;
 
     // Clamp x1 & y1 such that no parts of the vehicle extend over the border of the submap.
-    int x1 = clamp( cx + x_offset, x_min, x_max );
-    int y1 = clamp( cy + y_offset, y_min, y_max );
+    int x1 = clamp( c.x + x_offset, x_min, x_max );
+    int y1 = clamp( c.y + y_offset, y_min, y_max );
 
     vehicle *wreckage = m.add_vehicle( crashed_hull, tripoint( x1, y1, abs_sub.z ), dir1, rng( 1, 33 ),
                                        1 );
@@ -485,8 +482,8 @@ static bool mx_military( map &m, const tripoint & )
     }
     int num_monsters = rng( 0, 3 );
     for( int i = 0; i < num_monsters; i++ ) {
-        int mx = rng( 1, SEEX * 2 - 2 ), my = rng( 1, SEEY * 2 - 2 );
-        m.place_spawns( GROUP_NETHER_CAPTURED, 1, point( mx, my ), point( mx, my ), 1, true );
+        point m2( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) );
+        m.place_spawns( GROUP_NETHER_CAPTURED, 1, m2, m2, 1, true );
     }
     m.place_spawns( GROUP_MAYBE_MIL, 2, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ),
                     0.1f ); //0.1 = 1-5
@@ -513,8 +510,8 @@ static bool mx_science( map &m, const tripoint & )
     }
     int num_monsters = rng( 0, 3 );
     for( int i = 0; i < num_monsters; i++ ) {
-        int mx = rng( 1, SEEX * 2 - 2 ), my = rng( 1, SEEY * 2 - 2 );
-        m.place_spawns( GROUP_NETHER_CAPTURED, 1, point( mx, my ), point( mx, my ), 1, true );
+        point m2( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) );
+        m.place_spawns( GROUP_NETHER_CAPTURED, 1, m2, m2, 1, true );
     }
     m.place_items( item_group_id( "rare" ), 45, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ), true,
                    calendar::start_of_cataclysm );
@@ -550,8 +547,8 @@ static bool mx_collegekids( map &m, const tripoint & )
     }
     int num_monsters = rng( 0, 3 );
     for( int i = 0; i < num_monsters; i++ ) {
-        int mx = rng( 1, SEEX * 2 - 2 ), my = rng( 1, SEEY * 2 - 2 );
-        m.place_spawns( GROUP_NETHER_CAPTURED, 1, point( mx, my ), point( mx, my ), 1, true );
+        point m2( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) );
+        m.place_spawns( GROUP_NETHER_CAPTURED, 1, m2, m2, 1, true );
     }
 
     return true;
@@ -831,25 +828,23 @@ static bool mx_drugdeal( map &m, const tripoint &abs_sub )
     bool a_has_drugs = one_in( 2 );
 
     for( int i = 0; i < num_bodies_a; i++ ) {
-        int x = 0;
-        int y = 0;
-        int x_offset = 0;
-        int y_offset = 0;
+        point p;
+        point offset;
         int tries = 0;
         do { // Loop until we find a valid spot to dump a body, or we give up
             if( north_south ) {
-                x = rng( 0, SEEX * 2 - 1 );
-                y = rng( 0, SEEY - 4 );
-                x_offset = 0;
-                y_offset = -1;
+                p.x = rng( 0, SEEX * 2 - 1 );
+                p.y = rng( 0, SEEY - 4 );
+                offset.x = 0;
+                offset.y = -1;
             } else {
-                x = rng( 0, SEEX - 4 );
-                y = rng( 0, SEEY * 2 - 1 );
-                x_offset = -1;
-                y_offset = 0;
+                p.x = rng( 0, SEEX - 4 );
+                p.y = rng( 0, SEEY * 2 - 1 );
+                offset.x = -1;
+                offset.y = 0;
             }
             tries++;
-        } while( tries < 10 && m.impassable( point( x, y ) ) );
+        } while( tries < 10 && m.impassable( p ) );
 
         if( tries < 10 ) { // We found a valid spot!
             if( a_has_drugs && num_drugs > 0 ) {
@@ -858,50 +853,48 @@ static bool mx_drugdeal( map &m, const tripoint &abs_sub )
                     drugs_placed = num_drugs;
                     num_drugs = 0;
                 }
-                m.spawn_item( point( x, y ), drugtype, 0, drugs_placed );
+                m.spawn_item( p, drugtype, 0, drugs_placed );
             }
             if( one_in( 10 ) ) {
-                m.add_spawn( mon_zombie_spitter, 1, { x, y, abs_sub.z } );
+                m.add_spawn( mon_zombie_spitter, 1, { p, abs_sub.z } );
             } else {
-                m.place_items( item_group_id( "map_extra_drugdeal" ), 100, point( x, y ), point( x, y ), true,
+                m.place_items( item_group_id( "map_extra_drugdeal" ), 100, p, p, true,
                                calendar::start_of_cataclysm );
                 int splatter_range = rng( 1, 3 );
                 for( int j = 0; j <= splatter_range; j++ ) {
-                    m.add_field( {x + j * x_offset, y + j * y_offset, abs_sub.z}, fd_blood, 1, 0_turns );
+                    m.add_field( p + tripoint( j * offset.x, j * offset.y, abs_sub.z ), fd_blood, 1, 0_turns );
                 }
             }
         }
     }
     for( int i = 0; i < num_bodies_b; i++ ) {
-        int x = 0;
-        int y = 0;
-        int x_offset = 0;
-        int y_offset = 0;
+        point p2;
+        point offset2;
         int tries = 0;
         do { // Loop until we find a valid spot to dump a body, or we give up
             if( north_south ) {
-                x = rng( 0, SEEX * 2 - 1 );
-                y = rng( SEEY + 3, SEEY * 2 - 1 );
-                x_offset = 0;
-                y_offset = 1;
+                p2.x = rng( 0, SEEX * 2 - 1 );
+                p2.y = rng( SEEY + 3, SEEY * 2 - 1 );
+                offset2.x = 0;
+                offset2.y = 1;
             } else {
-                x = rng( SEEX + 3, SEEX * 2 - 1 );
-                y = rng( 0, SEEY * 2 - 1 );
-                x_offset = 1;
-                y_offset = 0;
+                p2.x = rng( SEEX + 3, SEEX * 2 - 1 );
+                p2.y = rng( 0, SEEY * 2 - 1 );
+                offset2.x = 1;
+                offset2.y = 0;
             }
             tries++;
-        } while( tries < 10 && m.impassable( point( x, y ) ) );
+        } while( tries < 10 && m.impassable( p2 ) );
 
         if( tries < 10 ) { // We found a valid spot!
             if( one_in( 20 ) ) {
-                m.add_spawn( mon_zombie_smoker, 1, { x, y, abs_sub.z } );
+                m.add_spawn( mon_zombie_smoker, 1, { p2, abs_sub.z } );
             } else {
-                m.place_items( item_group_id( "map_extra_drugdeal" ), 100, point( x, y ), point( x, y ), true,
+                m.place_items( item_group_id( "map_extra_drugdeal" ), 100, p2, p2, true,
                                calendar::start_of_cataclysm );
                 int splatter_range = rng( 1, 3 );
                 for( int j = 0; j <= splatter_range; j++ ) {
-                    m.add_field( {x + j * x_offset, y + j * y_offset, abs_sub.z}, fd_blood, 1, 0_turns );
+                    m.add_field( p2 + tripoint( j * offset2.x, j * offset2.y, abs_sub.z ), fd_blood, 1, 0_turns );
                 }
                 if( !a_has_drugs && num_drugs > 0 ) {
                     int drugs_placed = rng( 2, 6 );
@@ -909,15 +902,15 @@ static bool mx_drugdeal( map &m, const tripoint &abs_sub )
                         drugs_placed = num_drugs;
                         num_drugs = 0;
                     }
-                    m.spawn_item( point( x, y ), drugtype, 0, drugs_placed );
+                    m.spawn_item( p2, drugtype, 0, drugs_placed );
                 }
             }
         }
     }
     int num_monsters = rng( 0, 3 );
     for( int i = 0; i < num_monsters; i++ ) {
-        int mx = rng( 1, SEEX * 2 - 2 ), my = rng( 1, SEEY * 2 - 2 );
-        m.place_spawns( GROUP_NETHER_CAPTURED, 1, point( mx, my ), point( mx, my ), 1, true );
+        point m2( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) );
+        m.place_spawns( GROUP_NETHER_CAPTURED, 1, m2, m2, 1, true );
     }
 
     return true;
@@ -1534,12 +1527,12 @@ static bool mx_crater( map &m, const tripoint &abs_sub )
 {
     int size = rng( 2, 6 );
     int size_squared = size * size;
-    int x = rng( size, SEEX * 2 - 1 - size ), y = rng( size, SEEY * 2 - 1 - size );
-    for( int i = x - size; i <= x + size; i++ ) {
-        for( int j = y - size; j <= y + size; j++ ) {
+    point p( rng( size, SEEX * 2 - 1 - size ), rng( size, SEEY * 2 - 1 - size ) );
+    for( int i = p.x - size; i <= p.x + size; i++ ) {
+        for( int j = p.y - size; j <= p.y + size; j++ ) {
             //If we're using circular distances, make circular craters
             //Pythagoras to the rescue, x^2 + y^2 = hypotenuse^2
-            if( !trigdist || ( i - x ) * ( i - x ) + ( j - y ) * ( j - y ) <= size_squared ) {
+            if( !trigdist || ( i - p.x ) * ( i - p.x ) + ( j - p.y ) * ( j - p.y ) <= size_squared ) {
                 m.destroy( tripoint( i,  j, abs_sub.z ), true );
                 m.adjust_radiation( point( i, j ), rng( 20, 40 ) );
             }
@@ -1579,8 +1572,7 @@ static void place_fumarole( map &m, const point &p1, const point &p2, std::set<p
 static bool mx_portal_in( map &m, const tripoint &abs_sub )
 {
     const tripoint portal_location = { rng( 5, SEEX * 2 - 6 ), rng( 5, SEEX * 2 - 6 ), abs_sub.z };
-    const int x = portal_location.x;
-    const int y = portal_location.y;
+    const point p( portal_location.xy() );
 
     switch( rng( 1, 7 ) ) {
         //Mycus spreading through the portal
@@ -1593,7 +1585,7 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
                 }
             }
             //50% chance to spawn pouf-maker
-            m.place_spawns( GROUP_FUNGI_FUNGALOID, 2, point( x - 1, y - 1 ), point( x + 1, y + 1 ), 1, true );
+            m.place_spawns( GROUP_FUNGI_FUNGALOID, 2, p + point_north_west, p + point_south_east, 1, true );
             break;
         }
         //Netherworld monsters spawning around the portal
@@ -1621,9 +1613,9 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
         case 4: {
             m.add_field( portal_location, fd_fatigue, 3 );
             const int rad = 10;
-            for( int i = x - rad; i <= x + rad; i++ ) {
-                for( int j = y - rad; j <= y + rad; j++ ) {
-                    if( trig_dist( point( x, y ), point( i, j ) ) + rng( 0, 3 ) <= rad ) {
+            for( int i = p.x - rad; i <= p.x + rad; i++ ) {
+                for( int j = p.y - rad; j <= p.y + rad; j++ ) {
+                    if( trig_dist( p, point( i, j ) ) + rng( 0, 3 ) <= rad ) {
                         const tripoint loc( i, j, abs_sub.z );
                         dead_vegetation_parser( m, loc );
                         m.adjust_radiation( loc.xy(), rng( 20, 40 ) );
@@ -1635,37 +1627,36 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
         //Lava seams originating from the portal
         case 5: {
             if( abs_sub.z <= 0 ) {
-                int x1 = rng( 0,    SEEX     - 3 ), y1 = rng( 0,    SEEY     - 3 ),
-                    x2 = rng( SEEX, SEEX * 2 - 3 ), y2 = rng( SEEY, SEEY * 2 - 3 );
+                point p1( rng( 0,    SEEX     - 3 ), rng( 0,    SEEY     - 3 ) );
+                point p2( rng( SEEX, SEEX * 2 - 3 ), rng( SEEY, SEEY * 2 - 3 ) );
                 // Pick a random cardinal direction to also spawn lava in
                 // This will make the lava a single connected line, not just on diagonals
                 static const std::array<direction, 4> possibilities = { { direction::EAST, direction::WEST, direction::NORTH, direction::SOUTH } };
                 const direction extra_lava_dir = random_entry( possibilities );
-                int x_extra = 0;
-                int y_extra = 0;
+                point extra;
                 switch( extra_lava_dir ) {
                     case direction::NORTH:
-                        y_extra = -1;
+                        extra.y = -1;
                         break;
                     case direction::EAST:
-                        x_extra = 1;
+                        extra.x = 1;
                         break;
                     case direction::SOUTH:
-                        y_extra = 1;
+                        extra.y = 1;
                         break;
                     case direction::WEST:
-                        x_extra = -1;
+                        extra.x = -1;
                         break;
                     default:
                         break;
                 }
 
-                const tripoint portal_location = { x1 + x_extra, y1 + y_extra, abs_sub.z };
+                const tripoint portal_location = { p1 + tripoint( extra, abs_sub.z ) };
                 m.add_field( portal_location, fd_fatigue, 3 );
 
                 std::set<point> ignited;
-                place_fumarole( m, point( x1, y1 ), point( x2, y2 ), ignited );
-                place_fumarole( m, point( x1 + x_extra, y1 + y_extra ), point( x2 + x_extra, y2 + y_extra ),
+                place_fumarole( m, p1, p2, ignited );
+                place_fumarole( m, p1 + extra, p2 + extra,
                                 ignited );
 
                 for( auto &i : ignited ) {
@@ -1686,10 +1677,9 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
                 m.place_spawns( GROUP_MI_GO_CAMP_OM, 30, loc.xy() + point( -5, -5 ), loc.xy() + point( 5, 5 ), 1,
                                 true );
             }
-            const int x_pos = x + rng( -5, 5 );
-            const int y_pos = y + rng( -5, 5 );
-            circle( &m, ter_id( "t_wall_resin" ), point( x_pos, y_pos ), 6 );
-            rough_circle( &m, ter_id( "t_floor_resin" ), point( x_pos, y_pos ), 5 );
+            const point pos( p + point( rng( -5, 5 ), rng( -5, 5 ) ) );
+            circle( &m, ter_id( "t_wall_resin" ), pos, 6 );
+            rough_circle( &m, ter_id( "t_floor_resin" ), pos, 5 );
             break;
         }
         //Anomaly caused by the portal and spawned an artifact
@@ -1698,7 +1688,7 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
             artifact_natural_property prop =
                 static_cast<artifact_natural_property>( rng( ARTPROP_NULL + 1, ARTPROP_MAX - 1 ) );
             m.create_anomaly( portal_location, prop );
-            m.spawn_natural_artifact( { x + rng( -1, 1 ), y + rng( -1, 1 ), abs_sub.z }, prop );
+            m.spawn_natural_artifact( p + tripoint( rng( -1, 1 ), rng( -1, 1 ), abs_sub.z ), prop );
             break;
         }
     }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -229,7 +229,7 @@ static bool mx_house_wasp( map &m, const tripoint &loc )
     }
     const int num_pods = rng( 8, 12 );
     for( int i = 0; i < num_pods; i++ ) {
-        const point pod( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) );
+        const point pod{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
         point non;
         while( non.x == 0 && non.y == 0 ) {
             non.x = rng( -1, 1 );
@@ -288,7 +288,7 @@ static bool mx_house_spider( map &m, const tripoint &loc )
 
 static bool mx_helicopter( map &m, const tripoint &abs_sub )
 {
-    point c( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ) );
+    point c{ rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ) };
 
     for( int x = 0; x < SEEX * 2; x++ ) {
         for( int y = 0; y < SEEY * 2; y++ ) {
@@ -482,7 +482,7 @@ static bool mx_military( map &m, const tripoint & )
     }
     int num_monsters = rng( 0, 3 );
     for( int i = 0; i < num_monsters; i++ ) {
-        point m2( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) );
+        point m2{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
         m.place_spawns( GROUP_NETHER_CAPTURED, 1, m2, m2, 1, true );
     }
     m.place_spawns( GROUP_MAYBE_MIL, 2, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ),
@@ -510,7 +510,7 @@ static bool mx_science( map &m, const tripoint & )
     }
     int num_monsters = rng( 0, 3 );
     for( int i = 0; i < num_monsters; i++ ) {
-        point m2( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) );
+        point m2{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
         m.place_spawns( GROUP_NETHER_CAPTURED, 1, m2, m2, 1, true );
     }
     m.place_items( item_group_id( "rare" ), 45, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ), true,
@@ -547,7 +547,7 @@ static bool mx_collegekids( map &m, const tripoint & )
     }
     int num_monsters = rng( 0, 3 );
     for( int i = 0; i < num_monsters; i++ ) {
-        point m2( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) );
+        point m2{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
         m.place_spawns( GROUP_NETHER_CAPTURED, 1, m2, m2, 1, true );
     }
 
@@ -909,7 +909,7 @@ static bool mx_drugdeal( map &m, const tripoint &abs_sub )
     }
     int num_monsters = rng( 0, 3 );
     for( int i = 0; i < num_monsters; i++ ) {
-        point m2( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) );
+        point m2{ rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) };
         m.place_spawns( GROUP_NETHER_CAPTURED, 1, m2, m2, 1, true );
     }
 
@@ -1527,7 +1527,7 @@ static bool mx_crater( map &m, const tripoint &abs_sub )
 {
     int size = rng( 2, 6 );
     int size_squared = size * size;
-    point p( rng( size, SEEX * 2 - 1 - size ), rng( size, SEEY * 2 - 1 - size ) );
+    point p{ rng( size, SEEX * 2 - 1 - size ), rng( size, SEEY * 2 - 1 - size ) };
     for( int i = p.x - size; i <= p.x + size; i++ ) {
         for( int j = p.y - size; j <= p.y + size; j++ ) {
             //If we're using circular distances, make circular craters
@@ -1627,8 +1627,8 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
         //Lava seams originating from the portal
         case 5: {
             if( abs_sub.z <= 0 ) {
-                point p1( rng( 0,    SEEX     - 3 ), rng( 0,    SEEY     - 3 ) );
-                point p2( rng( SEEX, SEEX * 2 - 3 ), rng( SEEY, SEEY * 2 - 3 ) );
+                point p1{ rng( 0, SEEX - 3 ), rng( 0, SEEY - 3 ) };
+                point p2{ rng( SEEX, SEEX * 2 - 3 ), rng( SEEY, SEEY * 2 - 3 ) };
                 // Pick a random cardinal direction to also spawn lava in
                 // This will make the lava a single connected line, not just on diagonals
                 static const std::array<direction, 4> possibilities = { { direction::EAST, direction::WEST, direction::NORTH, direction::SOUTH } };
@@ -1677,7 +1677,7 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
                 m.place_spawns( GROUP_MI_GO_CAMP_OM, 30, loc.xy() + point( -5, -5 ), loc.xy() + point( 5, 5 ), 1,
                                 true );
             }
-            const point pos( p + point( rng( -5, 5 ), rng( -5, 5 ) ) );
+            const point pos{ p + point( rng( -5, 5 ), rng( -5, 5 ) ) };
             circle( &m, ter_id( "t_wall_resin" ), pos, 6 );
             rough_circle( &m, ter_id( "t_floor_resin" ), pos, 5 );
             break;
@@ -1688,7 +1688,7 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
             artifact_natural_property prop =
                 static_cast<artifact_natural_property>( rng( ARTPROP_NULL + 1, ARTPROP_MAX - 1 ) );
             m.create_anomaly( portal_location, prop );
-            m.spawn_natural_artifact( p + tripoint( rng( -1, 1 ), rng( -1, 1 ), abs_sub.z ), prop );
+            m.spawn_natural_artifact( p + tripoint{ rng( -1, 1 ), rng( -1, 1 ), abs_sub.z }, prop );
             break;
         }
     }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -400,8 +400,7 @@ void map::process_fields_in_submap( submap *const current_submap,
     maptile map_tile( current_submap, point_zero );
     int &locx = map_tile.pos_.x;
     int &locy = map_tile.pos_.y;
-    const int sm_offset_x = submap.x * SEEX;
-    const int sm_offset_y = submap.y * SEEY;
+    const point sm_offset( submap.x * SEEX, submap.y * SEEY );
 
     // Loop through all tiles in this submap indicated by current_submap
     for( locx = 0; locx < SEEX; locx++ ) {
@@ -418,8 +417,8 @@ void map::process_fields_in_submap( submap *const current_submap,
 
             // This is a translation from local coordinates to submap coordinates.
             // All submaps are in one long 1d array.
-            thep.x = locx + sm_offset_x;
-            thep.y = locy + sm_offset_y;
+            thep.x = locx + sm_offset.x;
+            thep.y = locy + sm_offset.y;
             // A const reference to the tripoint above, so that the code below doesn't accidentally change it
             const tripoint &p = thep;
 

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -128,8 +128,8 @@ bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )
     point sm_size = sm_p2.xy() - sm_p1.xy();
 
     if( sm_pos.z == cache_pos.z ) {
-        rectangle rect( cache_pos.xy(), cache_pos.xy() + cache_size );
-        if( rect.contains_inclusive( sm_p1.xy() ) && rect.contains_inclusive( sm_p2.xy() ) ) {
+        inclusive_rectangle rect( cache_pos.xy(), cache_pos.xy() + cache_size );
+        if( rect.contains( sm_p1.xy() ) && rect.contains( sm_p2.xy() ) ) {
             return false;
         }
     }
@@ -326,7 +326,7 @@ bool map_memory::save( const tripoint &pos )
     submaps.clear();
 
     constexpr point MM_HSIZE_P = point( MM_SIZE / 2, MM_SIZE / 2 );
-    rectangle rect_keep( sm_center.xy() - MM_HSIZE_P, sm_center.xy() + MM_HSIZE_P );
+    half_open_rectangle rect_keep( sm_center.xy() - MM_HSIZE_P, sm_center.xy() + MM_HSIZE_P );
 
     dbg( DL::Info ) << "[SAVE] Saving memory map around " << sm_center << ". Keeping submaps within "
                     << rect_keep.p_min << "->" << rect_keep.p_max;
@@ -354,7 +354,7 @@ bool map_memory::save( const tripoint &pos )
             result = result & res;
         }
         tripoint regp_sm = mmr_to_sm_copy( regp );
-        rectangle rect_reg( regp_sm.xy(), regp_sm.xy() + point( MM_REG_SIZE, MM_REG_SIZE ) );
+        half_open_rectangle rect_reg( regp_sm.xy(), regp_sm.xy() + point( MM_REG_SIZE, MM_REG_SIZE ) );
         if( rect_reg.overlaps_half_open( rect_keep ) ) {
             dbg( DL::Info ) << "Keeping mm_region " << regp << " [" << regp_sm << "]";
             // Put submaps back

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -285,7 +285,7 @@ void mapbuffer::deserialize( JsonIn &jsin )
                 version = jsin.get_int();
             } else if( submap_member_name == "coordinates" ) {
                 jsin.start_array();
-                tripoint loc( jsin.get_int(), jsin.get_int(), jsin.get_int() );
+                tripoint loc{ jsin.get_int(), jsin.get_int(), jsin.get_int() };
                 jsin.end_array();
                 submap_coordinates = loc;
             } else {

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -285,11 +285,9 @@ void mapbuffer::deserialize( JsonIn &jsin )
                 version = jsin.get_int();
             } else if( submap_member_name == "coordinates" ) {
                 jsin.start_array();
-                int locx = jsin.get_int();
-                int locy = jsin.get_int();
-                int locz = jsin.get_int();
+                tripoint loc( jsin.get_int(), jsin.get_int(), jsin.get_int() );
                 jsin.end_array();
-                submap_coordinates = tripoint( locx, locy, locz );
+                submap_coordinates = loc;
             } else {
                 sm->load( jsin, submap_member_name, version );
             }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -920,10 +920,9 @@ class jmapgen_sign : public jmapgen_piece
             }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            const int rx = x.get();
-            const int ry = y.get();
-            dat.m.furn_set( point( rx, ry ), f_null );
-            dat.m.furn_set( point( rx, ry ), furn_str_id( "f_sign" ) );
+            const point r( x.get(), y.get() );
+            dat.m.furn_set( r, f_null );
+            dat.m.furn_set( r, furn_str_id( "f_sign" ) );
 
             std::string signtext;
 
@@ -945,7 +944,7 @@ class jmapgen_sign : public jmapgen_piece
                 }
                 signtext = apply_all_tags( signtext, cityname );
             }
-            dat.m.set_signage( tripoint( rx, ry, dat.m.get_abs_sub().z ), signtext );
+            dat.m.set_signage( tripoint( r, dat.m.get_abs_sub().z ), signtext );
         }
         std::string apply_all_tags( std::string signtext, const std::string &cityname ) const {
             replace_city_tag( signtext, cityname );
@@ -974,8 +973,7 @@ class jmapgen_graffiti : public jmapgen_piece
             }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            const int rx = x.get();
-            const int ry = y.get();
+            const point r( x.get(), y.get() );
 
             std::string graffiti;
 
@@ -997,7 +995,7 @@ class jmapgen_graffiti : public jmapgen_piece
                 }
                 graffiti = apply_all_tags( graffiti, cityname );
             }
-            dat.m.set_graffiti( tripoint( rx, ry, dat.m.get_abs_sub().z ), graffiti );
+            dat.m.set_graffiti( tripoint( r, dat.m.get_abs_sub().z ), graffiti );
         }
         std::string apply_all_tags( std::string graffiti, const std::string &cityname ) const {
             replace_city_tag( graffiti, cityname );
@@ -1022,10 +1020,9 @@ class jmapgen_vending_machine : public jmapgen_piece
             }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            const int rx = x.get();
-            const int ry = y.get();
-            dat.m.furn_set( point( rx, ry ), f_null );
-            dat.m.place_vending( point( rx, ry ), item_group, reinforced );
+            point r{x.get(), y.get()};
+            dat.m.furn_set( r, f_null );
+            dat.m.place_vending( r, item_group, reinforced );
         }
         bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
             return dat.m.veh_at( tripoint( p, dat.zlevel() ) ).has_value();
@@ -1043,14 +1040,13 @@ class jmapgen_toilet : public jmapgen_piece
             amount( jsi, "amount", 0, 0 ) {
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            const int rx = x.get();
-            const int ry = y.get();
+            const point r( x.get(), y.get() );
             const int charges = amount.get();
-            dat.m.furn_set( point( rx, ry ), f_null );
+            dat.m.furn_set( r, f_null );
             if( charges == 0 ) {
-                dat.m.place_toilet( point( rx, ry ) ); // Use the default charges supplied as default values
+                dat.m.place_toilet( r ); // Use the default charges supplied as default values
             } else {
-                dat.m.place_toilet( point( rx, ry ), charges );
+                dat.m.place_toilet( r, charges );
             }
         }
         bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
@@ -1078,17 +1074,16 @@ class jmapgen_gaspump : public jmapgen_piece
             }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            const int rx = x.get();
-            const int ry = y.get();
+            const point r( x.get(), y.get() );
             int charges = amount.get();
-            dat.m.furn_set( point( rx, ry ), f_null );
+            dat.m.furn_set( r, f_null );
             if( charges == 0 ) {
                 charges = rng( 10000, 50000 );
             }
             if( !fuel.empty() ) {
-                dat.m.place_gas_pump( point( rx, ry ), charges, fuel );
+                dat.m.place_gas_pump( r, charges, fuel );
             } else {
-                dat.m.place_gas_pump( point( rx, ry ), charges );
+                dat.m.place_gas_pump( r, charges );
             }
         }
         bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
@@ -1560,11 +1555,10 @@ class jmapgen_computer : public jmapgen_piece
             }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            const int rx = x.get();
-            const int ry = y.get();
-            dat.m.ter_set( point( rx, ry ), t_console );
-            dat.m.furn_set( point( rx, ry ), f_null );
-            computer *cpu = dat.m.add_computer( tripoint( rx, ry, dat.m.get_abs_sub().z ), name.translated(),
+            const point r( x.get(), y.get() );
+            dat.m.ter_set( r, t_console );
+            dat.m.furn_set( r, f_null );
+            computer *cpu = dat.m.add_computer( tripoint( r, dat.m.get_abs_sub().z ), name.translated(),
                                                 security );
             for( const auto &opt : options ) {
                 cpu->add_option( opt );
@@ -2651,12 +2645,11 @@ bool jmapgen_setmap::apply( mapgendata &dat, const point &offset ) const
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_TRAP: {
-                const int cx = x_get();
-                const int cy = y_get();
+                const point c( x_get(), y_get() );
                 const int cx2 = x2_get();
                 const int cy2 = y2_get();
-                for( int tx = cx; tx <= cx2; tx++ ) {
-                    for( int ty = cy; ty <= cy2; ty++ ) {
+                for( int tx = c.x; tx <= cx2; tx++ ) {
+                    for( int ty = c.y; ty <= cy2; ty++ ) {
                         // TODO: the trap_id should be stored separately and not be wrapped in an jmapgen_int
                         mtrap_set( &m, point( tx, ty ), trap_id( val.get() ) );
                     }
@@ -3525,8 +3518,7 @@ void map::draw_lab( mapgendata &dat )
     bool central_lab = false;
     bool tower_lab = false;
 
-    int x = 0;
-    int y = 0;
+    point p2;
 
     int lw = 0;
     int rw = 0;
@@ -3547,10 +3539,10 @@ void map::draw_lab( mapgendata &dat )
 
         if( ice_lab ) {
             int temperature = -20 + 30 * ( dat.zlevel() );
-            set_temperature( point( x, y ), temperature );
-            set_temperature( point( x + SEEX, y ), temperature );
-            set_temperature( point( x, y + SEEY ), temperature );
-            set_temperature( point( x + SEEX, y + SEEY ), temperature );
+            set_temperature( p2, temperature );
+            set_temperature( p2 + point( SEEX, 0 ), temperature );
+            set_temperature( p2 + point( 0, SEEY ), temperature );
+            set_temperature( p2 + point( SEEX, SEEY ), temperature );
         }
 
         // Check for adjacent sewers; used below
@@ -3960,8 +3952,8 @@ void map::draw_lab( mapgendata &dat )
                             }
                             // and then randomly destroy 5% of the remaining nonstairs.
                         } else if( one_in( 20 ) &&
-                                   !has_flag_ter( "GOES_DOWN", point( x, y ) ) &&
-                                   !has_flag_ter( "GOES_UP", point( x, y ) ) ) {
+                                   !has_flag_ter( "GOES_DOWN", p2 ) &&
+                                   !has_flag_ter( "GOES_UP", p2 ) ) {
                             destroy( { i, j, abs_sub.z } );
                             // bashed squares can create dirt & floors, but we want rock floors.
                             if( t_dirt == ter( point( i, j ) ) || t_floor == ter( point( i, j ) ) ) {
@@ -4222,10 +4214,10 @@ void map::draw_lab( mapgendata &dat )
 
         if( ice_lab ) {
             int temperature = -20 + 30 * dat.zlevel();
-            set_temperature( point( x, y ), temperature );
-            set_temperature( point( x + SEEX, y ), temperature );
-            set_temperature( point( x, y + SEEY ), temperature );
-            set_temperature( point( x + SEEX, y + SEEY ), temperature );
+            set_temperature( p2, temperature );
+            set_temperature( p2 + point( SEEX, 0 ), temperature );
+            set_temperature( p2 + point( 0, SEEY ), temperature );
+            set_temperature( p2 + point( SEEX, SEEY ), temperature );
         }
 
         tw = is_ot_match( "lab", dat.north(), ot_match_type::contains ) ? 0 : 2;
@@ -5128,23 +5120,23 @@ void map::draw_triffid( mapgendata &dat )
         do {
             node_built[node] = true;
             step++;
-            int nodex = 1 + 6 * ( node % 4 ), nodey = 1 + 6 * static_cast<int>( node / 4 );
+            point node2( 1 + 6 * ( node % 4 ), 1 + 6 * static_cast<int>( node / 4 ) );
             // Clear a 4x4 dirt square
-            square( this, t_dirt, point( nodex, nodey ), point( nodex + 3, nodey + 3 ) );
+            square( this, t_dirt, node2, node2 + point( 3, 3 ) );
             // Spawn a monster in there
             if( step > 2 ) { // First couple of chambers are safe
                 int monrng = rng( 1, 25 );
-                int spawnx = nodex + rng( 0, 3 ), spawny = nodey + rng( 0, 3 );
+                point spawn( node2 + point( rng( 0, 3 ), rng( 0, 3 ) ) );
                 if( monrng <= 24 ) {
-                    place_spawns( GROUP_TRIFFID_OUTER, 1, point( nodex, nodey ),
-                                  point( nodex + 3, nodey + 3 ), 1, true );
+                    place_spawns( GROUP_TRIFFID_OUTER, 1, node2,
+                                  node2 + point( 3, 3 ), 1, true );
                 } else {
-                    for( int webx = nodex; webx <= nodex + 3; webx++ ) {
-                        for( int weby = nodey; weby <= nodey + 3; weby++ ) {
+                    for( int webx = node2.x; webx <= node2.x + 3; webx++ ) {
+                        for( int weby = node2.y; weby <= node2.y + 3; weby++ ) {
                             add_field( {webx, weby, abs_sub.z}, fd_web, rng( 1, 3 ) );
                         }
                     }
-                    place_spawns( GROUP_SPIDER, 1, point( spawnx, spawny ), point( spawnx, spawny ), 1, true );
+                    place_spawns( GROUP_SPIDER, 1, spawn, spawn, 1, true );
                 }
             }
             // TODO: Non-monster hazards?
@@ -5164,24 +5156,24 @@ void map::draw_triffid( mapgendata &dat )
             }
 
             if( move.empty() ) { // Nowhere to go!
-                square( this, t_slope_down, point( nodex + 1, nodey + 1 ), point( nodex + 2, nodey + 2 ) );
+                square( this, t_slope_down, node2 + point_south_east, node2 + point( 2, 2 ) );
                 done = true;
             } else {
                 switch( random_entry( move ) ) {
                     case direction::NORTH:
-                        square( this, t_dirt, point( nodex + 1, nodey - 2 ), point( nodex + 2, nodey - 1 ) );
+                        square( this, t_dirt, node2 + point( 1, -2 ), node2 + point( 2, -1 ) );
                         node -= 4;
                         break;
                     case direction::EAST:
-                        square( this, t_dirt, point( nodex + 4, nodey + 1 ), point( nodex + 5, nodey + 2 ) );
+                        square( this, t_dirt, node2 + point( 4, 1 ), node2 + point( 5, 2 ) );
                         node++;
                         break;
                     case direction::SOUTH:
-                        square( this, t_dirt, point( nodex + 1, nodey + 4 ), point( nodex + 2, nodey + 5 ) );
+                        square( this, t_dirt, node2 + point( 1, 4 ), node2 + point( 2, 5 ) );
                         node += 4;
                         break;
                     case direction::WEST:
-                        square( this, t_dirt, point( nodex - 2, nodey + 1 ), point( nodex - 1, nodey + 2 ) );
+                        square( this, t_dirt, node2 + point( -2, 1 ), node2 + point( -1, 2 ) );
                         node--;
                         break;
                     default:
@@ -5447,20 +5439,19 @@ void map::place_spawns( const mongroup_id &group, const int chance,
     // GetResultFromGroup decrements num
     while( num > 0 ) {
         int tries = 10;
-        int x = 0;
-        int y = 0;
+        point p;
 
         // Pick a spot for the spawn
         do {
-            x = rng( p1.x, p2.x );
-            y = rng( p1.y, p2.y );
+            p.x = rng( p1.x, p2.x );
+            p.y = rng( p1.y, p2.y );
             tries--;
-        } while( impassable( point( x, y ) ) && tries > 0 );
+        } while( impassable( p ) && tries > 0 );
 
         // Pick a monster type
         MonsterGroupResult spawn_details = MonsterGroupManager::GetResultFromGroup( group, &num );
 
-        add_spawn( spawn_details.name, spawn_details.pack_size, { x, y, abs_sub.z },
+        add_spawn( spawn_details.name, spawn_details.pack_size, { p, abs_sub.z },
                    friendly, -1, mission_id, name );
     }
 }
@@ -5573,15 +5564,14 @@ std::vector<item *> map::place_items( const item_group_id &loc, const int chance
                    !terrain.has_flag( "FLAT" );
         };
 
-        int px = 0;
-        int py = 0;
+        point p;
         do {
-            px = rng( p1.x, p2.x );
-            py = rng( p1.y, p2.y );
+            p.x = rng( p1.x, p2.x );
+            p.y = rng( p1.y, p2.y );
             tries++;
-        } while( is_valid_terrain( point( px, py ) ) && tries < 20 );
+        } while( is_valid_terrain( p ) && tries < 20 );
         if( tries < 20 ) {
-            auto put = put_items_from_loc( loc, tripoint( px, py, abs_sub.z ), turn );
+            auto put = put_items_from_loc( loc, tripoint( p, abs_sub.z ), turn );
             res.insert( res.end(), put.begin(), put.end() );
         }
     }
@@ -5858,16 +5848,15 @@ void map::rotate( int turns, const bool setpos_safe )
         // Then we place it back from scratch
         // It could be rewritten to utilize the fact that rotation shouldn't cross overmaps
 
-        int old_x = np_rc.sub_pos.x;
-        int old_y = np_rc.sub_pos.y;
+        point old( np_rc.sub_pos );
         if( np_rc.om_sub.x % 2 != 0 ) {
-            old_x += SEEX;
+            old.x += SEEX;
         }
         if( np_rc.om_sub.y % 2 != 0 ) {
-            old_y += SEEY;
+            old.y += SEEY;
         }
 
-        const point new_pos = point{ old_x, old_y } .rotate( turns, { SEEX * 2, SEEY * 2 } );
+        const point new_pos = old .rotate( turns, { SEEX * 2, SEEY * 2 } );
         if( setpos_safe ) {
             // setpos can't be used during mapgen, but spawn_at_precise clips position
             // to be between 0-11,0-11 and teleports NPCs when used inside of update_mapgen
@@ -6020,8 +6009,7 @@ void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
         }
     }
 
-    int trapx = rng( p1.x + 1, p2.x - 1 );
-    int trapy = rng( p1.y + 1, p2.y - 1 );
+    point trap( rng( p1.x + 1, p2.x - 1 ), rng( p1.y + 1, p2.y - 1 ) );
     switch( random_entry( valid_rooms ) ) {
         case room_closet:
             m->place_items( item_group_id( "cleaning" ), 80, p1, p2, false,
@@ -6105,7 +6093,7 @@ void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
             m->furn_set( point( static_cast<int>( ( p1.x + p2.x ) / 2 ) + 1,
                                 static_cast<int>( ( p1.y + p2.y ) / 2 ) + 1 ),
                          f_counter );
-            mtrap_set( m, point( trapx, trapy ), tr_telepad );
+            mtrap_set( m, trap, tr_telepad );
             m->place_items( item_group_id( "teleport" ), 70, point( ( p1.x + p2.x ) / 2,
                             static_cast<int>( ( p1.y + p2.y ) / 2 ) ),
                             point( static_cast<int>( ( p1.x + p2.x ) / 2 ) + 1, static_cast<int>( ( p1.y + p2.y ) / 2 ) + 1 ),
@@ -6114,9 +6102,9 @@ void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
             break;
         case room_goo:
             do {
-                mtrap_set( m, point( trapx, trapy ), tr_goo );
-                trapx = rng( p1.x + 1, p2.x - 1 );
-                trapy = rng( p1.y + 1, p2.y - 1 );
+                mtrap_set( m, trap, tr_goo );
+                trap.x = rng( p1.x + 1, p2.x - 1 );
+                trap.y = rng( p1.y + 1, p2.y - 1 );
             } while( !one_in( 5 ) );
             if( rotate == 0 ) {
                 mremove_trap( m, point( p1.x, p2.y ) );
@@ -6350,18 +6338,17 @@ void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
 void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bool create_rubble )
 {
     // TODO: Z
-    int cx = cp.x;
-    int cy = cp.y;
+    point c( cp.xy() );
     if( create_rubble ) {
-        rough_circle( this, t_dirt, point( cx, cy ), 11 );
-        rough_circle_furn( this, f_rubble, point( cx, cy ), 5 );
-        furn_set( point( cx, cy ), f_null );
+        rough_circle( this, t_dirt, c, 11 );
+        rough_circle_furn( this, f_rubble, c, 5 );
+        furn_set( c, f_null );
     }
     switch( prop ) {
         case ARTPROP_WRIGGLING:
         case ARTPROP_MOVING:
-            for( int i = cx - 5; i <= cx + 5; i++ ) {
-                for( int j = cy - 5; j <= cy + 5; j++ ) {
+            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
+                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
                     if( furn( point( i, j ) ) == f_rubble ) {
                         add_field( {i, j, abs_sub.z}, fd_push_items, 1 );
                         if( one_in( 3 ) ) {
@@ -6374,8 +6361,8 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
 
         case ARTPROP_GLOWING:
         case ARTPROP_GLITTERING:
-            for( int i = cx - 5; i <= cx + 5; i++ ) {
-                for( int j = cy - 5; j <= cy + 5; j++ ) {
+            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
+                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
                     if( furn( point( i, j ) ) == f_rubble && one_in( 2 ) ) {
                         mtrap_set( this, point( i, j ), tr_glow );
                     }
@@ -6385,8 +6372,8 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
 
         case ARTPROP_HUMMING:
         case ARTPROP_RATTLING:
-            for( int i = cx - 5; i <= cx + 5; i++ ) {
-                for( int j = cy - 5; j <= cy + 5; j++ ) {
+            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
+                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
                     if( furn( point( i, j ) ) == f_rubble && one_in( 2 ) ) {
                         mtrap_set( this, point( i, j ), tr_hum );
                     }
@@ -6396,8 +6383,8 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
 
         case ARTPROP_WHISPERING:
         case ARTPROP_ENGRAVED:
-            for( int i = cx - 5; i <= cx + 5; i++ ) {
-                for( int j = cy - 5; j <= cy + 5; j++ ) {
+            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
+                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
                     if( furn( point( i, j ) ) == f_rubble && one_in( 3 ) ) {
                         mtrap_set( this, point( i, j ), tr_shadow );
                     }
@@ -6406,9 +6393,9 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
             break;
 
         case ARTPROP_BREATHING:
-            for( int i = cx - 1; i <= cx + 1; i++ ) {
-                for( int j = cy - 1; j <= cy + 1; j++ ) {
-                    if( i == cx && j == cy ) {
+            for( int i = c.x - 1; i <= c.x + 1; i++ ) {
+                for( int j = c.y - 1; j <= c.y + 1; j++ ) {
+                    if( i == c.x && j == c.y ) {
                         place_spawns( GROUP_BREATHER_HUB, 1, point( i, j ), point( i, j ), 1,
                                       true );
                     } else {
@@ -6419,8 +6406,8 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
             break;
 
         case ARTPROP_DEAD:
-            for( int i = cx - 5; i <= cx + 5; i++ ) {
-                for( int j = cy - 5; j <= cy + 5; j++ ) {
+            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
+                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
                     if( furn( point( i, j ) ) == f_rubble ) {
                         mtrap_set( this, point( i, j ), tr_drain );
                     }
@@ -6429,8 +6416,8 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
             break;
 
         case ARTPROP_ITCHY:
-            for( int i = cx - 5; i <= cx + 5; i++ ) {
-                for( int j = cy - 5; j <= cy + 5; j++ ) {
+            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
+                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
                     if( furn( point( i, j ) ) == f_rubble ) {
                         set_radiation( point( i, j ), rng( 0, 10 ) );
                     }
@@ -6440,26 +6427,26 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
 
         case ARTPROP_ELECTRIC:
         case ARTPROP_CRACKLING:
-            add_field( {cx, cy, abs_sub.z}, fd_shock_vent, 3 );
+            add_field( {c, abs_sub.z}, fd_shock_vent, 3 );
             break;
 
         case ARTPROP_SLIMY:
-            add_field( {cx, cy, abs_sub.z}, fd_acid_vent, 3 );
+            add_field( {c, abs_sub.z}, fd_acid_vent, 3 );
             break;
 
         case ARTPROP_WARM:
-            for( int i = cx - 5; i <= cx + 5; i++ ) {
-                for( int j = cy - 5; j <= cy + 5; j++ ) {
+            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
+                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
                     if( furn( point( i, j ) ) == f_rubble ) {
-                        add_field( {i, j, abs_sub.z}, fd_fire_vent, 1 + ( rl_dist( point( cx, cy ), point( i, j ) ) % 3 ) );
+                        add_field( {i, j, abs_sub.z}, fd_fire_vent, 1 + ( rl_dist( c, point( i, j ) ) % 3 ) );
                     }
                 }
             }
             break;
 
         case ARTPROP_SCALED:
-            for( int i = cx - 5; i <= cx + 5; i++ ) {
-                for( int j = cy - 5; j <= cy + 5; j++ ) {
+            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
+                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
                     if( furn( point( i, j ) ) == f_rubble ) {
                         mtrap_set( this, point( i, j ), tr_snake );
                     }
@@ -6468,13 +6455,13 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
             break;
 
         case ARTPROP_FRACTAL:
-            create_anomaly( point( cx - 4, cy - 4 ),
+            create_anomaly( c + point( -4, -4 ),
                             static_cast<artifact_natural_property>( rng( ARTPROP_NULL + 1, ARTPROP_MAX - 1 ) ) );
-            create_anomaly( point( cx + 4, cy - 4 ),
+            create_anomaly( c + point( 4, -4 ),
                             static_cast<artifact_natural_property>( rng( ARTPROP_NULL + 1, ARTPROP_MAX - 1 ) ) );
-            create_anomaly( point( cx - 4, cy + 4 ),
+            create_anomaly( c + point( -4, 4 ),
                             static_cast<artifact_natural_property>( rng( ARTPROP_NULL + 1, ARTPROP_MAX - 1 ) ) );
-            create_anomaly( point( cx + 4, cy - 4 ),
+            create_anomaly( c + point( 4, -4 ),
                             static_cast<artifact_natural_property>( rng( ARTPROP_NULL + 1, ARTPROP_MAX - 1 ) ) );
             break;
         default:

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -920,7 +920,7 @@ class jmapgen_sign : public jmapgen_piece
             }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            const point r( x.get(), y.get() );
+            const point r{ x.get(), y.get() };
             dat.m.furn_set( r, f_null );
             dat.m.furn_set( r, furn_str_id( "f_sign" ) );
 
@@ -973,7 +973,7 @@ class jmapgen_graffiti : public jmapgen_piece
             }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            const point r( x.get(), y.get() );
+            const point r{ x.get(), y.get() };
 
             std::string graffiti;
 
@@ -1020,7 +1020,7 @@ class jmapgen_vending_machine : public jmapgen_piece
             }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            point r{x.get(), y.get()};
+            point r{ x.get(), y.get() };
             dat.m.furn_set( r, f_null );
             dat.m.place_vending( r, item_group, reinforced );
         }
@@ -1040,7 +1040,7 @@ class jmapgen_toilet : public jmapgen_piece
             amount( jsi, "amount", 0, 0 ) {
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            const point r( x.get(), y.get() );
+            const point r{ x.get(), y.get() };
             const int charges = amount.get();
             dat.m.furn_set( r, f_null );
             if( charges == 0 ) {
@@ -1074,7 +1074,7 @@ class jmapgen_gaspump : public jmapgen_piece
             }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            const point r( x.get(), y.get() );
+            const point r{ x.get(), y.get() };
             int charges = amount.get();
             dat.m.furn_set( r, f_null );
             if( charges == 0 ) {
@@ -1555,7 +1555,7 @@ class jmapgen_computer : public jmapgen_piece
             }
         }
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
-            const point r( x.get(), y.get() );
+            const point r{ x.get(), y.get() };
             dat.m.ter_set( r, t_console );
             dat.m.furn_set( r, f_null );
             computer *cpu = dat.m.add_computer( tripoint( r, dat.m.get_abs_sub().z ), name.translated(),
@@ -2645,11 +2645,10 @@ bool jmapgen_setmap::apply( mapgendata &dat, const point &offset ) const
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_TRAP: {
-                const point c( x_get(), y_get() );
-                const int cx2 = x2_get();
-                const int cy2 = y2_get();
-                for( int tx = c.x; tx <= cx2; tx++ ) {
-                    for( int ty = c.y; ty <= cy2; ty++ ) {
+                const point c{ x_get(), y_get() };
+                const point c2{ x2_get(), y2_get() };
+                for( int tx = c.x; tx <= c2.x; tx++ ) {
+                    for( int ty = c.y; ty <= c2.y; ty++ ) {
                         // TODO: the trap_id should be stored separately and not be wrapped in an jmapgen_int
                         mtrap_set( &m, point( tx, ty ), trap_id( val.get() ) );
                     }
@@ -5126,7 +5125,7 @@ void map::draw_triffid( mapgendata &dat )
             // Spawn a monster in there
             if( step > 2 ) { // First couple of chambers are safe
                 int monrng = rng( 1, 25 );
-                point spawn( node2 + point( rng( 0, 3 ), rng( 0, 3 ) ) );
+                point spawn( node2 + point{ rng( 0, 3 ), rng( 0, 3 ) } );
                 if( monrng <= 24 ) {
                     place_spawns( GROUP_TRIFFID_OUTER, 1, node2,
                                   node2 + point( 3, 3 ), 1, true );
@@ -6009,7 +6008,7 @@ void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
         }
     }
 
-    point trap( rng( p1.x + 1, p2.x - 1 ), rng( p1.y + 1, p2.y - 1 ) );
+    point trap{ rng( p1.x + 1, p2.x - 1 ), rng( p1.y + 1, p2.y - 1 ) };
     switch( random_entry( valid_rooms ) ) {
         case room_closet:
             m->place_items( item_group_id( "cleaning" ), 80, p1, p2, false,

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -555,8 +555,8 @@ size_t mapgen_function_json_base::calc_index( const point &p ) const
 static bool common_check_bounds( const jmapgen_int &x, const jmapgen_int &y,
                                  const point &mapgensize, const JsonObject &jso )
 {
-    rectangle bounds( point_zero, mapgensize );
-    if( !bounds.contains_half_open( point( x.val, y.val ) ) ) {
+    half_open_rectangle bounds( point_zero, mapgensize );
+    if( !bounds.contains( point( x.val, y.val ) ) ) {
         return false;
     }
 

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -3268,7 +3268,7 @@ void mapgen_lake_shore( mapgendata &dat )
         line_segments.push_back( { sw, nw } );
     }
 
-    static constexpr rectangle map_boundaries( nw_corner, se_corner );
+    static constexpr inclusive_rectangle map_boundaries( nw_corner, se_corner );
 
     // This will draw our shallow water coastline from the "from" point to the "to" point.
     // It buffers the points a bit for a thicker line. It also clears any furniture that might
@@ -3277,7 +3277,7 @@ void mapgen_lake_shore( mapgendata &dat )
         std::vector<point> points = line_to( from, to );
         for( auto &p : points ) {
             for( const point &bp : closest_points_first( p, 1 ) ) {
-                if( !map_boundaries.contains_inclusive( bp ) ) {
+                if( !map_boundaries.contains( bp ) ) {
                     continue;
                 }
                 // Use t_null for now instead of t_water_sh, because sometimes our extended terrain
@@ -3317,7 +3317,7 @@ void mapgen_lake_shore( mapgendata &dat )
     std::unordered_set<point> visited;
 
     const auto should_fill = [&]( const point & p ) {
-        if( !map_boundaries.contains_inclusive( p ) ) {
+        if( !map_boundaries.contains( p ) ) {
             return false;
         }
         return m->ter( p ) != t_null;

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -479,15 +479,15 @@ void mapgen_spider_pit( mapgendata &dat )
                     true, dat.when() );
     // Next, place webs and sinkholes
     for( int i = 0; i < 4; i++ ) {
-        int x = rng( 3, SEEX * 2 - 4 ), y = rng( 3, SEEY * 2 - 4 );
+        point p( rng( 3, SEEX * 2 - 4 ), rng( 3, SEEY * 2 - 4 ) );
         if( i == 0 ) {
-            m->ter_set( point( x, y ), t_slope_down );
+            m->ter_set( p, t_slope_down );
         } else {
-            m->ter_set( point( x, y ), dat.groundcover() );
-            mtrap_set( m, point( x, y ), tr_sinkhole );
+            m->ter_set( p, dat.groundcover() );
+            mtrap_set( m, p, tr_sinkhole );
         }
-        for( int x1 = x - 3; x1 <= x + 3; x1++ ) {
-            for( int y1 = y - 3; y1 <= y + 3; y1++ ) {
+        for( int x1 = p.x - 3; x1 <= p.x + 3; x1++ ) {
+            for( int y1 = p.y - 3; y1 <= p.y + 3; y1++ ) {
                 madd_field( m, point( x1, y1 ), fd_web, rng( 2, 3 ) );
                 if( m->ter( point( x1, y1 ) ) != t_slope_down ) {
                     m->ter_set( point( x1, y1 ), t_dirt );
@@ -1936,10 +1936,9 @@ void mapgen_cavern( mapgendata &dat )
     // Number of pillars
     int rn = rng( 0, 2 ) * rng( 0, 3 ) + rng( 0, 1 );
     for( int n = 0; n < rn; n++ ) {
-        int px = rng( 5, SEEX * 2 - 6 );
-        int py = rng( 5, SEEY * 2 - 6 );
-        for( int i = px - 1; i <= px + 1; i++ ) {
-            for( int j = py - 1; j <= py + 1; j++ ) {
+        point p( rng( 5, SEEX * 2 - 6 ), rng( 5, SEEY * 2 - 6 ) );
+        for( int i = p.x - 1; i <= p.x + 1; i++ ) {
+            for( int j = p.y - 1; j <= p.y + 1; j++ ) {
                 m->ter_set( point( i, j ), t_rock );
             }
         }
@@ -1976,24 +1975,23 @@ void mapgen_cavern( mapgendata &dat )
     m->place_items( item_group_id( "cavern" ), 60, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ),
                     false, dat.when() );
     if( one_in( 6 ) ) { // Miner remains
-        int x = 0;
-        int y = 0;
+        point p2;
         do {
-            x = rng( 0, SEEX * 2 - 1 );
-            y = rng( 0, SEEY * 2 - 1 );
-        } while( m->impassable( point( x, y ) ) );
+            p2.x = rng( 0, SEEX * 2 - 1 );
+            p2.y = rng( 0, SEEY * 2 - 1 );
+        } while( m->impassable( p2 ) );
         if( !one_in( 3 ) ) {
-            m->spawn_item( point( x, y ), "jackhammer" );
+            m->spawn_item( p2, "jackhammer" );
         }
         if( one_in( 3 ) ) {
-            m->spawn_item( point( x, y ), "mask_dust" );
+            m->spawn_item( p2, "mask_dust" );
         }
         if( one_in( 2 ) ) {
-            m->spawn_item( point( x, y ), "hat_hard" );
+            m->spawn_item( p2, "hat_hard" );
         }
         while( !one_in( 3 ) ) {
             for( int i = 0; i < 3; ++i ) {
-                m->put_items_from_loc( item_group_id( "cannedfood" ), tripoint( x, y, m->get_abs_sub().z ),
+                m->put_items_from_loc( item_group_id( "cannedfood" ), tripoint( p2, m->get_abs_sub().z ),
                                        dat.when() );
             }
         }
@@ -2194,8 +2192,7 @@ void mapgen_hellmouth( mapgendata &dat )
 void mapgen_ants_curved( mapgendata &dat )
 {
     map *const m = &dat.m;
-    int x = SEEX;
-    int y = 1;
+    point p( SEEX, 1 );
     int rn = 0;
     // First, set it all to rock
     fill_background( m, t_rock );
@@ -2209,30 +2206,30 @@ void mapgen_ants_curved( mapgendata &dat )
         m->ter_set( point( SEEX * 2 - 3, i ), t_rock_floor );
     }
     do {
-        for( int i = x - 2; i <= x + 3; i++ ) {
-            for( int j = y - 2; j <= y + 3; j++ ) {
+        for( int i = p.x - 2; i <= p.x + 3; i++ ) {
+            for( int j = p.y - 2; j <= p.y + 3; j++ ) {
                 if( i > 0 && i < SEEX * 2 - 1 && j > 0 && j < SEEY * 2 - 1 ) {
                     m->ter_set( point( i, j ), t_rock_floor );
                 }
             }
         }
         if( rn < SEEX ) {
-            x += rng( -1, 1 );
-            y++;
+            p.x += rng( -1, 1 );
+            p.y++;
         } else {
-            x++;
-            if( !one_in( x - SEEX ) ) {
-                y += rng( -1, 1 );
-            } else if( y < SEEY ) {
-                y++;
-            } else if( y > SEEY ) {
-                y--;
+            p.x++;
+            if( !one_in( p.x - SEEX ) ) {
+                p.y += rng( -1, 1 );
+            } else if( p.y < SEEY ) {
+                p.y++;
+            } else if( p.y > SEEY ) {
+                p.y--;
             }
         }
         rn++;
-    } while( x < SEEX * 2 - 1 || y != SEEY );
-    for( int i = x - 2; i <= x + 3; i++ ) {
-        for( int j = y - 2; j <= y + 3; j++ ) {
+    } while( p.x < SEEX * 2 - 1 || p.y != SEEY );
+    for( int i = p.x - 2; i <= p.x + 3; i++ ) {
+        for( int j = p.y - 2; j <= p.y + 3; j++ ) {
             if( i > 0 && i < SEEX * 2 - 1 && j > 0 && j < SEEY * 2 - 1 ) {
                 m->ter_set( point( i, j ), t_rock_floor );
             }
@@ -2383,17 +2380,16 @@ static void mapgen_ants_generic( mapgendata &dat )
         }
     }
     int rn = rng( 10, 20 );
-    int x = 0;
-    int y = 0;
+    point p;
     for( int n = 0; n < rn; n++ ) {
         int cw = rng( 1, 8 );
         do {
-            x = rng( 1 + cw, SEEX * 2 - 2 - cw );
-            y = rng( 1 + cw, SEEY * 2 - 2 - cw );
-        } while( m->ter( point( x, y ) ) == t_rock );
-        for( int i = x - cw; i <= x + cw; i++ ) {
-            for( int j = y - cw; j <= y + cw; j++ ) {
-                if( trig_dist( point( x, y ), point( i, j ) ) <= cw ) {
+            p.x = rng( 1 + cw, SEEX * 2 - 2 - cw );
+            p.y = rng( 1 + cw, SEEY * 2 - 2 - cw );
+        } while( m->ter( p ) == t_rock );
+        for( int i = p.x - cw; i <= p.x + cw; i++ ) {
+            for( int j = p.y - cw; j <= p.y + cw; j++ ) {
+                if( trig_dist( p, point( i, j ) ) <= cw ) {
                     m->ter_set( point( i, j ), t_rock_floor );
                 }
             }
@@ -2789,12 +2785,11 @@ void mapgen_forest_trail_straight( mapgendata &dat )
                     dat.region.forest_trail.trail_width_offset_max );
     };
 
-    int center_x = SEEX + center_offset();
-    int center_y = SEEY + center_offset();
+    point center( SEEX + center_offset(), SEEY + center_offset() );
 
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
-            if( i > center_x - width_offset() && i < center_x + width_offset() ) {
+            if( i > center.x - width_offset() && i < center.x + width_offset() ) {
                 m->furn_set( point( i, j ), f_null );
                 m->ter_set( point( i, j ), *dat.region.forest_trail.trail_terrain.pick() );
             }
@@ -2806,10 +2801,8 @@ void mapgen_forest_trail_straight( mapgendata &dat )
         m->rotate( 1 );
     }
 
-    m->place_items( item_group_id( "forest_trail" ), 75, point( center_x - 2, center_y - 2 ),
-                    point( center_x + 2,
-                           center_y + 2 ), true,
-                    dat.when() );
+    m->place_items( item_group_id( "forest_trail" ), 75, center + point( -2, -2 ),
+                    center + point( 2, 2 ), true, dat.when() );
 }
 
 void mapgen_forest_trail_curved( mapgendata &dat )
@@ -2828,15 +2821,14 @@ void mapgen_forest_trail_curved( mapgendata &dat )
                     dat.region.forest_trail.trail_width_offset_max );
     };
 
-    int center_x = SEEX + center_offset();
-    int center_y = SEEY + center_offset();
+    point center( SEEX + center_offset(), SEEY + center_offset() );
 
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
-            if( ( i > center_x - width_offset() && i < center_x + width_offset() &&
-                  j < center_y + width_offset() ) ||
-                ( j > center_y - width_offset() && j < center_y + width_offset() &&
-                  i > center_x - width_offset() ) ) {
+            if( ( i > center.x - width_offset() && i < center.x + width_offset() &&
+                  j < center.y + width_offset() ) ||
+                ( j > center.y - width_offset() && j < center.y + width_offset() &&
+                  i > center.x - width_offset() ) ) {
                 m->furn_set( point( i, j ), f_null );
                 m->ter_set( point( i, j ), *dat.region.forest_trail.trail_terrain.pick() );
             }
@@ -2853,10 +2845,8 @@ void mapgen_forest_trail_curved( mapgendata &dat )
         m->rotate( 3 );
     }
 
-    m->place_items( item_group_id( "forest_trail" ), 75, point( center_x - 2, center_y - 2 ),
-                    point( center_x + 2,
-                           center_y + 2 ), true,
-                    dat.when() );
+    m->place_items( item_group_id( "forest_trail" ), 75, center + point( -2, -2 ),
+                    center + point( 2, 2 ), true, dat.when() );
 }
 
 void mapgen_forest_trail_tee( mapgendata &dat )
@@ -2875,14 +2865,13 @@ void mapgen_forest_trail_tee( mapgendata &dat )
                     dat.region.forest_trail.trail_width_offset_max );
     };
 
-    int center_x = SEEX + center_offset();
-    int center_y = SEEY + center_offset();
+    point center( SEEX + center_offset(), SEEY + center_offset() );
 
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
-            if( ( i > center_x - width_offset() && i < center_x + width_offset() ) ||
-                ( j > center_y - width_offset() &&
-                  j < center_y + width_offset() && i > center_x - width_offset() ) ) {
+            if( ( i > center.x - width_offset() && i < center.x + width_offset() ) ||
+                ( j > center.y - width_offset() &&
+                  j < center.y + width_offset() && i > center.x - width_offset() ) ) {
                 m->furn_set( point( i, j ), f_null );
                 m->ter_set( point( i, j ), *dat.region.forest_trail.trail_terrain.pick() );
             }
@@ -2899,10 +2888,8 @@ void mapgen_forest_trail_tee( mapgendata &dat )
         m->rotate( 3 );
     }
 
-    m->place_items( item_group_id( "forest_trail" ), 75, point( center_x - 2, center_y - 2 ),
-                    point( center_x + 2,
-                           center_y + 2 ), true,
-                    dat.when() );
+    m->place_items( item_group_id( "forest_trail" ), 75, center + point( -2, -2 ),
+                    center + point( 2, 2 ), true, dat.when() );
 }
 
 void mapgen_forest_trail_four_way( mapgendata &dat )
@@ -2921,24 +2908,21 @@ void mapgen_forest_trail_four_way( mapgendata &dat )
                     dat.region.forest_trail.trail_width_offset_max );
     };
 
-    int center_x = SEEX + center_offset();
-    int center_y = SEEY + center_offset();
+    point center( SEEX + center_offset(), SEEY + center_offset() );
 
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
-            if( ( i > center_x - width_offset() && i < center_x + width_offset() ) ||
-                ( j > center_y - width_offset() &&
-                  j < center_y + width_offset() ) ) {
+            if( ( i > center.x - width_offset() && i < center.x + width_offset() ) ||
+                ( j > center.y - width_offset() &&
+                  j < center.y + width_offset() ) ) {
                 m->furn_set( point( i, j ), f_null );
                 m->ter_set( point( i, j ), *dat.region.forest_trail.trail_terrain.pick() );
             }
         }
     }
 
-    m->place_items( item_group_id( "forest_trail" ), 75, point( center_x - 2, center_y - 2 ),
-                    point( center_x + 2,
-                           center_y + 2 ), true,
-                    dat.when() );
+    m->place_items( item_group_id( "forest_trail" ), 75, center + point( -2, -2 ),
+                    center + point( 2, 2 ), true, dat.when() );
 }
 
 void mapgen_lake_shore( mapgendata &dat )
@@ -3107,7 +3091,7 @@ void mapgen_lake_shore( mapgendata &dat )
     const int sector_length = SEEX * 2 / 3;
 
     // Define the corners of the map. These won't change.
-    static constexpr point nw_corner( point_zero );
+    static constexpr point nw_corner{};
     static constexpr point ne_corner( SEEX * 2 - 1, 0 );
     static constexpr point se_corner( SEEX * 2 - 1, SEEY * 2 - 1 );
     static constexpr point sw_corner( 0, SEEY * 2 - 1 );

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -479,7 +479,7 @@ void mapgen_spider_pit( mapgendata &dat )
                     true, dat.when() );
     // Next, place webs and sinkholes
     for( int i = 0; i < 4; i++ ) {
-        point p( rng( 3, SEEX * 2 - 4 ), rng( 3, SEEY * 2 - 4 ) );
+        point p{ rng( 3, SEEX * 2 - 4 ), rng( 3, SEEY * 2 - 4 ) };
         if( i == 0 ) {
             m->ter_set( p, t_slope_down );
         } else {
@@ -1936,7 +1936,7 @@ void mapgen_cavern( mapgendata &dat )
     // Number of pillars
     int rn = rng( 0, 2 ) * rng( 0, 3 ) + rng( 0, 1 );
     for( int n = 0; n < rn; n++ ) {
-        point p( rng( 5, SEEX * 2 - 6 ), rng( 5, SEEY * 2 - 6 ) );
+        point p{ rng( 5, SEEX * 2 - 6 ), rng( 5, SEEY * 2 - 6 ) };
         for( int i = p.x - 1; i <= p.x + 1; i++ ) {
             for( int j = p.y - 1; j <= p.y + 1; j++ ) {
                 m->ter_set( point( i, j ), t_rock );

--- a/src/mapgenformat.cpp
+++ b/src/mapgenformat.cpp
@@ -15,26 +15,25 @@ void formatted_set_simple( map *m, const point &start, const char *cstr,
                            const format_effect<ter_id> &ter_b, const format_effect<furn_id> &furn_b )
 {
     const char *p = cstr;
-    int x = start.x;
-    int y = start.y;
+    point p2( start );
     while( *p != 0 ) {
         if( *p == '\n' ) {
-            y++;
-            x = start.x;
+            p2.y++;
+            p2.x = start.x;
         } else {
             const ter_id ter = ter_b.translate( *p );
             const furn_id furn = furn_b.translate( *p );
             if( ter != t_null ) {
-                m->ter_set( point( x, y ), ter );
+                m->ter_set( p2, ter );
             }
             if( furn != f_null ) {
                 if( furn == f_toilet ) {
-                    m->place_toilet( point( x, y ) );
+                    m->place_toilet( p2 );
                 } else {
-                    m->furn_set( point( x, y ), furn );
+                    m->furn_set( p2, furn );
                 }
             }
-            x++;
+            p2.x++;
         }
         p++;
     }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1601,8 +1601,8 @@ bool mattack::triffid_heartbeat( monster *z )
         int tries = 0;
         while( g->m.route( g->u.pos(), z->pos(), root_pathfind ).empty() &&
                tries < 20 ) {
-            int x = rng( g->u.posx(), z->posx() - 3 ), y = rng( g->u.posy(), z->posy() - 3 );
-            tripoint dest( x, y, z->posz() );
+            point p( rng( g->u.posx(), z->posx() - 3 ), rng( g->u.posy(), z->posy() - 3 ) );
+            tripoint dest( p, z->posz() );
             tries++;
             g->m.ter_set( dest, t_dirt );
             if( rl_dist( dest, g->u.pos() ) > 3 && g->num_creatures() < 30 &&

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -595,9 +595,9 @@ void mdeath::focused_beam( monster &z )
 
         item &settings = z.inv[0];
 
-        int x = z.posx() + settings.get_var( "SL_SPOT_X", 0 );
-        int y = z.posy() + settings.get_var( "SL_SPOT_Y", 0 );
-        tripoint p( x, y, z.posz() );
+        point p2( z.posx() + settings.get_var( "SL_SPOT_X", 0 ), z.posy() + settings.get_var( "SL_SPOT_Y",
+                  0 ) );
+        tripoint p( p2, z.posz() );
 
         std::vector <tripoint> traj = line_to( z.pos(), p, 0, 0 );
         for( auto &elem : traj ) {

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -559,8 +559,8 @@ void monexamine::push( monster &z )
         return;
     }
 
-    int deltax = z.posx() - g->u.posx(), deltay = z.posy() - g->u.posy();
-    z.move_to( tripoint( z.posx() + deltax, z.posy() + deltay, z.posz() ) );
+    point delta( z.posx() - g->u.posx(), z.posy() - g->u.posy() );
+    z.move_to( tripoint( z.posx() + delta.x, z.posy() + delta.y, z.posz() ) );
 }
 
 void monexamine::rename_pet( monster &z )

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1719,7 +1719,7 @@ bool monster::push_to( const tripoint &p, const int boost, const size_t depth )
     add_effect( effect_pushed, 1_turns );
 
     for( size_t i = 0; i < 6; i++ ) {
-        const point d( rng( -1, 1 ), rng( -1, 1 ) );
+        const point d{ rng( -1, 1 ), rng( -1, 1 ) };
         if( d.x == 0 && d.y == 0 ) {
             continue;
         }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -851,21 +851,20 @@ void monster::move()
         destination.z = posz();
     }
 
-    int new_dx = destination.x - pos().x;
-    int new_dy = destination.y - pos().y;
+    point new_d( destination.xy() - pos().xy() );
 
     // toggle facing direction for sdl flip
     if( !tile_iso ) {
-        if( new_dx < 0 ) {
+        if( new_d.x < 0 ) {
             facing = FD_LEFT;
-        } else if( new_dx > 0 ) {
+        } else if( new_d.x > 0 ) {
             facing = FD_RIGHT;
         }
     } else {
-        if( new_dy <= 0 && new_dx <= 0 ) {
+        if( new_d.y <= 0 && new_d.x <= 0 ) {
             facing = FD_LEFT;
         }
-        if( new_dx >= 0 && new_dy >= 0 ) {
+        if( new_d.x >= 0 && new_d.y >= 0 ) {
             facing = FD_RIGHT;
         }
     }
@@ -1720,19 +1719,18 @@ bool monster::push_to( const tripoint &p, const int boost, const size_t depth )
     add_effect( effect_pushed, 1_turns );
 
     for( size_t i = 0; i < 6; i++ ) {
-        const int dx = rng( -1, 1 );
-        const int dy = rng( -1, 1 );
-        if( dx == 0 && dy == 0 ) {
+        const point d( rng( -1, 1 ), rng( -1, 1 ) );
+        if( d.x == 0 && d.y == 0 ) {
             continue;
         }
 
         // Pushing forward is easier than pushing aside
-        const int direction_penalty = std::abs( dx - dir.x ) + std::abs( dy - dir.y );
+        const int direction_penalty = std::abs( d.x - dir.x ) + std::abs( d.y - dir.y );
         if( direction_penalty > 2 ) {
             continue;
         }
 
-        tripoint dest( p + point( dx, dy ) );
+        tripoint dest( p + d );
         const int dest_movecost_from = 50 * g->m.move_cost( dest );
 
         // Pushing into cars/windows etc. is harder
@@ -2048,12 +2046,10 @@ void monster::shove_vehicle( const tripoint &remote_destination,
                 int shove_moves = shove_veh_mass_moves_factor * veh_mass / 10_kilogram;
                 shove_moves = std::max( shove_moves, shove_moves_minimal );
                 this->mod_moves( -shove_moves );
-                const int destination_delta_x = remote_destination.x - nearby_destination.x;
-                const int destination_delta_y = remote_destination.y - nearby_destination.y;
-                const int destination_delta_z = remote_destination.z - nearby_destination.z;
-                const tripoint shove_destination( clamp( destination_delta_x, -1, 1 ),
-                                                  clamp( destination_delta_y, -1, 1 ),
-                                                  clamp( destination_delta_z, -1, 1 ) );
+                const tripoint destination_delta( -nearby_destination + remote_destination );
+                const tripoint shove_destination( clamp( destination_delta.x, -1, 1 ),
+                                                  clamp( destination_delta.y, -1, 1 ),
+                                                  clamp( destination_delta.z, -1, 1 ) );
                 veh.skidding = true;
                 veh.velocity = shove_velocity;
                 if( shove_destination != tripoint_zero ) {
@@ -2062,7 +2058,7 @@ void monster::shove_vehicle( const tripoint &remote_destination,
                     }
                     g->m.move_vehicle( veh, shove_destination, veh.face );
                 }
-                veh.move = tileray( point( destination_delta_x, destination_delta_y ) );
+                veh.move = tileray( destination_delta.xy() );
                 veh.smash( g->m, shove_damage_min, shove_damage_max, 0.10F );
             }
         }

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -761,8 +761,7 @@ void player_morale::display( int focus_eq, int pain_penalty, int fatigue_penalty
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
         win_w = std::min( max_window_width, FULL_SCREEN_WIDTH );
         win_h = FULL_SCREEN_HEIGHT;
-        const int win_x = ( TERMX - win_w ) / 2;
-        const int win_y = ( TERMY - win_h ) / 2;
+        const point win( ( TERMX - win_w ) / 2, ( TERMY - win_h ) / 2 );
 
         rows_visible = std::max( win_h - static_lines_height, 0 );
         if( rows_total < rows_visible ) {
@@ -771,7 +770,7 @@ void player_morale::display( int focus_eq, int pain_penalty, int fatigue_penalty
             offset = rows_total - rows_visible;
         }
 
-        w = catacurses::newwin( win_h, win_w, point( win_x, win_y ) );
+        w = catacurses::newwin( win_h, win_w, win );
 
         ui.position_from_window( w );
     } );

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -166,20 +166,19 @@ player::power_mut_ui_result player::power_mutations_ui()
         HEIGHT = std::min( TERMY, std::max( FULL_SCREEN_HEIGHT,
                                             TITLE_HEIGHT + mutations_count + DESCRIPTION_HEIGHT + 5 ) );
         WIDTH = FULL_SCREEN_WIDTH + ( TERMX - FULL_SCREEN_WIDTH ) / 2;
-        const int START_X = ( TERMX - WIDTH ) / 2;
-        const int START_Y = ( TERMY - HEIGHT ) / 2;
-        wBio = catacurses::newwin( HEIGHT, WIDTH, point( START_X, START_Y ) );
+        const point START( ( TERMX - WIDTH ) / 2, ( TERMY - HEIGHT ) / 2 );
+        wBio = catacurses::newwin( HEIGHT, WIDTH, START );
 
         // Description window @ the bottom of the bionic window
-        const int DESCRIPTION_START_Y = START_Y + HEIGHT - DESCRIPTION_HEIGHT - 1;
-        DESCRIPTION_LINE_Y = DESCRIPTION_START_Y - START_Y - 1;
+        const int DESCRIPTION_START_Y = START.y + HEIGHT - DESCRIPTION_HEIGHT - 1;
+        DESCRIPTION_LINE_Y = DESCRIPTION_START_Y - START.y - 1;
         w_description = catacurses::newwin( DESCRIPTION_HEIGHT, WIDTH - 2,
-                                            point( START_X + 1, DESCRIPTION_START_Y ) );
+                                            point( START.x + 1, DESCRIPTION_START_Y ) );
 
         // Title window
-        const int TITLE_START_Y = START_Y + 1;
+        const int TITLE_START_Y = START.y + 1;
         w_title = catacurses::newwin( TITLE_HEIGHT, WIDTH - 2,
-                                      point( START_X + 1, TITLE_START_Y ) );
+                                      point( START.x + 1, TITLE_START_Y ) );
 
         recalc_max_scroll_position();
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -737,12 +737,10 @@ void npc::place_on_map()
     // "submap_coords.x * SEEX + posx() % SEEX" (analog for y).
     // The main map assumes that pos is in its own (local to the main map)
     // coordinate system. We have to change pos to match that assumption
-    const int dmx = submap_coords.x - g->get_levx();
-    const int dmy = submap_coords.y - g->get_levy();
-    const int offset_x = position.x % SEEX;
-    const int offset_y = position.y % SEEY;
+    const point dm( submap_coords + point( -g->get_levx(), -g->get_levy() ) );
+    const point offset( position.x % SEEX, position.y % SEEY );
     // value of "submap_coords.x * SEEX + posx()" is unchanged
-    setpos( tripoint( offset_x + dmx * SEEX, offset_y + dmy * SEEY, posz() ) );
+    setpos( tripoint( offset.x + dm.x * SEEX, offset.y + dm.y * SEEY, posz() ) );
 
     if( g->is_empty( pos() ) || is_mounted() ) {
         return;
@@ -1375,10 +1373,9 @@ float npc::vehicle_danger( int radius ) const
             // FIXME: this can't be the right way to do this
             float facing = wrapped_veh.v->face.dir();
 
-            int ax = wrapped_veh.v->global_pos3().x;
-            int ay = wrapped_veh.v->global_pos3().y;
-            int bx = int( ax + std::cos( facing * M_PI / 180.0 ) * radius );
-            int by = int( ay + std::sin( facing * M_PI / 180.0 ) * radius );
+            point a( wrapped_veh.v->global_pos3().xy() );
+            point b( static_cast<int>( a.x + std::cos( facing * M_PI / 180.0 ) * radius ),
+                     static_cast<int>( a.y + std::sin( facing * M_PI / 180.0 ) * radius ) );
 
             // fake size
             /* This will almost certainly give the wrong size/location on customized
@@ -1387,10 +1384,10 @@ float npc::vehicle_danger( int radius ) const
             vehicle_part last_part = wrapped_veh.v->parts.back();
             int size = std::max( last_part.mount.x, last_part.mount.y );
 
-            double normal = std::sqrt( static_cast<float>( ( bx - ax ) * ( bx - ax ) + ( by - ay ) *
-                                       ( by - ay ) ) );
-            int closest = static_cast<int>( std::abs( ( posx() - ax ) * ( by - ay ) - ( posy() - ay ) *
-                                            ( bx - ax ) ) / normal );
+            double normal = std::sqrt( static_cast<float>( ( b.x - a.x ) * ( b.x - a.x ) + ( b.y - a.y ) *
+                                       ( b.y - a.y ) ) );
+            int closest = static_cast<int>( std::abs( ( posx() - a.x ) * ( b.y - a.y ) - ( posy() - a.y ) *
+                                            ( b.x - a.x ) ) / normal );
 
             if( size > closest ) {
                 danger = i;
@@ -2014,10 +2011,9 @@ bool npc::is_leader() const
 
 bool npc::within_boundaries_of_camp() const
 {
-    const int x = global_omt_location().x;
-    const int y = global_omt_location().y;
-    for( int x2 = x - 3; x2 < x + 3; x2++ ) {
-        for( int y2 = y - 3; y2 < y + 3; y2++ ) {
+    const point p( global_omt_location().xy() );
+    for( int x2 = p.x - 3; x2 < p.x + 3; x2++ ) {
+        for( int y2 = p.y - 3; y2 < p.y + 3; y2++ ) {
             cata::optional<basecamp *> bcp = overmap_buffer.find_camp( point( x2, y2 ) );
             if( bcp ) {
                 return true;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -352,8 +352,8 @@ int fold_and_print_from( const catacurses::window &w, const point &begin, int wi
 void scrollable_text( const std::function<catacurses::window()> &init_window,
                       const std::string &title, const std::string &text )
 {
-    constexpr int text_x = 1;
-    constexpr int text_y = 1;
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    constexpr point text2( 1, 1 );
 
     input_context ctxt( "SCROLLABLE_TEXT" );
     ctxt.register_action( "UP" );
@@ -392,12 +392,12 @@ void scrollable_text( const std::function<catacurses::window()> &init_window,
     ui.on_redraw( [&]( const ui_adaptor & ) {
         werase( w );
         draw_border( w, BORDER_COLOR, title, c_black_white );
-        for( int line = beg_line, pos_y = text_y; line < std::min<int>( beg_line + text_h, lines.size() );
+        for( int line = beg_line, pos_y = text2.y; line < std::min<int>( beg_line + text_h, lines.size() );
              ++line, ++pos_y ) {
             nc_color dummy = c_white;
-            print_colored_text( w, point( text_x, pos_y ), dummy, dummy, lines[line] );
+            print_colored_text( w, point( text2.x, pos_y ), dummy, dummy, lines[line] );
         }
-        scrollbar().offset_x( width - 1 ).offset_y( text_y ).content_size( lines.size() )
+        scrollbar().offset_x( width - 1 ).offset_y( text2.y ).content_size( lines.size() )
         .viewport_pos( std::min( beg_line, max_beg_line ) ).viewport_size( text_h ).apply( w );
         wnoutrefresh( w );
     } );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1488,11 +1488,11 @@ bool overmap::inbounds( const tripoint &p, int clearance )
     static constexpr tripoint overmap_boundary_min( 0, 0, -OVERMAP_DEPTH );
     static constexpr tripoint overmap_boundary_max( OMAPX, OMAPY, OVERMAP_HEIGHT + 1 );
 
-    static constexpr box overmap_boundaries( overmap_boundary_min, overmap_boundary_max );
-    box stricter_boundaries = overmap_boundaries;
+    static constexpr half_open_box overmap_boundaries( overmap_boundary_min, overmap_boundary_max );
+    half_open_box stricter_boundaries = overmap_boundaries;
     stricter_boundaries.shrink( tripoint( clearance, clearance, 0 ) );
 
-    return stricter_boundaries.contains_half_open( p );
+    return stricter_boundaries.contains( p );
 }
 
 const scent_trace &overmap::scent_at( const tripoint &loc ) const

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2300,10 +2300,10 @@ void overmap::place_forest_trails()
             // Do a simplistic calculation of the center of the forest (rather than
             // calculating the actual centroid--it's not that important) to have another
             // good point to form the foundation of the trail system.
-            int center_x = westmost.x + ( eastmost.x - westmost.x ) / 2;
-            int center_y = northmost.y + ( southmost.y - northmost.y ) / 2;
+            point center( westmost.x + ( eastmost.x - westmost.x ) / 2,
+                          northmost.y + ( southmost.y - northmost.y ) / 2 );
 
-            point center_point = point( center_x, center_y );
+            point center_point = center;
 
             // Because we didn't do the centroid of a concave polygon, there's no
             // guarantee that our center point is actually within the bounds of the
@@ -2867,74 +2867,73 @@ void overmap::place_river( point pa, point pb )
     const oter_id river_center( "river_center" );
     int river_chance = static_cast<int>( std::max( 1.0, 1.0 / settings->river_scale ) );
     int river_scale = static_cast<int>( std::max( 1.0, settings->river_scale ) );
-    int x = pa.x;
-    int y = pa.y;
+    point p2( pa );
     do {
-        x += rng( -1, 1 );
-        y += rng( -1, 1 );
-        if( x < 0 ) {
-            x = 0;
+        p2.x += rng( -1, 1 );
+        p2.y += rng( -1, 1 );
+        if( p2.x < 0 ) {
+            p2.x = 0;
         }
-        if( x > OMAPX - 1 ) {
-            x = OMAPX - 1;
+        if( p2.x > OMAPX - 1 ) {
+            p2.x = OMAPX - 1;
         }
-        if( y < 0 ) {
-            y = 0;
+        if( p2.y < 0 ) {
+            p2.y = 0;
         }
-        if( y > OMAPY - 1 ) {
-            y = OMAPY - 1;
+        if( p2.y > OMAPY - 1 ) {
+            p2.y = OMAPY - 1;
         }
         for( int i = -1 * river_scale; i <= 1 * river_scale; i++ ) {
             for( int j = -1 * river_scale; j <= 1 * river_scale; j++ ) {
-                if( y + i >= 0 && y + i < OMAPY && x + j >= 0 && x + j < OMAPX ) {
-                    tripoint p( x + j, y + i, 0 );
+                if( p2.y + i >= 0 && p2.y + i < OMAPY && p2.x + j >= 0 && p2.x + j < OMAPX ) {
+                    tripoint p( p2.x + j, p2.y + i, 0 );
                     if( !ter( p )->is_lake() && one_in( river_chance ) ) {
                         ter_set( p, river_center );
                     }
                 }
             }
         }
-        if( pb.x > x && ( rng( 0, int( OMAPX * 1.2 ) - 1 ) < pb.x - x ||
-                          ( rng( 0, int( OMAPX * .2 ) - 1 ) > pb.x - x &&
-                            rng( 0, int( OMAPY * .2 ) - 1 ) > std::abs( pb.y - y ) ) ) ) {
-            x++;
+        if( pb.x > p2.x && ( rng( 0, static_cast<int>( OMAPX * 1.2 ) - 1 ) < pb.x - p2.x ||
+                             ( rng( 0, static_cast<int>( OMAPX * 0.2 ) - 1 ) > pb.x - p2.x &&
+                               rng( 0, static_cast<int>( OMAPY * 0.2 ) - 1 ) > std::abs( pb.y - p2.y ) ) ) ) {
+            p2.x++;
         }
-        if( pb.x < x && ( rng( 0, int( OMAPX * 1.2 ) - 1 ) < x - pb.x ||
-                          ( rng( 0, int( OMAPX * .2 ) - 1 ) > x - pb.x &&
-                            rng( 0, int( OMAPY * .2 ) - 1 ) > std::abs( pb.y - y ) ) ) ) {
-            x--;
+        if( pb.x < p2.x && ( rng( 0, static_cast<int>( OMAPX * 1.2 ) - 1 ) < p2.x - pb.x ||
+                             ( rng( 0, static_cast<int>( OMAPX * 0.2 ) - 1 ) > p2.x - pb.x &&
+                               rng( 0, static_cast<int>( OMAPY * 0.2 ) - 1 ) > std::abs( pb.y - p2.y ) ) ) ) {
+            p2.x--;
         }
-        if( pb.y > y && ( rng( 0, int( OMAPY * 1.2 ) - 1 ) < pb.y - y ||
-                          ( rng( 0, int( OMAPY * .2 ) - 1 ) > pb.y - y &&
-                            rng( 0, int( OMAPX * .2 ) - 1 ) > std::abs( x - pb.x ) ) ) ) {
-            y++;
+        if( pb.y > p2.y && ( rng( 0, static_cast<int>( OMAPY * 1.2 ) - 1 ) < pb.y - p2.y ||
+                             ( rng( 0, static_cast<int>( OMAPY * 0.2 ) - 1 ) > pb.y - p2.y &&
+                               rng( 0, static_cast<int>( OMAPX * 0.2 ) - 1 ) > std::abs( p2.x - pb.x ) ) ) ) {
+            p2.y++;
         }
-        if( pb.y < y && ( rng( 0, int( OMAPY * 1.2 ) - 1 ) < y - pb.y ||
-                          ( rng( 0, int( OMAPY * .2 ) - 1 ) > y - pb.y &&
-                            rng( 0, int( OMAPX * .2 ) - 1 ) > std::abs( x - pb.x ) ) ) ) {
-            y--;
+        if( pb.y < p2.y && ( rng( 0, static_cast<int>( OMAPY * 1.2 ) - 1 ) < p2.y - pb.y ||
+                             ( rng( 0, static_cast<int>( OMAPY * 0.2 ) - 1 ) > p2.y - pb.y &&
+                               rng( 0, static_cast<int>( OMAPX * 0.2 ) - 1 ) > std::abs( p2.x - pb.x ) ) ) ) {
+            p2.y--;
         }
-        x += rng( -1, 1 );
-        y += rng( -1, 1 );
-        if( x < 0 ) {
-            x = 0;
+        p2.x += rng( -1, 1 );
+        p2.y += rng( -1, 1 );
+        if( p2.x < 0 ) {
+            p2.x = 0;
         }
-        if( x > OMAPX - 1 ) {
-            x = OMAPX - 2;
+        if( p2.x > OMAPX - 1 ) {
+            p2.x = OMAPX - 2;
         }
-        if( y < 0 ) {
-            y = 0;
+        if( p2.y < 0 ) {
+            p2.y = 0;
         }
-        if( y > OMAPY - 1 ) {
-            y = OMAPY - 1;
+        if( p2.y > OMAPY - 1 ) {
+            p2.y = OMAPY - 1;
         }
         for( int i = -1 * river_scale; i <= 1 * river_scale; i++ ) {
             for( int j = -1 * river_scale; j <= 1 * river_scale; j++ ) {
                 // We don't want our riverbanks touching the edge of the map for many reasons
-                if( inbounds( tripoint( x + j, y + i, 0 ), 1 ) ||
+                if( inbounds( tripoint( p2.x + j, p2.y + i, 0 ), 1 ) ||
                     // UNLESS, of course, that's where the river is headed!
-                    ( std::abs( pb.y - ( y + i ) ) < 4 && std::abs( pb.x - ( x + j ) ) < 4 ) ) {
-                    tripoint p( x + j, y + i, 0 );
+                    ( std::abs( pb.y - ( p2.y + i ) ) < 4 && std::abs( pb.x - ( p2.x + j ) ) < 4 ) ) {
+                    tripoint p( p2.x + j, p2.y + i, 0 );
                     if( !inbounds( p ) ) {
                         continue;
                     }
@@ -2945,7 +2944,7 @@ void overmap::place_river( point pa, point pb )
                 }
             }
         }
-    } while( pb.x != x || pb.y != y );
+    } while( pb.x != p2.x || pb.y != p2.y );
 }
 
 void overmap::place_cities()
@@ -3005,9 +3004,8 @@ void overmap::place_cities()
 
         // TODO: put cities closer to the edge when they can span overmaps
         // don't draw cities across the edge of the map, they will get clipped
-        int cx = rng( size - 1, OMAPX - size );
-        int cy = rng( size - 1, OMAPY - size );
-        const tripoint p( cx, cy, 0 );
+        point c( rng( size - 1, OMAPX - size ), rng( size - 1, OMAPY - size ) );
+        const tripoint p( c, 0 );
 
         if( ter( p ) == settings->default_oter ) {
             placement_attempts = 0;
@@ -4211,10 +4209,9 @@ bool overmap::place_special_attempt( overmap_special_batch &enabled_specials,
                                      const point &sector, const int sector_width, const bool place_optional,
                                      const bool must_be_unexplored )
 {
-    const int x = sector.x;
-    const int y = sector.y;
+    const point p2( sector );
 
-    const tripoint p( rng( x, x + sector_width - 1 ), rng( y, y + sector_width - 1 ), 0 );
+    const tripoint p( rng( p2.x, p2.x + sector_width - 1 ), rng( p2.y, p2.y + sector_width - 1 ), 0 );
     const city &nearest_city = get_nearest_city( p );
 
     std::shuffle( enabled_specials.begin(), enabled_specials.end(), rng_get_engine() );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3004,8 +3004,7 @@ void overmap::place_cities()
 
         // TODO: put cities closer to the edge when they can span overmaps
         // don't draw cities across the edge of the map, they will get clipped
-        point c( rng( size - 1, OMAPX - size ), rng( size - 1, OMAPY - size ) );
-        const tripoint p( c, 0 );
+        const tripoint p{ rng( size - 1, OMAPX - size ), rng( size - 1, OMAPY - size ), 0 };
 
         if( ter( p ) == settings->default_oter ) {
             placement_attempts = 0;
@@ -4209,9 +4208,10 @@ bool overmap::place_special_attempt( overmap_special_batch &enabled_specials,
                                      const point &sector, const int sector_width, const bool place_optional,
                                      const bool must_be_unexplored )
 {
-    const point p2( sector );
-
-    const tripoint p( rng( p2.x, p2.x + sector_width - 1 ), rng( p2.y, p2.y + sector_width - 1 ), 0 );
+    const tripoint p{
+        rng( sector.x, sector.x + sector_width - 1 ),
+        rng( sector.y, sector.y + sector_width - 1 ),
+        0};
     const city &nearest_city = get_nearest_city( p );
 
     std::shuffle( enabled_specials.begin(), enabled_specials.end(), rng_get_engine() );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1101,10 +1101,11 @@ void draw( const catacurses::window &w, const catacurses::window &wbar, const tr
         draw_camp_labels( w, center );
     }
 
-    rectangle screen_bounds( corner.xy(), corner.xy() + point( om_map_width, om_map_height ) );
+    half_open_rectangle screen_bounds( corner.xy(),
+                                       corner.xy() + point( om_map_width, om_map_height ) );
 
-    if( has_target && blink && !screen_bounds.contains_half_open( target.xy() ) ) {
-        point marker = clamp_half_open( target.xy(), screen_bounds ) - corner.xy();
+    if( has_target && blink && !screen_bounds.contains( target.xy() ) ) {
+        point marker = clamp( target.xy(), screen_bounds ) - corner.xy();
         std::string marker_sym = " ";
 
         switch( direction_from( center.xy(), target.xy() ) ) {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -789,8 +789,10 @@ std::vector<tripoint> overmapbuffer::get_npc_path( const tripoint &src, const tr
 bool overmapbuffer::reveal_route( const tripoint &source, const tripoint &dest,
                                   const omt_route_params &params )
 {
-    static const int RADIUS = 4;            // Maximal radius of search (in overmaps)
-    static const point O( RADIUS * OMAPX, RADIUS * OMAPY );   // half-height of the area to search in
+    // Maximal radius of search (in overmaps)
+    static const int RADIUS = 4;
+    // half-size of the area to search in
+    static const point O( RADIUS * OMAPX, RADIUS * OMAPY );
 
     if( source == overmap::invalid_tripoint || dest == overmap::invalid_tripoint ) {
         return false;

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -707,15 +707,16 @@ std::vector<tripoint> overmapbuffer::get_npc_path( const tripoint &src, const tr
         path_type &ptype )
 {
     std::vector<tripoint> path;
-    constexpr int RADIUS = 4;            // Maximal radius of search (in overmaps)
-    constexpr int OX = RADIUS * OMAPX;   // half-width of the area to search in
-    constexpr int OY = RADIUS * OMAPY;   // half-height of the area to search in
+    // Maximal radius of search (in overmaps)
+    constexpr int RADIUS = 4;
+    // half-size of the area to search in
+    constexpr point O( RADIUS * OMAPX, RADIUS * OMAPY );
     if( src == overmap::invalid_tripoint || dest == overmap::invalid_tripoint ) {
         return path;
     }
 
     // Local source - center of the local area
-    const point start( OX, OY );
+    const point start( O );
     // To convert local coordinates to global ones
     const tripoint base = src - start;
     // Local destination - relative to base
@@ -773,9 +774,9 @@ std::vector<tripoint> overmapbuffer::get_npc_path( const tripoint &src, const tr
     };
     pf::path route;
     if( ptype.only_road ) {
-        route = pf::find_path_4dir( start, finish, point( OX, OY ) * 2, estimate );
+        route = pf::find_path_4dir( start, finish, O * 2, estimate );
     } else {
-        route = pf::find_path_8dir( start, finish, point( OX, OY ) * 2, estimate );
+        route = pf::find_path_8dir( start, finish, O * 2, estimate );
     }
     for( auto node : route.nodes ) {
         tripoint convert_result = base + tripoint( node.pos, 0 );
@@ -789,15 +790,14 @@ bool overmapbuffer::reveal_route( const tripoint &source, const tripoint &dest,
                                   const omt_route_params &params )
 {
     static const int RADIUS = 4;            // Maximal radius of search (in overmaps)
-    static const int OX = RADIUS * OMAPX;   // half-width of the area to search in
-    static const int OY = RADIUS * OMAPY;   // half-height of the area to search in
+    static const point O( RADIUS * OMAPX, RADIUS * OMAPY );   // half-height of the area to search in
 
     if( source == overmap::invalid_tripoint || dest == overmap::invalid_tripoint ) {
         return false;
     }
 
     // Local source - center of the local area
-    const point start( OX, OY );
+    const point start( O );
     // To convert local coordinates to global ones
     const tripoint base = source - start;
     // Local destination - relative to base
@@ -849,7 +849,7 @@ bool overmapbuffer::reveal_route( const tripoint &source, const tripoint &dest,
         }
     };
 
-    const auto path = pf::find_path_4dir( start, finish, point( OX, OY ) * 2, estimate, reporter );
+    const auto path = pf::find_path_4dir( start, finish, O * 2, estimate, reporter );
 
     for( const auto &node : path.nodes ) {
         reveal( base + node.pos, params.radius );
@@ -1090,10 +1090,9 @@ shared_ptr_fast<npc> overmapbuffer::find_npc( character_id id )
 cata::optional<basecamp *> overmapbuffer::find_camp( const point &p )
 {
     for( auto &it : overmaps ) {
-        const int x = p.x;
-        const int y = p.y;
-        for( int x2 = x - 3; x2 < x + 3; x2++ ) {
-            for( int y2 = y - 3; y2 < y + 3; y2++ ) {
+        const point p2( p );
+        for( int x2 = p2.x - 3; x2 < p2.x + 3; x2++ ) {
+            for( int y2 = p2.y - 3; y2 < p2.y + 3; y2++ ) {
                 if( cata::optional<basecamp *> camp = it.second->find_camp( point( x2, y2 ) ) ) {
                     return camp;
                 }

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -216,8 +216,7 @@ void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const 
                                      const tripoint &global_omt, const point &start_input,
                                      const int width, const int height )
 {
-    const int cursx = global_omt.x;
-    const int cursy = global_omt.y;
+    const point curs( global_omt.xy() );
     const tripoint targ = you.get_active_mission_target();
     bool drew_mission = targ == overmap::invalid_tripoint;
     const int start_y = start_input.y + ( height / 2 ) - 2;
@@ -225,7 +224,7 @@ void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const 
 
     for( int i = -( width / 2 ); i <= width - ( width / 2 ) - 1; i++ ) {
         for( int j = -( height / 2 ); j <= height - ( height / 2 ) - 1; j++ ) {
-            const tripoint omp( cursx + i, cursy + j, g->get_levz() );
+            const tripoint omp( curs.x + i, curs.y + j, g->get_levz() );
             nc_color ter_color;
             std::string ter_sym;
             const bool seen = overmap_buffer.seen( omp );
@@ -352,11 +351,11 @@ void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const 
 
     // Print arrow to mission if we have one!
     if( !drew_mission ) {
-        double slope = ( cursx != targ.x ) ? static_cast<double>( targ.y - cursy ) / static_cast<double>
-                       ( targ.x - cursx ) : 4;
+        double slope = ( curs.x != targ.x ) ? static_cast<double>( targ.y - curs.y ) / static_cast<double>
+                       ( targ.x - curs.x ) : 4;
 
-        if( cursx == targ.x || std::fabs( slope ) > 3.5 ) {  // Vertical slope
-            if( targ.y > cursy ) {
+        if( curs.x == targ.x || std::fabs( slope ) > 3.5 ) {  // Vertical slope
+            if( targ.y > curs.y ) {
                 mvwputch( w_minimap, point( 3 + start_x, 6 + start_y ), c_red, '*' );
             } else {
                 mvwputch( w_minimap, point( 3 + start_x, 0 + start_y ), c_red, '*' );
@@ -365,8 +364,8 @@ void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const 
             int arrowx = -1;
             int arrowy = -1;
             if( std::fabs( slope ) >= 1. ) {  // y diff is bigger!
-                arrowy = ( targ.y > cursy ? 6 : 0 );
-                arrowx = static_cast<int>( 3 + 3 * ( targ.y > cursy ? slope : ( 0 - slope ) ) );
+                arrowy = ( targ.y > curs.y ? 6 : 0 );
+                arrowx = static_cast<int>( 3 + 3 * ( targ.y > curs.y ? slope : ( 0 - slope ) ) );
                 if( arrowx < 0 ) {
                     arrowx = 0;
                 }
@@ -374,8 +373,8 @@ void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const 
                     arrowx = 6;
                 }
             } else {
-                arrowx = ( targ.x > cursx ? 6 : 0 );
-                arrowy = static_cast<int>( 3 + 3 * ( targ.x > cursx ? slope : ( 0 - slope ) ) );
+                arrowx = ( targ.x > curs.x ? 6 : 0 );
+                arrowy = static_cast<int>( 3 + 3 * ( targ.x > curs.x ? slope : ( 0 - slope ) ) );
                 if( arrowy < 0 ) {
                     arrowy = 0;
                 }
@@ -400,7 +399,7 @@ void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const 
             if( i > -3 && i < 3 && j > -3 && j < 3 ) {
                 continue; // only do hordes on the border, skip inner map
             }
-            const tripoint omp( cursx + i, cursy + j, g->get_levz() );
+            const tripoint omp( curs.x + i, curs.y + j, g->get_levz() );
             int horde_size = overmap_buffer.get_horde_size( omp );
             if( horde_size >= HORDE_VISIBILITY_SIZE ) {
                 if( overmap_buffer.seen( omp )

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -396,19 +396,18 @@ void pixel_minimap::set_screen_rect( const SDL_Rect &screen_rect )
         SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, "0" );
 
     } else {
-        const int dx = ( size_on_screen.x - screen_rect.w ) / 2;
-        const int dy = ( size_on_screen.y - screen_rect.h ) / 2;
+        const point d( ( size_on_screen.x - screen_rect.w ) / 2, ( size_on_screen.y - screen_rect.h ) / 2 );
 
         main_tex_clip_rect = SDL_Rect{
-            std::max( dx, 0 ),
-            std::max( dy, 0 ),
-            size_on_screen.x - 2 * std::max( dx, 0 ),
-            size_on_screen.y - 2 * std::max( dy, 0 )
+            std::max( d.x, 0 ),
+            std::max( d.y, 0 ),
+            size_on_screen.x - 2 * std::max( d.x, 0 ),
+            size_on_screen.y - 2 * std::max( d.y, 0 )
         };
 
         screen_clip_rect = SDL_Rect{
-            screen_rect.x - std::min( dx, 0 ),
-            screen_rect.y - std::min( dy, 0 ),
+            screen_rect.x - std::min( d.x, 0 ),
+            screen_rect.y - std::min( d.y, 0 ),
             main_tex_clip_rect.w,
             main_tex_clip_rect.h
         };

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -30,12 +30,12 @@ std::ostream &operator<<( std::ostream &os, const tripoint &pos )
     return os << "(" << pos.x << "," << pos.y << "," << pos.z << ")";
 }
 
-point clamp_half_open( const point &p, const rectangle &r )
+point clamp( const point &p, const half_open_rectangle &r )
 {
     return point( clamp( p.x, r.p_min.x, r.p_max.x - 1 ), clamp( p.y, r.p_min.y, r.p_max.y - 1 ) );
 }
 
-point clamp_inclusive( const point &p, const rectangle &r )
+point clamp( const point &p, const inclusive_rectangle &r )
 {
     return point( clamp( p.x, r.p_min.x, r.p_max.x ), clamp( p.y, r.p_min.y, r.p_max.y ) );
 }

--- a/src/point.h
+++ b/src/point.h
@@ -101,25 +101,22 @@ struct point {
     }
 
     std::string to_string() const;
-};
 
-std::ostream &operator<<( std::ostream &, const point & );
+    friend inline constexpr bool operator<( const point &a, const point &b ) {
+        return a.x < b.x || ( a.x == b.x && a.y < b.y );
+    }
+    friend inline constexpr bool operator==( const point &a, const point &b ) {
+        return a.x == b.x && a.y == b.y;
+    }
+    friend inline constexpr bool operator!=( const point &a, const point &b ) {
+        return !( a == b );
+    }
+
+    friend std::ostream &operator<<( std::ostream &, const point & );
+};
 
 void serialize( const point &p, JsonOut &jsout );
 void deserialize( point &p, JsonIn &jsin );
-
-inline constexpr bool operator<( const point &a, const point &b )
-{
-    return a.x < b.x || ( a.x == b.x && a.y < b.y );
-}
-inline constexpr bool operator==( const point &a, const point &b )
-{
-    return a.x == b.x && a.y == b.y;
-}
-inline constexpr bool operator!=( const point &a, const point &b )
-{
-    return !( a == b );
-}
 
 // NOLINTNEXTLINE(cata-xy)
 struct tripoint {
@@ -198,31 +195,28 @@ struct tripoint {
 
     void serialize( JsonOut &jsout ) const;
     void deserialize( JsonIn &jsin );
+
+    friend std::ostream &operator<<( std::ostream &, const tripoint & );
+
+    friend inline constexpr bool operator==( const tripoint &a, const tripoint &b ) {
+        return a.x == b.x && a.y == b.y && a.z == b.z;
+    }
+    friend inline constexpr bool operator!=( const tripoint &a, const tripoint &b ) {
+        return !( a == b );
+    }
+    friend inline bool operator<( const tripoint &a, const tripoint &b ) {
+        if( a.x != b.x ) {
+            return a.x < b.x;
+        }
+        if( a.y != b.y ) {
+            return a.y < b.y;
+        }
+        if( a.z != b.z ) {
+            return a.z < b.z;
+        }
+        return false;
+    }
 };
-
-std::ostream &operator<<( std::ostream &, const tripoint & );
-
-inline constexpr bool operator==( const tripoint &a, const tripoint &b )
-{
-    return a.x == b.x && a.y == b.y && a.z == b.z;
-}
-inline constexpr bool operator!=( const tripoint &a, const tripoint &b )
-{
-    return !( a == b );
-}
-inline bool operator<( const tripoint &a, const tripoint &b )
-{
-    if( a.x != b.x ) {
-        return a.x < b.x;
-    }
-    if( a.y != b.y ) {
-        return a.y < b.y;
-    }
-    if( a.z != b.z ) {
-        return a.z < b.z;
-    }
-    return false;
-}
 
 struct rectangle {
     point p_min;

--- a/src/point.h
+++ b/src/point.h
@@ -238,6 +238,11 @@ struct half_open_rectangle : rectangle {
         return p.x >= p_min.x && p.x < p_max.x &&
                p.y >= p_min.y && p.y < p_max.y;
     }
+
+    constexpr bool overlaps_half_open( const rectangle &r ) const {
+        return !( r.p_min.x >= p_max.x || r.p_min.y >= p_max.y ||
+                  p_min.x >= r.p_max.x || p_min.y >= r.p_max.y );
+    }
 };
 
 struct inclusive_rectangle : rectangle {

--- a/src/point.h
+++ b/src/point.h
@@ -301,8 +301,8 @@ struct inclusive_box : box {
     }
 };
 
-static constexpr tripoint tripoint_zero { 0, 0, 0 };
-static constexpr point point_zero{ tripoint_zero.xy() };
+static constexpr tripoint tripoint_zero{};
+static constexpr point point_zero{};
 
 static constexpr point point_north{ 0, -1 };
 static constexpr point point_north_east{ 1, -1 };

--- a/src/point.h
+++ b/src/point.h
@@ -229,18 +229,21 @@ struct rectangle {
     point p_max;
     constexpr rectangle() = default;
     constexpr rectangle( const point &P_MIN, const point &P_MAX ) : p_min( P_MIN ), p_max( P_MAX ) {}
+};
 
-    constexpr bool contains_half_open( const point &p ) const {
+struct half_open_rectangle : rectangle {
+    using rectangle::rectangle;
+
+    constexpr bool contains( const point &p ) const {
         return p.x >= p_min.x && p.x < p_max.x &&
                p.y >= p_min.y && p.y < p_max.y;
     }
+};
 
-    constexpr bool overlaps_half_open( const rectangle &r ) const {
-        return !( r.p_min.x >= p_max.x || r.p_min.y >= p_max.y ||
-                  p_min.x >= r.p_max.x || p_min.y >= r.p_max.y );
-    }
+struct inclusive_rectangle : rectangle {
+    using rectangle::rectangle;
 
-    constexpr bool contains_inclusive( const point &p ) const {
+    constexpr bool contains( const point &p ) const {
         return p.x >= p_min.x && p.x <= p_max.x &&
                p.y >= p_min.y && p.y <= p_max.y;
     }
@@ -251,13 +254,13 @@ struct rectangle {
     }
 };
 
-// Clamp p to the half-open rectangle r.
+// Clamp p to the rectangle r.
 // This independently clamps each coordinate of p to the bounds of the
 // rectangle.
 // Useful for example to round an arbitrary point to the nearest point on the
 // screen, or the nearest point in a particular submap.
-point clamp_half_open( const point &p, const rectangle &r );
-point clamp_inclusive( const point &p, const rectangle &r );
+point clamp( const point &p, const half_open_rectangle &r );
+point clamp( const point &p, const inclusive_rectangle &r );
 
 struct box {
     tripoint p_min;
@@ -267,21 +270,29 @@ struct box {
     explicit constexpr box( const rectangle &R, int Z1, int Z2 ) :
         p_min( tripoint( R.p_min, Z1 ) ), p_max( tripoint( R.p_max, Z2 ) ) {}
 
-    constexpr bool contains_half_open( const tripoint &p ) const {
+    void shrink( const tripoint &amount ) {
+        p_min += amount;
+        p_max -= amount;
+    }
+};
+
+struct half_open_box : box {
+    using box::box;
+
+    constexpr bool contains( const tripoint &p ) const {
         return p.x >= p_min.x && p.x < p_max.x &&
                p.y >= p_min.y && p.y < p_max.y &&
                p.z >= p_min.z && p.z < p_max.z;
     }
+};
 
-    constexpr bool contains_inclusive( const tripoint &p ) const {
+struct inclusive_box : box {
+    using box::box;
+
+    constexpr bool contains( const tripoint &p ) const {
         return p.x >= p_min.x && p.x <= p_max.x &&
                p.y >= p_min.y && p.y <= p_max.y &&
                p.z >= p_min.z && p.z <= p_max.z;
-    }
-
-    void shrink( const tripoint &amount ) {
-        p_min += amount;
-        p_max -= amount;
     }
 };
 

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -81,14 +81,14 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
     const auto init_windows = [&]( ui_adaptor & ui ) {
         content_height = FULL_SCREEN_HEIGHT - 2 - header_height;
 
-        const int offset_x = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-        const int offset_y = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
+        const point offset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                            TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
 
-        w_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH, point( offset_x, offset_y ) );
+        w_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH, offset );
         w_header = catacurses::newwin( header_height, FULL_SCREEN_WIDTH - 2,
-                                       point( 1 + offset_x, 1 + offset_y ) );
+                                       offset + point_south_east );
         w = catacurses::newwin( content_height, FULL_SCREEN_WIDTH - 2,
-                                point( 1 + offset_x, header_height + 1 + offset_y ) );
+                                offset + point( 1, header_height + 1 ) );
 
         ui.position_from_window( w_border );
     };
@@ -327,11 +327,11 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
                 catacurses::window w_help;
                 ui_adaptor help_ui;
                 const auto init_help_window = [&]( ui_adaptor & help_ui ) {
-                    const int offset_x = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-                    const int offset_y = TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
+                    const point offset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                                        TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
 
                     w_help = catacurses::newwin( FULL_SCREEN_HEIGHT / 2 - 2, FULL_SCREEN_WIDTH * 3 / 4,
-                                                 point( offset_x + 19 / 2, 7 + offset_y + FULL_SCREEN_HEIGHT / 2 / 2 ) );
+                                                 offset + point( 19 / 2, 7 + FULL_SCREEN_HEIGHT / 2 / 2 ) );
 
                     help_ui.position_from_window( w_help );
                 };
@@ -511,17 +511,17 @@ void safemode::test_pattern( const int tab_in, const int row_in )
 
     ui_adaptor ui;
     const auto init_windows = [&]( ui_adaptor & ui ) {
-        const int offset_x = 15 + ( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0 );
-        const int offset_y = 5 + ( TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 :
-                                   0 );
+        const point offset( 15 + ( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0 ),
+                            5 + ( TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 :
+                                  0 ) );
 
         content_height = FULL_SCREEN_HEIGHT - 8;
         content_width = FULL_SCREEN_WIDTH - 30;
 
         w_test_rule_border = catacurses::newwin( content_height + 2, content_width,
-                             point( offset_x, offset_y ) );
+                             offset );
         w_test_rule_content = catacurses::newwin( content_height, content_width - 2,
-                              point( 1 + offset_x, 1 + offset_y ) );
+                              offset + point_south_east );
 
         ui.position_from_window( w_test_rule_border );
     };

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -170,11 +170,8 @@ void game::unserialize( std::istream &fin )
     int tmpturn = 0;
     int tmpcalstart = 0;
     int tmprun = 0;
-    int levx = 0;
-    int levy = 0;
-    int levz = 0;
-    int comx = 0;
-    int comy = 0;
+    tripoint lev;
+    point com;
     JsonIn jsin( fin );
     try {
         JsonObject data = jsin.get_object();
@@ -198,13 +195,13 @@ void game::unserialize( std::istream &fin )
         data.read( "auto_travel_mode", auto_travel_mode );
         data.read( "run_mode", tmprun );
         data.read( "mostseen", mostseen );
-        data.read( "levx", levx );
-        data.read( "levy", levy );
-        data.read( "levz", levz );
-        data.read( "om_x", comx );
-        data.read( "om_y", comy );
+        data.read( "levx", lev.x );
+        data.read( "levy", lev.y );
+        data.read( "levz", lev.z );
+        data.read( "om_x", com.x );
+        data.read( "om_y", com.y );
 
-        load_map( tripoint( levx + comx * OMAPX * 2, levy + comy * OMAPY * 2, levz ) );
+        load_map( tripoint( lev.x + com.x * OMAPX * 2, lev.y + com.y * OMAPY * 2, lev.z ) );
 
         safe_mode = static_cast<safe_mode_type>( tmprun );
         if( get_option<bool>( "SAFEMODE" ) && safe_mode == SAFE_MODE_OFF ) {

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -69,11 +69,10 @@ void scent_map::decay()
 void scent_map::draw( const catacurses::window &win, const int div, const tripoint &center ) const
 {
     assert( div != 0 );
-    const int maxx = getmaxx( win );
-    const int maxy = getmaxy( win );
-    for( int x = 0; x < maxx; ++x ) {
-        for( int y = 0; y < maxy; ++y ) {
-            const int sn = get( center + point( -maxx / 2 + x, -maxy / 2 + y ) ) / div;
+    const point max( getmaxx( win ), getmaxy( win ) );
+    for( int x = 0; x < max.x; ++x ) {
+        for( int y = 0; y < max.y; ++y ) {
+            const int sn = get( center + point( -max.x / 2 + x, -max.y / 2 + y ) ) / div;
             mvwprintz( win, point( x, y ), sev( sn / 10 ), "%d", sn % 10 );
         }
     }
@@ -139,7 +138,7 @@ bool scent_map::inbounds( const tripoint &p ) const
     if( !scent_map_z_level_inbounds ) {
         return false;
     }
-    static constexpr point scent_map_boundary_min( point_zero );
+    static constexpr point scent_map_boundary_min{};
     static constexpr point scent_map_boundary_max( MAPSIZE_X, MAPSIZE_Y );
 
     static constexpr half_open_rectangle scent_map_boundaries(

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -142,10 +142,10 @@ bool scent_map::inbounds( const tripoint &p ) const
     static constexpr point scent_map_boundary_min( point_zero );
     static constexpr point scent_map_boundary_max( MAPSIZE_X, MAPSIZE_Y );
 
-    static constexpr rectangle scent_map_boundaries(
+    static constexpr half_open_rectangle scent_map_boundaries(
         scent_map_boundary_min, scent_map_boundary_max );
 
-    return scent_map_boundaries.contains_half_open( p.xy() );
+    return scent_map_boundaries.contains( p.xy() );
 }
 
 void scent_map::update( const tripoint &center, map &m )

--- a/src/sdl_utils.cpp
+++ b/src/sdl_utils.cpp
@@ -86,10 +86,9 @@ SDL_Rect fit_rect_inside( const SDL_Rect &inner, const SDL_Rect &outer )
 
     const int w = factor * inner.w;
     const int h = factor * inner.h;
-    const int x = outer.x + ( outer.w - w ) / 2;
-    const int y = outer.y + ( outer.h - h ) / 2;
+    const point p( outer.x + ( outer.w - w ) / 2, outer.y + ( outer.h - h ) / 2 );
 
-    return SDL_Rect{ x, y, w, h };
+    return SDL_Rect{ p.x, p.y, w, h };
 }
 
 #endif // SDL_TILES

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3178,8 +3178,8 @@ cata::optional<tripoint> input_context::get_coordinates( const catacurses::windo
 
     // Translate mouse coordinates to map coordinates based on tile size
     // Check if click is within bounds of the window we care about
-    const rectangle win_bounds( win_min, win_max );
-    if( !win_bounds.contains_inclusive( coordinate ) ) {
+    const inclusive_rectangle win_bounds( win_min, win_max );
+    if( !win_bounds.contains( coordinate ) ) {
         return cata::nullopt;
     }
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2843,8 +2843,7 @@ int projected_window_height()
 static void init_term_size_and_scaling_factor()
 {
     scaling_factor = 1;
-    int terminal_x = get_option<int>( "TERMINAL_X" );
-    int terminal_y = get_option<int>( "TERMINAL_Y" );
+    point terminal( get_option<int>( "TERMINAL_X" ), get_option<int>( "TERMINAL_Y" ) );
 
 #if !defined(__ANDROID__)
 
@@ -2892,50 +2891,50 @@ static void init_term_size_and_scaling_factor()
             max_height = INT_MAX;
         }
 
-        if( terminal_x * fontwidth > max_width ||
+        if( terminal.x * fontwidth > max_width ||
             FULL_SCREEN_WIDTH * fontwidth * scaling_factor > max_width ) {
             if( FULL_SCREEN_WIDTH * fontwidth * scaling_factor > max_width ) {
                 dbg( DL::Warn ) << "SCALING_FACTOR set too high for display size, resetting to 1";
                 scaling_factor = 1;
-                terminal_x = max_width / fontwidth;
-                terminal_y = max_height / fontheight;
+                terminal.x = max_width / fontwidth;
+                terminal.y = max_height / fontheight;
                 get_options().get_option( "SCALING_FACTOR" ).setValue( "1" );
             } else {
-                terminal_x = max_width / fontwidth;
+                terminal.x = max_width / fontwidth;
             }
         }
 
-        if( terminal_y * fontheight > max_height ||
+        if( terminal.y * fontheight > max_height ||
             FULL_SCREEN_HEIGHT * fontheight * scaling_factor > max_height ) {
             if( FULL_SCREEN_HEIGHT * fontheight * scaling_factor > max_height ) {
                 dbg( DL::Warn ) << "SCALING_FACTOR set too high for display size, resetting to 1";
                 scaling_factor = 1;
-                terminal_x = max_width / fontwidth;
-                terminal_y = max_height / fontheight;
+                terminal.x = max_width / fontwidth;
+                terminal.y = max_height / fontheight;
                 get_options().get_option( "SCALING_FACTOR" ).setValue( "1" );
             } else {
-                terminal_y = max_height / fontheight;
+                terminal.y = max_height / fontheight;
             }
         }
 
-        terminal_x -= terminal_x % scaling_factor;
-        terminal_y -= terminal_y % scaling_factor;
+        terminal.x -= terminal.x % scaling_factor;
+        terminal.y -= terminal.y % scaling_factor;
 
-        terminal_x = std::max( FULL_SCREEN_WIDTH * scaling_factor, terminal_x );
-        terminal_y = std::max( FULL_SCREEN_HEIGHT * scaling_factor, terminal_y );
+        terminal.x = std::max( FULL_SCREEN_WIDTH * scaling_factor, terminal.x );
+        terminal.y = std::max( FULL_SCREEN_HEIGHT * scaling_factor, terminal.y );
 
         get_options().get_option( "TERMINAL_X" ).setValue(
-            std::max( FULL_SCREEN_WIDTH * scaling_factor, terminal_x ) );
+            std::max( FULL_SCREEN_WIDTH * scaling_factor, terminal.x ) );
         get_options().get_option( "TERMINAL_Y" ).setValue(
-            std::max( FULL_SCREEN_HEIGHT * scaling_factor, terminal_y ) );
+            std::max( FULL_SCREEN_HEIGHT * scaling_factor, terminal.y ) );
 
         get_options().save();
     }
 
 #endif //__ANDROID__
 
-    TERMINAL_WIDTH = terminal_x / scaling_factor;
-    TERMINAL_HEIGHT = terminal_y / scaling_factor;
+    TERMINAL_WIDTH = terminal.x / scaling_factor;
+    TERMINAL_HEIGHT = terminal.y / scaling_factor;
 }
 
 //Basic Init, create the font, backbuffer, etc

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -367,14 +367,13 @@ void start_location::burn( const tripoint &omtstart, const size_t count, const i
     tinymap m;
     m.load( player_location, false );
     m.build_outside_cache( m.get_abs_sub().z );
-    const int ux = g->u.posx() % HALF_MAPSIZE_X;
-    const int uy = g->u.posy() % HALF_MAPSIZE_Y;
+    const point u( g->u.posx() % HALF_MAPSIZE_X, g->u.posy() % HALF_MAPSIZE_Y );
     std::vector<tripoint> valid;
     for( const tripoint &p : m.points_on_zlevel() ) {
         if( !( m.has_flag_ter( "DOOR", p ) ||
                m.has_flag_ter( "OPENCLOSE_INSIDE", p ) ||
                m.is_outside( p ) ||
-               ( p.x >= ux - rad && p.x <= ux + rad && p.y >= uy - rad && p.y <= uy + rad ) ) ) {
+               ( p.x >= u.x - rad && p.x <= u.x + rad && p.y >= u.y - rad && p.y <= u.y + rad ) ) ) {
             if( m.has_flag( "FLAMMABLE", p ) || m.has_flag( "FLAMMABLE_ASH", p ) ) {
                 valid.push_back( p );
             }

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -59,9 +59,9 @@ void timed_event::actualize()
                 const mtype_id &robot_type = one_in( 2 ) ? mon_copbot : mon_riotbot;
 
                 g->events().send<event_type::becomes_wanted>( g->u.getID() );
-                int robx = u_pos.x > map_point.x ? 0 - SEEX * 2 : SEEX * 4;
-                int roby = u_pos.y > map_point.y ? 0 - SEEY * 2 : SEEY * 4;
-                g->place_critter_at( robot_type, tripoint( robx, roby, g->u.posz() ) );
+                point rob( u_pos.x > map_point.x ? 0 - SEEX * 2 : SEEX * 4,
+                           u_pos.y > map_point.y ? 0 - SEEY * 2 : SEEY * 4 );
+                g->place_critter_at( robot_type, tripoint( rob, g->u.posz() ) );
             }
         }
         break;

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -240,8 +240,7 @@ veh_interact::~veh_interact() = default;
 void veh_interact::allocate_windows()
 {
     // grid window
-    const int grid_x = 1;
-    const int grid_y = 1;
+    const point grid( point_south_east );
     const int grid_w = TERMX - 2; // exterior borders take 2
     const int grid_h = TERMY - 2; // exterior borders take 2
 
@@ -250,7 +249,7 @@ void veh_interact::allocate_windows()
 
     page_size = grid_h - ( mode_h + stats_h + name_h ) - 2;
 
-    const int pane_y = grid_y + mode_h + 1;
+    const int pane_y = grid.y + mode_h + 1;
 
     const int pane_w = ( grid_w / 3 ) - 1;
 
@@ -262,7 +261,7 @@ void veh_interact::allocate_windows()
     const int name_y = pane_y + page_size + 1;
     const int stats_y = name_y + name_h;
 
-    const int list_x = grid_x + disp_w + 1;
+    const int list_x = grid.x + disp_w + 1;
     const int msg_x  = list_x + pane_w + 1;
 
     // covers right part of w_name and w_stats in vertical/hybrid
@@ -270,17 +269,17 @@ void veh_interact::allocate_windows()
     const int details_x = list_x;
 
     const int details_h = 7;
-    const int details_w = grid_x + grid_w - details_x;
+    const int details_w = grid.x + grid_w - details_x;
 
     // make the windows
     w_border = catacurses::newwin( TERMY, TERMX, point_zero );
-    w_mode  = catacurses::newwin( mode_h,    grid_w, point( grid_x, grid_y ) );
+    w_mode  = catacurses::newwin( mode_h,    grid_w, grid );
     w_msg   = catacurses::newwin( page_size, pane_w, point( msg_x, pane_y ) );
-    w_disp  = catacurses::newwin( disp_h,    disp_w, point( grid_x, pane_y ) );
-    w_parts = catacurses::newwin( parts_h,   disp_w, point( grid_x, parts_y ) );
+    w_disp  = catacurses::newwin( disp_h,    disp_w, point( grid.x, pane_y ) );
+    w_parts = catacurses::newwin( parts_h,   disp_w, point( grid.x, parts_y ) );
     w_list  = catacurses::newwin( page_size, pane_w, point( list_x, pane_y ) );
-    w_stats = catacurses::newwin( stats_h,   grid_w, point( grid_x, stats_y ) );
-    w_name  = catacurses::newwin( name_h,    grid_w, point( grid_x, name_y ) );
+    w_stats = catacurses::newwin( stats_h,   grid_w, point( grid.x, stats_y ) );
+    w_name  = catacurses::newwin( name_h,    grid_w, point( grid.x, name_y ) );
     w_details = catacurses::newwin( details_h, details_w, point( details_x, details_y ) );
 }
 
@@ -2924,8 +2923,7 @@ void veh_interact::complete_vehicle( player &p )
     }
     vehicle *const veh = &vp->vehicle();
 
-    int dx = p.activity.values[4];
-    int dy = p.activity.values[5];
+    point d( p.activity.values[4], p.activity.values[5] );
     int vehicle_part = p.activity.values[6];
     const vpart_id part_id( p.activity.str_values[0] );
 
@@ -2966,16 +2964,16 @@ void veh_interact::complete_vehicle( player &p )
 
             p.invalidate_crafting_inventory();
 
-            int partnum = !base.is_null() ? veh->install_part( point( dx, dy ), part_id,
+            int partnum = !base.is_null() ? veh->install_part( d, part_id,
                           std::move( base ) ) : -1;
             if( partnum < 0 ) {
-                debugmsg( "complete_vehicle install part fails dx=%d dy=%d id=%s", dx, dy, part_id.c_str() );
+                debugmsg( "complete_vehicle install part fails dx=%d dy=%d id=%s", d.x, d.y, part_id.c_str() );
                 break;
             }
 
             // Need map-relative coordinates to compare to output of look_around.
             // Need to call coord_translate() directly since it's a new part.
-            const point q = veh->coord_translate( point( dx, dy ) );
+            const point q = veh->coord_translate( d );
 
             if( vpinfo.has_flag( VPFLAG_CONE_LIGHT ) ||
                 vpinfo.has_flag( VPFLAG_WIDE_CONE_LIGHT ) ||

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4335,8 +4335,8 @@ bool vehicle::balanced_wheel_config() const
 
     // Check center of mass inside support of wheels (roughly)
     const point &com = local_center_of_mass();
-    const rectangle support( min, max );
-    return support.contains_inclusive( com );
+    const inclusive_rectangle support( min, max );
+    return support.contains( com );
 }
 
 bool vehicle::valid_wheel_config() const

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -966,26 +966,25 @@ void vehicle::do_autodrive()
         stop_autodriving();
         return;
     }
-    int x_side = 0;
-    int y_side = 0;
+    point side;
     if( omt_diff.x > 0 ) {
-        x_side = 2 * SEEX - 1;
+        side.x = 2 * SEEX - 1;
     } else if( omt_diff.x < 0 ) {
-        x_side = 0;
+        side.x = 0;
     } else {
-        x_side = SEEX;
+        side.x = SEEX;
     }
     if( omt_diff.y > 0 ) {
-        y_side = 2 * SEEY - 1;
+        side.y = 2 * SEEY - 1;
     } else if( omt_diff.y < 0 ) {
-        y_side = 0;
+        side.y = 0;
     } else {
-        y_side = SEEY;
+        side.y = SEEY;
     }
     // get the shared border mid-point of the next path omt
     tripoint global_a = tripoint( veh_omt_pos.x * ( 2 * SEEX ), veh_omt_pos.y * ( 2 * SEEY ),
                                   veh_omt_pos.z );
-    tripoint autodrive_temp_target = ( global_a + tripoint( x_side, y_side,
+    tripoint autodrive_temp_target = ( global_a + tripoint( side,
                                        sm_pos.z ) - g->m.getabs( vehpos ) ) + vehpos;
     autodrive_local_target = g->m.getabs( autodrive_temp_target );
     drive_to_local_target( autodrive_local_target, false );
@@ -1813,7 +1812,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
 
     // Now that we have mapped all the parts of the carry vehicle to the vehicle with the rack
     // we can go ahead and merge
-    const point mount_zero = point_zero;
+    const point mount_zero{};
     if( found_all_parts ) {
         decltype( loot_zones ) new_zones;
         for( auto carry_map : carry_data ) {
@@ -6666,42 +6665,40 @@ static bool is_sm_tile_over_water( const tripoint &real_global_pos )
 {
 
     const tripoint smp = ms_to_sm_copy( real_global_pos );
-    const int px = modulo( real_global_pos.x, SEEX );
-    const int py = modulo( real_global_pos.y, SEEY );
+    const point p( modulo( real_global_pos.x, SEEX ), modulo( real_global_pos.y, SEEY ) );
     auto sm = MAPBUFFER.lookup_submap( smp );
     if( sm == nullptr ) {
         debugmsg( "is_sm_tile_outside(): couldn't find submap %d,%d,%d", smp.x, smp.y, smp.z );
         return false;
     }
 
-    if( px < 0 || px >= SEEX || py < 0 || py >= SEEY ) {
-        debugmsg( "err %d,%d", px, py );
+    if( p.x < 0 || p.x >= SEEX || p.y < 0 || p.y >= SEEY ) {
+        debugmsg( "err %d,%d", p.x, p.y );
         return false;
     }
 
-    return ( sm->get_ter( { px, py } ).obj().has_flag( TFLAG_CURRENT ) ||
-             sm->get_furn( { px, py } ).obj().has_flag( TFLAG_CURRENT ) );
+    return ( sm->get_ter( p ).obj().has_flag( TFLAG_CURRENT ) ||
+             sm->get_furn( p ).obj().has_flag( TFLAG_CURRENT ) );
 }
 
 static bool is_sm_tile_outside( const tripoint &real_global_pos )
 {
 
     const tripoint smp = ms_to_sm_copy( real_global_pos );
-    const int px = modulo( real_global_pos.x, SEEX );
-    const int py = modulo( real_global_pos.y, SEEY );
+    const point p( modulo( real_global_pos.x, SEEX ), modulo( real_global_pos.y, SEEY ) );
     auto sm = MAPBUFFER.lookup_submap( smp );
     if( sm == nullptr ) {
         debugmsg( "is_sm_tile_outside(): couldn't find submap %d,%d,%d", smp.x, smp.y, smp.z );
         return false;
     }
 
-    if( px < 0 || px >= SEEX || py < 0 || py >= SEEY ) {
-        debugmsg( "err %d,%d", px, py );
+    if( p.x < 0 || p.x >= SEEX || p.y < 0 || p.y >= SEEY ) {
+        debugmsg( "err %d,%d", p.x, p.y );
         return false;
     }
 
-    return !( sm->get_ter( { px, py } ).obj().has_flag( TFLAG_INDOORS ) ||
-              sm->get_furn( { px, py } ).obj().has_flag( TFLAG_INDOORS ) );
+    return !( sm->get_ter( p ).obj().has_flag( TFLAG_INDOORS ) ||
+              sm->get_furn( p ).obj().has_flag( TFLAG_INDOORS ) );
 }
 
 void vehicle::update_time( const time_point &update_to )

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1412,16 +1412,15 @@ void worldfactory::draw_modselection_borders( const catacurses::window &win,
     std::array<bool, 5> hv = {{true, true, true, false, false}}; // horizontal line = true, vertical line = false
 
     for( int i = 0; i < 5; ++i ) {
-        int x = xs[i];
-        int y = ys[i];
+        point p( xs[i], ys[i] );
         int l = ls[i];
         if( hv[i] ) {
             for( int j = 0; j < l; ++j ) {
-                mvwputch( win, point( x + j, y ), BORDER_COLOR, LINE_OXOX ); // -
+                mvwputch( win, p + point( j, 0 ), BORDER_COLOR, LINE_OXOX ); // -
             }
         } else {
             for( int j = 0; j < l; ++j ) {
-                mvwputch( win, point( x, y + j ), BORDER_COLOR, LINE_XOXO ); // |
+                mvwputch( win, p + point( 0, j ), BORDER_COLOR, LINE_XOXO ); // |
             }
         }
     }

--- a/tests/electric_grid_test.cpp
+++ b/tests/electric_grid_test.cpp
@@ -76,7 +76,7 @@ static inline void test_grid_veh( distribution_grid &grid, vehicle &veh, battery
 static void connect_grid_vehicle( map &m, vehicle &veh, vehicle_connector_tile &connector,
                                   const tripoint &connector_abs_pos )
 {
-    const point cable_part_pos = point_zero;
+    const point cable_part_pos;
     vehicle_part source_part( vpart_id( "jumper_cable" ), cable_part_pos, item( "jumper_cable" ) );
     source_part.target.first = connector_abs_pos;
     source_part.target.second = connector_abs_pos;

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -110,7 +110,7 @@ TEST_CASE( "default_overmap_generation_has_non_mandatory_specials_at_origin", "[
 static void do_lab_finale_test()
 {
     const oter_id labt_endgame( "central_lab_endgame" );
-    const point origin = point_zero;
+    const point origin;
     auto batch = overmap_specials::get_default_batch( origin );
     overmap_buffer.create_custom_overmap( origin, batch );
     overmap *test_overmap = overmap_buffer.get_existing( origin );

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -58,7 +58,7 @@ TEST_CASE( "default_overmap_generation_always_succeeds", "[slow]" )
 
 TEST_CASE( "default_overmap_generation_has_non_mandatory_specials_at_origin", "[slow]" )
 {
-    const point origin = point_zero;
+    const point origin{};
 
     overmap_special mandatory;
     overmap_special optional;

--- a/tests/point_test.cpp
+++ b/tests/point_test.cpp
@@ -25,61 +25,75 @@ TEST_CASE( "rectangle_containment", "[point]" )
 
 TEST_CASE( "rectangle_overlapping", "[point]" )
 {
-    rectangle r1( point( 0, 0 ), point( 2, 2 ) ); // NOLINT(cata-use-named-point-constants)
-    rectangle r2( point( 2, 2 ), point( 3, 3 ) );
-    rectangle r3( point( 0, 0 ), point( 2, 1 ) ); // NOLINT(cata-use-named-point-constants)
-    rectangle r4( point( -2, -4 ), point( 4, -1 ) );
-    rectangle r5( point( -1, -3 ), point( 0, -2 ) );
+    SECTION( "inclusive" ) {
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        inclusive_rectangle r1( point( 0, 0 ), point( 2, 2 ) );
+        inclusive_rectangle r2( point( 2, 2 ), point( 3, 3 ) );
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        inclusive_rectangle r3( point( 0, 0 ), point( 2, 1 ) );
+        inclusive_rectangle r4( point( -2, -4 ), point( 4, -1 ) );
+        inclusive_rectangle r5( point( -1, -3 ), point( 0, -2 ) );
 
-    CHECK( r1.overlaps_inclusive( r1 ) );
-    CHECK( r1.overlaps_inclusive( r2 ) );
-    CHECK( r1.overlaps_inclusive( r3 ) );
-    CHECK( !r1.overlaps_inclusive( r4 ) );
-    CHECK( !r1.overlaps_inclusive( r5 ) );
+        CHECK( r1.overlaps_inclusive( r1 ) );
+        CHECK( r1.overlaps_inclusive( r2 ) );
+        CHECK( r1.overlaps_inclusive( r3 ) );
+        CHECK( !r1.overlaps_inclusive( r4 ) );
+        CHECK( !r1.overlaps_inclusive( r5 ) );
 
-    CHECK( r2.overlaps_inclusive( r1 ) );
-    CHECK( r2.overlaps_inclusive( r2 ) );
-    CHECK( !r2.overlaps_inclusive( r3 ) );
-    CHECK( !r2.overlaps_inclusive( r4 ) );
-    CHECK( !r2.overlaps_inclusive( r5 ) );
+        CHECK( r2.overlaps_inclusive( r1 ) );
+        CHECK( r2.overlaps_inclusive( r2 ) );
+        CHECK( !r2.overlaps_inclusive( r3 ) );
+        CHECK( !r2.overlaps_inclusive( r4 ) );
+        CHECK( !r2.overlaps_inclusive( r5 ) );
 
-    CHECK( r3.overlaps_inclusive( r1 ) );
-    CHECK( !r3.overlaps_inclusive( r2 ) );
-    CHECK( r3.overlaps_inclusive( r3 ) );
-    CHECK( !r3.overlaps_inclusive( r4 ) );
-    CHECK( !r3.overlaps_inclusive( r5 ) );
+        CHECK( r3.overlaps_inclusive( r1 ) );
+        CHECK( !r3.overlaps_inclusive( r2 ) );
+        CHECK( r3.overlaps_inclusive( r3 ) );
+        CHECK( !r3.overlaps_inclusive( r4 ) );
+        CHECK( !r3.overlaps_inclusive( r5 ) );
 
-    CHECK( !r4.overlaps_inclusive( r1 ) );
-    CHECK( !r4.overlaps_inclusive( r2 ) );
-    CHECK( !r4.overlaps_inclusive( r3 ) );
-    CHECK( r4.overlaps_inclusive( r4 ) );
-    CHECK( r4.overlaps_inclusive( r5 ) );
-    CHECK( r5.overlaps_inclusive( r4 ) );
+        CHECK( !r4.overlaps_inclusive( r1 ) );
+        CHECK( !r4.overlaps_inclusive( r2 ) );
+        CHECK( !r4.overlaps_inclusive( r3 ) );
+        CHECK( r4.overlaps_inclusive( r4 ) );
+        CHECK( r4.overlaps_inclusive( r5 ) );
+        CHECK( r5.overlaps_inclusive( r4 ) );
+    }
 
-    CHECK( r1.overlaps_half_open( r1 ) );
-    CHECK( !r1.overlaps_half_open( r2 ) );
-    CHECK( r1.overlaps_half_open( r3 ) );
-    CHECK( !r1.overlaps_half_open( r4 ) );
-    CHECK( !r1.overlaps_half_open( r5 ) );
+    SECTION( "half_open" ) {
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        half_open_rectangle r1( point( 0, 0 ), point( 2, 2 ) );
+        half_open_rectangle r2( point( 2, 2 ), point( 3, 3 ) );
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        half_open_rectangle r3( point( 0, 0 ), point( 2, 1 ) );
+        half_open_rectangle r4( point( -2, -4 ), point( 4, -1 ) );
+        half_open_rectangle r5( point( -1, -3 ), point( 0, -2 ) );
 
-    CHECK( !r2.overlaps_half_open( r1 ) );
-    CHECK( r2.overlaps_half_open( r2 ) );
-    CHECK( !r2.overlaps_half_open( r3 ) );
-    CHECK( !r2.overlaps_half_open( r4 ) );
-    CHECK( !r2.overlaps_half_open( r5 ) );
+        CHECK( r1.overlaps_half_open( r1 ) );
+        CHECK( !r1.overlaps_half_open( r2 ) );
+        CHECK( r1.overlaps_half_open( r3 ) );
+        CHECK( !r1.overlaps_half_open( r4 ) );
+        CHECK( !r1.overlaps_half_open( r5 ) );
 
-    CHECK( r3.overlaps_half_open( r1 ) );
-    CHECK( !r3.overlaps_half_open( r2 ) );
-    CHECK( r3.overlaps_half_open( r3 ) );
-    CHECK( !r3.overlaps_half_open( r4 ) );
-    CHECK( !r3.overlaps_half_open( r5 ) );
+        CHECK( !r2.overlaps_half_open( r1 ) );
+        CHECK( r2.overlaps_half_open( r2 ) );
+        CHECK( !r2.overlaps_half_open( r3 ) );
+        CHECK( !r2.overlaps_half_open( r4 ) );
+        CHECK( !r2.overlaps_half_open( r5 ) );
 
-    CHECK( !r4.overlaps_half_open( r1 ) );
-    CHECK( !r4.overlaps_half_open( r2 ) );
-    CHECK( !r4.overlaps_half_open( r3 ) );
-    CHECK( r4.overlaps_half_open( r4 ) );
-    CHECK( r4.overlaps_half_open( r5 ) );
-    CHECK( r5.overlaps_half_open( r4 ) );
+        CHECK( r3.overlaps_half_open( r1 ) );
+        CHECK( !r3.overlaps_half_open( r2 ) );
+        CHECK( r3.overlaps_half_open( r3 ) );
+        CHECK( !r3.overlaps_half_open( r4 ) );
+        CHECK( !r3.overlaps_half_open( r5 ) );
+
+        CHECK( !r4.overlaps_half_open( r1 ) );
+        CHECK( !r4.overlaps_half_open( r2 ) );
+        CHECK( !r4.overlaps_half_open( r3 ) );
+        CHECK( r4.overlaps_half_open( r4 ) );
+        CHECK( r4.overlaps_half_open( r5 ) );
+        CHECK( r5.overlaps_half_open( r4 ) );
+    }
 }
 
 TEST_CASE( "box_shrinks", "[point]" )

--- a/tests/point_test.cpp
+++ b/tests/point_test.cpp
@@ -6,18 +6,21 @@
 
 TEST_CASE( "rectangle_containment", "[point]" )
 {
-    rectangle r( point( 0, 0 ), point( 2, 2 ) ); // NOLINT(cata-use-named-point-constants)
-    CHECK( !r.contains_half_open( point( 0, -1 ) ) ); // NOLINT(cata-use-named-point-constants)
-    CHECK( r.contains_half_open( point( 0, 0 ) ) ); // NOLINT(cata-use-named-point-constants)
-    CHECK( r.contains_half_open( point( 0, 1 ) ) ); // NOLINT(cata-use-named-point-constants)
-    CHECK( !r.contains_half_open( point( 0, 2 ) ) );
-    CHECK( !r.contains_half_open( point( 0, 3 ) ) );
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    half_open_rectangle r1( point( 0, 0 ), point( 2, 2 ) );
+    CHECK( !r1.contains( point( 0, -1 ) ) ); // NOLINT(cata-use-named-point-constants)
+    CHECK( r1.contains( point( 0, 0 ) ) ); // NOLINT(cata-use-named-point-constants)
+    CHECK( r1.contains( point( 0, 1 ) ) ); // NOLINT(cata-use-named-point-constants)
+    CHECK( !r1.contains( point( 0, 2 ) ) );
+    CHECK( !r1.contains( point( 0, 3 ) ) );
 
-    CHECK( !r.contains_inclusive( point( 0, -1 ) ) ); // NOLINT(cata-use-named-point-constants)
-    CHECK( r.contains_inclusive( point( 0, 0 ) ) ); // NOLINT(cata-use-named-point-constants)
-    CHECK( r.contains_inclusive( point( 0, 1 ) ) ); // NOLINT(cata-use-named-point-constants)
-    CHECK( r.contains_inclusive( point( 0, 2 ) ) );
-    CHECK( !r.contains_inclusive( point( 0, 3 ) ) );
+    // NOLINTNEXTLINE(cata-use-named-point-constants)
+    inclusive_rectangle r2( point( 0, 0 ), point( 2, 2 ) );
+    CHECK( !r2.contains( point( 0, -1 ) ) ); // NOLINT(cata-use-named-point-constants)
+    CHECK( r2.contains( point( 0, 0 ) ) ); // NOLINT(cata-use-named-point-constants)
+    CHECK( r2.contains( point( 0, 1 ) ) ); // NOLINT(cata-use-named-point-constants)
+    CHECK( r2.contains( point( 0, 2 ) ) );
+    CHECK( !r2.contains( point( 0, 3 ) ) );
 }
 
 TEST_CASE( "rectangle_overlapping", "[point]" )
@@ -81,20 +84,20 @@ TEST_CASE( "rectangle_overlapping", "[point]" )
 
 TEST_CASE( "box_shrinks", "[point]" )
 {
-    box b( tripoint_zero, tripoint( 3, 3, 3 ) );
+    half_open_box b( tripoint_zero, tripoint( 3, 3, 3 ) );
     CAPTURE( b );
-    CHECK( b.contains_half_open( tripoint( 1, 0, 0 ) ) ); // NOLINT(cata-use-named-point-constants)
-    CHECK( b.contains_half_open( tripoint( 2, 1, 2 ) ) );
+    CHECK( b.contains( tripoint( 1, 0, 0 ) ) ); // NOLINT(cata-use-named-point-constants)
+    CHECK( b.contains( tripoint( 2, 1, 2 ) ) );
     b.shrink( tripoint( 1, 1, 0 ) ); // NOLINT(cata-use-named-point-constants)
     CAPTURE( b );
     // Shrank in the x and y directions
     // NOLINTNEXTLINE(cata-use-named-point-constants)
-    CHECK( !b.contains_half_open( tripoint( 1, 0, 0 ) ) );
-    CHECK( !b.contains_half_open( tripoint( 2, 1, 2 ) ) );
+    CHECK( !b.contains( tripoint( 1, 0, 0 ) ) );
+    CHECK( !b.contains( tripoint( 2, 1, 2 ) ) );
     // Didn't shrink in the z direction
     // NOLINTNEXTLINE(cata-use-named-point-constants)
-    CHECK( b.contains_half_open( tripoint( 1, 1, 0 ) ) );
-    CHECK( b.contains_half_open( tripoint( 1, 1, 2 ) ) );
+    CHECK( b.contains( tripoint( 1, 1, 0 ) ) );
+    CHECK( b.contains( tripoint( 1, 1, 2 ) ) );
 }
 
 TEST_CASE( "point_to_string", "[point]" )

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -96,7 +96,7 @@ TEST_CASE( "Items rot away" )
 
     SECTION( "Item on map rots away" ) {
         clear_map();
-        const tripoint loc = { tripoint_zero };
+        const tripoint loc;
 
         if( calendar::turn <= calendar::start_of_cataclysm ) {
             calendar::turn = calendar::start_of_cataclysm + 1_minutes;

--- a/tests/shadowcasting_test.cpp
+++ b/tests/shadowcasting_test.cpp
@@ -38,8 +38,7 @@ static void oldCastLight( float ( &output_cache )[MAPSIZE * SEEX][MAPSIZE * SEEY
     for( int distance = row; distance <= radius && !blocked; distance++ ) {
         delta.y = -distance;
         for( delta.x = -distance; delta.x <= 0; delta.x++ ) {
-            const int currentX = offsetX + delta.x * xx + delta.y * xy;
-            const int currentY = offsetY + delta.x * yx + delta.y * yy;
+            const point current( offsetX + delta.x * xx + delta.y * xy, offsetY + delta.x * yx + delta.y * yy );
             const float leftSlope = ( delta.x - 0.5f ) / ( delta.y + 0.5f );
             const float rightSlope = ( delta.x + 0.5f ) / ( delta.y - 0.5f );
 
@@ -51,12 +50,12 @@ static void oldCastLight( float ( &output_cache )[MAPSIZE * SEEX][MAPSIZE * SEEY
 
             //check if it's within the visible area and mark visible if so
             if( rl_dist( tripoint_zero, delta ) <= radius ) {
-                output_cache[currentX][currentY] = VISIBILITY_FULL;
+                output_cache[current.x][current.y] = VISIBILITY_FULL;
             }
 
             if( blocked ) {
                 //previous cell was a blocking one
-                if( input_array[currentX][currentY] == LIGHT_TRANSPARENCY_SOLID ) {
+                if( input_array[current.x][current.y] == LIGHT_TRANSPARENCY_SOLID ) {
                     //hit a wall
                     newStart = rightSlope;
                 } else {
@@ -64,7 +63,7 @@ static void oldCastLight( float ( &output_cache )[MAPSIZE * SEEX][MAPSIZE * SEEY
                     start = newStart;
                 }
             } else {
-                if( input_array[currentX][currentY] == LIGHT_TRANSPARENCY_SOLID &&
+                if( input_array[current.x][current.y] == LIGHT_TRANSPARENCY_SOLID &&
                     distance < radius ) {
                     //hit a wall within sight line
                     blocked = true;
@@ -227,23 +226,22 @@ static void shadowcasting_runoff( const int iterations, const bool test_bresenha
 
     map dummy;
 
-    const int offsetX = 65;
-    const int offsetY = 65;
+    const point offset( 65, 65 );
 
     const auto start1 = std::chrono::high_resolution_clock::now();
     for( int i = 0; i < iterations; i++ ) {
         // First the control algorithm.
-        oldCastLight( seen_squares_control, transparency_cache, 0, 1, 1, 0, offsetX, offsetY, 0 );
-        oldCastLight( seen_squares_control, transparency_cache, 1, 0, 0, 1, offsetX, offsetY, 0 );
+        oldCastLight( seen_squares_control, transparency_cache, 0, 1, 1, 0, offset.x, offset.y, 0 );
+        oldCastLight( seen_squares_control, transparency_cache, 1, 0, 0, 1, offset.x, offset.y, 0 );
 
-        oldCastLight( seen_squares_control, transparency_cache, 0, -1, 1, 0, offsetX, offsetY, 0 );
-        oldCastLight( seen_squares_control, transparency_cache, -1, 0, 0, 1, offsetX, offsetY, 0 );
+        oldCastLight( seen_squares_control, transparency_cache, 0, -1, 1, 0, offset.x, offset.y, 0 );
+        oldCastLight( seen_squares_control, transparency_cache, -1, 0, 0, 1, offset.x, offset.y, 0 );
 
-        oldCastLight( seen_squares_control, transparency_cache, 0, 1, -1, 0, offsetX, offsetY, 0 );
-        oldCastLight( seen_squares_control, transparency_cache, 1, 0, 0, -1, offsetX, offsetY, 0 );
+        oldCastLight( seen_squares_control, transparency_cache, 0, 1, -1, 0, offset.x, offset.y, 0 );
+        oldCastLight( seen_squares_control, transparency_cache, 1, 0, 0, -1, offset.x, offset.y, 0 );
 
-        oldCastLight( seen_squares_control, transparency_cache, 0, -1, -1, 0, offsetX, offsetY, 0 );
-        oldCastLight( seen_squares_control, transparency_cache, -1, 0, 0, -1, offsetX, offsetY, 0 );
+        oldCastLight( seen_squares_control, transparency_cache, 0, -1, -1, 0, offset.x, offset.y, 0 );
+        oldCastLight( seen_squares_control, transparency_cache, -1, 0, 0, -1, offset.x, offset.y, 0 );
     }
     const auto end1 = std::chrono::high_resolution_clock::now();
 
@@ -251,7 +249,7 @@ static void shadowcasting_runoff( const int iterations, const bool test_bresenha
     for( int i = 0; i < iterations; i++ ) {
         // Then the current algorithm.
         castLightAll<float, float, sight_calc, sight_check, update_light, accumulate_transparency>(
-            seen_squares_experiment, transparency_cache, point( offsetX, offsetY ) );
+            seen_squares_experiment, transparency_cache, offset );
     }
     const auto end2 = std::chrono::high_resolution_clock::now();
 
@@ -270,7 +268,7 @@ static void shadowcasting_runoff( const int iterations, const bool test_bresenha
     for( int x = 0; test_bresenham && passed && x < MAPSIZE * SEEX; ++x ) {
         for( int y = 0; y < MAPSIZE * SEEX; ++y ) {
             // Check that both agree on the outcome, but not necessarily the same values.
-            if( bresenham_visibility_check( point( offsetX, offsetY ), point( x, y ), transparency_cache ) !=
+            if( bresenham_visibility_check( offset, point( x, y ), transparency_cache ) !=
                 ( seen_squares_experiment[x][y] > LIGHT_TRANSPARENCY_SOLID ) ) {
                 passed = false;
                 break;
@@ -279,7 +277,7 @@ static void shadowcasting_runoff( const int iterations, const bool test_bresenha
     }
 
     if( !passed ) {
-        print_grid_comparison( point( offsetX, offsetY ), transparency_cache, seen_squares_control,
+        print_grid_comparison( offset, transparency_cache, seen_squares_control,
                                seen_squares_experiment );
     }
 
@@ -297,14 +295,13 @@ static void shadowcasting_float_quad(
 
     map dummy;
 
-    const int offsetX = 65;
-    const int offsetY = 65;
+    const point offset( 65, 65 );
 
     const auto start1 = std::chrono::high_resolution_clock::now();
     for( int i = 0; i < iterations; i++ ) {
         castLightAll<float, four_quadrants, sight_calc, sight_check, update_light_quadrants,
                      accumulate_transparency>(
-                         lit_squares_quad, transparency_cache, point( offsetX, offsetY ) );
+                         lit_squares_quad, transparency_cache, offset );
     }
     const auto end1 = std::chrono::high_resolution_clock::now();
 
@@ -313,7 +310,7 @@ static void shadowcasting_float_quad(
         // Then the current algorithm.
         castLightAll<float, float, sight_calc, sight_check, update_light,
                      accumulate_transparency>(
-                         lit_squares_float, transparency_cache, point( offsetX, offsetY ) );
+                         lit_squares_float, transparency_cache, offset );
     }
     const auto end2 = std::chrono::high_resolution_clock::now();
 
@@ -333,7 +330,7 @@ static void shadowcasting_float_quad(
     bool passed = grids_are_equivalent( lit_squares_float, lit_squares_quad );
 
     if( !passed ) {
-        print_grid_comparison( point( offsetX, offsetY ), transparency_cache, lit_squares_float,
+        print_grid_comparison( offset, transparency_cache, lit_squares_float,
                                lit_squares_quad );
     }
 
@@ -351,19 +348,17 @@ static void shadowcasting_3d_2d( const int iterations )
 
     map dummy;
 
-    const int offsetX = 65;
-    const int offsetY = 65;
-    const int offsetZ = 0;
+    const tripoint offset( 65, 65, 0 );
 
     const auto start1 = std::chrono::high_resolution_clock::now();
     for( int i = 0; i < iterations; i++ ) {
         // First the control algorithm.
         castLightAll<float, float, sight_calc, sight_check, update_light, accumulate_transparency>(
-            seen_squares_control, transparency_cache, point( offsetX, offsetY ) );
+            seen_squares_control, transparency_cache, offset.xy() );
     }
     const auto end1 = std::chrono::high_resolution_clock::now();
 
-    const tripoint origin( offsetX, offsetY, offsetZ );
+    const tripoint origin( offset );
     std::array<const float ( * )[MAPSIZE *SEEX][MAPSIZE *SEEY], OVERMAP_LAYERS> transparency_caches;
     std::array<float ( * )[MAPSIZE *SEEX][MAPSIZE *SEEY], OVERMAP_LAYERS> seen_caches;
     std::array<const bool ( * )[MAPSIZE *SEEX][MAPSIZE *SEEY], OVERMAP_LAYERS> floor_caches;
@@ -397,7 +392,7 @@ static void shadowcasting_3d_2d( const int iterations )
     bool passed = grids_are_equivalent( seen_squares_control, seen_squares_experiment );
 
     if( !passed ) {
-        print_grid_comparison( point( offsetX, offsetY ), transparency_cache, seen_squares_control,
+        print_grid_comparison( offset.xy(), transparency_cache, seen_squares_control,
                                seen_squares_experiment );
     }
 

--- a/tests/submap_test.cpp
+++ b/tests/submap_test.cpp
@@ -8,6 +8,7 @@
 TEST_CASE( "submap rotation", "[submap]" )
 {
     // Corners are labelled starting from the upper-left one, clockwise.
+    // NOLINTNEXTLINE(cata-point-initialization)
     constexpr auto corner_1 = point_zero;
     constexpr auto corner_2 = point{ SEEX - 1, 0 };
     constexpr auto corner_3 = point{ SEEX - 1, SEEY - 1 };

--- a/tools/clang-tidy-plugin/CMakeLists.txt
+++ b/tools/clang-tidy-plugin/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(Clang REQUIRED CONFIG)
 add_library(
     CataAnalyzerPlugin MODULE
     CataTidyModule.cpp
+    CombineLocalsIntoPointCheck.cpp
     DeterminismCheck.cpp
     HeaderGuardCheck.cpp
     JsonTranslationInputCheck.cpp

--- a/tools/clang-tidy-plugin/CataTidyModule.cpp
+++ b/tools/clang-tidy-plugin/CataTidyModule.cpp
@@ -2,6 +2,7 @@
 
 #include "ClangTidyModule.h"
 #include "ClangTidyModuleRegistry.h"
+#include "CombineLocalsIntoPointCheck.h"
 #include "DeterminismCheck.h"
 #include "HeaderGuardCheck.h"
 #include "JsonTranslationInputCheck.h"
@@ -30,6 +31,8 @@ class CataModule : public ClangTidyModule
 {
     public:
         void addCheckFactories( ClangTidyCheckFactories &CheckFactories ) override {
+            CheckFactories.registerCheck<CombineLocalsIntoPointCheck>(
+                "cata-combine-locals-into-point" );
             CheckFactories.registerCheck<DeterminismCheck>( "cata-determinism" );
             CheckFactories.registerCheck<CataHeaderGuardCheck>( "cata-header-guard" );
             CheckFactories.registerCheck<JsonTranslationInputCheck>( "cata-json-translation-input" );

--- a/tools/clang-tidy-plugin/CombineLocalsIntoPointCheck.cpp
+++ b/tools/clang-tidy-plugin/CombineLocalsIntoPointCheck.cpp
@@ -1,0 +1,259 @@
+#include "CombineLocalsIntoPointCheck.h"
+
+#include <algorithm>
+#include <clang/AST/ASTContext.h>
+#include <clang/AST/Decl.h>
+#include <clang/AST/DeclBase.h>
+#include <clang/AST/DeclTemplate.h>
+#include <clang/AST/Expr.h>
+#include <clang/AST/ExprCXX.h>
+#include <clang/AST/Type.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/ASTMatchers/ASTMatchersInternal.h>
+#include <clang/Basic/Diagnostic.h>
+#include <clang/Basic/DiagnosticIDs.h>
+#include <clang/Basic/LLVM.h>
+#include <clang/Basic/SourceLocation.h>
+#include <clang/Lex/Lexer.h>
+#include <climits>
+#include <llvm/ADT/Twine.h>
+#include <llvm/Support/Casting.h>
+#include <string>
+#include <unordered_set>
+
+#include "Utils.h"
+#include "clang/Basic/OperatorKinds.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang
+{
+namespace tidy
+{
+namespace cata
+{
+
+void CombineLocalsIntoPointCheck::registerMatchers( MatchFinder *Finder )
+{
+    Finder->addMatcher(
+        varDecl( hasType( isInteger() ), isXParam() ).bind( "xdecl" ),
+        this
+    );
+    Finder->addMatcher(
+        declRefExpr(
+            hasDeclaration( varDecl( hasType( isInteger() ) ).bind( "decl" ) )
+        ).bind( "declref" ),
+        this
+    );
+}
+
+static bool nameExistsInContext( const DeclContext *Context, const std::string &Name )
+{
+    for( const Decl *D : Context->decls() ) {
+        if( const NamedDecl *ND = dyn_cast<NamedDecl>( D ) ) {
+            if( ND->getName() == Name ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static bool isKeyword( const std::string &S )
+{
+    static const std::unordered_set<std::string> keywords = {
+        "alignas", "alignof", "and", "and_eq", "asm", "atomic_cancel", "atomic_commit",
+        "atomic_noexcept", "auto", "bitand", "bitor", "bool", "break", "case", "catch", "char",
+        "char8_t", "char16_t", "char32_t", "class", "compl", "concept", "const", "consteval",
+        "constexpr", "constinit", "const_cast", "continue", "co_await", "co_return", "co_yield",
+        "decltype", "default", "delete", "do", "double", "dynamic_cast", "else", "enum", "explicit",
+        "export", "extern", "false", "float", "for", "friend", "goto", "if", "inline", "int",
+        "long", "mutable", "namespace", "new", "noexcept", "not", "not_eq", "nullptr", "operator",
+        "or", "or_eq", "private", "protected", "public", "reflexpr", "register", "reinterpret_cast",
+        "requires", "return", "short", "signed", "sizeof", "static", "static_assert", "static_cast",
+        "struct", "switch", "synchronized", "template", "this", "thread_local", "throw", "true",
+        "try", "typedef", "typeid", "typename", "union", "unsigned", "using", "virtual", "void",
+        "volatile", "wchar_t", "while", "xor", "xor_eq",
+    };
+    return keywords.count( S );
+}
+
+static void CheckDecl( CombineLocalsIntoPointCheck &Check, const MatchFinder::MatchResult &Result )
+{
+    const VarDecl *XDecl = Result.Nodes.getNodeAs<VarDecl>( "xdecl" );
+    if( !XDecl ) {
+        return;
+    }
+
+    // Only one modification per function
+    if( !Check.alteredFunctions.insert( getContainingFunction( Result, XDecl ) ).second ) {
+        return;
+    }
+
+    const Decl *NextDecl = XDecl->getNextDeclInContext();
+    const VarDecl *YDecl = dyn_cast_or_null<VarDecl>( NextDecl );
+    if( !YDecl ) {
+        return;
+    }
+    NextDecl = YDecl->getNextDeclInContext();
+    const VarDecl *ZDecl = dyn_cast_or_null<VarDecl>( NextDecl );
+
+    // Avoid altering bool variables
+    if( StringRef( XDecl->getType().getAsString() ).endswith( "ool" ) ) {
+        return;
+    }
+
+    if( XDecl->getType().getTypePtr()->isUnsignedIntegerType() ) {
+        return;
+    }
+
+    NameConvention NameMatcher( XDecl->getName() );
+
+    if( !NameMatcher || NameMatcher.Match( YDecl->getName() ) != NameConvention::YName ) {
+        return;
+    }
+
+    if( ZDecl && NameMatcher.Match( ZDecl->getName() ) != NameConvention::ZName ) {
+        ZDecl = nullptr;
+    }
+
+    auto GetGrandparent = [&]( const Decl * D ) -> const Stmt* {
+        const Stmt *ParentStmt = getParent<Stmt>( Result, D );
+        if( !ParentStmt )
+        {
+            return nullptr;
+        }
+        return getParent<Stmt>( Result, ParentStmt );
+    };
+
+    // Verify that all the decls are in the same place
+    const Stmt *XGrandparentStmt = GetGrandparent( XDecl );
+    const Stmt *YGrandparentStmt = GetGrandparent( YDecl );
+
+    if( XGrandparentStmt != YGrandparentStmt ) {
+        return;
+    }
+
+    if( ZDecl ) {
+        const Stmt *ZGrandparentStmt = GetGrandparent( ZDecl );
+
+        if( XGrandparentStmt != ZGrandparentStmt ) {
+            ZDecl = nullptr;
+        }
+    }
+
+    const Expr *XInit = XDecl->getAnyInitializer();
+    const Expr *YInit = YDecl->getInit();
+    const Expr *ZInit = ZDecl ? ZDecl->getInit() : nullptr;
+
+    if( !XInit || !YInit || ( ZDecl && !ZInit ) ) {
+        return;
+    }
+
+    std::string NewVarName = NameMatcher.getRoot();
+
+    if( !NewVarName.empty() && NewVarName.front() == '_' ) {
+        NewVarName.erase( NewVarName.begin() );
+    }
+
+    if( !NewVarName.empty() && NewVarName.back() == '_' ) {
+        NewVarName.pop_back();
+    }
+
+    if( NewVarName.empty() ) {
+        NewVarName = "p";
+    }
+
+    if( !isalpha( NewVarName.front() ) ) {
+        NewVarName = "p" + NewVarName;
+    }
+
+    // Ensure we don't use a keyword
+    if( isKeyword( NewVarName ) ) {
+        NewVarName += "_";
+    }
+
+    // Ensure we don't collide with an existing name
+    const DeclContext *Context = XDecl->getDeclContext();
+    if( nameExistsInContext( Context, NewVarName ) ) {
+        for( int suffix = 2; ; ++suffix ) {
+            std::string Candidate = NewVarName + std::to_string( suffix );
+            if( !nameExistsInContext( Context, Candidate ) ) {
+                NewVarName = Candidate;
+                break;
+            }
+        }
+    }
+
+    Check.usageReplacements.emplace( XDecl, NewVarName + ".x" );
+    Check.usageReplacements.emplace( YDecl, NewVarName + ".y" );
+    if( ZDecl ) {
+        Check.usageReplacements.emplace( ZDecl, NewVarName + ".z" );
+    }
+
+    // Construct replacement text
+    std::string Replacement =
+        ( "point " + NewVarName + "( " + getText( Result, XInit ) + ", " +
+          getText( Result, YInit ) ).str();
+    if( ZDecl ) {
+        Replacement = ( "tri" + Replacement + ", " + getText( Result, ZInit ) ).str();
+    }
+    Replacement += " )";
+
+    if( XDecl->isConstexpr() ) {
+        Replacement = "constexpr " + Replacement;
+    } else if( XDecl->getType().isConstQualified() ) {
+        Replacement = "const " + Replacement;
+    }
+
+    if( XDecl->isStaticLocal() ) {
+        Replacement = "static " + Replacement;
+    }
+
+    SourceLocation EndLoc = ZDecl ? ZDecl->getEndLoc() : YDecl->getEndLoc();
+    SourceRange RangeToReplace( XDecl->getBeginLoc(), EndLoc );
+    std::string Message = ZDecl ?
+                          "Variables %0, %1, and %2 could be combined into a single 'tripoint' variable." :
+                          "Variables %0 and %1 could be combined into a single 'point' variable.";
+    Check.diag( XDecl->getBeginLoc(), Message )
+            << XDecl << YDecl << ZDecl
+            << FixItHint::CreateReplacement( RangeToReplace, Replacement );
+    Check.diag( YDecl->getLocation(), "%0 variable", DiagnosticIDs::Note ) << YDecl;
+    if( ZDecl ) {
+        Check.diag( ZDecl->getLocation(), "%0 variable", DiagnosticIDs::Note ) << ZDecl;
+    }
+}
+
+static void CheckDeclRef( CombineLocalsIntoPointCheck &Check,
+                          const MatchFinder::MatchResult &Result )
+{
+    const DeclRefExpr *DeclRef = Result.Nodes.getNodeAs<DeclRefExpr>( "declref" );
+    const VarDecl *Decl = Result.Nodes.getNodeAs<VarDecl>( "decl" );
+    if( !DeclRef || !Decl ) {
+        return;
+    }
+
+    auto Replacement = Check.usageReplacements.find( Decl );
+    if( Replacement == Check.usageReplacements.end() ) {
+        return;
+    }
+
+    if( getText( Result, DeclRef ) != Decl->getName() ) {
+        return;
+    }
+
+    Check.diag( DeclRef->getBeginLoc(), "Update %0 to '%1'.", DiagnosticIDs::Note )
+            << Decl << Replacement->second
+            << FixItHint::CreateReplacement( DeclRef->getSourceRange(), Replacement->second );
+}
+
+void CombineLocalsIntoPointCheck::check( const MatchFinder::MatchResult &Result )
+{
+    CheckDecl( *this, Result );
+    CheckDeclRef( *this, Result );
+}
+
+} // namespace cata
+} // namespace tidy
+} // namespace clang

--- a/tools/clang-tidy-plugin/CombineLocalsIntoPointCheck.h
+++ b/tools/clang-tidy-plugin/CombineLocalsIntoPointCheck.h
@@ -1,0 +1,38 @@
+#ifndef CATA_TOOLS_CLANG_TIDY_PLUGIN_COMBINELOCALSINTOPOINTCHECK_H
+#define CATA_TOOLS_CLANG_TIDY_PLUGIN_COMBINELOCALSINTOPOINTCHECK_H
+
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <llvm/ADT/StringRef.h>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "ClangTidy.h"
+
+namespace clang
+{
+
+namespace tidy
+{
+class ClangTidyContext;
+
+namespace cata
+{
+
+class CombineLocalsIntoPointCheck : public ClangTidyCheck
+{
+    public:
+        CombineLocalsIntoPointCheck( StringRef Name, ClangTidyContext *Context )
+            : ClangTidyCheck( Name, Context ) {}
+        void registerMatchers( ast_matchers::MatchFinder *Finder ) override;
+        void check( const ast_matchers::MatchFinder::MatchResult &Result ) override;
+        using ClangTidyCheck::getLangOpts;
+
+        std::unordered_map<const VarDecl *, std::string> usageReplacements;
+        std::unordered_set<const FunctionDecl *> alteredFunctions;
+};
+
+} // namespace cata
+} // namespace tidy
+} // namespace clang
+
+#endif // CATA_TOOLS_CLANG_TIDY_PLUGIN_COMBINELOCALSINTOPOINTCHECK_H

--- a/tools/clang-tidy-plugin/Utils.h
+++ b/tools/clang-tidy-plugin/Utils.h
@@ -43,6 +43,18 @@ inline StringRef getText( const ast_matchers::MatchFinder::MatchResult &Result, 
     return getText( Result, Node->getSourceRange() );
 }
 
+template<typename T, typename U>
+static const T *getParent( const ast_matchers::MatchFinder::MatchResult &Result, const U *Node )
+{
+    for( const ast_type_traits::DynTypedNode &parent : Result.Context->getParents( *Node ) ) {
+        if( const T *Candidate = parent.get<T>() ) {
+            return Candidate;
+        }
+    }
+
+    return nullptr;
+}
+
 template<typename T>
 static const FunctionDecl *getContainingFunction(
     const ast_matchers::MatchFinder::MatchResult &Result, const T *Node )
@@ -148,6 +160,10 @@ class NameConvention
 
         bool operator!() const {
             return !valid;
+        }
+
+        const std::string &getRoot() const {
+            return root;
         }
     private:
         std::string root;

--- a/tools/clang-tidy-plugin/test/combine-locals-into-point.cpp
+++ b/tools/clang-tidy-plugin/test/combine-locals-into-point.cpp
@@ -1,0 +1,161 @@
+// RUN: %check_clang_tidy %s cata-combine-locals-into-point %t -- -plugins=%cata_plugin -- -isystem %cata_include
+
+#define CATA_NO_STL
+#include "point.h"
+
+void f0( const point & );
+
+void g0()
+{
+    int rx = 7;
+    // CHECK-MESSAGES: warning: Variables 'rx' and 'ry' could be combined into a single 'point' variable. [cata-combine-locals-into-point]
+    // CHECK-FIXES: point r( 7, 14 );
+    int ry = 14;
+    f0( point( rx, ry ) );
+    // CHECK-MESSAGES: note: Update 'rx' to 'r.x'.
+    // CHECK-MESSAGES: note: Update 'ry' to 'r.y'.
+    // CHECK-FIXES: f0( point( r.x, r.y ) );
+}
+
+void g1()
+{
+    const int x_fall = 7;
+    // CHECK-MESSAGES: warning: Variables 'x_fall' and 'y_fall' could be combined into a single 'point' variable. [cata-combine-locals-into-point]
+    // CHECK-FIXES: const point fall( 7, 14 );
+    const int y_fall = 14;
+    f0( point( x_fall, y_fall ) );
+    // CHECK-MESSAGES: note: Update 'x_fall' to 'fall.x'.
+    // CHECK-MESSAGES: note: Update 'y_fall' to 'fall.y'.
+    // CHECK-FIXES: f0( point( fall.x, fall.y ) );
+}
+
+void g2()
+{
+    int x = 7;
+    // CHECK-MESSAGES: warning: Variables 'x' and 'y' could be combined into a single 'point' variable. [cata-combine-locals-into-point]
+    // CHECK-FIXES: point p( 7, 14 );
+    int y = 14;
+    f0( point( x, y ) );
+    // CHECK-MESSAGES: note: Update 'x' to 'p.x'.
+    // CHECK-MESSAGES: note: Update 'y' to 'p.y'.
+    // CHECK-FIXES: f0( point( p.x, p.y ) );
+}
+
+void g3()
+{
+    // Don't mess with variables when the second is in a for loop
+    int x = 7;
+    for( int y = 0; y < 10; ++y ) {
+        f0( point( x, y ) );
+    }
+}
+
+void g4()
+{
+    const int fall_x = 7;
+    // CHECK-MESSAGES: warning: Variables 'fall_x' and 'fall_y' could be combined into a single 'point' variable. [cata-combine-locals-into-point]
+    // CHECK-FIXES: const point fall( 7, 14 );
+    const int fall_y = 14;
+    f0( point( fall_x, fall_y ) );
+    // CHECK-MESSAGES: note: Update 'fall_x' to 'fall.x'.
+    // CHECK-MESSAGES: note: Update 'fall_y' to 'fall.y'.
+    // CHECK-FIXES: f0( point( fall.x, fall.y ) );
+}
+
+void g5()
+{
+    int x_ = 7;
+    // CHECK-MESSAGES: warning: Variables 'x_' and 'y_' could be combined into a single 'point' variable. [cata-combine-locals-into-point]
+    // CHECK-FIXES: point p( 7, 14 );
+    int y_ = 14;
+    /*INDENT-OFF*/
+    auto f = [&]() { x_ = 1; };
+    /*INDENT-ON*/
+    // CHECK-MESSAGES: note: Update 'x_' to 'p.x'.
+    // CHECK-FIXES: auto f = [&]() { p.x = 1; };
+}
+
+void g5( const tripoint &p )
+{
+    int x = p.x;
+    // CHECK-MESSAGES: warning: Variables 'x' and 'y' could be combined into a single 'point' variable. [cata-combine-locals-into-point]
+    // CHECK-FIXES: point p2( p.x, p.y );
+    int y = p.y;
+    x = 1;
+    // CHECK-MESSAGES: note: Update 'x' to 'p2.x'.
+    // CHECK-FIXES: p2.x = 1;
+}
+
+void g6()
+{
+    int new_x = 0;
+    // CHECK-MESSAGES: warning: Variables 'new_x' and 'new_y' could be combined into a single 'point' variable. [cata-combine-locals-into-point]
+    // CHECK-FIXES: point new_( 0, 1 );
+    int new_y = 1;
+    new_x = 1;
+    // CHECK-MESSAGES: note: Update 'new_x' to 'new_.x'.
+    // CHECK-FIXES: new_.x = 1;
+}
+
+void g7()
+{
+    int x = 0;
+    // CHECK-MESSAGES: warning: Variables 'x', 'y', and 'z' could be combined into a single 'tripoint' variable. [cata-combine-locals-into-point]
+    // CHECK-FIXES: tripoint p( 0, 1, 2 );
+    int y = 1;
+    int z = 2;
+    x = 1;
+    // CHECK-MESSAGES: note: Update 'x' to 'p.x'.
+    // CHECK-FIXES: p.x = 1;
+}
+
+void g8( const tripoint &p1 )
+{
+    int x1 = p1.x;
+    // CHECK-MESSAGES: warning: Variables 'x1' and 'y1' could be combined into a single 'point' variable. [cata-combine-locals-into-point]
+    // CHECK-FIXES: point p12( p1.x, p1.y );
+    int y1 = p1.y;
+    x1 = 1;
+    // CHECK-MESSAGES: note: Update 'x1' to 'p12.x'.
+    // CHECK-FIXES: p12.x = 1;
+}
+
+void g9()
+{
+    // Don't mess with bools
+    bool x = false;
+    bool y = true;
+    const bool x1 = false;
+    const bool y1 = true;
+}
+
+void g10()
+{
+    // When multiple changes to be done in one function, only perform one (to
+    // avoid overlapping replacements)
+    int x = 0;
+    // CHECK-MESSAGES: warning: Variables 'x' and 'y' could be combined into a single 'point' variable. [cata-combine-locals-into-point]
+    // CHECK-FIXES: point p( 0, 1 );
+    int y = 1;
+    int x1 = x;
+    int y1 = y;
+}
+
+void g11()
+{
+    // When multiple changes to be done in one function, only perform one (to
+    // avoid overlapping replacements)
+    static constexpr int x = 0;
+    // CHECK-MESSAGES: warning: Variables 'x' and 'y' could be combined into a single 'point' variable. [cata-combine-locals-into-point]
+    // CHECK-FIXES: static constexpr point p( 0, 1 );
+    static constexpr int y = 1;
+}
+
+void g12()
+{
+    // Don't mess with unsigned things
+    unsigned x = false;
+    unsigned y = true;
+    const unsigned x1 = false;
+    const unsigned y1 = true;
+}

--- a/tools/clang-tidy-plugin/test/point-initialization.cpp
+++ b/tools/clang-tidy-plugin/test/point-initialization.cpp
@@ -10,13 +10,26 @@ struct non_point {
 
 point p0 = point_zero;
 // CHECK-MESSAGES: warning: Unnecessary initialization of 'p0'. 'point' is zero-initialized by default. [cata-point-initialization]
+// CHECK-FIXES: point p0;
 point p1( 0, 0 );
 // CHECK-MESSAGES: warning: Unnecessary initialization of 'p1'. 'point' is zero-initialized by default. [cata-point-initialization]
+// CHECK-FIXES: point p1;
+point p2( point_zero );
+// CHECK-MESSAGES: warning: Unnecessary initialization of 'p2'. 'point' is zero-initialized by default. [cata-point-initialization]
+// CHECK-FIXES: point p2;
+const point p3 = point_zero;
+// CHECK-MESSAGES: warning: Unnecessary initialization of 'p3'. 'point' is zero-initialized by default. [cata-point-initialization]
+// CHECK-FIXES: const point p3;
+static constexpr point p4 = point_zero;
+// CHECK-MESSAGES: warning: Unnecessary initialization of 'p4'. 'point' is zero-initialized by default. [cata-point-initialization]
+// CHECK-FIXES: static constexpr point p4;
 
 tripoint t0 = tripoint_zero;
 // CHECK-MESSAGES: warning: Unnecessary initialization of 't0'. 'tripoint' is zero-initialized by default. [cata-point-initialization]
+// CHECK-FIXES: tripoint t0;
 tripoint t1( 0, 0, 0 );
 // CHECK-MESSAGES: warning: Unnecessary initialization of 't1'. 'tripoint' is zero-initialized by default. [cata-point-initialization]
+// CHECK-FIXES: tripoint t1;
 
 // Verify that it doesn't trigger on only some zero args
 tripoint t1a( 0, 0, 1 );


### PR DESCRIPTION
#### Purpose of change
Slowly chipping away at remaining point refactors with type-safe coords being the final goal.

#### Describe the solution
Cherry-picked code from:
https://github.com/CleverRaven/Cataclysm-DDA/pull/41231
https://github.com/CleverRaven/Cataclysm-DDA/pull/41238
https://github.com/CleverRaven/Cataclysm-DDA/pull/40572

+Some compilation fixes and changes to BN-specific code.

+Changed (tri)point constructors to initializer lists for consistent init order (see https://github.com/CleverRaven/Cataclysm-DDA/pull/41238#issuecomment-643626902 )

#### Testing
Compiles, tests pass.
Some code produced by automatic refactor is quite ugly, but I've decided to keep it to avoid excessive merge conflicts.