### PR TITLE
Port over change giving churls a historical knife

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -531,7 +531,7 @@
     "items": {
       "both": {
         "items": [ "footrags", "loincloth", "cloak_wool", "ragpouch", "small_relic", "gloves_wraps", "tunic_rag" ],
-        "entries": [ { "item": "makeshift_knife", "container-item": "sheath" } ]
+        "entries": [ { "item": "knife_baselard", "container-item": "sheath" } ]
       },
       "female": [ "chestwrap" ]
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Port over minor DDA change giving the churl a baselard instead of makeshift knife"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Simple and easy change, reasoning as per the source PR:

> The Makeshift Knife is a chunk of recycled stainless steel scrap metal. The Churl, being a medieval peasant, starts with a Makeshift Knife- the implication is that it's all they could afford to build or borrow. Where did a 14th century English peasant get STEEL to recycle in the first place, and why don't they have a real knife instead of scrap metal with a rag tied to it?

In practice, the distinction between steel and iron is not a useful one as regards historical accuracy, but the idea of giving the churl something that's actually from the medieval period (admittedly late medieval) instead of a post-apoc scrap knife is sound and a lot more fitting the profession's flavor.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Replaced the makeshift knife in the churl's inventory with a baselard.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Per the source PR, using copper knife instead despite it not being very logical either.
2. Adding a seax or something else a lil closer to "generic iron knife that has probably existed in some form since antiquity" than a German/Swiss evolution of the knightly dagger, if we wanted to go full history nerd. Eh, this is still miles closer to fitting the profession than a post-apoc scrap knife.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

No lint or syntax errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Sauce: https://github.com/CleverRaven/Cataclysm-DDA/pull/40280