### PR TITLE
Port over changes to tailor mods

### DIFF
--- a/data/json/clothing_mods.json
+++ b/data/json/clothing_mods.json
@@ -7,9 +7,10 @@
     "implement_prompt": "Pad with leather",
     "destroy_prompt": "Destroy leather padding",
     "mod_value": [
-      { "type": "bash", "value": 1, "proportion": [ "thickness", "coverage" ] },
-      { "type": "cut", "value": 1, "proportion": [ "thickness", "coverage" ] },
-      { "type": "encumbrance", "value": 2, "round_up": true, "proportion": [ "thickness", "coverage" ] }
+      { "type": "bash", "value": 1, "proportion": [ "thickness" ] },
+      { "type": "cut", "value": 1, "proportion": [ "thickness" ] },
+      { "type": "encumbrance", "value": 2, "round_up": true, "proportion": [ "thickness", "coverage" ] },
+      { "type": "warmth", "value": 1, "proportion": [ "thickness", "coverage" ] }
     ]
   },
   {
@@ -21,9 +22,10 @@
     "destroy_prompt": "Destroy steel padding",
     "restricted": true,
     "mod_value": [
-      { "type": "bash", "value": 1, "proportion": [ "thickness", "coverage" ] },
-      { "type": "cut", "value": 1, "proportion": [ "thickness", "coverage" ] },
-      { "type": "encumbrance", "value": 2, "round_up": true, "proportion": [ "thickness", "coverage" ] }
+      { "type": "bash", "value": 3, "proportion": [ "thickness" ] },
+      { "type": "cut", "value": 3, "proportion": [ "thickness" ] },
+      { "type": "encumbrance", "value": 5, "round_up": true, "proportion": [ "thickness", "coverage" ] },
+      { "type": "warmth", "value": 1, "proportion": [ "thickness", "coverage" ] }
     ]
   },
   {
@@ -34,9 +36,10 @@
     "implement_prompt": "Pad with Kevlar",
     "destroy_prompt": "Destroy Kevlar padding",
     "mod_value": [
-      { "type": "bash", "value": 1, "proportion": [ "thickness", "coverage" ] },
-      { "type": "cut", "value": 2, "proportion": [ "thickness", "coverage" ] },
-      { "type": "encumbrance", "value": 2, "round_up": true, "proportion": [ "thickness", "coverage" ] }
+      { "type": "bash", "value": 1, "proportion": [ "thickness" ] },
+      { "type": "cut", "value": 2, "proportion": [ "thickness" ] },
+      { "type": "encumbrance", "value": 2, "round_up": true, "proportion": [ "thickness", "coverage" ] },
+      { "type": "warmth", "value": 1, "proportion": [ "thickness", "coverage" ] }
     ]
   },
   {

--- a/data/json/clothing_mods.json
+++ b/data/json/clothing_mods.json
@@ -9,8 +9,7 @@
     "mod_value": [
       { "type": "bash", "value": 1, "proportion": [ "thickness" ] },
       { "type": "cut", "value": 1, "proportion": [ "thickness" ] },
-      { "type": "encumbrance", "value": 2, "round_up": true, "proportion": [ "thickness", "coverage" ] },
-      { "type": "warmth", "value": 1, "proportion": [ "thickness", "coverage" ] }
+      { "type": "encumbrance", "value": 2, "round_up": true, "proportion": [ "thickness", "coverage" ] }
     ]
   },
   {
@@ -24,8 +23,7 @@
     "mod_value": [
       { "type": "bash", "value": 3, "proportion": [ "thickness" ] },
       { "type": "cut", "value": 3, "proportion": [ "thickness" ] },
-      { "type": "encumbrance", "value": 5, "round_up": true, "proportion": [ "thickness", "coverage" ] },
-      { "type": "warmth", "value": 1, "proportion": [ "thickness", "coverage" ] }
+      { "type": "encumbrance", "value": 5, "round_up": true, "proportion": [ "thickness", "coverage" ] }
     ]
   },
   {
@@ -38,8 +36,7 @@
     "mod_value": [
       { "type": "bash", "value": 1, "proportion": [ "thickness" ] },
       { "type": "cut", "value": 2, "proportion": [ "thickness" ] },
-      { "type": "encumbrance", "value": 2, "round_up": true, "proportion": [ "thickness", "coverage" ] },
-      { "type": "warmth", "value": 1, "proportion": [ "thickness", "coverage" ] }
+      { "type": "encumbrance", "value": 2, "round_up": true, "proportion": [ "thickness", "coverage" ] }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Port over changes to armor padding"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This ports over changes from DDA to leather padding, kevlar padding, and steel. Per the source PR, it makes steel armor padding actually distinct from leather and makes it so coverage does not factor into the protection, which makes it more viable to try and apply this to low-coverage objects.

Also, I might be planning to make superalloy padding a thing since superalloy sheets are currently only used in the MBR vest variant, for which I'd want the existing armormods to have their balance up to date before I think with adding that idea.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Ported over change implementing higher cut and bash protection for steel padding.
2. Ported over change making all three padding types modify their protection based on thickness, no longer caring about coverage.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. 
-->

With fur being more or less identical to leather protection-wise, maybe fur lining should get the same bash/cut bonuses as leather?

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Tested affected file for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/45713

Things not ported over:
1. Bonuses to ballistic damage types. I'll have to do these when I port over the ballistic damage type and rebalance it accordingly.
2. Because of the above, the cut protection of kevlar is unchanged for now, rather than reduced by .5 like in DDA.
3. The bonus warmth was dropped, per feedback suggesting it to be utterly pointless.