### PR TITLE
Fix two lines in mission dialogue to be a bit less odd

### DIFF
--- a/data/json/npcs/TALK_COMMON_MISSION.json
+++ b/data/json/npcs/TALK_COMMON_MISSION.json
@@ -51,7 +51,7 @@
           }
         },
         "no": {
-          "has_no_assigned_mission": "I have another job for you.  Want to hear about it?",
+          "has_no_assigned_mission": "I have a job for you.  Want to hear about it?",
           "no": {
             "has_many_assigned_missions": "I just have one job for you.  Want to hear about it?",
             "no": "I just have one job for you.  Want to hear about it?"
@@ -248,7 +248,7 @@
         "effect": { "npc_add_effect": "npc_player_still_looking", "duration": 43200 }
       },
       {
-        "text": "Mission success!  I don't know what else to say.",
+        "text": "Mission success!",
         "topic": "TALK_MISSION_SUCCESS",
         "condition": "mission_complete",
         "switch": true,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix two lines of mission dialogue"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Couple bits of mission talk topic were a bit odd. In particular, the "I have another mission" line showing up even when it's your first mission from that NPC. Far as I can tell the only way to actually get it to track whether you'd done a mission in the past would be add_var stuff but that'd have to be inserted into every single missiondef.

The other one was the "I don't know what else to say" one sounding like a debug message. Which, it sorta is but also in the context it shows up there is basically no way to actually replace it with custom mission success lines. It's the one used for conditional goal missions.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed "another job" line to "a job" since this line also shows up on your first mission from them.
2. Removed the "I don't know what else to say." bit from success message for conditional-goal missions to make it less obvious that it's a fallback message that's being intentionally used (vanilla usage is currently the cattail jelly mission).

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

As mentioned, implementing a u_add_var to every mission so NPCs could track if you've done a mission for them before would also fix the first problem, but it'd be a lot more effort over what amounts to a one-word change in the line.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
