### PR TITLE
Cherry-pick DDA fix for segfault during subway generation

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1797,14 +1797,6 @@ bool overmap::generate_sub( const int z )
     subway_points.insert( subway_points.end(), subway_lab_train_points.begin(),
                           subway_lab_train_points.end() );
     connect_closest_points( subway_points, z, *subway_tunnel );
-    // If on z = 4 and central lab is present, be sure to connect normal labs and central labs (just in case).
-    // Unless we're center of the world - then central lab has no train connections
-    const bool true_center = pos() == point_zero;
-    if( z == -4 && !central_lab_points.empty() && !true_center ) {
-        std::vector<point> extra_route;
-        extra_route.push_back( subway_lab_train_points.back() );
-        connect_closest_points( extra_route, z, *subway_tunnel );
-    }
 
     for( auto &i : subway_points ) {
         if( is_ot_match( "sub_station", ter( tripoint( i, z + 2 ) ), ot_match_type::type ) ) {


### PR DESCRIPTION
Source PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/47144

Segfault can be reproduced in BN when running tests on version 31c2adc6d885f750f3cbc34f72b2e61bc44493be with seed 1631905804 (compiled as `make TILES=1` with `g++ (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0`).