### PR TITLE
Speed up recipe search by item description

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3625,7 +3625,7 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
     }
 
     // does the item fit in any holsters?
-    std::vector<const itype *> holsters = Item_factory::find( [this]( const itype & e ) {
+    std::vector<const itype *> holsters = item_controller->find( [this]( const itype & e ) {
         if( !e.can_use( "holster" ) ) {
             return false;
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3712,7 +3712,9 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
     if( parts->test( iteminfo_parts::DESCRIPTION_APPLICABLE_RECIPES ) ) {
         itype_id tid = contents.empty() ? typeId() : contents.front().typeId();
         const inventory &crafting_inv = g->u.crafting_inventory();
-        const recipe_subset available_recipe_subset = g->u.get_available_recipes( crafting_inv );
+
+        const recipe_subset available_recipe_subset = g->u.get_available_recipes( crafting_inv, nullptr,
+                recipe_filter_by_component( tid ) );
         const std::set<const recipe *> &item_recipes = available_recipe_subset.of_component( tid );
 
         if( item_recipes.empty() ) {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3183,14 +3183,22 @@ std::vector<const itype *> Item_factory::get_runtime_types() const
 /** Find all templates matching the UnaryPredicate function */
 std::vector<const itype *> Item_factory::find( const std::function<bool( const itype & )> &func )
 {
+    assert( frozen );
+
     std::vector<const itype *> res;
 
-    std::vector<const itype *> opts = item_controller->all();
-
-    std::copy_if( opts.begin(), opts.end(), std::back_inserter( res ),
-    [&func]( const itype * e ) {
-        return func( *e );
-    } );
+    for( const auto &e : m_templates ) {
+        const itype *i = &e.second;
+        if( func( *i ) ) {
+            res.push_back( i );
+        }
+    }
+    for( const auto &e : m_runtimes ) {
+        const itype *i = e.second.get();
+        if( func( *i ) ) {
+            res.push_back( i );
+        }
+    }
 
     return res;
 }

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -223,7 +223,7 @@ class Item_factory
         std::vector<const itype *> get_runtime_types() const;
 
         /** Find all item templates (both static and runtime) matching UnaryPredicate function */
-        static std::vector<const itype *> find( const std::function<bool( const itype & )> &func );
+        std::vector<const itype *> find( const std::function<bool( const itype & )> &func );
 
         /**
          * Create a new (and currently unused) item type id.

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2876,7 +2876,7 @@ units::volume bandolier_actor::max_stored_volume() const
     // This is relevant only for bandoliers with the non-rigid flag
 
     // Find all valid ammo
-    auto ammo_types = Item_factory::find( [&]( const itype & t ) {
+    auto ammo_types = item_controller->find( [&]( const itype & t ) {
         return is_valid_ammo_type( t );
     } );
     // Figure out which has the greatest volume and calculate on that basis

--- a/src/player.h
+++ b/src/player.h
@@ -69,6 +69,8 @@ struct item_comp;
 struct tool_comp;
 struct w_point;
 
+using recipe_filter = std::function<bool( const recipe &r )>;
+
 /** @relates ret_val */
 template<>
 struct ret_val<edible_rating>::default_success : public
@@ -562,14 +564,17 @@ class player : public Character
         /** Returns all known recipes. */
         const recipe_subset &get_learned_recipes() const;
         /** Returns all recipes that are known from the books (either in inventory or nearby). */
-        recipe_subset get_recipes_from_books( const inventory &crafting_inv ) const;
+        recipe_subset get_recipes_from_books( const inventory &crafting_inv,
+                                              recipe_filter filter = nullptr ) const;
         /**
           * Returns all available recipes (from books and npc companions)
           * @param crafting_inv Current available items to craft
           * @param helpers List of NPCs that could help with crafting.
+          * @param filter If set, will return only recipes that match the filter (should be much faster).
           */
         recipe_subset get_available_recipes( const inventory &crafting_inv,
-                                             const std::vector<npc *> *helpers = nullptr ) const;
+                                             const std::vector<npc *> *helpers = nullptr,
+                                             recipe_filter filter = nullptr ) const;
 
         // crafting.cpp
         float morale_crafting_speed_multiplier( const recipe &rec ) const;

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -76,6 +76,20 @@ const recipe &recipe_dictionary::get_uncraft( const itype_id &id )
     return iter != recipe_dict.uncraft.end() ? iter->second : null_recipe;
 }
 
+recipe_filter recipe_filter_by_component( const itype_id &c )
+{
+    return [c]( const recipe & r ) {
+        for( const auto &opts : r.simple_requirements().get_components() ) {
+            for( const item_comp &comp : opts ) {
+                if( comp.type == c ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+}
+
 // searches for left-anchored partial match in the relevant recipe requirements set
 template <class group>
 bool search_reqs( group gp, const std::string &txt )

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -74,6 +74,10 @@ class recipe_dictionary
 
 extern recipe_dictionary recipe_dict;
 
+using recipe_filter = std::function<bool( const recipe &r )>;
+
+recipe_filter recipe_filter_by_component( const itype_id &c );
+
 class recipe_subset
 {
     public:


### PR DESCRIPTION
#### Purpose of change
I noticed that `d:` search in crafting UI takes enormous amount of time, particularly for characters that know all recipes.
In VS release build, it takes 27 seconds. Changes in this PR cut that number down to 4 seconds.

#### Describe the solution
When profiling, I noticed that approximately 70% of time is spent on formatting `You could use it to craft` item info section. Out of those 70%, 50% is spent on creating new `recipe_subset` from list of known recipes, and remaining 20% is spent on destroying the subset.

I've managed to bring the time down to 5 seconds by filtering out recipes that don't have the item as component before adding them to the subset.

Additional 1 second was squeezed out by getting rid of vector allocation in `Item_factory::find`, and iterating over original vectors instead.

#### Describe alternatives you've considered
Out of remaining time, approximately third is spent on finding holster iuse within all items, and another third on calling `res.include_if( get_learned_recipes(), filter )`, so there is definitely room for improvement.

#### Testing
In curses release build, searching for `d:longp` across all recipes is completed in 4 seconds (down from 11). 