### PR TITLE
Disable helicopter rotor collision

### DIFF
--- a/data/json/game_balance.json
+++ b/data/json/game_balance.json
@@ -208,12 +208,5 @@
     "info": "Makes mutation more balanced and interesting.",
     "stype": "bool",
     "value": true
-  },
-  {
-    "type": "EXTERNAL_OPTION",
-    "name": "HELI_ROTOR_COLLISION",
-    "info": "Allow helicopter rotors to collide with varous things.",
-    "stype": "bool",
-    "value": false
   }
 ]

--- a/data/json/game_balance.json
+++ b/data/json/game_balance.json
@@ -208,5 +208,12 @@
     "info": "Makes mutation more balanced and interesting.",
     "stype": "bool",
     "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "HELI_ROTOR_COLLISION",
+    "info": "Allow helicopter rotors to collide with varous things.",
+    "stype": "bool",
+    "value": false
   }
 ]

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -417,20 +417,6 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
         //  and turning (precalc[1])
         const tripoint dsp = global_pos3() + dp + parts[p].precalc[1];
         veh_collision coll = part_collision( p, dsp, just_detect, bash_floor );
-        if( coll.type == veh_coll_nothing && info.rotor_diameter() > 0 ) {
-            size_t radius = static_cast<size_t>( std::round( info.rotor_diameter() / 2.0f ) );
-            for( const tripoint &rotor_point : g->m.points_in_radius( dsp, radius ) ) {
-                veh_collision rotor_coll = part_collision( p, rotor_point, just_detect, false );
-                if( rotor_coll.type != veh_coll_nothing ) {
-                    coll = rotor_coll;
-                    if( just_detect ) {
-                        break;
-                    } else {
-                        colls.push_back( rotor_coll );
-                    }
-                }
-            }
-        }
         if( coll.type == veh_coll_nothing ) {
             continue;
         }
@@ -543,10 +529,6 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
     if( is_body_collision ) {
         // critters on a BOARDABLE part in this vehicle aren't colliding
         if( ovp && ( &ovp->vehicle() == this ) && get_pet( ovp->part_index() ) ) {
-            return ret;
-        }
-        // Rotors only collide with huge creatures
-        if( part_info( part ).rotor_diameter() > 0 && critter->get_size() != MS_HUGE ) {
             return ret;
         }
         // we just ran into a fish, so move it out of the way

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -417,8 +417,7 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
         //  and turning (precalc[1])
         const tripoint dsp = global_pos3() + dp + parts[p].precalc[1];
         veh_collision coll = part_collision( p, dsp, just_detect, bash_floor );
-        bool rotor_collision = get_option<bool>( "HELI_ROTOR_COLLISION" );
-        if( rotor_collision && coll.type == veh_coll_nothing && info.rotor_diameter() > 0 ) {
+        if( coll.type == veh_coll_nothing && info.rotor_diameter() > 0 ) {
             size_t radius = static_cast<size_t>( std::round( info.rotor_diameter() / 2.0f ) );
             for( const tripoint &rotor_point : g->m.points_in_radius( dsp, radius ) ) {
                 veh_collision rotor_coll = part_collision( p, rotor_point, just_detect, false );

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -417,7 +417,8 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
         //  and turning (precalc[1])
         const tripoint dsp = global_pos3() + dp + parts[p].precalc[1];
         veh_collision coll = part_collision( p, dsp, just_detect, bash_floor );
-        if( coll.type == veh_coll_nothing && info.rotor_diameter() > 0 ) {
+        bool rotor_collision = get_option<bool>( "HELI_ROTOR_COLLISION" );
+        if( rotor_collision && coll.type == veh_coll_nothing && info.rotor_diameter() > 0 ) {
             size_t radius = static_cast<size_t>( std::round( info.rotor_diameter() / 2.0f ) );
             for( const tripoint &rotor_point : g->m.points_in_radius( dsp, radius ) ) {
                 veh_collision rotor_coll = part_collision( p, rotor_point, just_detect, false );


### PR DESCRIPTION
Disable helicopter rotor collision and add option to enable it back

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Features "Disable helicopter rotor collision"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: Features "Disable helicopter rotor collision and add option to enable it"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
https://github.com/cataclysmbnteam/Cataclysm-BN/pull/819#issuecomment-907669620
>DrPariah 
> Do rotors still collide with map features? As an example, small boulders or young trees? If they do, it'd be nice to have no collision at all. It's super frustrating to finally find a working helicopter and lose it because the rotors disintegrated due to a twig being one space too close.

I've seen previously people complained about this exactly. Rotors are invisible for player and it is way too easy to lose it - and after that your flight is over.  It limits helicopter usablity a lot. Additionally warning about collision are not alway in place.
So I propose to disable collisions for rotor until better solution will be found for warning and rotor visibility.



<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Disable helicopter rotor collision. It has to be rewritten.
For now we can pretend that rotors are  placed "quite high" to hit something. Obvisoly it is not very relistic but it supposed to increase helicoper usability by a lot - no more instant rotor loss with random thing.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Put option to disable in debug menu inside game?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Spawn helicopter.
2) Fly to the nearest forest.
3) Land helicopter near tree line.
4) Take off.
5) Helicopter rotors are safe.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
Obviously it's not the better solution, but it should increase helicopter usability by removing most obvious complain.
**Save file for testing:**
[Heli2.zip](https://github.com/cataclysmbnteam/Cataclysm-BN/files/7220077/Heli2.zip)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
