### PR TITLE
Reduce debug.log file size by folding consecutive identical errors (Port of CDDA PR 51791)

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -138,6 +138,7 @@ struct buffered_prompt_info {
     std::string line;
     std::string funcname;
     std::string text;
+    bool force;
 };
 
 namespace
@@ -159,7 +160,8 @@ static void debug_error_prompt(
     const char *filename,
     const char *line,
     const char *funcname,
-    const char *text )
+    const char *text,
+    bool force )
 {
     assert( catacurses::stdscr );
     assert( filename != nullptr );
@@ -170,7 +172,7 @@ static void debug_error_prompt(
     std::string msg_key( filename );
     msg_key += line;
 
-    if( ignored_messages.count( msg_key ) > 0 ) {
+    if( !force && ignored_messages.count( msg_key ) > 0 ) {
         return;
     }
 
@@ -269,11 +271,98 @@ void replay_buffered_debugmsg_prompts()
             prompt.filename.c_str(),
             prompt.line.c_str(),
             prompt.funcname.c_str(),
-            prompt.text.c_str()
+            prompt.text.c_str(),
+            prompt.force
         );
     }
     buffered_prompts().clear();
 }
+
+struct time_info {
+    int hours;
+    int minutes;
+    int seconds;
+    int mseconds;
+
+    template <typename Stream>
+    friend Stream &operator<<( Stream &out, const time_info &t ) {
+        using char_t = typename Stream::char_type;
+        using base   = std::basic_ostream<char_t>;
+
+        static_assert( std::is_base_of<base, Stream>::value, "" );
+
+        out << std::setfill( '0' );
+        out << std::setw( 2 ) << t.hours << ':' << std::setw( 2 ) << t.minutes << ':' <<
+            std::setw( 2 ) << t.seconds << '.' << std::setw( 3 ) << t.mseconds;
+
+        return out;
+    }
+};
+
+static time_info get_time() noexcept;
+
+struct repetition_folder {
+    const char *m_filename = nullptr;
+    const char *m_line = nullptr;
+    const char *m_funcname = nullptr;
+    std::string m_text;
+    time_info m_time;
+
+    static constexpr time_info timeout = { 0, 0, 0, 100 }; // 100ms timeout
+    static constexpr int repetition_threshold = 10000;
+
+    int repeat_count = 0;
+
+    bool test( const char *filename, const char *line, const char *funcname, const std::string &text ) {
+        return m_filename == filename &&
+               m_line == line &&
+               m_funcname == funcname &&
+               m_text == text &&
+               !timed_out();
+    }
+    void set_time() {
+        m_time = get_time();
+    }
+    void set( const char *filename, const char *line, const char *funcname, const std::string &text ) {
+        m_filename = filename;
+        m_line = line;
+        m_funcname = funcname;
+        m_text = text;
+
+        set_time();
+
+        repeat_count = 0;
+    }
+    void increment_count() {
+        ++repeat_count;
+        set_time();
+    }
+    void reset() {
+        m_filename = nullptr;
+        m_line = nullptr;
+        m_funcname = nullptr;
+
+        m_time = time_info{0, 0, 0, 0};
+
+        repeat_count = 0;
+    }
+
+    bool timed_out() {
+        const time_info now = get_time();
+
+        const int now_raw = now.mseconds + 1000 * now.seconds + 60000 * now.minutes + 3600000 * now.hours;
+        const int old_raw = m_time.mseconds + 1000 * m_time.seconds + 60000 * m_time.minutes + 3600000 *
+                            m_time.hours;
+
+        const int timeout_raw = timeout.mseconds + 1000 * timeout.seconds + 60000 * timeout.minutes +
+                                3600000 * timeout.hours;
+
+        return ( now_raw - old_raw ) > timeout_raw;
+    }
+};
+
+static repetition_folder rep_folder;
+static void output_repetitions( std::ostream &out );
 
 void realDebugmsg( const char *filename, const char *line, const char *funcname,
                    const std::string &text )
@@ -285,19 +374,44 @@ void realDebugmsg( const char *filename, const char *line, const char *funcname,
     if( capturing ) {
         captured += text;
     } else {
-        *detail::realDebugLog( DL::Error, DC::DebugMsg, filename, line, funcname ) << text;
+        if( !rep_folder.test( filename, line, funcname, text ) ) {
+            *detail::realDebugLog( DL::Error, DC::DebugMsg, filename, line, funcname ) << text;
+            rep_folder.set( filename, line, funcname, text );
+        } else {
+            rep_folder.increment_count();
+        }
     }
 
     if( test_mode ) {
         return;
     }
 
+    // Show excessive repetition prompt once per excessive set
+    bool excess_repetition = rep_folder.repeat_count == repetition_folder::repetition_threshold;
+
     if( buffering_debugmsgs ) {
-        buffered_prompts().push_back( {filename, line, funcname, text } );
+        buffered_prompts().push_back( {filename, line, funcname, text, false } );
+        if( excess_repetition ) {
+            // prepend excessive error repetition to original text then prompt
+            std::string rep_err =
+                "Excessive error repetition detected.  Please file a bug report at https://github.com/cataclysmbnteam/Cataclysm-BN/issues\n            "
+                + text;
+            buffered_prompts().push_back( {filename, line, funcname, rep_err, true } );
+        }
         return;
     }
 
-    debug_error_prompt( filename, line, funcname, text.c_str() );
+    debug_error_prompt( filename, line, funcname, text.c_str(), false );
+    if( excess_repetition ) {
+        // prepend excessive error repetition to original text then prompt
+        std::string rep_err =
+            "Excessive error repetition detected.  Please file a bug report at https://github.com/cataclysmbnteam/Cataclysm-BN/issues\n            "
+            + text;
+        debug_error_prompt( filename, line, funcname, rep_err.c_str(), true );
+        // Do not count this prompt when considering repetition folding
+        // Might look weird in the log if the repetitions end exactly after this prompt is displayed.
+        rep_folder.set_time();
+    }
 }
 
 // Normal functions                                                 {{{1
@@ -381,27 +495,6 @@ struct NullBuf : public std::streambuf {
 // DebugFile OStream Wrapper                                        {{{2
 // ---------------------------------------------------------------------
 
-struct time_info {
-    int hours;
-    int minutes;
-    int seconds;
-    int mseconds;
-
-    template <typename Stream>
-    friend Stream &operator<<( Stream &out, const time_info &t ) {
-        using char_t = typename Stream::char_type;
-        using base   = std::basic_ostream<char_t>;
-
-        static_assert( std::is_base_of<base, Stream>::value, "" );
-
-        out << std::setfill( '0' );
-        out << std::setw( 2 ) << t.hours << ':' << std::setw( 2 ) << t.minutes << ':' <<
-            std::setw( 2 ) << t.seconds << '.' << std::setw( 3 ) << t.mseconds;
-
-        return out;
-    }
-};
-
 #if defined(_MSC_VER)
 static time_info get_time() noexcept
 {
@@ -465,6 +558,7 @@ DebugFile::~DebugFile()
 void DebugFile::deinit()
 {
     if( file && file.get() != &std::cerr ) {
+        output_repetitions( *file );
         *file << get_time() << " : Log shutdown.\n";
         *file << "-----------------------------------------\n\n";
     }
@@ -1019,6 +1113,25 @@ void debug_write_backtrace( std::ostream &out )
 }
 #endif
 
+void output_repetitions( std::ostream &out )
+{
+    // Need to complete the folding
+    if( rep_folder.repeat_count > 0 ) {
+        if( rep_folder.repeat_count > 1 ) {
+            out << "[ Previous repeated " << ( rep_folder.repeat_count - 1 ) << " times ]";
+        }
+        out << std::endl;
+        out << rep_folder.m_time << " ";
+        // repetition folding is only done through realDebugmsg
+        out << io::enum_to_string<DL>( DL::Error ) << " ";
+        out << io::enum_to_string<DC>( DC::DebugMsg ) << " ";
+        out << ": ";
+        out << rep_folder.m_filename << ":" << rep_folder.m_line << " [" << rep_folder.m_funcname << "] " <<
+            rep_folder.m_text << std::endl;
+        rep_folder.reset();
+    }
+}
+
 detail::DebugLogGuard::~DebugLogGuard()
 {
     *s << std::endl;
@@ -1033,6 +1146,9 @@ detail::DebugLogGuard detail::realDebugLog( DL lev, DC cl, const char *filename,
 
     if( checkDebugLevelClass( lev, cl ) ) {
         std::ostream &out = debugFile().get_file();
+
+        output_repetitions( out );
+
         out << get_time() << " ";
         out << io::enum_to_string<DL>( lev ) << " ";
         if( cl != DC::Main ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfixes "Reduce debug.log file size by folding consecutive identical errors"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Should prevent log file from growing into gigabytes when the same message is repeatedly and rapidly logged.
See https://github.com/CleverRaven/Cataclysm-DDA/issues/50017 for example.
This is a port of my CDDA PR with minor changes for formatting: https://github.com/CleverRaven/Cataclysm-DDA/pull/51791
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
This PR does two things to mitigate the issue.
1. Folds identical errors as much as possible by tracking the unique information of an error (filename, line, function, error message ) and increments a counter if these are identical AND the newest error is within a 100ms window following the previous error. 100ms is a lot of time for a computer, so if the threshold is exceeded it is probably unique enough to deserve its own error line.
2. Each run of 10000 or more identical errors will generate a prompt asking the user to file an issue. The prompt will be generated even if the originating error has been ignored.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Original version of PR had a killswitch at 10k repetitions with the reasoning that if an error is being repeated that many times so quickly there is a significant error occurring that should be dealt with. Easiest way I could think of to bring it to the dev's attention was to crash and rely on the players to complain. The move to prompting on repetitious but non-fatal errors should nag just enough to generate issues, but not completely break the game if the player wants to ignore it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added calls to `debugmsg` in loops to see how the folding looks. Used debug menu to force crash the game to make sure the folding is output properly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
https://media.discordapp.net/attachments/675502002230394880/890078801176965160/unknown.png
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
