### PR TITLE
[DDA Port] Fix vehicle flickering while driving at night

### DIFF
--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -691,6 +691,8 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     // updating info
     werase( w_info );
 
+    Character &player_character = get_player_character();
+
     const optional_vpart_position vp = g->m.veh_at( target );
     std::string veh_msg;
     if( !vp ) {
@@ -727,15 +729,17 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     }
     const auto &map_cache = g->m.get_cache( target.z );
 
-    const std::string u_see_msg = g->u.sees( target ) ? _( "yes" ) : _( "no" );
+    const std::string u_see_msg = player_character.sees( target ) ? _( "yes" ) : _( "no" );
     mvwprintw( w_info, point( 1, off++ ), _( "dist: %d u_see: %s veh: %s scent: %d" ),
-               rl_dist( g->u.pos(), target ), u_see_msg, veh_msg, g->scent.get( target ) );
+               rl_dist( player_character.pos(), target ), u_see_msg, veh_msg, g->scent.get( target ) );
     mvwprintw( w_info, point( 1, off++ ), _( "sight_range: %d, daylight_sight_range: %d," ),
-               g->u.sight_range( g->light_level( g->u.posz() ) ),
-               g->u.sight_range( current_daylight_level( calendar::turn ) ) );
-    mvwprintw( w_info, point( 1, off++ ), _( "transparency: %.5f, visibility: %.5f," ),
+               player_character.sight_range( g->light_level( player_character.posz() ) ),
+               player_character.sight_range( current_daylight_level( calendar::turn ) ) );
+    mvwprintw( w_info, point( 1, off++ ), _( "cache{transp:%.4f seen:%.4f cam:%.4f}" ),
                map_cache.transparency_cache[target.x][target.y],
-               map_cache.seen_cache[target.x][target.y] );
+               map_cache.seen_cache[target.x][target.y],
+               map_cache.camera_cache[target.x][target.y]
+             );
     map::apparent_light_info al = map::apparent_light_helper( map_cache, target );
     int apparent_light = static_cast<int>(
                              g->m.apparent_light_at( target, g->m.get_visibility_variables_cache() ) );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7851,8 +7851,13 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         build_transparency_cache( z );
         seen_cache_dirty |= ( build_floor_cache( z ) && affects_seen_cache );
         seen_cache_dirty |= get_cache( z ).seen_cache_dirty && affects_seen_cache;
+    }
+    // needs a separate pass as it changes the caches on neighbour z-levels (e.g. floor_cache);
+    // otherwise such changes might be overwritten by main cache-building logic
+    for( int z = minz; z <= maxz; z++ ) {
         do_vehicle_caching( z );
     }
+
     seen_cache_dirty |= build_vision_transparency_cache( zlev );
 
     if( seen_cache_dirty ) {


### PR DESCRIPTION
#### Purpose of change
Fix vehicle flickering while driving at night

#### Describe the solution
Cherry-picked https://github.com/CleverRaven/Cataclysm-DDA/pull/44886

#### Testing
Driving APC at night no longer causes the vehicle to flicker