### PR TITLE
[WIP]Autodoc un/install

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4229,6 +4229,32 @@
     "pre_special": "check_empty",
     "post_terrain": "f_rvoven"
   },
+  
+  {
+    "type": "construction",
+    "id": "constr_f_autodoc",
+    "description": "Place RV-kitchen unit",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "15 m",
+    "components": [ [ [ "f_autodoc", 1 ] ], [ [ "cable", 5 ] ], [ [ "power_supply", 1 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_terrain": "f_autodoc"
+  },
+  {
+    "type": "construction",
+    "id": "constr_f_autodoc_couch",
+    "description": "Place RV-kitchen unit",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "5 m",
+    "components": [ [ [ "f_autodoc_couch", 1 ] ], [ [ "cable", 5 ] ], [ [ "power_supply", 1 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_terrain": "f_autodoc_couch"
+  },
+  
   {
     "type": "construction",
     "id": "constr_t_gates_mech_control",


### PR DESCRIPTION
Making static bases is not attractive so we will be able at least to bring autodoc to our bases. Gotta make entries in construction menu as well as item autodoc and couch. Not sure if `look-like` works between furniture and items, if not i will add required entry in the tileset with later PR. Will have to test things like placing multiple autodocs around couch etc. If possible i want it to use power from powergrid.