### PR TITLE
Significantly lower fuel usage for helicopters

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5072,8 +5072,9 @@ void vehicle::idle( bool on_map )
         }
         // helicopters use basicaly nearly all of their power just to hover.
         // it becomes more efficient the closer they reach their safe cruise speed.
+        // But in BN it is simplified, so power usage on idle is much lower
         if( is_rotorcraft() && is_flying_in_air() ) {
-            idle_rate = 1000;
+            idle_rate = 100;
         }
         if( has_engine_type_not( fuel_type_muscle, true ) ) {
             consume_fuel( idle_rate, to_turns<int>( 1_turns ), true );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5070,9 +5070,8 @@ void vehicle::idle( bool on_map )
         if( idle_rate < 10 ) {
             idle_rate = 10;    // minimum idle is 1% of full throttle
         }
-        // helicopters use basicaly nearly all of their power just to hover.
-        // it becomes more efficient the closer they reach their safe cruise speed.
-        // But in BN it is simplified, so power usage on idle is much lower
+        // Helicopters use extra power just to stay in the air
+        // 100 means 10% of power
         if( is_rotorcraft() && is_flying_in_air() ) {
             idle_rate = 100;
         }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -197,7 +197,7 @@ void vehicle::thrust( int thd, int z )
     } else {
         load = ( thrusting ? 1000 : 0 );
     }
-    // rotorcraft need to spend +5% (in addtition to idle) of load to fly, +20% (in addtion to idle) to change z
+    // rotorcraft need to spend +5% (in addition to idle) of load to fly, +20% (in addition to idle) to ascend
     if( is_rotorcraft() && ( z > 0 || is_flying_in_air() ) ) {
         load = std::max( load, z > 0 ? 200 : 50 );
         thrusting = true;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -223,21 +223,6 @@ void vehicle::thrust( int thd, int z )
             cruise_velocity = 0;
             return;
         }
-        // helicopters improve efficiency the closer they get to 50-70 knots
-        // then it drops off as they go over that.
-        // see https://i.stack.imgur.com/0zIO7.jpg
-        /*if( is_rotorcraft() && is_flying_in_air() ) {
-            const int velocity_kt = velocity * 0.01;
-            int value;
-            if( velocity_kt < 70 ) {
-                value = 49 * std::pow( velocity_kt, 3 ) -
-                        4118 * std::pow( velocity_kt, 2 ) - 76512 * velocity_kt + 18458000;
-            } else {
-                value = 1864 * std::pow( velocity_kt, 2 ) - 272190 * velocity_kt + 19473000;
-            }
-            value *= 0.0001;
-            load = std::max( 200, std::min( 1000, ( ( value / 2 ) + 100 ) ) );
-        }*/
         //make noise and consume fuel
         noise_and_smoke( load );
         consume_fuel( load, 1 );

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -197,9 +197,9 @@ void vehicle::thrust( int thd, int z )
     } else {
         load = ( thrusting ? 1000 : 0 );
     }
-    // rotorcraft need to spend 15% of load to hover, 30% to change z
+    // rotorcraft need to spend +5% (in addtition to idle) of load to fly, +20%(int addtion to idle) to change z
     if( is_rotorcraft() && ( z > 0 || is_flying_in_air() ) ) {
-        load = std::max( load, z > 0 ? 300 : 150 );
+        load = std::max( load, z > 0 ? 200 : 50 );
         thrusting = true;
     }
 
@@ -226,7 +226,7 @@ void vehicle::thrust( int thd, int z )
         // helicopters improve efficiency the closer they get to 50-70 knots
         // then it drops off as they go over that.
         // see https://i.stack.imgur.com/0zIO7.jpg
-        if( is_rotorcraft() && is_flying_in_air() ) {
+        /*if( is_rotorcraft() && is_flying_in_air() ) {
             const int velocity_kt = velocity * 0.01;
             int value;
             if( velocity_kt < 70 ) {
@@ -237,7 +237,7 @@ void vehicle::thrust( int thd, int z )
             }
             value *= 0.0001;
             load = std::max( 200, std::min( 1000, ( ( value / 2 ) + 100 ) ) );
-        }
+        }*/
         //make noise and consume fuel
         noise_and_smoke( load );
         consume_fuel( load, 1 );

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -197,7 +197,7 @@ void vehicle::thrust( int thd, int z )
     } else {
         load = ( thrusting ? 1000 : 0 );
     }
-    // rotorcraft need to spend +5% (in addtition to idle) of load to fly, +20%(int addtion to idle) to change z
+    // rotorcraft need to spend +5% (in addtition to idle) of load to fly, +20% (in addtion to idle) to change z
     if( is_rotorcraft() && ( z > 0 || is_flying_in_air() ) ) {
         load = std::max( load, z > 0 ? 200 : 50 );
         thrusting = true;


### PR DESCRIPTION
Significantly lower fuel usage for helicopters

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfixes "Significantly lower fuel usage for helicopters"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: Bugfixes "Significantly lower fuel usage for helicopters"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
https://github.com/cataclysmbnteam/Cataclysm-BN/issues/486
Fuel usage on helicopters is insanely high and even not realistic. Mostly due bug that in fact that engine use 100% and more power in flight.
This PR fix that by reducing engine power necessary to mantain flight.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Engine power usage on hover reduced from 100% to 10%.
Engine power on flight reduced from 120% ~ 150% (yep it was that bad!) to 15%
Engine power for changing height from 130% to 30%
Engine power from accelerating/decelerating from 100~200(!?)% to max around 110%
Removed tricky statistical based fuel consumption since it was based on velocity instead of acceleration.
Engine efficiency is not touched- only engine fuel usage on flight was changed. So checks for lift weight should be unaffected.

V22 flight time fully fueled ~ <1 hour => 6 hours
UH-60 flight time fully fueled ~ <1 hour => 6 hours
Small helicopter flight time fully fueled ~ <1 hour => 6 hours
AH-60 rflight time fully fueled    => 6 hours

Looks like all helicopters after change can fly around 6 hours based on UI counter. It should be managable.
It is close to that mod solution: https://github.com/SpadeDraco/useful_helicopters but without JSON hacks with engine efficiency.



<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Spawn helicopter
2) Try to fly it and look to fuel consuption.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
I am not sure that we can measure ingame helicopters to real helicopters since ingame helicopter parameters does not match real helicopter parameters.
Example:
Fuel capacity for osprey V22 (https://en.wikipedia.org/wiki/Bell_Boeing_V-22_Osprey )
Ferry Maximum 4,451 US gal (3,706 imp gal; **16,850 l**) of JP-4 / JP-5 / JP-8 to MIL-T-5624
But ingame it is only **3600** liters

 But at least helicopters will be able to  for hours.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
