### PR TITLE
Tool belt rigid and less encumbering

### DIFF
--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -205,7 +205,7 @@
     "name": { "str": "tool belt" },
     "description": "A common belt with pockets, loops and sheaths to store up to six tools or blades.  Widely used by handymen and electricians.",
     "weight": "2000 g",
-    "rigid": false,
+    "rigid": true,
     "volume": "2250 ml",
     "price": 4500,
     "price_postapoc": 1500,
@@ -217,7 +217,7 @@
     "covers": [ "torso" ],
     "coverage": 20,
     "storage": "1 L",
-    "encumbrance": 2,
+    "encumbrance": 6,
     "material_thickness": 2,
     "use_action": {
       "type": "holster",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: Balance "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->
SUMMARY: Balance "Make tool belt a rigid item and set its encumbrance to lower level"

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->
I made tool belt a rigid item with 6 encumbrance which i feel is more in line with other belt and tool items.
Tool belt assumes 22 max encumbrance which translates to roughly 11 encumbrance when 6 items are in the belt, which is simply too much for the benefit it provides. There are much better alternatives for storing tool and this slot (torso waist) has already  a very strong alternative which is survivor harness.
Survivor utility belt which contains all necessary tools has only 2 encumbrance and provides 0.5 L volume on top of it.
I think this change will make this item at least marginally useful, other than a crafting component for crafting other better items.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I was considering to leave it a non-rigid item with 12 max encumbrance but the trend seems to be to go for non rigid items.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->
I changed the json and loaded the game with the change present and it did fine.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

![image](https://user-images.githubusercontent.com/72284934/135110678-f11fe61a-d13d-4253-a4ec-fd1ef47d61e6.png)
![image](https://user-images.githubusercontent.com/72284934/135110748-7a1a2633-f7e2-4dbf-a429-70295a5bb765.png)
![image](https://user-images.githubusercontent.com/72284934/135110808-e2dbf63a-9859-4435-9a43-d979ddeed495.png)
![image](https://user-images.githubusercontent.com/72284934/135111730-8ce65dc8-89c1-4450-b1f6-e7657b065bce.png)

