### PR TITLE
Fix item not removed on vehicle unfold or stepladder placement

### DIFF
--- a/data/json/items/tool/deployable.json
+++ b/data/json/items/tool/deployable.json
@@ -97,7 +97,7 @@
   },
   {
     "id": "folding_bicycle",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "tools",
     "name": { "str": "folding bicycle" },
     "description": "This is a bicycle folded into a relatively portable package.",
@@ -119,7 +119,7 @@
   },
   {
     "id": "generic_folded_vehicle",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "tools",
     "name": { "str_sp": "seeing this is a bug" },
     "description": "seeing this is a bug",
@@ -149,7 +149,7 @@
   },
   {
     "id": "inflatable_boat",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "tools",
     "symbol": "0",
     "color": "light_gray",

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -743,7 +743,7 @@
   },
   {
     "id": "stepladder",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "tools",
     "name": { "str": "stepladder" },
     "description": "This is a wooden stepladder.  Use it to set it down.",


### PR DESCRIPTION
#894 changed some items from `TOOL` type to `GENERIC`, which broke item consumption logic for `unfold_vehicle`, `UNFOLD_GENERIC` and `LADDER` use actions that relied on relevant item being tool without charges.

Revert type of all affected items as a quick fix.