### PR TITLE
Fix liquids spilling from some sealed containers

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6358,7 +6358,7 @@ bool item::is_bucket() const
     return type->container &&
            type->container->watertight &&
            !type->container->seals &&
-           type->container->unseals_into;
+           !type->container->unseals_into;
 }
 
 bool item::is_bucket_nonempty() const


### PR DESCRIPTION
Fixes liquids spilling from resealable containers (regression from #934).
Example cases: aluminum can with drink, tin can with meat soup.