### PR TITLE
Simplify logic for displaying crafting recipe list

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -383,69 +383,34 @@ const recipe *select_crafting_recipe( int &batch_size )
 
         cata::optional<point> cursor_pos;
         int recmin = 0, recmax = current.size();
-        if( recmax > dataLines ) {
-            if( line <= recmin + dataHalfLines ) {
-                for( int i = recmin; i < recmin + dataLines; ++i ) {
-                    std::string tmp_name = current[i]->result_name();
-                    if( batch ) {
-                        tmp_name = string_format( _( "%2dx %s" ), i + 1, tmp_name );
-                    }
-                    mvwprintz( w_data, point( 2, i - recmin ), c_dark_gray, "" ); // Clear the line
-                    const bool highlight = i == line;
-                    const nc_color col = highlight ? available[i].selected_color() : available[i].color();
-                    const point print_from( 2, i - recmin );
-                    if( highlight ) {
-                        cursor_pos = print_from;
-                    }
-                    mvwprintz( w_data, print_from, col, trim_by_length( tmp_name, 27 ) );
-                }
-            } else if( line >= recmax - dataHalfLines ) {
-                for( int i = recmax - dataLines; i < recmax; ++i ) {
-                    std::string tmp_name = current[i]->result_name();
-                    if( batch ) {
-                        tmp_name = string_format( _( "%2dx %s" ), i + 1, tmp_name );
-                    }
-                    mvwprintz( w_data, point( 2, dataLines + i - recmax ), c_light_gray, "" ); // Clear the line
-                    const bool highlight = i == line;
-                    const nc_color col = highlight ? available[i].selected_color() : available[i].color();
-                    const point print_from( 2, dataLines + i - recmax );
-                    if( highlight ) {
-                        cursor_pos = print_from;
-                    }
-                    mvwprintz( w_data, print_from, col,
-                               trim_by_length( tmp_name, 27 ) );
-                }
-            } else {
-                for( int i = line - dataHalfLines; i < line - dataHalfLines + dataLines; ++i ) {
-                    std::string tmp_name = current[i]->result_name();
-                    if( batch ) {
-                        tmp_name = string_format( _( "%2dx %s" ), i + 1, tmp_name );
-                    }
-                    mvwprintz( w_data, point( 2, dataHalfLines + i - line ), c_light_gray, "" ); // Clear the line
-                    const bool highlight = i == line;
-                    const nc_color col = highlight ? available[i].selected_color() : available[i].color();
-                    const point print_from( 2, dataHalfLines + i - line );
-                    if( highlight ) {
-                        cursor_pos = print_from;
-                    }
-                    mvwprintz( w_data, print_from, col,
-                               trim_by_length( tmp_name, 27 ) );
-                }
+
+        // Draw recipes with scroll list
+        // get subset to draw
+        int recipe_scroll_window_min = line - dataHalfLines;
+        int recipe_scroll_window_max = recipe_scroll_window_min + std::min( recmax, dataLines );
+
+        // move view window to stay within list
+        if( recipe_scroll_window_min < recmin ) {
+            recipe_scroll_window_max -= recipe_scroll_window_min;
+            recipe_scroll_window_min = recmin;
+        } else if( recipe_scroll_window_max > recmax ) {
+            recipe_scroll_window_min -= recipe_scroll_window_max - recmax;
+            recipe_scroll_window_max = recmax;
+        }
+
+        for( int i = recipe_scroll_window_min; i < recipe_scroll_window_max; ++i ) {
+            std::string tmp_name = current[i]->result_name();
+            if( batch ) {
+                tmp_name = string_format( _( "%2dx %s" ), i + 1, tmp_name );
             }
-        } else {
-            for( int i = 0; i < static_cast<int>( current.size() ) && i < dataHeight + 1; ++i ) {
-                std::string tmp_name = current[i]->result_name();
-                if( batch ) {
-                    tmp_name = string_format( _( "%2dx %s" ), i + 1, tmp_name );
-                }
-                const bool highlight = i == line;
-                const nc_color col = highlight ? available[i].selected_color() : available[i].color();
-                const point print_from( 2, i );
-                if( highlight ) {
-                    cursor_pos = print_from;
-                }
-                mvwprintz( w_data, print_from, col, trim_by_length( tmp_name, 27 ) );
+            const point print_from( 2, i - recipe_scroll_window_min );
+            mvwprintz( w_data, print_from, c_dark_gray, "" ); // Clear the line
+            const bool highlight = i == line;
+            const nc_color col = highlight ? available[i].selected_color() : available[i].color();
+            if( highlight ) {
+                cursor_pos = print_from;
             }
+            mvwprintz( w_data, print_from, col, trim_by_length( tmp_name, 27 ) );
         }
 
         const int count = batch ? line + 1 : 1; // batch size

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -324,6 +324,7 @@ const recipe *select_crafting_recipe( int &batch_size )
     }
     const auto &all_recipes = recipe_subset( {}, all_recipes_flat );
 
+    int recipe_scroll_window_min = 0;
     ui.on_redraw( [&]( const ui_adaptor & ) {
         const TAB_MODE m = ( batch ) ? BATCH : ( filterstring.empty() ) ? NORMAL : FILTERED;
         draw_recipe_tabs( w_head, tab.cur(), m );
@@ -382,11 +383,10 @@ const recipe *select_crafting_recipe( int &batch_size )
         mvwputch( w_data, point( width - 1, dataHeight - 1 ), BORDER_COLOR, LINE_XOOX ); // _|
 
         cata::optional<point> cursor_pos;
-        int recmin = 0, recmax = current.size();
+        int recmax = current.size();
 
         // Draw recipes with scroll list
         // get subset to draw
-        int recipe_scroll_window_min = recmin;
         calcStartPos( recipe_scroll_window_min, line, dataLines, recmax );
         int recipe_scroll_window_max = std::min( recmax, recipe_scroll_window_min + dataLines );
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -386,17 +386,9 @@ const recipe *select_crafting_recipe( int &batch_size )
 
         // Draw recipes with scroll list
         // get subset to draw
-        int recipe_scroll_window_min = line - dataHalfLines;
-        int recipe_scroll_window_max = recipe_scroll_window_min + std::min( recmax, dataLines );
-
-        // move view window to stay within list
-        if( recipe_scroll_window_min < recmin ) {
-            recipe_scroll_window_max -= recipe_scroll_window_min;
-            recipe_scroll_window_min = recmin;
-        } else if( recipe_scroll_window_max > recmax ) {
-            recipe_scroll_window_min -= recipe_scroll_window_max - recmax;
-            recipe_scroll_window_max = recmax;
-        }
+        int recipe_scroll_window_min = recmin;
+        calcStartPos( recipe_scroll_window_min, line, dataLines, recmax );
+        int recipe_scroll_window_max = std::min( recmax, recipe_scroll_window_min + dataLines );
 
         for( int i = recipe_scroll_window_min; i < recipe_scroll_window_max; ++i ) {
             std::string tmp_name = current[i]->result_name();

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -404,7 +404,6 @@ const recipe *select_crafting_recipe( int &batch_size )
                 tmp_name = string_format( _( "%2dx %s" ), i + 1, tmp_name );
             }
             const point print_from( 2, i - recipe_scroll_window_min );
-            mvwprintz( w_data, print_from, c_dark_gray, "" ); // Clear the line
             const bool highlight = i == line;
             const nc_color col = highlight ? available[i].selected_color() : available[i].color();
             if( highlight ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Infrastructure "Simplify logic for displaying crafting recipe list"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
In my ongoing attempts to more fully understand how the crafting gui works I found an uncommented blob of code filled with mostly redundant drawing code. Figured out that this section is to draw the recipe list with a scrollbar if it cannot be fully contained within the drawable area. I knew this could be simplified.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
There are 4 cases to consider, 3 require a scroll and 1 does not:
1. The list is shorter than the viewing window's line count.
We do not need a scroll, the minimum is at 0 and maximum is the list's length
2. The list window, centered on the current selection, extends before the start of the list
We push the list window forward so that it starts at the list start
3. The list window, centered on the current selection, extends past the end of the list
We pull the list window backward so that it ends at the list end
4. The list window, centered on the current selection, is contained within the list
We do nothing.

With these cases to consider it's possible to use a little bit of math to ensure the cases are valid.
Drawing is done by shifting the start of the list window to the start of the viewing window
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Easiest solution would have been to add comments so it is easier to understand at a glance. Another solution would be to create a specialized UI element / function to handle drawing vertical lists with optional scrollbars.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Had a few math errors initially, so I had to continually test to make sure the drawn elements were properly positioned, and that they did not try to escape off of the screen by drawing too much. It looks and responds identically to the original code.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->