### PR TITLE
Fix the mis-spawned nanofab in collapsed office tower

### DIFF
--- a/data/json/mapgen/collapsed_tower.json
+++ b/data/json/mapgen/collapsed_tower.json
@@ -128,7 +128,7 @@
         "#####|xppppppppppppp|| #|#  ####  #|# ~#~~~######|####|        6666|####",
         "#####|222222ppY66ppp||  |##########|   # ~~~    # ~~~~##           |####",
         "#####|ppppp2pppppppp||# |||   ## ##|# ~~#~~~~~~ #~~~#          BB  |####",
-        "#####|p//pp{pppppppp33# 3##| ##|   {~~~~~~~~~~~~~~~~##||||||BB#||  |####",
+        "#####|p/?pp{pppppppp33# 3##| ##|   {~~~~~~~~~~~~~~~~##||||||BB#||  |####",
         "#####|ppppp2pppppppp33  3 #| # +   { ##   ########~~ #|#########   |####",
         "#####|222222ppY66ppp|| #|##|###|   |||||||||||||||~~~~|###|#   #   |####",
         "#####|xppppppppppppp||  |#|||||| ##|##########~~#|##~~|###|#   # ##|####",
@@ -155,8 +155,9 @@
         "#####################################||||||#############################",
         "########################################################################"
       ],
+      "//": "0 to 21 Y for the first bash definition is intentional, to avoid letting bad RNG ruin the nanofab.",
       "set": [
-        { "point": "bash", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 50, 100 ] },
+        { "point": "bash", "x": [ 0, 23 ], "y": [ 0, 21 ], "repeat": [ 50, 100 ] },
         { "point": "bash", "x": [ 24, 47 ], "y": [ 0, 23 ], "repeat": [ 50, 100 ] },
         { "point": "bash", "x": [ 48, 71 ], "y": [ 0, 23 ], "repeat": [ 50, 100 ] },
         { "point": "bash", "x": [ 0, 23 ], "y": [ 24, 47 ], "repeat": [ 50, 100 ] },
@@ -174,7 +175,10 @@
         "Y": "t_thconc_floor_olight",
         "p": "t_metal_floor"
       },
-      "mapping": { "r": { "item": { "item": "standard_template_construct" } }, "R": { "item": { "item": "nanomaterial" } } },
+      "mapping": {
+        "r": { "item": { "item": "standard_template_construct" } },
+        "R": { "item": { "item": "nanomaterial", "chance": 80, "repeat": 2 } }
+      },
       "toilets": { ";": {  } },
       "place_items": [
         { "item": "office_mess", "x": [ 8, 23 ], "y": [ 4, 23 ], "chance": 100, "repeat": [ 20, 70 ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix the nanofab in collapsed office towers not having a console, prevent mapgen bash from hitting it"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So chatter in the BN discord revealed the nanofab in the collapsed office tower is spawned wrong and unusuable. Quick and basic look through the JSON revealed whoever made the map placed two nanofab bodies, having defined a terrain def for the control panel but not placed it.

Furthermore the bash stuff in the mapgen runs the risk of it spawning pre-busted anyway, completely out of the player's control. Given this is a pain in the ass location to clear and the nanofab is effectively the only real reward, this design's a bit anti-fun.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Fixed the nanofab room not actually having a console.
2. Moved the edge of the first bash effect to ensure it'll miss the nanofabricator.
3. Minor, made the nanomaterial spawn in the other room more variable, especially as testing found that the odds of being able to actually use the nanofab are pretty low given how vanishingly rare nanomaterial is.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Finding other locations in the game that could use more nanomaterial spawns would make it more interesting. Have the player scavenge labs, scrounging up nanites and STCs, then come back to locations that have the fabber.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

I checked the DDA version of the file and it's messed up there too.

https://www.youtube.com/watch?v=XJvOxFhVNbQ