### PR TITLE
Add looted items to mi-go locations

### DIFF
--- a/data/json/furniture_and_terrain/furniture-migo.json
+++ b/data/json/furniture_and_terrain/furniture-migo.json
@@ -104,34 +104,46 @@
     "type": "furniture",
     "id": "f_alien_pod",
     "name": "slimy pod",
-    "description": "This is a slick, translucent pod suspended on a thin stalk.  It is covered in a thick mucus, obscuring whatever is floating in the gel-like substance inside.",
+    "description": "This is a slick, translucent pod suspended on a thin stalk.  It is covered in a thick mucus, obscuring whatever is floating in the gel-like substance inside.  You could fairly easily tear it from the stalk and see if anything is inside.",
     "symbol": "0",
     "color": "magenta",
     "move_cost_mod": -1,
     "coverage": 40,
     "required_str": -1,
-    "flags": [ "TRANSPARENT" ],
+    "flags": [ "TRANSPARENT", "EASY_DECONSTRUCT" ],
+    "//": "Because pod type used in most mi-go areas is random, item drops are generated here instead.",
+    "deconstruct": { "items": [ { "group": "migo_pod_storage", "prob": 50, "count": [ 1, 2 ] } ] },
     "bash": {
-      "str_min": 25,
-      "str_max": 60,
+      "str_min": 8,
+      "str_max": 40,
       "sound": "splorch!",
       "sound_fail": "whump.",
-      "items": [ { "item": "fetid_goop", "count": [ 5, 10 ], "prob": 100 } ]
+      "items": [
+        { "item": "fetid_goop", "count": [ 5, 10 ], "prob": 100 },
+        { "group": "migo_pod_storage", "prob": 50 }
+      ]
     }
   },
   {
     "type": "furniture",
     "id": "f_alien_pod_organ",
     "name": "organ pod",
-    "description": "This is a translucent pod suspended on a thin stalk.  Inside you can see the dimly outlined shape of human organs, floating in some kind of preservative goo.",
+    "description": "This is a translucent pod suspended on a thin stalk.  Inside you can see the dimly outlined shape of human organs, floating in some kind of preservative goo.  You could fairly easily tear it from the stalk and see if anything is inside.",
     "symbol": "0",
     "color": "yellow",
     "move_cost_mod": -1,
     "coverage": 40,
     "required_str": -1,
     "light_emitted": 3,
-    "flags": [ "TRANSPARENT" ],
-    "bash": { "str_min": 25, "str_max": 60, "sound": "splorch!", "sound_fail": "whump." }
+    "flags": [ "TRANSPARENT", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "items": [ { "group": "migo_pod_samples", "count": [ 1, 3 ] } ] },
+    "bash": {
+      "str_min": 8,
+      "str_max": 40,
+      "sound": "splorch!",
+      "sound_fail": "whump.",
+      "items": [ { "group": "migo_pod_samples", "prob": 75, "count": [ 1, 2 ] } ]
+    }
   },
   {
     "type": "furniture",
@@ -145,7 +157,7 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "EASY_DECONSTRUCT" ],
     "deconstruct": { "items": [ { "item": "alien_pod_resin", "charges": [ 2, 6 ] } ] },
-    "bash": { "str_min": 25, "str_max": 60, "sound": "splorch!", "sound_fail": "whump." }
+    "bash": { "str_min": 8, "str_max": 40, "sound": "splorch!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",

--- a/data/json/itemgroups/Monsters_Animals_Lairs/monster_drops_lairs.json
+++ b/data/json/itemgroups/Monsters_Animals_Lairs/monster_drops_lairs.json
@@ -7,6 +7,67 @@
   },
   {
     "type": "item_group",
+    "id": "migo_pod_storage",
+    "subtype": "distribution",
+    "//": "Various human artifacts stored in pods by the mi-go.  Focuses on electronics and things that would otherwise be obviously technological in nature, plus what could be personal effects of victims.",
+    "entries": [
+      { "group": "everyday_gear", "prob": 25 },
+      { "group": "electronics", "prob": 25 },
+      { "group": "tools_science", "prob": 20 },
+      { "group": "tools_robotics", "prob": 15 },
+      { "group": "bionics", "prob": 15 },
+      { "group": "mil_hw", "prob": 5 },
+      { "group": "guns_survival", "prob": 5 },
+      { "group": "energy_weapon_armory", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "migo_pod_samples",
+    "subtype": "distribution",
+    "//": "Human and animal tissues preserved by the mi-go for study.",
+    "entries": [
+      { "group": "supplies_samples_lab", "prob": 25 },
+      { "item": "human_flesh", "prob": 20 },
+      { "item": "human_brain_embalmed", "prob": 15 },
+      { "item": "mutant_human_flesh", "prob": 15 },
+      { "item": "hstomach", "prob": 10 },
+      { "group": "monparts", "prob": 10 },
+      { "group": "cloning_vat", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "migo_table_study",
+    "subtype": "distribution",
+    "//": "Additional items potentially being studied by the mi-go.",
+    "entries": [
+      { "group": "robots", "prob": 20 },
+      { "group": "ammo_common", "prob": 20, "charges": [ 10, 30 ] },
+      { "group": "electronics", "prob": 15 },
+      { "group": "ammo_any_batteries", "prob": 15 },
+      { "group": "bionics", "prob": 10 },
+      { "group": "helicopter", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "migo_table_corpses",
+    "subtype": "distribution",
+    "//": "Corpses and leftovers of human study by the mi-go.",
+    "entries": [
+      { "item": "bone_human", "prob": 25, "count": [ 1, 15 ] },
+      { "group": "clothing_outdoor_set", "prob": 20, "damage": [ 1, 3 ] },
+      { "group": "map_extra_science", "prob": 20 },
+      { "group": "map_extra_military", "prob": 10 },
+      { "group": "survival_armor", "prob": 10, "count": [ 1, 3 ], "damage": [ 1, 3 ] },
+      { "item": "corpse_bloody", "prob": 5 },
+      { "item": "corpse_painful", "prob": 5 },
+      { "item": "corpse_halved_upper", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
     "id": "monparts",
     "subtype": "distribution",
     "entries": [

--- a/data/json/mapgen_palettes/mi-go_palette.json
+++ b/data/json/mapgen_palettes/mi-go_palette.json
@@ -38,6 +38,7 @@
       "P": [ [ "f_alien_pod", 2 ], [ "f_alien_pod_organ", 2 ], "f_alien_pod_resin" ],
       "p": [ [ "f_alien_pod", 2 ], [ "f_alien_pod_organ", 2 ], "f_alien_pod_resin" ],
       "O": "f_alien_pod_resin"
-    }
+    },
+    "items": { "n": [ { "item": "migo_table_study", "chance": 50, "repeat": 2 }, { "item": "migo_table_corpses", "chance": 50 } ] }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Content "Add items and organs to spawn in mi-go locations"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

One idea that recently came to mind for improving mi-go locations, making them worth exploring, was noting that there were no item spawns to be found anywhere. The slimy pods, due to their description implying something to be inside, seemed like a logical choice for this. Making it possible to open up organ pods seemed logical too.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Altered slimy pods and organ pods to be deconstructable, same as with resin pods, and changed description to confirm you could logically tear into it just like the other pod type.
2. Lowered bash requirements for pods in general, as it seems odd that they be deconstructable but not so much as have a pod fall off if whacked.
3. Set it so deconstructing or bashing slimy pods and organ pods returns itemgroups relevant to stuff the mi-go might logically take study after confiscating items from captives, or stolen following individuals escaping from captivity. Because of how mi-go locations spawn their pods at random, it's set this way instead of the alternative method of reworking pods to be sealed like crates and spawning items there, because otherwise we'd need to change it to explicit, non-randomized pod spawns. A side benefit of doing it this way however is that organs will stay fresh due to only being generated when the pod is opened up, which makes sense given the pods are likely preserving it.
4. Set the mapgen palette to spawn a similar mishmash of items on fleshy altars, focusing on clothing and corpses with some scattered hints of other items.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. As noted above, converting pods to behave like crates and changing the palette to spawn items in specific types of pods would work, but it would be increased hassle, lose the randomization of pod contents, and organs would no longer stay preserved.
2. If I knew how to make itemgroups apply flags to contents, then spawning the items filthy could be an option. More usefully, that would ensure that organs in the pods spawn with the cannibal flag and thus count as human organs specifically.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Ported file changes over to test build and load-tested.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Effectively a companion PR to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/962, that one makes mi-go locations actually feasible to explore without "grab Arcana and use Ward Against Heat" being the only viable option, while this gives the player an actual reason to explore it, along with giving captives in the mi-go scenario a slight hint of a fighting chance.