### PR TITLE
Allow constructing variants of grid batteries

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4082,6 +4082,46 @@
   },
   {
     "type": "construction",
+    "id": "constr_battery_large",
+    "description": "Install Storage Battery",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 3 ], [ "electronics", 1 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "SCREW", "level": 1 } ] ],
+    "tools": [ [ [ "soldering_iron", 20 ] ] ],
+    "components": [
+      [ [ "sheet_metal_small", 6 ] ],
+      [ [ "plastic_chunk", 2 ] ],
+      [ [ "pipe", 4 ] ],
+      [ [ "cable", 10 ] ],
+      [ [ "storage_battery", 1 ] ]
+    ],
+    "pre_note": "Will only work if constructed in a building with an electric grid.",
+    "pre_special": "check_empty",
+    "post_terrain": "f_battery_large"
+  },
+  {
+    "type": "construction",
+    "id": "constr_battery_huge",
+    "description": "Install Large Storage Battery",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 3 ], [ "electronics", 1 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "SCREW", "level": 1 } ] ],
+    "tools": [ [ [ "soldering_iron", 20 ] ] ],
+    "components": [
+      [ [ "sheet_metal_small", 6 ] ],
+      [ [ "plastic_chunk", 2 ] ],
+      [ [ "pipe", 4 ] ],
+      [ [ "cable", 10 ] ],
+      [ [ "large_storage_battery", 1 ] ]
+    ],
+    "pre_note": "Will only work if constructed in a building with an electric grid.",
+    "pre_special": "check_empty",
+    "post_terrain": "f_battery_huge"
+  },
+  {
+    "type": "construction",
     "id": "constr_charger",
     "description": "Install Charger",
     "category": "FURN",

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -680,6 +680,80 @@
   },
   {
     "type": "furniture",
+    "id": "f_battery_large",
+    "looks_like": "f_locker",
+    "name": "mounted storage battery",
+    "description": "A storage battery mount salvaged from a vehicle, and connected to building's electric grid.",
+    "symbol": ":",
+    "color": "blue_white",
+    "move_cost_mod": -1,
+    "coverage": 90,
+    "required_str": -1,
+    "active": [ "battery", { "max_stored": 40000 } ],
+    "examine_action": "check_power",
+    "deconstruct": {
+      "items": [
+        { "item": "sheet_metal_small", "count": [ 4, 6 ] },
+        { "item": "plastic_chunk", "count": 2 },
+        { "item": "pipe", "count": 4 },
+        { "item": "cable", "charges": [ 5, 10 ] },
+        { "item": "storage_battery", "count": 1 }
+      ]
+    },
+    "bash": {
+      "str_min": 16,
+      "str_max": 40,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "scrap", "count": [ 4, 8 ] },
+        { "item": "plastic_chunk", "count": [ 1, 2 ] },
+        { "item": "sheet_metal_small", "count": [ 1, 4 ] },
+        { "item": "pipe", "count": 1 },
+        { "item": "cable", "charges": [ 2, 8 ] },
+        { "item": "small_storage_battery", "count": [ 30, 60 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_battery_huge",
+    "looks_like": "f_locker",
+    "name": "mounted large storage battery",
+    "description": "A huge storage battery mount salvaged from a vehicle, and connected to building's electric grid.",
+    "symbol": ":",
+    "color": "blue_white",
+    "move_cost_mod": -1,
+    "coverage": 90,
+    "required_str": -1,
+    "active": [ "battery", { "max_stored": 80000 } ],
+    "examine_action": "check_power",
+    "deconstruct": {
+      "items": [
+        { "item": "sheet_metal_small", "count": [ 4, 6 ] },
+        { "item": "plastic_chunk", "count": 2 },
+        { "item": "pipe", "count": 4 },
+        { "item": "cable", "charges": [ 5, 10 ] },
+        { "item": "large_storage_battery", "count": 1 }
+      ]
+    },
+    "bash": {
+      "str_min": 16,
+      "str_max": 40,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "scrap", "count": [ 4, 8 ] },
+        { "item": "plastic_chunk", "count": [ 1, 2 ] },
+        { "item": "sheet_metal_small", "count": [ 1, 4 ] },
+        { "item": "pipe", "count": 1 },
+        { "item": "cable", "charges": [ 2, 8 ] },
+        { "item": "small_storage_battery", "count": [ 50, 100 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_charger",
     "looks_like": "f_utility_shelf",
     "name": "battery charger",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Content "Add grid constructions for standard and large storage batteries"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some basic ideas I had on my misc to-do list. Since variant solar panels are being worked on by Lamandus, I decided to quickly tackle variant grid batteries.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Added constructions and furniture for using a standard storage battery or a large storage battery. 40000 and 80000 power storage, just as with the battery items themselves.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Allowing small storage batteries to be plonked down as well, but at 500 storage their utulity is a bit more questionable.
2. Allowing a car battery as an option. Being more readily available than lithium-ion batteries, potentially usable for cheap battery backup systems IRL (example: https://www.youtube.com/watch?v=1q4dUt1yK0g), and having a more useful 2500 storage, it might be more feasible as an easiest-to-slap-together power option.
3. Possibly adding the ability to deploy solar and quantum solar backpacks as portable sources of grid solar power. I'd need to know how much solar power they collect relative to standard panels however.
4. Related, how well would a portable battery backup system that can be deployed instead of constructed work? Main thing is I don't know if undeploying a battery-type furniture will correctly translate its stored power into ammo/charges on a undeploy item, nor if a charged battery backup system would correctly place a charged battery.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and load errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

See also Lamandus' PR: https://github.com/cataclysmbnteam/Cataclysm-BN/pull/956