### PR TITLE
Add summary of CBM installation skills to relevant menus

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2257,10 +2257,19 @@ bool Character::can_install_bionics( const itype &type, player &installer, bool 
             return false;
         }
     } else {
-        if( !g->u.query_yn(
-                _( "WARNING: There is a %i percent chance of complications, such as damage or faulty installation!  Continue anyway?" ),
-                ( 100 - chance_of_success ) ) ) {
-            return false;
+        if( autodoc ) {
+            if( !g->u.query_yn(
+                    _( "WARNING: There is a %i percent chance of complications, such as damage or faulty installation!  Continue anyway?" ),
+                    ( 100 - chance_of_success ) ) ) {
+                return false;
+            }
+        }
+        else {
+            if( !g->u.query_yn(
+                    _( "WARNING: There is a %i percent chance of complications, such as damage or faulty installation!  The following skills affect self-installation: First Aid, Electronics, and Mechanics.\n\nContinue anyway?" ),
+                    ( 100 - chance_of_success ) ) ) {
+                return false;
+            }
         }
     }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4608,7 +4608,7 @@ void iexamine::autodoc( player &p, const tripoint &examp )
         const std::string &warning = warning_sign + colorize( _( " WARNING: Operator missing" ),
                                      c_red ) + warning_sign;
         autodoc_header = warning +
-                         _( "\n Using the Autodoc without an operator can lead to <color_light_cyan>serious injuries</color> and <color_light_cyan>various internal bionic malfunctions</color>.\n Manufacturer <color_light_green>guarantees automated bionic installation in functional condition</color>.\n Manufacturer <color_light_cyan>does not guarantee automated bionic uninstallation</color>.\n By continuing with the operation you accept the risks and acknowledge that you will not take any legal actions against this facility in case of an accident. " );
+                         _( "\n Using the Autodoc without an operator can lead to <color_light_cyan>serious injuries</color> and <color_light_cyan>various internal bionic malfunctions</color>.\n Manufacturer <color_light_green>guarantees automated bionic installation in functional condition</color>.\n Manufacturer <color_light_cyan>does not guarantee automated bionic uninstallation</color>.\n By continuing with the operation you accept the risks and acknowledge that you will not take any legal actions against this facility in case of an accident.\n\nThe following skills affect autodoc installation: Computers, First Aid, and Electronics." );
     }
     uilist amenu;
     amenu.text = autodoc_header;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Interface "Chance self-install and autodoc menus to list what skills affect success rate"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Per discussion mentioned in previous PRs about improving the workflow of bionics, I mentioned that it'd be smart to include a direct mention of what skills are important for bionic installation in the relevant UI areas.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed the install prompt so that, if self-installing, the prompt lists the skills needed to self-install.
2. Changed the autodoc exmaine_action UI so it lists the relevant skills for autodoc installation.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Dunno where else would be a logical place to tell the player up front what skills are important for installation. Now that autodoc install has a separate prompt, its wording could perhaps be tweaked to show the skill list one more time, I guess? Would technically be redundant with it mentioned in the preceding menu.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested changes, using a world with manual installation enabled.
2. Started in a world, debugged in a CBM and autodoc.
3. Tested that the skill message shows up on the self-install prompt, and on the autodoc menu.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

![image](https://user-images.githubusercontent.com/11582235/136115756-1e0ac567-487a-4444-b7dc-1d62079cb64b.png)

![image](https://user-images.githubusercontent.com/11582235/136115773-4e618bfb-e9b2-41db-a596-bc5649b9164f.png)
