### PR TITLE
Make dissection take longer and give more experience

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -787,7 +787,7 @@ int butcher_time_to_cut( const inventory &inv, const item &corpse_item, const bu
             time_to_cut = std::max( 400, time_to_cut / 10 );
             break;
         case DISSECT:
-            time_to_cut *= 5;
+            time_to_cut *= 7;
             break;
     }
 
@@ -1099,9 +1099,7 @@ static void butchery_drops_harvest( item *corpse_item, const mtype &mt, player &
     }
     // 20% of the original corpse weight is not an item, but liquid gore
 
-    if( action == DISSECT ) {
-        p.practice( skill_firstaid, std::max( 0, practice ), std::max( mt.size - MS_MEDIUM, 0 ) + 4 );
-    } else {
+    if( action != DISSECT ) {
         p.practice( skill_survival, std::max( 0, practice ), std::max( mt.size - MS_MEDIUM, 0 ) + 4 );
     }
 }
@@ -1256,6 +1254,15 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
             cbms.push_back( *it );
         }
         extract_or_wreck_cbms( cbms, roll, *p );
+        // those lines are for XP gain with dissecting. It depends on the size of the corpse, time to dissect the corpse and the amount of bionics you would gather.
+        int time_to_cut = size_factor_in_time_to_cut( corpse->size );
+        int level_cap = std::min<int>( MAX_SKILL, ( corpse->size + ( cbms.size() * 2 + 1 ) ) );
+        int size_mult = corpse->size > MS_MEDIUM ? ( corpse->size * corpse->size ) : 8;
+        int practice_amt = ( size_mult + 1 ) * ( ( time_to_cut / 150 ) + 1 ) *
+                           ( cbms.size() * cbms.size() / 2 + 1 );
+        p->practice( skill_firstaid, practice_amt, level_cap );
+        add_msg( m_debug, "Experience: %d, Level cap: %d, Time to cut: %d", practice_amt, level_cap,
+                 time_to_cut );
     }
 
     //end messages and effects


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Balance "Make dissection take longer and give more experience"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Right now dissection bringes not a lot of skill gain. 1% or 2% are the maximum what we get. Sure it is used to give us implants and stuff, but a skill gain would also make sense.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Raising the amount of time needed to dissect a corpse, do to using fine tools and cutting very carefully. It was changed in time needed, but raises XP.
The amount of XP you get depends now on 3 factors: the size of the corpse, the time you need to cut it up and also how many bionics (burned or not) you get! That means a chicken gives very few XP (small critter, no bionics [hopefully]), a shocker brute would give a lot more.

Old:
At lvl 1 a dissection gives 4%
At lvl 2 a dissection gives 1%
At lvl 3 a dissection gives 1%
At lvl 4 a dissection gives 0%
At lvl 5 a dissection gives 0%

New (Kevlar Hulk):
At lvl 1 a dissection gives 83%
At lvl 2 a dissection gives 37%
At lvl 3 a dissection gives 21%
At lvl 4 a dissection gives 13%
At lvl 5 a dissection gives 10%
At lvl 6 a dissection gives 7%

New (shocker brute):
At lvl 1 a dissection gives 44%
At lvl 2 a dissection gives 19%
At lvl 3 a dissection gives 11%
At lvl 4 a dissection gives 7%
At lvl 5 a dissection gives 4%
At lvl 6 a dissection gives 3%

New (shocker zombie):
At lvl 1 a dissection gives 26%
At lvl 2 a dissection gives 11%
At lvl 3 a dissection gives 6%
At lvl 4 a dissection gives 4%
At lvl 5 a dissection gives 2%
At lvl 6 a dissection gives 2%

New (normal/fat/tough zombie and brutes, etc.):
At lvl 1 a dissection gives 9%
At lvl 2 a dissection gives 4%
At lvl 3 a dissection gives 2%
At lvl 4 a dissection gives 1%
At lvl 5 a dissection gives 1%
At lvl 6 a dissection gives 0%


New (Chicken):
At lvl 1 a dissection gives 4%

New (moose):
At lvl 1 a dissection gives 21%

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Bandaging one little wound with 6000 makeshift bandages and call it a day.

Yes the new values seem a bit high at low level. But lvl 0 to 1 can be easily achieved to mentally call rags makeshift bandages. And 1 to 2 to boil them. It is around as quick as the new values.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
right now I play with these values, they feel quite alright. Changes can be made, but I would like to make dissection a bit more meaningful
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
