### PR TITLE
Fix prying breakage roll, implement busting doors

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -1395,11 +1395,21 @@
     "pry": {
       "success_message": "You pry open the door.",
       "fail_message": "You pry, but cannot pry open the door.",
+      "break_message": "You damage the door!",
       "pry_quality": 2,
       "pry_bonus_mult": 3,
       "noise": 12,
+      "break_noise": 10,
+      "breakable": true,
       "difficulty": 8,
-      "new_ter_type": "t_door_o"
+      "new_ter_type": "t_door_o",
+      "break_ter_type": "t_door_b",
+      "break_items": [
+        { "item": "2x4", "prob": 25 },
+        { "item": "wood_panel", "prob": 10 },
+        { "item": "splinter", "count": [ 1, 2 ] },
+        { "item": "nail", "charges": [ 0, 2 ] }
+      ]
     }
   },
   {
@@ -1443,11 +1453,21 @@
     "pry": {
       "success_message": "You pry open the door.",
       "fail_message": "You pry, but cannot pry open the door.",
+      "break_message": "You damage the door!",
       "pry_quality": 2,
       "pry_bonus_mult": 3,
       "noise": 12,
+      "break_noise": 10,
+      "breakable": true,
       "difficulty": 8,
-      "new_ter_type": "t_door_o"
+      "new_ter_type": "t_door_o",
+      "break_ter_type": "t_door_b",
+      "break_items": [
+        { "item": "2x4", "prob": 25 },
+        { "item": "wood_panel", "prob": 10 },
+        { "item": "splinter", "count": [ 1, 2 ] },
+        { "item": "nail", "charges": [ 0, 2 ] }
+      ]
     }
   },
   {
@@ -1491,11 +1511,21 @@
     "pry": {
       "success_message": "You pry open the door.",
       "fail_message": "You pry, but cannot pry open the door.",
+      "break_message": "You damage the door!",
       "pry_quality": 2,
       "pry_bonus_mult": 3,
       "noise": 12,
+      "break_noise": 10,
+      "breakable": true,
       "difficulty": 8,
-      "new_ter_type": "t_door_o_peep"
+      "new_ter_type": "t_door_o_peep",
+      "break_ter_type": "t_door_b_peep",
+      "break_items": [
+        { "item": "2x4", "prob": 25 },
+        { "item": "wood_panel", "prob": 10 },
+        { "item": "splinter", "count": [ 1, 2 ] },
+        { "item": "nail", "charges": [ 0, 2 ] }
+      ]
     }
   },
   {
@@ -1529,12 +1559,22 @@
     "pry": {
       "success_message": "You pry open the door.",
       "fail_message": "You pry, but cannot pry open the door.",
+      "break_message": "You damage the door!",
       "pry_quality": 2,
       "pry_bonus_mult": 3,
       "noise": 12,
+      "break_noise": 10,
       "alarm": true,
+      "breakable": true,
       "difficulty": 8,
-      "new_ter_type": "t_door_o_peep"
+      "new_ter_type": "t_door_o_peep",
+      "break_ter_type": "t_door_b_peep",
+      "break_items": [
+        { "item": "2x4", "prob": 25 },
+        { "item": "wood_panel", "prob": 10 },
+        { "item": "splinter", "count": [ 1, 2 ] },
+        { "item": "nail", "charges": [ 0, 2 ] }
+      ]
     }
   },
   {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2506,7 +2506,7 @@ int iuse::crowbar( player *p, item *it, bool, const tripoint &pos )
 
             /** @EFFECT_MECHANICS reduces chance of breaking window with crowbar */
             if( dice( 4, diff ) > ( dice( 2, p->get_skill_level( skill_mechanics ) ) + dice( 2,
-                    p->str_cur ) ) * pry_level ) {
+                                    p->str_cur ) ) * pry_level ) {
                 p->add_msg_if_player( m_mixed, pry->break_message );
                 sounds::sound( pnt, pry->break_noise, sounds::sound_t::combat, pry->break_sound, true, "smash",
                                "door" );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2505,8 +2505,8 @@ int iuse::crowbar( player *p, item *it, bool, const tripoint &pos )
             /** @EFFECT_STR reduces chance of breaking window with crowbar */
 
             /** @EFFECT_MECHANICS reduces chance of breaking window with crowbar */
-            if( dice( 4, diff ) > dice( 2, p->get_skill_level( skill_mechanics ) ) + dice( 2,
-                    p->str_cur ) ) {
+            if( dice( 4, diff ) > ( dice( 2, p->get_skill_level( skill_mechanics ) ) + dice( 2,
+                    p->str_cur ) ) * pry_level ) {
                 p->add_msg_if_player( m_mixed, pry->break_message );
                 sounds::sound( pnt, pry->break_noise, sounds::sound_t::combat, pry->break_sound, true, "smash",
                                "door" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Fix elevated chance of breaking target while prying, implement risk of breaking doors"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Follow-up PR to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/837, per request I was asked to implement door breakage chance and make 

Along the way I discovered that the JSONization messed with the formula for breakage a bit, making it so that the base failure rate for a normal starting survivor (prying 2, 8 strength, 0 mechanics skill) was MUCH higher than intended, so the second half of the above requested feature fixes that too.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed prying break roll to multiply the outcome of a failed pry attempt by the available prying quality. This fixed the breakage chance on failure being much higher than I'd actually intended (setting the base failure rate with level 2 prying back down to just under 50% instead of over 90%) and also makes it so that prying quality matters a lot more.
2. Implemented the idea of doors potentially breaking on a failed pry attempt that was initially set aside for later, as per request it's still desired as a feature to make the makeshift crowbar buff PR go in.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Continue to put off what is now the easy part after having stumbled my way through getting JSONization of the feature working.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected JSON file for syntax and lint errors.
2. Compile and load-tested.
3. Started life as a shelter baby with no skills and straight-8 stats, spawned myself a claw bar.
4. Waved it at the windows from the outside, closing any windows that opened successfully and leaving the ones that failed to pry once alone.
5. Observed that close to half the windows were busted by the end of this.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

![image](https://user-images.githubusercontent.com/11582235/139141709-5b6e9e2b-446f-4f09-8be0-e48acce18760.png)

This shows what the chances of breaking doors and windows on a failed pry are: https://anydice.com/program/24fb5

Context | Breakage Chance, Mechanics 0 | Breakage Chance, Mechanics 5 | Breakage Chance, Mechanics 10
------------ | ------------- | ------------- | -------------
Pry 2, Str 8 (Diff 8) | 47.59% | 8.19% | 2.25%
Pry 3, Str 8 (Diff 5) | 6.83% | 0.06% | 0.01%
Pry 4, Str 8 (Diff 2) | 0% | 0% | 0%
Pry 2, Str 20 (Diff 8) | 8.14% | 1.32% | 0.36%
Pry 3, Str 20 (Diff 5) | 1.09% | 0.01% | 0.00%
Pry 4, Str 20 (Diff 2) | 0% | 0% | 0%

Current takeaway: As intended, prying 2 will fail for a fresh shelter baby a lil under half the time, with skill and strength having a big impact on the failure chance. A proper crowbar meanwhile will rarely fail even with average strength and no mechanics skill, and a halligan bar laughs at these obstacles and calls them smol.

Overhauling the rolls to be an easier to calculate percentage-style roll is on the to-do list, ideally for after Viss' PR is finally merged now that the feature works right and hits roughly the desired balance point for what'll be makeshift crowbars.

Also on the to-do list as a side PR that can be done whenever is the idea of making prying 4 capable of working on pickable metal doors, per suggestion that a halligan bar would be tough enough to work on those.