### PR TITLE
Update farm_dairy_2.json

### DIFF
--- a/data/json/mapgen/farm_dairy_2.json
+++ b/data/json/mapgen/farm_dairy_2.json
@@ -238,7 +238,7 @@
         "W": { "item": "box_medium", "chance": 100 }
       },
       "items": {
-        "e": { "item": "tools_toolbox", "chance": 100 },
+        "e": { "item": "tools_home", "chance": 100 },
         "m": { "item": "SUS_junk_drawer", "chance": 100 },
         ")": { "item": "SUS_bathroom_sink", "chance": 70, "repeat": 2 },
         "_": [ { "item": "SUS_toilet", "chance": 90 }, { "item": "SUS_bathroom_cabinet", "chance": 90 } ],


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Fix for a little mapgen error on St John's farm"

#### Purpose of change

Tools are now can be available. Farm is not screaming at you with error when you're approaching. 

#### Describe the solution

Replacing `tools_toolbox` item group (not present in BN) with `tools_home`

#### Describe alternatives you've considered

* Replacing it with `tools_construction` or `tools_carpentry` since this is big farm.
* Actually implement `tools_toolbox` item group but since this is the only place where it's currently applicable, this may be bigger change than needed.

#### Testing

Debug world map testing without errors. Farm is cozy once again.

#### Additional context

Error log message:
`place_items: invalid item group 'tools_toolbox', om_terrain = 'farm_dairy_twd_7_north' (farm_dairy_twd_7)`