### PR TITLE
Prevent mopping in sealed container terrain

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5102,7 +5102,7 @@ int iuse::mop( player *p, item *it, bool, const tripoint & )
         fd_sludge
     };
     const std::function<bool( const tripoint & )> f = [&to_check]( const tripoint & pnt ) {
-        if( !g->m.has_flag( "LIQUIDCONT", pnt ) && !g->m.has_flag("SEALED", pnt ) ) {
+        if( !g->m.has_flag( "LIQUIDCONT", pnt ) && !g->m.has_flag( "SEALED", pnt ) ) {
             map_stack items = g->m.i_at( pnt );
             auto found = std::find_if( items.begin(), items.end(), []( const item & it ) {
                 return it.made_of( LIQUID );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5102,7 +5102,7 @@ int iuse::mop( player *p, item *it, bool, const tripoint & )
         fd_sludge
     };
     const std::function<bool( const tripoint & )> f = [&to_check]( const tripoint & pnt ) {
-        if( !g->m.has_flag( "LIQUIDCONT", pnt ) ) {
+        if( !g->m.has_flag( "LIQUIDCONT", pnt ) && !g->m.has_flag("SEALED", pnt ) ) {
             map_stack items = g->m.i_at( pnt );
             auto found = std::find_if( items.begin(), items.end(), []( const item & it ) {
                 return it.made_of( LIQUID );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2727,7 +2727,7 @@ bool map::mop_spills( const tripoint &p )
 {
     bool retval = false;
 
-    if( !has_flag( "LIQUIDCONT", p ) ) {
+    if( !has_flag( "LIQUIDCONT", p ) && !has_flag( "SEALED", p ) ) {
         auto items = i_at( p );
         auto new_end = std::remove_if( items.begin(), items.end(), []( const item & it ) {
             return it.made_of( LIQUID );


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Fix for being able to mop up liquids in sealed container terrain"

#### Purpose of change

Fixes #1060. No more clipping your mop through walls.

#### Describe the solution

While mopping: if the tile's terrain has the SEALED flag, the tile will not be searched for item-based liquids to mop (iuse.cpp), nor will these liquids be considered valid to mop up under any circumstance (map.cpp). This was already being done for the LIQUIDCONT flag.

#### Describe alternatives you've considered

Field- and vehicle-based liquids are not checked for SEALED terrain on the same tile, as I was unsure whether this was necessary -- does the former represent liquid on/around the container instead of inside it?

#### Testing

1. Built and launched the game on the latest bleeding-edge commit, bee8a49: VS2019 build --> run distribute.bat --> delete data/font/Terminus.ttf to force fallback font due to a severe rendering bug in vcpkg.
2. Started a Play Now! (Fixed Scenario) game.
3. Used debug tools to spawn in uncontained clean water and a t_gas_tank terrain on the same tile, as well as a mop in the character's inventory.
4. Attempted to mop up the liquid in the gas tank, and observed that it succeeded ("You mop up the spill.").
5. Switched to this PR's branch and repeated steps 1-3.
6. Attempted to mop up the liquid in the gas tank, and observed that it failed ("There is nothing to mop nearby.").
7. Replaced the terrain with non-SEALED t_gas_tank_smashed.
8. Observed that the liquid could now be mopped up ("You mop up the spill.").
