### PR TITLE
Fix transform iexamine printing wrong message

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1537,14 +1537,17 @@ void iexamine::transform( player &, const tripoint &pos )
     std::string message;
 
     if( g->m.has_furn( pos ) ) {
-        g->m.furn_set( pos, g->m.get_furn_transforms_into( pos ) );
         message = g->m.furn( pos ).obj().message;
+        if( !message.empty() ) {
+            add_msg( _( message ) );
+        }
+        g->m.furn_set( pos, g->m.get_furn_transforms_into( pos ) );
     } else {
-        g->m.ter_set( pos, g->m.get_ter_transforms_into( pos ) );
         message = g->m.ter( pos ).obj().message;
-    }
-    if( !message.empty() ) {
-        add_msg( _( message ) );
+        if( !message.empty() ) {
+            add_msg( _( message ) );
+        }
+        g->m.ter_set( pos, g->m.get_ter_transforms_into( pos ) );
     }
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix utility lights and other transforming terrain printing the message used by their target terrain instead of the correct message"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Quick and easy fix for transforming terrain grabbing the wrong message. Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1107

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Updated `iexamine::transform` in iexamine.cpp, scooting the `if( !message.empty() )` bit to be inside the swap functions, before the actual transformation part of the other two if statements. This ensures that it grabs the transformation message for the ter/furn in its state before transforming, instead of after.

Just moving it to the beginning doesn't work since it groks the message text in the transformation if statements instead, hence absorbing the "can I play a message" part into both transformation-related if statements.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Continuing to be weh and putting off everything.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Spawned into the refugee center.
3. Examined one of the lights and observed it printed the right message this time.
4. Flicked it back on, likewise it now actually says it's turned on.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
