### PR TITLE
Allow halligan bars to pry pickable metal doors

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -2233,7 +2233,7 @@
     "type": "terrain",
     "id": "t_door_metal_pickable",
     "name": "closed metal door",
-    "description": "An extremely resilient door made of assorted steel, carved and pounded into shape.  This one has an extra keyhole, so it's likely locked.  You could probably pick the lock.",
+    "description": "An extremely resilient door made of assorted steel, carved and pounded into shape.  This one has an extra keyhole, so it's likely locked.  You could probably pick the lock, or a very strong tool could pry it open.",
     "//": "Actually pickable, but locked",
     "symbol": "+",
     "looks_like": "t_door_metal_locked",
@@ -2255,6 +2255,15 @@
         { "item": "steel_plate", "prob": 75 },
         { "item": "hinge", "count": [ 1, 3 ] }
       ]
+    },
+    "pry": {
+      "success_message": "You pry open the door.",
+      "fail_message": "You pry, but cannot pry open the door.",
+      "pry_quality": 4,
+      "noise": 16,
+      "sound": "metal screeching!",
+      "difficulty": 6,
+      "new_ter_type": "t_door_metal_o"
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -2260,9 +2260,9 @@
       "success_message": "You pry open the door.",
       "fail_message": "You pry, but cannot pry open the door.",
       "pry_quality": 4,
-      "noise": 16,
+      "noise": 24,
       "sound": "metal screeching!",
-      "difficulty": 6,
+      "difficulty": 8,
       "new_ter_type": "t_door_metal_o"
     }
   },

--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -2262,7 +2262,7 @@
       "pry_quality": 4,
       "noise": 24,
       "sound": "metal screeching!",
-      "difficulty": 8,
+      "difficulty": 4,
       "new_ter_type": "t_door_metal_o"
     }
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Allow halligan bars to pry open pickable metal doors"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Per prior discussion on the prying overhaul, a misc idea that came up was the suggestion of allowing halligan bars to open metal doors, as an incentive to use them over normal crowbars.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Added prying entry to pickable metal doors, requiring prying 4 to open. Per feedback, went with difficulty of 4 (half that of of wooden doors, making them almost always open) and noise of 24 (double that of prying open a wooden door).

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Adding option to pry open safes, with risk of breaking them?

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and load errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Chance of successful prying at different strength values: https://anydice.com/program/2528b

Str | Success Rate
--- | ---
8 | 92.80%
12 | 98.54%
16 | 99.54%
20 | 99.81%