### PR TITLE
Fix cutting up packaged items, expand use of disassemble action

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -13,7 +13,7 @@
     "symbol": "!",
     "color": "red",
     "use_action": "DISASSEMBLE",
-    "flags": [ "NO_REPAIR" ]
+    "flags": [ "NO_REPAIR", "NO_SALVAGE" ]
   },
   {
     "id": "melatonin_tablet",

--- a/data/json/items/comestibles/mre.json
+++ b/data/json/items/comestibles/mre.json
@@ -13,7 +13,8 @@
     "volume": "750 ml",
     "material": [ "plastic" ],
     "looks_like": "mre_beef_box",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "flags": [ "NO_REPAIR", "NO_SALVAGE" ]
   },
   {
     "abstract": "mre_smallbox",
@@ -29,7 +30,8 @@
     "volume": "250 ml",
     "material": [ "plastic" ],
     "looks_like": "mre_beef_box",
-    "use_action": "DISASSEMBLE"
+    "use_action": "DISASSEMBLE",
+    "flags": [ "NO_REPAIR", "NO_SALVAGE" ]
   },
   {
     "abstract": "mre_entree",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -349,14 +349,16 @@
     "type": "GENERIC",
     "category": "spare_parts",
     "name": { "str": "bundle of rags", "str_pl": "bundles of rags" },
-    "description": "Cotton rags, bundled tightly together for storage.  Disassemble to unpack.",
+    "description": "Cotton rags, bundled tightly together for storage.  Activate or disassemble to unpack.",
     "weight": "800 g",
     "volume": "750 ml",
     "price": 0,
     "price_postapoc": 5,
     "material": "cotton",
     "symbol": ",",
-    "color": "white"
+    "color": "white",
+    "use_action": "DISASSEMBLE",
+    "flags": [ "NO_REPAIR", "NO_SALVAGE" ]
   },
   {
     "id": "bundle_leather",
@@ -370,7 +372,9 @@
     "price_postapoc": 50,
     "material": "leather",
     "symbol": ",",
-    "color": "brown"
+    "color": "brown",
+    "use_action": "DISASSEMBLE",
+    "flags": [ "NO_REPAIR", "NO_SALVAGE" ]
   },
   {
     "id": "bundle_wool",
@@ -384,7 +388,9 @@
     "price_postapoc": 50,
     "material": "wool",
     "symbol": ",",
-    "color": "white"
+    "color": "white",
+    "use_action": "DISASSEMBLE",
+    "flags": [ "NO_REPAIR", "NO_SALVAGE" ]
   },
   {
     "type": "GENERIC",
@@ -2984,7 +2990,7 @@
     "symbol": "!",
     "color": "green",
     "use_action": "DISASSEMBLE",
-    "flags": [ "NO_REPAIR" ]
+    "flags": [ "NO_REPAIR", "NO_SALVAGE" ]
   },
   {
     "id": "premium_survival_kit",
@@ -2999,7 +3005,7 @@
     "symbol": "!",
     "color": "green",
     "use_action": { "type": "unpack", "group": "premium_contents", "items_fit": true, "filthy_volume_threshold": "10 L" },
-    "flags": [ "NO_REPAIR" ]
+    "flags": [ "NO_REPAIR", "NO_SALVAGE" ]
   },
   {
     "id": "plastic_six_dice",

--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -178,7 +178,9 @@
     "to_hit": -2,
     "material": "steel",
     "symbol": ";",
-    "color": "brown"
+    "color": "brown",
+    "use_action": "DISASSEMBLE",
+    "flags": [ "NO_REPAIR", "NO_SALVAGE" ]
   },
   {
     "id": "kiln_full",

--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -1,10 +1,10 @@
 [
   {
-    "id": "radio_car_box",
+    "id": "radio_car_base",
     "type": "GENERIC",
     "category": "other",
-    "name": { "str": "radio car box", "str_pl": "radio car boxes" },
-    "description": "An RC car, with radio-control and batteries included!  Disassemble to unpack and enjoy.",
+    "name": { "str": "radio car base" },
+    "description": "Generic radio car kit, you shouldn't see this.",
     "weight": "3200 g",
     "volume": "2 L",
     "price": 30000,
@@ -15,8 +15,17 @@
     "color": "red"
   },
   {
+    "id": "radio_car_box",
+    "copy-from": "radio_car_base",
+    "type": "GENERIC",
+    "name": { "str": "radio car box", "str_pl": "radio car boxes" },
+    "description": "An RC car, with radio-control and batteries included!  Disassemble to unpack and enjoy.",
+    "use_action": "DISASSEMBLE",
+    "flags": [ "NO_REPAIR", "NO_SALVAGE" ]
+  },
+  {
     "id": "radiocontrol",
-    "copy-from": "radio_car_box",
+    "copy-from": "radio_car_base",
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "RC control" },
@@ -46,7 +55,7 @@
   },
   {
     "id": "radio_car",
-    "copy-from": "radio_car_box",
+    "copy-from": "radio_car_base",
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "RC car" },

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -40,7 +40,8 @@
     "symbol": "#",
     "color": "brown_yellow",
     "looks_like": "frame_wood_light",
-    "flags": [ "NONCONDUCTIVE" ]
+    "use_action": "DISASSEMBLE",
+    "flags": [ "NONCONDUCTIVE", "NO_REPAIR", "NO_SALVAGE" ]
   },
   {
     "id": "acetylene_machine",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -90,7 +90,7 @@
     "encumbrance": 35,
     "warmth": 10,
     "material_thickness": 3,
-    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "flags": [ "BELTED", "WATER_FRIENDLY", "NO_SALVAGE" ],
     "use_action": { "type": "unpack", "group": "gobag_contents", "filthy_volume_threshold": "10 L" }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Add NO_REPAIR and NO_SALVAGE to most packaged items with disassemble action, allow using that action on a few more items intended to be uncrafted"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Looks to be a simple fix for this, so far. Prevents you from cutting up any item with the disassemble or unpack use actions, thus preventing you from deleting contents with just a knife. Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1104

Also makes things a bit more intuitive for a few more items that are supposed to be dismantled to get contents.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added `NO_SALVAGE` to first aid kit.
2. Added `NO_REPAIR` and `NO_SALVAGE` to `mre_box` and `mre_smallbox`, for consistency with most of the affected items.
3. Added `DISASSEMBLE` action, `NO_REPAIR`, and `NO_SALVAGE` to rag, leather, and wool bundles.
4. Added `NO_SALVAGE` to survival kits.
5. Added `DISASSEMBLE` action, `NO_REPAIR`, and `NO_SALVAGE` to radio car box. Also reworked the radio controller and car to inherit from a shared base item, because copying from the car box is kinda weird and would've caused problems after giving the box a use action and flags.
6. Added `DISASSEMBLE` action, `NO_REPAIR`, and `NO_SALVAGE` to finished charcoal kiln and pallet of dry adobe bricks.
7. Added `NO_SALVAGE` to go bags. Left them repairable since they're clothing items, for now.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Could add NO_REPAIR to gobags if desired, but not being able to repair what is otherwise a backpack does seem to be just as odd as being able to sew up damaged contents.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and load errors.
2. Ported changes over to a test build.
3. Spawned in a first aid kit and a scalpel.
4. Tested the scalpel's item cutting action, first aid kit was excluded from the selection.
5. Dropped the kit on the floor and tried `B`, was only given the option to uncraft it.
6. Spawned in a rag bundle, confirmed that activating it gave me rags.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Premium survival kits have the same name as normal ones, weird.