### PR TITLE
Fix items with NO_UNWIELD being droppable via inventory item menu

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2487,6 +2487,16 @@ std::list<item *> Character::get_dependent_worn_items( const item &it )
 
 void Character::drop( item_location loc, const tripoint &where )
 {
+    item &oThisItem = *loc;
+    if( is_wielding( oThisItem ) ) {
+        const auto ret = can_unwield( *loc );
+
+        if( !ret.success() ) {
+            add_msg( m_info, "%s", ret.c_str() );
+            return;
+        }
+    }
+
     drop( { drop_location( loc, loc->count() ) }, where );
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2053,7 +2053,11 @@ int game::inventory_item_menu( item_location locThisItem,
         std::vector<iteminfo> vDummy;
 
         const bool bHPR = get_auto_pickup().has_rule( &oThisItem );
-        const hint_rating rate_drop_item = u.weapon.has_flag( "NO_UNWIELD" ) ? hint_rating::cant :
+        const bool cant_unwield_weapon = u.weapon.has_flag( "NO_UNWIELD" );
+        const bool cant_drop_this = cant_unwield_weapon && u.is_wielding( oThisItem );
+        const hint_rating rate_wield_item = cant_unwield_weapon ? hint_rating::cant :
+                                            hint_rating::good;
+        const hint_rating rate_drop_item = cant_drop_this ? hint_rating::cant :
                                            hint_rating::good;
 
         uilist action_menu;
@@ -2078,8 +2082,8 @@ int game::inventory_item_menu( item_location locThisItem,
         addentry( 'R', pgettext( "action", "read" ), u.rate_action_read( oThisItem ) );
         addentry( 'E', pgettext( "action", "eat" ), u.rate_action_eat( oThisItem ) );
         addentry( 'W', pgettext( "action", "wear" ), u.rate_action_wear( oThisItem ) );
-        addentry( 'w', pgettext( "action", "wield" ), hint_rating::good );
-        addentry( 't', pgettext( "action", "throw" ), hint_rating::good );
+        addentry( 'w', pgettext( "action", "wield" ), rate_wield_item );
+        addentry( 't', pgettext( "action", "throw" ), rate_drop_item );
         addentry( 'c', pgettext( "action", "change side" ), u.rate_action_change_side( oThisItem ) );
         addentry( 'T', pgettext( "action", "take off" ), u.rate_action_takeoff( oThisItem ) );
         addentry( 'd', pgettext( "action", "drop" ), rate_drop_item );


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Prevent using inventory item menu to drop items with the NO_UNWIELD flag; correct related hint colors"

#### Purpose of change

Fixes #1074. From the look of things, schizophrenia could also cause this issue; this should be fixed as well.

Also corrects the hint colors of relevant actions in the IIM (drop, wield, throw): previously, *all* items would hint as undroppable if the wielded item had NO_UNWIELD. Also, items with NO_UNWIELD would incorrectly hint as throwable and (un)wieldable; and items would hint as wieldable while a NO_UNWIELD item was wielded.

#### Describe the solution

Intercepts dropping in `Character::drop(item_location loc, const tripoint & where)`, a method used only by `game::inventory_item_menu` (IIM), `player::takeoff` ('take off' action), and `Character::suffer_from_schizophrenia` (schizophrenia effects). The purpose of this method appears to be to drop only a single item. New code is based on a check in `game::wield`.

Adjusted hint colors in `game::inventory_item_menu` as follows:
- Wield: always green --> grey if the current wielded item is NO_UNWIELD, green otherwise
- Throw: always green --> grey if the current wielded item is NO_UNWIELD *and* is the item being considered for throwing, green otherwise
- Drop: grey if the current wielded item is NO_UNWIELD, green otherwise --> grey if the current wielded item is NO_UNWIELD *and* is the item being considered for dropping, green otherwise

#### Describe alternatives you've considered

There may be other places to intercept dropping for this purpose. This may also be an unsafe place/way to do so (can NPCs trigger the message and maybe cause incorrect wording? was unsure how to test this); however, I haven't been able to find any such issues yet.

Adjusting hint colors may be more suitable for another PR, but I figured it was closely related enough to count. Set up as 2 separate commits just in case it wasn't.

#### Testing

##### Reproduction
1. Launched a release x64 build of bee8a49, with data/font/Terminus.ttf deleted due to a rendering bug in vcpkg.
2. Started a new game using Play Now! (Fixed Scenario).
3. Spawned in and wielded an extended toolset item.
4. Opened the inventory item menu for the extended toolset, and observed that drop hinted correctly as impossible/grey, but that wield and throw both incorrectly hinted as possible/green.
5. Opened the inventory item menu for another item (a cellphone), and observed that drop hinted incorrectly as grey, that wield hinted incorrectly as green, and that throw hinted correctly as green.
6. Opened the inventory item menu for the extended toolset, pressed the drop key, and observed that the toolset was dropped as with a normal item, despite hint color and item flags to the contrary.
##### Fix verification
7. Closed the previous game instance and launched a release x64 build of bee8a49 + this PR.
8. Started a new game using Play Now! (Fixed Scenario).
9. Spawned in and wielded an extended toolset item.
10. Opened the inventory item menu for the extended toolset, and observed that drop, wield, and throw all hinted correctly as grey.
11. Opened the inventory item menu for another item (a smartphone), and observed that wield hinted correctly as grey, and that drop and throw hinted correctly as green.
12. Opened the inventory item menu for the extended toolset, pressed the drop key, and observed that the toolset was not dropped ("You cannot unwield your extended toolset.").
##### Regression checks
13. Verified that all other combinations of IIM actions and NO_UNWIELD states worked as expected, matching both hint color and resultant action:
    - No NO_UNWIELD items, target item is not wielded --> IIM can drop, wield, and throw
    - No NO_UNWIELD items, target item is wielded --> IIM can drop, (un)wield, and throw
    - NO_UNWIELD item available but unwielded, target item is not wielded --> IIM can drop, wield, and throw
    - NO_UNWIELD item available but unwielded, target item is wielded --> IIM can drop, (un)wield, and throw
    - NO_UNWIELD item wielded, target item is not wielded --> IIM can drop and throw, but not wield
    - NO_UNWIELD item wielded, target item is wielded --> IIM cannot drop, throw, or (un)wield