### PR TITLE
[DDA Port] Fix multiple issues with "ledge" rays

### DIFF
--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -694,6 +694,7 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     werase( w_info );
 
     Character &player_character = get_player_character();
+    map &here = get_map();
 
     const optional_vpart_position vp = g->m.veh_at( target );
     std::string veh_msg;
@@ -744,10 +745,12 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
              );
     map::apparent_light_info al = map::apparent_light_helper( map_cache, target );
     int apparent_light = static_cast<int>(
-                             g->m.apparent_light_at( target, g->m.get_visibility_variables_cache() ) );
-    mvwprintw( w_info, point( 1, off++ ), _( "outside: %d obstructed: %d" ),
-               static_cast<int>( g->m.is_outside( target ) ),
-               static_cast<int>( al.obstructed ) );
+                             here.apparent_light_at( target, here.get_visibility_variables_cache() ) );
+    mvwprintw( w_info, point( 1, off++ ), _( "outside: %d obstructed: %d floor: %d" ),
+               static_cast<int>( here.is_outside( target ) ),
+               static_cast<int>( al.obstructed ),
+               static_cast<int>( here.has_floor( target ) )
+             );
     mvwprintw( w_info, point( 1, off++ ), _( "light_at: %s" ),
                map_cache.lm[target.x][target.y].to_string() );
     mvwprintw( w_info, point( 1, off++ ), _( "apparent light: %.5f (%d)" ),

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -372,6 +372,8 @@ void map::generate_lightmap( const int zlev )
     auto &lm = map_cache.lm;
     auto &sm = map_cache.sm;
     auto &outside_cache = map_cache.outside_cache;
+    auto &prev_floor_cache = get_cache( clamp( zlev + 1, -OVERMAP_DEPTH, OVERMAP_DEPTH ) ).floor_cache;
+    bool top_floor = zlev == OVERMAP_DEPTH;
     std::memset( lm, 0, sizeof( lm ) );
     std::memset( sm, 0, sizeof( sm ) );
 
@@ -419,22 +421,22 @@ void map::generate_lightmap( const int zlev )
                     const int y = sy + smy * SEEY;
                     const tripoint p( x, y, zlev );
                     // Project light into any openings into buildings.
-                    if( !outside_cache[p.x][p.y] ) {
+                    if( !outside_cache[p.x][p.y] || ( !top_floor && prev_floor_cache[p.x][p.y] ) ) {
                         // Apply light sources for external/internal divide
                         for( int i = 0; i < 4; ++i ) {
                             point neighbour = p.xy() + point( dir_x[i], dir_y[i] );
                             if( lightmap_boundaries.contains( neighbour )
-                                && outside_cache[neighbour.x][neighbour.y]
+                                && outside_cache[neighbour.x][neighbour.y] &&
+                                ( top_floor || !prev_floor_cache[neighbour.x][neighbour.y] )
                               ) {
+                                const float source_light =
+                                    std::min( natural_light, lm[neighbour.x][neighbour.y].max() );
                                 if( light_transparency( p ) > LIGHT_TRANSPARENCY_SOLID ) {
-                                    update_light_quadrants(
-                                        lm[p.x][p.y], natural_light, quadrant::default_ );
-                                    apply_directional_light( p, dir_d[i], natural_light );
+                                    update_light_quadrants( lm[p.x][p.y], source_light, quadrant::default_ );
+                                    apply_directional_light( p, dir_d[i], source_light );
                                 } else {
-                                    update_light_quadrants(
-                                        lm[p.x][p.y], natural_light, dir_quadrants[i][0] );
-                                    update_light_quadrants(
-                                        lm[p.x][p.y], natural_light, dir_quadrants[i][1] );
+                                    update_light_quadrants( lm[p.x][p.y], source_light, dir_quadrants[i][0] );
+                                    update_light_quadrants( lm[p.x][p.y], source_light, dir_quadrants[i][1] );
                                 }
                             }
                         }


### PR DESCRIPTION
Port of https://github.com/CleverRaven/Cataclysm-DDA/pull/44847

In BN, this bug most commonly affects fire lookout towers: their entire bottom level is pitch black when viewed from outside, even at day, and completely conceals zombies there. With this fix, the bottom level is merely darker than the surroundings.