### PR TITLE
Convert distribution grids and active tiles to use type safe coords

### DIFF
--- a/src/active_tile_data.cpp
+++ b/src/active_tile_data.cpp
@@ -1,4 +1,6 @@
 #include "active_tile_data.h"
+#include "active_tile_data_def.h"
+
 #include "coordinate_conversions.h"
 #include "debug.h"
 #include "distribution_grid.h"

--- a/src/active_tile_data.h
+++ b/src/active_tile_data.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include "calendar.h"
+#include "coordinates.h"
 
 class JsonObject;
 class JsonOut;
@@ -24,10 +25,11 @@ class active_tile_data
          * @param p absolute map coordinates (@ref map::getabs) of the tile being updated
          * @param grid distribution grid being updated, containing the tile being updated
          */
-        virtual void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) = 0;
+        virtual void update_internal( time_point to, const tripoint_abs_ms &p,
+                                      distribution_grid &grid ) = 0;
 
     public:
-        void update( time_point to, const tripoint &p, distribution_grid &grid ) {
+        void update( time_point to, const tripoint_abs_ms &p, distribution_grid &grid ) {
             update_internal( to, p, grid );
             last_updated = to;
         }
@@ -56,7 +58,7 @@ namespace active_tiles
 
 // TODO: Don't return a raw pointer
 template <typename T = active_tile_data>
-T * furn_at( const tripoint &pos );
+T * furn_at( const tripoint_abs_ms &pos );
 
 } // namespace active_tiles
 

--- a/src/active_tile_data.h
+++ b/src/active_tile_data.h
@@ -4,11 +4,9 @@
 
 #include <string>
 #include "calendar.h"
-#include "point.h"
 
 class JsonObject;
 class JsonOut;
-class map;
 struct tripoint;
 class distribution_grid;
 
@@ -50,62 +48,6 @@ class active_tile_data
 
         virtual void store( JsonOut &jsout ) const = 0;
         virtual void load( JsonObject &jo ) = 0;
-};
-
-class solar_tile : public active_tile_data
-{
-    public:
-        /* In W */
-        int power;
-
-        void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) override;
-        active_tile_data *clone() const override;
-        const std::string &get_type() const override;
-        void store( JsonOut &jsout ) const override;
-        void load( JsonObject &jo ) override;
-};
-
-class battery_tile : public active_tile_data
-{
-    public:
-        /* In J */
-        int stored;
-        int max_stored;
-
-        void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) override;
-        active_tile_data *clone() const override;
-        const std::string &get_type() const override;
-        void store( JsonOut &jsout ) const override;
-        void load( JsonObject &jo ) override;
-
-        int get_resource() const;
-        int mod_resource( int amt );
-};
-
-class charger_tile : public active_tile_data
-{
-    public:
-        /* In W */
-        int power;
-
-        void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) override;
-        active_tile_data *clone() const override;
-        const std::string &get_type() const override;
-        void store( JsonOut &jsout ) const override;
-        void load( JsonObject &jo ) override;
-};
-
-class vehicle_connector_tile : public active_tile_data
-{
-    public:
-        /* In absolute map square coordinates */
-        std::vector<tripoint> connected_vehicles;
-
-        void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) override;
-        active_tile_data *clone() const override;
-        const std::string &get_type() const override;
-        void store( JsonOut &jsout ) const override;
-        void load( JsonObject &jo ) override;
 };
 
 // TODO: Better place for this

--- a/src/active_tile_data_def.h
+++ b/src/active_tile_data_def.h
@@ -1,0 +1,64 @@
+#pragma once
+#ifndef CATA_SRC_ACTIVE_TILE_DATA_DEF_H
+#define CATA_SRC_ACTIVE_TILE_DATA_DEF_H
+
+#include "active_tile_data.h"
+#include "point.h"
+
+class battery_tile : public active_tile_data
+{
+    public:
+        /* In J */
+        int stored;
+        int max_stored;
+
+        void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) override;
+        active_tile_data *clone() const override;
+        const std::string &get_type() const override;
+        void store( JsonOut &jsout ) const override;
+        void load( JsonObject &jo ) override;
+
+        int get_resource() const;
+        int mod_resource( int amt );
+};
+
+class charger_tile : public active_tile_data
+{
+    public:
+        /* In W */
+        int power;
+
+        void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) override;
+        active_tile_data *clone() const override;
+        const std::string &get_type() const override;
+        void store( JsonOut &jsout ) const override;
+        void load( JsonObject &jo ) override;
+};
+
+class solar_tile : public active_tile_data
+{
+    public:
+        /* In W */
+        int power;
+
+        void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) override;
+        active_tile_data *clone() const override;
+        const std::string &get_type() const override;
+        void store( JsonOut &jsout ) const override;
+        void load( JsonObject &jo ) override;
+};
+
+class vehicle_connector_tile : public active_tile_data
+{
+    public:
+        /* In absolute map square coordinates */
+        std::vector<tripoint> connected_vehicles;
+
+        void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) override;
+        active_tile_data *clone() const override;
+        const std::string &get_type() const override;
+        void store( JsonOut &jsout ) const override;
+        void load( JsonObject &jo ) override;
+};
+
+#endif // CATA_SRC_ACTIVE_TILE_DATA_DEF_H

--- a/src/active_tile_data_def.h
+++ b/src/active_tile_data_def.h
@@ -12,7 +12,7 @@ class battery_tile : public active_tile_data
         int stored;
         int max_stored;
 
-        void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) override;
+        void update_internal( time_point to, const tripoint_abs_ms &p, distribution_grid &grid ) override;
         active_tile_data *clone() const override;
         const std::string &get_type() const override;
         void store( JsonOut &jsout ) const override;
@@ -28,7 +28,7 @@ class charger_tile : public active_tile_data
         /* In W */
         int power;
 
-        void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) override;
+        void update_internal( time_point to, const tripoint_abs_ms &p, distribution_grid &grid ) override;
         active_tile_data *clone() const override;
         const std::string &get_type() const override;
         void store( JsonOut &jsout ) const override;
@@ -41,7 +41,7 @@ class solar_tile : public active_tile_data
         /* In W */
         int power;
 
-        void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) override;
+        void update_internal( time_point to, const tripoint_abs_ms &p, distribution_grid &grid ) override;
         active_tile_data *clone() const override;
         const std::string &get_type() const override;
         void store( JsonOut &jsout ) const override;
@@ -51,10 +51,9 @@ class solar_tile : public active_tile_data
 class vehicle_connector_tile : public active_tile_data
 {
     public:
-        /* In absolute map square coordinates */
-        std::vector<tripoint> connected_vehicles;
+        std::vector<tripoint_abs_ms> connected_vehicles;
 
-        void update_internal( time_point to, const tripoint &p, distribution_grid &grid ) override;
+        void update_internal( time_point to, const tripoint_abs_ms &p, distribution_grid &grid ) override;
         active_tile_data *clone() const override;
         const std::string &get_type() const override;
         void store( JsonOut &jsout ) const override;

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1023,7 +1023,8 @@ void complete_construction( player *p )
     if( !built.post_terrain.empty() ) {
         if( built.post_is_furniture ) {
             g->m.furn_set( terp, furn_str_id( built.post_terrain ) );
-            active_tile_data *active = active_tiles::furn_at<active_tile_data>( g->m.getabs( terp ) );
+            active_tile_data *active = active_tiles::furn_at<active_tile_data>(
+                                           tripoint_abs_ms( g->m.getabs( terp ) ) );
             if( active != nullptr ) {
                 active->set_last_updated( calendar::turn );
             }

--- a/src/distribution_grid.cpp
+++ b/src/distribution_grid.cpp
@@ -4,6 +4,7 @@
 #include "distribution_grid.h"
 #include "coordinate_conversions.h"
 #include "active_tile_data.h"
+#include "active_tile_data_def.h"
 #include "map.h"
 #include "mapbuffer.h"
 #include "map_iterator.h"

--- a/src/distribution_grid.h
+++ b/src/distribution_grid.h
@@ -7,6 +7,7 @@
 #include <map>
 
 #include "calendar.h"
+#include "coordinates.h"
 #include "cuboid_rectangle.h"
 #include "memory_fast.h"
 #include "point.h"
@@ -15,10 +16,10 @@ class map;
 class mapbuffer;
 
 struct tile_location {
-    point on_submap;
-    tripoint absolute;
+    point_sm_ms on_submap;
+    tripoint_abs_ms absolute;
 
-    tile_location( point on_submap, tripoint absolute )
+    tile_location( point_sm_ms on_submap, tripoint_abs_ms absolute )
         : on_submap( on_submap )
         , absolute( absolute )
     {}
@@ -38,20 +39,20 @@ class distribution_grid
          * Map of submap coords to points on this submap
          * that contain an active tile.
          */
-        std::map<tripoint, std::vector<tile_location>> contents;
-        std::vector<tripoint> flat_contents;
-        std::vector<tripoint> submap_coords;
+        std::map<tripoint_abs_sm, std::vector<tile_location>> contents;
+        std::vector<tripoint_abs_ms> flat_contents;
+        std::vector<tripoint_abs_sm> submap_coords;
 
         mapbuffer &mb;
 
     public:
-        distribution_grid( const std::vector<tripoint> &global_submap_coords, mapbuffer &buffer );
+        distribution_grid( const std::vector<tripoint_abs_sm> &global_submap_coords, mapbuffer &buffer );
         bool empty() const;
         explicit operator bool() const;
         void update( time_point to );
         int mod_resource( int amt, bool recurse = true );
         int get_resource( bool recurse = true ) const;
-        const std::vector<tripoint> &get_contents() const {
+        const std::vector<tripoint_abs_ms> &get_contents() const {
             return flat_contents;
         }
 };
@@ -65,17 +66,17 @@ class distribution_grid_tracker
         /**
          * Mapping of sm position to grid it belongs to.
          */
-        std::map<tripoint, shared_ptr_fast<distribution_grid>> parent_distribution_grids;
+        std::map<tripoint_abs_sm, shared_ptr_fast<distribution_grid>> parent_distribution_grids;
 
         /**
          * @param omt_pos Absolute submap position of one of the tiles of the grid.
          */
-        distribution_grid &make_distribution_grid_at( const tripoint &sm_pos );
+        distribution_grid &make_distribution_grid_at( const tripoint_abs_sm &sm_pos );
 
         /**
          * In submap coords, to mirror @ref map
          */
-        half_open_rectangle<point> bounds;
+        half_open_rectangle<point_abs_sm> bounds;
 
         mapbuffer &mb;
 
@@ -87,21 +88,21 @@ class distribution_grid_tracker
          * Gets grid at given global map square coordinate. @ref map::getabs
          */
         /**@{*/
-        distribution_grid &grid_at( const tripoint &p );
-        const distribution_grid &grid_at( const tripoint &p ) const;
+        distribution_grid &grid_at( const tripoint_abs_ms &p );
+        const distribution_grid &grid_at( const tripoint_abs_ms &p ) const;
         /*@}*/
 
         /**
          * Identify grid at given overmap tile (for debug purposes).
          * @returns 0 if there's no grid.
          */
-        std::uintptr_t debug_grid_id( const tripoint &omp ) const;
+        std::uintptr_t debug_grid_id( const tripoint_abs_omt &omp ) const;
 
         void update( time_point to );
         /**
          * Loads grids in an area given by submap coords.
          */
-        void load( half_open_rectangle<point> area );
+        void load( half_open_rectangle<point_abs_sm> area );
         /**
          * Loads grids in the same area as a given map.
          */
@@ -110,7 +111,7 @@ class distribution_grid_tracker
         /**
          * Updates grid at given global map square coordinate.
          */
-        void on_changed( const tripoint &p );
+        void on_changed( const tripoint_abs_ms &p );
         void on_saved();
         void on_options_changed();
 };

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 
 #include "activity_actor.h"
+#include "active_tile_data_def.h"
 #include "ammo.h"
 #include "avatar.h"
 #include "basecamp.h"
@@ -5894,7 +5895,7 @@ void iexamine::dimensional_portal( player &p, const tripoint &examp )
 
 void iexamine::check_power( player &, const tripoint &examp )
 {
-    tripoint abspos = g->m.getabs( examp );
+    tripoint_abs_ms abspos( g->m.getabs( examp ) );
     battery_tile *battery = active_tiles::furn_at<battery_tile>( abspos );
     if( battery != nullptr ) {
         add_msg( m_info, _( "This battery stores %d kJ of electric power." ), battery->get_resource() );

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -460,7 +460,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
                 furn_item.set_flag( "PSEUDO" );
                 if( furn_item.has_flag( "USES_GRID_POWER" ) ) {
                     // TODO: The grid tracker should correspond to map!
-                    auto &grid = get_distribution_grid_tracker().grid_at( m.getabs( p ) );
+                    auto &grid = get_distribution_grid_tracker().grid_at( tripoint_abs_ms( m.getabs( p ) ) );
                     furn_item.charges = grid.get_resource();
                 } else {
                     furn_item.charges = ammo ? count_charges_in_list( ammo, m.i_at( p ) ) : 0;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -19,6 +19,7 @@
 
 #include "action.h"
 #include "activity_actor.h"
+#include "active_tile_data_def.h"
 #include "artifact.h"
 #include "avatar.h"
 #include "bodypart.h"

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9059,7 +9059,7 @@ int iuse::cable_attach( player *p, item *it, bool, const tripoint & )
         const tripoint vpos = *vpos_;
 
         const optional_vpart_position target_vp = g->m.veh_at( vpos );
-        tripoint target_global = g->m.getabs( vpos );
+        tripoint_abs_ms target_global( g->m.getabs( vpos ) );
         vehicle_connector_tile *grid_connection = active_tiles::furn_at<vehicle_connector_tile>
                 ( target_global );
         if( !target_vp && !grid_connection ) {
@@ -9082,8 +9082,8 @@ int iuse::cable_attach( player *p, item *it, bool, const tripoint & )
             point vcoords = source_vp->mount();
             vehicle_part source_part( vpid, vcoords, item( *it ) );
             if( grid_connection != nullptr ) {
-                source_part.target.first = target_global;
-                source_part.target.second = target_global;
+                source_part.target.first = target_global.raw();
+                source_part.target.second = target_global.raw();
                 source_part.set_flag( vehicle_part::targets_grid );
                 if( p != nullptr && p->has_item( *it ) ) {
                     p->add_msg_if_player( m_good, _( "You connect the %s to the electric grid." ),
@@ -9101,7 +9101,7 @@ int iuse::cable_attach( player *p, item *it, bool, const tripoint & )
                     return 0;
                 }
 
-                source_part.target.first = target_global;
+                source_part.target.first = target_global.raw();
                 source_part.target.second = g->m.getabs( target_veh->global_pos3() );
                 source_veh->install_part( vcoords, source_part );
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1381,13 +1381,13 @@ void map::furn_set( const tripoint &p, const furn_id &new_furniture )
     support_dirty( above );
 
     if( old_t.active ) {
-        current_submap->active_furniture.erase( l );
+        current_submap->active_furniture.erase( point_sm_ms( l ) );
         // TODO: Only for g->m? Observer pattern?
-        get_distribution_grid_tracker().on_changed( getabs( p ) );
+        get_distribution_grid_tracker().on_changed( tripoint_abs_ms( getabs( p ) ) );
     }
     if( new_t.active ) {
-        current_submap->active_furniture[l].reset( new_t.active->clone() );
-        get_distribution_grid_tracker().on_changed( getabs( p ) );
+        current_submap->active_furniture[point_sm_ms( l )].reset( new_t.active->clone() );
+        get_distribution_grid_tracker().on_changed( tripoint_abs_ms( getabs( p ) ) );
     }
 }
 
@@ -4828,7 +4828,7 @@ static void use_charges_from_furn( const furn_t &f, const itype_id &type, int &q
 
     const itype *itt = f.crafting_pseudo_item_type();
     if( itt != nullptr && itt->item_tags.count( flag_USES_GRID_POWER ) > 0 ) {
-        const tripoint abspos = m->getabs( p );
+        const tripoint_abs_ms abspos( m->getabs( p ) );
         auto &grid = get_distribution_grid_tracker().grid_at( abspos );
         item furn_item( itt, calendar::start_of_cataclysm, grid.get_resource() );
         int initial_quantity = quantity;

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 
+#include "coordinates.h"
 #include "point.h"
 
 class submap;
@@ -53,6 +54,9 @@ class mapbuffer
          * submap object, don't delete it on your own.
          */
         submap *lookup_submap( const tripoint &p );
+        submap *lookup_submap( const tripoint_abs_sm &p ) {
+            return lookup_submap( p.raw() );
+        }
 
     private:
         using submap_map_t = std::map<tripoint, submap *>;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -102,7 +102,7 @@ struct grids_draw_data {
     public:
         cata::optional<char> get_active( const tripoint_abs_omt &omp ) {
             // TODO: fix point types
-            uintptr_t id = get_distribution_grid_tracker().debug_grid_id( omp.raw() );
+            uintptr_t id = get_distribution_grid_tracker().debug_grid_id( omp );
             if( id == 0 ) {
                 return cata::nullopt;
             }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4148,7 +4148,7 @@ void submap::load( JsonIn &jsin, const std::string &member_name, int version )
     } else if( member_name == "active_furniture" ) {
         jsin.start_array();
         while( !jsin.end_array() ) {
-            point p;
+            point_sm_ms p;
             jsin.read( p );
             active_furniture[p].deserialize( jsin );
         }

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -298,9 +298,9 @@ void submap::rotate( int turns )
     }
     computers = rot_comp;
 
-    std::map<point, cata::poly_serialized<active_tile_data>> rot_active_furn;
+    std::map<point_sm_ms, cata::poly_serialized<active_tile_data>> rot_active_furn;
     for( auto &elem : active_furniture ) {
-        rot_active_furn.emplace( rotate_point( elem.first ), elem.second );
+        rot_active_furn.emplace( point_sm_ms( rotate_point( elem.first.raw() ) ), elem.second );
     }
     active_furniture = rot_active_furn;
 }

--- a/src/submap.h
+++ b/src/submap.h
@@ -247,7 +247,7 @@ class submap : maptile_soa<SEEX, SEEY>
         std::vector<std::unique_ptr<vehicle>> vehicles;
         std::map<tripoint, partial_con> partial_constructions;
         std::unique_ptr<basecamp> camp;  // only allowing one basecamp per submap
-        std::map<point, cata::poly_serialized<active_tile_data>> active_furniture;
+        std::map<point_sm_ms, cata::poly_serialized<active_tile_data>> active_furniture;
 
     private:
         std::map<point, computer> computers;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4892,10 +4892,10 @@ int traverse( StartPoint *start, int amount,
     visited_elements.insert( start );
     auto &grid_tracker = get_distribution_grid_tracker();
 
-    auto process_vehicle = [&]( const tripoint & target_pos ) {
+    auto process_vehicle = [&]( const tripoint_abs_ms & target_pos ) {
         auto *veh = vehicle::find_vehicle( target_pos );
         if( veh == nullptr ) {
-            debugmsg( "lost vehicle at %d,%d,%d", target_pos.x, target_pos.y, target_pos.z );
+            debugmsg( "lost vehicle at %s", target_pos.to_string() );
         }
         // Add this connected vehicle to the queue of vehicles to search next,
         // but only if we haven't seen this one before.
@@ -4913,10 +4913,10 @@ int traverse( StartPoint *start, int amount,
         return false;
     };
 
-    auto process_grid = [&]( const tripoint & target_pos ) {
+    auto process_grid = [&]( const tripoint_abs_ms & target_pos ) {
         auto *grid = &grid_tracker.grid_at( target_pos );
         if( !*grid ) {
-            debugmsg( "lost grid at %d,%d,%d", target_pos.x, target_pos.y, target_pos.z );
+            debugmsg( "lost grid at %s", target_pos.to_string() );
         }
         if( *grid && visited_elements.count( grid ) == 0 ) {
             connected_elements.emplace( grid );
@@ -4944,7 +4944,7 @@ int traverse( StartPoint *start, int amount,
                     continue;
                 }
 
-                const tripoint target_pos = current_veh.parts[p].target.second;
+                const tripoint_abs_ms target_pos( current_veh.parts[p].target.second );
                 if( current_veh.parts[p].has_flag( vehicle_part::targets_grid ) ) {
                     if( process_grid( target_pos ) ) {
                         break;
@@ -4964,7 +4964,7 @@ int traverse( StartPoint *start, int amount,
                     continue;
                 }
 
-                for( const tripoint &target_pos : connector->connected_vehicles ) {
+                for( const tripoint_abs_ms &target_pos : connector->connected_vehicles ) {
                     if( process_vehicle( target_pos ) ) {
                         break;
                     }
@@ -6099,10 +6099,10 @@ void vehicle::remove_remote_part( int part_num )
 {
     if( parts[part_num].has_flag( vehicle_part::targets_grid ) ) {
         vehicle_connector_tile *connector =
-            active_tiles::furn_at<vehicle_connector_tile>( parts[part_num].target.second );
+            active_tiles::furn_at<vehicle_connector_tile>( tripoint_abs_ms( parts[part_num].target.second ) );
         if( connector != nullptr ) {
             auto &vehs = connector->connected_vehicles;
-            auto iter = std::find( vehs.begin(), vehs.end(), g->m.getabs( global_pos3() ) );
+            auto iter = std::find( vehs.begin(), vehs.end(), tripoint_abs_ms( g->m.getabs( global_pos3() ) ) );
             if( iter != vehs.end() ) {
                 vehs.erase( iter );
             }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -18,6 +18,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "active_tile_data_def.h"
 #include "avatar.h"
 #include "bionics.h"
 #include "cata_utility.h"

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -730,6 +730,9 @@ class vehicle
          * @param where Location of the other vehicle's origin tile.
          */
         static vehicle *find_vehicle( const tripoint &where );
+        static vehicle *find_vehicle( const tripoint_abs_ms &where ) {
+            return find_vehicle( where.raw() );
+        }
 
     private:
         /**

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -596,7 +596,7 @@ TEST_CASE( "oven electric grid", "[crafting][overmap][grids][slow]" )
     map &m = get_map();
     avatar &u = get_avatar();
     constexpr tripoint start_pos = tripoint( 60, 60, 0 );
-    const tripoint start_pos_abs = m.getabs( start_pos );
+    const tripoint_abs_ms start_pos_abs( m.getabs( start_pos ) );
     u.setpos( start_pos );
     clear_avatar();
     clear_map();

--- a/tests/electric_grid_test.cpp
+++ b/tests/electric_grid_test.cpp
@@ -75,12 +75,12 @@ static inline void test_grid_veh( distribution_grid &grid, vehicle &veh, battery
 }
 
 static void connect_grid_vehicle( map &m, vehicle &veh, vehicle_connector_tile &connector,
-                                  const tripoint &connector_abs_pos )
+                                  const tripoint_abs_ms &connector_abs_pos )
 {
     const point cable_part_pos;
     vehicle_part source_part( vpart_id( "jumper_cable" ), cable_part_pos, item( "jumper_cable" ) );
-    source_part.target.first = connector_abs_pos;
-    source_part.target.second = connector_abs_pos;
+    source_part.target.first = connector_abs_pos.raw();
+    source_part.target.second = connector_abs_pos.raw();
     source_part.set_flag( vehicle_part::targets_grid );
     connector.connected_vehicles.clear();
     connector.connected_vehicles.emplace_back( m.getabs( veh.global_pos3() ) );
@@ -106,8 +106,8 @@ static grid_setup set_up_grid( map &m )
     const tripoint vehicle_local_pos = tripoint( 10, 10, 0 );
     const tripoint connector_local_pos = tripoint( 13, 10, 0 );
     const tripoint battery_local_pos = tripoint( 14, 10, 0 );
-    const tripoint connector_abs_pos = m.getabs( connector_local_pos );
-    const tripoint battery_abs_pos = m.getabs( battery_local_pos );
+    const tripoint_abs_ms connector_abs_pos( m.getabs( connector_local_pos ) );
+    const tripoint_abs_ms battery_abs_pos( m.getabs( battery_local_pos ) );
     m.furn_set( connector_local_pos, furn_str_id( "f_cable_connector" ) );
     m.furn_set( battery_local_pos, furn_str_id( "f_battery" ) );
     vehicle *veh = m.add_vehicle( vproto_id( "car" ), vehicle_local_pos, 0, 0, 0, false );

--- a/tests/electric_grid_test.cpp
+++ b/tests/electric_grid_test.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 
 #include "active_tile_data.h"
+#include "active_tile_data_def.h"
 #include "catch/catch.hpp"
 #include "coordinate_conversions.h"
 #include "distribution_grid.h"


### PR DESCRIPTION
And also extract active tile definitions from `active_tile_data.h` into a separate header.

This is pure refactor, with no changes to behavior intended.