### PR TITLE
Major performance improvements involving auto inventory letters

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -303,7 +303,7 @@ item &inventory::add_item( item newit, bool keep_invlet, bool assign_invlet, boo
                 }
                 elem.push_back( newit );
                 return elem.back();
-            } else if( keep_invlet && assign_invlet && it_ref->invlet == newit.invlet ) {
+            } else if( keep_invlet && assign_invlet && it_ref->invlet == newit.invlet && it_ref->invlet != '\0' ) {
                 // If keep_invlet is true, we'll be forcing other items out of their current invlet.
                 assign_empty_invlet( *it_ref, g->u );
             }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1057,12 +1057,14 @@ void inventory::assign_empty_invlet( item &it, const Character &p, const bool fo
         avatar &u = g->u;
         inventory_selector selector( u );
 
+        std::vector<char> binds = selector.all_bound_keys();
+
         for( const auto &inv_char : inv_chars ) {
             if( assigned_invlet.count( inv_char ) ) {
                 // don't overwrite assigned keys
                 continue;
             }
-            if( !selector.action_bound_to_key( inv_char ).empty() ) {
+            if( std::find( binds.begin(), binds.end(), inv_char ) != binds.end() ) {
                 // don't auto-assign bound keys
                 continue;
             }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -303,7 +303,8 @@ item &inventory::add_item( item newit, bool keep_invlet, bool assign_invlet, boo
                 }
                 elem.push_back( newit );
                 return elem.back();
-            } else if( keep_invlet && assign_invlet && it_ref->invlet == newit.invlet && it_ref->invlet != '\0' ) {
+            } else if( keep_invlet && assign_invlet && it_ref->invlet == newit.invlet &&
+                       it_ref->invlet != '\0' ) {
                 // If keep_invlet is true, we'll be forcing other items out of their current invlet.
                 assign_empty_invlet( *it_ref, g->u );
             }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1889,6 +1889,16 @@ std::string inventory_selector::action_bound_to_key( char key ) const
     return std::string();
 }
 
+std::vector<char> inventory_selector::all_bound_keys() const
+{
+    std::vector<char> retv;
+    for( const std::string &action_descriptor : ctxt.get_registered_actions_copy() ) {
+        std::vector<char> to_add = ctxt.keys_bound_to( action_descriptor );
+        retv.insert( retv.end(), to_add.begin(), to_add.end() );
+    }
+    return retv;
+}
+
 item_location inventory_pick_selector::execute()
 {
     shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -644,6 +644,8 @@ class inventory_selector
 
     public:
         std::string action_bound_to_key( char key ) const;
+        /** Returns all keys in the current context which are bound to an action. Warning: may contain duplicates. */
+        std::vector<char> all_bound_keys( ) const;
 };
 
 inventory_selector::stat display_stat( const std::string &caption, int cur_value, int max_value,


### PR DESCRIPTION
#### Summary

SUMMARY: Performance "Fixed potential seconds-long freeze while mass-applying auto inventory letters"

#### Purpose of change

Fixes #1112.

#### Describe the solution

`inventory::assign_empty_invlet`: now looks up action keybinds only once (as opposed to the previous once per key in `inv_chars`). This reduces freeze time in the situation described in #1112, but does not eliminate it.

`inventory::add_item`: now skips forcing other items out of their invlets if the target invlet is empty. This significantly reduces the number of calls to `assign_empty_invlet` during crafting inventory rebuilds, which occur frequently while picking up items. This is enough to completely resolve #1112.

#### Describe alternatives you've considered

This PR vastly increases the performance of crafting inventory rebuilds while auto inventory letters is on. However, it seems like picking up items *may* be triggering said rebuilds many times (via `item::final_info`) when once for the entire pile of items would suffice. If this is the case, it could be another route to fixing the issue, and/or be another issue in its own right.

It's also unclear whether the crafting inventory needs invlets at all, or if this could be skipped somehow.

I don't have a good grasp of what some of this code does, and the change to `add_item` in particular seems ripe for unintended side effects. I tested everything I could think of (regression checks section below), but maybe keep an eye on invlets for a while if this PR is merged.

#### Testing

##### Reproduction
1. Launched a release x64 build of bee8a49, with data/font/Terminus.ttf deleted due to a rendering bug in vcpkg.
2. Successfully reproduced the issue described by #1112, using the testing procedure therein.
##### Fix verification
3. Closed the previous game instance and launched a release x64 build of bee8a49 + this PR.
4. Repeated the testing procedure in #1112. Observed that no long freeze occurred at step 11.
##### Regression checks
5. Ensured that auto inventory letters was on.
6. Started another new world+game (latter via Play Now! (Fixed Scenario)).
7. Spawned one of every item.
8. Obtained the Debug Carrying Capacity mutation.
9. Picked up one of the nearby piles of items.
10. Observed that obtained items gained auto inventory letters as expected.
11. Picked up another pile of items.
12. Observed that already-assigned auto inventory letters did not change.
13. Manually assigned a letter to an item.
14. Picked up another pile of items.
15. Observed that the manually-assigned item did not get assigned another letter, and that another item did not get assigned a duplicate of its letter.
16. Dropped and reobtained the manually-assigned item and one auto-assigned item.
17. Observed that the items in step 16 retained their keys.