### PR TITLE
Misc fixes/changes for overmap weather display

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1541,7 +1541,7 @@ void debug()
                                    _( "Keep normal weather patterns" ) : _( "Disable weather forcing" ) );
             for( size_t i = 0; i < weather_types::get_all().size(); i++ ) {
                 weather_menu.addentry( i, true, MENU_AUTOASSIGN,
-                                       weather_types::get_all()[i].name );
+                                       weather_types::get_all()[i].name.translated() );
             }
 
             weather_menu.query();

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1291,7 +1291,7 @@ static void draw_om_sidebar(
 
     // Draw text describing the overmap tile at the cursor position.
     int lines = 1;
-    if( center_seen && !viewing_weather ) {
+    if( center_seen ) {
         if( !mgroups.empty() ) {
             int line_number = 6;
             for( const auto &mgroup : mgroups ) {
@@ -1319,20 +1319,23 @@ static void draw_om_sidebar(
             lines = fold_and_print( wbar, point( 3, 1 ), getmaxx( wbar ) - 3, c_light_gray,
                                     overmap_buffer.get_description_at( sm_pos ) );
         }
-    } else if( viewing_weather ) {
+    } else {
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        mvwprintz( wbar, point( 1, 1 ), c_dark_gray, _( "# Unexplored" ) );
+    }
+
+    // Describe the weather conditions on the following line, if weather is visible
+    if( viewing_weather ) {
         const bool weather_is_visible = ( uistate.overmap_debug_weather ||
                                           player_character.overmap_los( center, sight_points * 2 ) );
         if( weather_is_visible ) {
             // NOLINTNEXTLINE(cata-use-named-point-constants)
-            mvwprintz( wbar, point( 1, 1 ), get_weather_at_point( center )->color,
+            mvwprintz( wbar, point( 3, ++lines ), get_weather_at_point( center )->color,
                        get_weather_at_point( center )->name.translated() );
         } else {
             // NOLINTNEXTLINE(cata-use-named-point-constants)
-            mvwprintz( wbar, point( 1, 1 ), c_dark_gray, _( "# Unexplored" ) );
+            mvwprintz( wbar, point( 1, ++lines ), c_dark_gray, _( "# Weather unknown" ) );
         }
-    } else {
-        // NOLINTNEXTLINE(cata-use-named-point-constants)
-        mvwprintz( wbar, point( 1, 1 ), c_dark_gray, _( "# Unexplored" ) );
     }
 
     if( data.debug_editor && center_seen ) {

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1325,7 +1325,7 @@ static void draw_om_sidebar(
         if( weather_is_visible ) {
             // NOLINTNEXTLINE(cata-use-named-point-constants)
             mvwprintz( wbar, point( 1, 1 ), get_weather_at_point( center )->color,
-                       get_weather_at_point( center )->name );
+                       get_weather_at_point( center )->name.translated() );
         } else {
             // NOLINTNEXTLINE(cata-use-named-point-constants)
             mvwprintz( wbar, point( 1, 1 ), c_dark_gray, _( "# Unexplored" ) );

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -102,7 +102,7 @@ struct tiles_redraw_info {
 extern tiles_redraw_info redraw_info;
 #endif
 
-weather_type_id get_weather_at_point( const tripoint_abs_omt &pos );
+weather_type_id get_weather_at_point( const point_abs_omt &pos );
 std::tuple<char, nc_color, size_t> get_note_display_info( const std::string &note );
 } // namespace overmap_ui
 #endif // CATA_SRC_OVERMAP_UI_H

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -1408,7 +1408,7 @@ static void draw_loc_labels( const avatar &u, const catacurses::window &w, bool 
     } else {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         mvwprintz( w, point( 1, 1 ), c_light_gray, _( "Sky  :" ) );
-        wprintz( w, get_weather().weather_id->color, " %s", get_weather().weather_id->name );
+        wprintz( w, get_weather().weather_id->color, " %s", get_weather().weather_id->name.translated() );
     }
     // display lighting
     const auto ll = get_light_level( g->u.fine_detail_vision_mod() );
@@ -1602,7 +1602,8 @@ static void draw_env_compact( avatar &u, const catacurses::window &w )
     if( g->get_levz() < 0 ) {
         mvwprintz( w, point( 8, 3 ), c_light_gray, _( "Underground" ) );
     } else {
-        mvwprintz( w, point( 8, 3 ), get_weather().weather_id->color, get_weather().weather_id->name );
+        mvwprintz( w, point( 8, 3 ), get_weather().weather_id->color,
+                   get_weather().weather_id->name.translated() );
     }
     // display lighting
     const auto ll = get_light_level( g->u.fine_detail_vision_mod() );
@@ -1942,7 +1943,8 @@ static void draw_weather_classic( avatar &, const catacurses::window &w )
         mvwprintz( w, point_zero, c_light_gray, _( "Underground" ) );
     } else {
         mvwprintz( w, point_zero, c_light_gray, _( "Weather :" ) );
-        mvwprintz( w, point( 10, 0 ), get_weather().weather_id->color, get_weather().weather_id->name );
+        mvwprintz( w, point( 10, 0 ), get_weather().weather_id->color,
+                   get_weather().weather_id->name.translated() );
     }
     mvwprintz( w, point( 31, 0 ), c_light_gray, _( "Moon :" ) );
     nc_color clr = c_white;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -889,7 +889,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         for( int col = min_col; col < max_col; col++ ) {
             const tripoint_abs_omt omp = corner_NW + point( col, row );
 
-            const bool see = overmap_buffer.seen( omp );
+            const bool see = has_debug_vision || overmap_buffer.seen( omp );
             const bool los = see && you.overmap_los( omp, sight_points );
             // the full string from the ter_id including _north etc.
             std::string id;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -876,7 +876,8 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                              you.overmap_sight_range( g->light_level( you.posz() ) ) :
                              100;
     const bool showhordes = uistate.overmap_show_hordes;
-    const bool viewing_weather = uistate.overmap_debug_weather || uistate.overmap_visible_weather;
+    const bool viewing_weather = ( ( uistate.overmap_debug_weather || uistate.overmap_visible_weather )
+                                   && center_abs_omt.z() >= 0 );
     o = corner_NW.raw().xy();
 
     const auto global_omt_to_draw_position = []( const tripoint_abs_omt & omp ) {
@@ -899,13 +900,15 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                 const tripoint_abs_omt omp_sky( omp.xy(), OVERMAP_HEIGHT );
                 if( uistate.overmap_debug_weather ||
                     you.overmap_los( omp_sky, sight_points * 2 ) ) {
-                    id = overmap_ui::get_weather_at_point( omp_sky ).c_str();
+                    id = overmap_ui::get_weather_at_point( omp_sky.xy() ).c_str();
                 }
-            } else if( !see ) {
-                id = "unknown_terrain";
             }
             if( id.empty() ) {
-                id = get_omt_id_rotation_and_subtile( omp, rotation, subtile );
+                if( see ) {
+                    id = get_omt_id_rotation_and_subtile( omp, rotation, subtile );
+                } else {
+                    id = "unknown_terrain";
+                }
             }
 
             const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -103,7 +103,7 @@ struct weather_type {
         bool was_loaded = false;
     public:
         weather_type_id id;
-        std::string name;           // UI name of weather type.
+        translation name;           // UI name of weather type.
         nc_color color = c_magenta; // UI color of weather type.
         nc_color map_color = c_magenta; // Map color of weather type.
         uint32_t symbol = PERCENT_SIGN_UNICODE; // Map glyph of weather type.


### PR DESCRIPTION
#### Purpose of change
Misc bugfixes and changes following #1101

1. Fix enabling weather overlay reveals all terrain tiles in graphical mode
2. Equalize 'look at sky' and 'toggle weather overlay' behavior between ascii and graphical overmap
3. Fix debug vision not working in graphical overmap
4. Fix weather names not translated (Port of https://github.com/CleverRaven/Cataclysm-DDA/pull/46537)
5. Fix enabling weather overlay hides name of underlying terrain (Port of https://github.com/CleverRaven/Cataclysm-DDA/pull/52547)