### PR TITLE
Speed up debug submap grid rendering

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1586,12 +1586,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         };
 
         const auto is_mapbuffer = []( const tripoint & p ) {
-            for( const auto &it : MAPBUFFER ) {
-                if( it.first == p ) {
-                    return true;
-                }
-            }
-            return false;
+            return MAPBUFFER.is_submap_loaded( p );
         };
 
         constexpr int THICC = 1; // line thickness

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -65,6 +65,10 @@ class mapbuffer
             return submaps.end();
         }
 
+        bool is_submap_loaded( const tripoint &p ) const {
+            return submaps.count( p ) > 0;
+        }
+
     private:
         // There's a very good reason this is private,
         // if not handled carefully, this can erase in-use submaps and crash the game.


### PR DESCRIPTION
I _expected_ linear search to be expensive, but with large mapbuffer, maximized game window, Retrodays and lowest zoom level it's bad enough to double, or even triple, rendering times.