### PR TITLE
Update VS build instruction to avoid font problems

### DIFF
--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -29,9 +29,15 @@ Steps from current guide were tested on Windows 10 (64 bit), Visual Studio 2019 
 ```cmd
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
+git checkout 6bc4362fb49e53f1fff7f51e4e27e1946755ecc6
 .\bootstrap-vcpkg.bat
 .\vcpkg integrate install
 ```
+Note: 
+```
+git checkout 6bc4362fb49e53f1fff7f51e4e27e1946755ecc6 
+``` 
+used to grab vcpkg version without font problems.
 
 4. Install a necessary pre-requisite package:
 


### PR DESCRIPTION
Update VS build instruction to avoid font problems

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
@olanti-p reported that latest version of vcpkg has problems win font.
Instruction updated to avoid that.
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
@olanti-p reported that latest version of vcpkg has problems win font.
Instruction updated to avoid that.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
After
`cd vcpkg`
We must use
`git checkout 6bc4362fb49e53f1fff7f51e4e27e1946755ecc6` to grab vcpkg without font problems.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. Check doc spelling: https://github.com/Firestorm01X2/Cataclysm-BN/blob/feature/vs-doc-update/doc/COMPILING/COMPILING-VS-VCPKG.md
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
None
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
