### PR TITLE
Allow voltmeter to tell electric grid connections and amount of energy stored

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -901,6 +901,16 @@
   },
   {
     "type": "item_action",
+    "id": "REPORT_GRID_CHARGE",
+    "name": { "str": "Check grid charge" }
+  },
+  {
+    "type": "item_action",
+    "id": "REPORT_GRID_CONNECTIONS",
+    "name": { "str": "Check grid connections" }
+  },
+  {
+    "type": "item_action",
     "id": "TOWEL",
     "name": { "str": "Dry/clean yourself" }
   },

--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -903,6 +903,7 @@
     "material": [ "plastic" ],
     "symbol": ";",
     "color": "light_gray",
+    "use_action": [ "REPORT_GRID_CHARGE", "REPORT_GRID_CONNECTIONS" ],
     "magazines": [
       [
         "battery",

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -943,6 +943,8 @@ void Item_factory::init()
     add_iuse( "RADIO_ON", &iuse::radio_on );
     add_iuse( "REMOTEVEH", &iuse::remoteveh );
     add_iuse( "REMOVE_ALL_MODS", &iuse::remove_all_mods );
+    add_iuse( "REPORT_GRID_CHARGE", &iuse::report_grid_charge );
+    add_iuse( "REPORT_GRID_CONNECTIONS", &iuse::report_grid_connections );
     add_iuse( "RM13ARMOR_OFF", &iuse::rm13armor_off );
     add_iuse( "RM13ARMOR_ON", &iuse::rm13armor_on );
     add_iuse( "ROBOTCONTROL", &iuse::robotcontrol );

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -201,6 +201,8 @@ int coin_flip( player *, item *, bool, const tripoint & );
 int play_game( player *, item *, bool, const tripoint & );
 int magic_8_ball( player *, item *, bool, const tripoint & );
 int toggle_heats_food( player *, item *, bool, const tripoint & );
+int report_grid_charge( player *, item *, bool, const tripoint & );
+int report_grid_connections( player *, item *, bool, const tripoint & );
 
 // MACGUFFINS
 

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1659,3 +1659,20 @@ std::set<tripoint_abs_omt> overmapbuffer::electric_grid_at( const tripoint_abs_o
 
     return result;
 }
+
+std::vector<tripoint_rel_omt>
+overmapbuffer::electric_grid_connectivity_at( const tripoint_abs_omt &p )
+{
+    std::vector<tripoint_rel_omt> ret;
+    ret.reserve( six_cardinal_directions.size() );
+
+    overmap_with_local_coords omc = get_om_global( p );
+    const auto &connections_bitset = omc.om->electric_grid_connections[omc.local];
+    for( size_t i = 0; i < six_cardinal_directions.size(); i++ ) {
+        if( connections_bitset.test( i ) ) {
+            ret.emplace_back( six_cardinal_directions[i] );
+        }
+    }
+
+    return ret;
+}

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -573,6 +573,12 @@ class overmapbuffer
          * @param p Overmap coordinates of the point in the grid
          */
         std::set<tripoint_abs_omt> electric_grid_at( const tripoint_abs_omt &p );
+
+        /**
+         * Retrieve electric grid connections from given point.
+         * Returned vector may be empty.
+         */
+        std::vector<tripoint_rel_omt> electric_grid_connectivity_at( const tripoint_abs_omt &p );
 };
 
 extern overmapbuffer overmap_buffer;


### PR DESCRIPTION
#### Purpose of change
It is currently possible to see grid connections only via debug menu (#409), but even before that was implemented there were multiple requests for the ability to check grid connections in game.
Additionally, the only way to check grid charge level is by examining a battery, which is quite impractical when testing/debugging more complex grid stuff.

#### Describe the solution
Add 2 new item use functions:
* `REPORT_GRID_CHARGE` - report grid charge level
* `REPORT_GRID_CONNECTIONS` - reports grid connections to neighboring overmap tiles

And add both of them to the voltmeter.

#### Describe alternatives you've considered
Also rebrand voltmeter as multimeter, or add multimeter as separate item and move new functions there.

#### Testing
![image](https://user-images.githubusercontent.com/60584843/141194930-0e77869f-f577-44fb-a45f-942aa3ae5657.png)
![image](https://user-images.githubusercontent.com/60584843/141195131-352e78a4-adc8-4ac3-8198-a96d7a9aaf93.png)
