### PR TITLE
Implement steady consumers for grids

### DIFF
--- a/data/json/furniture_and_terrain/furniture-zztesting.json
+++ b/data/json/furniture_and_terrain/furniture-zztesting.json
@@ -2,12 +2,10 @@
   {
     "type": "furniture",
     "abstract": "f_floor_lamp_base",
-
     "symbol": "T",
     "color": "light_gray",
     "name": "-",
     "description": "-",
-
     "move_cost_mod": 2,
     "required_str": 1,
     "flags": [ "TRANSPARENT", "PLACE_ITEM", "EASY_DECONSTRUCT" ],
@@ -42,12 +40,10 @@
     "copy-from": "f_floor_lamp_base",
     "name": "floor lamp (no power)",
     "description": "A tall standing lamp, plugged into a wall.  This one has no power.",
-
     "examine_action": "transform",
     "transforms_into": "f_floor_lamp_off",
     "message": "You turn the lamp off.",
-    
-    "active": [ "charge_watcher", { "min_power": 5, "transform": {"id": "f_floor_lamp_on", "msg": "The lamp lights up." }} ]
+    "active": [ "charge_watcher", { "min_power": 5, "transform": { "id": "f_floor_lamp_on", "msg": "The lamp lights up." } } ]
   },
   {
     "type": "furniture",
@@ -58,7 +54,6 @@
     "looks_like": "f_floor_lamp",
     "name": "floor lamp (off)",
     "description": "A tall standing lamp, meant to plug into a wall and light up a room.",
-
     "examine_action": "transform",
     "transforms_into": "f_floor_lamp",
     "message": "You turn the lamp on."
@@ -72,13 +67,17 @@
     "looks_like": "f_floor_lamp",
     "name": "floor lamp (on)",
     "description": "A tall standing lamp, plugged into a wall.",
-
     "examine_action": "transform",
     "transforms_into": "f_floor_lamp_off",
     "message": "You turn the lamp off.",
-    
     "light_emitted": 160,
-
-    "active": [ "steady_consumer", { "power": 1, "consume_every": "20 s", "transform": {"id": "f_floor_lamp", "msg": "The lamp flickers and dies." } } ]
+    "active": [
+      "steady_consumer",
+      {
+        "power": 1,
+        "consume_every": "20 s",
+        "transform": { "id": "f_floor_lamp", "msg": "The lamp flickers and dies." }
+      }
+    ]
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-zztesting.json
+++ b/data/json/furniture_and_terrain/furniture-zztesting.json
@@ -1,17 +1,15 @@
 [
   {
     "type": "furniture",
-    "id": "f_floor_lamp",
-    "name": "floor lamp",
+    "abstract": "f_floor_lamp_base",
+
     "symbol": "T",
-    "looks_like": "f_rack_coat",
-    "description": "A tall standing lamp, meant to plug into a wall and light up a room.",
     "color": "light_gray",
+    "name": "-",
+    "description": "-",
+
     "move_cost_mod": 2,
     "required_str": 1,
-    "examine_action": "transform",
-    "transforms_into": "f_floor_lamp_on",
-    "message": "Click (off)",
     "flags": [ "TRANSPARENT", "PLACE_ITEM", "EASY_DECONSTRUCT" ],
     "deconstruct": {
       "items": [
@@ -38,15 +36,49 @@
   },
   {
     "type": "furniture",
-    "id": "f_floor_lamp_on",
+    "id": "f_floor_lamp",
     "symbol": "T",
+    "color": "light_gray",
+    "copy-from": "f_floor_lamp_base",
+    "name": "floor lamp (no power)",
+    "description": "A tall standing lamp, plugged into a wall.  This one has no power.",
+
+    "examine_action": "transform",
+    "transforms_into": "f_floor_lamp_off",
+    "message": "You turn the lamp off.",
+    
+    "active": [ "charge_watcher", { "min_power": 5, "transform": {"id": "f_floor_lamp_on", "msg": "The lamp lights up." }} ]
+  },
+  {
+    "type": "furniture",
+    "id": "f_floor_lamp_off",
+    "symbol": "T",
+    "color": "light_gray",
+    "copy-from": "f_floor_lamp_base",
     "looks_like": "f_floor_lamp",
-    "color": "yellow",
-    "copy-from": "f_floor_lamp",
+    "name": "floor lamp (off)",
+    "description": "A tall standing lamp, meant to plug into a wall and light up a room.",
+
     "examine_action": "transform",
     "transforms_into": "f_floor_lamp",
-    "message": "Click (on)",
-    "flags": [ "TRANSPARENT", "PLACE_ITEM", "EASY_DECONSTRUCT" ],
-    "light_emitted": 160
+    "message": "You turn the lamp on."
+  },
+  {
+    "type": "furniture",
+    "id": "f_floor_lamp_on",
+    "symbol": "T",
+    "color": "yellow",
+    "copy-from": "f_floor_lamp_base",
+    "looks_like": "f_floor_lamp",
+    "name": "floor lamp (on)",
+    "description": "A tall standing lamp, plugged into a wall.",
+
+    "examine_action": "transform",
+    "transforms_into": "f_floor_lamp_off",
+    "message": "You turn the lamp off.",
+    
+    "light_emitted": 160,
+
+    "active": [ "steady_consumer", { "power": 1, "consume_every": "20 s", "transform": {"id": "f_floor_lamp", "msg": "The lamp flickers and dies." } } ]
   }
 ]

--- a/src/active_tile_data.cpp
+++ b/src/active_tile_data.cpp
@@ -4,6 +4,7 @@
 #include "coordinate_conversions.h"
 #include "debug.h"
 #include "distribution_grid.h"
+#include "messages.h"
 #include "item.h"
 #include "itype.h"
 #include "json.h"
@@ -47,6 +48,22 @@ T *furn_at( const tripoint_abs_ms &p )
 template active_tile_data *furn_at<active_tile_data>( const tripoint_abs_ms & );
 template vehicle_connector_tile *furn_at<vehicle_connector_tile>( const tripoint_abs_ms & );
 template battery_tile *furn_at<battery_tile>( const tripoint_abs_ms & );
+template steady_consumer_tile *furn_at<steady_consumer_tile>( const tripoint_abs_ms & );
+template charge_watcher_tile *furn_at<charge_watcher_tile>( const tripoint_abs_ms & );
+
+void furn_transform::serialize( JsonOut &jsout ) const
+{
+    jsout.member( "id", id );
+    jsout.member( "msg", msg );
+}
+
+void furn_transform::deserialize( JsonIn &jsin )
+{
+    JsonObject jo( jsin );
+
+    jo.read( "id", id );
+    jo.read( "msg", msg );
+}
 
 } // namespace active_tiles
 
@@ -192,6 +209,42 @@ int battery_tile::mod_resource( int amt )
     }
 }
 
+void charge_watcher_tile::update_internal( time_point /*to*/, const tripoint_abs_ms &p,
+        distribution_grid &grid )
+{
+    int amt_stored = grid.get_resource();
+
+    if( amt_stored >= min_power ) {
+        get_distribution_grid_tracker().get_transform_queue().add( p, transform.id );
+        if( !transform.msg.empty() ) {
+            add_msg( "%s", _( transform.msg ) );
+        }
+    }
+}
+
+active_tile_data *charge_watcher_tile::clone() const
+{
+    return new charge_watcher_tile( *this );
+}
+
+const std::string &charge_watcher_tile::get_type() const
+{
+    static const std::string type( "charge_watcher" );
+    return type;
+}
+
+void charge_watcher_tile::store( JsonOut &jsout ) const
+{
+    jsout.member( "min_power", min_power );
+    jsout.member( "transform", transform );
+}
+
+void charge_watcher_tile::load( JsonObject &jo )
+{
+    jo.read( "min_power", min_power );
+    jo.read( "transform", transform );
+}
+
 void charger_tile::update_internal( time_point to, const tripoint_abs_ms &p,
                                     distribution_grid &grid )
 {
@@ -253,6 +306,57 @@ void charger_tile::load( JsonObject &jo )
     jo.read( "power", power );
 }
 
+void steady_consumer_tile::update_internal( time_point to, const tripoint_abs_ms &p,
+        distribution_grid &grid )
+{
+    int ticks = ticks_between( get_last_updated(), to, consume_every );
+    if( ticks == 0 ) {
+        return;
+    }
+
+    std::int64_t power = this->power * ticks;
+    int missing = grid.mod_resource( -power );
+
+    if( missing == 0 ) {
+        return;
+    }
+
+    if( transform.id.is_null() ) {
+        return;
+    }
+
+    get_distribution_grid_tracker().get_transform_queue().add( p, transform.id );
+
+    if( !transform.msg.empty() ) {
+        add_msg( "%s", _( transform.msg ) );
+    }
+}
+
+active_tile_data *steady_consumer_tile::clone() const
+{
+    return new steady_consumer_tile( *this );
+}
+
+const std::string &steady_consumer_tile::get_type() const
+{
+    static const std::string type( "steady_consumer" );
+    return type;
+}
+
+void steady_consumer_tile::store( JsonOut &jsout ) const
+{
+    jsout.member( "power", power );
+    jsout.member( "consume_every", consume_every );
+    jsout.member( "transform", transform );
+}
+
+void steady_consumer_tile::load( JsonObject &jo )
+{
+    jo.read( "power", power );
+    jo.read( "consume_every", consume_every );
+    jo.read( "transform", transform );
+}
+
 void vehicle_connector_tile::update_internal( time_point, const tripoint_abs_ms &,
         distribution_grid & )
 {
@@ -285,9 +389,11 @@ static std::map<std::string, std::unique_ptr<active_tile_data>> build_type_map()
     const auto add_type = [&type_map]( active_tile_data * arg ) {
         type_map[arg->get_type()].reset( arg );
     };
-    add_type( new solar_tile() );
     add_type( new battery_tile() );
+    add_type( new charge_watcher_tile() );
     add_type( new charger_tile() );
+    add_type( new solar_tile() );
+    add_type( new steady_consumer_tile() );
     add_type( new vehicle_connector_tile() );
     return type_map;
 }

--- a/src/active_tile_data.cpp
+++ b/src/active_tile_data.cpp
@@ -4,7 +4,6 @@
 #include "coordinate_conversions.h"
 #include "debug.h"
 #include "distribution_grid.h"
-#include "messages.h"
 #include "item.h"
 #include "itype.h"
 #include "json.h"
@@ -215,10 +214,7 @@ void charge_watcher_tile::update_internal( time_point /*to*/, const tripoint_abs
     int amt_stored = grid.get_resource();
 
     if( amt_stored >= min_power ) {
-        get_distribution_grid_tracker().get_transform_queue().add( p, transform.id );
-        if( !transform.msg.empty() ) {
-            add_msg( "%s", _( transform.msg ) );
-        }
+        get_distribution_grid_tracker().get_transform_queue().add( p, transform.id, transform.msg );
     }
 }
 
@@ -325,11 +321,7 @@ void steady_consumer_tile::update_internal( time_point to, const tripoint_abs_ms
         return;
     }
 
-    get_distribution_grid_tracker().get_transform_queue().add( p, transform.id );
-
-    if( !transform.msg.empty() ) {
-        add_msg( "%s", _( transform.msg ) );
-    }
+    get_distribution_grid_tracker().get_transform_queue().add( p, transform.id, transform.msg );
 }
 
 active_tile_data *steady_consumer_tile::clone() const

--- a/src/active_tile_data.cpp
+++ b/src/active_tile_data.cpp
@@ -52,13 +52,15 @@ template charge_watcher_tile *furn_at<charge_watcher_tile>( const tripoint_abs_m
 
 void furn_transform::serialize( JsonOut &jsout ) const
 {
+    jsout.start_object();
     jsout.member( "id", id );
     jsout.member( "msg", msg );
+    jsout.end_object();
 }
 
 void furn_transform::deserialize( JsonIn &jsin )
 {
-    JsonObject jo( jsin );
+    JsonObject jo = jsin.get_object();
 
     jo.read( "id", id );
     jo.read( "msg", msg );

--- a/src/active_tile_data_def.h
+++ b/src/active_tile_data_def.h
@@ -4,6 +4,18 @@
 
 #include "active_tile_data.h"
 #include "point.h"
+#include "type_id.h"
+
+namespace active_tiles
+{
+struct furn_transform {
+    furn_str_id id = furn_str_id::NULL_ID();
+    std::string msg;
+
+    void serialize( JsonOut &jsout ) const;
+    void deserialize( JsonIn &jsin );
+};
+} // namespace active_tiles
 
 class battery_tile : public active_tile_data
 {
@@ -20,6 +32,20 @@ class battery_tile : public active_tile_data
 
         int get_resource() const;
         int mod_resource( int amt );
+};
+
+class charge_watcher_tile : public active_tile_data
+{
+    public:
+        /* In J */
+        int min_power;
+        active_tiles::furn_transform transform;
+
+        void update_internal( time_point to, const tripoint_abs_ms &p, distribution_grid &grid ) override;
+        active_tile_data *clone() const override;
+        const std::string &get_type() const override;
+        void store( JsonOut &jsout ) const override;
+        void load( JsonObject &jo ) override;
 };
 
 class charger_tile : public active_tile_data
@@ -40,6 +66,21 @@ class solar_tile : public active_tile_data
     public:
         /* In W */
         int power;
+
+        void update_internal( time_point to, const tripoint_abs_ms &p, distribution_grid &grid ) override;
+        active_tile_data *clone() const override;
+        const std::string &get_type() const override;
+        void store( JsonOut &jsout ) const override;
+        void load( JsonObject &jo ) override;
+};
+
+class steady_consumer_tile : public active_tile_data
+{
+    public:
+        /* In J */
+        int power;
+        time_duration consume_every = 1_seconds;
+        active_tiles::furn_transform transform;
 
         void update_internal( time_point to, const tripoint_abs_ms &p, distribution_grid &grid ) override;
         active_tile_data *clone() const override;

--- a/src/distribution_grid.cpp
+++ b/src/distribution_grid.cpp
@@ -288,6 +288,15 @@ void grid_furn_transform_queue::apply( mapbuffer &mb, distribution_grid_tracker 
     }
 }
 
+std::string grid_furn_transform_queue::to_string() const
+{
+    std::string ret;
+    for( size_t i = 0; i < queue.size(); i++ ) {
+        ret += string_format( "% 2d: %s %s\n", i, queue[i].p.to_string(), queue[i].id );
+    }
+    return ret;
+}
+
 void distribution_grid_tracker::update( time_point to )
 {
     // TODO: Don't recalc this every update
@@ -299,7 +308,7 @@ void distribution_grid_tracker::update( time_point to )
         }
     }
     transform_queue.apply( mb, *this );
-    transform_queue.queue.clear();
+    transform_queue.clear();
 }
 
 void distribution_grid_tracker::load( half_open_rectangle<point_abs_sm> area )

--- a/src/distribution_grid.h
+++ b/src/distribution_grid.h
@@ -69,11 +69,23 @@ struct transform_queue_entry {
     }
 };
 
+/**
+ * Represents queued active tile / furniture transformations.
+ *
+ * Some active tiles can turn into other active tiles, or even inactive tiles, as a result
+ * of an update. If such transformation is applied immediately, it could trigger recalculation of
+ * the grid that's being updated, which would require additional code to handle.
+ *
+ * As a simpler alternative, we queue active tile transformations and apply them only after
+ * all grids have been updated. The transformations are applied according to FIFO method,
+ * so if some tile has multiple competing transforms queued, the last one will win out.
+ */
 class grid_furn_transform_queue
 {
-    public:
+    private:
         std::vector<transform_queue_entry> queue;
 
+    public:
         void add( const tripoint_abs_ms &p, const furn_str_id &id ) {
             queue.emplace_back( transform_queue_entry{ p, id } );
         }
@@ -87,6 +99,8 @@ class grid_furn_transform_queue
         bool operator==( const grid_furn_transform_queue &l ) const {
             return queue == l.queue;
         }
+
+        std::string to_string() const;
 };
 
 /**

--- a/src/distribution_grid.h
+++ b/src/distribution_grid.h
@@ -13,6 +13,7 @@
 #include "point.h"
 #include "type_id.h"
 
+class Character;
 class map;
 class mapbuffer;
 
@@ -63,9 +64,10 @@ class distribution_grid_tracker;
 struct transform_queue_entry {
     tripoint_abs_ms p;
     furn_str_id id;
+    std::string msg;
 
     bool operator==( const transform_queue_entry &l ) const {
-        return p == l.p && id == l.id;
+        return p == l.p && id == l.id && msg == l.msg;
     }
 };
 
@@ -86,11 +88,11 @@ class grid_furn_transform_queue
         std::vector<transform_queue_entry> queue;
 
     public:
-        void add( const tripoint_abs_ms &p, const furn_str_id &id ) {
-            queue.emplace_back( transform_queue_entry{ p, id } );
+        void add( const tripoint_abs_ms &p, const furn_str_id &id, const std::string &msg ) {
+            queue.emplace_back( transform_queue_entry{ p, id, msg } );
         }
 
-        void apply( mapbuffer &mb, distribution_grid_tracker &grid_tracker );
+        void apply( mapbuffer &mb, distribution_grid_tracker &grid_tracker, Character &u, map &m );
 
         void clear() {
             queue.clear();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9986,8 +9986,11 @@ bool game::grabbed_furn_move( const tripoint &dp )
     sounds::sound( fdest, furntype.move_str_req * 2, sounds::sound_t::movement,
                    _( "a scraping noise." ), true, "misc", "scraping" );
 
+    active_tile_data *atd = active_tiles::furn_at<active_tile_data>
+                            ( tripoint_abs_ms( m.getabs( fpos ) ) );
+
     // Actually move the furniture.
-    m.furn_set( fdest, m.furn( fpos ) );
+    m.furn_set( fdest, m.furn( fpos ), atd ? atd->clone() : nullptr );
     m.furn_set( fpos, f_null );
 
     if( fire_intensity == 1 && !pulling_furniture ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1386,7 +1386,9 @@ void map::furn_set( const tripoint &p, const furn_id &new_furniture )
         get_distribution_grid_tracker().on_changed( tripoint_abs_ms( getabs( p ) ) );
     }
     if( new_t.active ) {
-        current_submap->active_furniture[point_sm_ms( l )].reset( new_t.active->clone() );
+        active_tile_data *atd = new_t.active->clone();
+        atd->set_last_updated( calendar::turn );
+        current_submap->active_furniture[point_sm_ms( l )].reset( atd );
         get_distribution_grid_tracker().on_changed( tripoint_abs_ms( getabs( p ) ) );
     }
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1314,7 +1314,8 @@ furn_id map::furn( const tripoint &p ) const
     return current_submap->get_furn( l );
 }
 
-void map::furn_set( const tripoint &p, const furn_id &new_furniture )
+void map::furn_set( const tripoint &p, const furn_id &new_furniture,
+                    cata::poly_serialized<active_tile_data> new_active )
 {
     if( !inbounds( p ) ) {
         return;
@@ -1385,10 +1386,15 @@ void map::furn_set( const tripoint &p, const furn_id &new_furniture )
         // TODO: Only for g->m? Observer pattern?
         get_distribution_grid_tracker().on_changed( tripoint_abs_ms( getabs( p ) ) );
     }
-    if( new_t.active ) {
-        active_tile_data *atd = new_t.active->clone();
-        atd->set_last_updated( calendar::turn );
-        current_submap->active_furniture[point_sm_ms( l )].reset( atd );
+    if( new_t.active || new_active ) {
+        cata::poly_serialized<active_tile_data> atd;
+        if( new_active ) {
+            atd = new_active;
+        } else {
+            atd = new_t.active->clone();
+            atd->set_last_updated( calendar::turn );
+        }
+        current_submap->active_furniture[point_sm_ms( l )] = atd;
         get_distribution_grid_tracker().on_changed( tripoint_abs_ms( getabs( p ) ) );
     }
 }

--- a/src/map.h
+++ b/src/map.h
@@ -91,6 +91,11 @@ struct pathfinding_settings;
 template<typename T>
 struct weighted_int_list;
 
+namespace cata
+{
+template <class T> class poly_serialized;
+} // namespace cata
+
 class map_stack : public item_stack
 {
     private:
@@ -790,7 +795,15 @@ class map
         furn_id furn( const point &p ) const {
             return furn( tripoint( p, abs_sub.z ) );
         }
-        void furn_set( const tripoint &p, const furn_id &new_furniture );
+        /**
+        * Sets the furniture at given position.
+        *
+        * @param p Position within the map
+        * @param new_furniture Id of new furniture
+        * @param new_active Override default active tile of new furniture
+        */
+        void furn_set( const tripoint &p, const furn_id &new_furniture,
+                       cata::poly_serialized<active_tile_data> new_active = nullptr );
         void furn_set( const point &p, const furn_id &new_furniture ) {
             furn_set( tripoint( p, abs_sub.z ), new_furniture );
         }

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -423,7 +423,11 @@ ter_t null_terrain_t()
 template<typename C, typename F>
 void load_season_array( const JsonObject &jo, const std::string &key, C &container, F load_func )
 {
-    if( jo.has_string( key ) ) {
+    if( !jo.has_member( key ) ) {
+        // Throw 'member not found' error
+        jo.get_member( key );
+
+    } else if( jo.has_string( key ) ) {
         container.fill( load_func( jo.get_string( key ) ) );
 
     } else if( jo.has_array( key ) ) {

--- a/tests/electric_grid_test.cpp
+++ b/tests/electric_grid_test.cpp
@@ -293,12 +293,8 @@ static void test_steady_consumer( grid_setup_consumer &setup )
                 THEN( "the battery has been fully drained, and transform has been queued" ) {
                     REQUIRE( grid.get_resource() == 0 );
 
-                    const grid_furn_transform_queue single_dead_lamp = {{
-                            {
-                                setup.consumer_pos, f_floor_lamp
-                            }
-                        }
-                    };
+                    grid_furn_transform_queue single_dead_lamp;
+                    single_dead_lamp.add( setup.consumer_pos, f_floor_lamp );
 
                     REQUIRE( tf_queue == single_dead_lamp );
                 }
@@ -349,12 +345,8 @@ static void test_charge_watcher( grid_setup_watcher &setup )
             grid.update( to );
 
             THEN( "transform has been queued" ) {
-                const grid_furn_transform_queue single_lit_lamp = { {
-                        {
-                            setup.watcher_pos, f_floor_lamp_on
-                        }
-                    }
-                };
+                grid_furn_transform_queue single_lit_lamp;
+                single_lit_lamp.add( setup.watcher_pos, f_floor_lamp_on );
 
                 REQUIRE( tf_queue == single_lit_lamp );
             }

--- a/tests/electric_grid_test.cpp
+++ b/tests/electric_grid_test.cpp
@@ -8,11 +8,18 @@
 #include "distribution_grid.h"
 #include "game.h"
 #include "map.h"
+#include "mapbuffer.h"
 #include "map_helpers.h"
 #include "overmap.h"
 #include "overmapbuffer.h"
+#include "submap.h"
 #include "stringmaker.h"
 #include "vehicle.h"
+
+static furn_str_id f_battery( "f_battery" );
+static furn_str_id f_cable_connector( "f_cable_connector" );
+static furn_str_id f_floor_lamp( "f_floor_lamp" );
+static furn_str_id f_floor_lamp_on( "f_floor_lamp_on" );
 
 static itype_id itype_battery( "battery" );
 
@@ -115,8 +122,8 @@ static grid_setup set_up_grid( map &m )
     const tripoint battery_local_pos = tripoint( 14, 10, 0 );
     const tripoint_abs_ms connector_abs_pos( m.getabs( connector_local_pos ) );
     const tripoint_abs_ms battery_abs_pos( m.getabs( battery_local_pos ) );
-    m.furn_set( connector_local_pos, furn_str_id( "f_cable_connector" ) );
-    m.furn_set( battery_local_pos, furn_str_id( "f_battery" ) );
+    m.furn_set( connector_local_pos, f_cable_connector );
+    m.furn_set( battery_local_pos, f_battery );
     vehicle *veh = m.add_vehicle( vproto_id( "car" ), vehicle_local_pos, 0, 0, 0, false );
     vehicle_connector_tile *grid_connector =
         active_tiles::furn_at<vehicle_connector_tile>( connector_abs_pos );
@@ -167,30 +174,37 @@ struct grid_setup_consumer {
     tripoint_abs_ms consumer_pos;
 };
 
-static inline grid_setup_consumer set_up_grid_with_consumer( map &m, const char *consumer_id )
+struct grid_setup_watcher {
+    distribution_grid &grid;
+    charge_watcher_tile &watcher;
+    battery_tile &battery;
+    tripoint_abs_ms watcher_pos;
+};
+
+template<typename T, typename S>
+static S set_up_grid_with_consumer( map &m, const furn_str_id &act_tile_id )
 {
     // TODO: clear_grids()
     clear_grid_connections( m );
 
-    const tripoint consumer_local_pos = tripoint( 13, 9, 0 );
+    const tripoint act_local_pos = tripoint( 13, 10, 0 );
     const tripoint battery_local_pos = tripoint( 14, 10, 0 );
-    const tripoint_abs_ms consumer_abs_pos( m.getabs( consumer_local_pos ) );
+    const tripoint_abs_ms act_abs_pos( m.getabs( act_local_pos ) );
     const tripoint_abs_ms battery_abs_pos( m.getabs( battery_local_pos ) );
-    m.furn_set( consumer_local_pos, furn_str_id( consumer_id ) );
-    m.furn_set( battery_local_pos, furn_str_id( "f_battery" ) );
-    steady_consumer_tile *consumer =
-        active_tiles::furn_at<steady_consumer_tile>( consumer_abs_pos );
+    m.furn_set( act_local_pos, act_tile_id );
+    m.furn_set( battery_local_pos, f_battery );
+    T *act_tile = active_tiles::furn_at<T>( act_abs_pos );
     battery_tile *battery = active_tiles::furn_at<battery_tile>( battery_abs_pos );
 
-    CAPTURE( consumer_abs_pos );
+    CAPTURE( act_abs_pos );
     CAPTURE( battery_abs_pos );
-    REQUIRE( consumer );
+    REQUIRE( act_tile );
     REQUIRE( battery );
 
-    distribution_grid &grid = get_distribution_grid_tracker().grid_at( consumer_abs_pos );
+    distribution_grid &grid = get_distribution_grid_tracker().grid_at( act_abs_pos );
     REQUIRE( !grid.empty() );
     REQUIRE( &grid == &get_distribution_grid_tracker().grid_at( battery_abs_pos ) );
-    return grid_setup_consumer{grid, *consumer, *battery, consumer_abs_pos};
+    return S{grid, *act_tile, *battery, act_abs_pos};
 }
 
 static void require_empty_queue( const grid_furn_transform_queue &q )
@@ -199,7 +213,7 @@ static void require_empty_queue( const grid_furn_transform_queue &q )
     REQUIRE( q == empty_queue );
 }
 
-static inline void test_steady_consumer( grid_setup_consumer &setup )
+static void test_steady_consumer( grid_setup_consumer &setup )
 {
     grid_furn_transform_queue &tf_queue = get_distribution_grid_tracker().get_transform_queue();
     auto _cleanup = on_out_of_scope( [&]() {
@@ -281,7 +295,7 @@ static inline void test_steady_consumer( grid_setup_consumer &setup )
 
                     const grid_furn_transform_queue single_dead_lamp = {{
                             {
-                                setup.consumer_pos, furn_str_id( "f_floor_lamp" )
+                                setup.consumer_pos, f_floor_lamp
                             }
                         }
                     };
@@ -293,31 +307,136 @@ static inline void test_steady_consumer( grid_setup_consumer &setup )
     }
 }
 
+static void test_charge_watcher( grid_setup_watcher &setup )
+{
+    grid_furn_transform_queue &tf_queue = get_distribution_grid_tracker().get_transform_queue();
+    auto _cleanup = on_out_of_scope( [&]() {
+        tf_queue.clear();
+    } );
+
+    distribution_grid &grid = setup.grid;
+    charge_watcher_tile &watcher = setup.watcher;
+    battery_tile &battery = setup.battery;
+
+    CAPTURE( battery.max_stored );
+    CAPTURE( watcher.min_power );
+    CAPTURE( watcher.transform.id );
+
+    WHEN( "battery charge < watcher limit" ) {
+        int excess = battery.mod_resource( 3 );
+        REQUIRE( excess == 0 );
+        REQUIRE( battery.get_resource() == 3 );
+        REQUIRE( grid.get_resource() == battery.get_resource() );
+
+        AND_WHEN( "1 turn passes" ) {
+            time_point to = calendar::turn + 1_seconds;
+            grid.update( to );
+
+            THEN( "nothing happens" ) {
+                require_empty_queue( tf_queue );
+            }
+        }
+    }
+
+    WHEN( "battery charge >= watcher limit" ) {
+        int excess = battery.mod_resource( 5 );
+        REQUIRE( excess == 0 );
+        REQUIRE( battery.get_resource() == 5 );
+        REQUIRE( grid.get_resource() == battery.get_resource() );
+
+        AND_WHEN( "1 turn passes" ) {
+            time_point to = calendar::turn + 1_seconds;
+            grid.update( to );
+
+            THEN( "transform has been queued" ) {
+                const grid_furn_transform_queue single_lit_lamp = { {
+                        {
+                            setup.watcher_pos, f_floor_lamp_on
+                        }
+                    }
+                };
+
+                REQUIRE( tf_queue == single_lit_lamp );
+            }
+        }
+    }
+}
+
 TEST_CASE( "steady_consumer_in_bubble", "[grids]" )
 {
     calendar::turn = calendar::turn_zero;
     clear_map_and_put_player_underground();
 
     GIVEN( "consumer and battery are on one grid" ) {
-        auto setup = set_up_grid_with_consumer( g->m, "f_floor_lamp_on" );
+        grid_setup_consumer setup = set_up_grid_with_consumer<steady_consumer_tile, grid_setup_consumer>
+                                    ( g->m, f_floor_lamp_on );
         test_steady_consumer( setup );
     }
 }
 
-TEST_CASE( "steady_consumer_outside_bubble", "[grids]" )
+TEST_CASE( "charge_watcher_in_bubble", "[grids]" )
 {
     calendar::turn = calendar::turn_zero;
     clear_map_and_put_player_underground();
 
-    const tripoint old_abs_sub = g->m.get_abs_sub();
-    // Ugly: we move the real map instead of the tinymap to reuse clear_map() results
-    g->m.load( g->m.get_abs_sub() + point( g->m.getmapsize(), 0 ), true );
-    GIVEN( "consumer and battery are on one grid" ) {
-        tinymap m;
-        m.load( old_abs_sub, false );
-        auto setup = set_up_grid_with_consumer( m, "f_floor_lamp_on" );
-        m.save();
-
-        test_steady_consumer( setup );
+    GIVEN( "watcher and battery are on one grid" ) {
+        grid_setup_watcher setup = set_up_grid_with_consumer<charge_watcher_tile, grid_setup_watcher>
+                                   ( g->m, f_floor_lamp );
+        test_charge_watcher( setup );
     }
+}
+
+TEST_CASE( "grid_furn_transform_queue_in_bubble", "[grids]" )
+{
+    calendar::turn = calendar::turn_zero;
+    clear_map_and_put_player_underground();
+
+    tripoint pos_local( 22, 7, 0 );
+    tripoint_abs_ms pos_abs( get_map().getabs( pos_local ) );
+
+    grid_furn_transform_queue tf_queue;
+    tf_queue.add( pos_abs, f_floor_lamp_on );
+
+    CAPTURE( pos_abs );
+    REQUIRE( get_map().furn( pos_local ).id() != f_floor_lamp_on );
+    REQUIRE( active_tiles::furn_at<active_tile_data>( pos_abs ) == nullptr );
+
+    tf_queue.apply( MAPBUFFER, get_distribution_grid_tracker() );
+
+    REQUIRE( get_map().furn( pos_local ).id() == f_floor_lamp_on );
+    REQUIRE( active_tiles::furn_at<steady_consumer_tile>( pos_abs ) != nullptr );
+}
+
+TEST_CASE( "grid_furn_transform_queue_outside_bubble", "[grids]" )
+{
+    calendar::turn = calendar::turn_zero;
+    clear_map_and_put_player_underground();
+
+    tripoint pos_local( 22, 7, 0 );
+    tripoint_abs_ms pos_abs( get_map().getabs( pos_local ) );
+    tripoint_abs_sm pos_abs_sm;
+    point_sm_ms pos_in_sm;
+    std::tie( pos_abs_sm, pos_in_sm ) = project_remain<coords::sm>( pos_abs );
+
+    // Ugly: we move the real map to have submap exist in mapbuffer only
+    g->m.load( g->m.get_abs_sub() + point( g->m.getmapsize(), 0 ), true );
+
+    grid_furn_transform_queue tf_queue;
+    tf_queue.add( pos_abs, f_floor_lamp_on );
+
+    submap *sm = nullptr;
+    CAPTURE( pos_abs );
+    CAPTURE( pos_abs_sm );
+
+    sm = MAPBUFFER.lookup_submap( pos_abs_sm );
+    REQUIRE( sm );
+    REQUIRE( sm->get_furn( pos_in_sm.raw() ).id() != f_floor_lamp_on );
+    REQUIRE( active_tiles::furn_at<active_tile_data>( pos_abs ) == nullptr );
+
+    tf_queue.apply( MAPBUFFER, get_distribution_grid_tracker() );
+
+    sm = MAPBUFFER.lookup_submap( pos_abs_sm );
+    REQUIRE( sm );
+    REQUIRE( sm->get_furn( pos_in_sm.raw() ).id() == f_floor_lamp_on );
+    REQUIRE( active_tiles::furn_at<steady_consumer_tile>( pos_abs ) != nullptr );
 }

--- a/tests/stringmaker.h
+++ b/tests/stringmaker.h
@@ -74,11 +74,7 @@ struct StringMaker<talk_response> {
 template<>
 struct StringMaker<grid_furn_transform_queue> {
     static std::string convert( const grid_furn_transform_queue &q ) {
-        std::string msg = "\n";
-        for( size_t i = 0; i < q.queue.size(); i++ ) {
-            msg += string_format( "% 2d: %s %s\n", i, q.queue[i].p.to_string(), q.queue[i].id );
-        }
-        return string_format( "grid_furn_transform_queue(%s)", msg );
+        return string_format( "grid_furn_transform_queue(\n%s)", q.to_string() );
     }
 };
 

--- a/tests/stringmaker.h
+++ b/tests/stringmaker.h
@@ -6,6 +6,7 @@
 #include "catch/catch.hpp"
 #include "cata_variant.h"
 #include "dialogue.h"
+#include "distribution_grid.h"
 #include "item.h"
 
 // StringMaker specializations for Cata types for reporting via Catch2 macros
@@ -67,6 +68,17 @@ template<>
 struct StringMaker<talk_response> {
     static std::string convert( const talk_response &r ) {
         return string_format( "talk_response( text=\"%s\" )", r.text );
+    }
+};
+
+template<>
+struct StringMaker<grid_furn_transform_queue> {
+    static std::string convert( const grid_furn_transform_queue &q ) {
+        std::string msg = "\n";
+        for( size_t i = 0; i < q.queue.size(); i++ ) {
+            msg += string_format( "% 2d: %s %s\n", i, q.queue[i].p.to_string(), q.queue[i].id );
+        }
+        return string_format( "grid_furn_transform_queue(%s)", msg );
     }
 };
 


### PR DESCRIPTION
#### Purpose of change
This PR implements active furniture that constantly consumes electric charge, can be turned on and off, and can change into different furniture when it runs out of power. 

#### Describe the solution
The rough outline of how this works, using floor lamp as example:
1. Default state for the lamp is `f_floor_lamp`, "turned on, but has no power". In this state, the lamp constantly checks for presence of electric charge in the grid, and once it detects required amount, turns into `f_floor_lamp_on`. It can also be manually turned off by transforming to `f_floor_lamp_off` on examine.
2. `f_floor_lamp_on` is "turned on and has power" lamp, aka lit. In this state, the lamp consumes specified amount of charge from the grid, and once the charge runs out, turns back into `f_floor_lamp`. It also can be examined and "turned off" by being converted into `f_floor_lamp_off`.
3. The last state, "turned off lamp", or `f_floor_lamp_off`. In this state the lamp does not differ from any other non-active furniture, except it can be "turned on" by transforming into `f_floor_lamp` on examine.

This three-state logic allows for the following behaviors:
1. The player can manually turn the lamp on and off
2. If lamp runs out of charge, it turns off, but if grid regains charge, the lamp turns on back by itself
3. Using separate furniture definitions for states allows great customization of each state (e.g. you can have a force field which, as long as it has power, can become impassable, or emit fields, or change tile sprite).

#### Describe alternatives you've considered
A bunch, including cramming all 3 states into a single "steady consumer that can be turned off or can run out of power" active tile, but this approach feels much more flexible.
Another idea was to split "no power" check and "steady consumption" part into separate `active_tile`s to allow a more component-oriented approach, but each furniture can have only a single `active_tile` refer to it, so it's either both or neither.

#### Testing
TODO:
- [x] Write moar tests
- [x] Playtesting

Known bugs:
- [x] Dragging active lamp makes it skip consuming power
- [x] Transform message is printed regardless of line of sight
