### PR TITLE
Fix some minor city building and special issues

### DIFF
--- a/data/json/mapgen/mine/mine_entrance.json
+++ b/data/json/mapgen/mine/mine_entrance.json
@@ -162,6 +162,56 @@
   {
     "type": "mapgen",
     "method": "json",
+    "om_terrain": "mine_entrance_parking",
+    "weight": 500,
+    "object": {
+      "fill_ter": "t_region_groundcover_urban",
+      "rows": [
+        "  ;;;;;;;;;;;;;;;;;;;;  ",
+        " Y;;;;;;;;;;;;;;;;;;;;Y ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " °°°°°°°;;;;;;;;°°°°°°° ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " °°°°°°°;;;;;;;;°°°°°°° ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " °°°°°°°;;;;;;;;°°°°°°° ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        " ;;;;;;;;;;;;;;;;;;;;;; ",
+        "                        "
+      ],
+      "terrain": {
+        " ": [ [ "t_region_groundcover", 4 ], [ "t_region_shrub", 2 ], [ "t_region_tree", 1 ] ],
+        ";": "t_pavement",
+        "°": "t_pavement_y",
+        "Y": "t_pavement"
+      },
+      "furniture": { "Y": "f_street_light" },
+      "place_vehicles": [
+        { "vehicle": "parkinglotbasic", "x": 3, "y": 9, "chance": 25, "rotation": 180 },
+        { "vehicle": "parkinglotbasic", "x": 3, "y": 15, "chance": 25, "rotation": 180 },
+        { "vehicle": "parkinglotbasic", "x": 3, "y": 21, "chance": 25, "rotation": 180 },
+        { "vehicle": "parkinglotbasic", "x": 20, "y": 7, "chance": 25 },
+        { "vehicle": "parkinglotbasic", "x": 20, "y": 13, "chance": 25 },
+        { "vehicle": "parkinglotbasic", "x": 20, "y": 19, "chance": 25 }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "om_terrain": [ [ "mine_entrance_roof", "mine_entrance_loading_zone_roof" ] ],
     "object": {
       "rows": [

--- a/data/json/overmap/multitile_city_buildings.json
+++ b/data/json/overmap/multitile_city_buildings.json
@@ -804,13 +804,13 @@
     "id": "church",
     "locations": [ "land" ],
     "overmaps": [
-      { "point": [ 0, 0, 0 ], "overmap": "church_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "church_roof_north" },
-      { "point": [ 0, 0, 2 ], "overmap": "church_steeple_north" },
-      { "point": [ 0, 0, 3 ], "overmap": "church_steeple_north" },
-      { "point": [ 0, 0, 4 ], "overmap": "church_steeple_north" },
-      { "point": [ 0, 0, 5 ], "overmap": "church_steeple_end_north" },
-      { "point": [ 0, 0, 6 ], "overmap": "church_steeple_roof_north" }
+      { "point": [ 0, 0, 0 ], "overmap": "church_south" },
+      { "point": [ 0, 0, 1 ], "overmap": "church_roof_south" },
+      { "point": [ 0, 0, 2 ], "overmap": "church_steeple_south" },
+      { "point": [ 0, 0, 3 ], "overmap": "church_steeple_south" },
+      { "point": [ 0, 0, 4 ], "overmap": "church_steeple_south" },
+      { "point": [ 0, 0, 5 ], "overmap": "church_steeple_end_south" },
+      { "point": [ 0, 0, 6 ], "overmap": "church_steeple_roof_south" }
     ]
   },
   {
@@ -818,10 +818,10 @@
     "id": "church_1",
     "locations": [ "land" ],
     "overmaps": [
-      { "point": [ 0, 0, 0 ], "overmap": "church_1_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "church_2ndfloor_1_north" },
-      { "point": [ 0, 0, 2 ], "overmap": "church_3rdfloor_1_north" },
-      { "point": [ 0, 0, 3 ], "overmap": "church_roof_1_north" }
+      { "point": [ 0, 0, 0 ], "overmap": "church_1_south" },
+      { "point": [ 0, 0, 1 ], "overmap": "church_2ndfloor_1_south" },
+      { "point": [ 0, 0, 2 ], "overmap": "church_3rdfloor_1_south" },
+      { "point": [ 0, 0, 3 ], "overmap": "church_roof_1_south" }
     ]
   },
   {

--- a/data/json/overmap/overmap_special/mine.json
+++ b/data/json/overmap/overmap_special/mine.json
@@ -3,7 +3,7 @@
     "type": "overmap_special",
     "id": "Mine Entrance",
     "overmaps": [
-      { "point": [ 0, 0, 0 ], "overmap": "s_lot" },
+      { "point": [ 0, 0, 0 ], "overmap": "mine_entrance_parking_north" },
       { "point": [ 0, 1, 0 ], "overmap": "mine_entrance_north" },
       { "point": [ 1, 1, 0 ], "overmap": "mine_entrance_loading_zone_north" },
       { "point": [ 1, 0, 0 ], "overmap": "road_end_north" },
@@ -28,7 +28,7 @@
     "type": "overmap_special",
     "id": "Spiral mine",
     "overmaps": [
-      { "point": [ 0, 0, 0 ], "overmap": "s_lot" },
+      { "point": [ 0, 0, 0 ], "overmap": "mine_entrance_parking_north" },
       { "point": [ 0, 1, 0 ], "overmap": "mine_entrance_north" },
       { "point": [ 1, 1, 0 ], "overmap": "mine_entrance_loading_zone_north" },
       { "point": [ 1, 0, 0 ], "overmap": "road_end_north" },
@@ -68,7 +68,7 @@
     "type": "overmap_special",
     "id": "Amigara mine",
     "overmaps": [
-      { "point": [ 0, 0, 0 ], "overmap": "s_lot" },
+      { "point": [ 0, 0, 0 ], "overmap": "mine_entrance_parking_north" },
       { "point": [ 0, 1, 0 ], "overmap": "mine_entrance_north" },
       { "point": [ 1, 1, 0 ], "overmap": "mine_entrance_loading_zone_north" },
       { "point": [ 1, 0, 0 ], "overmap": "road_end_north" },
@@ -102,7 +102,7 @@
     "type": "overmap_special",
     "id": "Wyrms mine",
     "overmaps": [
-      { "point": [ 0, 0, 0 ], "overmap": "s_lot" },
+      { "point": [ 0, 0, 0 ], "overmap": "mine_entrance_parking_north" },
       { "point": [ 0, 1, 0 ], "overmap": "mine_entrance_north" },
       { "point": [ 1, 1, 0 ], "overmap": "mine_entrance_loading_zone_north" },
       { "point": [ 1, 0, 0 ], "overmap": "road_end_north" },

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -812,7 +812,7 @@
       { "point": [ 0, 0, 5 ], "overmap": "radio_tower_odd_north" },
       { "point": [ 0, 0, 6 ], "overmap": "radio_tower_top_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, 1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 0, 20 ],
     "occurrences": [ 0, 5 ],

--- a/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
@@ -1203,6 +1203,11 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "mine_entrance_parking",
+    "copy-from": "parking_2x1_0"
+  },
+  {
+    "type": "overmap_terrain",
     "id": [ "mine_shaft_middle", "mine_shaft_middle_east" ],
     "name": "mine shaft",
     "sym": "O",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix some buildings/specials having wrong rotation, fix mine entrance parking"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

While playing recently, I noticed a few city buildings, overmap specials, and even in once case part of a larger special were twisted up and facing the wrong way. For that last one, it turned out to be a case of using old hardcoded parking lots in the middle of a map special where it wouldn't generate right.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Fixed churches facing backwards. Both variants were affected, and can be explained by them having their entrance on the south side, when it seems most city mapgens are north-facing instead.
2. Fixed road connection of the basic radio tower being on the wrong side, making it backward. This seems to be because the other radio tower variant is facing the opposite direction and thus has its road connection on that side.
3. Fixed mine entrances using generic s_lot which lacks facing, instead defining an appropriate parking lot mapgen for that to use.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Unhardcoding basic parking lots to generate with proper support for rotations. That'd be a fair bit of work and only really benefit locations that should be using old-school parking lots. Mines probably shouldn't be one of them.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Ported file changes to test build and load-tested.
3. Visited churches, radio towers, and mine parking lots, confirming they didn't look wonky.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Pinging @Night-Pryanik as they may wish to port these fixes to DDA, and they were involved in JSONization of mine entrances.