### PR TITLE
Grid fixes and optimization

### DIFF
--- a/src/distribution_grid.h
+++ b/src/distribution_grid.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <vector>
 #include <map>
+#include <unordered_set>
 
 #include "calendar.h"
 #include "coordinates.h"
@@ -129,6 +130,11 @@ class distribution_grid_tracker
         mapbuffer &mb;
 
         grid_furn_transform_queue transform_queue;
+
+        /**
+         * Most grids are empty or idle, this contains the rest.
+         */
+        std::unordered_set<shared_ptr_fast<distribution_grid>> grids_requiring_updates;
 
     public:
         distribution_grid_tracker();

--- a/src/distribution_grid.h
+++ b/src/distribution_grid.h
@@ -46,6 +46,8 @@ class distribution_grid
         std::vector<tripoint_abs_ms> flat_contents;
         std::vector<tripoint_abs_sm> submap_coords;
 
+        mutable cata::optional<int> cached_amount_here;
+
         mapbuffer &mb;
 
     public:

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4841,9 +4841,10 @@ static void use_charges_from_furn( const furn_t &f, const itype_id &type, int &q
         auto &grid = get_distribution_grid_tracker().grid_at( abspos );
         item furn_item( itt, calendar::start_of_cataclysm, grid.get_resource() );
         int initial_quantity = quantity;
-        if( filter( furn_item ) && furn_item.use_charges( type, quantity, ret, p ) ) {
+        if( filter( furn_item ) ) {
+            furn_item.use_charges( type, quantity, ret, p );
             // That quantity math thing is atrocious. Punishment for the int& "argument".
-            grid.mod_resource( initial_quantity - quantity );
+            grid.mod_resource( quantity - initial_quantity );
         }
     } else if( itt != nullptr && itt->tool && !itt->tool->ammo_id.empty() ) {
         const itype_id ammo = ammotype( *itt->tool->ammo_id.begin() )->default_ammotype();

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -697,6 +697,7 @@ int border_helper::border_connection::as_curses_line() const
 
 bool query_yn( const std::string &text )
 {
+    // TODO: Queries are often opened in test_mode, shouldn't it be an error?
     const bool force_uc = get_option<bool>( "FORCE_CAPITAL_YN" );
     const auto &allow_key = force_uc ? input_context::disallow_lower_case
                             : input_context::allow_all_keys;

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -547,7 +547,6 @@ void inline_requirements( std::vector<std::vector<T>> &list,
         }
     }
 }
-#include "debug.h"
 void requirement_data::finalize()
 {
     for( auto &r : const_cast<std::map<requirement_id, requirement_data> &>( all() ) ) {
@@ -577,33 +576,6 @@ void requirement_data::finalize()
                                               : 1;
                     new_list.emplace_back( replacing_type, charge_factor * comp.count, true );
                 }
-            }
-
-            std::set<tool_comp> just_for_debug( new_list.begin(), new_list.end() );
-            if( just_for_debug.size() != new_list.size() ) {
-                std::stringstream ss;
-                for( const tool_comp &comp : list ) {
-                    const std::list<itype_id> replacements = item_controller->subtype_replacement( comp.type );
-                    if( replacements.size() > 1 ) {
-                        ss << comp.type.str() << " -> [ ";
-                        for( const itype_id &replacing_type : replacements ) {
-                            ss << replacing_type.str() << " ";
-                        }
-                        ss << "];";
-                    }
-                }
-                ss << "\nInitial: [ ";
-                for( const tool_comp &comp : list ) {
-                    ss << comp.type.str() << " ";
-                }
-                ss << "]";
-                ss << "\nFinal: [ ";
-                for( const tool_comp &comp : new_list ) {
-                    ss << comp.type.str() << " ";
-                }
-                ss << "]";
-                debugmsg( "Requirement %s bugged: %d != %d\n%s", r.first.str(), just_for_debug.size(),
-                          new_list.size(), ss.str() );
             }
 
             new_vec.emplace_back( new_list );

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -89,7 +89,15 @@ struct component {
 
 struct tool_comp : public component {
     tool_comp() = default;
-    tool_comp( const itype_id &TYPE, int COUNT ) : component( TYPE, COUNT ) { }
+    tool_comp( const itype_id &TYPE, int COUNT, bool subtype_expanded = false )
+        : component( TYPE, COUNT )
+        , subtype_expanded( subtype_expanded )
+    { }
+
+    // If true, do not expand subtypes
+    // Prevents double-expanding of subtype,
+    // for example hotplate->[hotplate, mess_kit]->[hotplate, mess_kit, mess_kit]
+    bool subtype_expanded = false;
 
     void load( const JsonValue &value );
     void dump( JsonOut &jsout ) const;

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -151,7 +151,10 @@ uilist::operator int() const
  */
 void uilist::init()
 {
-    assert( !test_mode ); // uilist should not be used in tests where there's no place for it
+    if( test_mode ) {
+        debugmsg( "uilist must not be used in test mode" );
+        return;
+    }
     w_x_setup = pos_scalar::auto_assign {};
     w_y_setup = pos_scalar::auto_assign {};
     w_width_setup = size_scalar::auto_assign {};
@@ -824,6 +827,11 @@ shared_ptr_fast<ui_adaptor> uilist::create_or_get_ui_adaptor()
  */
 void uilist::query( bool loop, int timeout )
 {
+    if( test_mode ) {
+        debugmsg( "Tried to open UI in test mode" );
+        ret = UILIST_ERROR;
+        return;
+    }
     keypress = 0;
     if( entries.empty() ) {
         ret = UILIST_ERROR;

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -625,16 +625,44 @@ TEST_CASE( "oven electric grid", "[crafting][overmap][grids][slow]" )
                 }
             }
 
-            AND_WHEN( "the player is near a pot and a bottle of water" ) {
+            // Massive ladder of when/then
+            // Any way to clean it up without re-running the slow test for every check?
+            AND_WHEN( "the player is near a pot and a chunk of meat" ) {
                 u.invalidate_crafting_inventory();
                 m.add_item( u.pos(), item( "pot" ) );
-                m.add_item( u.pos(), item( "water" ).in_its_container() );
-                THEN( "clean water can be crafted" ) {
-                    const recipe &r = *recipe_id( "water_clean" );
+                m.add_item( u.pos(), item( "meat" ) );
+                THEN( "cooked meat can be crafted" ) {
+                    const recipe &r = *recipe_id( "meat_cooked" );
                     const inventory &crafting_inv = u.crafting_inventory();
-                    bool can_craft = r.deduped_requirements().can_make_with_inventory(
-                                         crafting_inv, r.get_component_filter() );
+                    const deduped_requirement_data &ddrd = r.deduped_requirements();
+                    bool can_craft = ddrd.can_make_with_inventory( crafting_inv, r.get_component_filter() );
                     REQUIRE( can_craft );
+                    AND_THEN( "there is only one possible tool/component selection" ) {
+                        const auto filter = r.get_component_filter();
+                        const auto tool_options = ddrd.feasible_alternatives(
+                                                      u.crafting_inventory(), filter, 1, cost_adjustment::start_only );
+                        REQUIRE( tool_options.size() == 1u );
+                        AND_WHEN( "the player crafts cooked meat" ) {
+                            u.make_craft( r.ident(), 1 );
+                            REQUIRE( u.activity.id() == activity_id( "ACT_CRAFT" ) );
+                            // TODO: Nice way to finish a craft job
+                            for( size_t i = 0; i < 10000; i++ ) {
+                                u.set_moves( 100000 );
+                                u.activity.do_turn( u );
+                                if( u.activity.id() == activity_id::NULL_ID() ) {
+                                    break;
+                                }
+                            }
+                            REQUIRE( u.activity.id() == activity_id::NULL_ID() );
+                            THEN( "the crafting inventory now contains cooked meat" ) {
+                                u.invalidate_crafting_inventory();
+                                CHECK( u.crafting_inventory().has_amount( itype_id( "meat_cooked" ), 1 ) );
+                                AND_THEN( "the grid contains less than 10 power" ) {
+                                    CHECK( grid.get_resource() < 10 );
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #1030

According to @olanti-p 's benchmark (which I can't find right now...), grids consume a significant % of CPU cycles when just waiting in one spot.
Here I introduced basic optimization to avoid going through all the `121*121*21` submaps each second. Now only ones with non-empty grids will be checked.

Additionally, the steady consumer code in #1128 showed another big performance issue (currently debug-item-only): `get_resource`, when executed by 10 lamps on a tiny sample grid of 1connector+1battery+2cars, would cause a massive lag.
I added a cache that saves sum of energy in batteries on `get_resource`, then updates it on `mod_resource`. The cache should stay consistent with actual data because adding/removing active furniture forces grid rebuild (and thus cache clear).

In my profiling, submap gets were still significant, but not "dominant", and lost to field checks when nothing special was happening. Maybe a zombie or two lying in pools of their blood or something like that.