### PR TITLE
Reworking Specific Use Storage, part 1

### DIFF
--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -38,25 +38,11 @@
     "//2": "This group is for a junk drawer.",
     "subtype": "collection",
     "entries": [
-      { "item": "xacto", "prob": 80 },
-      { "item": "scissors", "prob": 80 },
-      { "item": "screwdriver", "prob": 70 },
-      { "item": "hammer", "prob": 60 },
-      { "item": "pliers", "prob": 60 },
-      { "item": "flashlight", "prob": 75 },
-      { "item": "hammer", "prob": 75 },
-      { "item": "permanent_marker", "prob": 75 },
-      { "item": "permanent_marker", "prob": 40 },
-      { "item": "paper", "prob": 55 },
-      { "item": "light_battery_cell", "count": [ 1, 2 ], "prob": 85 },
-      { "item": "battery_charger", "prob": 85 },
-      { "item": "string_36", "count": [ 1, 4 ], "prob": 80 },
-      { "item": "string_36", "count": [ 1, 4 ], "prob": 50 },
-      { "item": "string_36", "count": [ 1, 4 ], "prob": 20 },
-      { "item": "duct_tape", "prob": 50 },
-      { "item": "duct_tape", "prob": 30 },
-      { "item": "candle", "prob": 75 },
-      { "distribution": [ { "item": "matches" }, { "item": "lighter" } ], "prob": 90 }
+      { "group": "tools_common", "count": [ 1, 3 ], "prob": 75 },
+      { "group": "tools_recharging", "prob": 50 },
+      { "group": "tools_lighting", "prob": 50 },
+      { "group": "ammo_pocket_batteries", "prob": 75 },
+      { "group": "household_clutter", "count": [ 1, 3 ], "prob": 75 }
     ]
   },
   {

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -38,7 +38,7 @@
     "//2": "This group is for a junk drawer.",
     "subtype": "collection",
     "entries": [
-      { "group": "tools_common", "count": [ 1, 3 ], "prob": 75 },
+      { "group": "tools_drawer", "count": [ 1, 3 ], "prob": 75 },
       { "group": "tools_recharging", "prob": 50 },
       { "group": "tools_lighting", "prob": 50 },
       { "group": "ammo_pocket_batteries", "prob": 75 },

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -1049,7 +1049,7 @@
       { "item": "string_36", "prob": 75, "count": [ 1, 4 ] },
       { "item": "string_6", "prob": 50, "count": [ 1, 4 ] },
       { "item": "superglue", "prob": 40 },
-      { "item": "duct_tape", "prob": 60, "count": [ 1, 2 ] },
+      { "item": "duct_tape", "prob": 20 },
       { "item": "matches", "prob": 45 },
       { "item": "lighter", "prob": 45 },
       { "item": "ref_lighter", "prob": 10 }

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -1038,5 +1038,21 @@
       [ "fencing_epee", 20 ],
       [ "fencing_mask", 20 ]
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "household_clutter",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "permanent_marker", "prob": 50, "count": [ 1, 2 ] },
+      { "item": "paper", "prob": 75 },
+      { "item": "string_36", "prob": 75, "count": [ 1, 4 ] },
+      { "item": "string_6", "prob": 50, "count": [ 1, 4 ] },
+      { "item": "superglue", "prob": 40 },
+      { "item": "duct_tape", "prob": 60, "count": [ 1, 2 ] },
+      { "item": "matches", "prob": 45 },
+      { "item": "lighter", "prob": 45 },
+      { "item": "ref_lighter", "prob": 10 }
+    ]
   }
 ]

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -11,6 +11,7 @@
     "//": "Portable tools used for carpentry",
     "items": [
       { "group": "tools_common", "prob": 100 },
+      { "group": "tools_recharging", "prob": 5 },
       [ "circsaw_off", 100 ],
       [ "cordless_drill", 100 ],
       [ "hand_drill", 20 ],
@@ -59,8 +60,6 @@
       [ "crowbar", 10 ],
       [ "thermometer", 5 ],
       [ "multitool", 10 ],
-      [ "recharge_station", 10 ],
-      [ "hand_crank_charger", 25 ],
       [ "metal_file", 10 ],
       [ "clamp", 10 ]
     ]
@@ -79,6 +78,7 @@
       { "group": "tools_lighting_industrial", "prob": 100 },
       { "group": "tools_mechanic", "prob": 20 },
       { "group": "tools_plumbing", "prob": 20 },
+      { "group": "tools_recharging", "prob": 10 },
       [ "jumper_cable_heavy", 2 ],
       [ "jerrycan", 10 ],
       [ "jerrycan_big", 10 ],
@@ -147,6 +147,7 @@
     "//": "Portable tools for plumbing and pipefitting",
     "items": [
       { "group": "tools_common", "prob": 100 },
+      { "group": "tools_recharging", "prob": 5 },
       [ "wrench", 200 ],
       [ "claw_bar", 2 ],
       [ "crowbar", 10 ],
@@ -178,11 +179,10 @@
     "//": "Portable tools used by electricians and for electronics repair",
     "items": [
       { "group": "tools_common", "prob": 100 },
+      { "group": "tools_recharging", "prob": 50 },
       [ "soldering_iron", 100 ],
       [ "magnifying_glass", 100 ],
-      [ "voltmeter", 100 ],
-      [ "recharge_station", 10 ],
-      [ "hand_crank_charger", 40 ]
+      [ "voltmeter", 100 ]
     ]
   },
   {
@@ -209,6 +209,7 @@
       { "group": "tools_common", "prob": 100 },
       { "group": "tools_lighting", "prob": 50 },
       { "group": "tools_tailor", "prob": 50 },
+      { "group": "tools_recharging", "prob": 20 },
       [ "toolbox", 4 ],
       [ "toolbox_workshop", 1 ]
     ]
@@ -288,6 +289,12 @@
     "type": "item_group",
     "//": "Light sources used as industrial working equipment.",
     "items": [ [ "flashlight", 100 ], [ "heavy_flashlight", 40 ], [ "wearable_light", 60 ] ]
+  },
+  {
+    "id": "tools_recharging",
+    "type": "item_group",
+    "//": "Used for general spawns of battery charging equipment, except for cases where only certain tools are appropriate",
+    "items": [ [ "hand_crank_charger", 25 ], [ "battery_charger", 15 ], [ "recharge_station", 10 ] ]
   },
   {
     "id": "tools_survival",

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -65,6 +65,21 @@
     ]
   },
   {
+    "id": "tools_drawer",
+    "type": "item_group",
+    "//": "Limited selection of common domestic tools in junk drawers",
+    "items": [
+      [ "xacto", 80 ],
+      [ "scissors", 80 ],
+      [ "screwdriver", 70 ],
+      [ "hammer", 60 ],
+      [ "pliers", 60 ],
+      [ "thermometer", 50 ],
+      [ "magnifying_glass", 50 ],
+      [ "sewing_kit", 40 ]
+    ]
+  },
+  {
     "id": "tools_general",
     "type": "item_group",
     "//": "Common tools you might find in a hardware store or in a shop.",
@@ -294,7 +309,7 @@
     "id": "tools_recharging",
     "type": "item_group",
     "//": "Used for general spawns of battery charging equipment, except for cases where only certain tools are appropriate",
-    "items": [ [ "hand_crank_charger", 25 ], [ "battery_charger", 15 ], [ "recharge_station", 10 ] ]
+    "items": [ [ "hand_crank_charger", 50 ], [ "battery_charger", 40 ], [ "recharge_station", 10 ] ]
   },
   {
     "id": "tools_survival",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Overhaul content of junk drawers to have more variety, less consistent loot"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Was nudged to work on this part of my misc to-do list. In a nutshell, the "specific use storage" itemgroups have been a known problem for a while. They consistent of large collections of largely static items, varying very little yet also averaging towards a very high amount of the exact same stuff.

Thus, one of my goals is to make some of the common problematic itemgroups using "SUS" have a more varied output, with a general trend toward not reliably giving you the exact same items in every single house. Decided to start with junk drawers first, as they're the shining, premier example of a highly static, bland output that generally always gives you the same basic items every time.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added an itemgroup for most spawns of battery charging devices, shifting charging items out of `tools_common` as a result.
2. Defined a clutter distribution for the misc items in junk drawers.
3. Divided up contents of `SUS_junk_drawer` to cite existing itemgroups and the two new ones. General trend is towards wider variety of possible items, but less consistently being a cornucopia of stuff.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Starting in the first SUS file, though that'd be the clothing store stuff which seems to be less wacky.
2. Starting with or including fridges and dressers in this PR, as they're also some of the major itemgrourps in the folder to suffer from cornucopia syndrome.

Though since the dressers already favor itemgroups in their collection it might be an easy one at least. Just figured for now this one tweaks enough stuff in other itemgroup files to warrant being the first step here.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Ported itemgroup folder over to test build.
3. Load-tested, did an item group test before and after importing file changes.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

I've already made the amogus joke in the branch name so you don't have to.

![image](https://user-images.githubusercontent.com/11582235/144331915-cf18f1b1-f844-4753-96cb-73ce36075af8.png)

![image](https://user-images.githubusercontent.com/11582235/144331930-09b9d82e-ee6c-4f37-a3ee-a34464e77e4a.png)

The expanded variety from calling `ammo_pocket_batteries` makes the list way longer, but otherwise overall item spawns are down a good bit.