### PR TITLE
Stop Aftershock from enabling CBM slots

### DIFF
--- a/data/mods/Aftershock/options.json
+++ b/data/mods/Aftershock/options.json
@@ -4,11 +4,5 @@
     "type": "requirement",
     "//": "Anesthetic cost removed in this mod, as autodocs do all the heavy lifting.",
     "tools": [  ]
-  },
-  {
-    "type": "EXTERNAL_OPTION",
-    "name": "CBM_SLOTS_ENABLED",
-    "stype": "bool",
-    "value": true
   }
 ]


### PR DESCRIPTION
With tetanus gone, `Why BN enables bionic slots by default?` took the spot of the most asked question.
At least most people realize they're actually enabled by Aftershock...

Either way, this PR stops Aftershock from enabling CBM slots by default. We are not actively working on either slots or Aftershock, so it's unlikely they'll receive required polish in the near future, and those who want them can turn them back on via `cbm_slots` mod.