### PR TITLE
[DDA Port] Add a typesafe angle type and port various code to use it.

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -929,8 +929,9 @@ void game::draw_item_override( const tripoint &, const itype_id &, const mtype_i
 #endif
 
 #if defined(TILES)
-void game::draw_vpart_override( const tripoint &p, const vpart_id &id, const int part_mod,
-                                const int veh_dir, const bool hilite, const point &mount )
+void game::draw_vpart_override(
+    const tripoint &p, const vpart_id &id, const int part_mod, const units::angle veh_dir,
+    const bool hilite, const point &mount )
 {
     if( use_tiles ) {
         tilecontext->init_draw_vpart_override( p, id, part_mod, veh_dir, hilite, mount );
@@ -938,7 +939,7 @@ void game::draw_vpart_override( const tripoint &p, const vpart_id &id, const int
 }
 #else
 void game::draw_vpart_override( const tripoint &, const vpart_id &, const int,
-                                const int, const bool, const point & )
+                                const units::angle, const bool, const point & )
 {
 }
 #endif

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -168,7 +168,7 @@ projectile_attack_aim projectile_attack_roll( const dispersion_sources &dispersi
     aim.dispersion = dispersion.roll();
 
     // an isosceles triangle is formed by the intended and actual target tiles
-    aim.missed_by_tiles = iso_tangent( range, aim.dispersion );
+    aim.missed_by_tiles = iso_tangent( range, units::from_arcmin( aim.dispersion ) );
 
     // fraction we missed a monster target by (0.0 = perfect hit, 1.0 = miss)
     if( target_size > 0.0 ) {
@@ -233,10 +233,12 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
         // We missed enough to target a different tile
         double dx = target_arg.x - source.x;
         double dy = target_arg.y - source.y;
-        double rad = atan2( dy, dx );
+        units::angle rad = units::atan2( dy, dx );
 
         // cap wild misses at +/- 30 degrees
-        rad += ( one_in( 2 ) ? 1 : -1 ) * std::min( degmin2rad( aim.dispersion ), deg2rad( 30 ) );
+        units::angle dispersion_angle =
+            std::min( units::from_arcmin( aim.dispersion ), 30_degrees );
+        rad += ( one_in( 2 ) ? 1 : -1 ) * dispersion_angle;
 
         // TODO: This should also represent the miss on z axis
         const int offset = std::min<int>( range, std::sqrt( aim.missed_by_tiles ) );
@@ -245,8 +247,8 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
                         rng( range - offset, proj_arg.range );
         new_range = std::max( new_range, 1 );
 
-        target.x = source.x + roll_remainder( new_range * std::cos( rad ) );
-        target.y = source.y + roll_remainder( new_range * std::sin( rad ) );
+        target.x = source.x + roll_remainder( new_range * cos( rad ) );
+        target.y = source.y + roll_remainder( new_range * sin( rad ) );
 
         if( target == source ) {
             target.x = source.x + sgn( dx );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2887,7 +2887,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         char part_mod = 0;
         const vpart_id &vp_id = veh.part_id_string( veh_part, part_mod );
         const int subtile = part_mod == 1 ? open_ : part_mod == 2 ? broken : 0;
-        const int rotation = to_degrees( veh.face.dir() );
+        const int rotation = std::round( to_degrees( veh.face.dir() ) );
         const std::string vpname = "vp_" + vp_id.str();
         avatar &you = get_avatar();
         if( !veh.forward_velocity() && !veh.player_in_control( you ) &&

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1887,7 +1887,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
                 }
                 subtile = -1;
 
-                tileray face = tileray( rota );
+                tileray face = tileray( units::from_degrees( rota ) );
                 sym = special_symbol( face.dir_symbol( sym ) );
                 rota = 0;
 
@@ -2084,8 +2084,9 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
                 }
             }
 
-            //convert vehicle 360-degree direction (0=E,45=SE, etc) to 4-way tile rotation (0=N,1=W,etc)
-            tileray face = tileray( rota );
+            // convert vehicle 360-degree direction (0=E,45=SE, etc) to 4-way tile
+            // rotation (0=N,1=W,etc)
+            tileray face = tileray( units::from_degrees( rota ) );
             rota = 3 - face.dir4();
 
         }
@@ -2885,11 +2886,12 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         char part_mod = 0;
         const vpart_id &vp_id = veh.part_id_string( veh_part, part_mod );
         const int subtile = part_mod == 1 ? open_ : part_mod == 2 ? broken : 0;
-        const int rotation = veh.face.dir();
-        const std::string vpname = "vp_" + vp_id.str();
-        if( !veh.forward_velocity() && !veh.player_in_control( g->u ) &&
-            g->m.check_seen_cache( p ) ) {
-            g->u.memorize_tile( g->m.getabs( p ), vpname, subtile, rotation );
+        const int rotation = to_degrees( veh.face.dir() );
+        const std::string vpname = "vp_" + vp_id;
+        avatar &you = get_avatar();
+        if( !veh.forward_velocity() && !veh.player_in_control( you ) &&
+            here.check_seen_cache( p ) ) {
+            you.memorize_tile( here.getabs( p ), vpname, subtile, rotation );
         }
         if( !overridden ) {
             const cata::optional<vpart_reference> cargopart = vp.part_with_feature( "CARGO", true );
@@ -2908,13 +2910,14 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         if( vp2 ) {
             const char part_mod = std::get<1>( override->second );
             const int subtile = part_mod == 1 ? open_ : part_mod == 2 ? broken : 0;
-            const int rotation = std::get<2>( override->second );
+            const units::angle rotation = std::get<2>( override->second );
             const int draw_highlight = std::get<3>( override->second );
             const std::string vpname = "vp_" + vp2.str();
             // tile overrides are never memorized
             // tile overrides are always shown with full visibility
-            const bool ret = draw_from_id_string( vpname, C_VEHICLE_PART, empty_string, p, subtile, rotation,
-                                                  lit_level::LIT, false, height_3d );
+            const bool ret = draw_from_id_string( vpname, C_VEHICLE_PART, empty_string, p,
+                                                  subtile, to_degrees( rotation ), lit_level::LIT,
+                                                  false, height_3d );
             if( ret && draw_highlight ) {
                 draw_item_highlight( p );
             }
@@ -3299,7 +3302,7 @@ void cata_tiles::init_draw_item_override( const tripoint &p, const itype_id &id,
     item_override.emplace( p, std::make_tuple( id, mid, hilite ) );
 }
 void cata_tiles::init_draw_vpart_override( const tripoint &p, const vpart_id &id,
-        const int part_mod, const int veh_dir, const bool hilite, const point &mount )
+        const int part_mod, const units::angle veh_dir, const bool hilite, const point &mount )
 {
     vpart_override.emplace( p, std::make_tuple( id, part_mod, veh_dir, hilite, mount ) );
 }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2876,8 +2876,9 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
 {
     const auto override = vpart_override.find( p );
     const bool overridden = override != vpart_override.end();
+    map &here = get_map();
     // first memorize the actual vpart
-    const optional_vpart_position vp = g->m.veh_at( p );
+    const optional_vpart_position vp = here.veh_at( p );
     if( vp && !invisible[0] ) {
         const vehicle &veh = vp->vehicle();
         const int veh_part = vp->part_index();
@@ -2887,7 +2888,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         const vpart_id &vp_id = veh.part_id_string( veh_part, part_mod );
         const int subtile = part_mod == 1 ? open_ : part_mod == 2 ? broken : 0;
         const int rotation = to_degrees( veh.face.dir() );
-        const std::string vpname = "vp_" + vp_id;
+        const std::string vpname = "vp_" + vp_id.str();
         avatar &you = get_avatar();
         if( !veh.forward_velocity() && !veh.player_in_control( you ) &&
             here.check_seen_cache( p ) ) {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -518,7 +518,7 @@ class cata_tiles
         void void_item_override();
 
         void init_draw_vpart_override( const tripoint &p, const vpart_id &id, int part_mod,
-                                       int veh_dir, bool hilite, const point &mount );
+                                       units::angle veh_dir, bool hilite, const point &mount );
         void void_vpart_override();
 
         void init_draw_below_override( const tripoint &p, bool draw );
@@ -656,9 +656,9 @@ class cata_tiles
         std::map<tripoint, field_type_id> field_override;
         // bool represents item highlight
         std::map<tripoint, std::tuple<itype_id, mtype_id, bool>> item_override;
-        // int, int, bool represents part_mod, veh_dir, and highlight respectively
+        // int, angle, bool represents part_mod, veh_dir, and highlight respectively
         // point represents the mount direction
-        std::map<tripoint, std::tuple<vpart_id, int, int, bool, point>> vpart_override;
+        std::map<tripoint, std::tuple<vpart_id, int, units::angle, bool, point>> vpart_override;
         std::map<tripoint, bool> draw_below_override;
         // int represents spawn count
         std::map<tripoint, std::tuple<mtype_id, int, bool, Creature::Attitude>> monster_override;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -381,7 +381,6 @@ Character &get_player_character()
 
 // *INDENT-OFF*
 Character::Character() :
-
     visitable<Character>(),
     damage_bandaged( {{ 0 }} ),
     damage_disinfected( {{ 0 }} ),

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1222,7 +1222,7 @@ void construct::done_vehicle( const tripoint &p )
     map &m = get_map();
     avatar &u = get_avatar();
 
-    vehicle *veh = m.add_vehicle( vproto_id( "none" ), p, 270, 0, 0 );
+    vehicle *veh = m.add_vehicle( vproto_id( "none" ), p, 270_degrees, 0, 0 );
 
     if( !veh ) {
         debugmsg( "error constructing vehicle" );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -312,9 +312,10 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
     player &u = g->u; // Could easily protect something that isn't the player
     constexpr int hostile_adj = 2; // Priority bonus for hostile targets
     const int iff_dist = ( range + area ) * 3 / 2 + 6; // iff check triggers at this distance
-    int iff_hangle = 15 + area; // iff safety margin (degrees). less accuracy, more paranoia
+    // iff safety margin (degrees). less accuracy, more paranoia
+    units::angle iff_hangle = units::from_degrees( 15 + area );
     float best_target_rating = -1.0f; // bigger is better
-    int u_angle = 0;         // player angle relative to turret
+    units::angle u_angle = {};         // player angle relative to turret
     boo_hoo = 0;         // how many targets were passed due to IFF. Tragically.
     bool self_area_iff = false; // Need to check if the target is near the vehicle we're a part of
     bool area_iff = false;      // Need to check distance from target to player
@@ -330,7 +331,8 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
         if( in_veh && veh_pointer_or_null( vp ) == in_veh && vp->is_inside() ) {
             angle_iff = false; // No angle IFF, but possibly area IFF
         } else if( pldist < 3 ) {
-            iff_hangle = ( pldist == 2 ? 30 : 60 );  // granularity increases with proximity
+            // granularity increases with proximity
+            iff_hangle = ( pldist == 2 ? 30_degrees : 60_degrees );
         }
         u_angle = coord_to_angle( pos(), u.pos() );
     }
@@ -411,10 +413,10 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
         // only when the target is actually "hostile enough"
         bool maybe_boo = false;
         if( angle_iff ) {
-            int tangle = coord_to_angle( pos(), m->pos() );
-            int diff = std::abs( u_angle - tangle );
+            units::angle tangle = coord_to_angle( pos(), m->pos() );
+            units::angle diff = units::fabs( u_angle - tangle );
             // Player is in the angle and not too far behind the target
-            if( ( diff + iff_hangle > 360 || diff < iff_hangle ) &&
+            if( ( diff + iff_hangle > 360_degrees || diff < iff_hangle ) &&
                 ( dist * 3 / 2 + 6 > pldist ) ) {
                 maybe_boo = true;
             }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1507,7 +1507,7 @@ void debug()
 
                     if( veh_cond_menu.ret >= 0 && veh_cond_menu.ret < 3 ) {
                         // TODO: Allow picking this when add_vehicle has 3d argument
-                        vehicle *veh = g->m.add_vehicle( selected_opt, dest, -90, 100, veh_cond_menu.ret - 1 );
+                        vehicle *veh = g->m.add_vehicle( selected_opt, dest, -90_degrees, 100, veh_cond_menu.ret - 1 );
                         if( veh != nullptr ) {
                             g->m.board_vehicle( dest, &u );
                         }

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -641,10 +641,11 @@ void editmap::draw_main_ui_overlay()
                         const vpart_id &vp_id = veh.part_id_string( veh_part, part_mod );
                         const cata::optional<vpart_reference> cargopart = vp.part_with_feature( "CARGO", true );
                         bool draw_highlight = cargopart && !veh.get_items( cargopart->part_index() ).empty();
-                        int veh_dir = veh.face.dir();
+                        units::angle veh_dir = veh.face.dir();
                         g->draw_vpart_override( map_p, vp_id, part_mod, veh_dir, draw_highlight, vp->mount() );
                     } else {
-                        g->draw_vpart_override( map_p, vpart_id::NULL_ID(), 0, 0, false, point_zero );
+                        g->draw_vpart_override( map_p, vpart_id::NULL_ID(), 0, 0_degrees, false,
+                                                point_zero );
                     }
                     g->draw_below_override( map_p, g->m.has_zlevels() &&
                                             tmpmap.ter( tmp_p ).obj().has_flag( TFLAG_NO_FLOOR ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -852,9 +852,12 @@ vehicle *game::place_vehicle_nearby(
             tinymap target_map;
             target_map.load( project_to<coords::sm>( goal ), false );
             const tripoint tinymap_center( SEEX, SEEY, goal.z() );
-            static const std::vector<int> angles = {0, 90, 180, 270};
-            vehicle *veh = target_map.add_vehicle( id, tinymap_center, random_entry( angles ), rng( 50, 80 ),
-                                                   0, false );
+            static constexpr std::array<units::angle, 4> angles = {{
+                    0_degrees, 90_degrees, 180_degrees, 270_degrees
+                }
+            };
+            vehicle *veh = target_map.add_vehicle(
+                               id, tinymap_center, random_entry( angles ), rng( 50, 80 ), 0, false );
             if( veh ) {
                 tripoint abs_local = g->m.getlocal( target_map.getabs( tinymap_center ) );
                 veh->sm_pos =  ms_to_sm_remain( abs_local );
@@ -5379,7 +5382,7 @@ void game::moving_vehicle_dismount( const tripoint &dest_loc )
     }
     tileray ray( dest_loc.xy() + point( -u.posx(), -u.posy() ) );
     // TODO:: make dir() const correct!
-    const int d = ray.dir();
+    const units::angle d = ray.dir();
     add_msg( _( "You dive from the %s." ), veh->name );
     m.unboard_vehicle( u.pos() );
     u.moves -= 200;
@@ -5390,7 +5393,8 @@ void game::moving_vehicle_dismount( const tripoint &dest_loc )
         if( veh->velocity > 0 ) {
             fling_creature( &u, veh->face.dir(), veh->velocity / static_cast<float>( 100 ) );
         } else {
-            fling_creature( &u, veh->face.dir() + 180, -( veh->velocity ) / static_cast<float>( 100 ) );
+            fling_creature( &u, veh->face.dir() + 180_degrees,
+                            -( veh->velocity ) / static_cast<float>( 100 ) );
         }
     }
 }
@@ -10134,7 +10138,7 @@ void game::on_options_changed()
     grid_tracker_ptr->on_options_changed();
 }
 
-void game::fling_creature( Creature *c, const int &dir, float flvel, bool controlled )
+void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bool controlled )
 {
     if( c == nullptr ) {
         debugmsg( "game::fling_creature invoked on null target" );

--- a/src/game.h
+++ b/src/game.h
@@ -543,7 +543,8 @@ class game
         std::vector<monster *> get_fishable_monsters( std::unordered_set<tripoint> &fishable_locations );
 
         /** Flings the input creature in the given direction. */
-        void fling_creature( Creature *c, const int &dir, float flvel, bool controlled = false );
+        void fling_creature( Creature *c, const units::angle &dir, float flvel,
+                             bool controlled = false );
 
         float natural_light_level( int zlev ) const;
         /** Returns coarse number-of-squares of visibility at the current light level.
@@ -704,9 +705,10 @@ class game
         void draw_graffiti_override( const tripoint &p, bool has );
         void draw_trap_override( const tripoint &p, const trap_id &id );
         void draw_field_override( const tripoint &p, const field_type_id &id );
-        void draw_item_override( const tripoint &p, const itype_id &id, const mtype_id &mid, bool hilite );
-        void draw_vpart_override( const tripoint &p, const vpart_id &id, int part_mod, int veh_dir,
-                                  bool hilite, const point &mount );
+        void draw_item_override( const tripoint &p, const itype_id &id, const mtype_id &mid,
+                                 bool hilite );
+        void draw_vpart_override( const tripoint &p, const vpart_id &id, int part_mod,
+                                  units::angle veh_dir, bool hilite, const point &mount );
         void draw_below_override( const tripoint &p, bool draw );
         void draw_monster_override( const tripoint &p, const mtype_id &id, int count,
                                     bool more, Creature::Attitude att );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8014,16 +8014,16 @@ const itype_id &item::typeId() const
     return type ? type->get_id() : itype_id::NULL_ID();
 }
 
-bool item::getlight( float &luminance, int &width, int &direction ) const
+bool item::getlight( float &luminance, units::angle &width, units::angle &direction ) const
 {
     luminance = 0;
-    width = 0;
-    direction = 0;
+    width = 0_degrees;
+    direction = 0_degrees;
     if( light.luminance > 0 ) {
         luminance = static_cast<float>( light.luminance );
         if( light.width > 0 ) {  // width > 0 is a light arc
-            width = light.width;
-            direction = light.direction;
+            width = units::from_degrees( light.width );
+            direction = units::from_degrees( light.direction );
         }
         return true;
     } else {

--- a/src/item.h
+++ b/src/item.h
@@ -1445,7 +1445,7 @@ class item : public visitable<item>
          * @param width If greater 0, the light is emitted in an arc, this is the angle of it.
          * @param direction The direction of the light arc. In degrees.
          */
-        bool getlight( float &luminance, int &width, int &direction ) const;
+        bool getlight( float &luminance, units::angle &width, units::angle &direction ) const;
         /**
          * How much light (see lightmap.cpp) the item emits (it's assumed to be circular).
          */

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5639,7 +5639,8 @@ int iuse::unfold_generic( player *p, item *it, bool, const tripoint & )
         p->add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
         return 0;
     }
-    vehicle *veh = g->m.add_vehicle( vproto_id( "none" ), p->pos(), 0, 0, 0, false );
+    map &here = get_map();
+    vehicle *veh = here.add_vehicle( vproto_id( "none" ), p->pos(), 0_degrees, 0, 0, false );
     if( veh == nullptr ) {
         p->add_msg_if_player( m_info, _( "There's no room to unfold the %s." ), it->tname() );
         return 0;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -633,7 +633,7 @@ int unfold_vehicle_iuse::use( player &p, item &it, bool, const tripoint & ) cons
         }
     }
 
-    vehicle *veh = get_map().add_vehicle( vehicle_id, p.pos(), 0, 0, 0, false );
+    vehicle *veh = get_map().add_vehicle( vehicle_id, p.pos(), 0_degrees, 0, 0, false );
     if( veh == nullptr ) {
         p.add_msg_if_player( m_info, _( "There's no room to unfold the %s." ), it.tname() );
         return 0;

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -64,11 +64,11 @@ void map::add_light_from_items( const tripoint &p, item_stack::iterator begin,
                                 item_stack::iterator end )
 {
     for( auto itm_it = begin; itm_it != end; ++itm_it ) {
-        float ilum = 0.0; // brightness
-        int iwidth = 0; // 0-360 degrees. 0 is a circular light_source
-        int idir = 0;   // otherwise, it's a light_arc pointed in this direction
+        float ilum = 0.0f; // brightness
+        units::angle iwidth = 0_degrees; // 0-360 degrees. 0 is a circular light_source
+        units::angle idir = 0_degrees;   // otherwise, it's a light_arc pointed in this direction
         if( itm_it->getlight( ilum, iwidth, idir ) ) {
-            if( iwidth > 0 ) {
+            if( iwidth > 0_degrees ) {
                 apply_light_arc( p, idir, ilum, iwidth );
             } else {
                 add_light_source( p, ilum );
@@ -520,18 +520,20 @@ void map::generate_lightmap( const int zlev )
             if( vp.has_flag( VPFLAG_CONE_LIGHT ) ) {
                 if( veh_luminance > lit_level::LIT ) {
                     add_light_source( src, M_SQRT2 ); // Add a little surrounding light
-                    apply_light_arc( src, v->face.dir() + pt->direction, veh_luminance, 45 );
+                    apply_light_arc( src, v->face.dir() + pt->direction, veh_luminance,
+                                     45_degrees );
                 }
 
             } else if( vp.has_flag( VPFLAG_WIDE_CONE_LIGHT ) ) {
                 if( veh_luminance > lit_level::LIT ) {
                     add_light_source( src, M_SQRT2 ); // Add a little surrounding light
-                    apply_light_arc( src, v->face.dir() + pt->direction, veh_luminance, 90 );
+                    apply_light_arc( src, v->face.dir() + pt->direction, veh_luminance,
+                                     90_degrees );
                 }
 
             } else if( vp.has_flag( VPFLAG_HALF_CIRCLE_LIGHT ) ) {
                 add_light_source( src, M_SQRT2 ); // Add a little surrounding light
-                apply_light_arc( src, v->face.dir() + pt->direction, vp.bonus, 180 );
+                apply_light_arc( src, v->face.dir() + pt->direction, vp.bonus, 180_degrees );
 
             } else if( vp.has_flag( VPFLAG_CIRCLE_LIGHT ) ) {
                 const bool odd_turn = calendar::once_every( 2_turns );
@@ -1473,7 +1475,8 @@ void map::apply_directional_light( const tripoint &p, int direction, float lumin
     }
 }
 
-void map::apply_light_arc( const tripoint &p, int angle, float luminance, int wideangle )
+void map::apply_light_arc( const tripoint &p, units::angle angle, float luminance,
+                           units::angle wideangle )
 {
     if( luminance <= LIGHT_SOURCE_LOCAL ) {
         return;
@@ -1484,12 +1487,11 @@ void map::apply_light_arc( const tripoint &p, int angle, float luminance, int wi
     apply_light_source( p, LIGHT_SOURCE_LOCAL );
 
     // Normalize (should work with negative values too)
-    const double wangle = wideangle / 2.0;
+    const units::angle wangle = wideangle / 2.0;
 
-    int nangle = angle % 360;
+    units::angle nangle = fmod( angle, 360_degrees );
 
     tripoint end;
-    double rad = M_PI * static_cast<double>( nangle ) / 180;
     int range = LIGHT_RANGE( luminance );
     calc_ray_end( nangle, range, p, end );
     apply_light_ray( lit, p, end, luminance );
@@ -1503,23 +1505,22 @@ void map::apply_light_arc( const tripoint &p, int angle, float luminance, int wi
     }
 
     // attempt to determine beam intensity required to cover all squares
-    const double wstep = ( wangle / ( wdist * M_SQRT2 ) );
+    const units::angle wstep = ( wangle / ( wdist * M_SQRT2 ) );
 
     // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter)
-    for( double ao = wstep; ao <= wangle; ao += wstep ) {
+    for( units::angle ao = wstep; ao <= wangle; ao += wstep ) {
         if( trigdist ) {
             double fdist = ( ao * M_PI_2 ) / wangle;
-            double orad = ( M_PI * ao / 180.0 );
-            end.x = static_cast<int>( p.x + ( static_cast<double>( range ) - fdist * 2.0 ) * std::cos(
-                                          rad + orad ) );
-            end.y = static_cast<int>( p.y + ( static_cast<double>( range ) - fdist * 2.0 ) * std::sin(
-                                          rad + orad ) );
+            end.x = static_cast<int>(
+                        p.x + ( static_cast<double>( range ) - fdist * 2.0 ) * cos( nangle + ao ) );
+            end.y = static_cast<int>(
+                        p.y + ( static_cast<double>( range ) - fdist * 2.0 ) * sin( nangle + ao ) );
             apply_light_ray( lit, p, end, luminance );
 
-            end.x = static_cast<int>( p.x + ( static_cast<double>( range ) - fdist * 2.0 ) * std::cos(
-                                          rad - orad ) );
-            end.y = static_cast<int>( p.y + ( static_cast<double>( range ) - fdist * 2.0 ) * std::sin(
-                                          rad - orad ) );
+            end.x = static_cast<int>(
+                        p.x + ( static_cast<double>( range ) - fdist * 2.0 ) * cos( nangle - ao ) );
+            end.y = static_cast<int>(
+                        p.y + ( static_cast<double>( range ) - fdist * 2.0 ) * sin( nangle - ao ) );
             apply_light_ray( lit, p, end, luminance );
         } else {
             calc_ray_end( nangle + ao, range, p, end );

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -15,6 +15,12 @@
 #include "enums.h"
 #include "point_float.h"
 
+double iso_tangent( double distance, units::angle vertex )
+{
+    // we can use the cosine formula (a² = b² + c² - 2bc⋅cosθ) to calculate the tangent
+    return std::sqrt( 2 * std::pow( distance, 2 ) * ( 1 - cos( vertex ) ) );
+}
+
 void bresenham( const point &p1, const point &p2, int t,
                 const std::function<bool( const point & )> &interact )
 {
@@ -297,14 +303,9 @@ int manhattan_dist( const point &loc1, const point &loc2 )
     return d.x + d.y;
 }
 
-double atan2( const point &p )
+units::angle atan2( const point &p )
 {
-    return atan2( static_cast<double>( p.y ), static_cast<double>( p.x ) );
-}
-
-double atan2_degrees( const point &p )
-{
-    return atan2( p ) * 180.0 / M_PI;
+    return units::atan2( p.y, p.x );
 }
 
 // This more general version of this function gives correct values for larger values.
@@ -732,41 +733,41 @@ rl_vec2d rl_vec2d::operator/( const float rhs ) const
     return ret;
 }
 
-void calc_ray_end( int angle, const int range, const tripoint &p, tripoint &out )
+void calc_ray_end( units::angle angle, const int range, const tripoint &p, tripoint &out )
 {
     // forces input angle to be between 0 and 360, calculated from actual input
-    angle %= 360;
-    if( angle < 0 ) {
-        angle += 360;
+    angle = fmod( angle, 360_degrees );
+    if( angle < 0_degrees ) {
+        angle += 360_degrees;
     }
-    const double rad = deg2rad( angle );
     out.z = p.z;
     if( trigdist ) {
-        out.x = p.x + range * std::cos( rad );
-        out.y = p.y + range * std::sin( rad );
+        out.x = p.x + range * cos( angle );
+        out.y = p.y + range * sin( angle );
     } else {
         int mult = 0;
-        if( angle >= 135 && angle <= 315 ) {
+        if( angle >= 135_degrees && angle <= 315_degrees ) {
             mult = -1;
         } else {
             mult = 1;
         }
 
-        if( angle <= 45 || ( 135 <= angle && angle <= 215 ) || 315 < angle ) {
+        if( angle <= 45_degrees || ( 135_degrees <= angle && angle <= 215_degrees ) ||
+            315_degrees < angle ) {
             out.x = p.x + range * mult;
-            out.y = p.y + range * std::tan( rad ) * mult;
+            out.y = p.y + range * tan( angle ) * mult;
         } else {
-            out.x = p.x + range * 1 / std::tan( rad ) * mult;
+            out.x = p.x + range * 1 / tan( angle ) * mult;
             out.y = p.y + range * mult;
         }
     }
 }
 
-double coord_to_angle( const tripoint &a, const tripoint &b )
+units::angle coord_to_angle( const tripoint &a, const tripoint &b )
 {
-    double rad = atan2( b.y - a.y, b.x - a.x );
-    if( rad < 0 ) {
-        rad += 2 * M_PI;
+    units::angle rad = units::atan2( b.y - a.y, b.x - a.x );
+    if( rad < 0_degrees ) {
+        rad += 2_pi_radians;
     }
-    return rad * 180 / M_PI;
+    return rad;
 }

--- a/src/line.h
+++ b/src/line.h
@@ -11,36 +11,15 @@
 #include "math_defines.h"
 #include "point.h"
 #include "cached_options.h"
-
-/** Converts degrees to radians */
-constexpr double deg2rad( double v )
-{
-    return v * M_PI / 180;
-}
-
-/** Converts degrees to radians */
-constexpr double rad2deg( double v )
-{
-    return v * 180 / M_PI;
-}
-
-/** Converts arc minutes to radians */
-constexpr double degmin2rad( double v )
-{
-    return deg2rad( v ) / 60;
-}
+#include "units_angle.h"
 
 /**
  * Calculate base of an isosceles triangle
  * @param distance one of the equal lengths
- * @param vertex the unequal angle expressed in MoA
+ * @param vertex the unequal angle
  * @returns base in equivalent units to distance
  */
-inline double iso_tangent( double distance, double vertex )
-{
-    // we can use the cosine formula (a² = b² + c² - 2bc⋅cosθ) to calculate the tangent
-    return std::sqrt( 2 * std::pow( distance, 2 ) * ( 1 - std::cos( degmin2rad( vertex ) ) ) );
-}
+double iso_tangent( double distance, units::angle vertex );
 
 //! This compile-time usable function combines the sign of each (x, y, z) component into a single integer
 //! to allow simple runtime and compile-time mapping of (x, y, z) tuples to @ref direction enumerators.
@@ -253,9 +232,8 @@ float rl_dist_exact( const tripoint &loc1, const tripoint &loc2 );
 // Sum of distance in both axes
 int manhattan_dist( const point &loc1, const point &loc2 );
 
-// get angle of direction represented by point (in radians or degrees)
-double atan2( const point & );
-double atan2_degrees( const point & );
+// get angle of direction represented by point
+units::angle atan2( const point & );
 
 // Get the magnitude of the slope ranging from 0.0 to 1.0
 float get_normalized_angle( const point &start, const point &end );
@@ -264,7 +242,7 @@ std::vector<point> squares_in_direction( const point &p1, const point &p2 );
 // Returns a vector of squares adjacent to @from that are closer to @to than @from is.
 // Currently limited to the same z-level as @from.
 std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &to );
-void calc_ray_end( int angle, int range, const tripoint &p, tripoint &out );
+void calc_ray_end( units::angle, int range, const tripoint &p, tripoint &out );
 /**
  * Calculates the horizontal angle between the lines from (0,0,0) to @p a and
  * the line from (0,0,0) to @p b.
@@ -272,6 +250,6 @@ void calc_ray_end( int angle, int range, const tripoint &p, tripoint &out );
  * Example: if @p a is (0,1) and @p b is (1,0), the result will 90 degree
  * The function currently ignores the z component.
  */
-double coord_to_angle( const tripoint &a, const tripoint &b );
+units::angle coord_to_angle( const tripoint &a, const tripoint &b );
 
 #endif // CATA_SRC_LINE_H

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -229,7 +229,7 @@ void spell_type::load( const JsonObject &jo, const std::string & )
         { "explosion", spell_effect::explosion },
         { "flashbang", spell_effect::flashbang },
         { "mod_moves", spell_effect::mod_moves },
-        { "map", spell_effect::map },
+        { "map", spell_effect::map_area },
         { "morale", spell_effect::morale },
         { "charm_monster", spell_effect::charm_monster },
         { "mutate", spell_effect::mutate },

--- a/src/magic.h
+++ b/src/magic.h
@@ -550,7 +550,7 @@ void vomit( const spell &sp, Creature &caster, const tripoint &target );
 void explosion( const spell &sp, Creature &, const tripoint &target );
 void flashbang( const spell &sp, Creature &caster, const tripoint &target );
 void mod_moves( const spell &sp, Creature &caster, const tripoint &target );
-void map( const spell &sp, Creature &caster, const tripoint & );
+void map_area( const spell &sp, Creature &caster, const tripoint & );
 void morale( const spell &sp, Creature &caster, const tripoint &target );
 void charm_monster( const spell &sp, Creature &caster, const tripoint &target );
 void mutate( const spell &sp, Creature &caster, const tripoint &target );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -185,12 +185,12 @@ std::set<tripoint> spell_effect::spell_effect_cone( const spell &sp, const tripo
         const tripoint &target, const int aoe_radius, const bool ignore_walls )
 {
     std::set<tripoint> targets;
-    // cones go all the way to end (if they don't hit an obstacle)
-    const int range = sp.range() + 1;
-    const int initial_angle = coord_to_angle( source, target );
+    const units::angle initial_angle = coord_to_angle( source, target );
+    const units::angle half_width = units::from_degrees( aoe_radius / 2.0 );
+    const units::angle start_angle = initial_angle - half_width;
+    const units::angle end_angle = initial_angle + half_width;
     std::set<tripoint> end_points;
-    for( int angle = initial_angle - std::floor( aoe_radius / 2.0 );
-         angle <= initial_angle + std::ceil( aoe_radius / 2.0 ); angle++ ) {
+    for( units::angle angle = start_angle; angle <= end_angle; angle += 1_degrees ) {
         tripoint potential;
         calc_ray_end( angle, range, source, potential );
         end_points.emplace( potential );
@@ -835,11 +835,12 @@ void spell_effect::spawn_summoned_monster( const spell &sp, Creature &caster,
 void spell_effect::spawn_summoned_vehicle( const spell &sp, Creature &caster,
         const tripoint &target )
 {
-    if( g->m.veh_at( target ) ) {
+    map &here = get_map();
+    if( here.veh_at( target ) ) {
         caster.add_msg_if_player( m_bad, _( "There is already a vehicle there." ) );
         return;
     }
-    if( vehicle *veh = g->m.add_vehicle( sp.summon_vehicle_id(), target, -90, 100, 0 ) ) {
+    if( vehicle *veh = here.add_vehicle( sp.summon_vehicle_id(), target, -90_degrees, 100, 0 ) ) {
         veh->magic = true;
         const time_duration summon_time = sp.duration_turns();
         if( !sp.has_flag( spell_flag::PERMANENT ) ) {

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -185,6 +185,8 @@ std::set<tripoint> spell_effect::spell_effect_cone( const spell &sp, const tripo
         const tripoint &target, const int aoe_radius, const bool ignore_walls )
 {
     std::set<tripoint> targets;
+    // cones go all the way to end (if they don't hit an obstacle)
+    const int range = sp.range() + 1;
     const units::angle initial_angle = coord_to_angle( source, target );
     const units::angle half_width = units::from_degrees( aoe_radius / 2.0 );
     const units::angle start_angle = initial_angle - half_width;
@@ -933,7 +935,7 @@ void spell_effect::mod_moves( const spell &sp, Creature &caster, const tripoint 
     }
 }
 
-void spell_effect::map( const spell &sp, Creature &caster, const tripoint & )
+void spell_effect::map_area( const spell &sp, Creature &caster, const tripoint & )
 {
     const avatar *you = caster.as_avatar();
     if( !you ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -605,7 +605,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
     if( dp.z != 0 && veh.is_rotorcraft() ) {
         can_move = true;
     }
-    int coll_turn = 0;
+    units::angle coll_turn = 0_degrees;
     if( impulse > 0 ) {
         coll_turn = shake_vehicle( veh, velocity_before, facing.dir() );
         const int volume = std::min<int>( 100, std::sqrt( impulse ) );
@@ -631,16 +631,16 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
         }
     }
 
-    const int last_turn_dec = 1;
-    if( veh.last_turn < 0 ) {
+    const units::angle last_turn_dec = 1_degrees;
+    if( veh.last_turn < 0_degrees ) {
         veh.last_turn += last_turn_dec;
         if( veh.last_turn > -last_turn_dec ) {
-            veh.last_turn = 0;
+            veh.last_turn = 0_degrees;
         }
-    } else if( veh.last_turn > 0 ) {
+    } else if( veh.last_turn > 0_degrees ) {
         veh.last_turn -= last_turn_dec;
         if( veh.last_turn < last_turn_dec ) {
-            veh.last_turn = 0;
+            veh.last_turn = 0_degrees;
         }
     }
 
@@ -656,7 +656,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
         }
 
         veh.move = facing;
-        if( coll_turn != 0 ) {
+        if( coll_turn != 0_degrees ) {
             veh.skidding = true;
             veh.turn( coll_turn );
         }

--- a/src/map.h
+++ b/src/map.h
@@ -772,7 +772,7 @@ class map
                                          const std::vector<veh_collision> &collisions );
         // Throws vehicle passengers about the vehicle, possibly out of it
         // Returns change in vehicle orientation due to lost control
-        int shake_vehicle( vehicle &veh, int velocity_before, int direction );
+        units::angle shake_vehicle( vehicle &veh, int velocity_before, units::angle direction );
 
         // Actually moves the vehicle
         // Unlike displace_vehicle, this one handles collisions
@@ -1541,16 +1541,16 @@ class map
         void build_obstacle_cache( const tripoint &start, const tripoint &end,
                                    float( &obstacle_cache )[MAPSIZE_X][MAPSIZE_Y] );
 
-        vehicle *add_vehicle( const vgroup_id &type, const tripoint &p, int dir,
+        vehicle *add_vehicle( const vgroup_id &type, const tripoint &p, units::angle dir,
                               int init_veh_fuel = -1, int init_veh_status = -1,
                               bool merge_wrecks = true );
-        vehicle *add_vehicle( const vgroup_id &type, const point &p, int dir,
+        vehicle *add_vehicle( const vgroup_id &type, const point &p, units::angle dir,
                               int init_veh_fuel = -1, int init_veh_status = -1,
                               bool merge_wrecks = true );
-        vehicle *add_vehicle( const vproto_id &type, const tripoint &p, int dir,
+        vehicle *add_vehicle( const vproto_id &type, const tripoint &p, units::angle dir,
                               int init_veh_fuel = -1, int init_veh_status = -1,
                               bool merge_wrecks = true );
-        vehicle *add_vehicle( const vproto_id &type, const point &p, int dir,
+        vehicle *add_vehicle( const vproto_id &type, const point &p, units::angle dir,
                               int init_veh_fuel = -1, int init_veh_status = -1,
                               bool merge_wrecks = true );
         // Light/transparency
@@ -1864,7 +1864,8 @@ class map
         void add_light_source( const tripoint &p, float luminance );
         // Handle just cardinal directions and 45 deg angles.
         void apply_directional_light( const tripoint &p, int direction, float luminance );
-        void apply_light_arc( const tripoint &p, int angle, float luminance, int wideangle = 30 );
+        void apply_light_arc( const tripoint &p, units::angle, float luminance,
+                              units::angle wideangle = 30_degrees );
         void apply_light_ray( bool lit[MAPSIZE_X][MAPSIZE_Y],
                               const tripoint &s, const tripoint &e, float luminance );
         void add_light_from_items( const tripoint &p, item_stack::iterator begin,

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -52,6 +52,7 @@
 #include "trap.h"
 #include "type_id.h"
 #include "ui.h"
+#include "units.h"
 #include "veh_type.h"
 #include "vehicle.h"
 #include "vehicle_group.h"
@@ -375,7 +376,7 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
         }
     }
 
-    int dir1 = rng( 0, 359 );
+    units::angle dir1 = random_direction();
 
     auto crashed_hull = vgroup_id( "crashed_helicopters" )->pick();
 
@@ -404,8 +405,8 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
     int x1 = clamp( c.x + x_offset, x_min, x_max );
     int y1 = clamp( c.y + y_offset, y_min, y_max );
 
-    vehicle *wreckage = m.add_vehicle( crashed_hull, tripoint( x1, y1, abs_sub.z ), dir1, rng( 1, 33 ),
-                                       1 );
+    vehicle *wreckage = m.add_vehicle(
+                            crashed_hull, tripoint( x1, y1, abs_sub.z ), dir1, rng( 1, 33 ), 1 );
 
     const auto controls_at = []( vehicle * wreckage, const tripoint & pos ) {
         return !wreckage->get_parts_at( pos, "CONTROLS", part_status_flag::any ).empty() ||
@@ -664,7 +665,8 @@ static bool mx_roadblock( map &m, const tripoint &abs_sub )
 
         if( one_in( 2 ) ) {
             // The truck's wrecked...with fuel.  Explosive barrel?
-            m.add_vehicle( vproto_id( "military_cargo_truck" ), point( 12, SEEY * 2 - 12 ), 0, 70, -1 );
+            m.add_vehicle( vproto_id( "military_cargo_truck" ), point( 12, SEEY * 2 - 12 ),
+                           0_degrees, 70, -1 );
             if( road_at_north ) {
                 spawn_turret( point( 12, 6 ) );
             }
@@ -678,8 +680,8 @@ static bool mx_roadblock( map &m, const tripoint &abs_sub )
                 spawn_turret( point( 6, 12 ) );
             }
         } else {  // Vehicle & turrets
-            m.add_vehicle( vgroup_id( "military_vehicles" ), tripoint( 12, SEEY * 2 - 10, abs_sub.z ), 0, 70,
-                           -1 );
+            m.add_vehicle( vgroup_id( "military_vehicles" ),
+                           tripoint( 12, SEEY * 2 - 10, abs_sub.z ), 0_degrees, 70, -1 );
             if( road_at_north ) {
                 spawn_turret( point( 12, 6 ) );
             }
@@ -736,8 +738,8 @@ static bool mx_roadblock( map &m, const tripoint &abs_sub )
             m.add_spawn( mon_turret_riot, 1, { 1, 12, abs_sub.z } );
         }
 
-        m.add_vehicle( vproto_id( "policecar" ), point( 8, 6 ), 20 );
-        m.add_vehicle( vproto_id( "policecar" ), point( 16, SEEY * 2 - 6 ), 145 );
+        m.add_vehicle( vproto_id( "policecar" ), point( 8, 6 ), 20_degrees );
+        m.add_vehicle( vproto_id( "policecar" ), point( 16, SEEY * 2 - 6 ), 145_degrees );
 
         line_furn( &m, f_sandbag_wall, point( 6, 10 ), point( 9, 10 ) );
         m.add_spawn( mon_turret_searchlight, 1, { 7, 11, abs_sub.z } );
@@ -1125,7 +1127,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
 
         //50% chance to spawn a humvee in the left block
         if( one_in( 2 ) ) {
-            m.add_vehicle( vproto_id( "humvee" ), point( 5, 3 ), 270, 70, -1 );
+            m.add_vehicle( vproto_id( "humvee" ), point( 5, 3 ), 270_degrees, 70, -1 );
         }
 
         //Sandbag block at the right edge
@@ -1268,8 +1270,8 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
 
         //50% chance to spawn two humvees blocking the road
         if( one_in( 2 ) ) {
-            m.add_vehicle( vproto_id( "humvee" ), point( 7, 19 ), 0, 70, -1 );
-            m.add_vehicle( vproto_id( "humvee" ), point( 15, 20 ), 180, 70, -1 );
+            m.add_vehicle( vproto_id( "humvee" ), point( 7, 19 ), 0_degrees, 70, -1 );
+            m.add_vehicle( vproto_id( "humvee" ), point( 15, 20 ), 180_degrees, 70, -1 );
         }
 
         //Spawn 6-20 mines in the upper submap.
@@ -1346,7 +1348,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
             m.add_field( { 1, 6, abs_sub.z }, fd_gibs_flesh, 1 );
 
             //Add the culprit
-            m.add_vehicle( vproto_id( "car_fbi" ), point( 7, 7 ), 0, 70, 1 );
+            m.add_vehicle( vproto_id( "car_fbi" ), point( 7, 7 ), 0_degrees, 70, 1 );
 
             //Remove tent parts after drive-through
             square_furn( &m, f_null, point( 0, 6 ), point( 8, 9 ) );
@@ -1466,7 +1468,7 @@ static bool mx_minefield( map &m_orig, const tripoint &abs_sub )
             m.load( project_to<coords::sm>( abs_omt + point_west ), false );
         }
         //Spawn military cargo truck blocking the entry
-        m.add_vehicle( vproto_id( "military_cargo_truck" ), point( 15, 11 ), 270, 70, 1 );
+        m.add_vehicle( vproto_id( "military_cargo_truck" ), point( 15, 11 ), 270_degrees, 70, 1 );
 
         //Spawn sandbag barricades around the truck
         line_furn( &m, f_sandbag_half, point( 14, 3 ), point( 14, 8 ) );
@@ -2508,10 +2510,10 @@ static bool mx_roadworks( map &m, const tripoint &abs_sub )
     // vehicle placer
     switch( rng( 1, 6 ) ) {
         case 1:
-            m.add_vehicle( vproto_id( "road_roller" ), veh, rng( 0, 360 ) );
+            m.add_vehicle( vproto_id( "road_roller" ), veh, random_direction() );
             break;
         case 2:
-            m.add_vehicle( vproto_id( "excavator" ), veh, rng( 0, 360 ) );
+            m.add_vehicle( vproto_id( "excavator" ), veh, random_direction() );
             break;
         case 3:
         case 4:
@@ -2535,8 +2537,8 @@ static bool mx_mayhem( map &m, const tripoint &abs_sub )
     switch( rng( 1, 3 ) ) {
         //Car accident resulted in a shootout with two victims
         case 1: {
-            m.add_vehicle( vproto_id( "car" ), point( 18, 9 ), 270 );
-            m.add_vehicle( vproto_id( "4x4_car" ), point( 20, 5 ), 0 );
+            m.add_vehicle( vproto_id( "car" ), point( 18, 9 ), 270_degrees );
+            m.add_vehicle( vproto_id( "4x4_car" ), point( 20, 5 ), 0_degrees );
 
             m.spawn_item( { 16, 10, abs_sub.z }, itype_shot_hull );
             m.add_corpse( { 16, 9, abs_sub.z } );
@@ -2554,7 +2556,7 @@ static bool mx_mayhem( map &m, const tripoint &abs_sub )
         }
         //Some cocky moron with friends got dragged out of limo and shooted down by a military
         case 2: {
-            m.add_vehicle( vproto_id( "limousine" ), point( 18, 9 ), 270 );
+            m.add_vehicle( vproto_id( "limousine" ), point( 18, 9 ), 270_degrees );
 
             m.add_corpse( { 16, 9, abs_sub.z } );
             m.add_corpse( { 16, 11, abs_sub.z } );
@@ -2571,7 +2573,7 @@ static bool mx_mayhem( map &m, const tripoint &abs_sub )
         }
         //Some unfortunate stopped at the roadside to change tire, but was ambushed and killed
         case 3: {
-            m.add_vehicle( vproto_id( "car" ), point( 18, 12 ), 270 );
+            m.add_vehicle( vproto_id( "car" ), point( 18, 12 ), 270_degrees );
 
             m.add_field( { 16, 15, abs_sub.z }, fd_blood, rng( 1, 3 ) );
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1345,7 +1345,7 @@ class jmapgen_vehicle : public jmapgen_piece
     public:
         vgroup_id type;
         jmapgen_int chance;
-        std::vector<int> rotation;
+        std::vector<units::angle> rotation;
         int fuel;
         int status;
         jmapgen_vehicle( const JsonObject &jsi ) :
@@ -1356,9 +1356,11 @@ class jmapgen_vehicle : public jmapgen_piece
             , fuel( jsi.get_int( "fuel", -1 ) )
             , status( jsi.get_int( "status", -1 ) ) {
             if( jsi.has_array( "rotation" ) ) {
-                rotation = jsi.get_int_array( "rotation" );
+                for( const JsonValue &elt : jsi.get_array( "rotation" ) ) {
+                    rotation.push_back( units::from_degrees( elt.get_int() ) );
+                }
             } else {
-                rotation.push_back( jsi.get_int( "rotation", 0 ) );
+                rotation.push_back( units::from_degrees( jsi.get_int( "rotation", 0 ) ) );
             }
 
             if( !type.is_valid() ) {
@@ -2929,7 +2931,7 @@ void map::draw_office_tower( mapgendata &dat )
         int num_chairs = rng( 0, 6 );
         for( int i = 0; i < num_chairs; i++ ) {
             add_vehicle( vproto_id( "swivel_chair" ), point( rng( 6, 16 ), rng( 6, 16 ) ),
-                         0, -1, -1, false );
+                         0_degrees, -1, -1, false );
         }
     };
 
@@ -3287,54 +3289,54 @@ void map::draw_office_tower( mapgendata &dat )
             if( dat.west() == "office_tower_b_entrance" ) {
                 rotate( 1 );
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "car" ), point( 17, 7 ), 180 );
+                    add_vehicle( vproto_id( "car" ), point( 17, 7 ), 180_degrees );
                 }
                 if( x_in_y( 1, 3 ) ) {
-                    add_vehicle( vproto_id( "motorcycle" ), point( 17, 13 ), 180 );
+                    add_vehicle( vproto_id( "motorcycle" ), point( 17, 13 ), 180_degrees );
                 }
                 if( x_in_y( 1, 5 ) ) {
                     if( one_in( 3 ) ) {
-                        add_vehicle( vproto_id( "fire_truck" ), point( 6, 13 ), 0 );
+                        add_vehicle( vproto_id( "fire_truck" ), point( 6, 13 ), 0_degrees );
                     } else {
-                        add_vehicle( vproto_id( "pickup" ), point( 17, 19 ), 180 );
+                        add_vehicle( vproto_id( "pickup" ), point( 17, 19 ), 180_degrees );
                     }
                 }
             } else if( dat.north() == "office_tower_b_entrance" ) {
                 rotate( 2 );
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "car" ), point( 10, 17 ), 270 );
+                    add_vehicle( vproto_id( "car" ), point( 10, 17 ), 270_degrees );
                 }
                 if( x_in_y( 1, 3 ) ) {
-                    add_vehicle( vproto_id( "motorcycle" ), point( 4, 18 ), 270 );
+                    add_vehicle( vproto_id( "motorcycle" ), point( 4, 18 ), 270_degrees );
                 }
                 if( x_in_y( 1, 5 ) ) {
                     if( one_in( 3 ) ) {
-                        add_vehicle( vproto_id( "fire_truck" ), point( 6, 13 ), 0 );
+                        add_vehicle( vproto_id( "fire_truck" ), point( 6, 13 ), 0_degrees );
                     } else {
-                        add_vehicle( vproto_id( "pickup" ), point( 16, 17 ), 270 );
+                        add_vehicle( vproto_id( "pickup" ), point( 16, 17 ), 270_degrees );
                     }
                 }
             } else if( dat.east() == "office_tower_b_entrance" ) {
                 rotate( 3 );
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "car" ), point( 6, 4 ), 0 );
+                    add_vehicle( vproto_id( "car" ), point( 6, 4 ), 0_degrees );
                 }
                 if( x_in_y( 1, 3 ) ) {
-                    add_vehicle( vproto_id( "motorcycle" ), point( 6, 10 ), 180 );
+                    add_vehicle( vproto_id( "motorcycle" ), point( 6, 10 ), 180_degrees );
                 }
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "pickup" ), point( 6, 16 ), 0 );
+                    add_vehicle( vproto_id( "pickup" ), point( 6, 16 ), 0_degrees );
                 }
 
             } else {
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "pickup" ), point( 7, 6 ), 90 );
+                    add_vehicle( vproto_id( "pickup" ), point( 7, 6 ), 90_degrees );
                 }
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "car" ), point( 14, 6 ), 90 );
+                    add_vehicle( vproto_id( "car" ), point( 14, 6 ), 90_degrees );
                 }
                 if( x_in_y( 1, 3 ) ) {
-                    add_vehicle( vproto_id( "motorcycle" ), point( 19, 6 ), 90 );
+                    add_vehicle( vproto_id( "motorcycle" ), point( 19, 6 ), 90_degrees );
                 }
             }
         } else if( ( dat.west() == "office_tower_b_entrance" && dat.north() == "office_tower_b" ) ||
@@ -3374,49 +3376,49 @@ void map::draw_office_tower( mapgendata &dat )
             if( dat.north() == "office_tower_b_entrance" ) {
                 rotate( 1 );
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "car" ), point( 8, 15 ), 0 );
+                    add_vehicle( vproto_id( "car" ), point( 8, 15 ), 0_degrees );
                 }
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "pickup" ), point( 7, 10 ), 180 );
+                    add_vehicle( vproto_id( "pickup" ), point( 7, 10 ), 180_degrees );
                 }
                 if( x_in_y( 1, 3 ) ) {
-                    add_vehicle( vproto_id( "beetle" ), point( 7, 3 ), 0 );
+                    add_vehicle( vproto_id( "beetle" ), point( 7, 3 ), 0_degrees );
                 }
             } else if( dat.east() == "office_tower_b_entrance" ) {
                 rotate( 2 );
                 if( x_in_y( 1, 5 ) ) {
                     if( one_in( 3 ) ) {
-                        add_vehicle( vproto_id( "fire_truck" ), point( 6, 13 ), 0 );
+                        add_vehicle( vproto_id( "fire_truck" ), point( 6, 13 ), 0_degrees );
                     } else {
-                        add_vehicle( vproto_id( "pickup" ), point( 7, 7 ), 270 );
+                        add_vehicle( vproto_id( "pickup" ), point( 7, 7 ), 270_degrees );
                     }
                 }
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "car" ), point( 13, 8 ), 90 );
+                    add_vehicle( vproto_id( "car" ), point( 13, 8 ), 90_degrees );
                 }
                 if( x_in_y( 1, 3 ) ) {
-                    add_vehicle( vproto_id( "beetle" ), point( 20, 7 ), 90 );
+                    add_vehicle( vproto_id( "beetle" ), point( 20, 7 ), 90_degrees );
                 }
             } else if( dat.south() == "office_tower_b_entrance" ) {
                 rotate( 3 );
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "pickup" ), point( 16, 7 ), 0 );
+                    add_vehicle( vproto_id( "pickup" ), point( 16, 7 ), 0_degrees );
                 }
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "car" ), point( 15, 13 ), 180 );
+                    add_vehicle( vproto_id( "car" ), point( 15, 13 ), 180_degrees );
                 }
                 if( x_in_y( 1, 3 ) ) {
-                    add_vehicle( vproto_id( "beetle" ), point( 15, 20 ), 180 );
+                    add_vehicle( vproto_id( "beetle" ), point( 15, 20 ), 180_degrees );
                 }
             } else {
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "pickup" ), point( 16, 16 ), 90 );
+                    add_vehicle( vproto_id( "pickup" ), point( 16, 16 ), 90_degrees );
                 }
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "car" ), point( 9, 15 ), 270 );
+                    add_vehicle( vproto_id( "car" ), point( 9, 15 ), 270_degrees );
                 }
                 if( x_in_y( 1, 3 ) ) {
-                    add_vehicle( vproto_id( "beetle" ), point( 4, 16 ), 270 );
+                    add_vehicle( vproto_id( "beetle" ), point( 4, 16 ), 270_degrees );
                 }
             }
         } else {
@@ -3454,56 +3456,56 @@ void map::draw_office_tower( mapgendata &dat )
                 rotate( 1 );
                 if( x_in_y( 1, 5 ) ) {
                     if( one_in( 3 ) ) {
-                        add_vehicle( vproto_id( "cube_van" ), point( 17, 4 ), 180 );
+                        add_vehicle( vproto_id( "cube_van" ), point( 17, 4 ), 180_degrees );
                     } else {
-                        add_vehicle( vproto_id( "cube_van_cheap" ), point( 17, 4 ), 180 );
+                        add_vehicle( vproto_id( "cube_van_cheap" ), point( 17, 4 ), 180_degrees );
                     }
                 }
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "pickup" ), point( 17, 10 ), 180 );
+                    add_vehicle( vproto_id( "pickup" ), point( 17, 10 ), 180_degrees );
                 }
                 if( x_in_y( 1, 3 ) ) {
-                    add_vehicle( vproto_id( "car" ), point( 17, 17 ), 180 );
+                    add_vehicle( vproto_id( "car" ), point( 17, 17 ), 180_degrees );
                 }
             } else if( dat.east() == "office_tower_b" && dat.north() == "office_tower_b" ) {
                 rotate( 2 );
                 if( x_in_y( 1, 5 ) ) {
                     if( one_in( 3 ) ) {
-                        add_vehicle( vproto_id( "cube_van" ), point( 6, 17 ), 270 );
+                        add_vehicle( vproto_id( "cube_van" ), point( 6, 17 ), 270_degrees );
                     } else {
-                        add_vehicle( vproto_id( "cube_van_cheap" ), point( 6, 17 ), 270 );
+                        add_vehicle( vproto_id( "cube_van_cheap" ), point( 6, 17 ), 270_degrees );
                     }
                 }
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "pickup" ), point( 12, 17 ), 270 );
+                    add_vehicle( vproto_id( "pickup" ), point( 12, 17 ), 270_degrees );
                 }
                 if( x_in_y( 1, 3 ) ) {
-                    add_vehicle( vproto_id( "fire_truck" ), point( 18, 17 ), 270 );
+                    add_vehicle( vproto_id( "fire_truck" ), point( 18, 17 ), 270_degrees );
                 }
             } else if( dat.east() == "office_tower_b" && dat.south() == "office_tower_b" ) {
                 rotate( 3 );
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "cube_van_cheap" ), point( 6, 6 ), 0 );
+                    add_vehicle( vproto_id( "cube_van_cheap" ), point( 6, 6 ), 0_degrees );
                 }
                 if( x_in_y( 1, 5 ) ) {
                     if( one_in( 3 ) ) {
-                        add_vehicle( vproto_id( "fire_truck" ), point( 6, 13 ), 0 );
+                        add_vehicle( vproto_id( "fire_truck" ), point( 6, 13 ), 0_degrees );
                     } else {
-                        add_vehicle( vproto_id( "pickup" ), point( 6, 13 ), 0 );
+                        add_vehicle( vproto_id( "pickup" ), point( 6, 13 ), 0_degrees );
                     }
                 }
                 if( x_in_y( 1, 3 ) ) {
-                    add_vehicle( vproto_id( "car" ), point( 5, 19 ), 180 );
+                    add_vehicle( vproto_id( "car" ), point( 5, 19 ), 180_degrees );
                 }
             } else {
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "flatbed_truck" ), point( 16, 6 ), 90 );
+                    add_vehicle( vproto_id( "flatbed_truck" ), point( 16, 6 ), 90_degrees );
                 }
                 if( x_in_y( 1, 5 ) ) {
-                    add_vehicle( vproto_id( "cube_van_cheap" ), point( 10, 6 ), 90 );
+                    add_vehicle( vproto_id( "cube_van_cheap" ), point( 10, 6 ), 90_degrees );
                 }
                 if( x_in_y( 1, 3 ) ) {
-                    add_vehicle( vproto_id( "car" ), point( 4, 6 ), 90 );
+                    add_vehicle( vproto_id( "car" ), point( 4, 6 ), 90_degrees );
                 }
             }
         }
@@ -5596,25 +5598,25 @@ void map::add_spawn( const mtype_id &type, int count, const tripoint &p, bool fr
     place_on_submap->spawns.push_back( tmp );
 }
 
-vehicle *map::add_vehicle( const vgroup_id &type, const tripoint &p, const int dir,
+vehicle *map::add_vehicle( const vgroup_id &type, const tripoint &p, const units::angle dir,
                            const int veh_fuel, const int veh_status, const bool merge_wrecks )
 {
     return add_vehicle( type.obj().pick(), p, dir, veh_fuel, veh_status, merge_wrecks );
 }
 
-vehicle *map::add_vehicle( const vgroup_id &type, const point &p, int dir,
+vehicle *map::add_vehicle( const vgroup_id &type, const point &p, units::angle dir,
                            int veh_fuel, int veh_status, bool merge_wrecks )
 {
     return add_vehicle( type.obj().pick(), p, dir, veh_fuel, veh_status, merge_wrecks );
 }
 
-vehicle *map::add_vehicle( const vproto_id &type, const point &p, int dir,
+vehicle *map::add_vehicle( const vproto_id &type, const point &p, units::angle dir,
                            int veh_fuel, int veh_status, bool merge_wrecks )
 {
     return add_vehicle( type, tripoint( p, abs_sub.z ), dir, veh_fuel, veh_status, merge_wrecks );
 }
 
-vehicle *map::add_vehicle( const vproto_id &type, const tripoint &p, const int dir,
+vehicle *map::add_vehicle( const vproto_id &type, const tripoint &p, const units::angle dir,
                            const int veh_fuel, const int veh_status, const bool merge_wrecks )
 {
     if( !type.is_valid() ) {
@@ -5623,7 +5625,7 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint &p, const int d
     }
     if( !inbounds( p ) ) {
         dbg( DL::Warn ) << string_format( "Out of bounds add_vehicle t=%s d=%d p=%s",
-                                          type.c_str(), dir, p.to_string() );
+                                          type, to_degrees( dir ), p.to_string() );
         return nullptr;
     }
 

--- a/src/matrix_math.cpp
+++ b/src/matrix_math.cpp
@@ -3,11 +3,11 @@
 namespace matrices
 {
 
-matrix_3d rotation_z_axis( double angle )
+matrix_3d rotation_z_axis( units::angle angle )
 {
     return matrix_3d( {
-        std::cos( angle ), -std::sin( angle ), 0,
-        std::sin( angle ), std::cos( angle ), 0,
+        cos( angle ), -sin( angle ), 0,
+        sin( angle ), cos( angle ), 0,
         0, 0, 1
     } );
 }

--- a/src/matrix_math.h
+++ b/src/matrix_math.h
@@ -7,6 +7,8 @@
 
 #include "point_traits.h"
 
+#include "units_angle.h"
+
 template<size_t w, size_t h, typename T = float>
 struct matrix {
     private:
@@ -43,7 +45,7 @@ using matrix_3d = matrix<3u, 3u, double>;
 namespace matrices
 {
 
-matrix_3d rotation_z_axis( double angle );
+matrix_3d rotation_z_axis( units::angle angle );
 
 } // namespace matrices
 

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -563,7 +563,7 @@ void mission_start::ranch_scavenger_2( mission *miss )
                                 "ranch_camp_48", 1, miss, false, RANCH_SIZE );
     tinymap bay;
     bay.load( project_to<coords::sm>( site ), false );
-    bay.add_vehicle( vproto_id( "car_chassis" ), point( 20, 15 ), 0 );
+    bay.add_vehicle( vproto_id( "car_chassis" ), point( 20, 15 ), 0_degrees );
     bay.draw_square_ter( t_wall_half, point( 18, 19 ), point( 21, 22 ) );
     bay.draw_square_ter( t_dirt, point( 19, 20 ), point( 20, 21 ) );
     bay.ter_set( point( 19, 19 ), t_door_frame );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -493,18 +493,19 @@ bool mattack::shriek_stun( monster *z )
         return false;
     }
 
-    int target_angle = coord_to_angle( z->pos(), target->pos() );
-    int cone_angle = 20;
-    for( const tripoint &cone : g->m.points_in_radius( z->pos(), 4 ) ) {
-        int tile_angle = coord_to_angle( z->pos(), cone );
-        int diff = std::abs( target_angle - tile_angle );
+    units::angle target_angle = coord_to_angle( z->pos(), target->pos() );
+    units::angle cone_angle = 20_degrees;
+    map &here = get_map();
+    for( const tripoint &cone : here.points_in_radius( z->pos(), 4 ) ) {
+        units::angle tile_angle = coord_to_angle( z->pos(), cone );
+        units::angle diff = units::fabs( target_angle - tile_angle );
         // Skip the target, because it's outside cone or it's the source
-        if( diff + cone_angle > 360 || diff > cone_angle || cone == z->pos() ) {
+        if( diff + cone_angle > 360_degrees || diff > cone_angle || cone == z->pos() ) {
             continue;
         }
         // Affect the target
         // Small bash to every square, silent to not flood message box
-        g->m.bash( cone, 4, true );
+        here.bash( cone, 4, true );
 
         // If a monster is there, chance for stun
         Creature *target = g->critter_at( cone );
@@ -1886,10 +1887,11 @@ bool mattack::fungus_growth( monster *z )
 
 bool mattack::fungus_sprout( monster *z )
 {
+    Character &player_character = get_player_character();
     // To avoid map shift weirdness
     bool push_player = false;
     for( const tripoint &dest : g->m.points_in_radius( z->pos(), 1 ) ) {
-        if( g->u.pos() == dest ) {
+        if( player_character.pos() == dest ) {
             push_player = true;
         }
         if( monster *const wall = g->place_critter_at( mon_fungal_wall, dest ) ) {
@@ -1898,9 +1900,9 @@ bool mattack::fungus_sprout( monster *z )
     }
 
     if( push_player ) {
-        const int angle = coord_to_angle( z->pos(), g->u.pos() );
+        const units::angle angle = coord_to_angle( z->pos(), player_character.pos() );
         add_msg( m_bad, _( "You're shoved away as a fungal wall grows!" ) );
-        g->fling_creature( &g->u, angle, rng( 10, 50 ) );
+        g->fling_creature( &player_character, angle, rng( 10, 50 ) );
     }
 
     return true;
@@ -2591,7 +2593,7 @@ bool mattack::ranged_pull( monster *z )
         // Recalculate the ray each step
         // We can't depend on either the target position being constant (obviously),
         // but neither on z pos staying constant, because we may want to shift the map mid-pull
-        const int dir = coord_to_angle( target->pos(), z->pos() );
+        const units::angle dir = coord_to_angle( target->pos(), z->pos() );
         tileray tdir( dir );
         tdir.advance();
         pt.x = target->posx() + tdir.dx();

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1376,11 +1376,11 @@ float npc::vehicle_danger( int radius ) const
         const wrapped_vehicle &wrapped_veh = vehicles[i];
         if( wrapped_veh.v->is_moving() ) {
             // FIXME: this can't be the right way to do this
-            float facing = wrapped_veh.v->face.dir();
+            units::angle facing = wrapped_veh.v->face.dir();
 
             point a( wrapped_veh.v->global_pos3().xy() );
-            point b( static_cast<int>( a.x + std::cos( facing * M_PI / 180.0 ) * radius ),
-                     static_cast<int>( a.y + std::sin( facing * M_PI / 180.0 ) * radius ) );
+            point b( static_cast<int>( a.x + units::cos( facing ) * radius ),
+                     static_cast<int>( a.y + units::sin( facing ) * radius ) );
 
             // fake size
             /* This will almost certainly give the wrong size/location on customized

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2100,10 +2100,10 @@ bool npc::wont_hit_friend( const tripoint &tar, const item &it, bool throwing ) 
         return true;    // If we're *really* sure that our aim is dead-on
     }
 
-    int target_angle = coord_to_angle( pos(), tar );
+    units::angle target_angle = coord_to_angle( pos(), tar );
 
     // TODO: Base on dispersion
-    int safe_angle = 30;
+    units::angle safe_angle = 30_degrees;
 
     for( const auto &fr : ai_cache.friends ) {
         const shared_ptr_fast<Creature> ally_p = fr.lock();
@@ -2113,15 +2113,15 @@ bool npc::wont_hit_friend( const tripoint &tar, const item &it, bool throwing ) 
         const Creature &ally = *ally_p;
 
         // TODO: Extract common functions with turret target selection
-        int safe_angle_ally = safe_angle;
+        units::angle safe_angle_ally = safe_angle;
         int ally_dist = rl_dist( pos(), ally.pos() );
         if( ally_dist < 3 ) {
-            safe_angle_ally += ( 3 - ally_dist ) * 30;
+            safe_angle_ally += ( 3 - ally_dist ) * 30_degrees;
         }
 
-        int ally_angle = coord_to_angle( pos(), ally.pos() );
-        int angle_diff = std::abs( ally_angle - target_angle );
-        angle_diff = std::min( 360 - angle_diff, angle_diff );
+        units::angle ally_angle = coord_to_angle( pos(), ally.pos() );
+        units::angle angle_diff = units::fabs( ally_angle - target_angle );
+        angle_diff = std::min( 360_degrees - angle_diff, angle_diff );
         if( angle_diff < safe_angle_ally ) {
             // TODO: Disable NPC whining is it's other NPC who prevents aiming
             return false;

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -1742,8 +1742,7 @@ static void draw_health_classic( avatar &u, const catacurses::window &w )
     // vehicle display
     if( veh ) {
         veh->print_fuel_indicators( w, point( 39, 2 ) );
-        mvwprintz( w, point( 35, 4 ), c_light_gray,
-                   std::to_string( ( veh->face.dir() + 90 ) % 360 ) + "°" );
+        mvwprintz( w, point( 35, 4 ), c_light_gray, veh->face.to_string_azimuth_from_north() );
         // target speed > current speed
         const float strain = veh->strain();
         if( veh->cruise_on ) {
@@ -1857,8 +1856,7 @@ static void draw_veh_compact( const avatar &u, const catacurses::window &w )
     }
     if( veh ) {
         veh->print_fuel_indicators( w, point_zero );
-        mvwprintz( w, point( 6, 0 ), c_light_gray,
-                   std::to_string( ( veh->face.dir() + 90 ) % 360 ) + "°" );
+        mvwprintz( w, point( 6, 0 ), c_light_gray, veh->face.to_string_azimuth_from_north() );
         // target speed > current speed
         const float strain = veh->strain();
         if( veh->cruise_on ) {
@@ -1890,8 +1888,7 @@ static void draw_veh_padding( const avatar &u, const catacurses::window &w )
     }
     if( veh ) {
         veh->print_fuel_indicators( w, point_east );
-        mvwprintz( w, point( 7, 0 ), c_light_gray,
-                   std::to_string( ( veh->face.dir() + 90 ) % 360 ) + "°" );
+        mvwprintz( w, point( 7, 0 ), c_light_gray, veh->face.to_string_azimuth_from_north() );
         // target speed > current speed
         const float strain = veh->strain();
         nc_color col_vel = strain <= 0 ? c_light_blue :

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -63,6 +63,8 @@
 #include "type_id.h"
 #include "ui_manager.h"
 #include "units.h"
+#include "units_angle.h"
+#include "units_utility.h"
 #include "value_ptr.h"
 #include "vehicle.h"
 #include "vpart_position.h"
@@ -843,7 +845,7 @@ int player::fire_gun( const tripoint &target, const int max_shots, item &gun )
         } else {
             // 30 degree cap, like for projectiles
             double angle_offset_arcmin = std::min( dispersion.roll(), 1800.0 ) * ( one_in( 2 ) ? 1 : -1 );
-            double angle_offset = degmin2rad( angle_offset_arcmin );
+            double angle_offset = units::to_radians( units::from_arcmin( angle_offset_arcmin ) );
             double dx = aim.x - pos().x;
             double dy = aim.y - pos().y;
             double new_angle = atan2( dy, dx ) + angle_offset;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1217,7 +1217,8 @@ static double confidence_estimate( int range, double target_size,
     if( range == 0 ) {
         return 2 * target_size;
     }
-    const double max_lateral_offset = iso_tangent( range, dispersion.max() );
+    const double max_lateral_offset =
+        iso_tangent( range, units::from_arcmin( dispersion.max() ) );
     return 1 / ( max_lateral_offset / target_size );
 }
 
@@ -2823,11 +2824,12 @@ void target_ui::recalc_aim_turning_penalty()
         // Raise it proportionally to how much
         // the player has to turn from previous aiming point
         const double recoil_per_degree = MAX_RECOIL / 180.0;
-        const double angle_curr = coord_to_angle( src, curr_recoil_pos );
-        const double angle_desired = coord_to_angle( src, dst );
-        const double phi = std::fmod( std::abs( angle_curr - angle_desired ), 360.0 );
-        const double angle = phi > 180.0 ? 360.0 - phi : phi;
-        predicted_recoil = std::min( MAX_RECOIL, curr_recoil + angle * recoil_per_degree );
+        const units::angle angle_curr = coord_to_angle( src, curr_recoil_pos );
+        const units::angle angle_desired = coord_to_angle( src, dst );
+        const units::angle phi = normalize( angle_curr - angle_desired );
+        const units::angle angle = std::min( phi, 360.0_degrees - phi );
+        predicted_recoil =
+            std::min( MAX_RECOIL, curr_recoil + to_degrees( angle ) * recoil_per_degree );
     }
 }
 

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -7,6 +7,7 @@
 
 #include "calendar.h"
 #include "cata_utility.h"
+#include "units.h"
 
 unsigned int rng_bits()
 {
@@ -31,6 +32,11 @@ double rng_float( double lo, double hi )
         std::swap( lo, hi );
     }
     return rng_real_dist( rng_get_engine(), std::uniform_real_distribution<>::param_type( lo, hi ) );
+}
+
+units::angle random_direction()
+{
+    return rng_float( 0_pi_radians, 2_pi_radians );
 }
 
 double normal_roll( double mean, double stddev )

--- a/src/rng.h
+++ b/src/rng.h
@@ -9,6 +9,7 @@
 #include <type_traits>
 
 #include "optional.h"
+#include "units_fwd.h"
 
 class map;
 class time_duration;
@@ -28,6 +29,16 @@ unsigned int rng_bits();
 
 int rng( int lo, int hi );
 double rng_float( double lo, double hi );
+
+template<typename U>
+units::quantity<double, U> rng_float( units::quantity<double, U> lo,
+                                      units::quantity<double, U> hi )
+{
+    return { rng_float( lo.value(), hi.value() ), U{} };
+}
+
+units::angle random_direction();
+
 bool one_in( int chance );
 bool one_turn_in( const time_duration &duration );
 bool x_in_y( double x, double y );

--- a/src/rng.h
+++ b/src/rng.h
@@ -9,7 +9,7 @@
 #include <type_traits>
 
 #include "optional.h"
-#include "units_fwd.h"
+#include "units_angle.h"
 
 class map;
 class time_duration;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2445,7 +2445,9 @@ void vehicle_part::deserialize( JsonIn &jsin )
     data.read( "mount_dx", mount.x );
     data.read( "mount_dy", mount.y );
     data.read( "open", open );
-    data.read( "direction", direction );
+    int direction_int;
+    data.read( "direction", direction_int );
+    direction = units::from_degrees( direction_int );
     data.read( "blood", blood );
     data.read( "enabled", enabled );
     data.read( "flags", flags );
@@ -2515,7 +2517,7 @@ void vehicle_part::serialize( JsonOut &json ) const
     json.member( "mount_dx", mount.x );
     json.member( "mount_dy", mount.y );
     json.member( "open", open );
-    json.member( "direction", direction );
+    json.member( "direction", std::lround( to_degrees( direction ) ) );
     json.member( "blood", blood );
     json.member( "enabled", enabled );
     json.member( "flags", flags );
@@ -2587,7 +2589,9 @@ void vehicle::deserialize( JsonIn &jsin )
     data.read( "om_id", om_id );
     data.read( "faceDir", fdir );
     data.read( "moveDir", mdir );
-    data.read( "turn_dir", turn_dir );
+    int turn_dir_int;
+    data.read( "turn_dir", turn_dir_int );
+    turn_dir = units::from_degrees( turn_dir_int );
     data.read( "velocity", velocity );
     data.read( "falling", is_falling );
     data.read( "floating", is_floating );
@@ -2606,8 +2610,9 @@ void vehicle::deserialize( JsonIn &jsin )
         last_update = calendar::turn;
     }
 
-    face.init( fdir );
-    move.init( mdir );
+    units::angle fdir_angle = units::from_degrees( fdir );
+    face.init( fdir_angle );
+    move.init( units::from_degrees( mdir ) );
     data.read( "name", name );
     std::string temp_id;
     std::string temp_old_id;
@@ -2634,7 +2639,7 @@ void vehicle::deserialize( JsonIn &jsin )
     // is what they're expecting.
     data.read( "pivot", pivot_anchor[0] );
     pivot_anchor[1] = pivot_anchor[0];
-    pivot_rotation[1] = pivot_rotation[0] = fdir;
+    pivot_rotation[1] = pivot_rotation[0] = fdir_angle;
     data.read( "is_following", is_following );
     data.read( "is_patrolling", is_patrolling );
     data.read( "autodrive_local_target", autodrive_local_target );
@@ -2760,9 +2765,9 @@ void vehicle::serialize( JsonOut &json ) const
     json.member( "posx", pos.x );
     json.member( "posy", pos.y );
     json.member( "om_id", om_id );
-    json.member( "faceDir", face.dir() );
-    json.member( "moveDir", move.dir() );
-    json.member( "turn_dir", turn_dir );
+    json.member( "faceDir", std::lround( to_degrees( face.dir() ) ) );
+    json.member( "moveDir", std::lround( to_degrees( move.dir() ) ) );
+    json.member( "turn_dir", std::lround( to_degrees( turn_dir ) ) );
     json.member( "velocity", velocity );
     json.member( "falling", is_falling );
     json.member( "floating", is_floating );

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -31,6 +31,7 @@
 #include "rng.h"
 #include "sdl_wrappers.h"
 #include "sounds.h"
+#include "units_angle.h"
 
 #define dbg(x) DebugLogFL((x),DC::SDL)
 
@@ -506,7 +507,7 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
 }
 
 void sfx::play_variant_sound( const std::string &id, const std::string &variant, int volume,
-                              int angle, double pitch_min, double pitch_max )
+                              units::angle angle, double pitch_min, double pitch_max )
 {
     if( test_mode ) {
         return;
@@ -543,7 +544,7 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
         }
     }
     if( !failed ) {
-        if( Mix_SetPosition( channel, static_cast<Sint16>( angle ), 1 ) == 0 ) {
+        if( Mix_SetPosition( channel, static_cast<Sint16>( to_degrees( angle ) ), 1 ) == 0 ) {
             // Not critical
             dbg( DL::Info ) << "Mix_SetPosition failed: " << Mix_GetError();
         }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -679,7 +679,8 @@ void sfx::do_vehicle_engine_sfx()
     }
 
     static const channel ch = channel::interior_engine_sound;
-    if( !g->u.in_vehicle ) {
+    const Character &player_character = get_player_character();
+    if( !player_character.in_vehicle ) {
         fade_audio_channel( ch, 300 );
         add_msg( m_debug, "STOP interior_engine_sound, OUT OF CAR" );
         return;
@@ -765,11 +766,11 @@ void sfx::do_vehicle_engine_sfx()
     if( current_gear > previous_gear ) {
         play_variant_sound( "vehicle", "gear_shift", get_heard_volume( player_character.pos() ),
                             0_degrees, 0.8, 0.8 );
-        add_msg_debug( "GEAR UP" );
+        add_msg( m_debug, "GEAR UP" );
     } else if( current_gear < previous_gear ) {
         play_variant_sound( "vehicle", "gear_shift", get_heard_volume( player_character.pos() ),
                             0_degrees, 1.2, 1.2 );
-        add_msg_debug( "GEAR DOWN" );
+        add_msg( m_debug, "GEAR DOWN" );
     }
     if( ( safe_speed != 0 ) ) {
         if( current_gear == 0 ) {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -763,11 +763,13 @@ void sfx::do_vehicle_engine_sfx()
     }
 
     if( current_gear > previous_gear ) {
-        play_variant_sound( "vehicle", "gear_shift", get_heard_volume( g->u.pos() ), 0, 0.8, 0.8 );
-        add_msg( m_debug, "GEAR UP" );
+        play_variant_sound( "vehicle", "gear_shift", get_heard_volume( player_character.pos() ),
+                            0_degrees, 0.8, 0.8 );
+        add_msg_debug( "GEAR UP" );
     } else if( current_gear < previous_gear ) {
-        play_variant_sound( "vehicle", "gear_shift", get_heard_volume( g->u.pos() ), 0, 1.2, 1.2 );
-        add_msg( m_debug, "GEAR DOWN" );
+        play_variant_sound( "vehicle", "gear_shift", get_heard_volume( player_character.pos() ),
+                            0_degrees, 1.2, 1.2 );
+        add_msg_debug( "GEAR DOWN" );
     }
     if( ( safe_speed != 0 ) ) {
         if( current_gear == 0 ) {
@@ -858,7 +860,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
 
     if( is_channel_playing( ch ) ) {
         if( engine_external_id_and_variant == id_and_variant ) {
-            Mix_SetPosition( ch_int, get_heard_angle( veh->global_pos3() ), 0 );
+            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->global_pos3() ) ), 0 );
             set_channel_volume( ch, vol );
             add_msg( m_debug, "PLAYING exterior_engine_sound, vol: ex:%d true:%d", vol, Mix_Volume( ch_int,
                      -1 ) );
@@ -867,7 +869,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
             Mix_HaltChannel( ch_int );
             add_msg( m_debug, "STOP exterior_engine_sound, change id/var" );
             play_ambient_variant_sound( id_and_variant.first, id_and_variant.second, 128, ch, 0 );
-            Mix_SetPosition( ch_int, get_heard_angle( veh->global_pos3() ), 0 );
+            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->global_pos3() ) ), 0 );
             set_channel_volume( ch, vol );
             add_msg( m_debug, "START exterior_engine_sound %s %s vol: %d", id_and_variant.first,
                      id_and_variant.second,
@@ -876,7 +878,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
     } else {
         play_ambient_variant_sound( id_and_variant.first, id_and_variant.second, 128, ch, 0 );
         add_msg( m_debug, "Vol: %d %d", vol, Mix_Volume( ch_int, -1 ) );
-        Mix_SetPosition( ch_int, get_heard_angle( veh->global_pos3() ), 0 );
+        Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->global_pos3() ) ), 0 );
         add_msg( m_debug, "Vol: %d %d", vol, Mix_Volume( ch_int, -1 ) );
         set_channel_volume( ch, vol );
         add_msg( m_debug, "START exterior_engine_sound NEW %s %s vol: ex:%d true:%d", id_and_variant.first,
@@ -1016,7 +1018,7 @@ void sfx::generate_gun_sound( const player &source_arg, const item &firing )
     }
 
     itype_id weapon_id = firing.typeId();
-    int angle = 0;
+    units::angle angle = 0_degrees;
     int distance = 0;
     std::string selected_sound;
     // this does not mean p == g->u (it could be a vehicle turret)
@@ -1058,10 +1060,10 @@ struct sound_thread {
     skill_id weapon_skill;
     int weapon_volume;
     // volume and angle for calls to play_variant_sound
-    int ang_src;
+    units::angle ang_src;
     int vol_src;
     int vol_targ;
-    int ang_targ;
+    units::angle ang_targ;
 
     // Operator overload required for thread API.
     void operator()() const;
@@ -1105,7 +1107,7 @@ sfx::sound_thread::sound_thread( const tripoint &source, const tripoint &target,
     if( !p ) {
         p = &g->u;
         // sound comes from the same place as the player is, calculation of angle wouldn't work
-        ang_src = 0;
+        ang_src = 0_degrees;
         vol_src = heard_volume;
         vol_targ = heard_volume;
     } else {
@@ -1175,7 +1177,7 @@ void sfx::do_projectile_hit( const Creature &target )
     }
 
     const int heard_volume = sfx::get_heard_volume( target.pos() );
-    const int angle = get_heard_angle( target.pos() );
+    const units::angle angle = get_heard_angle( target.pos() );
     if( target.is_monster() ) {
         const monster &mon = dynamic_cast<const monster &>( target );
         static const std::set<material_id> fleshy = {
@@ -1477,7 +1479,7 @@ void sfx::do_footstep()
         };
 
         const auto play_plmove_sound_variant = [&]( const std::string & variant ) {
-            play_variant_sound( "plmove", variant, heard_volume, 0, 0.8, 1.2 );
+            play_variant_sound( "plmove", variant, heard_volume, 0_degrees, 0.8, 1.2 );
             start_sfx_timestamp = std::chrono::high_resolution_clock::now();
         };
 
@@ -1546,11 +1548,11 @@ void sfx::do_obstacle( const std::string &obst )
         "t_sewage",
     };
     if( sfx::has_variant_sound( "plmove", obst ) ) {
-        play_variant_sound( "plmove", obst, heard_volume, 0, 0.8, 1.2 );
+        play_variant_sound( "plmove", obst, heard_volume, 0_degrees, 0.8, 1.2 );
     } else if( water.count( obst ) > 0 ) {
-        play_variant_sound( "plmove", "walk_water", heard_volume, 0, 0.8, 1.2 );
+        play_variant_sound( "plmove", "walk_water", heard_volume, 0_degrees, 0.8, 1.2 );
     } else {
-        play_variant_sound( "plmove", "clear_obstacle", heard_volume, 0, 0.8, 1.2 );
+        play_variant_sound( "plmove", "clear_obstacle", heard_volume, 0_degrees, 0.8, 1.2 );
     }
     // prevent footsteps from triggering
     start_sfx_timestamp = std::chrono::high_resolution_clock::now();
@@ -1584,7 +1586,8 @@ void sfx::end_activity_sounds()
 void sfx::load_sound_effects( const JsonObject & ) { }
 void sfx::load_sound_effect_preload( const JsonObject & ) { }
 void sfx::load_playlist( const JsonObject & ) { }
-void sfx::play_variant_sound( const std::string &, const std::string &, int, int, double, double ) { }
+void sfx::play_variant_sound( const std::string &, const std::string &, int, units::angle, double,
+                              double ) { }
 void sfx::play_variant_sound( const std::string &, const std::string &, int ) { }
 void sfx::play_ambient_variant_sound( const std::string &, const std::string &, int, channel, int,
                                       double, int ) { }
@@ -1640,10 +1643,10 @@ int sfx::get_heard_volume( const tripoint &source )
     return ( heard_volume );
 }
 
-int sfx::get_heard_angle( const tripoint &source )
+units::angle sfx::get_heard_angle( const tripoint &source )
 {
-    int angle = coord_to_angle( g->u.pos(), source ) + 90;
+    units::angle angle = coord_to_angle( get_player_character().pos(), source ) + 90_degrees;
     //add_msg(m_warning, "angle: %i", angle);
-    return ( angle );
+    return angle;
 }
 /*@}*/

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -6,6 +6,8 @@
 #include <utility>
 #include <vector>
 
+#include "units_angle.h"
+
 class Creature;
 class JsonObject;
 class item;
@@ -130,8 +132,8 @@ enum class group : int {
 void load_sound_effects( const JsonObject &jsobj );
 void load_sound_effect_preload( const JsonObject &jsobj );
 void load_playlist( const JsonObject &jsobj );
-void play_variant_sound( const std::string &id, const std::string &variant, int volume, int angle,
-                         double pitch_min = -1.0, double pitch_max = -1.0 );
+void play_variant_sound( const std::string &id, const std::string &variant, int volume,
+                         units::angle angle, double pitch_min = -1.0, double pitch_max = -1.0 );
 void play_variant_sound( const std::string &id, const std::string &variant, int volume );
 void play_ambient_variant_sound( const std::string &id, const std::string &variant, int volume,
                                  channel channel, int fade_in_duration, double pitch = -1.0, int loops = -1 );
@@ -144,7 +146,7 @@ void do_hearing_loss( int turns = -1 );
 void remove_hearing_loss();
 void do_projectile_hit( const Creature &target );
 int get_heard_volume( const tripoint &source );
-int get_heard_angle( const tripoint &source );
+units::angle get_heard_angle( const tripoint &source );
 void do_footstep();
 void do_danger_music();
 void do_ambient();

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -286,7 +286,7 @@ void submap::rotate( int turns )
         elem->pos = new_pos;
         // turn the steering wheel, vehicle::turn does not actually
         // move the vehicle.
-        elem->turn( turns * 90 );
+        elem->turn( turns * 90_degrees );
         // The facing direction and recalculate the positions of the parts
         elem->face = elem->turn_dir;
         elem->precalc_mounts( 0, elem->turn_dir, elem->pivot_anchor[0] );

--- a/src/tileray.cpp
+++ b/src/tileray.cpp
@@ -18,7 +18,7 @@ tileray::tileray( const point &ad )
     init( ad );
 }
 
-tileray::tileray( int adir ): direction( adir )
+tileray::tileray( units::angle adir ): direction( adir )
 {
     init( adir );
 }
@@ -28,11 +28,11 @@ void tileray::init( const point &ad )
     delta = ad;
     abs_d = delta.abs();
     if( delta == point_zero ) {
-        direction = 0;
+        direction = 0_degrees;
     } else {
-        direction = static_cast<int>( atan2_degrees( delta ) );
-        if( direction < 0 ) {
-            direction += 360;
+        direction = atan2( delta );
+        if( direction < 0_degrees ) {
+            direction += 360_degrees;
         }
     }
     last_d = point_zero;
@@ -40,14 +40,13 @@ void tileray::init( const point &ad )
     infinite = false;
 }
 
-void tileray::init( int adir )
+void tileray::init( units::angle adir )
 {
     leftover = 0;
-    // Clamp adir to the range [0, 359]
-    direction = ( adir < 0 ? 360 - ( ( -adir ) % 360 ) : adir % 360 );
+    // Clamp adir to the range [0, 360)
+    direction = normalize( adir );
     last_d = point_zero;
-    float direction_radians = static_cast<float>( direction ) * M_PI / 180.0;
-    rl_vec2d delta_f( std::cos( direction_radians ), std::sin( direction_radians ) );
+    rl_vec2d delta_f( units::cos( direction ), units::sin( direction ) );
     delta = ( delta_f * 100 ).as_point();
     abs_d = delta.abs();
     steps = 0;
@@ -71,18 +70,23 @@ int tileray::dy() const
     return last_d.y;
 }
 
-int tileray::dir() const
+units::angle tileray::dir() const
 {
     return direction;
 }
 
+int tileray::quadrant() const
+{
+    return static_cast<int>( std::floor( direction / 90_degrees ) ) % 4;
+}
+
 int tileray::dir4() const
 {
-    if( direction >= 45 && direction <= 135 ) {
+    if( direction >= 45_degrees && direction <= 135_degrees ) {
         return 1;
-    } else if( direction > 135 && direction < 225 ) {
+    } else if( direction > 135_degrees && direction < 225_degrees ) {
         return 2;
-    } else if( direction >= 225 && direction <= 315 ) {
+    } else if( direction >= 225_degrees && direction <= 315_degrees ) {
         return 3;
     } else {
         return 0;
@@ -92,12 +96,12 @@ int tileray::dir4() const
 int tileray::dir8() const
 {
     int oct = 0;
-    int dir = direction;
-    if( dir < 23 || dir > 337 ) {
+    units::angle dir = direction;
+    if( dir < 23_degrees || dir > 337_degrees ) {
         return 0;
     }
-    while( dir > 22 ) {
-        dir -= 45;
+    while( dir > 22_degrees ) {
+        dir -= 45_degrees;
         oct += 1;
     }
     return oct;
@@ -164,17 +168,20 @@ int tileray::dir_symbol( int sym ) const
     return sym;
 }
 
+std::string tileray::to_string_azimuth_from_north() const
+{
+    return to_string( std::lround( to_degrees( dir() + 90_degrees ) ) % 360 ) + "°";
+}
+
 int tileray::ortho_dx( int od ) const
 {
-    int quadr = ( direction / 90 ) % 4;
-    od *= -sy[quadr];
+    od *= -sy[quadrant()];
     return mostly_vertical() ? od : 0;
 }
 
 int tileray::ortho_dy( int od ) const
 {
-    int quadr = ( direction / 90 ) % 4;
-    od *= sx[quadr];
+    od *= sx[quadrant()];
     return mostly_vertical() ? 0 : od;
 }
 
@@ -192,7 +199,7 @@ void tileray::advance( int num )
     int anum = std::abs( num );
     steps = anum;
     const bool vertical = mostly_vertical();
-    if( direction % 90 ) {
+    if( abs_d.x && abs_d.y ) {
         for( int i = 0; i < anum; i++ ) {
             if( vertical ) {
                 // mostly vertical line
@@ -218,7 +225,7 @@ void tileray::advance( int num )
     }
 
     // offset calculated for 0-90 deg quadrant, we need to adjust if direction is other
-    int quadr = ( direction / 90 ) % 4;
+    int quadr = quadrant();
     last_d.x *= sx[quadr];
     last_d.y *= sy[quadr];
     if( num < 0 ) {

--- a/src/tileray.cpp
+++ b/src/tileray.cpp
@@ -5,11 +5,12 @@
 #include "line.h"
 #include "math_defines.h"
 #include "point_float.h"
+#include "units_utility.h"
 
 static const int sx[4] = { 1, -1, -1, 1 };
 static const int sy[4] = { 1, 1, -1, -1 };
 
-tileray::tileray(): leftover( 0 ), direction( 0 ), steps( 0 ), infinite( false )
+tileray::tileray(): leftover( 0 ), direction( 0_degrees ), steps( 0 ), infinite( false )
 {
 }
 
@@ -170,7 +171,7 @@ int tileray::dir_symbol( int sym ) const
 
 std::string tileray::to_string_azimuth_from_north() const
 {
-    return to_string( std::lround( to_degrees( dir() + 90_degrees ) ) % 360 ) + "°";
+    return std::to_string( std::lround( to_degrees( dir() + 90_degrees ) ) % 360 ) + "°";
 }
 
 int tileray::ortho_dx( int od ) const

--- a/src/tileray.h
+++ b/src/tileray.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_TILERAY_H
 
 #include "point.h"
+#include "units_angle.h"
 
 // Class for calculating tile coordinates
 // of a point that moves along the ray with given
@@ -28,25 +29,30 @@ class tileray
         point delta;            // ray delta
         int leftover = 0;       // counter to shift coordinates
         point abs_d;            // absolute value of delta
-        int direction = 0;      // ray direction
+        units::angle direction = 0_degrees; // ray direction
         point last_d;           // delta of last advance
         int steps = 0;          // how many steps we advanced so far
         bool infinite = false;  // ray is infinite (end will always return true)
     public:
         tileray();
         tileray( const point &ad );
-        tileray( int adir );
+        tileray( units::angle adir );
 
-        void init( const point &ad );  // init ray with ad
-        void init( int adir );         // init ray with direction
+        void init( const point &ad );   // init ray with ad
+        void init( units::angle adir ); // init ray with direction
 
         int dx() const;       // return dx of last advance (-1 to 1)
         int dy() const;       // return dy of last advance (-1 to 1)
-        int dir() const;      // return direction of ray (degrees)
+        units::angle dir() const;      // return direction of ray
+        int quadrant() const;
         int dir4() const;     // return 4-sided direction (0 = east, 1 = south, 2 = west, 3 = north)
         int dir8() const;     // return 8-sided direction (0 = east, 1 = southeast, 2 = south ...)
         // convert certain symbols from north-facing variant into current dir facing
         int dir_symbol( int sym ) const;
+
+        /** convert to a string representation of the azimuth from north, in integer degrees */
+        std::string to_string_azimuth_from_north() const;
+
         // return dx for point at "od" distance in orthogonal direction
         int ortho_dx( int od ) const;
         // return dy for point at "od" distance in orthogonal direction

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -44,6 +44,18 @@ void energy::deserialize( JsonIn &jsin )
     *this = read_from_json_string( jsin, units::energy_units );
 }
 
+template<>
+void angle::serialize( JsonOut &jsout ) const
+{
+    jsout.write( string_format( "%f rad", value_ ) );
+}
+
+template<>
+void angle::deserialize( JsonIn &jsin )
+{
+    *this = read_from_json_string( jsin, units::angle_units );
+}
+
 std::string display( const units::energy v )
 {
     const int kj = units::to_kilojoule( v );

--- a/src/units.h
+++ b/src/units.h
@@ -9,6 +9,8 @@
 #include <vector>
 
 #include "units_def.h"
+
+#include "units_angle.h"
 #include "units_volume.h"
 #include "units_mass.h"
 #include "units_energy.h"
@@ -39,6 +41,11 @@ inline std::ostream &operator<<( std::ostream &o, energy_in_joule_tag )
 inline std::ostream &operator<<( std::ostream &o, money_in_cent_tag )
 {
     return o << "cent";
+}
+
+inline std::ostream &operator<<( std::ostream &o, angle_in_radians_tag )
+{
+    return o << "rad";
 }
 
 inline std::ostream &operator<<( std::ostream &o, temperature_in_millidegree_celsius_tag )
@@ -79,6 +86,12 @@ static const std::vector<std::pair<std::string, money>> money_units = { {
 static const std::vector<std::pair<std::string, volume>> volume_units = { {
         { "ml", 1_ml },
         { "L", 1_liter }
+    }
+};
+static const std::vector<std::pair<std::string, angle>> angle_units = { {
+        { "arcmin", 1_arcmin },
+        { "°", 1_degrees },
+        { "rad", 1_radians },
     }
 };
 } // namespace units

--- a/src/units_angle.h
+++ b/src/units_angle.h
@@ -1,0 +1,114 @@
+#pragma once
+#ifndef CATA_SRC_UNITS_ANGLE_H
+#define CATA_SRC_UNITS_ANGLE_H
+
+#include <algorithm>
+
+#include "units_def.h"
+#include "math_defines.h"
+
+namespace units
+{
+
+class angle_in_radians_tag
+{
+};
+
+using angle = quantity<double, angle_in_radians_tag>;
+
+template<typename value_type>
+inline constexpr quantity<value_type, angle_in_radians_tag> from_radians( const value_type v )
+{
+    return quantity<value_type, angle_in_radians_tag>( v, angle_in_radians_tag{} );
+}
+
+inline constexpr double to_radians( const units::angle v )
+{
+    return v.value();
+}
+
+template<typename value_type>
+inline constexpr quantity<double, angle_in_radians_tag> from_degrees( const value_type v )
+{
+    return from_radians( v * M_PI / 180 );
+}
+
+inline constexpr double to_degrees( const units::angle v )
+{
+    return to_radians( v ) * 180 / M_PI;
+}
+
+template<typename value_type>
+inline constexpr quantity<double, angle_in_radians_tag> from_arcmin( const value_type v )
+{
+    return from_degrees( v / 60.0 );
+}
+
+inline constexpr double to_arcmin( const units::angle v )
+{
+    return to_degrees( v ) * 60;
+}
+
+inline double sin( angle a )
+{
+    return std::sin( to_radians( a ) );
+}
+
+inline double cos( angle a )
+{
+    return std::cos( to_radians( a ) );
+}
+
+inline double tan( angle a )
+{
+    return std::tan( to_radians( a ) );
+}
+
+inline units::angle atan2( double y, double x )
+{
+    return from_radians( std::atan2( y, x ) );
+}
+
+} // namespace units
+
+inline constexpr units::angle operator"" _radians( const long double v )
+{
+    return units::from_radians( v );
+}
+
+inline constexpr units::angle operator"" _radians( const unsigned long long v )
+{
+    return units::from_radians( v );
+}
+
+inline constexpr units::angle operator"" _pi_radians( const long double v )
+{
+    return units::from_radians( v * M_PI );
+}
+
+inline constexpr units::angle operator"" _pi_radians( const unsigned long long v )
+{
+    return units::from_radians( v * M_PI );
+}
+
+inline constexpr units::angle operator"" _degrees( const long double v )
+{
+    return units::from_degrees( v );
+}
+
+inline constexpr units::angle operator"" _degrees( const unsigned long long v )
+{
+    return units::from_degrees( v );
+}
+
+inline constexpr units::angle operator"" _arcmin( const long double v )
+{
+    return units::from_arcmin( v );
+}
+
+inline constexpr units::angle operator"" _arcmin( const unsigned long long v )
+{
+    return units::from_arcmin( v );
+}
+
+#endif // CATA_SRC_UNITS_ANGLE_H

--- a/src/units_def.h
+++ b/src/units_def.h
@@ -2,9 +2,10 @@
 #ifndef CATA_SRC_UNITS_DEF_H
 #define CATA_SRC_UNITS_DEF_H
 
+#include <cmath>
+
 class JsonIn;
 class JsonOut;
-
 
 namespace units
 {
@@ -125,6 +126,18 @@ class quantity
     private:
         value_type value_;
 };
+
+template<typename V, typename U>
+inline quantity<V, U> fabs( quantity<V, U> q )
+{
+    return quantity<V, U>( std::fabs( q.value() ), U{} );
+}
+
+template<typename V, typename U>
+inline quantity<V, U> fmod( quantity<V, U> num, quantity<V, U> den )
+{
+    return quantity<V, U>( std::fmod( num.value(), den.value() ), U{} );
+}
 
 /**
  * Multiplication and division with scalars. Result is a quantity with the same unit

--- a/src/units_utility.cpp
+++ b/src/units_utility.cpp
@@ -20,6 +20,15 @@ const char *velocity_units( const units_type vel_units )
     return "error: unknown units!";
 }
 
+units::angle normalize( units::angle a, units::angle mod )
+{
+    a = units::fmod( a, mod );
+    if( a < 0_degrees ) {
+        a += mod;
+    }
+    return a;
+}
+
 const char *weight_units()
 {
     return get_option<std::string>( "USE_METRIC_WEIGHTS" ) == "lbs" ? _( "lbs" ) : _( "kg" );

--- a/src/units_utility.h
+++ b/src/units_utility.h
@@ -4,6 +4,8 @@
 
 #include "units.h"
 
+#include <type_traits>
+
 /**
  * Type of object that a measurement is taken on.  Used, for example, to display wind speed in m/s
  * while displaying vehicle speed in km/h.
@@ -23,6 +25,20 @@ T divide_round_up( units::quantity<T, U> num, units::quantity<T, U> den )
     T n = num.value();
     T d = den.value();
     return ( n + d - 1 ) / d;
+}
+
+/** Given an angle, add or subtract multiples of 360_degrees until it's in the
+ * range [0, 360_degrees).
+ *
+ * With a second argument, can use a different maximum.
+ */
+units::angle normalize( units::angle, units::angle mod = 360_degrees );
+
+template<typename T, typename U, std::enable_if_t<std::is_floating_point<T>::value>* = nullptr>
+units::quantity<T, U> round_to_multiple_of( units::quantity<T, U> val, units::quantity<T, U> of )
+{
+    int multiple = std::lround( val / of );
+    return multiple * of;
 }
 
 /**

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3018,15 +3018,7 @@ void veh_interact::complete_vehicle( player &p )
                 // Restore previous view offsets.
                 p.view_offset = old_view_offset;
 
-                int dir = static_cast<int>( atan2( static_cast<float>( delta.y ),
-                                                   static_cast<float>( delta.x ) ) * 180.0 / M_PI );
-                dir -= veh->face.dir();
-                while( dir < 0 ) {
-                    dir += 360;
-                }
-                while( dir > 360 ) {
-                    dir -= 360;
-                }
+                units::angle dir = normalize( atan2( delta ) - veh->face.dir() );
 
                 veh->part( partnum ).direction = dir;
             }

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -157,7 +157,7 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who_c )
                                         pt.get_base().damage_color() );
     bool wasbroken = pt.is_broken();
     if( wasbroken ) {
-        const int dir = pt.direction;
+        const units::angle dir = pt.direction;
         point loc = pt.mount;
         auto replacement_id = pt.info().get_id();
         get_map().spawn_items( who.pos(), pt.pieces_for_broken_part() );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1830,7 +1830,8 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
         for( auto carry_map : carry_data ) {
             std::string offset = string_format( "%s%3d", carry_map.old_mount == mount_zero ? axis : " ",
                                                 axis == "X" ? carry_map.old_mount.x : carry_map.old_mount.y );
-            std::string unique_id = string_format( "%s%3d%s", offset, to_degrees( relative_dir ),
+            std::string unique_id = string_format( "%s%3d%s", offset,
+                                                   static_cast<int>( to_degrees( relative_dir ) ),
                                                    carry_veh->name );
             for( int carry_part : carry_map.carry_parts_here ) {
                 parts.push_back( carry_veh->parts[ carry_part ] );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -62,6 +62,7 @@
 #include "string_id.h"
 #include "submap.h"
 #include "translations.h"
+#include "units_utility.h"
 #include "veh_type.h"
 #include "vehicle_selector.h"
 #include "weather.h"

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -246,9 +246,9 @@ units::volume vehicle_stack::max_volume() const
 vehicle::vehicle( const vproto_id &type_id, int init_veh_fuel,
                   int init_veh_status ): type( type_id )
 {
-    turn_dir = 0;
-    face.init( 0 );
-    move.init( 0 );
+    turn_dir = 0_degrees;
+    face.init( 0_degrees );
+    move.init( 0_degrees );
     of_turn_carry = 0;
 
     if( !type.str().empty() && type.is_valid() ) {
@@ -761,16 +761,13 @@ void vehicle::autopilot_patrol()
     drive_to_local_target( autodrive_local_target, false );
 }
 
-std::set<point> vehicle::immediate_path( int rotate )
+std::set<point> vehicle::immediate_path( units::angle rotate )
 {
     std::set<point> points_to_check;
     const int distance_to_check = 10 + ( velocity / 800 );
-    int adjusted_angle = ( face.dir() + rotate ) % 360;
-    if( adjusted_angle < 0 ) {
-        adjusted_angle += 360;
-    }
+    units::angle adjusted_angle = normalize( face.dir() + rotate );
     // clamp to multiples of 15.
-    adjusted_angle = ( ( adjusted_angle + 15 / 2 ) / 15 ) * 15;
+    adjusted_angle = round_to_multiple_of( adjusted_angle, 15_degrees );
     tileray collision_vector;
     collision_vector.init( adjusted_angle );
     point top_left_actual = global_pos3().xy() + coord_translate( front_left );
@@ -788,24 +785,24 @@ std::set<point> vehicle::immediate_path( int rotate )
     return points_to_check;
 }
 
-static int get_turn_from_angle( const double angle, const tripoint &vehpos, const tripoint &target,
-                                bool reverse = false )
+static int get_turn_from_angle( const units::angle angle, const tripoint &vehpos,
+                                const tripoint &target, bool reverse = false )
 {
-    if( angle > 10.0 && angle <= 45.0 ) {
+    if( angle > 10.0_degrees && angle <= 45.0_degrees ) {
         return reverse ? 4 : 1;
-    } else if( angle > 45.0 && angle <= 90.0 ) {
+    } else if( angle > 45.0_degrees && angle <= 90.0_degrees ) {
         return 3;
-    } else if( angle > 90.0 && angle < 180.0 ) {
+    } else if( angle > 90.0_degrees && angle < 180.0_degrees ) {
         return reverse ? 1 : 4;
-    } else if( angle < -10.0 && angle >= -45.0 ) {
+    } else if( angle < -10.0_degrees && angle >= -45.0_degrees ) {
         return reverse ? -4 : -1;
-    } else if( angle < -45.0 && angle >= -90.0 ) {
+    } else if( angle < -45.0_degrees && angle >= -90.0_degrees ) {
         return -3;
-    } else if( angle < -90.0 && angle > -180.0 ) {
+    } else if( angle < -90.0_degrees && angle > -180.0_degrees ) {
         return reverse ? -1 : -4;
         // edge case of being exactly on the button for the target.
         // just keep driving, the next path point will be picked up.
-    } else if( ( angle == 180 || angle == -180 ) && vehpos == target ) {
+    } else if( ( angle == 180_degrees || angle == -180_degrees ) && vehpos == target ) {
         return 0;
     }
     return 0;
@@ -838,8 +835,9 @@ void vehicle::drive_to_local_target( const tripoint &target, bool follow_protoco
         return;
     }
     refresh();
-    tripoint vehpos = g->m.getabs( global_pos3() );
-    double angle = get_angle_from_targ( target );
+    map &here = get_map();
+    tripoint vehpos = here.getabs( global_pos3() );
+    units::angle angle = get_angle_from_targ( target );
     // now we got the angle to the target, we can work out when we are heading towards disaster.
     // Check the tileray in the direction we need to head towards.
     std::set<point> points_to_check = immediate_path( angle );
@@ -936,7 +934,7 @@ void vehicle::drive_to_local_target( const tripoint &target, bool follow_protoco
     is_patrolling ? autodrive( point( turn_x, accel_y ) ) : pldrive( point( turn_x, accel_y ) );
 }
 
-double vehicle::get_angle_from_targ( const tripoint &targ )
+units::angle vehicle::get_angle_from_targ( const tripoint &targ )
 {
     tripoint vehpos = g->m.getabs( global_pos3() );
     rl_vec2d facevec = face_vec();
@@ -947,7 +945,7 @@ double vehicle::get_angle_from_targ( const tripoint &targ )
     // dot product.
     double dotx = ( facevec.x * targetvec.x ) + ( facevec.y * targetvec.y );
 
-    return atan2( crossy, dotx ) * 180 / M_PI;
+    return units::atan2( crossy, dotx );
 }
 
 void vehicle::do_autodrive()
@@ -1759,18 +1757,18 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
         }
     }
 
-    int relative_dir = modulo( carry_veh->face.dir() - face.dir(), 360 );
-    int relative_180 = modulo( relative_dir, 180 );
-    int face_dir_180 = modulo( face.dir(), 180 );
+    units::angle relative_dir = normalize( carry_veh->face.dir() - face.dir() );
+    units::angle relative_180 = units::fmod( relative_dir, 180_degrees );
+    units::angle face_dir_180 = normalize( face.dir(), 180_degrees );
 
     // if the carrier is skewed N/S and the carried vehicle isn't aligned with
     // the carrier, force the carried vehicle to be at a right angle
-    if( face_dir_180 >= 45 && face_dir_180 <= 135 ) {
-        if( relative_180 >= 45 && relative_180 <= 135 ) {
-            if( relative_dir < 180 ) {
-                relative_dir = 90;
+    if( face_dir_180 >= 45_degrees && face_dir_180 <= 135_degrees ) {
+        if( relative_180 >= 45_degrees && relative_180 <= 135_degrees ) {
+            if( relative_dir < 180_degrees ) {
+                relative_dir = 90_degrees;
             } else {
-                relative_dir = 270;
+                relative_dir = 270_degrees;
             }
         }
     }
@@ -1831,8 +1829,9 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
         for( auto carry_map : carry_data ) {
             std::string offset = string_format( "%s%3d", carry_map.old_mount == mount_zero ? axis : " ",
                                                 axis == "X" ? carry_map.old_mount.x : carry_map.old_mount.y );
-            std::string unique_id = string_format( "%s%3d%s", offset, relative_dir, carry_veh->name );
-            for( auto carry_part : carry_map.carry_parts_here ) {
+            std::string unique_id = string_format( "%s%3d%s", offset, to_degrees( relative_dir ),
+                                                   carry_veh->name );
+            for( int carry_part : carry_map.carry_parts_here ) {
                 parts.push_back( carry_veh->parts[ carry_part ] );
                 vehicle_part &carried_part = parts.back();
                 carried_part.mount = carry_map.carry_mount;
@@ -2102,20 +2101,22 @@ bool vehicle::remove_carried_vehicle( const std::vector<int> &carried_parts )
     if( veh_record.empty() ) {
         return false;
     }
-    int new_dir = modulo( std::stoi( veh_record.substr( 4, 3 ) ) + face.dir(), 360 );
-    int host_dir = modulo( face.dir(), 180 );
+    units::angle new_dir =
+        normalize( units::from_degrees( std::stoi( veh_record.substr( 4, 3 ) ) ) + face.dir() );
+    units::angle host_dir = normalize( face.dir(), 180_degrees );
     // if the host is skewed N/S, and the carried vehicle is going to come at an angle,
     // force it to east/west instead
-    if( host_dir >= 45 && host_dir <= 135 ) {
-        if( new_dir <= 45 || new_dir >= 315 ) {
-            new_dir = 0;
-        } else if( new_dir >= 135 && new_dir <= 225 ) {
-            new_dir = 180;
+    if( host_dir >= 45_degrees && host_dir <= 135_degrees ) {
+        if( new_dir <= 45_degrees || new_dir >= 315_degrees ) {
+            new_dir = 0_degrees;
+        } else if( new_dir >= 135_degrees && new_dir <= 225_degrees ) {
+            new_dir = 180_degrees;
         }
     }
     vehicle *new_vehicle = g->m.add_vehicle( vproto_id( "none" ), new_pos3, new_dir );
     if( new_vehicle == nullptr ) {
-        add_msg( m_debug, "Unable to unload bike rack, host face %d, new_dir %d!", face.dir(), new_dir );
+        add_msg( m_debug, "Unable to unload bike rack, host face %d, new_dir %d!",
+                 to_degrees( face.dir() ), to_degrees( new_dir ) );
         return false;
     }
 
@@ -3061,7 +3062,8 @@ point vehicle::coord_translate( const point &p ) const
     return q.xy();
 }
 
-void vehicle::coord_translate( int dir, const point &pivot, const point &p, tripoint &q ) const
+void vehicle::coord_translate( units::angle dir, const point &pivot, const point &p,
+                               tripoint &q ) const
 {
     tileray tdir( dir );
     tdir.advance( p.x - pivot.x );
@@ -3077,7 +3079,8 @@ void vehicle::coord_translate( tileray tdir, const point &pivot, const point &p,
     q.y = tdir.dy() + tdir.ortho_dy( p.y - pivot.y );
 }
 
-point vehicle::rotate_mount( int old_dir, int new_dir, const point &pivot, const point &p ) const
+point vehicle::rotate_mount( units::angle old_dir, units::angle new_dir, const point &pivot,
+                             const point &p ) const
 {
     tripoint q;
     coord_translate( new_dir - old_dir, pivot, p, q );
@@ -3096,7 +3099,7 @@ tripoint vehicle::mount_to_tripoint( const point &mount, const point &offset ) c
     return global_pos3() + mnt_translated;
 }
 
-void vehicle::precalc_mounts( int idir, int dir, const point &pivot )
+void vehicle::precalc_mounts( int idir, units::angle dir, const point &pivot )
 {
     if( idir < 0 || idir > 1 ) {
         idir = 0;
@@ -5852,7 +5855,7 @@ void vehicle::do_towing_move()
     const tripoint tower_tow_point = g->m.getabs( global_part_pos3( tow_index ) );
     const tripoint towed_tow_point = g->m.getabs( towed_veh->global_part_pos3( other_tow_index ) );
     // same as above, but where the pulling vehicle is pulling from
-    double towing_veh_angle = towed_veh->get_angle_from_targ( tower_tow_point );
+    units::angle towing_veh_angle = towed_veh->get_angle_from_targ( tower_tow_point );
     const bool reverse = towed_veh->tow_data.tow_direction == TOW_BACK;
     int accel_y = 0;
     tripoint vehpos = g->m.getabs( towed_veh->global_pos3() );
@@ -6627,9 +6630,9 @@ bool vehicle::restore( const std::string &data )
         return false;
     }
     refresh();
-    face.init( 0 );
-    turn_dir = 0;
-    turn( 0 );
+    face.init( 0_degrees );
+    turn_dir = 0_degrees;
+    turn( 0_degrees );
     precalc_mounts( 0, pivot_rotation[0], pivot_anchor[0] );
     precalc_mounts( 1, pivot_rotation[1], pivot_anchor[1] );
     last_update = calendar::turn;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -419,7 +419,7 @@ struct vehicle_part {
         bool open = false;
 
         /** direction the part is facing */
-        int direction = 0;
+        units::angle direction = 0_degrees;
 
         /**
          * Coordinates for some kind of target; jumper cables and turrets use this
@@ -838,10 +838,10 @@ class vehicle
         }
         bool handle_potential_theft( player &p, bool check_only = false, bool prompt = true );
         // project a tileray forward to predict obstacles
-        std::set<point> immediate_path( int rotate = 0 );
+        std::set<point> immediate_path( units::angle rotate = 0_degrees );
         std::set<point> collision_check_points;
         void autopilot_patrol();
-        double get_angle_from_targ( const tripoint &targ );
+        units::angle get_angle_from_targ( const tripoint &targ );
         void drive_to_local_target( const tripoint &target, bool follow_protocol );
         tripoint get_autodrive_target() {
             return autodrive_local_target;
@@ -1058,13 +1058,15 @@ class vehicle
         point coord_translate( const point &p ) const;
 
         // Translate mount coordinates "p" into tile coordinates "q" using given pivot direction and anchor
-        void coord_translate( int dir, const point &pivot, const point &p, tripoint &q ) const;
+        void coord_translate( units::angle dir, const point &pivot, const point &p,
+                              tripoint &q ) const;
         // Translate mount coordinates "p" into tile coordinates "q" using given tileray and anchor
         // should be faster than previous call for repeated translations
         void coord_translate( tileray tdir, const point &pivot, const point &p, tripoint &q ) const;
 
         // Rotates mount coordinates "p" from old_dir to new_dir along pivot
-        point rotate_mount( int old_dir, int new_dir, const point &pivot, const point &p ) const;
+        point rotate_mount( units::angle old_dir, units::angle new_dir, const point &pivot,
+                            const point &p ) const;
 
         tripoint mount_to_tripoint( const point &mount ) const;
         tripoint mount_to_tripoint( const point &mount, const point &offset ) const;
@@ -1094,7 +1096,7 @@ class vehicle
             bool isHorizontal = false );
 
         // Pre-calculate mount points for (idir=0) - current direction or (idir=1) - next turn direction
-        void precalc_mounts( int idir, int dir, const point &pivot );
+        void precalc_mounts( int idir, units::angle dir, const point &pivot );
 
         // get a list of part indices where is a passenger inside
         std::vector<int> boarded_parts() const;
@@ -1407,7 +1409,7 @@ class vehicle
         void cruise_thrust( int amount );
 
         // turn vehicle left (negative) or right (positive), degrees
-        void turn( int deg );
+        void turn( units::angle deg );
 
         // Returns if any collision occurred
         bool collision( std::vector<veh_collision> &colls,
@@ -1688,11 +1690,11 @@ class vehicle
          * &wheels_on_rail          - resulting wheels that land on ter_flag_to_check
          * &turning_wheels_that_are_one_axis_counter - number of wheels that are on one axis and will land on rail
          */
-        void precalculate_vehicle_turning( int new_turn_dir, bool check_rail_direction,
+        void precalculate_vehicle_turning( units::angle new_turn_dir, bool check_rail_direction,
                                            ter_bitflags ter_flag_to_check, int &wheels_on_rail,
                                            int &turning_wheels_that_are_one_axis_counter ) const;
-        bool allow_auto_turn_on_rails( int &corrected_turn_dir ) const;
-        bool allow_manual_turn_on_rails( int &corrected_turn_dir ) const;
+        bool allow_auto_turn_on_rails( units::angle &corrected_turn_dir ) const;
+        bool allow_manual_turn_on_rails( units::angle &corrected_turn_dir ) const;
         bool is_wheel_state_correct_to_turn_on_rails( int wheels_on_rail, int wheel_count,
                 int turning_wheels_that_are_one_axis ) const;
         /**
@@ -1855,9 +1857,9 @@ class vehicle
         int om_id;
         // direction, to which vehicle is turning (player control). will rotate frame on next move
         // must be a multiple of 15 degrees
-        int turn_dir = 0;
+        units::angle turn_dir = 0_degrees;
         // amount of last turning (for calculate skidding due to handbrake)
-        int last_turn = 0;
+        units::angle last_turn = 0_degrees;
         // goes from ~1 to ~0 while proceeding every turn
         float of_turn;
         // leftover from previous turn
@@ -1868,7 +1870,7 @@ class vehicle
         // the time point when it was successfully stolen
         cata::optional<time_point> theft_time;
         // rotation used for mount precalc values
-        std::array<int, 2> pivot_rotation = { { 0, 0 } };
+        std::array<units::angle, 2> pivot_rotation = { { 0_degrees, 0_degrees } };
 
         bounding_box rail_wheel_bounding_box;
         point front_left;

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -12,6 +12,7 @@
 #include "point.h"
 #include "rng.h"
 #include "translations.h"
+#include "units_angle.h"
 #include "vehicle.h"
 #include "vpart_position.h"
 
@@ -34,7 +35,7 @@ const VehicleGroup &string_id<VehicleGroup>::obj() const
     return iter->second;
 }
 
-int VehicleFacings::pick() const
+units::angle VehicleFacings::pick() const
 {
     return random_entry( values );
 }
@@ -87,10 +88,10 @@ VehicleFacings::VehicleFacings( const JsonObject &jo, const std::string &key )
 {
     if( jo.has_array( key ) ) {
         for( const int i : jo.get_array( key ) ) {
-            values.push_back( i );
+            values.push_back( units::from_degrees( i ) );
         }
     } else {
-        values.push_back( jo.get_int( key ) );
+        values.push_back( units::from_degrees( jo.get_int( key ) ) );
     }
 }
 
@@ -226,17 +227,18 @@ static void builtin_jackknifed_semi( map &m, const std::string &terrainid )
         return;
     }
 
-    const int facing = loc->pick_facing();
+    const units::angle facing = loc->pick_facing();
+    int facing_degrees = std::lround( to_degrees( facing ) );
     const point semi_p = loc->pick_point();
     point trailer_p;
 
-    if( facing == 0 ) {
+    if( facing_degrees == 0 ) {
         trailer_p.x = semi_p.x + 4;
         trailer_p.y = semi_p.y - 10;
-    } else if( facing == 90 ) {
+    } else if( facing_degrees == 90 ) {
         trailer_p.x = semi_p.x + 12;
         trailer_p.y = semi_p.y + 1;
-    } else if( facing == 180 ) {
+    } else if( facing_degrees == 180 ) {
         trailer_p.x = semi_p.x - 4;
         trailer_p.y = semi_p.y + 10;
     } else {
@@ -244,8 +246,10 @@ static void builtin_jackknifed_semi( map &m, const std::string &terrainid )
         trailer_p.y = semi_p.y - 1;
     }
 
-    m.add_vehicle( vgroup_id( "semi_truck" ), semi_p, ( facing + 135 ) % 360, -1, 1 );
-    m.add_vehicle( vgroup_id( "truck_trailer" ), trailer_p, ( facing + 90 ) % 360, -1, 1 );
+    m.add_vehicle( vgroup_id( "semi_truck" ), semi_p,
+                   units::fmod( facing + 135_degrees, 360_degrees ), -1, 1 );
+    m.add_vehicle( vgroup_id( "truck_trailer" ), trailer_p,
+                   units::fmod( facing + 90_degrees, 360_degrees ), -1, 1 );
 }
 
 static void builtin_pileup( map &m, const std::string &, const std::string &vg )
@@ -289,8 +293,13 @@ static void builtin_parkinglot( map &m, const std::string & )
         pos_p.z = m.get_abs_sub().z;
 
         if( !m.veh_at( pos_p ) ) {
-            m.add_vehicle( vgroup_id( "parkinglot" ), pos_p,
-                           ( one_in( 2 ) ? 0 : 180 ) + one_in( 10 ) * rng( 0, 179 ), -1, -1 );
+            units::angle facing;
+            if( one_in( 10 ) ) {
+                facing = random_direction();
+            } else {
+                facing = one_in( 2 ) ? 0_degrees : 180_degrees;
+            }
+            m.add_vehicle( vgroup_id( "parkinglot" ), pos_p, facing, -1, -1 );
         }
     }
 }

--- a/src/vehicle_group.h
+++ b/src/vehicle_group.h
@@ -12,6 +12,7 @@
 #include "string_id.h"
 #include "type_id.h"
 #include "weighted_list.h"
+#include "units_angle.h"
 
 class JsonObject;
 class VehicleGroup;
@@ -53,16 +54,16 @@ class VehicleGroup
 struct VehicleFacings {
     VehicleFacings( const JsonObject &jo, const std::string &key );
 
-    int pick() const;
+    units::angle pick() const;
 
-    std::vector<int> values;
+    std::vector<units::angle> values;
 };
 
 struct VehicleLocation {
     VehicleLocation( const jmapgen_int &x, const jmapgen_int &y, const VehicleFacings &facings )
         : x( x ), y( y ), facings( facings ) {}
 
-    int pick_facing() const {
+    units::angle pick_facing() const {
         return facings.pick();
     }
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -35,6 +35,7 @@
 #include "string_id.h"
 #include "translations.h"
 #include "trap.h"
+#include "units_angle.h"
 #include "veh_type.h"
 #include "vpart_position.h"
 
@@ -93,7 +94,7 @@ int vehicle::slowdown( int at_velocity ) const
     } else if( !is_falling && !is_flying ) {
         double f_rolling_drag = coeff_rolling_drag() * ( vehicles::rolling_constant_to_variable + mps );
         // increase rolling resistance by up to 25x if the vehicle is skidding at right angle to facing
-        const double skid_factor = 1 + 24 * std::abs( std::sin( deg2rad( face.dir() - move.dir() ) ) );
+        const double skid_factor = 1 + 24 * std::abs( units::sin( face.dir() - move.dir() ) );
         f_total_drag += f_rolling_drag * skid_factor;
     }
     double accel_slowdown = f_total_drag / to_kilogram( total_mass() );
@@ -313,24 +314,18 @@ void vehicle::cruise_thrust( int amount )
     }
 }
 
-void vehicle::turn( int deg )
+void vehicle::turn( units::angle deg )
 {
-    if( deg == 0 ) {
+    if( deg == 0_degrees ) {
         return;
     }
     if( velocity < 0 && !::get_option<bool>( "REVERSE_STEERING" ) ) {
         deg = -deg;
     }
     last_turn = deg;
-    turn_dir += deg;
-    if( turn_dir < 0 ) {
-        turn_dir += 360;
-    }
-    if( turn_dir >= 360 ) {
-        turn_dir -= 360;
-    }
+    turn_dir = normalize( turn_dir + deg );
     // quick rounding the turn dir to a multiple of 15
-    turn_dir = 15 * ( ( turn_dir * 2 + 15 ) / 30 );
+    turn_dir = round_to_multiple_of( turn_dir, 15_degrees );
 }
 
 void vehicle::stop( bool update_cache )
@@ -338,7 +333,7 @@ void vehicle::stop( bool update_cache )
     velocity = 0;
     skidding = false;
     move = face;
-    last_turn = 0;
+    last_turn = 0_degrees;
     of_turn_carry = 0;
     if( !update_cache ) {
         return;
@@ -525,7 +520,8 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         if( here.has_flag( "SWIMMABLE", critter->pos() ) ) {
             tripoint end_pos = critter->pos();
             tripoint start_pos;
-            const int angle = move.dir() + 45 * ( parts[part].mount.x > pivot_point().x ? -1 : 1 );
+            const units::angle angle =
+                move.dir() + 45_degrees * ( parts[part].mount.x > pivot_point().x ? -1 : 1 );
             std::set<tripoint> &cur_points = get_points( true );
             // push the animal out of way until it's no longer in our vehicle and not in
             // anyone else's position
@@ -744,13 +740,14 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
             if( !vert_coll ) {
                 if( std::fabs( vel2_a ) > 10.0f ||
                     std::fabs( e * mass * vel1_a ) > std::fabs( mass2 * ( 10.0f - vel2_a ) ) ) {
-                    const int angle = rng( -60, 60 );
+                    const units::angle angle = rng_float( -60_degrees, 60_degrees );
                     // Also handle the weird case when we don't have enough force
                     // but still have to push (in such case compare momentum)
                     const float push_force = std::max<float>( std::fabs( vel2_a ), 10.1f );
                     // move.dir is where the vehicle is facing. If velocity is negative,
                     // we're moving backwards and have to adjust the angle accordingly.
-                    const int angle_sum = angle + move.dir() + ( vel2_a > 0 ? 0 : 180 );
+                    const units::angle angle_sum =
+                        angle + move.dir() + ( vel2_a > 0 ? 0_degrees : 180_degrees );
                     g->fling_creature( critter, angle_sum, push_force );
                 } else if( std::fabs( vel2_a ) > std::fabs( vel2 ) ) {
                     vel2 = vel2_a;
@@ -830,7 +827,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
             //delta_v = 50 mph -> 100% probability of skidding
             //delta_v = 25 mph -> 50% probability of skidding
             skidding = true;
-            turn( one_in( 2 ) ? turn_amount : -turn_amount );
+            turn( units::from_degrees( one_in( 2 ) ? turn_amount : -turn_amount ) );
         }
     }
 
@@ -940,9 +937,9 @@ void vehicle::autodrive( const point &p )
             }
         }
     }
-    int turn_delta = 15 * p.x;
+    units::angle turn_delta = 15_degrees * p.x;
     const float handling_diff = handling_difficulty();
-    if( turn_delta != 0 ) {
+    if( turn_delta != 0_degrees ) {
         float eff = steering_effectiveness();
         if( eff == -2 ) {
             return;
@@ -1061,9 +1058,9 @@ void vehicle::pldrive( const point &p, int z )
         player_character.moves = std::min( player_character.moves, 0 );
         thrust( 0, z );
     }
-    int turn_delta = 15 * p.x;
+    units::angle turn_delta = 15_degrees * p.x;
     const float handling_diff = handling_difficulty();
-    if( turn_delta != 0 ) {
+    if( turn_delta != 0_degrees ) {
         float eff = steering_effectiveness();
         if( eff == -2 ) {
             add_msg( m_info, _( "You cannot steer an animal-drawn vehicle with no animal harnessed." ) );
@@ -1152,7 +1149,7 @@ void vehicle::pldrive( const point &p, int z )
 // A chance to stop skidding if moving in roughly the faced direction
 void vehicle::possibly_recover_from_skid()
 {
-    if( last_turn > 13 ) {
+    if( last_turn > 13_degrees ) {
         // Turning on the initial skid is delayed, so move==face, initially. This filters out that case.
         return;
     }
@@ -1200,26 +1197,26 @@ rl_vec2d vehicle::velo_vec() const
     return ret;
 }
 
-inline rl_vec2d degree_to_vec( double degrees )
+static inline rl_vec2d angle_to_vec( units::angle angle )
 {
-    return rl_vec2d( std::cos( degrees * M_PI / 180 ), std::sin( degrees * M_PI / 180 ) );
+    return rl_vec2d( units::cos( angle ), units::sin( angle ) );
 }
 
 // normalized.
 rl_vec2d vehicle::move_vec() const
 {
-    return degree_to_vec( move.dir() );
+    return angle_to_vec( move.dir() );
 }
 
 // normalized.
 rl_vec2d vehicle::face_vec() const
 {
-    return degree_to_vec( face.dir() );
+    return angle_to_vec( face.dir() );
 }
 
 rl_vec2d vehicle::dir_vec() const
 {
-    return degree_to_vec( turn_dir );
+    return angle_to_vec( turn_dir );
 }
 
 float get_collision_factor( const float delta_v )
@@ -1231,7 +1228,7 @@ float get_collision_factor( const float delta_v )
     }
 }
 
-void vehicle::precalculate_vehicle_turning( int new_turn_dir, bool check_rail_direction,
+void vehicle::precalculate_vehicle_turning( units::angle new_turn_dir, bool check_rail_direction,
         const ter_bitflags ter_flag_to_check, int &wheels_on_rail,
         int &turning_wheels_that_are_one_axis ) const
 {
@@ -1240,7 +1237,7 @@ void vehicle::precalculate_vehicle_turning( int new_turn_dir, bool check_rail_di
     // calculate direction after turn
     mdir.init( new_turn_dir );
     tripoint dp;
-    bool is_diagonal_movement = new_turn_dir % 90 == 45;
+    bool is_diagonal_movement = std::lround( to_degrees( new_turn_dir ) ) % 90 == 45;
 
     if( std::abs( velocity ) >= 20 ) {
         mdir.advance( velocity < 0 ? -1 : 1 );
@@ -1324,25 +1321,20 @@ void vehicle::precalculate_vehicle_turning( int new_turn_dir, bool check_rail_di
 }
 
 // rounds turn_dir to 45*X degree, respecting face_dir
-static int get_corrected_turn_dir( int turn_dir, int face_dir )
+static units::angle get_corrected_turn_dir( units::angle turn_dir, units::angle face_dir )
 {
-    int corrected_turn_dir = 0;
+    units::angle corrected_turn_dir = 0_degrees;
 
     // Driver turned vehicle, round angle to 45 deg
-    if( turn_dir > face_dir && turn_dir < face_dir + 180 ) {
-        corrected_turn_dir = face_dir + 45;
-    } else if( turn_dir < face_dir || turn_dir > 270 ) {
-        corrected_turn_dir = face_dir - 45;
+    if( turn_dir > face_dir && turn_dir < face_dir + 180_degrees ) {
+        corrected_turn_dir = face_dir + 45_degrees;
+    } else if( turn_dir < face_dir || turn_dir > 270_degrees ) {
+        corrected_turn_dir = face_dir - 45_degrees;
     }
-    if( corrected_turn_dir < 0 ) {
-        corrected_turn_dir += 360;
-    } else if( corrected_turn_dir >= 360 ) {
-        corrected_turn_dir -= 360;
-    }
-    return corrected_turn_dir;
+    return normalize( corrected_turn_dir );
 }
 
-bool vehicle::allow_manual_turn_on_rails( int &corrected_turn_dir ) const
+bool vehicle::allow_manual_turn_on_rails( units::angle &corrected_turn_dir ) const
 {
     bool allow_turn_on_rail = false;
     // driver tried to turn rails vehicle
@@ -1360,7 +1352,7 @@ bool vehicle::allow_manual_turn_on_rails( int &corrected_turn_dir ) const
     return allow_turn_on_rail;
 }
 
-bool vehicle::allow_auto_turn_on_rails( int &corrected_turn_dir ) const
+bool vehicle::allow_auto_turn_on_rails( units::angle &corrected_turn_dir ) const
 {
     bool allow_turn_on_rail = false;
     // check if autoturn is possible
@@ -1370,12 +1362,14 @@ bool vehicle::allow_auto_turn_on_rails( int &corrected_turn_dir ) const
         precalculate_vehicle_turning( face.dir(), true, TFLAG_RAIL, straight_wheels_on_rail,
                                       straight_turning_wheels_that_are_one_axis );
 
-        int left_turn_dir = get_corrected_turn_dir( face.dir() - 45, face.dir() );
+        units::angle left_turn_dir =
+            get_corrected_turn_dir( face.dir() - 45_degrees, face.dir() );
         int leftturn_wheels_on_rail, leftturn_turning_wheels_that_are_one_axis;
         precalculate_vehicle_turning( left_turn_dir, true, TFLAG_RAIL, leftturn_wheels_on_rail,
                                       leftturn_turning_wheels_that_are_one_axis );
 
-        int right_turn_dir = get_corrected_turn_dir( face.dir() + 45, face.dir() );
+        units::angle right_turn_dir =
+            get_corrected_turn_dir( face.dir() + 45_degrees, face.dir() );
         int rightturn_wheels_on_rail, rightturn_turning_wheels_that_are_one_axis;
         precalculate_vehicle_turning( right_turn_dir, true, TFLAG_RAIL, rightturn_wheels_on_rail,
                                       rightturn_turning_wheels_that_are_one_axis );
@@ -1528,7 +1522,7 @@ vehicle *vehicle::act_on_map()
 
     if( skidding && one_in( 4 ) ) {
         // Might turn uncontrollably while skidding
-        turn( one_in( 2 ) ? -15 : 15 );
+        turn( one_in( 2 ) ? -15_degrees : 15_degrees );
     }
 
     if( should_fall ) {
@@ -1538,7 +1532,7 @@ vehicle *vehicle::act_on_map()
 
     bool allow_turn_on_rail = false;
     if( can_use_rails && !falling_only ) {
-        int corrected_turn_dir;
+        units::angle corrected_turn_dir;
         allow_turn_on_rail = allow_manual_turn_on_rails( corrected_turn_dir );
         if( !allow_turn_on_rail ) {
             allow_turn_on_rail = allow_auto_turn_on_rails( corrected_turn_dir );
@@ -1730,13 +1724,14 @@ float map::vehicle_wheel_traction( const vehicle &veh,
     return traction_wheel_area;
 }
 
-int map::shake_vehicle( vehicle &veh, const int velocity_before, const int direction )
+units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
+                                 const units::angle direction )
 {
     const int d_vel = std::abs( veh.velocity - velocity_before ) / 100;
 
     std::vector<rider_data> riders = veh.get_riders();
 
-    int coll_turn = 0;
+    units::angle coll_turn = 0_degrees;
     for( const rider_data &r : riders ) {
         const int ps = r.prt;
         Creature *rider = r.psg;
@@ -1801,11 +1796,8 @@ int map::shake_vehicle( vehicle &veh, const int velocity_before, const int direc
                 if( turn_amount < 1 ) {
                     turn_amount = 1;
                 }
-                turn_amount *= 15;
-                if( turn_amount > 120 ) {
-                    turn_amount = 120;
-                }
-                coll_turn = one_in( 2 ) ? turn_amount : -turn_amount;
+                units::angle turn_angle = std::min( turn_amount * 15_degrees, 120_degrees );
+                coll_turn = one_in( 2 ) ? turn_angle : -turn_angle;
             }
         }
 
@@ -1822,7 +1814,7 @@ int map::shake_vehicle( vehicle &veh, const int velocity_before, const int direc
                          pet->disp_name(), veh.name );
             }
             ///\EFFECT_STR reduces distance thrown from seat in a vehicle impact
-            g->fling_creature( rider, direction + rng( 0, 60 ) - 30,
+            g->fling_creature( rider, direction + rng_float( -30_degrees, 30_degrees ),
                                std::max( 10, d_vel - move_resist / 100 ) );
         }
     }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -36,6 +36,7 @@
 #include "translations.h"
 #include "trap.h"
 #include "units_angle.h"
+#include "units_utility.h"
 #include "veh_type.h"
 #include "vpart_position.h"
 

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -150,10 +150,10 @@ void handbrake()
     vehicle *const veh = &vp->vehicle();
     add_msg( _( "You pull a handbrake." ) );
     veh->cruise_velocity = 0;
-    if( veh->last_turn != 0 && rng( 15, 60 ) * 100 < std::abs( veh->velocity ) ) {
+    if( veh->last_turn != 0_degrees && rng( 15, 60 ) * 100 < std::abs( veh->velocity ) ) {
         veh->skidding = true;
         add_msg( m_warning, _( "You lose control of %s." ), veh->name );
-        veh->turn( veh->last_turn > 0 ? 60 : -60 );
+        veh->turn( veh->last_turn > 0_degrees ? 60_degrees : -60_degrees );
     } else {
         int braking_power = std::abs( veh->velocity ) / 2 + 10 * 100;
         if( std::abs( veh->velocity ) < braking_power ) {

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -423,12 +423,12 @@ void weather_effect::thunder( int intensity )
     if( !g->u.has_effect( effect_sleep ) && !g->u.is_deaf() && one_in( intensity ) ) {
         if( g->get_levz() >= 0 ) {
             add_msg( _( "You hear a distant rumble of thunder." ) );
-            sfx::play_variant_sound( "environment", "thunder_far", 80, rng( 0, 359 ) );
+            sfx::play_variant_sound( "environment", "thunder_far", 80, random_direction() );
         } else if( one_in( std::max( roll_remainder( 2.0f * g->get_levz() /
                                      g->u.mutation_value( "hearing_modifier" ) ), 1 ) ) ) {
             add_msg( _( "You hear a rumble of thunder from above." ) );
             sfx::play_variant_sound( "environment", "thunder_far",
-                                     ( 80 * g->u.mutation_value( "hearing_modifier" ) ), rng( 0, 359 ) );
+                                     ( 80 * g->u.mutation_value( "hearing_modifier" ) ), random_direction() );
         }
     }
 }
@@ -446,7 +446,7 @@ void weather_effect::lightning( int intensity )
     if( one_in( intensity ) ) {
         if( g->get_levz() >= 0 ) {
             add_msg( _( "A flash of lightning illuminates your surroundings!" ) );
-            sfx::play_variant_sound( "environment", "thunder_near", 100, rng( 0, 359 ) );
+            sfx::play_variant_sound( "environment", "thunder_near", 100, random_direction() );
             get_weather().lightning_active = true;
         }
     } else {

--- a/tests/creature_in_field_test.cpp
+++ b/tests/creature_in_field_test.cpp
@@ -23,7 +23,7 @@ TEST_CASE( "creature_in_field", "[monster],[field]" )
             }
         }
         WHEN( "A monster in a vehicle stands in it" ) {
-            g->m.add_vehicle( vproto_id( "handjack" ), target_location, 0 );
+            g->m.add_vehicle( vproto_id( "handjack" ), target_location, 0_degrees );
             monster &test_monster = spawn_test_monster( "mon_zombie", target_location );
             REQUIRE( test_monster.get_hp() == test_monster.get_hp_max() );
             THEN( "the monster doesn't take damage" ) {

--- a/tests/electric_grid_test.cpp
+++ b/tests/electric_grid_test.cpp
@@ -123,7 +123,7 @@ static grid_setup set_up_grid( map &m )
     const tripoint_abs_ms battery_abs_pos( m.getabs( battery_local_pos ) );
     m.furn_set( connector_local_pos, f_cable_connector );
     m.furn_set( battery_local_pos, f_battery );
-    vehicle *veh = m.add_vehicle( vproto_id( "car" ), vehicle_local_pos, 0, 0, 0, false );
+    vehicle *veh = m.add_vehicle( vproto_id( "car" ), vehicle_local_pos, 0_degrees, 0, 0, false );
     vehicle_connector_tile *grid_connector =
         active_tiles::furn_at<vehicle_connector_tile>( connector_abs_pos );
     battery_tile *battery = active_tiles::furn_at<battery_tile>( battery_abs_pos );

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -109,7 +109,8 @@ static void check_vehicle_damage( const std::string &explosive_id, const std::st
     clear_map_and_put_player_underground();
     tripoint origin( 30, 30, 0 );
 
-    vehicle *target_vehicle = g->m.add_vehicle( vproto_id( vehicle_id ), origin, 0, -1, 0 );
+    vehicle *target_vehicle = get_map().add_vehicle( vproto_id( vehicle_id ), origin, 0_degrees,
+                              -1, 0 );
     std::vector<int> before_hp = get_part_hp( target_vehicle );
 
     while( g->m.veh_at( origin ) ) {

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -350,7 +350,7 @@ TEST_CASE( "npc-movement" )
             }
             // create vehicles
             if( type == 'V' || type == 'W' || type == 'M' ) {
-                vehicle *veh = here.add_vehicle( vproto_id( "none" ), p, 270, 0, 0 );
+                vehicle *veh = here.add_vehicle( vproto_id( "none" ), p, 270_degrees, 0, 0 );
                 REQUIRE( veh != nullptr );
                 veh->install_part( point_zero, vpart_frame_vertical );
                 veh->install_part( point_zero, vpart_seat );

--- a/tests/ranged_aiming_test.cpp
+++ b/tests/ranged_aiming_test.cpp
@@ -189,7 +189,8 @@ TEST_CASE( "Aiming a turret from a solid vehicle", "[ranged][aiming]" )
     } );
     REQUIRE( impassable_tiles_before == 0 );
 
-    vehicle *veh = g->m.add_vehicle( vproto_id( "turret_test" ), shooter_pos, 0, 100, 0, false );
+    vehicle *veh = g->m.add_vehicle( vproto_id( "turret_test" ), shooter_pos, 0_degrees, 100, 0,
+                                     false );
     REQUIRE( veh != nullptr );
 
     WHEN( "Shooter's line of fire becomes blocked by vehicle's windshield" ) {

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -415,7 +415,7 @@ TEST_CASE( "Losing book during reading", "[reading][book]" )
     }
 
     SECTION( "Book in car" ) {
-        vehicle *veh = g->m.add_vehicle( vproto_id( "car" ), u.pos(), 0, 0, 0 );
+        vehicle *veh = g->m.add_vehicle( vproto_id( "car" ), u.pos(), 0_degrees, 0, 0 );
         REQUIRE( veh != nullptr );
         int part = veh->part_with_feature( point_zero, "CARGO", true );
         REQUIRE( part >= 0 );

--- a/tests/shape_test.cpp
+++ b/tests/shape_test.cpp
@@ -15,7 +15,7 @@ class square_distance_from_zero_shape : public shape_impl
 TEST_CASE( "cone_test", "[shape]" )
 {
     SECTION( "90 degrees, length 1" ) {
-        cone c( deg2rad( 90 ), 1.0 );
+        cone c( 90_degrees, 1.0 );
         CHECK( c.signed_distance( rl_vec3d{0.0, 0.0, 0.0} ) == Approx( 0.0 ).margin( 0.001 ) );
         CHECK( c.signed_distance( rl_vec3d{0.0, 1.0, 0.0} ) == Approx( 1.0 ).margin( 0.001 ) );
         CHECK( c.signed_distance( rl_vec3d{0.0, -1.0, 0.0} ) == Approx( 0.0 ).margin( 0.001 ) );
@@ -27,7 +27,7 @@ TEST_CASE( "cone_test", "[shape]" )
     }
 
     SECTION( "45 degrees, length 2" ) {
-        cone c( deg2rad( 45 ), 2.0 );
+        cone c( 45_degrees, 2.0 );
         CHECK( c.signed_distance( rl_vec3d{0.0, 0.0, 0.0} ) == Approx( 0.0 ).margin( 0.001 ) );
         CHECK( c.signed_distance( rl_vec3d{0.0, 1.0, 0.0} ) == Approx( 1.0 ).margin( 0.001 ) );
         CHECK( c.signed_distance( rl_vec3d{0.0, -2.0, 0.0} ) == Approx( 0.0 ).margin( 0.001 ) );
@@ -38,7 +38,7 @@ TEST_CASE( "cone_test", "[shape]" )
 TEST_CASE( "offset_cone_test", "[shape]" )
 {
     SECTION( "cone offset by (-1, 0, 0), 90 degrees, length 1" ) {
-        offset_shape sh( std::make_shared<cone>( deg2rad( 90 ), 1.0 ), rl_vec3d{1.0, 0.0, 0.0} );
+        offset_shape sh( std::make_shared<cone>( 90_degrees, 1.0 ), rl_vec3d{1.0, 0.0, 0.0} );
         CHECK( sh.signed_distance( rl_vec3d{1.0, 0.0, 0.0} ) == Approx( 0.0 ).margin( 0.001 ) );
         CHECK( sh.signed_distance( rl_vec3d{1.0, 1.0, 0.0} ) == Approx( 1.0 ).margin( 0.001 ) );
         CHECK( sh.signed_distance( rl_vec3d{1.0, -1.0, 0.0} ) == Approx( 0.0 ).margin( 0.001 ) );
@@ -53,10 +53,10 @@ TEST_CASE( "offset_cone_test", "[shape]" )
 TEST_CASE( "rotated_cone_test", "[shape]" )
 {
     SECTION( "cone rotated by -90 degrees around z-axis to positive x direction, 90 degrees, length 1" ) {
-        std::shared_ptr<cone> cn = std::make_shared<cone>( deg2rad( 90 ), 1.0 );
-        std::shared_ptr<shape_impl> ro = std::make_shared<rotate_z_shape>( cn, deg2rad( -90 ) );
+        std::shared_ptr<cone> cn = std::make_shared<cone>( 90_degrees, 1.0 );
+        std::shared_ptr<shape_impl> ro = std::make_shared<rotate_z_shape>( cn, -90_degrees );
         const shape_impl &sh = *ro;
-        REQUIRE( ( rl_vec3d{0.0, 1.0, 0.0}.rotated( deg2rad( -90 ) ) - rl_vec3d{1.0, 0.0, 0.0} ).magnitude()
+        REQUIRE( ( rl_vec3d{0.0, 1.0, 0.0}.rotated( units::to_radians( -90_degrees ) ) - rl_vec3d{1.0, 0.0, 0.0} ).magnitude()
                  == Approx( 0.0 ).margin( 0.00001 ) );
         CHECK( sh.signed_distance( rl_vec3d{0.0, 0.0, 0.0} ) == Approx( 0.0 ).margin( 0.001 ) );
         CHECK( sh.signed_distance( rl_vec3d{1.0, 0.0, 0.0} ) == Approx( 1.0 ).margin( 0.001 ) );
@@ -72,8 +72,8 @@ TEST_CASE( "rotated_cone_test", "[shape]" )
 TEST_CASE( "offset_rotated_cone_test", "[shape]" )
 {
     SECTION( "cone rotated by -90 degrees around z-axis to negative x direction, 90 degrees, length 1" ) {
-        std::shared_ptr<cone> cn = std::make_shared<cone>( deg2rad( 90 ), 1.0 );
-        std::shared_ptr<shape_impl> rotated = std::make_shared<rotate_z_shape>( cn, deg2rad( -90 ) );
+        std::shared_ptr<cone> cn = std::make_shared<cone>( 90_degrees, 1.0 );
+        std::shared_ptr<shape_impl> rotated = std::make_shared<rotate_z_shape>( cn, -90_degrees );
         offset_shape sh( rotated, rl_vec3d{1.0, 0.0, 0.0} );
         CHECK( sh.signed_distance( rl_vec3d{1.0, 0.0, 0.0} ) == Approx( 0.0 ).margin( 0.001 ) );
         CHECK( sh.signed_distance( rl_vec3d{2.0, 0.0, 0.0} ) == Approx( 1.0 ).margin( 0.001 ) );
@@ -92,7 +92,7 @@ TEST_CASE( "rotate_z_shape_test", "[shape]" )
     REQUIRE( s->signed_distance( rl_vec3d( 1.0, 0.0, 0.0 ) ) == Approx( 1.0 ) );
     SECTION( "rotate unit vector by multiples of 22.5 degrees" ) {
         for( int mult = -8; mult <= 8; mult++ ) {
-            std::shared_ptr<shape_impl> r = std::make_shared<rotate_z_shape>( s, deg2rad( mult * 22.5 ) );
+            std::shared_ptr<shape_impl> r = std::make_shared<rotate_z_shape>( s, mult * 22.5_degrees );
             CHECK( r->signed_distance( rl_vec3d( 1.0, 0.0, 0.0 ) ) == Approx( 1.0 ) );
             CHECK( r->signed_distance( rl_vec3d( 0.0, 1.0, 0.0 ) ) == Approx( 1.0 ) );
             CHECK( r->signed_distance( rl_vec3d( 0.0, 0.0, 1.0 ) ) == Approx( 1.0 ) );
@@ -127,7 +127,7 @@ TEST_CASE( "cylinder_test", "[shape]" )
     }
 
     SECTION( "rotated to point in positive x direction" ) {
-        std::shared_ptr<shape_impl> s = std::make_shared<rotate_z_shape>( cyl, deg2rad( -90 ) );
+        std::shared_ptr<shape_impl> s = std::make_shared<rotate_z_shape>( cyl, -90_degrees );
         CHECK( s->signed_distance( rl_vec3d{0.0, 0.0, 0.0} ) == Approx( 0.0 ) );
         CHECK( s->signed_distance( rl_vec3d{-length, 0.0, 0.0} ) == Approx( 0.0 ) );
         CHECK( s->signed_distance( rl_vec3d{0.0, radius, 0.0} ) == Approx( 0.0 ) );
@@ -137,7 +137,7 @@ TEST_CASE( "cylinder_test", "[shape]" )
 
 TEST_CASE( "cone_factory_test", "[shape]" )
 {
-    cone_factory c( deg2rad( 15 ), 10.0 );
+    cone_factory c( 15_degrees, 10.0 );
     SECTION( "(0,0,0) to (5,5,0)" ) {
         std::shared_ptr<shape> s = c.create( rl_vec3d(), rl_vec3d( 5, 5, 0 ) );
         CHECK( s->distance_at( rl_vec3d( 0, 0, 0 ) ) > 0.0 );
@@ -215,7 +215,7 @@ static void shape_coverage_vs_distance_no_obstacle( const shape_factory_impl &c,
 TEST_CASE( "expected shape coverage mass test", "[shape]" )
 {
     clear_map();
-    cone_factory c( deg2rad( 15 ), 10.0 );
+    cone_factory c( 15_degrees, 10.0 );
     const tripoint origin( 60, 60, 0 );
     for( const tripoint &end : points_in_radius<tripoint>( origin, 5 ) ) {
         shape_coverage_vs_distance_no_obstacle( c, origin, end );
@@ -228,7 +228,7 @@ TEST_CASE( "expected shape coverage mass test", "[shape]" )
 TEST_CASE( "expected shape coverage without obstacles", "[shape]" )
 {
     clear_map();
-    cone_factory c( deg2rad( 22.5 ), 10.0 );
+    cone_factory c( 22.5_degrees, 10.0 );
     const tripoint origin( 60, 60, 0 );
     const tripoint offset( 5, 5, 0 );
     const tripoint end = origin + offset;
@@ -246,7 +246,7 @@ TEST_CASE( "expected shape coverage without obstacles", "[shape]" )
 TEST_CASE( "expected shape coverage through windows", "[shape]" )
 {
     clear_map();
-    cone_factory c( deg2rad( 22.5 ), 10.0 );
+    cone_factory c( 22.5_degrees, 10.0 );
     const tripoint origin( 60, 60, 0 );
     const tripoint offset( 5, 0, 0 );
     const tripoint end = origin + offset;

--- a/tests/units_test.cpp
+++ b/tests/units_test.cpp
@@ -5,8 +5,10 @@
 #include "calendar.h"
 #include "catch/catch.hpp"
 #include "json.h"
+#include "options_helpers.h"
 #include "units.h"
 #include "units_serde.h"
+#include "units_utility.h"
 
 TEST_CASE( "units_have_correct_ratios", "[units]" )
 {
@@ -33,6 +35,10 @@ TEST_CASE( "units_have_correct_ratios", "[units]" )
     CHECK( 1_minutes == time_duration::from_minutes( 1 ) );
     CHECK( 1_hours == time_duration::from_hours( 1 ) );
     CHECK( 1_days == time_duration::from_days( 1 ) );
+
+    CHECK( M_PI * 1_radians == 1_pi_radians );
+    CHECK( 2_pi_radians == 360_degrees );
+    CHECK( 60_arcmin == 1_degrees );
 }
 
 static units::energy parse_energy_quantity( const std::string &json )
@@ -81,4 +87,51 @@ TEST_CASE( "time_duration parsing from JSON", "[units]" )
            1_hours + 1_days );
     CHECK( parse_time_duration( "\"1 turns -4 minutes 1 hours -4 days\"" ) == 1_turns - 4_minutes +
            1_hours - 4_days );
+}
+
+static units::angle parse_angle( const std::string &json )
+{
+    std::istringstream buffer( json );
+    JsonIn jsin( buffer );
+    return read_from_json_string<units::angle>( jsin, units::angle_units );
+}
+
+TEST_CASE( "angle parsing from JSON", "[units]" )
+{
+    CHECK_THROWS( parse_angle( "\"\"" ) ); // empty string
+    CHECK_THROWS( parse_angle( "27" ) ); // not a string at all
+    CHECK_THROWS( parse_angle( "\"    \"" ) ); // only spaces
+    CHECK_THROWS( parse_angle( "\"27\"" ) ); // no time unit
+
+    CHECK( parse_angle( "\"1 rad\"" ) == 1_radians );
+    CHECK( parse_angle( "\"1 °\"" ) == 1_degrees );
+    CHECK( parse_angle( "\"+1 arcmin\"" ) == 1_arcmin );
+}
+
+TEST_CASE( "angles_to_trig_functions" )
+{
+    CHECK( sin( 0_radians ) == 0 );
+    CHECK( sin( 0.5_pi_radians ) == Approx( 1 ) );
+    CHECK( sin( 270_degrees ) == Approx( -1 ) );
+    CHECK( cos( 1_pi_radians ) == Approx( -1 ) );
+    CHECK( cos( 360_degrees ) == Approx( 1 ) );
+    CHECK( units::atan2( 0, -1 ) == 1_pi_radians );
+    CHECK( units::atan2( 0, 1 ) == 0_radians );
+    CHECK( units::atan2( 1, 0 ) == 90_degrees );
+    CHECK( units::atan2( -1, 0 ) == -90_degrees );
+}
+
+TEST_CASE( "rounding" )
+{
+    CHECK( round_to_multiple_of( 0_degrees, 15_degrees ) == 0_degrees );
+    CHECK( round_to_multiple_of( 1_degrees, 15_degrees ) == 0_degrees );
+    CHECK( round_to_multiple_of( 7_degrees, 15_degrees ) == 0_degrees );
+    CHECK( round_to_multiple_of( 8_degrees, 15_degrees ) == 15_degrees );
+    CHECK( round_to_multiple_of( 15_degrees, 15_degrees ) == 15_degrees );
+    CHECK( round_to_multiple_of( 360_degrees, 15_degrees ) == 360_degrees );
+    CHECK( round_to_multiple_of( -1_degrees, 15_degrees ) == 0_degrees );
+    CHECK( round_to_multiple_of( -7_degrees, 15_degrees ) == 0_degrees );
+    CHECK( round_to_multiple_of( -8_degrees, 15_degrees ) == -15_degrees );
+    CHECK( round_to_multiple_of( -15_degrees, 15_degrees ) == -15_degrees );
+    CHECK( round_to_multiple_of( -360_degrees, 15_degrees ) == -360_degrees );
 }

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -52,7 +52,7 @@ static vehicle *setup_drag_test( const vproto_id &veh_id )
     clear_game_drag( ter_id( "t_pavement" ) );
 
     const tripoint map_starting_point( 60, 60, 0 );
-    vehicle *veh_ptr = g->m.add_vehicle( veh_id, map_starting_point, -90, 0, 0 );
+    vehicle *veh_ptr = get_map().add_vehicle( veh_id, map_starting_point, -90_degrees, 0, 0 );
 
     REQUIRE( veh_ptr != nullptr );
     if( veh_ptr == nullptr ) {

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -172,7 +172,8 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
     clear_game( terrain );
 
     const tripoint map_starting_point( 60, 60, 0 );
-    vehicle *veh_ptr = g->m.add_vehicle( veh_id, map_starting_point, -90, 0, 0 );
+    map &here = get_map();
+    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, -90_degrees, 0, 0 );
 
     REQUIRE( veh_ptr != nullptr );
     if( veh_ptr == nullptr ) {
@@ -246,7 +247,7 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
                 veh.cruise_velocity = accelerating ? target_velocity : 0;
             } else {
                 veh.velocity = 0;
-                veh.last_turn = 0;
+                veh.last_turn = 0_degrees;
                 veh.of_turn_carry = 0;
             }
             reset_counter = 0;

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -31,7 +31,8 @@ static void test_repair( const std::vector<item> &tools, bool expect_craftable )
     }
 
     const tripoint vehicle_origin = test_origin + tripoint_south_east;
-    vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "bicycle" ), vehicle_origin, -90, 0, 0 );
+    vehicle *veh_ptr = get_map().add_vehicle( vproto_id( "bicycle" ), vehicle_origin, -90_degrees,
+                       0, 0 );
     REQUIRE( veh_ptr != nullptr );
     // Find the frame at the origin.
     vehicle_part *origin_frame = nullptr;

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -40,7 +40,7 @@ TEST_CASE( "vehicle power with reactor and solar panels", "[vehicle][power]" )
 
     SECTION( "vehicle with reactor" ) {
         const tripoint reactor_origin = tripoint( 10, 10, 0 );
-        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "reactor_test" ), reactor_origin, 0, 0, 0 );
+        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "reactor_test" ), reactor_origin, 0_degrees, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
 
         REQUIRE( !veh_ptr->reactors.empty() );
@@ -68,7 +68,8 @@ TEST_CASE( "vehicle power with reactor and solar panels", "[vehicle][power]" )
 
     SECTION( "vehicle with solar panels" ) {
         const tripoint solar_origin = tripoint( 5, 5, 0 );
-        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "solar_panel_test" ), solar_origin, 0, 0, 0 );
+        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "solar_panel_test" ), solar_origin, 0_degrees, 0,
+                                             0 );
         REQUIRE( veh_ptr != nullptr );
 
         GIVEN( "it is 3 hours after sunrise, with sunny weather" ) {
@@ -132,7 +133,7 @@ TEST_CASE( "maximum reverse velocity", "[vehicle][power][reverse]" )
 
     GIVEN( "a scooter with combustion engine and charged battery" ) {
         const tripoint origin = tripoint( 10, 0, 0 );
-        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "scooter_test" ), origin, 0, 0, 0 );
+        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "scooter_test" ), origin, 0_degrees, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
         veh_ptr->charge_battery( 500 );
         REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 500 );
@@ -157,7 +158,8 @@ TEST_CASE( "maximum reverse velocity", "[vehicle][power][reverse]" )
 
     GIVEN( "a scooter with an electric motor and charged battery" ) {
         const tripoint origin = tripoint( 15, 0, 0 );
-        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "scooter_electric_test" ), origin, 0, 0, 0 );
+        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "scooter_electric_test" ), origin, 0_degrees, 0,
+                                             0 );
         REQUIRE( veh_ptr != nullptr );
         veh_ptr->charge_battery( 5000 );
         REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) == 5000 );
@@ -188,7 +190,8 @@ TEST_CASE( "Vehicle charging station", "[vehicle][power]" )
 
     GIVEN( "Vehicle with a charged battery and an active recharging station on a box" ) {
         const tripoint vehicle_origin = tripoint( 10, 10, 0 );
-        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "recharge_test" ), vehicle_origin, 0, 100, 0 );
+        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "recharge_test" ), vehicle_origin, 0_degrees, 100,
+                                             0 );
         REQUIRE( veh_ptr != nullptr );
         REQUIRE( veh_ptr->fuel_left( fuel_type_battery ) > 1000 );
         veh_ptr->update_time( calendar::turn_zero );

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -93,7 +93,7 @@ static void clear_game_and_set_ramp( const int transit_x, bool use_ramp, bool up
 // Clear map and create a ramp
 // Spawn a vehicle
 // Drive it over the ramp, and confirm that the vehicle changes z-levels
-static void ramp_transition_angled( const vproto_id &veh_id, const int angle,
+static void ramp_transition_angled( const vproto_id &veh_id, const units::angle angle,
                                     const int transition_x, bool use_ramp, bool up )
 {
     map &here = get_map();
@@ -196,22 +196,22 @@ static void test_ramp( std::string type, const int transition_x )
 {
     CAPTURE( type );
     SECTION( "no ramp" ) {
-        ramp_transition_angled( vproto_id( type ), 180, transition_x, false, false );
+        ramp_transition_angled( vproto_id( type ), 180_degrees, transition_x, false, false );
     }
     SECTION( "ramp up" ) {
-        ramp_transition_angled( vproto_id( type ), 180, transition_x, true, true );
+        ramp_transition_angled( vproto_id( type ), 180_degrees, transition_x, true, true );
     }
     SECTION( "ramp down" ) {
-        ramp_transition_angled( vproto_id( type ), 180, transition_x, true, false );
+        ramp_transition_angled( vproto_id( type ), 180_degrees, transition_x, true, false );
     }
     SECTION( "angled no ramp" ) {
-        ramp_transition_angled( vproto_id( type ), 225, transition_x, false, false );
+        ramp_transition_angled( vproto_id( type ), 225_degrees, transition_x, false, false );
     }
     SECTION( "angled ramp down" ) {
-        ramp_transition_angled( vproto_id( type ), 225, transition_x, true, false );
+        ramp_transition_angled( vproto_id( type ), 225_degrees, transition_x, true, false );
     }
     SECTION( "angled ramp up" ) {
-        ramp_transition_angled( vproto_id( type ), 225, transition_x, true, true );
+        ramp_transition_angled( vproto_id( type ), 225_degrees, transition_x, true, true );
     }
 }
 
@@ -247,7 +247,7 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
     const int start_z = drop_pos ? 1 : 0;
 
     const tripoint map_starting_point( 60, 60, start_z );
-    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, 180, 1, 0 );
+    vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, 180_degrees, 1, 0 );
 
     REQUIRE( veh_ptr != nullptr );
     if( veh_ptr == nullptr ) {

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -13,7 +13,7 @@ TEST_CASE( "vehicle_split_section" )
 {
     map &here = get_map();
     Character &player_character = get_player_character();
-    for( int dir = 0; dir < 360; dir += 15 ) {
+    for( units::angle dir = 0_degrees; dir < 360_degrees; dir += 15_degrees ) {
         CHECK( !player_character.in_vehicle );
         const tripoint test_origin( 15, 15, 0 );
         player_character.setpos( test_origin );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -19,7 +19,7 @@ TEST_CASE( "detaching_vehicle_unboards_passengers" )
     clear_map();
     const tripoint test_origin( 60, 60, 0 );
     const tripoint vehicle_origin = test_origin;
-    vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "bicycle" ), vehicle_origin, -90, 0, 0 );
+    vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "bicycle" ), vehicle_origin, -90_degrees, 0, 0 );
     g->m.board_vehicle( test_origin, &g->u );
     REQUIRE( g->u.in_vehicle );
     g->m.detach_vehicle( veh_ptr );
@@ -32,7 +32,7 @@ TEST_CASE( "destroy_grabbed_vehicle_section" )
         const tripoint test_origin( 60, 60, 0 );
         g->place_player( test_origin );
         const tripoint vehicle_origin = test_origin + tripoint_south_east;
-        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "bicycle" ), vehicle_origin, -90, 0, 0 );
+        vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "bicycle" ), vehicle_origin, -90_degrees, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
         tripoint grab_point = test_origin + tripoint_east;
         g->u.grab( OBJECT_VEHICLE, grab_point );
@@ -54,7 +54,7 @@ TEST_CASE( "add_item_to_broken_vehicle_part" )
     clear_map();
     const tripoint test_origin( 60, 60, 0 );
     const tripoint vehicle_origin = test_origin;
-    vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "bicycle" ), vehicle_origin, 0, 0, 0 );
+    vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "bicycle" ), vehicle_origin, 0_degrees, 0, 0 );
     REQUIRE( veh_ptr != nullptr );
 
     const tripoint pos = vehicle_origin + tripoint_west;

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -63,7 +63,7 @@ TEST_CASE( "vehicle_turret", "[vehicle] [gun] [magazine] [.]" )
 {
     for( auto e : turret_types() ) {
         SECTION( e->name() ) {
-            vehicle *veh = g->m.add_vehicle( vproto_id( "none" ), point( 65, 65 ), 270, 0, 0 );
+            vehicle *veh = g->m.add_vehicle( vproto_id( "none" ), point( 65, 65 ), 270_degrees, 0, 0 );
             REQUIRE( veh );
 
             const int idx = veh->install_part( point_zero, e->get_id(), true );

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -412,7 +412,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
         std::vector<tripoint> tiles = closest_points_first( p.pos(), 1 );
         tiles.erase( tiles.begin() ); // player tile
         tripoint veh = random_entry( tiles );
-        REQUIRE( g->m.add_vehicle( vproto_id( "shopping_cart" ), veh, 0, 0, 0 ) );
+        REQUIRE( g->m.add_vehicle( vproto_id( "shopping_cart" ), veh, 0_degrees, 0, 0 ) );
 
         REQUIRE( std::count_if( tiles.begin(), tiles.end(), []( const tripoint & e ) {
             return static_cast<bool>( g->m.veh_at( e ) );


### PR DESCRIPTION
#### Purpose of change
Reducing merge conflicts, improving type safety.

Original PR:
https://github.com/CleverRaven/Cataclysm-DDA/pull/44805
Followup bugfix for display of vehicles rotated to 225 degrees:
https://github.com/CleverRaven/Cataclysm-DDA/pull/45604
And another for formatting error when racking a vehicle:
https://github.com/CleverRaven/Cataclysm-DDA/pull/44975

#### Testing
Some playtesting; automated tests.