### PR TITLE
fix hunting_blind icon (graphical_overmap)

### DIFF
--- a/data/mods/Graphical_Overmap/go_overmap_terrain_recreational.json
+++ b/data/mods/Graphical_Overmap/go_overmap_terrain_recreational.json
@@ -277,8 +277,8 @@
     "type": "overmap_terrain",
     "id": "hunting_blind",
     "copy-from": "hunting_blind",
-    "sym": "\u00ED",
-    "color": "brown"
+    "sym": "\u00A0",
+    "color": "light_red"
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
#### Summary

In Graphical_Overmap, icon for "hunting_blind" is a tower, which is misleading.

Not sure if it will be ported to BN, but I ported my fix here. 
It fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/53173
