### PR TITLE
Update Nomad traits to scale better, obsolete Antsy and Restless

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6334,28 +6334,7 @@
     "points": -1,
     "starting_trait": true,
     "description": "You're too adventurous for your own good.  The more time you spend somewhere, the unhappier it makes you to be there.",
-    "changes_to": [ "NOMAD2" ],
-    "category": [ "BIRD", "FISH", "CHIMERA" ],
     "valid": false
-  },
-  {
-    "type": "mutation",
-    "id": "NOMAD2",
-    "name": { "str": "Antsy" },
-    "points": -2,
-    "description": "You can't bear to stay still for long.  Your morale will suffer unless you constantly explore new territory.",
-    "prereqs": [ "NOMAD" ],
-    "changes_to": [ "NOMAD3" ],
-    "category": [ "BIRD", "FISH", "CHIMERA" ]
-  },
-  {
-    "type": "mutation",
-    "id": "NOMAD3",
-    "name": { "str": "Restless" },
-    "points": -4,
-    "description": "Spending any amount of time in familiar places makes you miserable.  Must.  Keep.  Moving.",
-    "prereqs": [ "NOMAD2" ],
-    "category": [ "CHIMERA" ]
   },
   {
     "type": "mutation",

--- a/data/json/obsoletion/mutations.json
+++ b/data/json/obsoletion/mutations.json
@@ -156,5 +156,21 @@
     "starting_trait": false,
     "valid": false,
     "cancels": [ "FORGETFUL" ]
+  },
+  {
+    "type": "mutation",
+    "id": "NOMAD2",
+    "name": { "str": "Antsy" },
+    "points": -2,
+    "description": "You can't bear to stay still for long.  Your morale will suffer unless you constantly explore new territory.",
+    "//": "Un-obsolete NOMAD2 and NOMAD3 if we ever get a way to ensure that a category mutation can only develop if the character starts with a chargen-only trait, instead of automatically dragging the prereq in when it tries to develop the target mutation.",
+    "//2": "Reminder for if the above is accomplished: NOMAD2 was BIRD, FISH, and CHIMERA; NOMAD3 was CHIMERA."
+  },
+  {
+    "type": "mutation",
+    "id": "NOMAD3",
+    "name": { "str": "Restless" },
+    "points": -4,
+    "description": "Spending any amount of time in familiar places makes you miserable.  Must.  Keep.  Moving."
   }
 ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8779,16 +8779,16 @@ void Character::apply_persistent_morale()
         float min_time, max_time;
         if( has_trait( trait_NOMAD ) ) {
             max_unhappiness = 20;
-            min_time = to_moves<float>( 12_hours );
-            max_time = to_moves<float>( 1_days );
+            min_time = to_moves<float>( 2_days );
+            max_time = to_moves<float>( 4_days );
         } else if( has_trait( trait_NOMAD2 ) ) {
             max_unhappiness = 40;
-            min_time = to_moves<float>( 4_hours );
-            max_time = to_moves<float>( 8_hours );
+            min_time = to_moves<float>( 1_days );
+            max_time = to_moves<float>( 2_days );
         } else { // traid_NOMAD3
             max_unhappiness = 60;
-            min_time = to_moves<float>( 1_hours );
-            max_time = to_moves<float>( 2_hours );
+            min_time = to_moves<float>( 12_hours );
+            max_time = to_moves<float>( 1_days );
         }
         // The penalty starts at 1 at min_time and scales up to max_unhappiness at max_time.
         const float t = ( total_time - min_time ) / ( max_time - min_time );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Make Nomad trait series less punishing relative to point value, obsolete Antsy and Restless for now"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

In a nutshell, the Nomad mutation chain is badly thought out. It STARTS at an aggressive rate of morale penalty buildup that is enough to force the player to not want to spend more than a night's rest at any given location, behavior that's better suited for what the top-tier trait Restless should be encouraging. So what's Restless do instead, if not that? Makes it so if a Chimera mutant needs to stop to craft or cook, they'll suddenly become too depressed to do anything in a whopping 2 hours.

As an alternative to simply removing the behavior outright, I opted to nudge their behavior to something closer to what would fit the niches it seems to expect players to fall into, in particular making it so Nomad is actually worth 1 point and not behaving like it deserves to give you 4-5 points.

Per feedback however, it was requested that Antsy and Restless should only be kept if they can be rigged to only develop if you started with Nomad, instead of randomly showing up on their own if you use mutagen. Currently there's no way to accomplish that.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed the scaling of morale for Nomad from 12-24 hours to 2-4 days. This gives nomad characters a couple days to poke around and explore an area before being nudged to move on.
2. Changed scaling of Antsy from 4-8 hours to 1-2 days. As expected, this is more restrictive than what Nomad gets but still offers a slight bit of time to take stock of the area before moving on.
3. Changed morale scales for Restless from 1-2 hours to 12-24 hours, matching the behavior of Nomad prior to this change. This better suits the idea of never staying in one place for more than a day, as this gives you just enough time to get a good's night sleep with a light bit of activity before or after, before you're nudged to move on.
4. Obsoleted Antsy and Restless for the time being, per request from Coolthulhu. Added comments noting what needs to be done to re-add them, and reminder for what categories they were prior to obsoletion.
5. Removed category and evolution hooks from Nomad, making it fully a chargen-only trait.

Basically, the time given to Nomad characters seemed a better fit for the highest tier of the trait series. Then, instead of `NOMAD2` being 3x more forgiving than `NOMAD3` and `NOMAD` being 4x more forgiving than `NOMAD2`, I simply made it a factor of 2 for both steps. I left the decay rates (7, 14, and 28 days) and morale cap (20, 40, 60) unaffected, so this mostly focuses on keeping the scaling consistent, using a specified target time for `NOMAD3`, without a 12x or other large multiplier giving regular `NOMAD` too much of a free pass.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1171
2. Letting Viss be the only one that has to deal with complaints about changing half-baked features.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested change.
2. Started up a Nomad character, no skills, in the shelter.
3. Spent the day grinding up skills from zero until night time.
4. Observed that I was not depressed yet even into the next morning.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

For comparison, Pyromania maxes out at -30 morale after a couple days of no fire. It's easier to manage but will likely max out quicker (and at a worse penalty than Nomad). It's a 2-point trait however, which may complicate the comparison.