### PR TITLE
Un-valid NOMAD2+3

### DIFF
--- a/data/json/obsoletion/mutations.json
+++ b/data/json/obsoletion/mutations.json
@@ -163,6 +163,7 @@
     "name": { "str": "Antsy" },
     "points": -2,
     "description": "You can't bear to stay still for long.  Your morale will suffer unless you constantly explore new territory.",
+    "valid": false,
     "//": "Un-obsolete NOMAD2 and NOMAD3 if we ever get a way to ensure that a category mutation can only develop if the character starts with a chargen-only trait, instead of automatically dragging the prereq in when it tries to develop the target mutation.",
     "//2": "Reminder for if the above is accomplished: NOMAD2 was BIRD, FISH, and CHIMERA; NOMAD3 was CHIMERA."
   },
@@ -171,6 +172,7 @@
     "id": "NOMAD3",
     "name": { "str": "Restless" },
     "points": -4,
-    "description": "Spending any amount of time in familiar places makes you miserable.  Must.  Keep.  Moving."
+    "description": "Spending any amount of time in familiar places makes you miserable.  Must.  Keep.  Moving.",
+    "valid": false
   }
 ]


### PR DESCRIPTION
Being in "obsolete.json" does nothing by itself, in case of traits, they must be `"valid": false`.