### PR TITLE
[DDA Port] Spawn audits of various locations

### DIFF
--- a/data/json/mapgen/field_baseball.json
+++ b/data/json/mapgen/field_baseball.json
@@ -61,11 +61,11 @@
         { "group": "trash_cart", "x": 36, "y": 1, "chance": 90, "repeat": [ 2, 4 ] },
         { "group": "fast_food", "x": [ 37, 45 ], "y": [ 1, 3 ], "chance": 80, "repeat": [ 2, 4 ] }
       ],
-      "place_monsters": [
-        { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 1, 2 ] },
-        { "monster": "GROUP_ZOMBIE", "x": [ 26, 45 ], "y": [ 2, 21 ], "repeat": [ 1, 2 ] },
-        { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 26, 45 ], "repeat": [ 1, 2 ] },
-        { "monster": "GROUP_ZOMBIE", "x": [ 26, 45 ], "y": [ 26, 45 ], "repeat": [ 1, 2 ] }
+      "place_monster": [
+        { "group": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 3, 7 ] },
+        { "group": "GROUP_ZOMBIE", "x": [ 26, 45 ], "y": [ 2, 21 ], "repeat": [ 3, 7 ] },
+        { "group": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 26, 45 ], "repeat": [ 3, 7 ] },
+        { "group": "GROUP_ZOMBIE", "x": [ 26, 45 ], "y": [ 26, 45 ], "repeat": [ 3, 7 ] }
       ]
     }
   },

--- a/data/json/mapgen/field_football.json
+++ b/data/json/mapgen/field_football.json
@@ -104,7 +104,7 @@
         { "item": "football_items", "x": [ 48, 71 ], "y": [ 11, 13 ], "chance": 80, "repeat": [ 1, 2 ] },
         { "item": "football_items", "x": [ 72, 80 ], "y": [ 11, 13 ], "chance": 60, "repeat": [ 1, 2 ] }
       ],
-      "place_monsters": [ { "monster": "GROUP_FOOTBALL", "x": [ 48, 71 ], "y": [ 11, 13 ], "chance": 1 } ],
+      "place_monster": [ { "group": "GROUP_FOOTBALL", "x": [ 48, 71 ], "y": [ 4, 20 ], "repeat": [ 8, 12 ] } ],
       "place_vehicles": [ { "vehicle": "football_vehicles", "x": 59, "y": 12, "chance": 60 } ]
     },
     "om_terrain": [ [ "football_field_a1", "football_field_a2", "football_field_a3", "football_field_a4", "football_field_a5" ] ],
@@ -146,7 +146,7 @@
         { "point": "terrain", "id": "t_dirt", "x": [ 0, 2 ], "y": [ 0, 23 ], "repeat": [ 18, 24 ] },
         { "point": "terrain", "id": "t_dirt", "x": [ 116, 119 ], "y": [ 0, 23 ], "repeat": [ 24, 32 ] }
       ],
-      "place_monsters": [ { "monster": "GROUP_FOOTBALL", "x": [ 55, 63 ], "y": [ 3, 19 ], "chance": 1, "repeat": [ 3, 4 ] } ]
+      "place_monster": [ { "group": "GROUP_FOOTBALL", "x": [ 55, 63 ], "y": [ 3, 19 ], "chance": 1, "repeat": [ 8, 12 ] } ]
     },
     "om_terrain": [ [ "football_field_b1", "football_field_b2", "football_field_b3", "football_field_b4", "football_field_b5" ] ],
     "type": "mapgen",
@@ -217,7 +217,7 @@
         { "item": "football_items", "x": [ 48, 71 ], "y": [ 9, 11 ], "chance": 80, "repeat": [ 1, 2 ] },
         { "item": "football_items", "x": [ 72, 80 ], "y": [ 9, 11 ], "chance": 60, "repeat": [ 1, 2 ] }
       ],
-      "place_monsters": [ { "monster": "GROUP_FOOTBALL", "x": [ 48, 71 ], "y": [ 9, 11 ], "chance": 1 } ],
+      "place_monster": [ { "group": "GROUP_FOOTBALL", "x": [ 48, 71 ], "y": [ 4, 20 ], "repeat": [ 8, 12 ] } ],
       "place_vehicles": [ { "vehicle": "football_vehicles", "x": 59, "y": 10, "chance": 60 } ]
     },
     "om_terrain": [ [ "football_field_c1", "football_field_c2", "football_field_c3", "football_field_c4", "football_field_c5" ] ],

--- a/data/json/mapgen/hospital.json
+++ b/data/json/mapgen/hospital.json
@@ -126,16 +126,16 @@
         ]
       },
       "place_loot": [ { "group": "autodoc_installation_programs", "x": 1, "y": [ 34, 37 ], "chance": 75, "repeat": 4 } ],
-      "place_monsters": [
-        { "monster": "GROUP_HOSPITAL", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 0, 3 ], "density": 3 },
-        { "monster": "GROUP_HOSPITAL", "x": [ 25, 46 ], "y": [ 1, 22 ], "repeat": [ 0, 3 ], "density": 3 },
-        { "monster": "GROUP_HOSPITAL", "x": [ 49, 70 ], "y": [ 1, 22 ], "repeat": [ 0, 3 ], "density": 3 },
-        { "monster": "GROUP_HOSPITAL", "x": [ 1, 22 ], "y": [ 25, 46 ], "repeat": [ 0, 3 ], "density": 3 },
-        { "monster": "GROUP_HOSPITAL", "x": [ 25, 46 ], "y": [ 25, 46 ], "repeat": [ 0, 3 ], "density": 3 },
-        { "monster": "GROUP_HOSPITAL", "x": [ 49, 70 ], "y": [ 25, 46 ], "repeat": [ 0, 3 ], "density": 3 },
-        { "monster": "GROUP_HOSPITAL", "x": [ 1, 22 ], "y": [ 49, 70 ], "repeat": [ 0, 3 ], "density": 3 },
-        { "monster": "GROUP_HOSPITAL", "x": [ 25, 46 ], "y": [ 49, 70 ], "repeat": [ 0, 3 ], "density": 3 },
-        { "monster": "GROUP_HOSPITAL", "x": [ 49, 70 ], "y": [ 49, 70 ], "repeat": [ 0, 3 ], "density": 3 }
+      "place_monster": [
+        { "group": "GROUP_HOSPITAL", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 15, 20 ] },
+        { "group": "GROUP_HOSPITAL", "x": [ 25, 46 ], "y": [ 1, 22 ], "repeat": [ 15, 20 ] },
+        { "group": "GROUP_HOSPITAL", "x": [ 49, 70 ], "y": [ 1, 22 ], "repeat": [ 15, 20 ] },
+        { "group": "GROUP_HOSPITAL", "x": [ 1, 22 ], "y": [ 25, 46 ], "repeat": [ 15, 20 ] },
+        { "group": "GROUP_HOSPITAL", "x": [ 25, 46 ], "y": [ 25, 46 ], "repeat": [ 15, 20 ] },
+        { "group": "GROUP_HOSPITAL", "x": [ 49, 70 ], "y": [ 25, 46 ], "repeat": [ 15, 20 ] },
+        { "group": "GROUP_HOSPITAL", "x": [ 1, 22 ], "y": [ 49, 70 ], "repeat": [ 15, 20 ] },
+        { "group": "GROUP_HOSPITAL", "x": [ 25, 46 ], "y": [ 49, 70 ], "repeat": [ 15, 20 ] },
+        { "group": "GROUP_HOSPITAL", "x": [ 49, 70 ], "y": [ 49, 70 ], "repeat": [ 15, 20 ] }
       ]
     }
   }

--- a/data/json/mapgen/park.json
+++ b/data/json/mapgen/park.json
@@ -35,7 +35,7 @@
         "''''''''''''''''''''''''"
       ],
       "palettes": [ "park_scenic_palette" ],
-      "monsters": { "'": { "monster": "GROUP_PARK_PLAYGROUND", "chance": 70 } },
+      "place_monster": [ { "group": "GROUP_PARK_PLAYGROUND", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 10, 20 ] } ],
       "vehicles": { "'": { "vehicle": "park_playground_vehicles", "chance": 1 } }
     }
   },
@@ -75,10 +75,7 @@
         "                        "
       ],
       "palettes": [ "park_asphalt_palette" ],
-      "monsters": {
-        ".": { "monster": "GROUP_PARK_PLAYGROUND", "chance": 20 },
-        " ": { "monster": "GROUP_PARK_PLAYGROUND", "chance": 200 }
-      }
+      "place_monster": [ { "group": "GROUP_PARK_SCENIC", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 10, 20 ] } ]
     }
   },
   {
@@ -117,7 +114,7 @@
         "                        "
       ],
       "palettes": [ "park_asphalt_palette" ],
-      "monsters": { ".": { "monster": "GROUP_PARK_PLAYGROUND", "chance": 50 }, "b": { "monster": "GROUP_PARK_DOG", "chance": 100 } }
+      "place_monster": [ { "group": "GROUP_PARK_SCENIC", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 10, 20 ] } ]
     }
   },
   {
@@ -157,7 +154,7 @@
       ],
       "palettes": [ "park_asphalt_palette" ],
       "items": { "b": { "item": "shoes", "chance": 15, "repeat": [ 2, 5 ] } },
-      "monsters": { "$": { "monster": "GROUP_PARK_SCENIC", "chance": 50 }, " ": { "monster": "GROUP_PARK_PLAYGROUND", "chance": 100 } }
+      "place_monster": [ { "group": "GROUP_PARK_SCENIC", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 10, 20 ] } ]
     }
   },
   {
@@ -197,7 +194,7 @@
       ],
       "palettes": [ "park_scenic_palette" ],
       "place_item": [ { "item": "char_smoker", "x": 7, "y": 7 } ],
-      "monsters": { ".": { "monster": "GROUP_PARK_SCENIC", "chance": 20 } },
+      "place_monster": [ { "group": "GROUP_PARK_SCENIC", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 10, 20 ] } ],
       "vehicles": { ".": { "vehicle": "park_playground_vehicles", "chance": 1 } }
     }
   },
@@ -237,7 +234,7 @@
         " , ,   z ...... z       "
       ],
       "palettes": [ "park_scenic_palette" ],
-      "monsters": { ".": { "monster": "GROUP_PARK_SCENIC", "chance": 50 }, " ": { "monster": "GROUP_PARK_SCENIC", "chance": 100 } },
+      "place_monster": [ { "group": "GROUP_PARK_SCENIC", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 10, 20 ] } ],
       "vehicles": { ".": { "vehicle": "park_playground_vehicles", "chance": 1 } }
     }
   },
@@ -308,7 +305,7 @@
         { "item": "feces_dog", "x": 20, "y": 10, "repeat": [ 1, 10 ] },
         { "item": "feces_dog", "x": 11, "y": 12, "repeat": [ 5, 20 ] }
       ],
-      "monsters": { ",": { "monster": "GROUP_PARK_DOG", "chance": 30 }, " ": { "monster": "GROUP_PARK_DOG", "chance": 60 } }
+      "place_monster": [ { "group": "GROUP_PARK_DOG", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 5, 12 ] } ]
     }
   },
   {
@@ -363,7 +360,7 @@
         { "chance": 10, "item": "field", "x": 2, "y": 16 },
         { "chance": 10, "item": "field", "x": 1, "y": 13 }
       ],
-      "monsters": { "'": { "monster": "GROUP_PARK_SCENIC", "chance": 100 }, "s": { "monster": "GROUP_PARK_SCENIC", "chance": 20 } },
+      "place_monster": [ { "group": "GROUP_PARK_SCENIC", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 10, 20 ] } ],
       "vehicles": { "'": { "vehicle": "park_playground_vehicles", "chance": 1 }, "p": { "vehicle": "suburban_home", "chance": 1 } }
     }
   },
@@ -419,7 +416,7 @@
         { "chance": 5, "item": "stoner", "x": 7, "y": 16 },
         { "chance": 5, "item": "forage_mushroom", "x": 3, "y": 21 }
       ],
-      "monsters": { "'": { "monster": "GROUP_PARK_SCENIC", "chance": 100 }, "_": { "monster": "GROUP_PARK_SCENIC", "chance": 20 } },
+      "place_monster": [ { "group": "GROUP_PARK_SCENIC", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 10, 20 ] } ],
       "vehicles": { "'": { "vehicle": "park_playground_vehicles", "chance": 1 } }
     }
   },
@@ -468,7 +465,7 @@
         { "chance": 10, "item": "toy_box", "x": 14, "y": 13 }
       ],
       "place_toilets": [ { "x": 21, "y": 3 }, { "x": 21, "y": 5 } ],
-      "monsters": { "'": { "monster": "GROUP_PARK_SCENIC", "chance": 60 }, "g": { "monster": "GROUP_PARK_PLAYGROUND", "chance": 40 } },
+      "place_monster": [ { "group": "GROUP_PARK_SCENIC", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 10, 20 ] } ],
       "vehicles": { "'": { "vehicle": "park_playground_vehicles", "chance": 1 } }
     }
   },
@@ -508,11 +505,7 @@
       ],
       "palettes": [ "park_scenic_palette" ],
       "items": { "_": { "item": "forest", "chance": 4 } },
-      "monsters": {
-        "s": { "monster": "GROUP_PARK_SCENIC", "chance": 40 },
-        ":": { "monster": "GROUP_PARK_SCENIC", "chance": 50 },
-        "'": { "monster": "GROUP_PARK_SCENIC", "chance": 100 }
-      },
+      "place_monster": [ { "group": "GROUP_PARK_SCENIC", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 10, 20 ] } ],
       "vehicles": { "s": { "vehicle": "park_playground_vehicles", "chance": 1 } }
     }
   },
@@ -553,7 +546,7 @@
       "palettes": [ "park_scenic_palette" ],
       "terrain": { "O": "t_sidewalk" },
       "items": { "|": { "item": "stoner", "chance": 1 } },
-      "monsters": { "s": { "monster": "GROUP_PARK_SCENIC", "chance": 50 }, "'": { "monster": "GROUP_PARK_SCENIC", "chance": 100 } },
+      "place_monster": [ { "group": "GROUP_PARK_SCENIC", "x": [ 15, 17 ], "y": [ 15, 17 ], "repeat": [ 10, 20 ] } ],
       "vehicles": { "s": { "vehicle": "park_playground_vehicles", "chance": 1 } }
     }
   },
@@ -594,11 +587,7 @@
       "palettes": [ "park_scenic_palette" ],
       "vendingmachines": { "v": { "item_group": "vending_drink" } },
       "items": { "X": [ { "item": "trash", "chance": 75, "repeat": [ 2, 7 ] }, { "item": "vending_drink_items", "chance": 25 } ] },
-      "monsters": {
-        "'": { "monster": "GROUP_PARK_SCENIC", "chance": 100 },
-        ":": { "monster": "GROUP_PARK_SCENIC", "chance": 60 },
-        "s": { "monster": "GROUP_PARK_SCENIC", "chance": 50 }
-      },
+      "place_monster": [ { "group": "GROUP_PARK_SCENIC", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 10, 20 ] } ],
       "vehicles": { "s": { "vehicle": "park_playground_vehicles", "chance": 1 } }
     }
   }

--- a/data/json/mapgen/pool.json
+++ b/data/json/mapgen/pool.json
@@ -40,7 +40,7 @@
         { "chance": 15, "item": "magazines", "x": 6, "y": 2 }
       ],
       "place_toilets": [ { "x": 3, "y": 20 }, { "x": 20, "y": 20 } ],
-      "place_monsters": [ { "monster": "GROUP_MAPGEN_POOL", "x": [ 6, 17 ], "y": [ 6, 15 ], "repeat": [ 1, 3 ] } ],
+      "place_monster": [ { "group": "GROUP_MAPGEN_POOL", "x": [ 6, 17 ], "y": [ 6, 15 ], "repeat": [ 2, 6 ] } ],
       "rows": [
         "sssssssssssssssssssssss_",
         "_||||||||||++||||||||||_",
@@ -165,7 +165,7 @@
         { "chance": 20, "repeat": 2, "item": "clothing_female", "x": 2, "y": 6 }
       ],
       "place_toilets": [ { "x": 2, "y": 3 }, { "x": 4, "y": 3 }, { "x": 19, "y": 3 }, { "x": 21, "y": 3 } ],
-      "place_monsters": [ { "monster": "GROUP_MAPGEN_POOL", "x": [ 4, 19 ], "y": [ 11, 19 ], "repeat": [ 1, 3 ] } ],
+      "place_monster": [ { "group": "GROUP_MAPGEN_POOL", "x": [ 4, 19 ], "y": [ 11, 19 ], "repeat": [ 2, 6 ] } ],
       "rows": [
         "ssssssssssssssssssssssss",
         "sssssssssssssssssssssss_",
@@ -297,7 +297,7 @@
         { "chance": 10, "repeat": [ 1, 2 ], "item": "magazines", "x": 2, "y": 17 }
       ],
       "place_toilets": [ { "x": 6, "y": 3 }, { "x": 8, "y": 3 }, { "x": 15, "y": 3 }, { "x": 17, "y": 3 } ],
-      "place_monsters": [ { "monster": "GROUP_MAPGEN_POOL", "x": [ 5, 18 ], "y": [ 5, 18 ], "repeat": [ 1, 3 ] } ],
+      "place_monster": [ { "group": "GROUP_MAPGEN_POOL", "x": [ 5, 18 ], "y": [ 5, 18 ], "repeat": [ 2, 6 ] } ],
       "rows": [
         "ssssssssssssssssssssssss",
         "ssssssssssssssssssssssss",
@@ -474,7 +474,7 @@
         "{": "t_floor",
         "|": "t_brick_wall"
       },
-      "place_monsters": [ { "monster": "GROUP_MAPGEN_POOL", "x": [ 5, 18 ], "y": [ 5, 18 ], "repeat": [ 1, 3 ] } ],
+      "place_monster": [ { "group": "GROUP_MAPGEN_POOL", "x": [ 5, 18 ], "y": [ 5, 18 ], "repeat": [ 2, 6 ] } ],
       "place_signs": [ { "signage": "Women", "x": 9, "y": 19 }, { "signage": "Men", "x": 14, "y": 19 } ]
     },
     "om_terrain": "pool_3",
@@ -557,7 +557,7 @@
         { "chance": 10, "item": "light_reading", "x": 12, "y": 8 }
       ],
       "place_toilets": [ { "x": 6, "y": 3 }, { "x": 8, "y": 3 }, { "x": 15, "y": 3 }, { "x": 17, "y": 3 } ],
-      "place_monsters": [ { "monster": "GROUP_MAPGEN_POOL", "x": [ 6, 17 ], "y": [ 11, 17 ], "repeat": [ 1, 3 ] } ],
+      "place_monster": [ { "group": "GROUP_MAPGEN_POOL", "x": [ 6, 17 ], "y": [ 11, 17 ], "repeat": [ 2, 6 ] } ],
       "rows": [
         "...........ss...........",
         "...........ss...........",
@@ -647,12 +647,6 @@
     }
   },
   {
-    "name": "GROUP_MAPGEN_POOL",
-    "type": "monstergroup",
-    "default": "mon_null",
-    "monsters": [ { "monster": "mon_zombie_swimmer", "freq": 500, "cost_multiplier": 0 } ]
-  },
-  {
     "type": "mapgen",
     "method": "json",
     "om_terrain": "pool_5",
@@ -692,7 +686,7 @@
         "s": "t_sidewalk"
       },
       "furniture": { "n": "f_dive_block" },
-      "place_monsters": [ { "monster": "GROUP_MAPGEN_POOL", "x": [ 5, 18 ], "y": [ 5, 18 ], "repeat": [ 1, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_MAPGEN_POOL", "x": [ 5, 18 ], "y": [ 5, 18 ], "repeat": [ 2, 6 ] } ]
     }
   },
   {
@@ -743,13 +737,7 @@
         "n": "f_dive_block",
         "x": [ "f_datura", "f_bluebell", "f_mutpoppy", "f_dahlia", "f_flower_tulip", "f_chamomile", "f_flower_spurge", "f_lily" ]
       },
-      "place_monsters": [ { "monster": "GROUP_MAPGEN_POOL", "x": [ 5, 18 ], "y": [ 5, 18 ], "repeat": [ 1, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_MAPGEN_POOL", "x": [ 5, 18 ], "y": [ 5, 18 ], "repeat": [ 2, 6 ] } ]
     }
-  },
-  {
-    "name": "GROUP_MAPGEN_POOL",
-    "type": "monstergroup",
-    "default": "mon_null",
-    "monsters": [ { "monster": "mon_zombie_swimmer", "freq": 300, "cost_multiplier": 0 } ]
   }
 ]

--- a/data/json/mapgen/pool.json
+++ b/data/json/mapgen/pool.json
@@ -647,6 +647,12 @@
     }
   },
   {
+    "name": "GROUP_MAPGEN_POOL",
+    "type": "monstergroup",
+    "default": "mon_null",
+    "monsters": [ { "monster": "mon_zombie_swimmer", "freq": 500, "cost_multiplier": 0 } ]
+  },
+  {
     "type": "mapgen",
     "method": "json",
     "om_terrain": "pool_5",

--- a/data/json/mapgen/school_1.json
+++ b/data/json/mapgen/school_1.json
@@ -87,18 +87,18 @@
       "palettes": [ "school_palette" ],
       "place_items": [  ],
       "place_item": [ { "item": "american_flag", "x": 36, "y": 58, "amount": 1 } ],
-      "place_monsters": [
-        { "monster": "GROUP_SCHOOL", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 1, 1 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 1, 22 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 1, 22 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 1, 22 ], "y": [ 25, 46 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 25, 46 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 25, 46 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 1, 22 ], "y": [ 49, 70 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 49, 70 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 49, 70 ], "repeat": [ 1, 2 ], "density": 0.1 }
+      "place_monster": [
+        { "monster": [ "mon_nursebot", "mon_nursebot_defective" ], "x": [ 27, 33 ], "y": [ 20, 23 ], "chance": 50 },
+        { "group": "GROUP_SCHOOL", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 5, 10 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 1, 22 ], "repeat": [ 5, 10 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 1, 22 ], "repeat": [ 5, 10 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 1, 22 ], "y": [ 25, 46 ], "repeat": [ 5, 10 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 25, 46 ], "repeat": [ 5, 10 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 25, 46 ], "repeat": [ 5, 10 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 1, 22 ], "y": [ 49, 70 ], "repeat": [ 5, 10 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 49, 70 ], "repeat": [ 5, 10 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 49, 70 ], "repeat": [ 5, 10 ] }
       ],
-      "place_monster": [ { "monster": [ "mon_nursebot", "mon_nursebot_defective" ], "x": [ 27, 33 ], "y": [ 20, 23 ], "chance": 50 } ],
       "place_vehicles": [ { "vehicle": "school_vehicles", "x": 9, "y": 7, "chance": 25, "rotation": 0 } ]
     }
   },
@@ -189,13 +189,13 @@
       ],
       "palettes": [ "school_palette" ],
       "place_items": [  ],
-      "place_monsters": [
-        { "monster": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 1, 22 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 1, 22 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 1, 22 ], "y": [ 25, 46 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 25, 46 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 25, 46 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 1, 22 ], "y": [ 49, 70 ], "repeat": [ 1, 2 ], "density": 0.1 }
+      "place_monster": [
+        { "group": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 1, 22 ], "repeat": [ 2, 6 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 1, 22 ], "repeat": [ 2, 6 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 1, 22 ], "y": [ 25, 46 ], "repeat": [ 2, 6 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 25, 46 ], "repeat": [ 2, 6 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 25, 46 ], "repeat": [ 2, 6 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 1, 22 ], "y": [ 49, 70 ], "repeat": [ 2, 6 ] }
       ]
     }
   },
@@ -286,13 +286,13 @@
       ],
       "palettes": [ "school_palette" ],
       "place_items": [  ],
-      "place_monsters": [
-        { "monster": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 1, 22 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 1, 22 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 1, 22 ], "y": [ 25, 46 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 25, 46 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 25, 46 ], "repeat": [ 1, 2 ], "density": 0.1 },
-        { "monster": "GROUP_SCHOOL", "x": [ 1, 22 ], "y": [ 49, 70 ], "repeat": [ 1, 2 ], "density": 0.1 }
+      "place_monster": [
+        { "group": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 1, 22 ], "repeat": [ 2, 6 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 1, 22 ], "repeat": [ 2, 6 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 1, 22 ], "y": [ 25, 46 ], "repeat": [ 2, 6 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 25, 46 ], "y": [ 25, 46 ], "repeat": [ 2, 6 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 49, 70 ], "y": [ 25, 46 ], "repeat": [ 2, 6 ] },
+        { "group": "GROUP_SCHOOL", "x": [ 1, 22 ], "y": [ 49, 70 ], "repeat": [ 2, 6 ] }
       ]
     }
   },

--- a/data/json/mapgen/stadium_football.json
+++ b/data/json/mapgen/stadium_football.json
@@ -77,7 +77,7 @@
         { "chance": 65, "item": "barbecue", "x": 1, "y": [ 13, 14 ] },
         { "chance": 55, "item": "hand_tools", "x": 3, "y": 5 }
       ],
-      "place_monsters": [ { "chance": 3, "density": 1, "monster": "GROUP_ZOMBIE", "x": 13, "y": 20 } ],
+      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 4, 20 ], "y": [ 4, 20 ], "repeat": [ 4, 10 ] } ],
       "rows": [
         "ssssssssssssssssssssssss",
         "__________----__________",
@@ -182,9 +182,9 @@
         { "chance": 45, "item": "trash", "x": 1, "y": 7 },
         { "chance": 45, "item": "trash", "x": 11, "y": 2 }
       ],
-      "place_monsters": [
-        { "chance": 3, "density": 1, "monster": "GROUP_MALL", "x": 8, "y": 9 },
-        { "chance": 4, "density": 0, "monster": "GROUP_FOOTBALL", "x": 21, "y": 10 }
+      "place_monster": [
+        { "group": "GROUP_MALL", "x": [ 4, 20 ], "y": [ 4, 20 ], "repeat": [ 4, 10 ] },
+        { "group": "GROUP_FOOTBALL", "x": [ 4, 20 ], "y": [ 4, 20 ], "repeat": [ 4, 10 ] }
       ],
       "rows": [
         "-.....|...|#_#_#_r_GGggg",
@@ -276,10 +276,7 @@
         { "chance": 45, "item": "trash", "x": 13, "y": 5 },
         { "chance": 45, "item": "trash", "x": 9, "y": 3 }
       ],
-      "place_monsters": [
-        { "chance": 3, "density": 1, "monster": "GROUP_MALL", "x": 14, "y": 13 },
-        { "chance": 4, "density": 1, "monster": "GROUP_ARCADE", "x": 3, "y": 13 }
-      ],
+      "place_monster": [ { "group": "GROUP_MALL", "x": 14, "y": 13 }, { "group": "GROUP_ARCADE", "x": 3, "y": 13 } ],
       "rows": [
         "-.....|...|#_#_#_r_GGggg",
         "-....l|..{|#_#_#_r_Ggggg",
@@ -371,10 +368,10 @@
         { "chance": 45, "item": "hardware", "x": [ 16, 19 ], "y": 22 },
         { "chance": 45, "item": "hardware", "x": 1, "y": [ 13, 14 ] }
       ],
-      "place_monster": [ { "monster": "mon_zombie_technician", "x": 13, "y": 15 } ],
-      "place_monsters": [
-        { "chance": 5, "density": 1, "monster": "GROUP_MALL", "x": 4, "y": 4 },
-        { "chance": 4, "density": 1, "monster": "GROUP_MALL", "x": 14, "y": 3 }
+      "place_monster": [
+        { "monster": "mon_zombie_technician", "x": 13, "y": 15 },
+        { "group": "GROUP_MALL", "x": [ 4, 20 ], "y": [ 4, 20 ], "repeat": [ 4, 10 ] },
+        { "group": "GROUP_MALL", "x": [ 4, 20 ], "y": [ 4, 20 ], "repeat": [ 4, 10 ] }
       ],
       "rows": [
         "-.........|#_#_#_r_GGggg",
@@ -495,7 +492,7 @@
         { "chance": 65, "item": "vending_food", "x": 18, "y": 10 },
         { "chance": 65, "item": "vending_drink", "x": 19, "y": 10 }
       ],
-      "place_monsters": [ { "chance": 2, "density": 1, "monster": "GROUP_FOOTBALL", "x": 12, "y": 19 } ],
+      "place_monster": [ { "chance": 2, "group": "GROUP_FOOTBALL", "x": 12, "y": 19, "repeat": [ 4, 10 ] } ],
       "rows": [
         "ssssssssssssssssssssssss",
         ".........bb.....ssssssss",
@@ -550,7 +547,7 @@
     "object": {
       "place_item": [ { "item": "cleats", "repeat": 1, "x": 16, "y": 17 } ],
       "furniture": { ".": "f_null" },
-      "place_monsters": [ { "chance": 2, "density": 1, "monster": "GROUP_FOOTBALL", "x": 11, "y": 12 } ],
+      "place_monster": [ { "group": "GROUP_FOOTBALL", "x": 11, "y": 12, "repeat": [ 4, 10 ] } ],
       "rows": [
         "........................",
         "........................",
@@ -588,7 +585,7 @@
     "object": {
       "place_item": [ { "item": "cleats", "repeat": 1, "x": 16, "y": 17 } ],
       "furniture": { ".": "f_null" },
-      "place_monsters": [ { "chance": 2, "density": 1, "monster": "GROUP_FOOTBALL", "x": 11, "y": 12 } ],
+      "place_monster": [ { "group": "GROUP_FOOTBALL", "x": 11, "y": 12, "repeat": [ 4, 10 ] } ],
       "rows": [
         "........................",
         "........................",
@@ -655,9 +652,9 @@
         { "chance": 45, "item": "sports", "x": 10, "y": 14 },
         { "chance": 5, "item": "guns_pistol_common", "x": 10, "y": 19 }
       ],
-      "place_monsters": [
-        { "chance": 3, "density": 1, "monster": "GROUP_HOUSE", "x": 14, "y": 13 },
-        { "chance": 2, "density": 1, "monster": "GROUP_FOOTBALL", "x": 13, "y": 1 }
+      "place_monster": [
+        { "group": "GROUP_HOUSE", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 4, 10 ] },
+        { "group": "GROUP_FOOTBALL", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 4, 10 ] }
       ],
       "place_toilets": [ { "x": 2, "y": 22 }, { "x": 4, "y": 22 }, { "x": 6, "y": 22 }, { "x": 8, "y": 22 } ],
       "rows": [
@@ -769,7 +766,7 @@
         { "chance": 65, "item": "trash", "x": 22, "y": 7 },
         { "chance": 65, "item": "trash", "x": 9, "y": 7 }
       ],
-      "place_monsters": [ { "chance": 2, "density": 1, "monster": "GROUP_FOOTBALL", "x": 12, "y": 19 } ],
+      "place_monster": [ { "group": "GROUP_FOOTBALL", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 4, 10 ] } ],
       "rows": [
         "ssssssssssssssssssssssss",
         "ssssssss.BB.............",
@@ -821,7 +818,7 @@
     "object": {
       "place_item": [ { "item": "cleats", "repeat": 1, "x": 16, "y": 17 } ],
       "furniture": { ".": "f_null" },
-      "place_monsters": [ { "chance": 2, "density": 1, "monster": "GROUP_FOOTBALL", "x": 11, "y": 12 } ],
+      "place_monster": [ { "group": "GROUP_FOOTBALL", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 4, 10 ] } ],
       "rows": [
         "........................",
         "........................",
@@ -859,7 +856,7 @@
     "object": {
       "furniture": { ".": "f_null" },
       "place_items": [ { "chance": 45, "item": "trash", "x": 4, "y": 12 } ],
-      "place_monsters": [ { "chance": 2, "density": 1, "monster": "GROUP_FOOTBALL", "x": 11, "y": 12 } ],
+      "place_monster": [ { "group": "GROUP_FOOTBALL", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 4, 10 ] } ],
       "rows": [
         "........................",
         "........................",
@@ -920,7 +917,7 @@
         { "chance": 45, "item": "sports", "x": 3, "y": 19 },
         { "chance": 45, "item": "sports", "x": 4, "y": 17 }
       ],
-      "place_monsters": [ { "chance": 3, "density": 1, "monster": "GROUP_HOUSE", "x": 14, "y": 13 } ],
+      "place_monster": [ { "group": "GROUP_HOUSE", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 4, 10 ] } ],
       "rows": [
         "________________________",
         "________________________",
@@ -1042,7 +1039,7 @@
         { "chance": 55, "item": "bowling_food", "x": 22, "y": 15 },
         { "chance": 55, "item": "bowling_food", "x": 17, "y": 15 }
       ],
-      "place_monsters": [ { "chance": 3, "density": 1, "monster": "GROUP_HOUSE", "x": 14, "y": 13 } ],
+      "place_monster": [ { "group": "GROUP_HOUSE", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 4, 10 ] } ],
       "place_toilets": [
         { "x": 5, "y": 4 },
         { "x": 7, "y": 4 },
@@ -1145,7 +1142,7 @@
         { "chance": 55, "item": "bowling_food", "x": 18, "y": 4 },
         { "chance": 65, "item": "bar_food", "x": 17, "y": 19 }
       ],
-      "place_monsters": [ { "chance": 3, "density": 1, "monster": "GROUP_HOUSE", "x": 14, "y": 13 } ],
+      "place_monster": [ { "group": "GROUP_HOUSE", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 4, 10 ] } ],
       "rows": [
         "ggggG_r_#_#_#|...|.....-",
         "gggGG_r_#_#_#|...|.....-",
@@ -1236,7 +1233,7 @@
         { "chance": 55, "item": "bowling_food", "x": 18, "y": 6 },
         { "chance": 55, "item": "bowling_food", "x": 18, "y": 4 }
       ],
-      "place_monsters": [ { "chance": 3, "density": 1, "monster": "GROUP_HOUSE", "x": 14, "y": 13 } ],
+      "place_monster": [ { "group": "GROUP_HOUSE", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 4, 10 ] } ],
       "rows": [
         "ggggG_r_#_#_#R...|o..Ct-",
         "gggGG_r_#_#_#R{..|....t-",
@@ -1328,7 +1325,7 @@
         { "chance": 45, "item": "shoes", "x": 4, "y": 19 },
         { "chance": 45, "item": "shoes", "x": 4, "y": 15 }
       ],
-      "place_monsters": [ { "chance": 3, "density": 1, "monster": "GROUP_HOUSE", "x": 14, "y": 13 } ],
+      "place_monster": [ { "group": "GROUP_HOUSE", "x": [ 1, 23 ], "y": [ 1, 23 ], "repeat": [ 4, 10 ] } ],
       "place_toilets": [ { "x": 18, "y": 2 }, { "x": 22, "y": 2 } ],
       "rows": [
         "ggggG_R_b_b_b|.........-",

--- a/data/json/mapgen/trailer_park.json
+++ b/data/json/mapgen/trailer_park.json
@@ -37,7 +37,7 @@
         { "chance": 5, "item": "road", "x": 5, "y": 10 },
         { "chance": 5, "item": "road", "x": 2, "y": 8 }
       ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": 17, "y": 13, "repeat": [ 1, 6 ], "density": 0.1 } ],
+      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 14, 23 ], "y": [ 10, 16 ], "repeat": [ 1, 6 ] } ],
       "place_toilets": [ { "x": 7, "y": 3 }, { "x": 8, "y": 21 } ],
       "rows": [
         "________________________",
@@ -126,10 +126,10 @@
         { "chance": 35, "item": "softdrugs", "x": 7, "y": 20 },
         { "chance": 35, "item": "house_suicide_clothing", "x": 7, "y": 19 }
       ],
-      "place_monsters": [
-        { "monster": "GROUP_ZOMBIE", "x": 10, "y": 19, "repeat": [ 1, 6 ], "density": 0.1 },
-        { "monster": "GROUP_ZOMBIE", "x": 17, "y": 13, "repeat": [ 1, 6 ], "density": 0.1 },
-        { "monster": "GROUP_DOGS", "x": 3, "y": 14, "repeat": [ 1, 2 ], "density": 0.1 }
+      "place_monster": [
+        { "group": "GROUP_ZOMBIE", "x": [ 7, 13 ], "y": [ 16, 23 ], "repeat": [ 1, 6 ] },
+        { "group": "GROUP_ZOMBIE", "x": [ 14, 20 ], "y": [ 10, 16 ], "repeat": [ 1, 6 ] },
+        { "group": "GROUP_DOGS", "x": [ 0, 6 ], "y": [ 11, 17 ], "repeat": [ 1, 2 ] }
       ],
       "place_loot": [ { "item": "television", "x": 20, "y": 6, "chance": 100 }, { "item": "stepladder", "x": 19, "y": 5, "chance": 100 } ],
       "place_toilets": [ { "x": 8, "y": 21 } ],
@@ -237,9 +237,9 @@
         { "chance": 45, "item": "kitchen", "x": 18, "y": 21 },
         { "chance": 30, "item": "kitchen", "x": 6, "y": 2 }
       ],
-      "place_monsters": [
-        { "monster": "GROUP_ZOMBIE", "x": 17, "y": 13, "repeat": [ 1, 6 ], "density": 0.1 },
-        { "monster": "GROUP_DOGS", "x": 3, "y": 14, "repeat": [ 1, 2 ], "density": 0.1 }
+      "place_monster": [
+        { "group": "GROUP_ZOMBIE", "x": [ 14, 20 ], "y": [ 10, 16 ], "repeat": [ 1, 6 ] },
+        { "group": "GROUP_DOGS", "x": [ 0, 6 ], "y": [ 11, 17 ], "repeat": [ 1, 2 ] }
       ],
       "place_toilets": [ { "x": 18, "y": 2 }, { "x": 8, "y": 21 } ],
       "rows": [

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -2,7 +2,7 @@
   {
     "name": "GROUP_PARK_SCENIC",
     "type": "monstergroup",
-	"default": "mon_null",
+    "default": "mon_null",
     "monsters": [
       { "monster": "mon_zombie", "freq": 100, "cost_multiplier": 1 },
       { "monster": "mon_zombie_child", "freq": 100, "cost_multiplier": 1 },
@@ -35,7 +35,7 @@
     "default": "mon_null",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie_child", "freq": 295, "cost_multiplier": 1,           "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zombie_child", "freq": 295, "cost_multiplier": 1, "pack_size": [ 1, 2 ] },
       { "monster": "mon_zombie", "freq": 100, "cost_multiplier": 2 },
       { "monster": "mon_zombie_tough", "freq": 75, "cost_multiplier": 3 },
       { "monster": "mon_zombie_fat", "freq": 50, "cost_multiplier": 2 },

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -2,19 +2,17 @@
   {
     "name": "GROUP_PARK_SCENIC",
     "type": "monstergroup",
+	"default": "mon_null",
     "monsters": [
-      { "monster": "mon_zombie", "weight": 100 },
-      { "monster": "mon_zombie_child", "weight": 100 },
-      { "monster": "mon_zombie_tough", "weight": 75, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_fat", "weight": 50 },
-      { "monster": "mon_zombie_rot", "weight": 50 },
-      { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 2 },
-      { "monster": "mon_feral_human_pipe", "weight": 40 },
-      { "monster": "mon_feral_human_crowbar", "weight": 40 },
-      { "monster": "mon_feral_human_axe", "weight": 20, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_crawler", "weight": 25 },
-      { "monster": "mon_zombie_brainless", "weight": 25 },
-      { "monster": "mon_zombie_dog", "weight": 25, "pack_size": [ 1, 2 ] }
+      { "monster": "mon_zombie", "freq": 100, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_child", "freq": 100, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_tough", "freq": 75, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_fat", "freq": 50, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_rot", "freq": 50, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_runner", "freq": 20, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_crawler", "freq": 25, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_brainless", "freq": 25, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_dog", "freq": 25, "cost_multiplier": 1, "pack_size": [ 1, 2 ] }
     ]
   },
   {
@@ -34,35 +32,34 @@
   },
   {
     "name": "GROUP_PARK_PLAYGROUND",
+    "default": "mon_null",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie_child", "weight": 295, "pack_size": [ 1, 2 ] },
-      { "monster": "mon_zombie", "weight": 100, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_tough", "weight": 75, "cost_multiplier": 3 },
-      { "monster": "mon_zombie_fat", "weight": 50, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_rot", "weight": 50, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 3 },
-      { "monster": "mon_zombie_crawler", "weight": 25, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_brainless", "weight": 25, "cost_multiplier": 2 }
+      { "monster": "mon_zombie_child", "freq": 295, "cost_multiplier": 1,           "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zombie", "freq": 100, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_tough", "freq": 75, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_fat", "freq": 50, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_rot", "freq": 50, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_runner", "freq": 20, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_crawler", "freq": 25, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_brainless", "freq": 25, "cost_multiplier": 2 }
     ]
   },
   {
     "name": "GROUP_PARK_DOG",
     "type": "monstergroup",
+    "default": "mon_null",
     "monsters": [
-      { "monster": "mon_zombie", "weight": 125 },
-      { "monster": "mon_zombie_dog", "weight": 125, "pack_size": [ 1, 2 ] },
-      { "monster": "mon_dog_zombie_cop", "weight": 25 },
-      { "monster": "mon_dog_zombie_rot", "weight": 125, "pack_size": [ 1, 2 ] },
-      { "monster": "mon_zombie_tough", "weight": 75, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_fat", "weight": 50 },
-      { "monster": "mon_zombie_rot", "weight": 50, "pack_size": [ 1, 2 ] },
-      { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 2 },
-      { "monster": "mon_feral_human_pipe", "weight": 20 },
-      { "monster": "mon_feral_human_crowbar", "weight": 20 },
-      { "monster": "mon_feral_human_axe", "weight": 10, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_crawler", "weight": 25 },
-      { "monster": "mon_zombie_brainless", "weight": 25 }
+      { "monster": "mon_zombie", "freq": 125, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_dog", "freq": 125, "cost_multiplier": 1, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_dog_zombie_cop", "freq": 25, "cost_multiplier": 1 },
+      { "monster": "mon_dog_zombie_rot", "freq": 125, "cost_multiplier": 1, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zombie_tough", "freq": 75, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_fat", "freq": 50, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_rot", "freq": 50, "cost_multiplier": 1, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zombie_runner", "freq": 20, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_crawler", "freq": 25, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_brainless", "freq": 25, "cost_multiplier": 1 }
     ]
   },
   {
@@ -375,13 +372,13 @@
   {
     "type": "monstergroup",
     "name": "GROUP_SCHOOL",
+    "default": "mon_null",
     "//": "School monster spawns.",
     "monsters": [
-      { "monster": "mon_null", "weight": 1 },
-      { "monster": "mon_zombie_child", "weight": 4 },
-      { "monster": "mon_zombie_fat", "weight": 1 },
-      { "monster": "mon_zombie_tough", "weight": 1 },
-      { "monster": "mon_zombie", "weight": 3 }
+      { "monster": "mon_zombie_child", "freq": 650, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_fat", "freq": 50, "cost_multiplier": 1 },
+      { "monster": "mon_zombie_tough", "freq": 50, "cost_multiplier": 1 },
+      { "monster": "mon_zombie", "freq": 150, "cost_multiplier": 1 }
     ]
   },
   {

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -372,13 +372,13 @@
   {
     "type": "monstergroup",
     "name": "GROUP_SCHOOL",
-    "default": "mon_null",
     "//": "School monster spawns.",
     "monsters": [
-      { "monster": "mon_zombie_child", "freq": 650, "cost_multiplier": 1 },
-      { "monster": "mon_zombie_fat", "freq": 50, "cost_multiplier": 1 },
-      { "monster": "mon_zombie_tough", "freq": 50, "cost_multiplier": 1 },
-      { "monster": "mon_zombie", "freq": 150, "cost_multiplier": 1 }
+      { "monster": "mon_null", "weight": 1 },
+      { "monster": "mon_zombie_child", "weight": 4 },
+      { "monster": "mon_zombie_fat", "weight": 1 },
+      { "monster": "mon_zombie_tough", "weight": 1 },
+      { "monster": "mon_zombie", "weight": 3 }
     ]
   },
   {

--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -25,6 +25,7 @@
     * [Spawn monsters from a group with "monster"](#spawn-monsters-from-a-group-with-monster)
     * [Spawn items from a group with "item"](#spawn-items-from-a-group-with-item)
   * [Spawn a single monster with "place_monster"](#spawn-a-single-monster-with-place_monster)
+  * [Spawn an entire group of monsters with "place_monsters"](#spawn-an-entire-group-of-monsters-with-place_monsters)
   * [Spawn specific items with a "place_item" array](#spawn-specific-items-with-a-place_item-array)
   * [Extra map features with specials](#extra-map-features-with-specials)
     * [Place smoke, gas, or blood with "fields"](#place-smoke-gas-or-blood-with-fields)
@@ -571,6 +572,18 @@ Example:
 
 This places "mon_secubot" at random coordinate (7-18, 7-18). The monster is placed with 30% probablity. The placement is
 repeated by random number of times `[1-3]`.
+
+
+## Spawn an entire group of monsters with "place_monsters"
+Using `place_monsters` to spawn a group of monsters works in a similar fashion to `place_monster`. The key difference is that `place_monsters` guarantees that each valid entry in the group is spawned. It is strongly advised that you avoid using this flag with larger monster groups, as the total number of spawns is quite difficult to control.
+
+|Field|Description  |
+|--|--|
+| monster | The ID of the monster group that you wish to spawn |
+| x, y        | Spawn coordinates ( specific or area rectangle ). Value: 0-23 or `[ 0-23, 0-23 ]` - random value between `[ a, b ]`.
+| chance      | Represents a 1 in N chance that the entire group will spawn. This is done once for each repeat. If this dice roll fails, the entire group specified will not spawn. Leave blank to guarantee spawns.
+| repeat      | The spawning is repeated this many times. Can be a number or a range. Again, this represents the number of times the group will be spawned.
+| density | This number is multiplied by the spawn density of the world the player is in and then probabilistically rounded to determine how many times to spawn the group. This is done for each time the spawn is repeated. For instance, if the final multiplier from this calculation ends up being `2`, and the repeat value is `6`, then the group will be spawned `2 * 6` or 12 times.
 
 
 ## Spawn specific items with a "place_item" array


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfixes "Port spawn audits from DDA"

#### Purpose of change
Over the last month I have been slowly [auditing the spawn tables of various overmaps](https://github.com/CleverRaven/Cataclysm-DDA/pulls?q=is%3Apr+is%3Aclosed+author%3AInglonias+spawn+audit) in DDA. Some, such as parks and hospitals, had an absurd number of zombies for their size and importance, and others had high spawn variance which made them either too easy or too hard, but rarely good gameplay (trailer parks, sports arenas and fields, pools).

#### Describe the solution
Ported my spawn audits from DDA over to BN. I did this manually, rather than using a git cherry-pick, since I couldn't be bothered to learn how to do that across repositories. 

#### Describe alternatives you've considered
N/A

#### Testing
I ensured that the game starts with no JSON errors, and went around to the various overmap locations to ensure that numbers more or less matched up with what I see in DDA.

#### Additional context
I'm unreasonably proud of my work here considering all I really did was document a JSON flag and tweak a few numbers. Nonetheless, the overall effect is quite pleasant on gameplay, especially for parks given how common those are.
