### PR TITLE
Enable elevated bridges by default

### DIFF
--- a/data/mods/default.json
+++ b/data/mods/default.json
@@ -4,6 +4,6 @@
     "id": "dev:default",
     "name": "default",
     "description": "contains all the mods recommended by the developers",
-    "dependencies": [ "dda", "no_npc_food", "novitamins" ]
+    "dependencies": [ "dda", "no_npc_food", "novitamins", "elevated_bridges" ]
   }
 ]


### PR DESCRIPTION
Enable elevated bridges by default

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Features"Enable elevated bridges by default"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: Features"Enable elevated bridges by default"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Survey (https://www.reddit.com/r/cataclysmbn/comments/qyz509/does_anyone_play_with_zlevels_off/) and observation indicates that
1) Most players plays with z-levels on
2) A lot of players like 3d bridges

So it is better to enable elevated bridges mod by default
1) It should fit most players base. Players, who don't want that feature still can disable the mod and z-levels.
2) It will provide better presentation for game itself.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Enable "elevated_bridges" as default mod for new worlds.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Start creating new world
2) Observe default mod list
3) "elevated_bridges" must be enabled.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
None
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
