### PR TITLE
Small expanded digestive system buff

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -296,7 +296,7 @@
     "id": "bio_digestion",
     "type": "bionic",
     "name": { "str": "Expanded Digestive System" },
-    "description": "You have been outfitted with three synthetic stomachs and industrial-grade intestines.  Not only can you extract much more nutrition from food, but you are highly resistant to foodborne illness, and can sometimes eat rotten food.",
+    "description": "You have been outfitted with three synthetic stomachs and industrial-grade intestines.  Not only can you extract much more nutrition from food, but you are immune to foodborne illness, parasites, and can even eat rotten food.",
     "occupied_bodyparts": [ [ "torso", 20 ] ],
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ]
   },

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -269,7 +269,7 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Expanded Digestive System CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "This module contains three synthetic stomachs and industrial-grade intestines.  Not only will these extract much more nutrition from food, but also increase the user's resistance to foodborne illness, and occasionally allow the digestion of rotten food.",
+    "description": "This module contains three synthetic stomachs and industrial-grade intestines.  Not only will these extract much more nutrition from food, but also make the user immune to foodborne illness, parasites , and even allow the digestion of rotten food.",
     "price": 550000,
     "difficulty": 6
   },

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -269,7 +269,7 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Expanded Digestive System CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "This module contains three synthetic stomachs and industrial-grade intestines.  Not only will these extract much more nutrition from food, but also make the user immune to foodborne illness, parasites , and even allow the digestion of rotten food.",
+    "description": "This module contains three synthetic stomachs and industrial-grade intestines.  Not only will these extract much more nutrition from food, but also make the user immune to foodborne illness, parasites, and even allow the digestion of rotten food.",
     "price": 550000,
     "difficulty": 6
   },

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -861,7 +861,7 @@ bool player::eat( item &food, bool force )
     if( spoiled && !saprophage ) {
         add_msg_if_player( m_bad, _( "Ick, this %s doesn't taste so good…" ), food.tname() );
         if( !has_trait( trait_SAPROVORE ) && !has_trait( trait_EATDEAD ) &&
-            !has_bionic( bio_digestion ) {
+            !has_bionic( bio_digestion ) ) {
             add_effect( effect_foodpoison, rng( 6_minutes, ( nutr + 1 ) * 6_minutes ) );
         }
     } else if( spoiled && saprophage ) {

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -861,7 +861,7 @@ bool player::eat( item &food, bool force )
     if( spoiled && !saprophage ) {
         add_msg_if_player( m_bad, _( "Ick, this %s doesn't taste so good…" ), food.tname() );
         if( !has_trait( trait_SAPROVORE ) && !has_trait( trait_EATDEAD ) &&
-            ( !has_bionic( bio_digestion ) || one_in( 3 ) ) ) {
+            ( !has_bionic( bio_digestion ) ) {
             add_effect( effect_foodpoison, rng( 6_minutes, ( nutr + 1 ) * 6_minutes ) );
         }
     } else if( spoiled && saprophage ) {

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -861,7 +861,7 @@ bool player::eat( item &food, bool force )
     if( spoiled && !saprophage ) {
         add_msg_if_player( m_bad, _( "Ick, this %s doesn't taste so good…" ), food.tname() );
         if( !has_trait( trait_SAPROVORE ) && !has_trait( trait_EATDEAD ) &&
-            ( !has_bionic( bio_digestion ) ) {
+            ( !has_bionic( bio_digestion ) {
             add_effect( effect_foodpoison, rng( 6_minutes, ( nutr + 1 ) * 6_minutes ) );
         }
     } else if( spoiled && saprophage ) {

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -861,7 +861,7 @@ bool player::eat( item &food, bool force )
     if( spoiled && !saprophage ) {
         add_msg_if_player( m_bad, _( "Ick, this %s doesn't taste so good…" ), food.tname() );
         if( !has_trait( trait_SAPROVORE ) && !has_trait( trait_EATDEAD ) &&
-            ( !has_bionic( bio_digestion ) && one_in( 3 ) ) ) {
+            ( !has_bionic( bio_digestion ) ) {
             add_effect( effect_foodpoison, rng( 6_minutes, ( nutr + 1 ) * 6_minutes ) );
         }
     } else if( spoiled && saprophage ) {

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -861,7 +861,7 @@ bool player::eat( item &food, bool force )
     if( spoiled && !saprophage ) {
         add_msg_if_player( m_bad, _( "Ick, this %s doesn't taste so good…" ), food.tname() );
         if( !has_trait( trait_SAPROVORE ) && !has_trait( trait_EATDEAD ) &&
-            ( !has_bionic( bio_digestion ) {
+            !has_bionic( bio_digestion ) ) {
             add_effect( effect_foodpoison, rng( 6_minutes, ( nutr + 1 ) * 6_minutes ) );
         }
     } else if( spoiled && saprophage ) {

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -861,7 +861,7 @@ bool player::eat( item &food, bool force )
     if( spoiled && !saprophage ) {
         add_msg_if_player( m_bad, _( "Ick, this %s doesn't taste so good…" ), food.tname() );
         if( !has_trait( trait_SAPROVORE ) && !has_trait( trait_EATDEAD ) &&
-            ( !has_bionic( bio_digestion ) ) {
+            ( !has_bionic( bio_digestion ) && one_in( 3 ) ) ) {
             add_effect( effect_foodpoison, rng( 6_minutes, ( nutr + 1 ) * 6_minutes ) );
         }
     } else if( spoiled && saprophage ) {

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -737,7 +737,7 @@ ret_val<edible_rating> Character::will_eat( const item &food, bool interactive )
 
     if( food.rotten() ) {
         const bool saprovore = has_trait( trait_SAPROVORE );
-        if( !saprophage && !saprovore ) {
+        if( !saprophage && !saprovore && !has_bionic( bio_digestion ) ) {
             add_consequence( _( "This is rotten and smells awful!" ), edible_rating::rotten );
         }
     }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -861,7 +861,7 @@ bool player::eat( item &food, bool force )
     if( spoiled && !saprophage ) {
         add_msg_if_player( m_bad, _( "Ick, this %s doesn't taste so good…" ), food.tname() );
         if( !has_trait( trait_SAPROVORE ) && !has_trait( trait_EATDEAD ) &&
-            !has_bionic( bio_digestion ) ) {
+            !has_bionic( bio_digestion ) {
             add_effect( effect_foodpoison, rng( 6_minutes, ( nutr + 1 ) * 6_minutes ) );
         }
     } else if( spoiled && saprophage ) {


### PR DESCRIPTION
#### Summary

Buffed Expanded Digestive System to always prevent food poisoning, and also updated its descriptions to clarify this change, along with clarifying that it prevents Parasites.

#### Purpose of change

It felt weird for Expanded Digestive System to have a small chance of not preventing food poisoning, it was an unnecessary gamble and in my opinion made it a rather boring choice for a bionic. Now it will always prevent food poisoning, just like Saprovore.