### PR TITLE
Allow Mycus characters to use bandages in both menus

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -136,6 +136,7 @@ static const std::string flag_LUPINE( "LUPINE" );
 static const std::string flag_MYCUS_OK( "MYCUS_OK" );
 static const std::string flag_NEGATIVE_MONOTONY_OK( "NEGATIVE_MONOTONY_OK" );
 static const std::string flag_NO_BLOAT( "NO_BLOAT" );
+static const std::string flag_NO_INGEST( "NO_INGEST" );
 static const std::string flag_NO_PARASITES( "NO_PARASITES" );
 static const std::string flag_NO_RELOAD( "NO_RELOAD" );
 static const std::string flag_NUTRIENT_OVERRIDE( "NUTRIENT_OVERRIDE" );
@@ -684,7 +685,8 @@ ret_val<edible_rating> Character::can_eat( const item &food ) const
     }
 
     // For all those folks who loved eating marloss berries.  D:< mwuhahaha
-    if( has_trait( trait_M_DEPENDENT ) && !food.has_flag( flag_MYCUS_OK ) ) {
+    if( has_trait( trait_M_DEPENDENT ) && !food.has_flag( flag_MYCUS_OK ) &&
+        !food.has_flag( flag_NO_INGEST ) ) {
         return ret_val<edible_rating>::make_failure( edible_rating::inedible_mutation,
                 _( "We can't eat that.  It's not right for us." ) );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix Mycus Feeder denying use of NO_INGEST items"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Per discussion on the discord, I was reminded that Mycus characters couldn't use bandages, which was pointed out as an annoyance. Turns out they can use such times, but only from the activate menu, not the consume menu.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Changed the check in consumption.cpp allowing items with NO_INGEST to be applied by characters with Mycus Feeder, for consistency with being able to use such items in the action menu.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Breaking use of comestibles in general, even through the activate menu. Bad idea because that basically full-stop halts any form of consumable tool.
2. Adding some sort of regen trait to Mycus category, possibly requiring activatable mutations to be ported over to have a fungal equivalent to DDA's version of Hyper Metabolism.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compile and load tested.
2. Checked bandages are usable in both menus.
3. Checked affected file for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

![image](https://user-images.githubusercontent.com/11582235/147427493-680ace25-84da-4825-a54a-178d7854a71f.png)