### PR TITLE
Add floor lamp construction

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4441,12 +4441,12 @@
     "id": "constr_f_floor_lamp",
     "description": "Build floor lamp",
     "category": "FURN",
-    "required_skills": [ [ "fabrication", 4 ], [ "electronics", 1 ] ],
+    "required_skills": [ [ "fabrication", 2 ], [ "electronics", 0 ] ],
     "time": "20 m",
     "qualities": [ [ { "id": "SCREW", "level": 1 } ] ],
     "components": [ [ [ "cable", 2 ] ], [ [ "amplifier", 4 ] ], [ [ "light_bulb", 4 ] ], [ [ "steel_lump", 1 ] ], [ [ "pipe", 1 ] ] ],
     "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
     "pre_special": "check_empty",
-    "post_terrain": "f_floor_lamp"
+    "post_terrain": "f_floor_lamp_off"
   }
 ]

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4444,7 +4444,7 @@
     "required_skills": [ [ "fabrication", 4 ], [ "electronics", 1 ] ],
     "time": "20 m",
     "qualities": [ [ { "id": "SCREW", "level": 1 } ] ],
-    "components": [ [ [ "cable", 2 ] ], [ [ "amplifier", 4 ] ], [ [ "light_bulb", 4 ] ], [ [ "steel_lump", 1 ] ] , [ [ "pipe", 1 ] ] ],
+    "components": [ [ [ "cable", 2 ] ], [ [ "amplifier", 4 ] ], [ [ "light_bulb", 4 ] ], [ [ "steel_lump", 1 ] ], [ [ "pipe", 1 ] ] ],
     "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
     "pre_special": "check_empty",
     "post_terrain": "f_floor_lamp"

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4435,5 +4435,18 @@
     "components": [ [ [ "autodoc_couch", 1 ] ] ],
     "pre_special": "check_empty",
     "post_terrain": "f_autodoc_couch"
+  },
+  {
+    "type": "construction",
+    "id": "constr_f_floor_lamp",
+    "description": "Build floor lamp",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 4 ], [ "electronics", 1 ] ],
+    "time": "20 m",
+    "qualities": [ [ { "id": "SCREW", "level": 1 } ] ],
+    "components": [ [ [ "cable", 2 ] ], [ [ "amplifier", 4 ] ], [ [ "light_bulb", 4 ] ], [ [ "steel_lump", 1 ] ] , [ [ "pipe", 1 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_terrain": "f_floor_lamp"
   }
 ]


### PR DESCRIPTION
#### Summary

SUMMARY: Content "Add floor lamp construction"

#### Purpose of change

Floor lamp is a simple and good interior light source, but since it was unconstructible, it wasn't available in basement, second or higher floors you built.
This will add a simple construction recipe, which requires 2 cables, 4 amplifiers, 4 light bulbs, 1 steel lump, and 1 pipe, the maximum amount from the deconstruction recipe.

#### Describe the solution

Adding a construction recipe that results in a floor lamp.

#### Describe alternatives you've considered

#### Testing

Test completed. It works well, and if in a house with working eletric grid, it automatically lights on like normal floor lamp, from #1128.

#### Additional context
