### PR TITLE
feat(UI): [CR]Per-character default context keybindings for mutations

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1506,13 +1506,6 @@
   },
   {
     "type": "keybinding",
-    "id": "TOGGLE_EXAMINE",
-    "category": "MUTATIONS",
-    "name": "Toggle activate/examine",
-    "bindings": [ { "input_method": "keyboard", "key": "!" } ]
-  },
-  {
-    "type": "keybinding",
     "name": "Pause",
     "category": "DEFAULTMODE",
     "id": "pause",

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -10,6 +10,7 @@
 
 #include "calendar.h"
 #include "character.h"
+#include "character_keybinds.h"
 #include "enums.h"
 #include "item.h"
 #include "player.h"
@@ -19,6 +20,7 @@
 class JsonIn;
 class JsonObject;
 class JsonOut;
+class character_keybinds;
 class faction;
 class mission;
 class monster;
@@ -219,6 +221,8 @@ class avatar : public player
             return mon_visible;
         }
 
+        const character_keybinds &get_character_keybinds() const;
+
     private:
         std::unique_ptr<map_memory> player_map_memory;
         bool show_map_memory = true;
@@ -255,6 +259,9 @@ class avatar : public player
         int per_upgrade = 0;
 
         monster_visible_info mon_visible;
+
+        // Keybinds just for this specific character
+        pimpl<character_keybinds> keybinds;
 };
 
 avatar &get_avatar();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3172,7 +3172,7 @@ std::vector<std::string> Character::get_overlay_ids() const
     }
 
     // then get mutations
-    for( const std::pair<const trait_id, trait_data> &mut : my_mutations ) {
+    for( const std::pair<const trait_id, mutation_state> &mut : my_mutations ) {
         overlay_id = ( mut.second.powered ? "active_" : "" ) + mut.first.str();
         order = get_overlay_order_of_mutation( overlay_id );
         mutation_sorting.insert( std::pair<int, std::string>( order, overlay_id ) );
@@ -6273,7 +6273,7 @@ float Character::active_light() const
     lumination = static_cast<float>( maxlum );
 
     float mut_lum = 0.0f;
-    for( const std::pair<const trait_id, trait_data> &mut : my_mutations ) {
+    for( const std::pair<const trait_id, mutation_state> &mut : my_mutations ) {
         if( mut.second.powered ) {
             float curr_lum = 0.0f;
             for( const auto elem : mut.first->lumination ) {
@@ -7818,7 +7818,7 @@ void Character::recalculate_enchantment_cache()
     } );
 
     // get from traits/ mutations
-    for( const std::pair<const trait_id, trait_data> &mut_map : my_mutations ) {
+    for( const std::pair<const trait_id, mutation_state> &mut_map : my_mutations ) {
         const mutation_branch &mut = mut_map.first.obj();
 
         for( const enchantment_id &ench_id : mut.enchantments ) {
@@ -7847,7 +7847,7 @@ void Character::recalculate_enchantment_cache()
 void Character::rebuild_mutation_cache()
 {
     cached_mutations.clear();
-    for( const std::pair<const trait_id, trait_data> &mut : my_mutations ) {
+    for( const std::pair<const trait_id, mutation_state> &mut : my_mutations ) {
         cached_mutations.push_back( &mut.first.obj() );
     }
     for( const trait_id &mut : enchantment_cache->get_mutations() ) {
@@ -9635,7 +9635,7 @@ bool Character::has_opposite_trait( const trait_id &flag ) const
             return true;
         }
     }
-    for( const std::pair<const trait_id, trait_data> &mut : my_mutations ) {
+    for( const std::pair<const trait_id, mutation_state> &mut : my_mutations ) {
         for( const trait_id &canceled_trait : mut.first->cancels ) {
             if( canceled_trait == flag ) {
                 return true;

--- a/src/character_keybinds.h
+++ b/src/character_keybinds.h
@@ -9,15 +9,18 @@
 class character_keybinds
 {
     private:
-    using keybinds_map = std::map<std::string, action_attributes>;
+        using keybinds_map = std::map<std::string, action_attributes>;
         keybinds_map keybinds;
-        public:
-keybinds_map::const_iterator begin() const {
-    return keybinds.begin();
-}
-keybinds_map::const_iterator end() const {
-    return keybinds.end();
-}
+    public:
+        keybinds_map::const_iterator begin() const {
+            return keybinds.begin();
+        }
+        keybinds_map::const_iterator end() const {
+            return keybinds.end();
+        }
 };
+
+// Global function - might not be the cleanest way to do it
+const character_keybinds &get_character_keybinds();
 
 #endif // CATA_SRC_CHARACTER_KEYBINDS_H

--- a/src/character_keybinds.h
+++ b/src/character_keybinds.h
@@ -1,0 +1,23 @@
+#pragma once
+#ifndef CATA_SRC_CHARACTER_KEYBINDS_H
+#define CATA_SRC_CHARACTER_KEYBINDS_H
+
+#include <map>
+
+#include "input.h"
+
+class character_keybinds
+{
+    private:
+    using keybinds_map = std::map<std::string, action_attributes>;
+        keybinds_map keybinds;
+        public:
+keybinds_map::const_iterator begin() const {
+    return keybinds.begin();
+}
+keybinds_map::const_iterator end() const {
+    return keybinds.end();
+}
+};
+
+#endif // CATA_SRC_CHARACTER_KEYBINDS_H

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -47,6 +47,7 @@
 #include "catacharset.h"
 #include "character.h"
 #include "character_martial_arts.h"
+#include "character_keybinds.h"
 #include "clzones.h"
 #include "colony.h"
 #include "color.h"
@@ -2522,6 +2523,11 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "MOUSE_MOVE" );
     ctxt.register_action( "SELECT" );
     ctxt.register_action( "SEC_SELECT" );
+    // TODO: Proper check if the character is the one we want (initialized etc.)
+    const avatar &u = get_avatar();
+    for( const auto &pr : u.get_character_keybinds() ) {
+        ctxt.register_action(pr.first);
+    }
     return ctxt;
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -317,7 +317,7 @@ game::~game() = default;
 // Load everything that will not depend on any mods
 void game::load_static_data()
 {
-    // UI stuff, not mod-specific per definition
+    // UI stuff that does not depend on mods
     inp_mngr.init();            // Load input config JSON
     // Init mappings for loading the json stuff
     DynamicDataLoader::get_instance();
@@ -2523,10 +2523,8 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "MOUSE_MOVE" );
     ctxt.register_action( "SELECT" );
     ctxt.register_action( "SEC_SELECT" );
-    // TODO: Proper check if the character is the one we want (initialized etc.)
-    const avatar &u = get_avatar();
-    for( const auto &pr : u.get_character_keybinds() ) {
-        ctxt.register_action(pr.first);
+    for( const std::string &action : inp_mngr.get_custom_actions_for_context( "DEFAULTMODE" ) ) {
+        ctxt.register_action( action );
     }
     return ctxt;
 }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2050,7 +2050,7 @@ bool game::handle_action()
                 u.power_bionics();
                 break;
             case ACTION_MUTATIONS:
-                u.power_mutations();
+                mutations::power_mutations( u );
                 break;
 
             case ACTION_SORT_ARMOR:

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -523,6 +523,7 @@ void DynamicDataLoader::unload_data()
 {
     finalized = false;
 
+    inp_mngr.reset();
     achievement::reset();
     activity_type::reset();
     ammo_effects::reset();

--- a/src/input.h
+++ b/src/input.h
@@ -178,10 +178,14 @@ struct input_event {
  * A set of attributes for an action
  */
 struct action_attributes {
-    action_attributes() : is_user_created( false ) {}
-    bool is_user_created;
+    action_attributes() = default;
+    bool is_user_created = false;
+    /** Runtime generated keybinding, don't save with the rest. */
+    bool is_custom = false;
     translation name;
     std::vector<input_event> input_events;
+    // TODO?: cata::optional?
+    std::string parent_context;
 };
 
 // Definitions for joystick/gamepad.
@@ -242,10 +246,21 @@ class input_manager
          */
         void init();
         /**
-         * Opposite of @ref init, save the data that has been loaded by @ref init,
+         * Save the data that has been loaded by @ref init,
          * and possibly been modified.
          */
         void save();
+        /**
+         * Reloads the mod-independent data.
+         */
+        void reset();
+
+        /**
+         * Adds a mod-dependent action.
+         */
+        void add_custom_action( const std::string &action_descriptor, const std::string &context,
+                                const translation &name );
+        std::vector<std::string> get_custom_actions_for_context( const std::string &context ) const;
 
         /**
          * Return the previously pressed key, or 0 if there is no previous input

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -164,7 +164,7 @@ void Character::set_mutation( const trait_id &trait )
     if( iter != my_mutations.end() ) {
         return;
     }
-    my_mutations.emplace( trait, trait_data{} );
+    my_mutations.emplace( trait, mutation_state{} );
     rebuild_mutation_cache();
     mutation_effect( trait );
     recalc_sight_limits();
@@ -480,7 +480,7 @@ bool Character::can_install_cbm_on_bp( const std::vector<bodypart_id> &bps ) con
 void Character::activate_mutation( const trait_id &mut )
 {
     const mutation_branch &mdata = mut.obj();
-    trait_data &tdata = my_mutations[mut];
+    mutation_state &tdata = my_mutations[mut];
     int cost = mdata.cost;
     // You can take yourself halfway to Near Death levels of hunger/thirst.
     // Fatigue can go to Exhausted.
@@ -666,7 +666,7 @@ void Character::deactivate_mutation( const trait_id &mut )
 
 trait_id Character::trait_by_invlet( const int ch ) const
 {
-    for( const std::pair<const trait_id, trait_data> &mut : my_mutations ) {
+    for( const std::pair<const trait_id, mutation_state> &mut : my_mutations ) {
         if( mut.second.key == ch ) {
             return mut.first;
         }
@@ -1752,4 +1752,14 @@ std::string Character::visible_mutations( const int visibility_cap ) const
         return std::string();
     } );
     return trait_str;
+}
+
+void Character::set_mutation_state( const trait_id &mut, const mutation_state &new_state )
+{
+    auto iter = my_mutations.find( mut );
+    if( iter != my_mutations.end() ) {
+        iter->second = new_state;
+    }
+
+    debugmsg( "Tried to set state of mutation %s that isn't in my_mutations", mut.str() );
 }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1759,7 +1759,7 @@ void Character::set_mutation_state( const trait_id &mut, const mutation_state &n
     auto iter = my_mutations.find( mut );
     if( iter != my_mutations.end() ) {
         iter->second = new_state;
+    } else {
+        debugmsg( "Tried to set state of mutation %s that isn't in my_mutations", mut.str() );
     }
-
-    debugmsg( "Tried to set state of mutation %s that isn't in my_mutations", mut.str() );
 }

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -524,4 +524,26 @@ mutagen_attempt mutagen_common_checks( Character &guy, const item &it, bool stro
 
 void test_crossing_threshold( Character &guy, const mutation_category_trait &m_category );
 
+namespace mutations
+{
+
+enum class power_mut_ui_cmd {
+    Exit,
+    Activate,
+    Deactivate,
+};
+struct power_mut_ui_result {
+    power_mut_ui_result() = default;
+    power_mut_ui_result( power_mut_ui_cmd cmd, const trait_id &mut )
+        : cmd( cmd ), mut( mut )
+    {}
+    power_mut_ui_cmd cmd;
+    trait_id mut;
+};
+
+power_mut_ui_result power_mutations_ui( Character &c );
+void power_mutations( Character &c );
+
+} // namespace mutations
+
 #endif // CATA_SRC_MUTATION_H

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -20,6 +20,9 @@
 #include "trait_group.h"
 #include "translations.h"
 
+// To create nested bindings
+#include "input.h"
+
 using TraitGroupMap =
     std::map<trait_group::Trait_group_tag, shared_ptr_fast<Trait_group>>;
 using TraitSet = std::set<trait_id>;
@@ -683,6 +686,8 @@ void mutation_branch::finalize()
         for( const std::string &cat : branch.category ) {
             mutations_category[cat].push_back( trait_id( branch.id ) );
         }
+
+        inp_mngr.add_custom_action( branch.id.str(), "mutations", branch.raw_name );
     }
     finalize_trait_blacklist();
 }

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -252,7 +252,7 @@ power_mut_ui_result power_mutations_ui( Character &c )
 #endif
 
     // TODO: Structure instead of ugly hack - biggest problem is Android testing
-    for( const auto &a : active ) {
+    for( const trait_id &a : active ) {
         register_mutation( ctxt, a );
     }
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2792,7 +2792,7 @@ std::vector<trait_id> Character::get_base_traits() const
 std::vector<trait_id> Character::get_mutations( bool include_hidden ) const
 {
     std::vector<trait_id> result;
-    for( const std::pair<const trait_id, trait_data> &t : my_mutations ) {
+    for( const std::pair<const trait_id, mutation_state> &t : my_mutations ) {
         if( include_hidden || t.first.obj().player_display ) {
             result.push_back( t.first );
         }

--- a/src/player.h
+++ b/src/player.h
@@ -175,7 +175,6 @@ class player : public Character
 
         /** Generates and handles the UI for player interaction with installed bionics */
         void power_bionics();
-        void power_mutations();
 
         /** Returns the bionic with the given invlet, or NULL if no bionic has that invlet */
         bionic *bionic_by_invlet( int ch );
@@ -461,17 +460,6 @@ class player : public Character
         bool can_sleep();
 
     private:
-        enum class power_mut_ui_cmd {
-            Exit,
-            Activate,
-            Deactivate,
-        };
-        struct power_mut_ui_result {
-            power_mut_ui_cmd cmd;
-            trait_id mut;
-        };
-        power_mut_ui_result power_mutations_ui();
-
         /** last time we checked for sleep */
         time_point last_sleep_check = calendar::turn_zero;
         bool bio_soporific_powered_at_last_sleep_check = false;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -331,7 +331,7 @@ void character_id::deserialize( JsonIn &jsin )
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ///// Character.h, avatar + npc
 
-void Character::trait_data::serialize( JsonOut &json ) const
+void mutation_state::serialize( JsonOut &json ) const
 {
     json.start_object();
     json.member( "key", key );
@@ -340,7 +340,7 @@ void Character::trait_data::serialize( JsonOut &json ) const
     json.end_object();
 }
 
-void Character::trait_data::deserialize( JsonIn &jsin )
+void mutation_state::deserialize( JsonIn &jsin )
 {
     JsonObject data = jsin.get_object();
     data.allow_omitted_members();

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -200,7 +200,7 @@ void Character::suffer_water_damage( const mutation_branch &mdata )
 }
 
 void Character::suffer_mutation_power( const mutation_branch &mdata,
-                                       Character::trait_data &tdata )
+                                       mutation_state &tdata )
 {
     if( tdata.powered && tdata.charge > 0 ) {
         // Already-on units just lose a bit of charge
@@ -1478,12 +1478,12 @@ void Character::suffer()
         process_bionic( i );
     }
 
-    for( std::pair<const trait_id, Character::trait_data> &mut : my_mutations ) {
+    for( std::pair<const trait_id, mutation_state> &mut : my_mutations ) {
         const mutation_branch &mdata = mut.first.obj();
         if( calendar::once_every( 1_minutes ) ) {
             suffer_water_damage( mdata );
         }
-        Character::trait_data &tdata = mut.second;
+        mutation_state &tdata = mut.second;
         if( tdata.powered ) {
             suffer_mutation_power( mdata, tdata );
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

Implement keybindings specific to a character, working in default context, but bound from a more specific one.

#### Purpose of change

Being able to bind abilities, such as mutations, to default context, would help a lot with QoL of certain "moves".
For example, using a gun vs using finger laser bionic.

Since there are rather few "free" keybinds and mutations and bionics are supposed to vary between characters, those keybinds should be per-character, not global to the game.

Fixes #1059

#### Describe the solution

Per character keybindings are a separate set of keybindings applied on top of existing local+global ones.
They are saved and loaded with a character and overwrite regular local+global binds.
Character keybindings also exist in local and global variants.

Mutation UI, and for now only mutation UI, generates actions (the "thing you bind to a key") for individual mutations. Unlike static ones, those are world-dependent, similar to item actions.
Unlike item actions, those actions have to be inserted into input manager, since they are "seen" outside their parent context.
When any of those actions is bound in mutation UI, it will also appear in default mode - the keybind set used for character actions when there are no menus open and keypad moves the character etc. If a mutation action is executed, it works as if it was activated from mutation UI, but doesn't require opening mutation UI.

Shortcomings:
* [ ] Generated mutation actions should get a struct. Currently they are stringly typed, created by string concatenation and parsed from a string, which is obviously bad practice. This is to minimize conflict with Android builds, which have their own input management code. I'll fix it later, when I get it working and get my Android environment good enough to test things in it
* [ ] Need an idea how to handle world-dependent global (non-character) keybinds in a world that lacks proper dependencies. Error? Skip? Refuse to bind? Allow binding, but warn? Silently load and just have an error string for those cases?
* [ ] Character keybinds on top of non-character ones should start working...

#### Describe alternatives you've considered

For ranged mutations/bionics, a hardcoded "configure character to default this thing when firing" button would be useful.
Could also cover throwing.

I could have picked a different UI to work with here. For example, bionics or item actions.

#### Testing

Ideally, all of this should work:
* Debug in butterfly wings and vomit3 mutations
* Open mutation UI, then keybindings
* Add a character global keybind for butterfly wings on `b`
  * Warning should be printed
  * The existing keybind for `b` for other characters is not removed
* Add a non-character global for vomit3 on `v`
  * This should overwrite the keybind for everyone
* Press `b` in default mode
* Butterfly wings mutation is activated
* Press `b` twice
* Butterfly wings mutation is deactivated and then reactivated
* Press `v` in default mode
* vomit3 mutation is activated
* Save+load
* Keybinds persist
* Load different character, with no vomit3 mutation
* `b` key is bound to "go southwest"
* Press `v`
* "Character doesn't have this mutation" message is printed
* Load different character, in a world where vomit3 mutation is blacklisted (and another world, where this mutation is never loaded)
* Press `v`
* Nothing happens (no crash or debug messages, but regular messages are fine)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
