### PR TITLE
Streamline coal recipes

### DIFF
--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -763,7 +763,7 @@
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "survival marker" },
-    "description": "This is a sharpened piece of charcoal that is almost guaranteed to make your hands all covered in charcoal.  Use it to write something down.",
+    "description": "This is a sharpened piece of coal or charcoal that is almost guaranteed to make your hands all covered in soot.  Use it to write something down.",
     "weight": "113 g",
     "volume": "15 ml",
     "price": 0,

--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -16,7 +16,7 @@
       [ "book_icef", 5 ]
     ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "components": [ [ [ "chem_saltpetre", 150 ] ], [ [ "chem_sulphur", 300 ] ], [ [ "charcoal", 10 ], [ "coal_lump", 10 ] ] ]
+    "components": [ [ [ "chem_saltpetre", 150 ] ], [ [ "chem_sulphur", 300 ] ], [ [ "charcoal", 10 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -255,7 +255,7 @@
     "flags": [ "UNCRAFT_BY_QUANTITY" ],
     "components": [
       [ [ "oxy_powder", 50 ] ],
-      [ [ "charcoal", 5 ], [ "coal_lump", 5 ] ],
+      [ [ "charcoal", 5 ] ],
       [ [ "superglue", 1 ] ],
       [ [ "scrap", 2 ], [ "can_food_unsealed", 1 ], [ "can_drink_unsealed", 1 ], [ "canister_empty", 1 ] ]
     ]
@@ -312,7 +312,7 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "oxy_powder", 50 ] ],
-      [ [ "charcoal", 5 ], [ "coal_lump", 5 ] ],
+      [ [ "charcoal", 5 ] ],
       [ [ "superglue", 1 ] ],
       [ [ "scrap", 2 ], [ "can_food_unsealed", 1 ], [ "can_drink_unsealed", 1 ], [ "canister_empty", 1 ] ]
     ]

--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -163,7 +163,7 @@
     "components": [
       [ [ "water_clean", 1 ], [ "water", 1 ] ],
       [ [ "scrap", 1 ] ],
-      [ [ "coal_lump", 5 ], [ "lye_powder", 20 ] ]
+      [ [ "charcoal", 5 ], [ "coal_lump", 5 ], [ "lye_powder", 20 ] ]
     ]
   },
   {

--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -163,7 +163,7 @@
     "components": [
       [ [ "water_clean", 1 ], [ "water", 1 ] ],
       [ [ "scrap", 1 ] ],
-      [ [ "charcoal", 5 ], [ "coal_lump", 5 ], [ "lye_powder", 20 ] ]
+      [ [ "coal_lump", 5 ], [ "lye_powder", 20 ] ]
     ]
   },
   {
@@ -726,7 +726,7 @@
     "autolearn": true,
     "byproducts": [ [ "chem_zinc" ] ],
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "BOIL", "level": 2 } ],
-    "components": [ [ [ "material_zincite", 1 ] ], [ [ "coal_lump", 1 ] ] ]
+    "components": [ [ [ "material_zincite", 1 ] ], [ [ "charcoal", 1 ] ] ]
   },
   {
     "result": "chem_zinc_powder",
@@ -739,7 +739,7 @@
     "time": "2 h",
     "autolearn": true,
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "BOIL", "level": 2 } ],
-    "components": [ [ [ "chem_zinc", 785 ] ], [ [ "coal_lump", 25 ], [ "charcoal", 50 ] ] ]
+    "components": [ [ [ "chem_zinc", 785 ] ], [ [ "charcoal", 50 ] ] ]
   },
   {
     "result": "chem_manganese_dioxide",

--- a/data/json/recipes/chem/drugs.json
+++ b/data/json/recipes/chem/drugs.json
@@ -227,7 +227,7 @@
     "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
     "components": [
       [ [ "syringe", 1 ] ],
-      [ [ "charcoal", 5 ], [ "coal_lump", 5 ] ],
+      [ [ "charcoal", 5 ] ],
       [ [ "datura_seed", 8 ] ],
       [ [ "salt_water", 1 ], [ "saline", 5 ] ],
       [ [ "bleach", 1 ], [ "oxy_powder", 100 ] ]
@@ -334,7 +334,7 @@
       [ [ "material_quicklime", 1 ] ],
       [ [ "scrap", 1 ] ],
       [ [ "ammonia", 1 ] ],
-      [ [ "charcoal", 5 ], [ "coal_lump", 5 ] ],
+      [ [ "charcoal", 5 ] ],
       [ [ "lye_powder", 5 ] ]
     ]
   },

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -45,7 +45,7 @@
     "id": "cvd_diamond",
     "type": "requirement",
     "//": "Materials required to apply diamond coating (per 250ml volume)",
-    "components": [ [ [ "plasma", 5 ] ], [ [ "charcoal", 25 ], [ "coal_lump", 25 ] ] ]
+    "components": [ [ [ "plasma", 5 ] ], [ [ "coal_lump", 25 ] ] ]
   },
   {
     "id": "autoclave",


### PR DESCRIPTION
#### Summary
SUMMARY: [Balance] "Streamline coal recipes"

#### Purpose of change

Some recipes in CBN for coal and charcoal are used interchangeably when they are not the same material. This change will streamline charcoal so that it is used in most of the recipes instead of coal, with a few exceptions. Coal will have it's purpose further geared towards being mainly a fuel source, with the exception of ammonia and diamond coating weapons. Most of these changes are reflected in the real-world, with some obvious exceptions (adrenaline, Prussian blue)

#### Describe the solution

Components: coal removed from black powder recipe, leaving charcoal
Other: coal removed from rebreather / gas filter recipe, leaving charcoal
Chems: charcoal removed from ammonia, leaving coal
Chems: coal removed from zinc production, replaced with charcoal
Drugs: coal removed from Prussian blue and adrenaline recipes, leaving charcoal
Materials: charcoal removed from diamond coating recipe, leaving coal
Misc: update description of survival marker to reflect that it can be made with both charcoal and coal