### PR TITLE
Fix to .30-06 M2 AP (Black Powder) values and naming.

### DIFF
--- a/data/json/items/ammo/3006.json
+++ b/data/json/items/ammo/3006.json
@@ -68,9 +68,9 @@
   },
   {
     "id": "bp_3006fmj",
-    "copy-from": "bp_3006",
+    "copy-from": "3006fmj",
     "type": "AMMO",
-    "name": { "str": ".30-06 Springfield M2 AP, black powder" },
+    "name": { "str": ".30-06 M2 AP, black powder" },
     "proportional": {
       "price": 0.3,
       "damage": { "damage_type": "stab", "amount": 0.76, "armor_penetration": 0.5 },


### PR DESCRIPTION
M2 AP BP ammo was derived from normal 3006 BP, which made it worse than any item. Changed this to copy-from the normal M2 AP ammo before applying BP modifiers. Name also changed to reflect correct M2 AP naming.

Fixes #1213
