### PR TITLE
Fixed atomic battery itemgroups having wrong items

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -694,20 +694,20 @@
     "id": "ammo_atomic_batteries",
     "type": "item_group",
     "items": [
-      { "item": "light_battery_cell", "prob": 4, "charges": [ 500, 1000 ] },
+      { "item": "light_atomic_battery_cell", "prob": 4, "charges": [ 500, 1000 ] },
       { "item": "light_minus_atomic_battery_cell", "prob": 3, "charges": [ 250, 500 ] },
-      { "item": "medium_battery_cell", "prob": 2, "charges": [ 2500, 5000 ] },
-      { "item": "heavy_battery_cell", "prob": 1, "charges": [ 5000, 10000 ] }
+      { "item": "medium_atomic_battery_cell", "prob": 2, "charges": [ 2500, 5000 ] },
+      { "item": "heavy_atomic_battery_cell", "prob": 1, "charges": [ 5000, 10000 ] }
     ]
   },
   {
     "id": "ammo_atomic_batteries_full",
     "type": "item_group",
     "items": [
-      { "item": "light_battery_cell", "prob": 4, "charges": 1000 },
+      { "item": "light_atomic_battery_cell", "prob": 4, "charges": 1000 },
       { "item": "light_minus_atomic_battery_cell", "prob": 3, "charges": 500 },
-      { "item": "medium_battery_cell", "prob": 2, "charges": 5000 },
-      { "item": "heavy_battery_cell", "prob": 1, "charges": 10000 }
+      { "item": "medium_atomic_battery_cell", "prob": 2, "charges": 5000 },
+      { "item": "heavy_atomic_battery_cell", "prob": 1, "charges": 10000 }
     ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Quickfix for atomic battery itemgroups"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fixes a mistake I made ages ago in Cataclysm++ that in turn got ported over when https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1109 used the itemgroups from it as a base.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Updates itemgroups `ammo_atomic_batteries` and `ammo_atomic_batteries_full` to actually use item IDs for the atomic batteries.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Putting it off after having spotted it.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and load errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
