### PR TITLE
Make bionic corpse identification a bit more visible to the player

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1207,6 +1207,11 @@
     "context": [  ]
   },
   {
+    "id": "CBM_SCANNED",
+    "type": "json_flag",
+    "context": [  ]
+  },
+  {
     "id": "CHALLENGE",
     "type": "json_flag",
     "context": [  ]

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4443,7 +4443,8 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     }
     if( has_flag( flag_CBM_SCANNED ) ) {
         tagtext += _( " (CBM detected)" );
-    } if( has_flag( flag_ETHEREAL_ITEM ) ) {
+    }
+    if( has_flag( flag_ETHEREAL_ITEM ) ) {
         tagtext += string_format( _( " (%s turns)" ), get_var( "ethereal" ) );
     } else if( goes_bad() || is_food() ) {
         if( has_own_flag( "DIRTY" ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4442,7 +4442,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         }
     }
     if( has_flag( flag_CBM_SCANNED ) ) {
-        tagtext += _( " (CBM detected)" );
+        tagtext += _( " (bionic detected)" );
     }
     if( has_flag( flag_ETHEREAL_ITEM ) ) {
         tagtext += string_format( _( " (%s turns)" ), get_var( "ethereal" ) );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4441,7 +4441,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
             tagtext += _( " (unread)" );
         }
     }
-    if( has_flag( flag_CBM_SCANNED ) ) {
+    if( has_var( "bionics_scanned_by" ) && has_flag( flag_CBM_SCANNED ) ) {
         tagtext += _( " (bionic detected)" );
     }
     if( has_flag( flag_ETHEREAL_ITEM ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -165,6 +165,7 @@ static const std::string flag_BIPOD( "BIPOD" );
 static const std::string flag_BYPRODUCT( "BYPRODUCT" );
 static const std::string flag_CABLE_SPOOL( "CABLE_SPOOL" );
 static const std::string flag_CANNIBALISM( "CANNIBALISM" );
+static const std::string flag_CBM_SCANNED( "CBM_SCANNED" );
 static const std::string flag_CHARGEDIM( "CHARGEDIM" );
 static const std::string flag_COLLAPSIBLE_STOCK( "COLLAPSIBLE_STOCK" );
 static const std::string flag_CONDUCTIVE( "CONDUCTIVE" );
@@ -4440,7 +4441,9 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
             tagtext += _( " (unread)" );
         }
     }
-    if( has_flag( flag_ETHEREAL_ITEM ) ) {
+    if( has_flag( flag_CBM_SCANNED ) ) {
+        tagtext += _( " (CBM detected)" );
+    } if( has_flag( flag_ETHEREAL_ITEM ) ) {
         tagtext += string_format( _( " (%s turns)" ), get_var( "ethereal" ) );
     } else if( goes_bad() || is_food() ) {
         if( has_own_flag( "DIRTY" ) ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2312,6 +2312,7 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
 
             corpse.set_var( "bionics_scanned_by", p->getID().get_value() );
             if( !cbms.empty() ) {
+                corpse.set_flag( "CBM_SCANNED" );
                 std::string bionics_string =
                     enumerate_as_string( cbms.begin(), cbms.end(),
                 []( const item * entry ) -> std::string {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Interface "Flag corpses confirmed to have bionics to make them easier to sort"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Per some discussion on the BN discord, a thought that came up is that the bionic scanner changes the description of corpses that've been tested positive for CBMs, but it would be more useful for sorting out what corpses are worth dissecting if a positive scan was more visible.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Updated flags.json to add `CBM_SCANNED` flag.
2. Updated item.cpp so that items that have been scanned and have the flag will show relevant tagtext, per feedback.
3. Updated iuse.cpp so that the bionic scanner marks corpses with the flag when it confirms them to have CBMs.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Add a "CBMs were detected in this corpse, you may wish to dissect it instead" message to the summary for each butchery method in the butchery menu, if the currently-selected corpse has the flag. This will make it hint to new players the intended way to get CBMs.
2. Find a way to also tagtext the flag to the monster name when selecting which monster to butcher, which will help make it easier to track which ones have detected CBMs when you're sifting through a pile of corpses.
3. Finding some way to automatically add a similiar flag to corpses when CBMs are generated, which adds a more generic "you can discern evidence of something embedded in the corpse" message in the correct contexts if you have enough first aid skill. This would logically be replaced with the effects of a positive ID from the scanner if scanned. That said, this feature probably should only hint at CBMs if an especially easy-to-detect CBM (like armor plating) is generated, and/or require higher skill to detect less visible CBMs, making it a more complex change beyond the scope of this PR.
4. Making chance of generating bionics on a corpse not effectively 100% (see below) in exchange for a correspending increase in the chance of successfully harvesting them without damage.
5. Shortening the tagtext to just `(CBM)` instead of `(bionic detected)`.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested.
2. Spawned in and killed some basic zeds, confirmed they didn't show the flag.
3. Spawned in and killed some zombie technicians, confirmed they didn't yet show the flag yet.
4. Spawned in and used a bionic scanner, confirmed that bionic zeds gained the flag.
5. Checked to confirm the zombie corpses still didn't show as having CBMs after scanning.
6. Debug-spawned in a corpse with the flag manually added, confirmed it didn't show with the tagtext yet due to not having been scanned.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Two oddities I found:
1. There seems to not actually be any chance of having NO bionics in a corpse, so this is still only a newbie-friendly feature. Far as I can tell, experienced players can still be safe in assuming that every bionic monster will have SOMETHING generate in them, and thus it will never be useful for allowing the player to tell at a glance which bionic zeds can be safely ignored.
2. Broken cyborgs were also tested, and don't tagtext (fresh) to their names like normal zeds, presumably due to body materials? I checked broken cyborg corpses in a test build too, just to confirm it wasn't caused by this PR (which seemed unlikely since technician zombies with the flag still also showed as fresh).