### PR TITLE
Changes to Web Rope and Web Diver mutations

### DIFF
--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -1141,5 +1141,30 @@
       "sound_fail": "whump.",
       "items": [ { "item": "grip_hook", "count": [ 4, 4 ] }, { "item": "rope_30", "count": [ 1, 1 ] } ]
     }
+  },
+ {
+  "type": "furniture",
+  "id": "f_rope_up_web",
+  "name": "web rope leading up",
+  "looks_like": "t_rope_up",
+  "description": "A web rope.  You could climb it up.",
+  "symbol": "<",
+  "color": "white",
+  "move_cost_mod": 1,
+  "required_str": 10,
+  "flags": [
+    "LADDER",
+    "TRANSPARENT",
+    "SEEN_FROM_ABOVE"
+  ],
+  "examine_action": "deployed_furniture",
+  "deployed_item": "rope_30",
+  "bash": {
+    "str_min": 3,
+    "str_max": 40,
+    "sound": "smash!",
+    "sound_fail": "whump.",
+    "items": [ { "item": "rope_30", "count": [ 1, 1 ] } ]
   }
+}
 ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3613,7 +3613,7 @@
     "id": "WEB_RAPPEL",
     "name": { "str": "Web Diver" },
     "points": 1,
-    "description": "Your webbing is easily strong enough to support your weight.  You'll use it to descend down any sheer drops you may encounter.",
+    "description": "Your webbing is easily strong enough to support your weight.  You'll use it to descend down any sheer drops you may encounter, and to catch yourself should you fall.",
     "prereqs": [ "WEB_WEAVER" ],
     "threshreq": [ "THRESH_SPIDER" ],
     "category": [ "SPIDER" ]
@@ -3623,15 +3623,14 @@
     "id": "WEB_ROPE",
     "name": { "str": "Rope Webs" },
     "points": 2,
-    "description": "With spinnerets like THESE, who needs rope?!  Activate to produce rope.",
+    "description": "With spinnerets like THESE, who needs rope?!  Activate to sling a web rope that you can climb, and can be disassembled into rope.",
     "prereqs": [ "WEB_WEAVER" ],
     "threshreq": [ "THRESH_SPIDER" ],
     "category": [ "SPIDER" ],
     "active": true,
     "cost": 30,
     "hunger": true,
-    "thirst": true,
-    "spawn_item": { "type": "rope_30", "message": "You spin a rope from your silk." }
+    "thirst": true
   },
   {
     "type": "mutation",

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -83,6 +83,7 @@ static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
 static const trait_id trait_TREE_COMMUNION( "TREE_COMMUNION" );
 static const trait_id trait_VOMITOUS( "VOMITOUS" );
 static const trait_id trait_WEB_WEAVER( "WEB_WEAVER" );
+static const trait_id trait_WEB_ROPE( "WEB_ROPE" );
 
 namespace io
 {
@@ -531,6 +532,17 @@ void Character::activate_mutation( const trait_id &mut )
     if( mut == trait_WEB_WEAVER ) {
         g->m.add_field( pos(), fd_web, 1 );
         add_msg_if_player( _( "You start spinning web with your spinnerets!" ) );
+    }else if( mut == trait_WEB_ROPE) {
+        if (g->m.move_cost(pos()) != 2 && g->m.move_cost(pos()) != 3) {
+            add_msg_if_player(m_info, _("You can't spin a web rope there."));
+        } else if (g->m.has_furn(pos())) {
+            add_msg_if_player(m_info, _("There is already furniture at that location."));
+        } else {
+            add_msg_if_player(m_good, _("You spin a climbable rope of web."));
+            g->m.furn_set(pos(), furn_str_id("f_rope_up_web"));
+            mod_moves(to_turns<int>(2_seconds));
+        }
+        tdata.powered = false;
     } else if( mut == trait_BURROW ) {
         tdata.powered = false;
         item burrowing_item( itype_id( "fake_burrowing" ) );

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -355,7 +355,7 @@ player::power_mut_ui_result player::power_mutations_ui()
                                 ret.cmd = power_mut_ui_cmd::Deactivate;
                                 ret.mut = mut_id;
                                 exit = true;
-                            } else if( ( !mut_data.hunger || get_kcal_percent() >= 0.8f ) &&
+                            } else if( ( !mut_data.hunger || get_kcal_percent() >= 0.5f ) &&
                                        ( !mut_data.thirst || get_thirst() <= thirst_levels::dehydrated ) &&
                                        ( !mut_data.fatigue || get_fatigue() <= 400 ) ) {
                                 if( trans && !trans->msg_transform.empty() ) {

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -55,6 +55,7 @@ static const itype_id itype_rope_30( "rope_30" );
 
 static const trait_id trait_WINGS_BIRD( "WINGS_BIRD" );
 static const trait_id trait_WINGS_BUTTERFLY( "WINGS_BUTTERFLY" );
+static const trait_id trait_WEB_RAPPEL( "WEB_RAPPEL" );
 
 static const mtype_id mon_blob( "mon_blob" );
 static const mtype_id mon_shadow( "mon_shadow" );
@@ -766,6 +767,8 @@ bool trapfunc::pit( const tripoint &p, Creature *c, item * )
         if( ( n->has_trait( trait_WINGS_BIRD ) ) || ( ( one_in( 2 ) ) &&
                 ( n->has_trait( trait_WINGS_BUTTERFLY ) ) ) ) {
             n->add_msg_if_player( _( "You flap your wings and flutter down gracefully." ) );
+        } else if (n->has_trait(trait_WEB_RAPPEL)) {
+            n->add_msg_if_player(_("You quickly spin a line of silk and rappel down."));
         } else if( n->has_active_bionic( bio_shock_absorber ) ) {
             n->add_msg_if_player( m_info,
                                   _( "You hit the ground hard, but your shock absorbers handle the impact admirably!" ) );
@@ -815,6 +818,8 @@ bool trapfunc::pit_spikes( const tripoint &p, Creature *c, item * )
         if( ( n->has_trait( trait_WINGS_BIRD ) ) || ( ( one_in( 2 ) ) &&
                 ( n->has_trait( trait_WINGS_BUTTERFLY ) ) ) ) {
             n->add_msg_if_player( _( "You flap your wings and flutter down gracefully." ) );
+        } else if (n->has_trait(trait_WEB_RAPPEL)) {
+            n->add_msg_if_player(_("You quickly spin a line of silk and rappel down."));
         } else if( n->has_active_bionic( bio_shock_absorber ) ) {
             n->add_msg_if_player( m_info,
                                   _( "You hit the ground hard, but your shock absorbers handle the impact admirably!" ) );
@@ -892,6 +897,8 @@ bool trapfunc::pit_glass( const tripoint &p, Creature *c, item * )
         if( ( n->has_trait( trait_WINGS_BIRD ) ) || ( ( one_in( 2 ) ) &&
                 ( n->has_trait( trait_WINGS_BUTTERFLY ) ) ) ) {
             n->add_msg_if_player( _( "You flap your wings and flutter down gracefully." ) );
+        } else if (n->has_trait(trait_WEB_RAPPEL)) {
+            n->add_msg_if_player(_("You quickly spin a line of silk and rappel down."));
         } else if( n->has_active_bionic( bio_shock_absorber ) ) {
             n->add_msg_if_player( m_info,
                                   _( "You hit the ground hard, but your shock absorbers handle the impact admirably!" ) );
@@ -1077,6 +1084,9 @@ bool trapfunc::sinkhole( const tripoint &p, Creature *c, item *i )
         } else if( query_for_item( pl, itype_rope_30,
                                    _( "You step into a sinkhole!  Throw your rope out to try to catch something?" ) ) ) {
             success = sinkhole_safety_roll( pl, itype_rope_30, 12 );
+        } else if (pl->has_trait(trait_WEB_RAPPEL) && query_yn(
+                                   _("You step into a sinkhole!  Throw a web out to try to catch something? " ) ) ) {
+            success = sinkhole_safety_roll(pl, itype_rope_30, 3);
         }
 
         pl->add_msg_player_or_npc( m_warning, _( "The sinkhole collapses!" ),
@@ -1114,6 +1124,8 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
             if( g->u.has_trait( trait_WINGS_BIRD ) || ( one_in( 2 ) &&
                     g->u.has_trait( trait_WINGS_BUTTERFLY ) ) ) {
                 add_msg( _( "You flap your wings and flutter down gracefully." ) );
+            } else if ( g->u.has_trait(trait_WEB_RAPPEL) ) {
+                add_msg( _("You quickly spin a line of silk and rappel down."));
             } else if( g->u.has_active_bionic( bio_shock_absorber ) ) {
                 add_msg( m_info,
                          _( "You hit the ground hard, but your shock absorbers handle the impact admirably!" ) );
@@ -1195,6 +1207,9 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
             pl->has_trait( trait_WINGS_BUTTERFLY ) ) ) {
         pl->add_msg_player_or_npc( _( "You flap your wings and flutter down gracefully." ),
                                    _( "<npcname> flaps their wings and flutters down gracefully." ) );
+    } else if (pl->has_trait(trait_WEB_RAPPEL)) {
+        pl->add_msg_player_or_npc( _("You quickly spin a line of silk and rappel down."),
+                                   _("<npcname> quickly spins a line of silk and rappels down."));
     } else if( pl->has_active_bionic( bio_shock_absorber ) ) {
         pl->add_msg_if_player( m_info,
                                _( "You hit the ground hard, but your shock absorbers handle the impact admirably!" ) );


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Added additional utility functionality to Web Diver and Web Rope mutations to diversify the spider line, and changed the kCal limitation in the mutation_ui.cpp to align with the kCal limitation present in mutation.cpp."

#### Purpose of change

Both to diversify the spider mutation line by giving it tools that make it more suited for urban exploration, to clear up confusion about Web Diver not actually helping you descend from ledges (despite its description).

#### Describe the solution

Web Rope:
Now, when you activate Web Rope, instead of placing a rope in your inventory, it will spawn an f_rope_up_web piece of furniture, which behaves identically to the grappling hook's f_rope_up except that it turns into a long rope when taken down.

Web Diver:
Instead of only helping you descend half broken stairs, web diver will now also let you safely descend in any of the situations in which wings would would allow you to descend (namely ledges & pits). 

kCal Requirement Change:
I also changed the kCal check that stops you from using a mutation in the UI from 80% to 50%.  At least one other player has noted that 80% was high enough they thought it was a bug, and I noticed that it confusingly clashed with the exact same check that occurs slightly higher up the stack in the activate_mutation method (which is where I got the value of 50%).

#### Describe alternatives you've considered

Both of these mutations keep their existing functionality with my changes. If the new functionality is deemed too powerful when viewed in combination with the existing functionality, we could change/remove the existing functionality.

#### Testing

Web Rope: I create web rope/attempted to create a web rope across a variety of terrain types, and in all situations in which I could create a normal f_rope_up.

Web Diver:
I jumped off a bunch of different buildings, and fell in pits, verifying that the mutation prevented me from taking fall damage, and the correct message played.
