### PR TITLE
Give AISLE flag to internal doors

### DIFF
--- a/data/json/vehicleparts/doors.json
+++ b/data/json/vehicleparts/doors.json
@@ -105,7 +105,7 @@
     "damage_reduction": { "all": 28 },
     "description": "An interior door.  Solid construction means you can't see through it when closed.",
     "durability": 240,
-    "flags": [ "OBSTACLE", "OPAQUE", "OPENABLE", "ROOF", "BOARDABLE" ],
+    "flags": [ "OBSTACLE", "OPAQUE", "OPENABLE", "AISLE", "ROOF", "BOARDABLE" ],
     "item": "frame",
     "location": "center",
     "looks_like": "door",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2381,7 +2381,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
     },
-    "flags": [ "OBSTACLE", "OPENABLE", "BOARDABLE", "WINDOW" ],
+    "flags": [ "OBSTACLE", "OPENABLE", "BOARDABLE", "AISLE", "WINDOW" ],
     "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] } ],
     "damage_reduction": { "all": 8 }
   },
@@ -2404,7 +2404,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
     },
-    "flags": [ "OBSTACLE", "OPENABLE", "BOARDABLE", "OPAQUE" ],
+    "flags": [ "OBSTACLE", "OPENABLE", "BOARDABLE", "AISLE", "OPAQUE" ],
     "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] } ],
     "damage_reduction": { "all": 12 }
   },

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2381,7 +2381,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
     },
-    "flags": [ "OBSTACLE", "OPENABLE", "BOARDABLE", "AISLE", "WINDOW" ],
+    "flags": [ "OBSTACLE", "OPENABLE", "BOARDABLE", "WINDOW" ],
     "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] } ],
     "damage_reduction": { "all": 8 }
   },
@@ -2404,7 +2404,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
     },
-    "flags": [ "OBSTACLE", "OPENABLE", "BOARDABLE", "AISLE", "OPAQUE" ],
+    "flags": [ "OBSTACLE", "OPENABLE", "BOARDABLE", "OPAQUE" ],
     "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] } ],
     "damage_reduction": { "all": 12 }
   },


### PR DESCRIPTION
#### Summary

SUMMARY: [Balance] "Give internal and wooden vehicle doors the "AISLE" flag."

#### Purpose of change

Internal doors are supposed to be nothing but simple dividers that allow you to pass from one room of a spacious vehicle into another, without hindering the persons movement when said door is open.

#### Describe the solution

By giving internal doors the "AISLE" flag, they are considered a walkway without hampering movement inside of a vehicle. This change is meant to discourage the removal of internal doors in vehicles only to replace it with an aisle to not get a movespeed penalty when walking on and off the tile in question. As per Chaosvolts asking specifically, this flag was also added to wooden doors specifically. They are flimsy enough to be actual weakpoints, yet make for an interesting option when needing a quick escape. Given that wooden doors (like any wooden part) need to be nailed in (as in requiring 20 nails to add to a vehicle) it can be safely assumed specific framing to hold the door is added, which generally includes stepable walkways.

#### Describe alternatives you've considered

Reducing or removing the movement penalty of vehicular doors that are considered [inside] entirely,

#### Testing

Tested in the newest available version of BN. Ran affected files through the DDA linting tool without requiring any further edits.