### PR TITLE
Make Taste Modifer use power properly.

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -945,7 +945,7 @@ bool player::eat( item &food, bool force )
     }
 
     if( has_active_bionic( bio_taste_blocker ) ) {
-        mod_power_level( units::from_kilojoule( -std::min( 0, food.get_comestible_fun() ) ) );
+        mod_power_level( units::from_kilojoule( std::min( 0, food.get_comestible_fun() ) ) );
     }
 
     if( food.has_flag( flag_FUNGAL_VECTOR ) && !has_trait( trait_M_IMMUNE ) ) {


### PR DESCRIPTION
Taste Modifier is currently broken, it creates power equal to food's fun value instead of using power, this is because it subtracts the fun value, but the fun value is always negative. I fixed this by removing a single errant Minus sign from the equation.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1168