### PR TITLE
Don't give every generic arsonist cat ears

### DIFF
--- a/data/json/mapgen/refugee_center/refugee_center.json
+++ b/data/json/mapgen/refugee_center/refugee_center.json
@@ -307,7 +307,7 @@
       ],
       "place_npcs": [
         { "class": "scavenger_merc", "x": 49, "y": 3 },
-        { "class": "arsonist", "x": 38, "y": 19 },
+        { "class": "arsonist", "x": 38, "y": 19, "add_trait": "FELINE_EARS" },
         { "class": "old_guard_rep", "x": 47, "y": 10 },
         { "class": "guard", "x": 46, "y": 3 },
         { "class": "evac_merchant", "x": 71, "y": 0 },

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -21,8 +21,7 @@
     "traits": [
       { "group": "BG_survival_story_CRIMINAL" },
       { "group": "NPC_starting_traits" },
-      { "group": "Appearance_demographics" },
-      [ "FELINE_EARS", 100 ]
+      { "group": "Appearance_demographics" }
     ],
     "bonus_dex": { "rng": [ -2, 0 ] },
     "bonus_int": { "rng": [ -2, 0 ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Set Makayla specifically to have feline ears, not every generic arsonist NPC"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Since the refugee center uses an NPC class that generic NPCs can also use, I was going to just add an ears mutation to this NPC via the mapgen entry.

Then I double-checked and realized that someone already had the idea of "the arsonist should actually have mutant ears since their dialogue implies it" but did it basically backwards, via injecting it into the NPC class. Since this class is still marked as one dynamic and static NPCs can use, it means all generic arsonists you meet will ALL have cat ears.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Set it so the refugee center mapgen calls `add_trait` to slap cat ears on the center's arsonist.
2. Removed Feline Ears from the trait selection of the arsonist NPC class.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Setting `"common": false` for the arsonist NPC class.
2. Moving the arsonist's NPC class back to the base classes file since it shouldn't be in the individual NPC's file if it's not solely for them to use.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and lint errors.
2. Ported file change to test build, spawned in a refugee center.
3. Confirmed the local arsonist still has cat ears.
4. Debug spawned NPCs in until I got an arsonist, confirmed that they don't have cat ears.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Side note, this gives a rare example of `add_trait` actually put to use at the mapgen level, and working examples are always handy.