### PR TITLE
Fix xgettext warnings

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3765,7 +3765,7 @@ void activity_handlers::craft_do_turn( player_activity *act, player *p )
     if( five_percent_steps > 0 ) {
         if( !p->craft_consume_tools( *craft, five_percent_steps, false ) ) {
             // So we don't skip over any tool comsuption
-            craft->item_counter -= craft->item_counter % 500'000 + 1;
+            craft->item_counter -= craft->item_counter % 500000 + 1;
             p->cancel_activity();
             return;
         }

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -504,8 +504,8 @@ bool trading_window::perform_trade( npc &np, const std::string &deal )
 
     // Shopkeeps are happy to have large inventories.
     if( np.mission == NPC_MISSION_SHOPKEEP ) {
-        volume_left = 5'000_liter;
-        weight_left = 5'000_kilogram;
+        volume_left = 5000_liter;
+        weight_left = 5000_kilogram;
     }
 
     input_context ctxt( "NPC_TRADE" );


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
`xgettext` gets confused by thousands separators in code, and emits warnings during string extraction.
Normally that's not an issue, but these warnings show up on each and every PR, and that's getting annoying.
![image](https://user-images.githubusercontent.com/60584843/148794550-68099f59-e63f-44cd-9202-3b1b987325b9.png)

#### Describe the solution
Get rid of problematic thousands separators. Looks like there's only 3 of them in the codebase, so their presense can be considered as going against code style anyway.

#### Testing
CI will tell.