### PR TITLE
Fix CTD when attempting to modify shoulder strap

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4724,7 +4724,10 @@ int sew_advanced_actor::use( player &p, item &it, bool, const tripoint & ) const
     // We need extra thread to lose it on bad rolls
     const int thread_needed = mod.volume() / 125_ml + 10;
 
-    const auto valid_mods = mod.find_armor_data()->valid_mods;
+    std::vector<std::string> valid_mods;
+    if( mod.find_armor_data() ) {
+        valid_mods = mod.find_armor_data()->valid_mods;
+    }
 
     const auto get_compare_color = [&]( const int before, const int after,
     const bool higher_is_better ) {


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed CTD when attempting to modify shoulder strap"

#### Purpose of change
Fixes #1230

#### Describe the solution
If item is armor, that doesn't necessarily mean it has armor data (lmao).
As such, check for null pointer before dereferencing.

#### Testing
Game no longer crashes, and allows padding shoulder strap with leather and fur. Pretty sure it doesn't do anything useful, but that's an issue for another time.
