### PR TITLE
Make evac shelters and necropolis spawning a bit more robust

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1099,7 +1099,7 @@
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 3, 10 ],
+    "city_distance": [ 3, 15 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "URBAN", "ELECTRIC_GRID" ]
@@ -1114,7 +1114,7 @@
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 3, 10 ],
+    "city_distance": [ 2, 14 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "URBAN", "ELECTRIC_GRID" ]
@@ -1129,7 +1129,7 @@
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 3, 10 ],
+    "city_distance": [ 2, 14 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "URBAN", "ELECTRIC_GRID" ]
@@ -1144,7 +1144,7 @@
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 3, 10 ],
+    "city_distance": [ 2, 14 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "URBAN", "ELECTRIC_GRID" ]
@@ -1159,7 +1159,7 @@
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 3, 10 ],
+    "city_distance": [ 2, 14 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "URBAN", "ELECTRIC_GRID" ]
@@ -1174,7 +1174,7 @@
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 3, 10 ],
+    "city_distance": [ 2, 14 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "URBAN", "ELECTRIC_GRID" ]
@@ -1567,7 +1567,7 @@
       { "point": [ 4, 9, 0 ], "terrain": "road", "connection": "local_road", "from": [ 4, 8, 0 ] }
     ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 20, -1 ],
+    "city_distance": [ 12, -1 ],
     "occurrences": [ 33, 100 ],
     "flags": [ "UNIQUE" ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Make it a bit easier for evac shelters and necropolises to find a desirable place to spawn"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I've noticed that in certain city settings, the default evac shelter can get very prone to failing to spawn, especially when city placement is abnormally close or distant. Saw a similiar poroblem with necropolis, which is a potential issue for any future plans to nudge the player toward them (ideally after becoming the marshal).

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Increased min and max city distance for evac shelters from 3/10 to 2/14, expanding their spawn ranges a modest bit.
2. Decreased minimum city distance for necropolis from 20 to 12.

These should overall be relatively minor tweaks to make the specials in question a bit more robust in terms of spawning range, especially in worlds with abnormal city settings, hopefully without too much oddball placement like excessively-distant evac shelters or necropolises in weird locations (though that seems like both could still happen even prior to these changes anyway, mapgen is weird sometimes).

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Messing with the starting location code to search an even wider area? Dunno.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and load errors.
2. Load-tested with compiled test build, created a world with max city distance.
3. Tested default scenario multiple times, did not get any failures to find starting location.
4. Repeated evacuee scenario test with a world using zero city distance, could still spawn.
5. Temporarily ported over Arcana to gain a test scenario that uses the necropolis in some way.
6. Tested the "ruined city" starting location in Urban Awakening multiple times on default city settings.
7. Tested the "ruined city" starting location in Urban Awakening multiple times with city distance zero.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
