### PR TITLE
Fix harvested NPC bionics not being in intended state

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9880,13 +9880,9 @@ void Character::place_corpse()
     // Restore amount of installed pseudo-modules of Power Storage Units
     std::pair<int, int> storage_modules = amount_of_storage_bionics();
     for( int i = 0; i < storage_modules.first; ++i ) {
-        item.set_flag( "NO_STERILE" );
-        item.set_flag( "NO_PACKED" );
         body.components.push_back( item( "bio_power_storage" ) );
     }
     for( int i = 0; i < storage_modules.second; ++i ) {
-        item.set_flag( "NO_STERILE" );
-        item.set_flag( "NO_PACKED" );
         body.components.push_back( item( "bio_power_storage_mkII" ) );
     }
     g->m.add_item_or_charges( pos(), body );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9871,10 +9871,8 @@ void Character::place_corpse()
     for( const bionic &bio : *my_bionics ) {
         if( bio.info().itype().is_valid() ) {
             item cbm( bio.id.str(), calendar::turn );
-            cbm.set_flag( "FILTHY" );
             cbm.set_flag( "NO_STERILE" );
             cbm.set_flag( "NO_PACKED" );
-            cbm.faults.emplace( fault_id( "fault_bionic_salvaged" ) );
             body.components.push_back( cbm );
         }
     }
@@ -9882,9 +9880,13 @@ void Character::place_corpse()
     // Restore amount of installed pseudo-modules of Power Storage Units
     std::pair<int, int> storage_modules = amount_of_storage_bionics();
     for( int i = 0; i < storage_modules.first; ++i ) {
+        item.set_flag( "NO_STERILE" );
+        item.set_flag( "NO_PACKED" );
         body.components.push_back( item( "bio_power_storage" ) );
     }
     for( int i = 0; i < storage_modules.second; ++i ) {
+        item.set_flag( "NO_STERILE" );
+        item.set_flag( "NO_PACKED" );
         body.components.push_back( item( "bio_power_storage_mkII" ) );
     }
     g->m.add_item_or_charges( pos(), body );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -183,6 +183,8 @@ static const itype_id itype_string_36( "string_36" );
 static const itype_id itype_toolset( "toolset" );
 static const itype_id itype_UPS( "UPS" );
 static const itype_id itype_UPS_off( "UPS_off" );
+static const itype_id itype_power_storage( "bio_power_storage" );
+static const itype_id itype_power_storage_mkII( "bio_power_storage_mkII" );
 
 static const skill_id skill_archery( "archery" );
 static const skill_id skill_dodge( "dodge" );
@@ -9880,10 +9882,16 @@ void Character::place_corpse()
     // Restore amount of installed pseudo-modules of Power Storage Units
     std::pair<int, int> storage_modules = amount_of_storage_bionics();
     for( int i = 0; i < storage_modules.first; ++i ) {
-        body.components.push_back( item( "bio_power_storage" ) );
+        item cbm( itype_power_storage );
+        cbm.set_flag( "NO_STERILE" );
+        cbm.set_flag( "NO_PACKED" );
+        body.components.push_back( cbm );
     }
     for( int i = 0; i < storage_modules.second; ++i ) {
-        body.components.push_back( item( "bio_power_storage_mkII" ) );
+        item cbm( itype_power_storage_mkII );
+        cbm.set_flag( "NO_STERILE" );
+        cbm.set_flag( "NO_PACKED" );
+        body.components.push_back( cbm );
     }
     g->m.add_item_or_charges( pos(), body );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix CBMs harvested from NPCs not being in same state as ones from monsters"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Most of this turned out to be easy to fix, general issues where NPC bionics would be either still faulty and filthy, and power storage for some reason was coming out ready-to-install.

The former was utterly trivival to fix, the latter I was only able to figure out thanks to discussion with @acssimpson on the BN discord. One of my initial stabs at the solution had been pretty much right on the money, but I'd forgot to define the items being asked for at the beginning of the file.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Updated harvest of regular CBMs from NPCs to remove use of fault and filth, to be consistent with bionics from monsters.
2. Updated harvest of power storage CBMs to properly have non-sterile and non-packed, like the above and like monster harvested CBMs.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

The whole "generate power storage based off capacity" method is just plain weird since it can transmutate power storage CBMs, but the only sane alternative would be to write up new features to make players and NPCs track what types of power storage have been installed and how many of each, instead of just tracking capacity.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Successfully revive an inactive prototype cyborg as an NPC.
3. Debug kill and dissect them.
4. Observe that regular CBMs harvested from them are no longer faulty or filthy.
5. Also observe that power storage CBMs are in the same state, and no longer ready to install.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
