### PR TITLE
Npc item spawning fix

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -417,9 +417,6 @@ void npc::randomize( const npc_class_id &type )
     recalc_hp();
 
     starting_weapon( myclass );
-    starting_clothes( *this, myclass, male );
-    starting_inv( *this, myclass );
-    has_new_items = true;
     clear_mutations();
 
     // Add fixed traits
@@ -434,6 +431,11 @@ void npc::randomize( const npc_class_id &type )
             mutate_category( mr.first );
         }
     }
+
+    starting_clothes(*this, myclass, male);
+    starting_inv(*this, myclass);
+    has_new_items = true;
+
     // Add bionics
     for( const auto &bl : type->bionic_list ) {
         int chance = bl.second;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -432,8 +432,8 @@ void npc::randomize( const npc_class_id &type )
         }
     }
 
-    starting_clothes(*this, myclass, male);
-    starting_inv(*this, myclass);
+    starting_clothes( *this, myclass, male );
+    starting_inv( *this, myclass );
     has_new_items = true;
 
     // Add bionics


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

SUMMARY: Bugfixes "swapped the order in which NPCs receive items in order to prevent a freeze that occurred due to items dropped via mutation being dropped out of bounds"


#### Purpose of change

Bugfix, don't think there is an open issue.

#### Describe the solution

I shuffled the order that NPC are randomly generated, so now items are assigned items after they mutate. This means that they won't be given clothing, just to have it fall off when they gain spider arms or whatever.

#### Describe alternatives you've considered

I suppose you could intercept the drop item call and delete the item from existence instead of trying to drop it onto the 'ground', but I'm not entirely sure that would fix the problem.

#### Testing

Made a world with maximum npc multiplier, and passed 12 hours. This was literally impossible with bug, and now happens just fine.

