### PR TITLE
Update Wayfarer logic

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -246,6 +246,7 @@ static const trait_id trait_PARKOUR( "PARKOUR" );
 static const trait_id trait_VINES2( "VINES2" );
 static const trait_id trait_VINES3( "VINES3" );
 static const trait_id trait_THICKSKIN( "THICKSKIN" );
+static const trait_id trait_WAYFARER( "WAYFARER" );
 
 static const trap_str_id tr_unfinished_construction( "tr_unfinished_construction" );
 
@@ -5435,6 +5436,10 @@ void game::control_vehicle()
                         ( veh->avail_part_with_feature( veh_part, "CONTROL_ANIMAL", true ) >= 0 &&
                           veh->has_engine_type( fuel_type_animal, false ) && veh->has_harnessed_animal() ) ) &&
                u.in_vehicle ) {
+        if( u.has_trait( trait_WAYFARER ) ) {
+            add_msg( m_info, _( "You refuse to take control of this vehicle." ) );
+            return;
+        }
         if( !veh->interact_vehicle_locked() ) {
             veh->handle_potential_theft( dynamic_cast<player &>( u ) );
             return;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -112,7 +112,6 @@ static const bionic_id bio_remote( "bio_remote" );
 static const trait_id trait_HIBERNATE( "HIBERNATE" );
 static const trait_id trait_PROF_CHURL( "PROF_CHURL" );
 static const trait_id trait_SHELL2( "SHELL2" );
-static const trait_id trait_WAYFARER( "WAYFARER" );
 
 static const std::string flag_LITCIG( "LITCIG" );
 static const std::string flag_LOCKED( "LOCKED" );
@@ -2128,8 +2127,6 @@ bool game::handle_action()
                     add_msg( m_info, _( "You can't operate a vehicle while you're in your shell." ) );
                 } else if( u.is_mounted() ) {
                     u.dismount();
-                } else if( u.has_trait( trait_WAYFARER ) ) {
-                    add_msg( m_info, _( "You refuse to take control of this vehicle." ) );
                 } else {
                     control_vehicle();
                 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Set Wayfarer to only mention a vehicle if you're actually trying to control one, allow normal access to secondary vehicle functions"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I always found it a bit odd how Wayfarer gives just a hard "I refuse to operate vehicles" message when you hit `^`, even when you're nowhere near a vehicle. Looked into how to go about fixing that, and realized that I could also use this to make it so you can more easily fiddle with secondary vehicle functions while still being unable to drive. Since right now, you have to `e` on vehicle controls and go through an extra layer of keypress to access secondary vehicle functions, instead of using `^` like you normally would.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Moved the check for players with Wayfarer out of `game::handle_action()` and into `game::control_vehicle()`, placed in the part of the function that handles what happens when the player is on a vehicle-controlling tile and not already in a state of control (which should not normally be accessible if you have Wayfarer, but this allows you to successfully let go of controls if you somehow gain Wayfarer while driving).

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. I could move the shell mutation check to this function too, but the idea there seems to be that you're currently in your shell and does effectively unable to do anything, so it makes more sense for it to hard-stop the `^` action.
2. Messing with the order of things so you can at least use wagons was extremely tempting, but that would be a separate balance concern entirely, and might warrant making the trait give less points.
3. Breaking the ability to turn on the lights and such via `e` is also a possible option, but that means no remembering where vehicles are, no using generators or autoclaves, etc. It'd make Wayfarer even more restrictive than merely "no driving" like it currently is.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Spawned in as a character with Wayfarer.
3. Pressing `^` while just standing around correctly tells me there's no vehicle nearby.
4. Spawned in a car.
5. Trying to `^` while directly standing in the driver's seat correctly prints Wayfarer's message.
6. Moving to passenger's seat and hitting `^` lets me fiddle with the engine and lights, same as if I `e`'d on it.
7. Turned engine on from adjacent seat and moved back into the driver's seat.
8. Confirmed I still can't cheese Wayfarer this way, as it still won't let me take control of the now-running vehicle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
