### PR TITLE
Allow to fix glass sheets and other glass items

### DIFF
--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -978,7 +978,7 @@
       {
         "type": "repair_item",
         "item_action_type": "repair_metal",
-        "materials": [ "kevlar", "plastic", "iron", "steel", "hardsteel", "aluminum", "copper", "silver", "gold" ],
+        "materials": [ "kevlar", "plastic", "iron", "steel", "hardsteel", "aluminum", "copper", "silver", "gold", "glass" ],
         "skill": "mechanics",
         "cost_scaling": 0.1,
         "move_cost": 1000
@@ -1025,7 +1025,7 @@
       {
         "type": "repair_item",
         "item_action_type": "repair_metal",
-        "materials": [ "iron", "steel", "hardsteel", "aluminum", "copper", "bronze", "silver", "gold", "platinum", "superalloy" ],
+        "materials": [ "iron", "steel", "hardsteel", "aluminum", "copper", "bronze", "silver", "gold", "platinum", "superalloy", "glass" ],
         "skill": "fabrication",
         "tool_quality": 10,
         "cost_scaling": 0.1,
@@ -1063,7 +1063,7 @@
       {
         "type": "repair_item",
         "item_action_type": "repair_metal",
-        "materials": [ "iron", "steel", "hardsteel", "aluminum", "copper", "bronze", "silver", "gold", "platinum", "superalloy" ],
+        "materials": [ "iron", "steel", "hardsteel", "aluminum", "copper", "bronze", "silver", "gold", "platinum", "superalloy", "glass" ],
         "skill": "fabrication",
         "tool_quality": 5,
         "cost_scaling": 0.1,

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -560,6 +560,8 @@
     "fire_resist": 3,
     "elec_resist": 4,
     "chip_resist": 0,
+    "repaired_with": "glass_shard",
+    "salvaged_into": "glass_shard",
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "scratched",


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Allow to fix glass sheets and other glass items"

#### Purpose of change

Before this PR, if we want to fix a glass sheet, we had to install it on a car, repair it, and remove it again. This will simplify it by allowing repair it directly.

#### Describe the solution

Arc welder, makeshift arc welder, and extended toolset can repair glass-based thing. It will require glass shards as material.

#### Describe alternatives you've considered

Adding Iron material to every glass items, like reinforced glass sheet.

#### Testing

Test completed by editing json file. It worked well.

#### Additional context

