### PR TITLE
Make black gunpowder recipes less absurdly wasteful

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -875,7 +875,7 @@
     "description": "A handful of black gunpowder, made by mixing charcoal and sulfur with saltpeter.  Pretty useless for making modern cartridges, as the soot produced when it burns will quickly clog any firearm, but it could be used to make some vicious bombs.",
     "material": "powder",
     "volume": "100 ml",
-    "weight": "1 g",
+    "weight": "1800 mg",
     "bashing": 1,
     "ammo_type": "components",
     "container": "bag_plastic",

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -875,7 +875,7 @@
     "description": "A handful of black gunpowder, made by mixing charcoal and sulfur with saltpeter.  Pretty useless for making modern cartridges, as the soot produced when it burns will quickly clog any firearm, but it could be used to make some vicious bombs.",
     "material": "powder",
     "volume": "100 ml",
-    "weight": "1800 mg",
+    "weight": "2 g",
     "bashing": 1,
     "ammo_type": "components",
     "container": "bag_plastic",

--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -6,7 +6,7 @@
     "subcategory": "CSC_AMMO_COMPONENTS",
     "skill_used": "cooking",
     "difficulty": 4,
-    "time": "20 m",
+    "time": "2 m",
     "autolearn": [ [ "cooking", 5 ], [ "fabrication", 5 ] ],
     "book_learn": [
       [ "textbook_anarch", 6 ],
@@ -15,8 +15,11 @@
       [ "textbook_armschina", 5 ],
       [ "book_icef", 5 ]
     ],
+    "charges": 10,
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "components": [ [ [ "chem_saltpetre", 150 ] ], [ [ "chem_sulphur", 300 ] ], [ [ "charcoal", 10 ], [ "coal_lump", 10 ] ] ]
+    "//": "Roughly consistent by weight, saltpeter is in smaller stack sizes than most chems, so much less is used.",
+    "//2": "Charcoal is in excess of the amount required however, due to even smaller stack size.",
+    "components": [ [ [ "chem_saltpetre", 2 ] ], [ [ "chem_sulphur", 5 ] ], [ [ "charcoal", 1 ], [ "coal_lump", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -27,7 +30,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "cooking", 1 ],
     "difficulty": 4,
-    "time": "20 m",
+    "time": "2 m",
     "book_learn": [
       [ "textbook_anarch", 4 ],
       [ "recipe_bullets", 2 ],
@@ -36,9 +39,10 @@
       [ "adv_chemistry", 3 ],
       [ "textbook_chemistry", 3 ]
     ],
+    "charges": 10,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "hotplate", 50 ], [ "toolset", 50 ] ] ],
-    "components": [ [ [ "oxy_powder", 200 ] ], [ [ "ammonia", 2 ], [ "lye_powder", 200 ] ], [ [ "charcoal", 25 ] ] ]
+    "tools": [ [ [ "hotplate", 5 ], [ "toolset", 5 ] ] ],
+    "components": [ [ [ "oxy_powder", 5 ] ], [ [ "lye_powder", 5 ] ], [ [ "charcoal", 1 ], [ "coal_lump", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Make recipe for black gunpowder more consistent by weight, wasting less valuable ingredients, make in smaller batches"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Per some musings on the BN discord, some work to make production of blackpowder actually respect conservation of matter a bit better. Less so for realism reasons, and moreso because leaning more towards realistic in this case works out to using way less of the most annoying-to-get materials.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Changed material demand of the standard blackpowder recipe to be made in batches of 10 instead of 100, per Coolthulhu's suggestion. Time scaled down accordingly. Material usage scaled down and nudged more towards consistent ratios by weight. Comment explaining why it looks so wacky added to the recipe as well.

Also updated the generic recipe slightly to be as close as consistent with the above change as possible, making it use 5 and 5 of oxy and lye powder (but removing ammonia as an option), plus 1 charcoal or coal lump.

Also set weight of 1 unit of black powder to an amount within the range of densities used for blackpowder in reality, to reinforce the conservation of mass changes.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Rounding saltpeter use up to 3 would get closer to that sweet, delicious 75% by weight, but then it wouldn't properly divide saltpeter's stack size.
2. Making it so that sulfur and saltpeter have 100-mL stacks of 100 (like blackpowder does) would make the recipe look somewhat less odd in comparison (12-13 saltpeter, 1 sulfur), but it'd require overhauling every recipe that uses them.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

