### PR TITLE
Port over minor extension to starch shelf life

### DIFF
--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -18,7 +18,7 @@
     "name": { "str_sp": "starch" },
     "weight": "180 g",
     "color": "light_gray",
-    "spoils_in": "1 day 6 hours",
+    "spoils_in": "3 days 12 hours",
     "comestible_type": "FOOD",
     "symbol": "%",
     "healthy": 1,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Port over minor change to starch shelf life from DDA"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Simple port of a recent tweak in DDA. Per original PR, reasoning is combination of an example indicating cattail starch was allowed to sit out to dry in open conditions for a period longer than it'd take to rot in-game without issue, in tandem with its short spoilage time being a hindrance to crafting flour (exacerbated by all the "hours as meat = days as jerky" issues spoilage currently has).

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Updated `spoils_in` of starch by the same amount proposed in the source PR, increasing from 1 day and 6 hours to 3 days and 12 hours.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Fixing the issues that make this a problem in the first place (and are why Nonperishable Overhaul mod exists) is on my todo list, but it'll take several steps.
2. One minor entry that's part of my to-do list is making smoked meat and jerky go back to lasting 42 days like it was when they were first made perishable. That's partly to tie in with plans to potentially make certain food last forever again if their spoilage rate is above a certain time period, but I could include them in this PR early since that's the only super-easy JSON bit of the planned spoilage fixes.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/54320