### PR TITLE
Port over update making fire ring less hassle to build

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -3253,9 +3253,10 @@
     "category": "FURN",
     "required_skills": [ [ "fabrication", 0 ] ],
     "time": "15 m",
+    "qualities": [ { "id": "DIG", "level": 1 } ],
     "components": [ [ [ "rock", 20 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
-    "pre_terrain": "t_pit_shallow",
+    "pre_terrain": "t_dirt",
     "dark_craftable": true,
     "post_terrain": "f_firering"
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Port over update making fire rings slightly easier to build from DDA"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Another easy JSON port of a recent DDA change.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Tweaked it so fire rings are built on dirt and require digging quality of 1 in the construction, instead of being built on shallow pits. Makes things a bit less hassle, as the source PR notes. Adding my own two cents as the one who added it back in ye olden days, back in my day digging a shallow pit was a construction and didn't wear you out, so it was definitely less hassle as originally added to More Survival Tools.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Honestly it's a minor one either way since you're literally halfway to building a fireplace in terms of both digging quality and rocks required, but the added exertion to something that should be something as simple as "make sure you're not starting it on dry grass" is a fair point to consider.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/54386