### PR TITLE
Port over change giving bite attack to grim howlers

### DIFF
--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -178,7 +178,7 @@
     "dodge": 2,
     "vision_night": 5,
     "harvest": "zombie_fur",
-    "special_attacks": [ [ "HOWL", 10 ], { "type": "bite", "attack_upper": false, "cooldown": 2, "accuracy": 4, "infection_chance": 8 } ],
+    "special_attacks": [ [ "HOWL", 10 ], { "type": "bite", "cooldown": 2, "accuracy": 4, "infection_chance": 8 } ],
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "fear_triggers": [ "FIRE" ],
     "death_function": [ "NORMAL" ],

--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -178,7 +178,7 @@
     "dodge": 2,
     "vision_night": 5,
     "harvest": "zombie_fur",
-    "special_attacks": [ [ "HOWL", 10 ] ],
+    "special_attacks": [ [ "HOWL", 10 ], { "type": "bite", "attack_upper": false, "cooldown": 2, "accuracy": 4, "infection_chance": 8 } ],
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "fear_triggers": [ "FIRE" ],
     "death_function": [ "NORMAL" ],

--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -178,7 +178,7 @@
     "dodge": 2,
     "vision_night": 5,
     "harvest": "zombie_fur",
-    "special_attacks": [ [ "HOWL", 10 ], { "type": "bite", "cooldown": 2, "accuracy": 4, "infection_chance": 8 } ],
+    "special_attacks": [ [ "HOWL", 10 ], { "type": "bite", "cooldown": 2, "accuracy": 4, "no_infection_chance": 12 } ],
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "fear_triggers": [ "FIRE" ],
     "death_function": [ "NORMAL" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Port over change giving grim howlers a bite attack from DDA"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Ported over change giving grim howlers a basic bite attack, like most zombie wildlife tends to have. Turns out it's statted to be identical to that of rot-weilers, as no_infection_chance and infection_chance are slightly different things.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Ported over change giving grim howlers a basic bite attack, like most zombie wildlife tends to have. Stats seem to be close to the bite attack rot-weilers have, except lower infection chance (fitting since rot-weilers seem to be flavored as a putrid/decaying zog variant).

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Jawed terrors, zombears, and decayed pouncers are all predatory zanimals that probably deserve a bite attack. The first two maybe could lean towards higher potential damage but much lower risk of infection to make them statistically different from normal biting zanimals.
2. Zombeavers and antlered horrors also lack a bit but it's borderline whether they should have it or not, sticking to carnivorous/omnivorous (since festering boars are allowed to bite) animals would entail leaving beavers and moose bite-free but giving it to the other animals above.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/54082