### PR TITLE
Fix Pistol Bayonets on Weapon UI

### DIFF
--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -391,6 +391,7 @@
     "location": "underbarrel",
     "mod_targets": [ "pistol" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 15 ] ],
+    "mode_modifier": [ [ "REACH", "bayonet", 2, [ "MELEE", "REACH_ATTACK" ] ] ],
     "flags": [ "STAB" ]
   },
   {


### PR DESCRIPTION
Makes pistol bayonets appear on the weapon UI with their new shiny +6 piercing damage. They were the only bayonets that did not have the REACH_ATTACK flag. That said, this and the makeshift bayonets are the only ones that do not have the category of weapons, but that might be another day.
 
 Testing: 
 1. Spawned test world, added pistol bayonet to M17.
 2. Pierce damage shows on pistol now.
 
 Fixes #803