### PR TITLE
Minor changes to melee stamina/speed formulas to make them more intuitive/less punishing

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2170,7 +2170,7 @@ int Character::attack_cost( const item &weap ) const
     /** @EFFECT_DEX increases attack speed */
     const int dexbonus = dex_cur / 2;
     const int encumbrance_penalty = encumb( bp_torso ) +
-                                    ( encumb( bp_arm_l ) + encumb( bp_arm_r ) ) / 2;
+                                    ( encumb( bp_hand_l ) + encumb( bp_hand_r ) ) / 2;
     const int ma_move_cost = mabuff_attack_cost_penalty();
     const float stamina_ratio = static_cast<float>( get_stamina() ) / static_cast<float>
                                 ( get_stamina_max() );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -599,9 +599,8 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
     // using 16_gram normalizes it to 8 str. Same effort expenditure
     // for each strike, regardless of weight. This is compensated
     // for by the additional move cost as weapon weight increases
-    const int weight_cost = cur_weapon.weight() / ( 16_gram );
-    const int encumbrance_cost = roll_remainder( ( encumb( bp_arm_l ) + encumb( bp_arm_r ) ) *
-                                 2.0f );
+    const int weight_cost = cur_weapon.weight() / ( 8_gram + 1_gram * std::max( 1, str_cur ) );
+    const int encumbrance_cost = ( encumb( bp_arm_l ) + encumb( bp_arm_r ) );
     const int deft_bonus = hit_spread < 0 && has_trait( trait_DEFT ) ? 50 : 0;
     /** @EFFECT_MELEE reduces stamina cost of melee attacks */
     const int mod_sta = ( weight_cost + encumbrance_cost - melee - deft_bonus + 50 ) * -1;
@@ -2171,7 +2170,7 @@ int Character::attack_cost( const item &weap ) const
     /** @EFFECT_DEX increases attack speed */
     const int dexbonus = dex_cur / 2;
     const int encumbrance_penalty = encumb( bp_torso ) +
-                                    ( encumb( bp_hand_l ) + encumb( bp_hand_r ) ) / 2;
+                                    ( encumb( bp_arm_l ) + encumb( bp_arm_r ) ) / 2;
     const int ma_move_cost = mabuff_attack_cost_penalty();
     const float stamina_ratio = static_cast<float>( get_stamina() ) / static_cast<float>
                                 ( get_stamina_max() );


### PR DESCRIPTION
#### Summary

SUMMARY: Balance "Changed melee speed to use arm instead of hand encumb, and melee stamina cost to use the sum of arm encumbs, instead of the sum of arm encumbs*2.

#### Purpose of change

Melee in BN is currently very punishing in terms of stamina costs for characters wearing any sort of armor. After deep diving into the melee formula, I found some inconsistencies that I wanted to remedy so that armored melee wouldn't be as punishing, and melee results would map better to playing intuition.

#### Describe the solution

Attack speed now uses arm encumb instead of hand encumb to calculate the encumbrance modifier.

Stamina cost has two changes made to it:
the first was to change the calculation to use the sum(L_arm+R_arm), instead of sum(L_arm+R_arm)*2. This brings us in line with DDA's current stamina costs coincidently.
The second was to reimplement a hybrid solution for how weapon weight plays into stamina costs. In the distant past, strength played a large roll in the stamina calculations, allowing stronger characters to more easily swing a heavy weapon. However this was removed in favor of a static calculation, which was fairly unintuitive. I reimplemented a hybrid version of the strength formula that provides the same bonus at 8 strength, a 50% improvement at 16 str, and 100% larger at 24 strength. Once again, this only effects the stamina drain calculated due to weapon weight.

I also 

#### Describe alternatives you've considered

I tested with sum(L_arm+R_arm)/2, which is far more intuitive to me, but I found it a bit too permissive. I'm aware that the whole system needs a stern talking to, but until then this should make melee feel a lot better.

I also tested with the previous strength equation, and found it was also too large of a change from the current system, and seemed very jarring. Excessively punishing to weak characters, and it trivialized melee for very, very strong characters (hydraulic muscles basically giving you infinite melee stamina until you ran out of power).

#### Testing

I've played multiple characters from start-end game using this change, and recorded my impressions, as well as doing the math for various weapons/encumbrances/strengths, with how many expected swings a character could make before being out of breath, and found that these changes constitute a modest improvement, without blowing the top off the system.

