### PR TITLE
Fix Exploding Arrow Duplication Exploit

### DIFF
--- a/data/json/recipes/ammo/arrows.json
+++ b/data/json/recipes/ammo/arrows.json
@@ -362,9 +362,6 @@
     "skills_required": [ [ "archery", 4 ] ],
     "difficulty": 4,
     "time": "7 m",
-    "reversible": true,
-    "decomp_learn": 6,
-    "//": "you just take the warhead off or put it on, rather than making the warhead",
     "book_learn": [ [ "recipe_arrows", 6 ], [ "textbook_anarch", 4 ], [ "recipe_bullets", 7 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 } ],
     "components": [


### PR DESCRIPTION
Removed reversible flag as most other arrow recipes are one way - this also allows us to keep batch count consistent with other non-reversible arrow recipes, which is the source of the problem. The alternative is turning down batch count to 1.

Partially addresses #621.