### PR TITLE
Fix Hyper-Metabolism with an example of active mutation enchantments

### DIFF
--- a/data/json/mutations/mutation_enchantments.json
+++ b/data/json/mutations/mutation_enchantments.json
@@ -11,5 +11,11 @@
         "npc_message": "%1$s's ink glands spay some ink into %2$s's eyes."
       }
     ]
+  },
+  {
+    "type": "enchantment",
+    "id": "MEP_EATHEALTH_REGEN",
+    "condition": "ACTIVE",
+    "intermittent_activation": { "effects": [ { "frequency": "30 seconds", "spell_effects": [ { "id": "hyper_metabolism_regen" } ] } ] }
   }
 ]

--- a/data/json/mutations/mutation_spells.json
+++ b/data/json/mutations/mutation_spells.json
@@ -18,5 +18,15 @@
     "flags": [ "SILENT", "NO_LEGS", "NO_HANDS", "RANDOM_DAMAGE", "RANDOM_DURATION", "RANDOM_TARGET" ],
     "energy_source": "NONE",
     "damage_type": "bio"
+  },
+  {
+    "type": "SPELL",
+    "id": "hyper_metabolism_regen",
+    "name": { "str": "Hyper-Metabolism Regen" },
+    "description": "Steady self-healing when Hyper-Metabolism is active.",
+    "valid_targets": [ "self" ],
+    "effect": "target_attack",
+    "min_damage": -1,
+    "max_damage": -1
   }
 ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2868,13 +2868,17 @@
     "id": "EATHEALTH",
     "name": { "str": "Hyper-Metabolism" },
     "points": 15,
-    "description": "You metabolize nutrients so rapidly that you can convert food directly into useful tissue.  Excess nutrition will convert to HP, rather than being wasted.  Activate to skip prompt for overeating.",
+    "description": "Your particular metabolism allows you to burn calories at a prodigious rate to regenerate tissues in a matter of minutes, this is however a very wasteful process.  Activate to start healing.",
     "prereqs": [ "HUNGER3" ],
     "types": [ "METABOLISM" ],
     "threshreq": [ "THRESH_CHIMERA" ],
     "category": [ "CHIMERA" ],
     "valid": false,
-    "active": true
+    "active": true,
+    "cost": 1,
+    "time": 5,
+    "hunger": true,
+    "enchantments": [ "MEP_EATHEALTH_REGEN" ]
   },
   {
     "type": "mutation",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -205,7 +205,6 @@ static const trait_id trait_ANTENNAE( "ANTENNAE" );
 static const trait_id trait_ANTLERS( "ANTLERS" );
 static const trait_id trait_BADBACK( "BADBACK" );
 static const trait_id trait_DEBUG_NODMG( "DEBUG_NODMG" );
-static const trait_id trait_EATHEALTH( "EATHEALTH" );
 static const trait_id trait_SQUEAMISH( "SQUEAMISH" );
 static const trait_id trait_WOOLALLERGY( "WOOLALLERGY" );
 
@@ -4188,9 +4187,6 @@ void Character::set_stored_kcal( int kcal )
     if( stored_calories != kcal ) {
         stored_calories = std::min( kcal, max_stored_kcal() );
 
-        if( kcal > max_stored_kcal() && has_trait( trait_EATHEALTH ) ) {
-            healall( roll_remainder( ( kcal - max_stored_kcal() ) / 50.0f ) );
-        }
     }
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix Hyper-Metabolism being useless, with a demonstration of active mutation enchantments"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I finally bothered to test whether active mutations can correctly trigger active enchantments, and on finding out they can I realized that lets me make a fix for Hyper-Metabolism without yet having to port over transforming mutations.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1255
Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/312

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed Hyper-Metabolism to consume hunger when active, and to have an active enchantment. I went with about 20% as much hunger consumption as DDA's version. Reason is that the enchantment is rigged to achieve the same target HP regen as in the DDA PR's test, but their test was done just by waiting around. While this version will have more consistent static regen than healing rate mutation modifiers, it won't benefit for the massive multipliers that bandages+antiseptic+sleep will give you, so unlike the DDA version the target "60 HP over 30 minutes base regen" is as high as it will get.
2. Defined enchantment, set to active condition and casts a spell one every 30 seconds via intermittent activation.
3. Defined the spell used by it, heals 1 HP each time it triggers.
4. Removed the bit of hardcode that involved Hyper-Metabolism's old, non-functional behavior. Kept the bit that removes tapeworm however.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Porting over transforming mutations anyway because we can eventually port over a lot more mutations from DDA that use it. Lot more effort though, plus the full selection of mutations would also require we port over EOC too.
2. Reworking both the regen proc and the hunger loss to hit you for bigger amounts less frequently, but with the same target for regen and hunger over time.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Tested affected files for syntax and lint errors.
2. Compiled and load-tested.
3. Rigged up a character with Hyper-Metabolism and Self-Aware.
4. Set all HP to 1, turned the mutation on, and waited 30 minutes.
5. Observed that 68 HP had healed (expected 60), stored kcal had gone down by 3402 (slightly above expected amount of 3200).
6. Checked atyle of affected source file.

As can be seen, `intermittent_activation` is on par with turns_per_charge in terms of not being exact for whatever reason. Different in kcal burned is probably due to uncertainty injected in via Extreme Metabolism trait, which comes along with Hyper-Metabolism.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

DDA's take on the fix, from which I grabbed the target numbers for base regen and hunger cost: https://github.com/CleverRaven/Cataclysm-DDA/pull/45687

Lots of unrelated `mut_id` code changes that could be worth messing with porting over in it, but deemed them outside the scope of this PR.

The fact that we have active enchantments for mutations is a game-changer I did notice we had, we could do a lot of shit with this even without transforming mutations.