### PR TITLE
Fixed hyper metabolism

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4187,10 +4187,6 @@ void Character::set_stored_kcal( int kcal )
 {
     if( stored_calories != kcal ) {
         stored_calories = std::min( kcal, max_stored_kcal() );
-
-        if( kcal > max_stored_kcal() && has_trait( trait_EATHEALTH ) ) {
-            healall( roll_remainder( ( kcal - max_stored_kcal() ) / 50.0f ) );
-        }
     }
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -205,7 +205,6 @@ static const trait_id trait_ANTENNAE( "ANTENNAE" );
 static const trait_id trait_ANTLERS( "ANTLERS" );
 static const trait_id trait_BADBACK( "BADBACK" );
 static const trait_id trait_DEBUG_NODMG( "DEBUG_NODMG" );
-static const trait_id trait_EATHEALTH( "EATHEALTH" );
 static const trait_id trait_SQUEAMISH( "SQUEAMISH" );
 static const trait_id trait_WOOLALLERGY( "WOOLALLERGY" );
 

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -77,6 +77,7 @@ static const trait_id trait_BEAK_HUM( "BEAK_HUM" );
 static const trait_id trait_CANNIBAL( "CANNIBAL" );
 static const trait_id trait_CARNIVORE( "CARNIVORE" );
 static const trait_id trait_EATDEAD( "EATDEAD" );
+static const trait_id trait_EATHEALTH( "EATHEALTH" );
 static const trait_id trait_FANGS_SPIDER( "FANGS_SPIDER" );
 static const trait_id trait_GIZZARD( "GIZZARD" );
 static const trait_id trait_GOURMAND( "GOURMAND" );
@@ -1226,9 +1227,18 @@ bool Character::consume_effects( item &food )
 
     int excess_kcal = get_stored_kcal() + stomach.get_calories() + ingested.nutr.kcal -
                       max_stored_kcal();
+
+    // Moved hypermetabolism check here to prevent it being gimped by various bloating/vomit problems.
+    if( excess_kcal > 0 && has_trait( trait_EATHEALTH ) ) {
+        healall( roll_remainder( excess_kcal / 50.0f ) );
+        mod_stored_kcal( -excess_kcal );
+        excess_kcal = 0;
+    }
+
     int excess_quench = -( get_thirst() - comest.quench );
     stomach.ingest( ingested );
     mod_thirst( -contained_food.type->comestible->quench );
+
 
     if( ( excess_kcal > 0 || excess_quench > 0 ) && !food.has_flag( flag_NO_BLOAT ) ) {
         add_effect( effect_bloated, 5_minutes );


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Fixed hyper metabolism mutation for chimera"

#### Purpose of change

Hyper metabolism has been broken for a while. When trying to eat enough to heal, the character would instead become bloated and then vomit.

https://github.com/cataclysmbnteam/Cataclysm-BN/issues/312
https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1255
https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1289

#### Describe the solution

Instead of making the hypermetabolism check part of the mod_kcal, I moved the check to the consumption logic.

#### Describe alternatives you've considered

Reworking the entire food system to not be bunko, but this seemed faster.

#### Testing

![hyperMet](https://user-images.githubusercontent.com/72810820/150912150-b4d8f263-285a-4964-8d9f-e495ced079df.gif)

