### PR TITLE
Allow shooting adjacent enemies across z-levels.

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -310,14 +310,26 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
         prev_point = tp;
         tp = trajectory[i];
 
-        if( ( tp.z > prev_point.z && g->m.has_floor( tp ) ) ||
-            ( tp.z < prev_point.z && g->m.has_floor( prev_point ) ) ) {
-            // Currently strictly no shooting through floor
-            // TODO: Bash the floor
-            tp = prev_point;
-            traj_len = --i;
-            break;
+        if( tp.z != prev_point.z ) {
+            tripoint floor1 = prev_point;
+            tripoint floor2 = tp;
+
+            if( floor1.z < floor2.z ) {
+                floor1.z++;
+            } else {
+                floor2.z++;
+            }
+            // We only stop the bullet if there are two floors in a row
+            // this allow the shooter to shoot adjacent enemies from rooftops.
+            if( here.has_floor( floor1 ) && here.has_floor( floor2 ) ) {
+                // Currently strictly no shooting through floor
+                // TODO: Bash the floor
+                tp = prev_point;
+                traj_len = --i;
+                break;
+            }
         }
+
         // Drawing the bullet uses player g->u, and not player p, because it's drawn
         // relative to YOUR position, which may not be the gunman's position.
         if( do_animation && !do_draw_line ) {

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -305,7 +305,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
     int projectile_skip_calculation = range * projectile_skip_multiplier;
     int projectile_skip_current_frame = rng( 0, projectile_skip_calculation );
     bool has_momentum = true;
-
+    map &here = get_map();
     for( size_t i = 1; i < traj_len && ( has_momentum || stream ); ++i ) {
         prev_point = tp;
         tp = trajectory[i];


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fix rooftop shooting"

#### Purpose of change

This is direct copy of https://github.com/CleverRaven/Cataclysm-DDA/pull/52386.

#### Describe the solution

Whenever the bullet trajectory changes z-levels, check both tiles if there is a floor in between. This should still prevent the player
from shooting directly through the floor.