### PR TITLE
JSONize ranged bash (reinforced glass letting bullets through etc.)

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -1066,7 +1066,8 @@
         { "item": "nail", "charges": [ 1, 4 ] },
         { "item": "splinter", "count": [ 1, 4 ] },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 20, 40 ], "block_unaimed_chance": "12.5%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -111,7 +111,8 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_mdoor_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ],
+      "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 8 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -217,7 +218,8 @@
         { "item": "wood_panel", "prob": 10 },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 20, 40 ] }
     }
   },
   {
@@ -1449,7 +1451,8 @@
         { "item": "wood_panel", "prob": 10 },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 15, 30 ] }
     },
     "pry": {
       "success_message": "You pry open the door.",
@@ -1507,7 +1510,8 @@
         { "item": "2x4", "prob": 25 },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 15, 30 ] }
     },
     "pry": {
       "success_message": "You pry open the door.",
@@ -1555,7 +1559,8 @@
         { "item": "wood_panel", "prob": 10 },
         { "item": "splinter", "count": [ 1, 2 ] },
         { "item": "nail", "charges": [ 0, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 15, 30 ] }
     },
     "pry": {
       "success_message": "You pry open the door.",
@@ -1837,7 +1842,8 @@
         { "item": "wood_panel", "prob": 10 },
         { "item": "nail", "charges": [ 2, 10 ] },
         { "item": "splinter", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 15, 35 ] }
     }
   },
   {
@@ -1865,7 +1871,8 @@
         { "item": "nail", "charges": [ 2, 20 ] },
         { "item": "splinter", "count": 1 },
         { "item": "hinge", "count": [ 1, 2 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 15, 35 ] }
     }
   },
   {
@@ -1921,7 +1928,8 @@
         { "item": "wood_panel", "prob": 10 },
         { "item": "nail", "charges": [ 1, 8 ] },
         { "item": "splinter", "count": 1 }
-      ]
+      ],
+      "ranged": { "reduction": [ 15, 35 ] }
     }
   },
   {
@@ -1949,7 +1957,8 @@
         { "item": "nail", "charges": [ 6, 54 ] },
         { "item": "splinter", "count": 1 },
         { "item": "hinge", "count": [ 0, 1 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 15, 35 ] }
     }
   },
   {
@@ -2372,7 +2381,8 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_door_frame",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "ranged": { "reduction": [ 1, 8 ], "reduction_laser": [ 0, 5 ] }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-floors_indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors_indoor.json
@@ -65,7 +65,8 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_thconc_floor",
-      "items": [ { "item": "glass_shard", "count": [ 0, 2 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 0, 2 ] } ],
+      "ranged": { "reduction": [ 1, 1 ], "block_unaimed_chance": "25%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -42,7 +42,8 @@
       "sound": "crunch!",
       "sound_fail": "clang!",
       "ter_set": "t_gas_pump_smashed",
-      "items": [ { "item": "scrap", "count": 1 } ]
+      "items": [ { "item": "scrap", "count": 1 } ],
+      "ranged": { "reduction": [ 60, 60 ], "destroy_threshold": -45, "flammable": true, "block_unaimed_chance": "33%" }
     }
   },
   {
@@ -595,7 +596,8 @@
       "sound_vol": 16,
       "sound_fail_vol": 12,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "scrap", "count": [ 0, 2 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "scrap", "count": [ 0, 2 ] } ],
+      "ranged": { "reduction": [ 10, 10 ] }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -643,7 +643,8 @@
         { "item": "wood_panel", "count": [ 0, 2 ] },
         { "item": "nail", "charges": [ 4, 10 ] },
         { "item": "splinter", "count": [ 1, 5 ] }
-      ]
+      ],
+      "ranged": { "reduction": [ 20, 40 ], "block_unaimed_chance": "12.5%" }
     }
   },
   {
@@ -722,7 +723,8 @@
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_null",
-      "items": [ { "item": "splinter", "count": [ 10, 20 ] } ]
+      "items": [ { "item": "splinter", "count": [ 10, 20 ] } ],
+      "ranged": { "reduction": [ 20, 40 ], "block_unaimed_chance": "12.5%" }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -890,7 +890,8 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "ranged": { "reduction": [ 1, 8 ], "reduction_laser": [ 0, 5 ] }
     }
   },
   {
@@ -913,7 +914,8 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "ranged": { "reduction": [ 1, 8 ], "reduction_laser": [ 0, 5 ] }
     }
   },
   {
@@ -936,7 +938,8 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "ranged": { "reduction": [ 1, 8 ], "reduction_laser": [ 0, 5 ] }
     }
   },
   {
@@ -959,7 +962,8 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] } ],
+      "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 8 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -981,7 +985,8 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 } ],
+      "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 8 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -1003,7 +1008,8 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ],
+      "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 8 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -1026,7 +1032,8 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 3, 6 ] }, { "item": "wire", "prob": 20 }, { "item": "scrap", "count": [ 3, 5 ] } ],
+      "ranged": { "reduction": [ 40, 40 ], "reduction_laser": [ 0, 8 ], "destroy_threshold": 40 }
     }
   },
   {
@@ -1069,7 +1076,8 @@
       "sound_fail": "slap!",
       "sound_vol": 8,
       "sound_fail_vol": 4,
-      "ter_set": "t_null"
+      "ter_set": "t_null",
+      "ranged": { "reduction": [ 4, 16 ], "flammable": true }
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -24,6 +24,15 @@
   },
   {
     "type": "terrain",
+    "id": "t_window_copyfrom",
+    "copy-from": "t_window",
+    "name": "window",
+    "description": "A giant sheet of glass inserted into a window, typically found on the side of shops to showcase goods.",
+    "symbol": "\"",
+    "color": "light_cyan"
+  },
+  {
+    "type": "terrain",
     "id": "t_window_taped",
     "name": "taped window",
     "description": "Duct tape covers this window, blocking sunlight and visibility.  You could remove the duct tape by cutting it off.",

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -248,53 +248,23 @@
   {
     "type": "terrain",
     "id": "t_window_alarm",
+    "copy-from": "t_window",
     "name": "window",
     "description": "A giant sheet of glass inserted into a window, typically found on the side of shops to showcase goods.",
     "symbol": "\"",
     "color": "light_cyan",
     "move_cost": 0,
-    "roof": "t_flat_roof",
-    "flags": [
-      "TRANSPARENT",
-      "FLAMMABLE",
-      "ALARMED",
-      "NOITEM",
-      "REDUCE_SCENT",
-      "BARRICADABLE_WINDOW",
-      "CONNECT_TO_WALL",
-      "BLOCK_WIND"
-    ],
-    "bash": {
-      "str_min": 3,
-      "str_max": 6,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 10,
-      "ter_set": "t_window_frame"
-    }
+    "extend": { "flags": [ "ALARMED" ] }
   },
   {
     "type": "terrain",
     "id": "t_window_alarm_taped",
+    "copy-from": "t_window_taped",
     "name": "taped window",
     "description": "Duct tape covers this window, blocking out any sunlight and visibility.  You could remove the duct tape by cutting it off.",
     "symbol": "\"",
     "color": "dark_gray",
-    "move_cost": 0,
-    "coverage": 95,
-    "roof": "t_flat_roof",
-    "flags": [ "FLAMMABLE", "NOITEM", "ALARMED", "WALL", "BARRICADABLE_WINDOW", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 6,
-      "str_max": 12,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 10,
-      "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 1, 5 ] } ]
-    }
+    "extend": { "flags": [ "ALARMED" ] }
   },
   {
     "type": "terrain",
@@ -355,13 +325,13 @@
   {
     "type": "terrain",
     "id": "t_window_boarded",
+    "copy-from": "t_window",
     "name": "boarded up window",
     "description": "A glass window that has been covered with nailed down planks, blocking sunlight and visibility.  It's not much stronger, but it could be further reinforced with strategically placed two by fours.",
     "symbol": "#",
     "color": "brown",
     "move_cost": 0,
     "coverage": 95,
-    "roof": "t_flat_roof",
     "flags": [ "FLAMMABLE", "NOITEM", "REDUCE_SCENT", "CONNECT_TO_WALL", "BLOCK_WIND" ],
     "bash": {
       "str_min": 3,
@@ -371,7 +341,8 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "splinter", "count": [ 0, 2 ] }, { "item": "glass_shard", "count": [ 1, 4 ] } ]
+      "items": [ { "item": "splinter", "count": [ 0, 2 ] }, { "item": "glass_shard", "count": [ 1, 4 ] } ],
+      "ranged": { "reduction": [ 10, 30 ] }
     }
   },
   {
@@ -508,23 +479,17 @@
   {
     "type": "terrain",
     "id": "t_window_bars_alarm",
+    "copy-from": "t_window",
     "name": "window with metal bars",
     "looks_like": "t_window_bars",
     "description": "A giant sheet of glass inserted into a window with thick security grilles, making it impossible to crawl through.  Typically installed for high-value stores, or at least stores in bad neighborhoods.  This one has a small sticker in a corner stating, 'Protected by AtmoWeb, leading AI in terminating crime'.",
     "symbol": "#",
     "color": "light_gray",
     "move_cost": 0,
-    "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "NOITEM", "REDUCE_SCENT", "ALARMED", "CONNECT_TO_WALL", "BLOCK_WIND" ],
+    "delete":{"flags": [ "FLAMMABLE", "BARRICADABLE_WINDOW" ]},
+    "extend":{"flags": [ "ALARMED" ]},
     "bash": {
-      "str_min": 3,
-      "str_max": 6,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 10,
-      "ter_set": "t_window_bars",
-      "items": [ { "item": "glass_shard", "count": [ 1, 5 ] } ]
+      "ter_set": "t_window_bars"
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -19,60 +19,34 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 1, 5 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 1, 5 ] } ],
+      "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 0, 5 ] }
     }
   },
   {
     "type": "terrain",
-    "id": "t_window_copyfrom",
-    "copy-from": "t_window",
-    "name": "window",
-    "description": "A giant sheet of glass inserted into a window, typically found on the side of shops to showcase goods.",
-    "symbol": "\"",
-    "color": "light_cyan"
-  },
-  {
-    "type": "terrain",
     "id": "t_window_taped",
+    "copy-from": "t_window",
     "name": "taped window",
     "description": "Duct tape covers this window, blocking sunlight and visibility.  You could remove the duct tape by cutting it off.",
     "symbol": "\"",
     "color": "dark_gray",
     "move_cost": 0,
     "coverage": 95,
-    "roof": "t_flat_roof",
-    "flags": [ "FLAMMABLE", "NOITEM", "WALL", "CONNECT_TO_WALL", "BLOCK_WIND" ],
-    "bash": {
-      "str_min": 6,
-      "str_max": 12,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 10,
-      "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 1, 5 ] } ]
-    }
+    "delete": { "flags": [ "TRANSPARENT", "BARRICADABLE_WINDOW" ] },
+    "bash": { "str_min": 6, "str_max": 12, "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 1, 10 ] } }
   },
   {
     "type": "terrain",
     "id": "t_window_domestic",
+    "copy-from": "t_window",
     "name": "window with curtains",
     "description": "A window with fancy curtains on the inside that can be drawn closed to block visibility and shut out any light.",
     "symbol": "\"",
     "color": "light_gray",
     "move_cost": 0,
-    "coverage": 60,
-    "roof": "t_flat_roof",
-    "flags": [
-      "TRANSPARENT",
-      "FLAMMABLE",
-      "NOITEM",
-      "OPENCLOSE_INSIDE",
-      "BARRICADABLE_WINDOW_CURTAINS",
-      "REDUCE_SCENT",
-      "CONNECT_TO_WALL",
-      "BLOCK_WIND"
-    ],
+    "delete": { "flags": [ "BARRICADABLE_WINDOW" ] },
+    "extend": { "flags": [ "OPENCLOSE_INSIDE", "BARRICADABLE_WINDOW_CURTAINS" ] },
     "examine_action": "curtains",
     "close": "t_curtains",
     "open": "t_window_open",
@@ -87,13 +61,6 @@
       ]
     },
     "bash": {
-      "str_min": 3,
-      "str_max": 6,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 10,
-      "ter_set": "t_window_frame",
       "items": [
         { "item": "glass_shard", "count": [ 1, 3 ] },
         { "item": "sheet", "count": 2 },
@@ -125,36 +92,16 @@
   {
     "type": "terrain",
     "id": "t_window_no_curtains",
+    "copy-from": "t_window",
     "name": "window without curtains",
     "description": "A smaller window typically found in residential homes.  You could install a curtain rod and drapes if you had the supplies and skill.",
     "symbol": "\"",
     "color": "white",
     "move_cost": 0,
-    "coverage": 60,
-    "roof": "t_flat_roof",
-    "flags": [
-      "TRANSPARENT",
-      "FLAMMABLE",
-      "NOITEM",
-      "OPENCLOSE_INSIDE",
-      "BARRICADABLE_WINDOW",
-      "REDUCE_SCENT",
-      "CONNECT_TO_WALL",
-      "BLOCK_WIND"
-    ],
+    "extend": { "flags": [ "OPENCLOSE_INSIDE" ] },
     "examine_action": "locked_object",
     "open": "t_window_no_curtains_open",
-    "deconstruct": { "ter_set": "t_window_empty", "items": [ { "item": "glass_sheet", "count": 1 } ] },
-    "bash": {
-      "str_min": 3,
-      "str_max": 6,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 10,
-      "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 1, 3 ] } ]
-    },
+    "bash": { "items": [ { "item": "glass_shard", "count": [ 1, 3 ] } ] },
     "pry": {
       "success_message": "You pry open the window.",
       "fail_message": "You pry, but cannot pry open the window.",
@@ -174,119 +121,68 @@
   {
     "type": "terrain",
     "id": "t_window_no_curtains_open",
+    "copy-from": "t_window",
     "name": "open window without curtains",
     "description": "A smaller window typically found in residential homes.  It's open and can be crawled through.",
     "symbol": "'",
     "color": "white",
     "move_cost": 4,
-    "coverage": 60,
-    "roof": "t_flat_roof",
-    "flags": [
-      "TRANSPARENT",
-      "FLAMMABLE",
-      "NOITEM",
-      "OPENCLOSE_INSIDE",
-      "MOUNTABLE",
-      "CONNECT_TO_WALL",
-      "THIN_OBSTACLE",
-      "SMALL_PASSAGE",
-      "PERMEABLE"
-    ],
+    "extend": { "flags": [ "OPENCLOSE_INSIDE", "MOUNTABLE", "BLOCK_WIND", "THIN_OBSTACLE", "SMALL_PASSAGE", "PERMEABLE" ] },
     "close": "t_window_no_curtains",
-    "bash": {
-      "str_min": 3,
-      "str_max": 6,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 10,
-      "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 1, 3 ] } ]
-    }
+    "bash": { "items": [ { "item": "glass_shard", "count": [ 1, 3 ] } ] }
   },
   {
     "type": "terrain",
     "id": "t_window_no_curtains_taped",
+    "copy-from": "t_window_taped",
     "name": "taped window",
     "description": "A smaller window typically found in residential homes.  This one has been blocked out with duct tape.  You could remove the duct tape by cutting it off.",
     "//": "Taped window without curtains",
     "symbol": "\"",
     "color": "dark_gray",
     "move_cost": 0,
-    "coverage": 95,
-    "roof": "t_flat_roof",
-    "flags": [ "FLAMMABLE", "NOITEM", "WALL", "BLOCK_WIND" ],
+    "delete": { "flags": [ "TRANSPARENT", "REDUCE_SCENT", "BARRICADABLE_WINDOW", "CONNECT_TO_WALL" ] },
+    "extend": { "flags": [ "WALL" ] },
     "bash": {
-      "str_min": 6,
-      "str_max": 12,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 10,
-      "ter_set": "t_window_frame",
-      "items": [ { "item": "glass_shard", "count": [ 1, 3 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 1, 3 ] } ],
+      "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 1, 10 ] }
     }
   },
   {
     "type": "terrain",
     "id": "t_window_domestic_taped",
+    "copy-from": "t_window_no_curtains_taped",
     "name": "taped window",
     "description": "A window with fancy curtains on the inside.  This one has been blocked out with duct tape.  You could remove the duct tape by cutting it off.",
     "//": "Taped window with curtains",
     "symbol": "\"",
     "color": "dark_gray",
     "move_cost": 0,
-    "coverage": 95,
-    "roof": "t_flat_roof",
-    "flags": [ "FLAMMABLE", "NOITEM", "WALL", "BLOCK_WIND" ],
     "examine_action": "curtains",
     "bash": {
-      "str_min": 6,
-      "str_max": 12,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 10,
-      "ter_set": "t_window_frame",
       "items": [
         { "item": "glass_shard", "count": [ 1, 3 ] },
         { "item": "sheet", "count": 2 },
         { "item": "stick", "count": 1 },
         { "item": "string_36", "count": 1 }
-      ]
+      ],
+      "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 1, 10 ] }
     }
   },
   {
     "type": "terrain",
     "id": "t_window_open",
+    "copy-from": "t_window",
     "name": "open window with curtains",
     "description": "A window with fancy curtains on the inside that can be drawn closed to block visibility and shut out any light.  It's open and you can crawl through.",
     "symbol": "'",
     "color": "light_gray",
     "move_cost": 4,
-    "coverage": 60,
-    "roof": "t_flat_roof",
-    "flags": [
-      "TRANSPARENT",
-      "FLAMMABLE",
-      "NOITEM",
-      "OPENCLOSE_INSIDE",
-      "MOUNTABLE",
-      "CONNECT_TO_WALL",
-      "THIN_OBSTACLE",
-      "SMALL_PASSAGE",
-      "PERMEABLE"
-    ],
+    "delete": { "flags": [ "REDUCE_SCENT", "BARRICADABLE_WINDOW", "BLOCK_WIND" ] },
+    "extend": { "flags": [ "OPENCLOSE_INSIDE", "MOUNTABLE", "THIN_OBSTACLE", "SMALL_PASSAGE", "PERMEABLE" ] },
     "examine_action": "curtains",
     "close": "t_window_domestic",
     "bash": {
-      "str_min": 3,
-      "str_max": 6,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 10,
-      "ter_set": "t_window_frame",
       "items": [
         { "item": "glass_shard", "count": [ 1, 3 ] },
         { "item": "sheet", "count": 2 },
@@ -298,22 +194,15 @@
   {
     "type": "terrain",
     "id": "t_curtains",
+    "copy-from": "t_window",
     "name": "window with closed curtains",
     "description": "A window with fancy curtains that have been drawn shut, blocking sunlight and visibility.  The curtains can only be opened on the inside.  If you examined the curtains more closely, you could peek through the drapes or tear down everything.  Or you could just smash the window open.",
     "symbol": "\"",
     "color": "dark_gray",
     "move_cost": 0,
     "coverage": 95,
-    "roof": "t_flat_roof",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "OPENCLOSE_INSIDE",
-      "REDUCE_SCENT",
-      "BARRICADABLE_WINDOW_CURTAINS",
-      "CONNECT_TO_WALL",
-      "BLOCK_WIND"
-    ],
+    "delete": { "flags": [ "TRANSPARENT", "BARRICADABLE_WINDOW" ] },
+    "extend": { "flags": [ "OPENCLOSE_INSIDE", "BARRICADABLE_WINDOW_CURTAINS" ] },
     "open": "t_window_domestic",
     "examine_action": "curtains",
     "deconstruct": {
@@ -327,19 +216,13 @@
       ]
     },
     "bash": {
-      "str_min": 3,
-      "str_max": 6,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 10,
-      "ter_set": "t_window_frame",
       "items": [
         { "item": "glass_shard", "count": [ 1, 3 ] },
         { "item": "sheet", "count": 2 },
         { "item": "stick", "count": 1 },
         { "item": "string_36", "count": 1 }
-      ]
+      ],
+      "ranged": { "reduction": [ 1, 3 ], "reduction_laser": [ 1, 10 ] }
     },
     "pry": {
       "success_message": "You pry open the window.",

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -486,11 +486,9 @@
     "symbol": "#",
     "color": "light_gray",
     "move_cost": 0,
-    "delete":{"flags": [ "FLAMMABLE", "BARRICADABLE_WINDOW" ]},
-    "extend":{"flags": [ "ALARMED" ]},
-    "bash": {
-      "ter_set": "t_window_bars"
-    }
+    "delete": { "flags": [ "FLAMMABLE", "BARRICADABLE_WINDOW" ] },
+    "extend": { "flags": [ "ALARMED" ] },
+    "bash": { "ter_set": "t_window_bars" }
   },
   {
     "type": "terrain",

--- a/src/assign.h
+++ b/src/assign.h
@@ -21,9 +21,6 @@ namespace cata
 {
 template<typename T>
 class optional;
-
-template<typename T>
-class value_ptr;
 } // namespace cata
 namespace detail
 {
@@ -33,10 +30,6 @@ class is_optional_helper : public std::false_type
 };
 template<typename T>
 class is_optional_helper<cata::optional<T>> : public std::true_type
-{
-};
-template<typename T>
-class is_optional_helper<cata::value_ptr<T>> : public std::true_type
 {
 };
 } // namespace detail
@@ -161,8 +154,8 @@ bool assign( const JsonObject &jo, const std::string &name, std::pair<T, T> &val
     return true;
 }
 
-// Note: is_optional excludes any types based on cata::optional and cata::value_ptr, which are
-// handled below in separate functions.
+// Note: is_optional excludes any types based on cata::optional, which is
+// handled below in a separate function.
 template < typename T, typename std::enable_if < std::is_class<T>::value &&!is_optional<T>::value,
            int >::type = 0 >
 bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict = false )
@@ -663,23 +656,6 @@ inline bool assign( const JsonObject &jo, const std::string &name, cata::optiona
     }
     if( !val ) {
         val.emplace();
-    }
-    return assign( jo, name, *val, strict );
-}
-
-template<typename T>
-inline bool assign( const JsonObject &jo, const std::string &name, cata::value_ptr<T> &val,
-                    const bool strict = false )
-{
-    if( !jo.has_member( name ) ) {
-        return false;
-    }
-    if( jo.has_null( name ) ) {
-        val.reset();
-        return true;
-    }
-    if( !val ) {
-        val.reset( new T() );
     }
     return assign( jo, name, *val, strict );
 }

--- a/src/assign.h
+++ b/src/assign.h
@@ -21,6 +21,9 @@ namespace cata
 {
 template<typename T>
 class optional;
+
+template<typename T>
+class value_ptr;
 } // namespace cata
 namespace detail
 {
@@ -30,6 +33,10 @@ class is_optional_helper : public std::false_type
 };
 template<typename T>
 class is_optional_helper<cata::optional<T>> : public std::true_type
+{
+};
+template<typename T>
+class is_optional_helper<cata::value_ptr<T>> : public std::true_type
 {
 };
 } // namespace detail
@@ -154,8 +161,8 @@ bool assign( const JsonObject &jo, const std::string &name, std::pair<T, T> &val
     return true;
 }
 
-// Note: is_optional excludes any types based on cata::optional, which is
-// handled below in a separate function.
+// Note: is_optional excludes any types based on cata::optional and cata::value_ptr, which are
+// handled below in separate functions.
 template < typename T, typename std::enable_if < std::is_class<T>::value &&!is_optional<T>::value,
            int >::type = 0 >
 bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict = false )
@@ -656,6 +663,23 @@ inline bool assign( const JsonObject &jo, const std::string &name, cata::optiona
     }
     if( !val ) {
         val.emplace();
+    }
+    return assign( jo, name, *val, strict );
+}
+
+template<typename T>
+inline bool assign( const JsonObject &jo, const std::string &name, cata::value_ptr<T> &val,
+                    const bool strict = false )
+{
+    if( !jo.has_member( name ) ) {
+        return false;
+    }
+    if( jo.has_null( name ) ) {
+        val.reset();
+        return true;
+    }
+    if( !val ) {
+        val.reset( new T() );
     }
     return assign( jo, name, *val, strict );
 }

--- a/src/assign.h
+++ b/src/assign.h
@@ -555,6 +555,94 @@ inline bool assign( const JsonObject &jo, const std::string &name, units::energy
     return true;
 }
 
+namespace
+{
+
+template<typename T, typename F>
+inline bool assign_unit_common( const JsonObject &jo, const std::string &name, T &val, F parse,
+                                bool strict, const T lo, const T hi )
+{
+    T out;
+
+    // Object via which to report errors which differs for proportional/relative values
+    JsonObject err = jo;
+    err.allow_omitted_members();
+    JsonObject relative = jo.get_object( "relative" );
+    relative.allow_omitted_members();
+    JsonObject proportional = jo.get_object( "proportional" );
+    proportional.allow_omitted_members();
+
+    // Do not require strict parsing for relative and proportional values as rules
+    // such as +10% are well-formed independent of whether they affect base value
+    if( relative.has_member( name ) ) {
+        T tmp;
+        err = relative;
+        if( !parse( err, tmp ) ) {
+            err.throw_error( "invalid relative value specified", name );
+        }
+        strict = false;
+        out = val + tmp;
+
+    } else if( proportional.has_member( name ) ) {
+        double scalar;
+        err = proportional;
+        if( !err.read( name, scalar ) || scalar <= 0 || scalar == 1 ) {
+            err.throw_error( "multiplier must be a positive number other than 1", name );
+        }
+        strict = false;
+        out = val * scalar;
+
+    } else if( !parse( jo, out ) ) {
+        return false;
+    }
+
+    if( out < lo || out > hi ) {
+        err.throw_error( "value outside supported range", name );
+    }
+
+    if( strict && out == val ) {
+        report_strict_violation( err, "cannot assign explicit value the same as default or inherited value",
+                                 name );
+    }
+
+    val = out;
+
+    return true;
+}
+
+} // namespace
+
+inline bool assign( const JsonObject &jo, const std::string &name, units::probability &val,
+                    bool strict = false,
+                    const units::probability lo = units::probability_min,
+                    const units::probability hi = units::probability_max )
+{
+    const auto parse = [&name]( const JsonObject & obj, units::probability & out ) {
+        if( obj.has_string( name ) ) {
+            long double tmp;
+            std::string suffix;
+            std::istringstream str( obj.get_string( name ) );
+            str.imbue( std::locale::classic() );
+            str >> tmp >> suffix;
+            if( str.peek() != std::istringstream::traits_type::eof() ) {
+                obj.throw_error( "syntax error when specifying volume", name );
+            }
+            if( suffix == "pm" ) {
+                out = units::from_one_in_million( static_cast<units::probability::value_type>( tmp ) );
+            } else if( suffix == "%" ) {
+                out = units::from_percent( tmp );
+            } else {
+                obj.throw_error( "unrecognized volumetric unit", name );
+            }
+            return true;
+        }
+
+        return false;
+    };
+
+    return assign_unit_common( jo, name, val, parse, strict, lo, hi );
+}
+
 inline bool assign( const JsonObject &jo, const std::string &name, nc_color &val,
                     const bool strict = false )
 {

--- a/src/assign.h
+++ b/src/assign.h
@@ -555,9 +555,6 @@ inline bool assign( const JsonObject &jo, const std::string &name, units::energy
     return true;
 }
 
-namespace
-{
-
 template<typename T, typename F>
 inline bool assign_unit_common( const JsonObject &jo, const std::string &name, T &val, F parse,
                                 bool strict, const T lo, const T hi )
@@ -609,8 +606,6 @@ inline bool assign_unit_common( const JsonObject &jo, const std::string &name, T
 
     return true;
 }
-
-} // namespace
 
 inline bool assign( const JsonObject &jo, const std::string &name, units::probability &val,
                     bool strict = false,

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -24,12 +24,18 @@
 static const skill_id skill_survival( "survival" );
 
 static const trait_id trait_ILLITERATE( "ILLITERATE" );
+static const trait_id trait_DEBUG_NIGHTVISION( "DEBUG_NIGHTVISION" );
 
 enum class description_target : int {
     creature,
     furniture,
     terrain
 };
+
+static bool debug_vision()
+{
+    return debug_mode || get_player_character().has_trait( trait_DEBUG_NIGHTVISION );
+}
 
 static const Creature *seen_critter( const game &g, const tripoint &p )
 {
@@ -210,6 +216,19 @@ std::string map_data_common_t::extended_description() const
             }
         } else {
             ss << _( "It can be deconstructed, but won't yield any resources." ) << std::endl;
+        }
+    }
+
+    if( debug_vision() ) {
+        ss << "Bash: " << bash.str_min << "-" << bash.str_max << "\n";
+        if( bash.ranged ) {
+            static std::string indent = "    ";
+            ss << "Ranged: " << "\n";
+            ss << indent << "Reduction:" << bash.ranged->reduction.min << "-" << bash.ranged->reduction.max;
+            if( bash.ranged->reduction_laser ) {
+                ss << indent << "Laser res:" << bash.ranged->reduction_laser->min << "-" <<
+                   bash.ranged->reduction_laser->max;
+            }
         }
     }
 

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -229,6 +229,7 @@ std::string map_data_common_t::extended_description() const
                 ss << indent << "Laser res:" << bash.ranged->reduction_laser->min << "-" <<
                    bash.ranged->reduction_laser->max;
             }
+            ss << indent << "Block unaimed chance: " << bash.ranged->block_unaimed_chance;
         }
     }
 

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -250,7 +250,7 @@ void field_type::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "display_field", display_field, false );
     optional( jo, was_loaded, "wandering_field", wandering_field_id, "fd_null" );
 
-    bash_info.load( jo, "bash", map_bash_info::field );
+    optional( jo, was_loaded, "bash", bash_info );
     if( was_loaded && jo.has_member( "copy-from" ) && looks_like.empty() ) {
         looks_like = jo.get_string( "copy-from" );
     }
@@ -277,6 +277,8 @@ void field_type::check() const
             debugmsg( "Intensity level %d defined for field type \"%s\" has empty name.", i, id.c_str() );
         }
     }
+
+    bash_info.check( id.str(), map_bash_info::map_object_type::field );
 }
 
 size_t field_type::count()

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -706,17 +706,16 @@ static void smash()
             add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), fd_to_smsh.first->get_name() );
             return;
         } else if( smashskill >= rng( bash_info.str_min, bash_info.str_max ) ) {
-            sounds::sound( smashp, bash_info.sound_vol, sounds::sound_t::combat, bash_info.sound, true, "smash",
-                           "field" );
+            sounds::sound( smashp, bash_info.sound_vol.value_or( -1 ),
+                           sounds::sound_t::combat, bash_info.sound, true, "smash", "field" );
             m.remove_field( smashp, fd_to_smsh.first );
             m.spawn_items( smashp, item_group::items_from( bash_info.drop_group, calendar::turn ) );
             u.mod_moves( - bash_info.fd_bash_move_cost );
             add_msg( m_info, bash_info.field_bash_msg_success.translated() );
             return;
         } else {
-            sounds::sound( smashp, bash_info.sound_fail_vol, sounds::sound_t::combat, bash_info.sound_fail,
-                           true, "smash",
-                           "field" );
+            sounds::sound( smashp, bash_info.sound_fail_vol.value_or( -1 ),
+                           sounds::sound_t::combat, bash_info.sound_fail, true, "smash", "field" );
             return;
         }
     }

--- a/src/itype.h
+++ b/src/itype.h
@@ -744,8 +744,6 @@ struct islot_ammo : common_ranged_data {
 
     void load( const JsonObject &jo );
     void deserialize( JsonIn &jsin );
-
-    // 
 };
 
 struct islot_bionic {

--- a/src/itype.h
+++ b/src/itype.h
@@ -744,6 +744,8 @@ struct islot_ammo : common_ranged_data {
 
     void load( const JsonObject &jo );
     void deserialize( JsonIn &jsin );
+
+    // 
 };
 
 struct islot_bionic {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3630,23 +3630,23 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
     ter_id terrain = ter( p );
     ter_t ter = terrain.obj();
 
-    if(ter.bash.ranged) {
+    if( ter.bash.ranged ) {
         const ranged_bash_info &ri = *ter.bash.ranged;
-        if(ri.reduction_laser && ammo_effects.count( "LASER" ) != 0) {
-            dam -= rng(ri.reduction_laser->min, ri.reduction_laser->max);
+        if( ri.reduction_laser && ammo_effects.count( "LASER" ) != 0 ) {
+            dam -= rng( ri.reduction_laser->min, ri.reduction_laser->max );
         } else {
-            dam -= rng(ri.reduction.min, ri.reduction.max);
-            if(dam > ri.destroy_threshold) {
+            dam -= rng( ri.reduction.min, ri.reduction.max );
+            if( dam > ri.destroy_threshold ) {
                 bash_params params{0, false, true, hit_items, 1.0, false};
-                bash_ter_success(p, params);
+                bash_ter_success( p, params );
             }
         }
-        if(ri.flammable && inc) {
-            add_field(p, fd_fire, 1);
+        if( ri.flammable && inc ) {
+            add_field( p, fd_fire, 1 );
         }
     } else if( terrain == t_wall_wood_broken ||
-        terrain == t_wall_log_broken ||
-        terrain == t_door_b ) {
+               terrain == t_wall_log_broken ||
+               terrain == t_door_b ) {
         if( hit_items || one_in( 8 ) ) { // 1 in 8 chance of hitting the door
             dam -= rng( 20, 40 );
             if( dam > 0 ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3681,7 +3681,8 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
 
     if( ter.bash.ranged ) {
         const ranged_bash_info &ri = *ter.bash.ranged;
-        if( ri.reduction_laser && ammo_effects.count( "LASER" ) != 0 ) {
+        if( hit_items || check( ri.block_unaimed_chance ) ) {
+        } else if( ri.reduction_laser && ammo_effects.count( "LASER" ) != 0 ) {
             dam -= rng( ri.reduction_laser->min, ri.reduction_laser->max );
         } else {
             dam -= rng( ri.reduction.min, ri.reduction.max );
@@ -3689,22 +3690,9 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
                 bash_params params{0, false, true, hit_items, 1.0, false};
                 bash_ter_success( p, params );
             }
-        }
-        if( ri.flammable && inc ) {
-            add_field( p, fd_fire, 1 );
-        }
-    } else if( terrain == t_wall_wood_broken ||
-               terrain == t_wall_log_broken ||
-               terrain == t_door_b ) {
-        if( hit_items || one_in( 8 ) ) { // 1 in 8 chance of hitting the door
-            dam -= rng( 20, 40 );
-            if( dam > 0 ) {
-                sounds::sound( p, 10, sounds::sound_t::combat, _( "crash!" ), false,
-                               "smash", "wall" );
-                ter_set( p, t_dirt );
+            if( ri.flammable && inc ) {
+                add_field( p, fd_fire, 1 );
             }
-        } else {
-            dam -= rng( 0, 1 );
         }
     } else if( terrain == t_door_c ||
                terrain == t_door_locked ||
@@ -3724,39 +3712,6 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
             sounds::sound( p, 10, sounds::sound_t::combat, _( "crash!" ), false,
                            "smash", "door_boarded" );
             ter_set( p, t_door_b );
-        }
-    } else if( terrain == t_window_taped ||
-               terrain == t_window_alarm_taped ||
-               terrain == t_window ||
-               terrain == t_window_no_curtains ||
-               terrain == t_window_no_curtains_taped ||
-               terrain == t_window_alarm ) {
-        if( ammo_effects.count( "LASER" ) ) {
-            if( terrain == t_window_taped ||
-                terrain == t_window_alarm_taped ||
-                terrain == t_window_no_curtains_taped ) {
-                dam -= rng( 1, 5 );
-            }
-            dam -= rng( 0, 5 );
-        } else {
-            dam -= rng( 1, 3 );
-            if( dam > 0 ) {
-                break_glass( p, 16 );
-                ter_set( p, t_window_frame );
-            }
-        }
-    } else if( terrain == t_window_bars_alarm ) {
-        dam -= rng( 1, 3 );
-        if( dam > 0 ) {
-            break_glass( p, 16 );
-            ter_set( p, t_window_bars );
-            spawn_item( p, itype_glass_shard, 1 );
-        }
-    } else if( terrain == t_window_boarded ) {
-        dam -= rng( 10, 30 );
-        if( dam > 0 ) {
-            break_glass( p, 16 );
-            ter_set( p, t_window_frame );
         }
     } else if( terrain == t_wall_glass  ||
                terrain == t_wall_glass_alarm ||

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3725,25 +3725,6 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
                            "smash", "door_boarded" );
             ter_set( p, t_door_b );
         }
-    } else if( terrain == t_window_domestic_taped ||
-               terrain == t_curtains ||
-               terrain == t_window_domestic ) {
-        if( ammo_effects.count( "LASER" ) ) {
-            if( terrain == t_window_domestic_taped ||
-                terrain == t_curtains ) {
-                dam -= rng( 1, 5 );
-            }
-            dam -= rng( 0, 5 );
-        } else {
-            dam -= rng( 1, 3 );
-            if( dam > 0 ) {
-                break_glass( p, 16 );
-                ter_set( p, t_window_frame );
-                spawn_item( p, itype_sheet, 1 );
-                spawn_item( p, itype_stick );
-                spawn_item( p, itype_string_36 );
-            }
-        }
     } else if( terrain == t_window_taped ||
                terrain == t_window_alarm_taped ||
                terrain == t_window ||

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3650,7 +3650,7 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
 {
     float initial_damage = 0.0;
     for( const damage_unit &dam : proj.impact ) {
-        initial_damage += dam.amount;
+        initial_damage += dam.amount * dam.damage_multiplier;
         initial_damage += dam.res_pen;
     }
     if( initial_damage < 0 ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -103,15 +103,11 @@ static const itype_id itype_dehydrator( "dehydrator" );
 static const itype_id itype_electrolysis_kit( "electrolysis_kit" );
 static const itype_id itype_food_processor( "food_processor" );
 static const itype_id itype_forge( "forge" );
-static const itype_id itype_glass_shard( "glass_shard" );
 static const itype_id itype_hotplate( "hotplate" );
 static const itype_id itype_kiln( "kiln" );
 static const itype_id itype_nail( "nail" );
 static const itype_id itype_press( "press" );
-static const itype_id itype_sheet( "sheet" );
 static const itype_id itype_soldering_iron( "soldering_iron" );
-static const itype_id itype_stick( "stick" );
-static const itype_id itype_string_36( "string_36" );
 static const itype_id itype_vac_sealer( "vac_sealer" );
 static const itype_id itype_welder( "welder" );
 
@@ -3199,9 +3195,7 @@ bash_results map::bash_ter_success( const tripoint &p, const bash_params &params
         ter_set( p, t_open_air );
     }
 
-    if( true ) {
-        spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );
-    }
+    spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );
 
     if( ter( p ) == t_open_air ) {
         if( !zlevels ) {
@@ -3339,13 +3333,11 @@ bash_results map::bash_ter_furn( const tripoint &p, const bash_params &params )
     std::string soundfxvariant;
     const auto &ter_obj = ter( p ).obj();
     const auto &furn_obj = furn( p ).obj();
-    bool smash_furn = false;
     bool smash_ter = false;
     const map_bash_info *bash = nullptr;
 
     if( furn_obj.id && furn_obj.bash.str_max != -1 ) {
         bash = &furn_obj.bash;
-        smash_furn = true;
     } else if( ter_obj.bash.str_max != -1 ) {
         bash = &ter_obj.bash;
         smash_ter = true;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3677,7 +3677,8 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
 
     if( ter.bash.ranged ) {
         const ranged_bash_info &ri = *ter.bash.ranged;
-        if( hit_items || check( ri.block_unaimed_chance ) ) {
+        if( !hit_items && !check( ri.block_unaimed_chance ) ) {
+            // Nothing, it's a miss
         } else if( ri.reduction_laser && ammo_effects.count( "LASER" ) != 0 ) {
             dam -= rng( ri.reduction_laser->min, ri.reduction_laser->max );
         } else {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3628,8 +3628,23 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
     };
 
     ter_id terrain = ter( p );
+    ter_t ter = terrain.obj();
 
-    if( terrain == t_wall_wood_broken ||
+    if(ter.bash.ranged) {
+        const ranged_bash_info &ri = *ter.bash.ranged;
+        if(ri.reduction_laser && ammo_effects.count( "LASER" ) != 0) {
+            dam -= rng(ri.reduction_laser->min, ri.reduction_laser->max);
+        } else {
+            dam -= rng(ri.reduction.min, ri.reduction.max);
+            if(dam > ri.destroy_threshold) {
+                bash_params params{0, false, true, hit_items, 1.0, false};
+                bash_ter_success(p, params);
+            }
+        }
+        if(ri.flammable && inc) {
+            add_field(p, fd_fire, 1);
+        }
+    } else if( terrain == t_wall_wood_broken ||
         terrain == t_wall_log_broken ||
         terrain == t_door_b ) {
         if( hit_items || one_in( 8 ) ) { // 1 in 8 chance of hitting the door

--- a/src/map.h
+++ b/src/map.h
@@ -140,12 +140,6 @@ struct bash_params {
      * can destroy a wall and a floor under it rather than only one at a time.
      */
     float roll;
-    // Was anything hit?
-    bool did_bash;
-    // Was anything destroyed?
-    bool success;
-    // Did we bash furniture, terrain or vehicle
-    bool bashed_solid;
     /*
      * Are we bashing this location from above?
      * Used in determining what sort of terrain the location will turn into,
@@ -153,6 +147,21 @@ struct bash_params {
      * have a roof either.
     */
     bool bashing_from_above;
+};
+
+struct bash_results {
+    bash_results( bool did_bash, bool success, bool bashed_solid )
+        : did_bash( did_bash ), success( success ), bashed_solid( bashed_solid )
+    {}
+    bash_results() = default;
+    // Was anything hit?
+    bool did_bash = false;
+    // Was anything destroyed?
+    bool success = false;
+    // Did we bash furniture, terrain or vehicle
+    bool bashed_solid = false;
+
+    bash_results &operator|=( const bash_results &other );
 };
 
 /** Draw parameters used by map::drawsq() and similar methods. */
@@ -1111,9 +1120,9 @@ class map
          * @param bash_floor Allow bashing the floor and the tile that supports it
          * @param bashing_vehicle Vehicle that should NOT be bashed (because it is doing the bashing)
          */
-        bash_params bash( const tripoint &p, int str, bool silent = false,
-                          bool destroy = false, bool bash_floor = false,
-                          const vehicle *bashing_vehicle = nullptr );
+        bash_results bash( const tripoint &p, int str, bool silent = false,
+                           bool destroy = false, bool bash_floor = false,
+                           const vehicle *bashing_vehicle = nullptr );
 
         // Effects of attacks/items
         bool hit_with_acid( const tripoint &p );
@@ -1875,15 +1884,15 @@ class map
         std::unique_ptr<vehicle> add_vehicle_to_map( std::unique_ptr<vehicle> veh, bool merge_wrecks );
 
         // Internal methods used to bash just the selected features
-        // Information on what to bash/what was bashed is read from/written to the bash_params struct
-        void bash_ter_furn( const tripoint &p, bash_params &params );
-        void bash_items( const tripoint &p, bash_params &params );
-        void bash_vehicle( const tripoint &p, bash_params &params );
-        void bash_field( const tripoint &p, bash_params &params );
+        // Information on what to bash/what was bashed is read from/written to the bash_params/bash_results struct
+        bash_results bash_ter_furn( const tripoint &p, const bash_params &params );
+        bash_results bash_items( const tripoint &p, const bash_params &params );
+        bash_results bash_vehicle( const tripoint &p, const bash_params &params );
+        bash_results bash_field( const tripoint &p, const bash_params &params );
 
         // Successfully bashing things down
-        void bash_ter_success( const tripoint &p, bash_params &params );
-        void bash_furn_success( const tripoint &p, bash_params &params );
+        bash_results bash_ter_success( const tripoint &p, const bash_params &params );
+        bash_results bash_furn_success( const tripoint &p, const bash_params &params );
 
         // Gets the roof type of the tile at p
         // Second argument refers to whether we have to get a roof (we're over an unpassable tile)

--- a/src/map.h
+++ b/src/map.h
@@ -125,6 +125,7 @@ struct visibility_variables {
 };
 
 struct bash_params {
+    bash_params() = default;
     // Initial strength
     int strength;
     // Make a sound?

--- a/src/map.h
+++ b/src/map.h
@@ -1881,10 +1881,14 @@ class map
         void bash_vehicle( const tripoint &p, bash_params &params );
         void bash_field( const tripoint &p, bash_params &params );
 
+        // Successfully bashing things down
+        void bash_ter_success( const tripoint &p, bash_params &params );
+        void bash_furn_success( const tripoint &p, bash_params &params );
+
         // Gets the roof type of the tile at p
         // Second argument refers to whether we have to get a roof (we're over an unpassable tile)
         // or can just return air because we bashed down an entire floor tile
-        ter_id get_roof( const tripoint &p, bool allow_air );
+        ter_id get_roof( const tripoint &p, bool allow_air ) const;
 
     public:
         void process_items();

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -266,8 +266,8 @@ void map_bash_info::deserialize( JsonIn &jsin )
 
     assign( jo, "bash_below", bash_below );
 
-    optional( jo, was_loaded, "sound", sound );
-    optional( jo, was_loaded, "sound_fail", sound_fail );
+    assign( jo, "sound", sound );
+    assign( jo, "sound_fail", sound_fail );
 
     assign( jo, "furn_set", furn_set );
 

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -205,6 +205,13 @@ static void load_map_bash_tent_centers( const JsonArray &ja, std::vector<furn_st
     }
 }
 
+void correct_if_magic( cata::optional<int> &val )
+{
+    if( val.value_or( 0 ) == -1 ) {
+        val.reset();
+    }
+}
+
 map_bash_info::map_bash_info() : str_min( -1 ), str_max( -1 ),
     str_min_blocked( -1 ), str_max_blocked( -1 ),
     str_min_supported( -1 ), str_max_supported( -1 ),
@@ -232,8 +239,11 @@ bool map_bash_info::load( const JsonObject &jsobj, const std::string &member,
 
     explosive = j.get_int( "explosive", -1 );
 
-    sound_vol = j.get_int( "sound_vol", -1 );
-    sound_fail_vol = j.get_int( "sound_fail_vol", -1 );
+    assign( j, "sound_vol", sound_vol );
+    correct_if_magic( sound_vol );
+
+    assign( j, "sound_fail_vol", sound_fail_vol );
+    correct_if_magic( sound_fail_vol );
 
     collapse_radius = j.get_int( "collapse_radius", 1 );
 

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -328,7 +328,7 @@ void map_bash_info::check( const std::string &id, map_object_type type ) const
 
     if( !errors.empty() ) {
         const std::string &type_str = map_object_type_to_str( type );
-        debugmsg( _( "Errors for \"bash\" field in \"%s\": \"%s\": \n%s" ),
+        debugmsg( _( "Errors for \"bash\" field in \"%s\": \"%s\":\n%s" ),
                   type_str, id,
                   enumerate_as_string( errors, enumeration_conjunction::newline ) );
     }

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -41,7 +41,7 @@ const units::volume DEFAULT_MAX_VOLUME_IN_SQUARE = units::from_liter( 1000 );
 generic_factory<ter_t> terrain_data( "terrain" );
 generic_factory<furn_t> furniture_data( "furniture" );
 
-static bool is_json_check_strict( const std::string &src )
+bool is_json_check_strict( const std::string &src )
 {
     return json_report_unused_fields || src == "dda";
 }

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -214,6 +214,7 @@ void ranged_bash_info::deserialize( JsonIn &jsin )
     assign( jo, "reduction_laser", reduction_laser );
     assign( jo, "destroy_threshold", destroy_threshold );
     assign( jo, "flammable", flammable );
+    assign( jo, "block_unaimed_chance", block_unaimed_chance );
 }
 
 static void load_map_bash_tent_centers( const JsonArray &ja, std::vector<furn_str_id> &centers )

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -224,7 +224,7 @@ static void load_map_bash_tent_centers( const JsonArray &ja, std::vector<furn_st
     }
 }
 
-void correct_if_magic( cata::optional<int> &val )
+static void correct_if_magic( cata::optional<int> &val )
 {
     if( val.value_or( 0 ) == -1 ) {
         val.reset();

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -198,6 +198,14 @@ static const std::unordered_map<std::string, ter_connects> ter_connects_map = { 
     }
 };
 
+bool ranged_bash_info::load( const JsonObject &jo )
+{
+    assign(jo, "reduction", reduction);
+    assign(jo, "reduction_laser", reduction_laser);
+    assign(jo, "destroy_threshold", destroy_threshold);
+    assign(jo, "flammable", flammable);
+}
+
 static void load_map_bash_tent_centers( const JsonArray &ja, std::vector<furn_str_id> &centers )
 {
     for( const std::string &line : ja ) {
@@ -280,6 +288,8 @@ bool map_bash_info::load( const JsonObject &jsobj, const std::string &member,
     if( j.has_array( "tent_centers" ) ) {
         load_map_bash_tent_centers( j.get_array( "tent_centers" ), tent_centers );
     }
+
+    assign(j, "ranged", ranged);
 
     return true;
 }

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -30,18 +30,27 @@ struct tripoint;
 using iexamine_function = void ( * )( player &, const tripoint & );
 
 struct ranged_bash_info {
-    numeric_interval<int> reduction; // Damage reduction when shot. Rolled like rng(min, max).
-    // As above, but for lasers. If set, lasers won't destroy us.
-    cata::optional<numeric_interval<int>> reduction_laser;
-    int destroy_threshold = 0; // If reduced dmg is still above this value, destroy us.
-    bool flammable = false; // If true, getting hit with any heat damage creates a fire.
-    void deserialize( JsonIn &jsin );
+        numeric_interval<int> reduction; // Damage reduction when shot. Rolled like rng(min, max).
+        // As above, but for lasers. If set, lasers won't destroy us.
+        cata::optional<numeric_interval<int>> reduction_laser;
+        int destroy_threshold = 0; // If reduced dmg is still above this value, destroy us.
+        bool flammable = false; // If true, getting hit with any heat damage creates a fire.
+        units::probability block_unaimed_chance =
+            100_pct; // Chance to intercept projectiles not aimed at this tile
+        void deserialize( JsonIn &jsin );
 
-    // In C++20, this would be = default
-    bool operator==( const ranged_bash_info &rhs ) const {
-        return std::tie( reduction, reduction_laser, destroy_threshold, flammable ) ==
-               std::tie( rhs.reduction, rhs.reduction_laser, rhs.destroy_threshold, rhs.flammable );
-    }
+    private:
+        auto tie() const {
+            return std::tie( reduction, reduction_laser, destroy_threshold, flammable, block_unaimed_chance );
+        }
+    public:
+
+        // In C++20, this would be = default
+        bool operator==( const ranged_bash_info &rhs ) const {
+            return tie() == rhs.tie();
+        }
+
+
 };
 
 struct map_bash_info {

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -12,6 +12,7 @@
 #include "active_tile_data.h"
 #include "calendar.h"
 #include "color.h"
+#include "optional.h"
 #include "poly_serialized.h"
 #include "translations.h"
 #include "type_id.h"
@@ -35,8 +36,8 @@ struct map_bash_info {
     int str_min_supported;  // Alternative values for floor supported by something from below
     int str_max_supported;
     int explosive;          // Explosion on destruction
-    int sound_vol;          // sound volume of breaking terrain/furniture
-    int sound_fail_vol;     // sound volume on fail
+    cata::optional<int> sound_vol;          // sound volume of breaking terrain/furniture
+    cata::optional<int> sound_fail_vol;     // sound volume on fail
     int collapse_radius;    // Radius of the tent supported by this tile
     int fd_bash_move_cost = 100; // cost to bash a field
     bool destroy_only;      // Only used for destroying, not normally bashable

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -35,7 +35,13 @@ struct ranged_bash_info {
     cata::optional<numeric_interval<int>> reduction_laser;
     int destroy_threshold = 0; // If reduced dmg is still above this value, destroy us.
     bool flammable = false; // If true, getting hit with any heat damage creates a fire.
-    bool load( const JsonObject &jo );
+    void deserialize( JsonIn &jsin );
+
+    // In C++20, this would be = default
+    bool operator==( const ranged_bash_info &rhs ) const {
+        return std::tie( reduction, reduction_laser, destroy_threshold, flammable ) ==
+               std::tie( rhs.reduction, rhs.reduction_laser, rhs.destroy_threshold, rhs.flammable );
+    }
 };
 
 struct map_bash_info {
@@ -90,7 +96,13 @@ struct furn_workbench_info {
     units::mass allowed_mass;
     units::volume allowed_volume;
     furn_workbench_info();
-    bool load( const JsonObject &jsobj, const std::string &member );
+    void deserialize( JsonIn &jsin );
+
+    // In C++20, this would be = default
+    bool operator==( const furn_workbench_info &rhs ) const {
+        return std::tie( multiplier, allowed_mass, allowed_volume )
+               == std::tie( rhs.multiplier, rhs.allowed_mass, rhs.allowed_volume );
+    }
 };
 struct plant_data {
     // What the furniture turns into when it grows or you plant seeds in it
@@ -102,7 +114,14 @@ struct plant_data {
     // What percent of the normal harvest this crop gives
     float harvest_multiplier;
     plant_data();
-    bool load( const JsonObject &jsobj, const std::string &member );
+
+    void deserialize( JsonIn &jsin );
+
+    // In C++20, this would be = default
+    bool operator==( const plant_data &rhs ) const {
+        return std::tie( transform, base, growth_multiplier, harvest_multiplier )
+               == std::tie( rhs.transform, rhs.base, rhs.growth_multiplier, rhs.harvest_multiplier );
+    }
 };
 
 struct lockpicking_open_result {
@@ -445,7 +464,7 @@ struct furn_t : map_data_common_t {
 
     cata::value_ptr<plant_data> plant;
 
-    cata::value_ptr<float> surgery_skill_multiplier;
+    cata::optional<float> surgery_skill_multiplier;
 
     cata::poly_serialized<active_tile_data> active;
 

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -12,6 +12,7 @@
 #include "active_tile_data.h"
 #include "calendar.h"
 #include "color.h"
+#include "numeric_interval.h"
 #include "optional.h"
 #include "poly_serialized.h"
 #include "translations.h"
@@ -27,6 +28,15 @@ struct ter_t;
 struct tripoint;
 
 using iexamine_function = void ( * )( player &, const tripoint & );
+
+struct ranged_bash_info {
+    numeric_interval<int> reduction; // Damage reduction when shot. Rolled like rng(min, max).
+    // As above, but for lasers. If set, lasers won't destroy us.
+    cata::optional<numeric_interval<int>> reduction_laser;
+    int destroy_threshold = 0; // If reduced dmg is still above this value, destroy us.
+    bool flammable = false; // If true, getting hit with any heat damage creates a fire.
+    bool load( const JsonObject &jo );
+};
 
 struct map_bash_info {
     int str_min;            // min str(*) required to bash
@@ -51,6 +61,8 @@ struct map_bash_info {
     furn_str_id furn_set;   // furniture to set (only used by furniture, not terrain)
     // ids used for the special handling of tents
     std::vector<furn_str_id> tent_centers;
+    // Ranged-specific data, for map::shoot
+    cata::optional<ranged_bash_info> ranged;
     map_bash_info();
     enum map_object_type {
         furniture = 0,

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -18,7 +18,7 @@
 #include "catacharset.h"
 #include "character_id.h"
 #include "clzones.h"
-#include "common_types.h"
+#include "numeric_interval.h"
 #include "computer.h"
 #include "coordinate_conversions.h"
 #include "coordinates.h"

--- a/src/numeric_interval.h
+++ b/src/numeric_interval.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef CATA_SRC_COMMON_TYPES_H
-#define CATA_SRC_COMMON_TYPES_H
+#ifndef CATA_SRC_NUMERIC_INTERVAL_H
+#define CATA_SRC_NUMERIC_INTERVAL_H
 
 #include <limits>
 #include <type_traits>
@@ -46,4 +46,4 @@ struct numeric_interval {
     }
 };
 
-#endif // CATA_SRC_COMMON_TYPES_H
+#endif // CATA_SRC_NUMERIC_INTERVAL_H

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -15,7 +15,7 @@
 #include "cuboid_rectangle.h"
 #include "catacharset.h"
 #include "color.h"
-#include "common_types.h"
+#include "numeric_interval.h"
 #include "coordinates.h"
 #include "int_id.h"
 #include "overmap_location.h"

--- a/src/output.h
+++ b/src/output.h
@@ -659,7 +659,8 @@ inline std::string get_labeled_bar( const double val, const int width, const std
 enum class enumeration_conjunction {
     none,
     and_,
-    or_
+    or_,
+    newline
 };
 
 /**
@@ -679,6 +680,8 @@ std::string enumerate_as_string( const _Container &values,
                 return ( values.size() > 2 ? _( ", and " ) : _( " and " ) );
             case enumeration_conjunction::or_:
                 return ( values.size() > 2 ? _( ", or " ) : _( " or " ) );
+            case enumeration_conjunction::newline:
+                return "\n";
         }
         debugmsg( "Unexpected conjunction" );
         return _( ", " );
@@ -687,7 +690,9 @@ std::string enumerate_as_string( const _Container &values,
     std::string res;
     for( auto iter = values.begin(); iter != values.end(); ++iter ) {
         if( iter != values.begin() ) {
-            if( std::next( iter ) == values.end() ) {
+            if( conj == enumeration_conjunction::newline ) {
+                res += "\n";
+            } else if( std::next( iter ) == values.end() ) {
                 res += final_separator;
             } else {
                 res += _( ", " );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -14,7 +14,7 @@
 #include "cata_utility.h"
 #include "character_id.h"
 #include "color.h"
-#include "common_types.h"
+#include "numeric_interval.h"
 #include "coordinate_conversions.h"
 #include "coordinates.h"
 #include "debug.h"

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -77,6 +77,11 @@ bool x_in_y( double x, double y )
     return rng_float( 0.0, 1.0 ) <= x / y;
 }
 
+bool check( units::probability p )
+{
+    return rng( 0, 1000000 - 1 ) < units::to_one_in_million( p );
+}
+
 int dice( int number, int sides )
 {
     int ret = 0;

--- a/src/rng.h
+++ b/src/rng.h
@@ -10,6 +10,7 @@
 
 #include "optional.h"
 #include "units_angle.h"
+#include "units_probability.h"
 
 class map;
 class time_duration;
@@ -42,6 +43,7 @@ units::angle random_direction();
 bool one_in( int chance );
 bool one_turn_in( const time_duration &duration );
 bool x_in_y( double x, double y );
+bool check( units::probability p );
 int dice( int number, int sides );
 
 // Returns x + x_in_y( x-int(x), 1 )

--- a/src/units.h
+++ b/src/units.h
@@ -16,6 +16,7 @@
 #include "units_energy.h"
 #include "units_money.h"
 #include "units_temperature.h"
+#include "units_probability.h"
 
 namespace units
 {
@@ -51,6 +52,11 @@ inline std::ostream &operator<<( std::ostream &o, angle_in_radians_tag )
 inline std::ostream &operator<<( std::ostream &o, temperature_in_millidegree_celsius_tag )
 {
     return o << "mC";
+}
+
+inline std::ostream &operator<<( std::ostream &o, probability_in_one_in_million_tag )
+{
+    return o << "pm";
 }
 
 template<typename value_type, typename tag_type>
@@ -92,6 +98,12 @@ static const std::vector<std::pair<std::string, angle>> angle_units = { {
         { "arcmin", 1_arcmin },
         { "°", 1_degrees },
         { "rad", 1_radians },
+    }
+};
+static const std::vector<std::pair<std::string, probability>> probability_units = { {
+        { "pm", 1_pm },
+        { "pct", 1_pct },
+        { "%", 1_pct }
     }
 };
 } // namespace units

--- a/src/units_probability.h
+++ b/src/units_probability.h
@@ -1,0 +1,67 @@
+#pragma once
+#ifndef CATA_SRC_UNITS_PROBABILITY_H
+#define CATA_SRC_UNITS_PROBABILITY_H
+
+#include "units_def.h"
+
+namespace units
+{
+
+class probability_in_one_in_million_tag
+{
+};
+
+using probability = quantity<int, probability_in_one_in_million_tag>;
+
+const probability probability_min = units::probability(
+                                        0,
+                                        units::probability::unit_type{} );
+
+const probability probability_max = units::probability(
+                                        1000000,
+                                        units::probability::unit_type{} );
+
+template<typename value_type>
+inline constexpr quantity<value_type, probability_in_one_in_million_tag>
+from_one_in_million(
+    const value_type v )
+{
+    return quantity<value_type, probability_in_one_in_million_tag>( v,
+            probability_in_one_in_million_tag{} );
+}
+
+template<typename value_type>
+inline constexpr quantity<value_type, probability_in_one_in_million_tag>
+from_percent(
+    const value_type v )
+{
+    return quantity<value_type, probability_in_one_in_million_tag>( 10000 * v,
+            probability_in_one_in_million_tag{} );
+}
+
+template<typename value_type>
+inline constexpr value_type to_one_in_million( const
+        quantity<value_type, probability_in_one_in_million_tag> &v )
+{
+    return v / from_one_in_million<value_type>( 1 );
+}
+
+} // namespace units
+
+inline constexpr units::probability operator"" _pm( const unsigned long long v )
+{
+    return units::from_one_in_million<int>( v );
+}
+
+inline constexpr units::probability operator"" _pct( const unsigned long long v )
+{
+    return units::from_one_in_million<int>( v * 10000 );
+}
+
+inline constexpr units::probability operator"" _pct( const long double v )
+{
+    return units::from_one_in_million<int>( v * 10000 );
+}
+
+
+#endif // CATA_SRC_UNITS_PROBABILITY_H

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -7,7 +7,6 @@
 
 #include "calendar.h"
 #include "catch/catch.hpp"
-#include "common_types.h"
 #include "faction.h"
 #include "field.h"
 #include "field_type.h"
@@ -19,6 +18,7 @@
 #include "memory_fast.h"
 #include "npc.h"
 #include "npc_class.h"
+#include "numeric_interval.h"
 #include "optional.h"
 #include "overmapbuffer.h"
 #include "pimpl.h"

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -4,9 +4,9 @@
 
 #include "calendar.h"
 #include "catch/catch.hpp"
-#include "common_types.h"
 #include "enums.h"
 #include "game_constants.h"
+#include "numeric_interval.h"
 #include "omdata.h"
 #include "overmap.h"
 #include "overmap_types.h"


### PR DESCRIPTION
Bash struct gets a new member: `ranged`, which is optional. This is used by `map::shoot`.
It's possible to set the following:
* Reduction of damage of a projectile passing through this terrain. It's an array with `min` and `max` and is rolled as `rng(min, max)`.
* As above, but special-cased for lasers.
* "Destruction threshold" which is amount of damage after reduction needed to destroy this thing. If laser reduction is set, lasers never destroy this terrain. Defaults to 0, meaning any hit ranged above reduction will wreck this terrain.
* Flammability, which makes incendiary ammo and heat damage create small fires when hitting this terrain.
* Chance to intercept a bullet passing through this tile but not aimed at this tile. Defaults to 100%.

If `ranged` is unset, the behavior is unchanged: non-transparent, non-passable tiles block 100% of damage and are bashed as in melee. Transparent or passable tiles don't intercept projectiles at all.

Destroyed terrain goes through same destruction routines as successfully bashed one, so it's more robust than old destruction, which only set things properly for non-hardcoded cases. For hardcoded cases, it often just called `ter_set` and spawned a hardcoded set of items.

Added better support for `copy-from` for terrain, since terrain is massively duplicated. Some of the new JSON-de-hardcoding was done with `copy-from`, to limit copypaste.
For example, bash field is now `copy-from`-able, so the 10 different types of windows we have, not counting taped, reinforced, painted etc. variants of those 10 types, will no longer need to have the bash data copypasted. Once it is set to use `copy-from`, of course.

The bullet interception chance is implemented using new units: `probability`. Now, probability is not exactly a unit, but this was a simple way to support explicit percent, as opposed to the unstandardized `chance` names which pollute the JSONs with ambiguity ("is this the `one_in` chance or the percentage chance?"). Underlying unit is "one in million", below which values are rounded. Percentage can be specified as float: `"12.5%"`.

Renamed `common_types.h` to `numeric_interval.h`, because the file name suggested that it would be a dumpster full of classes that don't fit anywhere else, which of course is bad style and also redundant, since we already have an excess of such trash magnet files.