### PR TITLE
[DDA Port] Streamline Visual Studio project setup process, clarify docs, another VS2022 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ Cataclysm.exe.lastcodeanalysissucceeded
 #Visual Studio 2017
 /msvc-full-features/PredictedInputCache_Debug_x64.dat
 
+#vcpkg
+/msvc-full-features/vcpkg_installed
+
 # PVS Studio
 /msvc-full-features/*PVS-Studio*
 

--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -10,6 +10,7 @@ Steps from current guide were tested on Windows 10 (64 bit), Visual Studio 2019 
 * NTFS partition with ~15 Gb free space (~10 Gb for Visual Studio, ~1 Gb for vcpkg installation, ~3 Gb for repository and ~1 Gb for build cache);
 * Git for Windows (installer can be downloaded from [Git homepage](https://git-scm.com/));
 * Visual Studio 2019 (or 2015 Visual Studio Update 3 and above);
+  * **Note**: If you are using Visual Studio 2022, you must install the Visual Studio 2019 compilers to work around a vcpkg bug. In the Visual Studio Installer, select the 'Individual components' tab and search for / select the component that looks like 'MSVC v142 - VS 2019 C++ x64/x86 Build Tools'. See https://github.com/microsoft/vcpkg/issues/22287.
 * Latest version of vcpkg (see instructions on [vcpkg homepage](https://github.com/Microsoft/vcpkg)).
 
 **Note:** Windows XP is unsupported!

--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -23,22 +23,16 @@ Steps from current guide were tested on Windows 10 (64 bit), Visual Studio 2019 
 
 2. Install `Git for Windows` (installer can be downloaded from [Git homepage](https://git-scm.com/)).
 
-3. Install and configure `vcpkg`:
+3. Install and configure latest `vcpkg`:
 
 ***WARNING: It is important that, wherever you decide to clone this repo, the path does not include whitespace. That is, `C:/dev/vcpkg` is acceptable, but `C:/dev test/vcpkg` is not.***
 
 ```cmd
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
-git checkout 6bc4362fb49e53f1fff7f51e4e27e1946755ecc6
 .\bootstrap-vcpkg.bat
 .\vcpkg integrate install
 ```
-Note: 
-```
-git checkout 6bc4362fb49e53f1fff7f51e4e27e1946755ecc6 
-``` 
-used to grab vcpkg version without font problems.
 
 4. (Optionally) Install (or upgrade) necessary packages with following command line:
 

--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -34,35 +34,6 @@ cd vcpkg
 .\vcpkg integrate install
 ```
 
-4. (Optionally) Install (or upgrade) necessary packages with following command line:
-
-#### Install YASM-tool:
-
-```cmd
-.\vcpkg --triplet x86-windows install yasm-tool yasm-tool-helper
-```
-
-5. Install the dependencies for your desired architecture.
-
-
-#### 64-bit dependencies:
-
-```cmd
-.\vcpkg --triplet x64-windows-static install sdl2 sdl2-image sdl2-mixer[libflac,mpg123,libmodplug,libvorbis] sdl2-ttf gettext
-```
-
-#### 32-bit dependencies:
-
-```cmd
-.\vcpkg --triplet x86-windows-static install sdl2 sdl2-image sdl2-mixer[libflac,mpg123,libmodplug,libvorbis] sdl2-ttf gettext
-```
-
-#### upgrade all dependencies:
-
-```cmd
-.\vcpkg upgrade
-```
-
 ## Cloning and compilation:
 
 1. Clone Cataclysm-BN repository with following command line:
@@ -80,7 +51,7 @@ cd Cataclysm-BN
 
 This will configure Visual Studio to compile the release version, with support for Sound, Tiles, and Localization (note, however, that language files themselves are not automatically compiled; this will be done later).
 
-4. Start the build process by selecting either `Build > Build Solution` or `Build > Build > 1 Cataclysm-vcpkg-static`. The process may take a long period of time, so you'd better prepare a cup of coffee and some books in front of your computer :)
+4. Start the build process by selecting either `Build > Build Solution` or `Build > Build > 1 Cataclysm-vcpkg-static`. The process may take a long period of time, so you'd better prepare a cup of coffee and some books in front of your computer :) The first build of each architecture will also download and install dependencies through vcpkg, which can take an especially long time.
 
 5. If you need localization support, execute the bash script `lang/compile_mo.sh` inside Git Bash GUI just like on a UNIX-like system. This will compile the language files that were not automatically compiled in step 2 above.
 

--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -57,7 +57,7 @@ This will configure Visual Studio to compile the release version, with support f
 
 Even if you do not need languages other than English, you may still want to execute `lang/compile_mo.sh en` or `lang/compile_mo.sh all` to compile the language file for English, in order to work-around a [libintl bug](https://savannah.gnu.org/bugs/index.php?58006) that is causing significant slow-down on Windows targets if a language file is not found.
 
-### Debugging
+### Running from Visual Studio and debugging
 
 Ensure that the Cataclysm project (`Cataclysm-vcpkg-static`) is the selected startup project, configure the working directory in the project settings to `$(ProjectDir)..`, and then press the debug button (or use the appropriate shortcut, e.g. F5).
 

--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -43,7 +43,7 @@ git checkout 6bc4362fb49e53f1fff7f51e4e27e1946755ecc6
 ``` 
 used to grab vcpkg version without font problems.
 
-4. Install a necessary pre-requisite package:
+4. (Optionally) Install (or upgrade) necessary packages with following command line:
 
 #### Install YASM-tool:
 
@@ -83,7 +83,7 @@ git clone https://github.com/cataclysmbnteam/Cataclysm-BN.git
 cd Cataclysm-BN
 ```
 
-2. Open the provided solution (`msvc-full-features\Cataclysm-vcpkg-static.sln`) in `Visual Studio`.
+2. Open the provided solution (`msvc-full-features\Cataclysm-vcpkg-static.sln`) in `Visual Studio`, select configuration (`Release` or `Debug`) and platform (`x64` or `x86`) and build it. All necessary dependencies will be built and cached for future use by vcpkg automatically.
 
 3. Open the `Build > Configuration Manager` menu and adjust `Active solution configuration` and `Active solution platform` to match your intended target.
 

--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -20,10 +20,6 @@ Steps from current guide were tested on Windows 10 (64 bit), Visual Studio 2019 
 
 - Select the "Desktop development with C++" and "Game development with C++" workloads.
 
-- If you're installing Visual Studio **2022**, go to "Individual components" tab and for every enabled `v143` component
-  enable corresponding `v142` component. This enables Visual Studio 2019 toolchain, which we will be using, as
-  2022 one is not fully supported by `vcpkg` yet.
-
 2. Install `Git for Windows` (installer can be downloaded from [Git homepage](https://git-scm.com/)).
 
 3. Install and configure `vcpkg`:

--- a/doc/DEVELOPER_TOOLING.md
+++ b/doc/DEVELOPER_TOOLING.md
@@ -29,9 +29,11 @@ If you have only `astyle` then use:
 astyle --options=.astylerc --recursive src/*.cpp,*.h tests/*.cpp,*.h`
 ```
 
-On Windows, there is an [AStyle extension for Visual Studio](https://github.com/lukamicoder/astyle-extension)
+On Windows, there is an [AStyle extension for Visual Studio](https://github.com/lukamicoder/astyle-extension).
 
-#### Instruction:
+It does not support Visual Studio 2022 yet, but there is [an alternative](https://github.com/olanti-p/BN_Astyle) available.
+
+#### Instruction (Visual Studio 2019 or older):
 
 1. Install aforementioned extension to Visual Studio IDE.
 

--- a/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
@@ -27,6 +27,16 @@
       <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgTriplet>
       <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgTriplet>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnabled>true</VcpkgEnabled>
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+    <VcpkgManifestInstall>true</VcpkgManifestInstall>
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+    <VcpkgAutoLink>true</VcpkgAutoLink>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows</VcpkgUserTriplet>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows</VcpkgUserTriplet>
+    <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
 
   <PropertyGroup Label="Configuration">

--- a/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
@@ -33,9 +33,10 @@
     <VcpkgManifestInstall>true</VcpkgManifestInstall>
     <VcpkgUseStatic>true</VcpkgUseStatic>
     <VcpkgAutoLink>true</VcpkgAutoLink>
-    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows</VcpkgUserTriplet>
-    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows</VcpkgUserTriplet>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgUserTriplet>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgUserTriplet>
     <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+    <VcpkgAdditionalInstallOptions>--clean-after-build</VcpkgAdditionalInstallOptions>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
 

--- a/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
@@ -27,6 +27,16 @@
     <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgTriplet>
     <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgTriplet>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnabled>true</VcpkgEnabled>
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+    <VcpkgManifestInstall>true</VcpkgManifestInstall>
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+    <VcpkgAutoLink>true</VcpkgAutoLink>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows</VcpkgUserTriplet>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows</VcpkgUserTriplet>
+    <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
@@ -33,9 +33,10 @@
     <VcpkgManifestInstall>true</VcpkgManifestInstall>
     <VcpkgUseStatic>true</VcpkgUseStatic>
     <VcpkgAutoLink>true</VcpkgAutoLink>
-    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows</VcpkgUserTriplet>
-    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows</VcpkgUserTriplet>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgUserTriplet>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgUserTriplet>
     <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+    <VcpkgAdditionalInstallOptions>--clean-after-build</VcpkgAdditionalInstallOptions>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/msvc-full-features/Cataclysm-vcpkg-static.sln
+++ b/msvc-full-features/Cataclysm-vcpkg-static.sln
@@ -7,6 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		..\.editorconfig = ..\.editorconfig
 		AStyleExtension-Cataclysm-DDA.cfg = AStyleExtension-Cataclysm-DDA.cfg
+		vcpkg.json = vcpkg.json
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Cataclysm-vcpkg-static", "Cataclysm-vcpkg-static.vcxproj", "{19F0BE17-3DAF-40E8-A9D2-904A56382E54}"

--- a/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
@@ -27,6 +27,16 @@
     <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgTriplet>
     <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgTriplet>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnabled>true</VcpkgEnabled>
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+    <VcpkgManifestInstall>true</VcpkgManifestInstall>
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+    <VcpkgAutoLink>true</VcpkgAutoLink>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows</VcpkgUserTriplet>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows</VcpkgUserTriplet>
+    <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
@@ -33,9 +33,10 @@
     <VcpkgManifestInstall>true</VcpkgManifestInstall>
     <VcpkgUseStatic>true</VcpkgUseStatic>
     <VcpkgAutoLink>true</VcpkgAutoLink>
-    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows</VcpkgUserTriplet>
-    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows</VcpkgUserTriplet>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgUserTriplet>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgUserTriplet>
     <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+    <VcpkgAdditionalInstallOptions>--clean-after-build</VcpkgAdditionalInstallOptions>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/msvc-full-features/JsonFormatter.vcxproj
+++ b/msvc-full-features/JsonFormatter.vcxproj
@@ -27,6 +27,16 @@
     <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgTriplet>
     <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgTriplet>
   </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnabled>true</VcpkgEnabled>
+    <VcpkgEnableManifest>true</VcpkgEnableManifest>
+    <VcpkgManifestInstall>true</VcpkgManifestInstall>
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+    <VcpkgAutoLink>true</VcpkgAutoLink>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows</VcpkgUserTriplet>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows</VcpkgUserTriplet>
+    <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/msvc-full-features/JsonFormatter.vcxproj
+++ b/msvc-full-features/JsonFormatter.vcxproj
@@ -33,9 +33,10 @@
     <VcpkgManifestInstall>true</VcpkgManifestInstall>
     <VcpkgUseStatic>true</VcpkgUseStatic>
     <VcpkgAutoLink>true</VcpkgAutoLink>
-    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows</VcpkgUserTriplet>
-    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows</VcpkgUserTriplet>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgUserTriplet>
+    <VcpkgUserTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgUserTriplet>
     <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
+    <VcpkgAdditionalInstallOptions>--clean-after-build</VcpkgAdditionalInstallOptions>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -10,5 +10,6 @@
         },
         "sdl2-ttf",
         "gettext"
-    ]
+    ],
+    "builtin-baseline": "49b67d9cb856424ff69f10e7721aec5299624268"
 }

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -1,0 +1,14 @@
+{
+    "name": "cdda-vcpkg-dependencies",
+    "version-string": "0.E",
+    "dependencies": [
+        "sdl2",
+        "sdl2-image",
+        {
+          "name": "sdl2-mixer",
+          "features": [ "dynamic-load", "libflac", "mpg123", "libmodplug", "libvorbis" ]
+        },
+        "sdl2-ttf",
+        "gettext"
+    ]
+}

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -6,7 +6,7 @@
         "sdl2-image",
         {
           "name": "sdl2-mixer",
-          "features": [ "dynamic-load", "libflac", "mpg123", "libmodplug", "libvorbis" ]
+          "features": [ "libflac", "mpg123", "libmodplug", "libvorbis" ]
         },
         "sdl2-ttf",
         "gettext"

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -1,6 +1,6 @@
 {
-    "name": "cdda-vcpkg-dependencies",
-    "version-string": "0.E",
+    "name": "bn-vcpkg-dependencies",
+    "version-string": "experimental",
     "dependencies": [
         "sdl2",
         "sdl2-image",


### PR DESCRIPTION
#### Purpose of change
As in the title.

#### Describe the solution
Cherry-picked some DDA code:
https://github.com/CleverRaven/Cataclysm-DDA/pull/41908
https://github.com/CleverRaven/Cataclysm-DDA/pull/54170
https://github.com/CleverRaven/Cataclysm-DDA/pull/51616 (partially)

Also removed an obsolete workaround and my previous blind attempt at fixing docs for vs2022 (#1294).

#### Describe alternatives you've considered
Migrating BN to meson.

#### Testing
Installed from scratch vcpkg and Visual Studio 2022 Community, got it to compile BN without problems.
~There's still the issue of the astyle plugin not supporting vs2022 yet, but that's relatively minor and can be solved by setting up msys2 to run `make astyle`.~
Nevermind that, I managed to cobble together Astyle extension for vs2022, so that's not a problem anymore either.