### PR TITLE
Add an option to display absolute overmap coordinates

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1478,6 +1478,15 @@ void options_manager::add_options_interface()
     { { "metric", translate_marker( "Metric" ) }, { "imperial", translate_marker( "Imperial" ) } },
     "imperial" );
 
+    add(
+        "OVERMAP_COORDINATE_FORMAT",
+        "interface",
+        translate_marker( "Overmap coordinates format" ),
+        translate_marker( "Are overmap coordinates displayed using relative format like 1'158, 2'56 or absolute format like 338, 416?" ),
+    { { "relative", translate_marker( "Relative" ) }, { "absolute", translate_marker( "Absolute" ) } },
+    "absolute"
+    );
+
     add( "24_HOUR", "interface", translate_marker( "Time format" ),
          translate_marker( "12h: AM/PM, e.g. 7:31 AM - Military: 24h Military, e.g. 0731 - 24h: Normal 24h, e.g. 7:31" ),
          //~ 12h time, e.g.  11:59pm

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1482,8 +1482,8 @@ void options_manager::add_options_interface()
         "OVERMAP_COORDINATE_FORMAT",
         "interface",
         translate_marker( "Overmap coordinates format" ),
-        translate_marker( "Are overmap coordinates displayed using relative format like 1'158, 2'56 or absolute format like 338, 416?" ),
-    { { "relative", translate_marker( "Relative" ) }, { "absolute", translate_marker( "Absolute" ) } },
+        translate_marker( "Are overmap coordinates displayed using absolute format like 338, 416 or subdivided into two components like 1'158, 2'56?" ),
+    { { "subdivided", translate_marker( "Subdivided" ) }, { "absolute", translate_marker( "Absolute" ) } },
     "absolute"
     );
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -184,7 +184,7 @@ struct grids_draw_data {
 
 static std::string fmt_omt_coords( const tripoint_abs_omt &coord )
 {
-    if( get_option<std::string>( "OVERMAP_COORDINATE_FORMAT" ) == "relative" ) {
+    if( get_option<std::string>( "OVERMAP_COORDINATE_FORMAT" ) == "subdivided" ) {
         point_abs_om abs_coord;
         tripoint_om_omt rel_coord;
         std::tie( abs_coord, rel_coord ) = project_remain<coords::om>( coord );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -670,9 +670,6 @@ static tripoint_abs_omt show_notes_manager( const tripoint_abs_omt &origin )
                 entry_to_select = i;
             }
             const std::string direction_str = direction_name_short( direction_from( p_player, note.p ) );
-            point_abs_om abs_om;
-            tripoint_om_omt rel_omt;
-            std::tie( abs_om, rel_omt ) = project_remain<coords::om>( note.p );
             const std::string location_desc = overmap_buffer.get_description_at(
                                                   project_to<coords::sm>( note.p ) );
 
@@ -704,12 +701,29 @@ static tripoint_abs_omt show_notes_manager( const tripoint_abs_omt &origin )
                 }
             }
 
+            std::string coord_string;
+
+            if( get_option<std::string>( "OVERMAP_COORDINATE_FORMAT" ) == "relative" ) {
+                point_abs_om abs_om;
+                tripoint_om_omt rel_omt;
+                std::tie( abs_om, rel_omt ) = project_remain<coords::om>( note.p );
+
+                coord_string = string_format(
+                                   _( "<color_red>LEVEL %i, %d'%d, %d'%d</color>: %s (Distance: <color_white>%d %s</color>) <color_red>%s</color>" ),
+                                   rel_omt.z(), abs_om.x(), rel_omt.x(), abs_om.y(), rel_omt.y(), location_desc, note.dist_from_pl,
+                                   trim_whitespaces( direction_str ), is_dangerous ? _( "DANGEROUS AREA!" ) : "" );
+            } else {
+                point_abs_omt abs_omt = note.p.xy();
+
+                coord_string = string_format(
+                                   _( "<color_red>LEVEL %i, %d, %d</color>: %s (Distance: <color_white>%d %s</color>) <color_red>%s</color>" ),
+                                   note.p.z(), abs_omt.x(), abs_omt.y(), location_desc, note.dist_from_pl,
+                                   trim_whitespaces( direction_str ), is_dangerous ? _( "DANGEROUS AREA!" ) : "" );
+            }
+
             nmenu.addentry_desc( string_format(
                                      "[%s] %s", colorize( note.symbol, note.col ), note.text ),
-                                 string_format(
-                                     _( "<color_red>LEVEL %i, %d'%d, %d'%d</color>: %s (Distance: <color_white>%d %s</color>) <color_red>%s</color>" ),
-                                     rel_omt.z(), abs_om.x(), rel_omt.x(), abs_om.y(), rel_omt.y(), location_desc, note.dist_from_pl,
-                                     trim_whitespaces( direction_str ), is_dangerous ? _( "DANGEROUS AREA!" ) : "" ) );
+                                 coord_string );
             nmenu.entries[i].ctxt = string_format(
                                         "%s<color_white>% 4d %s</color>", dr_short, note.dist_from_pl, direction_str
                                     );
@@ -1423,11 +1437,17 @@ static void draw_om_sidebar(
     }
 
     point_abs_omt abs_omt = center.xy();
-    point_abs_om om;
-    point_om_omt omt;
-    std::tie( om, omt ) = project_remain<coords::om>( abs_omt );
-    mvwprintz( wbar, point( 1, getmaxy( wbar ) - 1 ), c_red,
-               _( "LEVEL %i, %d'%d, %d'%d" ), center.z(), om.x(), omt.x(), om.y(), omt.y() );
+
+    if( get_option<std::string>( "OVERMAP_COORDINATE_FORMAT" ) == "relative" ) {
+        point_abs_om om;
+        point_om_omt omt;
+        std::tie( om, omt ) = project_remain<coords::om>( abs_omt );
+        mvwprintz( wbar, point( 1, getmaxy( wbar ) - 1 ), c_red,
+                   _( "LEVEL %i, %d'%d, %d'%d" ), center.z(), om.x(), omt.x(), om.y(), omt.y() );
+    } else {
+        mvwprintz( wbar, point( 1, getmaxy( wbar ) - 1 ), c_red,
+                   _( "LEVEL %i, %d, %d" ), center.z(), abs_omt.x(), abs_omt.y() );
+    }
     wnoutrefresh( wbar );
 }
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -182,6 +182,19 @@ struct grids_draw_data {
         std::unordered_map<std::size_t, std::pair<std::vector<tripoint_abs_omt>, char>> list_inactive;
 };
 
+static std::string fmt_omt_coords( const tripoint_abs_omt &coord )
+{
+    if( get_option<std::string>( "OVERMAP_COORDINATE_FORMAT" ) == "relative" ) {
+        point_abs_om abs_coord;
+        tripoint_om_omt rel_coord;
+        std::tie( abs_coord, rel_coord ) = project_remain<coords::om>( coord );
+
+        return string_format( "%d'%d, %d'%d", abs_coord.x(), rel_coord.x(), abs_coord.y(), rel_coord.y() );
+    } else {
+        return string_format( "%d, %d", coord.x(), coord.y() );
+    }
+}
+
 static void create_note( const tripoint_abs_omt &curs );
 
 // {note symbol, note color, offset to text}
@@ -701,29 +714,13 @@ static tripoint_abs_omt show_notes_manager( const tripoint_abs_omt &origin )
                 }
             }
 
-            std::string coord_string;
-
-            if( get_option<std::string>( "OVERMAP_COORDINATE_FORMAT" ) == "relative" ) {
-                point_abs_om abs_om;
-                tripoint_om_omt rel_omt;
-                std::tie( abs_om, rel_omt ) = project_remain<coords::om>( note.p );
-
-                coord_string = string_format(
-                                   _( "<color_red>LEVEL %i, %d'%d, %d'%d</color>: %s (Distance: <color_white>%d %s</color>) <color_red>%s</color>" ),
-                                   rel_omt.z(), abs_om.x(), rel_omt.x(), abs_om.y(), rel_omt.y(), location_desc, note.dist_from_pl,
-                                   trim_whitespaces( direction_str ), is_dangerous ? _( "DANGEROUS AREA!" ) : "" );
-            } else {
-                point_abs_omt abs_omt = note.p.xy();
-
-                coord_string = string_format(
-                                   _( "<color_red>LEVEL %i, %d, %d</color>: %s (Distance: <color_white>%d %s</color>) <color_red>%s</color>" ),
-                                   note.p.z(), abs_omt.x(), abs_omt.y(), location_desc, note.dist_from_pl,
-                                   trim_whitespaces( direction_str ), is_dangerous ? _( "DANGEROUS AREA!" ) : "" );
-            }
-
             nmenu.addentry_desc( string_format(
                                      "[%s] %s", colorize( note.symbol, note.col ), note.text ),
-                                 coord_string );
+                                 string_format(
+                                     _( "<color_red>LEVEL %i, %s</color>: %s (Distance: <color_white>%d %s</color>) <color_red>%s</color>" ),
+                                     note.p.z(),
+                                     fmt_omt_coords( note.p ), location_desc, note.dist_from_pl,
+                                     trim_whitespaces( direction_str ), is_dangerous ? _( "DANGEROUS AREA!" ) : "" ) );
             nmenu.entries[i].ctxt = string_format(
                                         "%s<color_white>% 4d %s</color>", dr_short, note.dist_from_pl, direction_str
                                     );
@@ -1436,18 +1433,9 @@ static void draw_om_sidebar(
         print_hint( "QUIT" );
     }
 
-    point_abs_omt abs_omt = center.xy();
+    mvwprintz( wbar, point( 1, getmaxy( wbar ) - 1 ), c_red, _( "LEVEL %i, %s" ), center.z(),
+               fmt_omt_coords( center ) );
 
-    if( get_option<std::string>( "OVERMAP_COORDINATE_FORMAT" ) == "relative" ) {
-        point_abs_om om;
-        point_om_omt omt;
-        std::tie( om, omt ) = project_remain<coords::om>( abs_omt );
-        mvwprintz( wbar, point( 1, getmaxy( wbar ) - 1 ), c_red,
-                   _( "LEVEL %i, %d'%d, %d'%d" ), center.z(), om.x(), omt.x(), om.y(), omt.y() );
-    } else {
-        mvwprintz( wbar, point( 1, getmaxy( wbar ) - 1 ), c_red,
-                   _( "LEVEL %i, %d, %d" ), center.z(), abs_omt.x(), abs_omt.y() );
-    }
     wnoutrefresh( wbar );
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Interface "An option to display absolute overmap coordinates instead of relative coordinates"

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: Interface "An option to display absolute overmap coordinates instead of relative coordinates"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

#### Purpose of change
Overmap displays your current position like 3'59, 2'33 which is a strange unit that's pretty much useless: it's not very easy to remember, it's not clear how it works and, for the purposes of stuff like calculating distances manually, it's converted into absolute coordinates anyway. This PR alleviates this by adding an option (enabled by default) to display absolute coordinates instead.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
The only two places where overmap coordinates are seemingly displayed is the bottom right corner of [m]ap screen and notes panel in the same screen. Depending on the option's value, it will display them differently.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
N/A
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
![image](https://user-images.githubusercontent.com/860874/152785927-3d18237c-8ef1-4672-af1e-914437e7242c.png)
![image](https://user-images.githubusercontent.com/860874/152785992-345cb1fa-b2c1-48bc-b2d9-e7a164630448.png)
![image](https://user-images.githubusercontent.com/860874/152786017-73aa5b70-bd6e-4217-bfab-1733345661b5.png)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
