### PR TITLE
Disable some graphics-related keys when their functionality is disabled

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2503,12 +2503,16 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "debug_submap_grid" );
     ctxt.register_action( "debug_hour_timer" );
     ctxt.register_action( "debug_mode" );
-    ctxt.register_action( "zoom_out" );
-    ctxt.register_action( "zoom_in" );
+    if( use_tiles ) {
+        ctxt.register_action( "zoom_out" );
+        ctxt.register_action( "zoom_in" );
+    }
 #if !defined(__ANDROID__)
     ctxt.register_action( "toggle_fullscreen" );
 #endif
+#if defined(TILES)
     ctxt.register_action( "toggle_pixel_minimap" );
+#endif // TILES
     ctxt.register_action( "toggle_panel_adm" );
     ctxt.register_action( "reload_tileset" );
     ctxt.register_action( "toggle_auto_features" );
@@ -6852,9 +6856,13 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
-    ctxt.register_action( "zoom_out" );
-    ctxt.register_action( "zoom_in" );
+    if( use_tiles ) {
+        ctxt.register_action( "zoom_out" );
+        ctxt.register_action( "zoom_in" );
+    }
+#if defined(TILES)
     ctxt.register_action( "toggle_pixel_minimap" );
+#endif // TILES
 
     const int old_levz = get_levz();
     const int min_levz = std::max( old_levz - fov_3d_z_range, -OVERMAP_DEPTH );
@@ -6881,15 +6889,19 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
             std::string fast_scroll_text = string_format( _( "%s - %s" ),
                                            ctxt.get_desc( "TOGGLE_FAST_SCROLL" ),
                                            ctxt.get_action_name( "TOGGLE_FAST_SCROLL" ) );
+#if defined(TILES)
             std::string pixel_minimap_text = string_format( _( "%s - %s" ),
                                              ctxt.get_desc( "toggle_pixel_minimap" ),
                                              ctxt.get_action_name( "toggle_pixel_minimap" ) );
+#endif // TILES
 
             center_print( w_info, getmaxy( w_info ) - 2, c_light_gray, extended_descr_text );
             mvwprintz( w_info, point( 1, getmaxy( w_info ) - 1 ), fast_scroll ? c_light_green : c_green,
                        fast_scroll_text );
+#if defined(TILES)
             right_print( w_info, getmaxy( w_info ) - 1, 1, pixel_minimap_option ? c_light_green : c_green,
                          pixel_minimap_text );
+#endif // TILES
 
             int first_line = 1;
             const int last_line = getmaxy( w_info ) - 3;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1920,8 +1920,10 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
     ictxt.register_action( "CONFIRM" );
     ictxt.register_action( "LEVEL_UP" );
     ictxt.register_action( "LEVEL_DOWN" );
-    ictxt.register_action( "ZOOM_OUT" );
-    ictxt.register_action( "ZOOM_IN" );
+    if( use_tiles && use_tiles_overmap ) {
+        ictxt.register_action( "ZOOM_OUT" );
+        ictxt.register_action( "ZOOM_IN" );
+    }
     ictxt.register_action( "HELP_KEYBINDINGS" );
     ictxt.register_action( "MOUSE_MOVE" );
     ictxt.register_action( "SELECT" );


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Disable some graphics-related keys when their functionality is disabled"

#### Purpose of change
Disable some keys related to graphical features when these features are absent (curses, SDL with tiles disabled).
Fixes #1313

#### Describe the solution
Sprinkle in some conditions and `#ifdef`s

#### Testing
Disabled tiles in SDL build - zoom keys went absent.