### PR TITLE
Porting over CDDA's "change shape" feature

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1236,6 +1236,13 @@
   },
   {
     "type": "keybinding",
+    "id": "CHANGE_SHAPE",
+    "category": "VEH_INTERACT",
+    "name": "Change part shape",
+    "bindings": [ { "input_method": "keyboard", "key": "p" } ]
+  },  
+  {
+    "type": "keybinding",
     "id": "ASSIGN_CREW",
     "category": "VEH_INTERACT",
     "name": "Assign crew",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1240,7 +1240,7 @@
     "category": "VEH_INTERACT",
     "name": "Change part shape",
     "bindings": [ { "input_method": "keyboard", "key": "p" } ]
-  },  
+  },
   {
     "type": "keybinding",
     "id": "ASSIGN_CREW",

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2449,6 +2449,8 @@ void vehicle_part::deserialize( JsonIn &jsin )
     data.read( "direction", direction_int );
     direction = units::from_degrees( direction_int );
     data.read( "blood", blood );
+    data.read( "proxy_part_id", proxy_part_id );
+    data.read( "proxy_sym", proxy_sym );
     data.read( "enabled", enabled );
     data.read( "flags", flags );
     data.read( "passenger_id", passenger_id );
@@ -2519,6 +2521,8 @@ void vehicle_part::serialize( JsonOut &json ) const
     json.member( "open", open );
     json.member( "direction", std::lround( to_degrees( direction ) ) );
     json.member( "blood", blood );
+    json.member( "proxy_part_id", proxy_part_id );
+    json.member( "proxy_sym", proxy_sym );
     json.member( "enabled", enabled );
     json.member( "flags", flags );
     if( !carry_names.empty() ) {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -223,6 +223,7 @@ veh_interact::veh_interact( vehicle &veh, const point &p )
     main_context.register_action( "SIPHON" );
     main_context.register_action( "UNLOAD" );
     main_context.register_action( "ASSIGN_CREW" );
+    main_context.register_action( "CHANGE_SHAPE" );
     main_context.register_action( "RELABEL" );
     main_context.register_action( "PREV_TAB" );
     main_context.register_action( "NEXT_TAB" );
@@ -459,6 +460,9 @@ void veh_interact::do_main_loop()
             if( veh->handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
                 finish = do_unload();
             }
+        } else if( action == "CHANGE_SHAPE" ) {
+            // purely cosmetic
+            do_change_shape();
         } else if( action == "ASSIGN_CREW" ) {
             if( owned_by_player ) {
                 do_assign_crew();
@@ -625,6 +629,18 @@ task_reason veh_interact::cant_do( char mode )
                 return e.part().is_seat();
             } ) ? CAN_DO : INVALID_TARGET;
 
+        case 'p': {
+            // Change part shape
+            has_tools = true;
+
+            if( cpart >= 0 ) {
+                const int displayed_part = veh->part_displayed_at( veh->part( cpart ).mount );
+                const vpart_info &displayed_vpart = veh->part( displayed_part ).info();
+                // Does the displayed part have different shapes?
+                valid_target = vpart_shapes[displayed_vpart.name() + displayed_vpart.item.str()].size() > 1;
+            }
+            break;
+        }
         case 'a':
             // relabel
             valid_target = cpart >= 0;
@@ -1960,6 +1976,51 @@ bool veh_interact::do_unload()
     return true;
 }
 
+void veh_interact::do_change_shape()
+{
+    if( cant_do( 'p' ) == task_reason::INVALID_TARGET ) {
+        msg = _( "No parts here or the part visible from your position does not have different shapes" );
+        return;
+    }
+
+    vehicle_part &part = veh->part( veh->part_displayed_at( veh->part( cpart ).mount ) );
+    const vpart_info &part_info = part.info();
+
+    using v_shapes = std::vector<const vpart_info *, std::allocator<const vpart_info *>>;
+    const v_shapes &shapes = vpart_shapes[part_info.name() + part_info.item.str()];
+
+    uilist smenu;
+    smenu.text = _( "Choose shape:" );
+    smenu.w_width_setup = [this]() {
+        return getmaxx( w_list );
+    };
+    smenu.w_x_setup = [this]( const int ) {
+        return getbegx( w_list );
+    };
+    smenu.w_y_setup = [this]( const int ) {
+        return getbegy( w_list );
+    };
+
+    int ret_code = 0;
+    for( const vpart_info *const shape : shapes ) {
+        uilist_entry entry( shape->name() );
+        entry.retval = ret_code++;
+        entry.extratxt.left = 1;
+        entry.extratxt.sym = special_symbol( shape->sym );
+        entry.extratxt.color = shape->color;
+        smenu.entries.emplace_back( entry );
+    }
+
+    sort_uilist_entries_by_line_drawing( smenu.entries );
+
+    smenu.query();
+    if( smenu.ret >= 0 ) {
+        const vpart_info* selected_shape = shapes[smenu.ret];
+        part.proxy_part_id = selected_shape->get_id();
+        part.proxy_sym = selected_shape->sym;
+    }
+}
+
 void veh_interact::do_assign_crew()
 {
     if( cant_do( 'w' ) != CAN_DO ) {
@@ -2487,7 +2548,7 @@ void veh_interact::display_stats() const
         const double water_clearance = veh->water_hull_height() - veh->water_draft();
         std::string draft_string = water_clearance > 0 ?
                                    _( "Draft/Clearance:<color_light_blue>%4.2f</color>m/<color_light_blue>%4.2f</color>m" ) :
-                                   _( "Draft/Clearance:<color_light_blue>%4.2f</color>m/<color_light_red>%4.2f</color>m" ) ;
+                                   _( "Draft/Clearance:<color_light_blue>%4.2f</color>m/<color_light_red>%4.2f</color>m" );
 
         fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
                         draft_string.c_str(),
@@ -2543,7 +2604,7 @@ void veh_interact::display_mode()
         size_t esc_pos = display_esc( w_mode );
 
         // broken indentation preserved to avoid breaking git history for large number of lines
-        const std::array<std::string, 10> actions = { {
+        const std::array<std::string, 11> actions = { {
                 { _( "<i>nstall" ) },
                 { _( "<r>epair" ) },
                 { _( "<m>end" ) },
@@ -2552,6 +2613,7 @@ void veh_interact::display_mode()
                 { _( "<s>iphon" ) },
                 { _( "unloa<d>" ) },
                 { _( "cre<w>" ) },
+                { _( "sha<p>e" ) },
                 { _( "r<e>name" ) },
                 { _( "l<a>bel" ) },
             }
@@ -2566,6 +2628,7 @@ void veh_interact::display_mode()
                 !cant_do( 's' ),
                 !cant_do( 'd' ),
                 !cant_do( 'w' ),
+                !cant_do( 'p' ),
                 true,          // 'rename' is always available
                 !cant_do( 'a' ),
             }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2015,7 +2015,7 @@ void veh_interact::do_change_shape()
 
     smenu.query();
     if( smenu.ret >= 0 ) {
-        const vpart_info* selected_shape = shapes[smenu.ret];
+        const vpart_info *selected_shape = shapes[smenu.ret];
         part.proxy_part_id = selected_shape->get_id();
         part.proxy_sym = selected_shape->sym;
     }

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -152,6 +152,7 @@ class veh_interact
         void do_siphon();
         // Returns true if exiting the screen
         bool do_unload();
+        void do_change_shape();
         void do_assign_crew();
         void do_relabel();
         /*@}*/

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -423,7 +423,7 @@ struct vehicle_part {
 
 
         vpart_id proxy_part_id = vpart_id::NULL_ID();
-        char proxy_sym = NULL;
+        char proxy_sym = '\0';
         /**
          * Coordinates for some kind of target; jumper cables and turrets use this
          * Two coordinate pairs are stored: actual target point, and target vehicle center.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -421,6 +421,9 @@ struct vehicle_part {
         /** direction the part is facing */
         units::angle direction = 0_degrees;
 
+
+        vpart_id proxy_part_id = vpart_id::NULL_ID();
+        char proxy_sym = NULL;
         /**
          * Coordinates for some kind of target; jumper cables and turrets use this
          * Two coordinate pairs are stored: actual target point, and target vehicle center.

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -44,7 +44,7 @@ char vehicle::part_sym( const int p, const bool exact ) const
         return '\'';
     } else {
         return parts[displayed_part].is_broken() ?
-               part_info( displayed_part ).sym_broken : ( parts[displayed_part].proxy_sym == NULL ?  part_info(
+               part_info( displayed_part ).sym_broken : ( parts[displayed_part].proxy_sym == '\0' ?  part_info(
                            displayed_part ).sym : parts[displayed_part].proxy_sym );
     }
 }

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -43,8 +43,9 @@ char vehicle::part_sym( const int p, const bool exact ) const
         // open door
         return '\'';
     } else {
-        return parts[ displayed_part ].is_broken() ?
-               part_info( displayed_part ).sym_broken : part_info( displayed_part ).sym;
+        return parts[displayed_part].is_broken() ?
+               part_info( displayed_part ).sym_broken : ( parts[displayed_part].proxy_sym == NULL ?  part_info(
+                           displayed_part ).sym : parts[displayed_part].proxy_sym );
     }
 }
 
@@ -64,7 +65,8 @@ vpart_id vehicle::part_id_string( const int p, char &part_mod ) const
         return vpart_id::NULL_ID();
     }
 
-    const vpart_id idinfo = parts[displayed_part].id;
+    const vpart_id idinfo = parts[displayed_part].proxy_part_id == vpart_id::NULL_ID() ?
+                            parts[displayed_part].id : parts[displayed_part].proxy_part_id;
 
     if( part_flag( displayed_part, VPFLAG_OPENABLE ) && parts[displayed_part].open ) {
         // open


### PR DESCRIPTION
#### Summary
SUMMARY: Feature "The shape of a visible vehicle part can be changed instantly at no cost (CDDA's change shape equivalent)"

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/issues/27770

#### Describe the solution
This PR essentially replicates https://github.com/CleverRaven/Cataclysm-DDA/pull/48477
However, it differs in how it works. Whereas CDDA's version is a "select part, change shape", in this PR the visible/displayed part is immediately selected. This also does make it context-sensitive since a player inside a vehicle sees different parts than a player outside of it. Other than that, no other difference other than the implementation.

Bardcore essentially added a new value to vehicle parts that is serialized/deserialized from JSON and stores the symbol. This is in contrast to CDDA's part variant system.

#### Describe alternatives you've considered
N/A

#### Testing
Tested by Bardcore: new symbols get saved and loaded, no apparent issues had been discovered.

#### Additional context
![image](https://user-images.githubusercontent.com/860874/152887229-0a46e7a4-6be1-4bb7-b39a-6bbad974c6d4.png)
![image](https://user-images.githubusercontent.com/860874/152887285-f78dadc7-087b-46b2-88fd-66c065a47753.png)
![image](https://user-images.githubusercontent.com/860874/152887300-ada50734-0bc6-4684-a147-47efdef219c6.png)
![image](https://user-images.githubusercontent.com/860874/152887348-73ff035f-df32-4319-930f-795bc61ac29a.png)
![image](https://user-images.githubusercontent.com/860874/152887385-40d5475f-47fd-4419-910b-c4530e55d83f.png)
