### PR TITLE
Misc fixes for explosions and radio activation

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1648,12 +1648,7 @@
     "context": [  ]
   },
   {
-    "id": "RADIOCAR",
-    "type": "json_flag",
-    "context": [  ]
-  },
-  {
-    "id": "RADIO_CONTAINER",
+    "id": "RADIO_CONTROLLED",
     "type": "json_flag",
     "context": [  ]
   },

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -940,6 +940,7 @@
     "symbol": "*",
     "color": "light_green",
     "turns_per_charge": 1,
+    "max_charges": 1000,
     "use_action": {
       "type": "explosion",
       "fields_type": "fd_nuke_gas",

--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -80,7 +80,7 @@
   },
   {
     "id": "radio_mod",
-    "type": "GENERIC",
+    "type": "TOOL",
     "category": "spare_parts",
     "name": { "str": "radio activation mod" },
     "description": "This small piece of electronics can be attached to certain items and activate them after receiving a radio signal.",

--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -65,7 +65,6 @@
     "charges_per_use": 1,
     "proportional": { "weight": 0.73, "volume": 0.75, "price": 0.8 },
     "use_action": "RADIOCAR",
-    "flags": [ "RADIO_CONTAINER" ],
     "magazines": [ [ "battery", [ "light_minus_disposable_cell", "light_minus_battery_cell", "light_minus_atomic_battery_cell" ] ] ]
   },
   {
@@ -76,7 +75,7 @@
     "description": "This remote-controlled car is on, and draining its batteries just like a real electric car!  Use a remote control to drive it around.",
     "turns_per_charge": 5,
     "use_action": "RADIOCARON",
-    "flags": [ "LIGHT_8", "RADIO_CONTAINER", "TRADER_AVOID" ]
+    "flags": [ "LIGHT_8", "RADIO_CONTROLLED", "TRADER_AVOID" ]
   },
   {
     "id": "radio_mod",

--- a/data/json/recipes/electronic/tools.json
+++ b/data/json/recipes/electronic/tools.json
@@ -629,7 +629,13 @@
     "components": [
       [ [ "antenna", 1 ] ],
       [ [ "pilot_light", 1 ] ],
-      [ [ "light_minus_battery_cell", 1 ] ],
+      [
+        [ "light_minus_battery_cell", 1 ],
+        [ "light_minus_disposable_cell", 1 ],
+        [ "light_battery_cell", 1 ],
+        [ "light_disposable_cell", 1 ],
+        [ "light_plus_battery_cell", 1 ]
+      ],
       [ [ "amplifier", 1 ] ],
       [ [ "cable", 2 ] ]
     ]

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -1281,11 +1281,12 @@ Melee flags are fully compatible with tool flags, and vice versa.
 - ```NO_UNLOAD``` Cannot be unloaded.
 - ```POWERED``` If turned ON, item uses its own source of power, instead of relying on power of the user
 - ```RADIOCARITEM``` Item can be put into a remote controlled car.
-- ```RADIOSIGNAL_1``` Activated per radios signal 1.
-- ```RADIOSIGNAL_2``` Activated per radios signal 2.
-- ```RADIOSIGNAL_3``` Activated per radios signal 3.
-- ```RADIO_ACTIVATION``` It is activated by a remote control (also requires RADIOSIGNAL*).
-- ```RADIO_CONTAINER``` It's a container of something that is radio controlled.
+- ```RADIOSIGNAL_1``` Activated per radios signal 1 (Red).
+- ```RADIOSIGNAL_2``` Activated per radios signal 2 (Blue).
+- ```RADIOSIGNAL_3``` Activated per radios signal 3 (Green).
+- ```RADIO_ACTIVATION``` Item can be activated by a remote control (also requires RADIOSIGNAL_*).
+- ```RADIO_INVOKE_PROC``` After being activated via radio signal the item will have its charges removed. Can be used for bypassing bomb countdown.
+- ```RADIO_CONTROLLABLE``` It can be moved around via a remote control.
 - ```RADIO_MODABLE``` Indicates the item can be made into a radio-activated item.
 - ```RADIO_MOD``` The item has been made into a radio-activated item.
 - ```RECHARGE``` Gain charges when placed in a cargo area with a recharge station.

--- a/src/animation.h
+++ b/src/animation.h
@@ -49,6 +49,14 @@ struct point_with_value {
 using one_bucket = std::vector<point_with_value>;
 using bucketed_points = std::list<one_bucket>;
 
+namespace explosion_handler
+{
+void draw_explosion( const tripoint &p, int radius, const nc_color &col,
+                     const std::string &exp_name );
+void draw_custom_explosion( const tripoint &p, const std::map<tripoint, nc_color> &area,
+                            const std::string &exp_name );
+}; // namespace explosion_handler
+
 // TODO: Better file
 bucketed_points bucket_by_distance( const tripoint &origin,
                                     const std::map<tripoint, double> &to_bucket );

--- a/src/animation.h
+++ b/src/animation.h
@@ -55,7 +55,7 @@ void draw_explosion( const tripoint &p, int radius, const nc_color &col,
                      const std::string &exp_name );
 void draw_custom_explosion( const tripoint &p, const std::map<tripoint, nc_color> &area,
                             const std::string &exp_name );
-}; // namespace explosion_handler
+} // namespace explosion_handler
 
 // TODO: Better file
 bucketed_points bucket_by_distance( const tripoint &origin,

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -884,7 +884,15 @@ bool Character::activate_bionic( int b, bool eff_only )
         mod_moves( -100 );
     } else if( bio.id == bio_shockwave ) {
         add_msg_activate();
-        explosion_handler::shockwave( pos(), 3, 4, 2, 8, true, "explosion" );
+
+        shockwave_data sw;
+        sw.affects_player = false;
+        sw.radius = 3;
+        sw.force = 4;
+        sw.stun = 2;
+        sw.dam_mult = 8;
+
+        explosion_handler::shockwave( pos(), sw, "explosion" );
         add_msg_if_player( m_neutral, _( "You unleash a powerful shockwave!" ) );
         mod_moves( -100 );
     } else if( bio.id == bio_meteorologist ) {

--- a/src/creature.h
+++ b/src/creature.h
@@ -31,6 +31,8 @@ class window;
 } // namespace catacurses
 class avatar;
 class Character;
+class npc;
+class monster;
 class field;
 class field_entry;
 class JsonObject;
@@ -90,6 +92,18 @@ class Creature
         }
         virtual bool is_monster() const {
             return false;
+        }
+        virtual monster *as_monster() {
+            return nullptr;
+        }
+        virtual const monster *as_monster() const {
+            return nullptr;
+        }
+        virtual npc *as_npc() {
+            return nullptr;
+        }
+        virtual const npc *as_npc() const {
+            return nullptr;
         }
         virtual Character *as_character() {
             return nullptr;

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -755,7 +755,7 @@ void explosion_funcs::resonance_cascade( const queued_explosion &qe )
         g->u.add_effect( effect_teleglow, rng( minglow, maxglow ) * 100 );
     }
 
-    constexpr half_open_rectangle<point> map_bounds( point( 0, 0 ), point( MAPSIZE_X, MAPSIZE_Y ) );
+    constexpr half_open_rectangle<point> map_bounds( point_zero, point( MAPSIZE_X, MAPSIZE_Y ) );
     constexpr point cascade_reach( 8, 8 );
 
     point start = clamp( p.xy() - cascade_reach, map_bounds );
@@ -867,9 +867,9 @@ explosion_queue &get_explosion_queue()
 
 void explosion_queue::execute()
 {
-    // Using indices here in case explosions trigger more explosions and modify the queue
-    for( size_t i = 0; i < elems.size(); i++ ) {
-        queued_explosion exp = std::move( elems[i] );
+    while( !elems.empty() ) {
+        queued_explosion exp = std::move( elems.front() );
+        elems.pop_front();
         switch( exp.type ) {
             case ExplosionType::Regular:
                 explosion_funcs::regular( exp );
@@ -888,7 +888,6 @@ void explosion_queue::execute()
                 break;
         }
     }
-    elems.clear();
 }
 
 } // namespace explosion_handler

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "animation.h"
 #include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -532,21 +532,21 @@ void flashbang( const tripoint &p, bool player_immune, const std::string &exp_na
     // TODO: Blind/deafen NPC
 }
 
-void shockwave( const tripoint &p, int radius, int force, int stun, int dam_mult,
-                bool ignore_player, const std::string &exp_name )
+void shockwave( const tripoint &p, const shockwave_data &sw, const std::string &exp_name )
 {
-    draw_explosion( p, radius, c_blue, exp_name );
+    draw_explosion( p, sw.radius, c_blue, exp_name );
 
-    sounds::sound( p, force * force * dam_mult / 2, sounds::sound_t::combat, _( "Crack!" ), false,
+    sounds::sound( p, sw.force * sw.force * sw.dam_mult / 2, sounds::sound_t::combat, _( "Crack!" ),
+                   false,
                    "misc", "shockwave" );
 
     for( monster &critter : g->all_monsters() ) {
         if( critter.posz() != p.z ) {
             continue;
         }
-        if( rl_dist( critter.pos(), p ) <= radius ) {
+        if( rl_dist( critter.pos(), p ) <= sw.radius ) {
             add_msg( _( "%s is caught in the shockwave!" ), critter.name() );
-            g->knockback( p, critter.pos(), force, stun, dam_mult );
+            g->knockback( p, critter.pos(), sw.force, sw.stun, sw.dam_mult );
         }
     }
     // TODO: combine the two loops and the case for g->u using all_creatures()
@@ -554,16 +554,16 @@ void shockwave( const tripoint &p, int radius, int force, int stun, int dam_mult
         if( guy.posz() != p.z ) {
             continue;
         }
-        if( rl_dist( guy.pos(), p ) <= radius ) {
+        if( rl_dist( guy.pos(), p ) <= sw.radius ) {
             add_msg( _( "%s is caught in the shockwave!" ), guy.name );
-            g->knockback( p, guy.pos(), force, stun, dam_mult );
+            g->knockback( p, guy.pos(), sw.force, sw.stun, sw.dam_mult );
         }
     }
-    if( rl_dist( g->u.pos(), p ) <= radius && !ignore_player &&
+    if( rl_dist( g->u.pos(), p ) <= sw.radius && sw.affects_player &&
         ( !g->u.has_trait( trait_LEG_TENT_BRACE ) || g->u.footwear_factor() == 1 ||
           ( g->u.footwear_factor() == .5 && one_in( 2 ) ) ) ) {
         add_msg( m_bad, _( "You're caught in the shockwave!" ) );
-        g->knockback( p, g->u.pos(), force, stun, dam_mult );
+        g->knockback( p, g->u.pos(), sw.force, sw.stun, sw.dam_mult );
     }
 }
 

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -2,11 +2,10 @@
 #ifndef CATA_SRC_EXPLOSION_H
 #define CATA_SRC_EXPLOSION_H
 
-#include <map>
 #include <string>
+
 #include "optional.h"
 #include "projectile.h"
-#include "type_id.h"
 
 struct tripoint;
 class JsonObject;
@@ -59,11 +58,6 @@ void scrambler_blast( const tripoint &p );
 void emp_blast( const tripoint &p );
 /** Shockwave applies knockback with given parameters to all targets within radius of p. */
 void shockwave( const tripoint &p, const shockwave_data &sw, const std::string &exp_name );
-
-void draw_explosion( const tripoint &p, int radius, const nc_color &col,
-                     const std::string &exp_name );
-void draw_custom_explosion( const tripoint &p, const std::map<tripoint, nc_color> &area,
-                            const std::string &exp_name );
 
 projectile shrapnel_from_legacy( int power, float blast_radius );
 float blast_radius_from_legacy( int power, float distance_factor );

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -23,6 +23,14 @@ struct explosion_data {
     explicit operator bool() const;
 };
 
+struct shockwave_data {
+    int radius              = 0;
+    int force               = 0;
+    int stun                = 0;
+    int dam_mult            = 0;
+    bool affects_player     = false;
+};
+
 // handles explosion related functions
 namespace explosion_handler
 {
@@ -49,11 +57,8 @@ void resonance_cascade( const tripoint &p );
 void scrambler_blast( const tripoint &p );
 /** Triggers an EMP blast at p. */
 void emp_blast( const tripoint &p );
-// shockwave applies knockback to all targets within radius of p
-// parameters force, stun, and dam_mult are passed to knockback()
-// ignore_player determines if player is affected, useful for bionic, etc.
-void shockwave( const tripoint &p, int radius, int force, int stun, int dam_mult,
-                bool ignore_player, const std::string &exp_name );
+/** Shockwave applies knockback with given parameters to all targets within radius of p. */
+void shockwave( const tripoint &p, const shockwave_data &sw, const std::string &exp_name );
 
 void draw_explosion( const tripoint &p, int radius, const nc_color &col,
                      const std::string &exp_name );

--- a/src/explosion_queue.h
+++ b/src/explosion_queue.h
@@ -1,0 +1,70 @@
+#pragma once
+#ifndef CATA_SRC_EXPLOSION_QUEUE_H
+#define CATA_SRC_EXPLOSION_QUEUE_H
+
+#include "explosion.h"
+#include "point.h"
+
+#include <string>
+#include <vector>
+
+namespace explosion_handler
+{
+
+enum class ExplosionType {
+    Regular,
+    Flashbang,
+    ResonanceCascade,
+    Shockwave
+};
+
+struct queued_explosion {
+    queued_explosion() = default;
+    queued_explosion( const tripoint &pos, ExplosionType type ) : pos( pos ), type( type ) {}
+
+    /** Origin */
+    tripoint pos;
+    /** Explosion type */
+    ExplosionType type = ExplosionType::Regular;
+    /** Data for Regular explosion */
+    explosion_data exp_data;
+    /** Data for Shockwave explosion */
+    shockwave_data swave_data;
+    /** Graphical name for the explosion */
+    std::string graphics_name;
+    /** Whether it affects player */
+    bool affects_player = false;
+};
+
+namespace explosion_funcs
+{
+
+void regular( const queued_explosion &qe );
+void flashbang( const queued_explosion &qe );
+void resonance_cascade( const queued_explosion &qe );
+void shockwave( const queued_explosion &qe );
+
+} // namespace explosion_funcs
+
+class explosion_queue
+{
+    private:
+        std::vector<queued_explosion> elems;
+
+    public:
+        inline void add( queued_explosion &&exp ) {
+            elems.push_back( std::move( exp ) );
+        }
+
+        void execute();
+
+        inline void clear() {
+            elems.clear();
+        }
+};
+
+explosion_queue &get_explosion_queue();
+
+} // namespace explosion_handler
+
+#endif // CATA_SRC_EXPLOSION_QUEUE_H

--- a/src/explosion_queue.h
+++ b/src/explosion_queue.h
@@ -6,7 +6,7 @@
 #include "point.h"
 
 #include <string>
-#include <vector>
+#include <deque>
 
 namespace explosion_handler
 {
@@ -49,7 +49,7 @@ void shockwave( const queued_explosion &qe );
 class explosion_queue
 {
     private:
-        std::vector<queued_explosion> elems;
+        std::deque<queued_explosion> elems;
 
     public:
         inline void add( queued_explosion &&exp ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4401,6 +4401,10 @@ void game::monmove()
         }
 
         if( !critter.is_dead() ) {
+            critter.process_items();
+        }
+
+        if( !critter.is_dead() ) {
             critter.process_turn();
         }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -65,6 +65,7 @@
 #include "enums.h"
 #include "event.h"
 #include "event_bus.h"
+#include "explosion_queue.h"
 #include "faction.h"
 #include "field.h"
 #include "field_type.h"
@@ -598,6 +599,7 @@ void game::setup()
     mission::clear_all();
     Messages::clear_messages();
     timed_events = timed_event_manager();
+    explosion_handler::get_explosion_queue().clear();
 
     SCT.vSCT.clear(); //Delete pending messages
 
@@ -1582,6 +1584,10 @@ bool game::do_turn()
     update_stair_monsters();
     mon_info_update();
     u.process_turn();
+
+    explosion_handler::get_explosion_queue().execute();
+    cleanup_dead();
+
     if( u.moves < 0 && get_option<bool>( "FORCE_REDRAW" ) ) {
         ui_manager::redraw();
         refresh_display();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -29,6 +29,7 @@
 #include "faction.h"
 #include "field.h"
 #include "field_type.h"
+#include "fstream_utils.h"
 #include "game_constants.h"
 #include "game_inventory.h"
 #include "gamemode.h"
@@ -47,6 +48,7 @@
 #include "magic.h"
 #include "make_static.h"
 #include "map.h"
+#include "map_selector.h"
 #include "mapdata.h"
 #include "mapsharing.h"
 #include "messages.h"
@@ -99,7 +101,6 @@ static const efftype_id effect_alarm_clock( "alarm_clock" );
 static const efftype_id effect_laserlocked( "laserlocked" );
 static const efftype_id effect_relax_gas( "relax_gas" );
 
-static const itype_id itype_radio_car_on( "radio_car_on" );
 static const itype_id itype_radiocontrol( "radiocontrol" );
 static const itype_id itype_shoulder_strap( "shoulder_strap" );
 
@@ -371,29 +372,30 @@ inline static void rcdrive( const point &d )
 {
     player &u = g->u;
     map &m = g->m;
-    std::stringstream car_location_string( u.get_value( "remote_controlling" ) );
+    std::string car_location_string = u.get_value( "remote_controlling" );
 
-    if( car_location_string.str().empty() ) {
-        //no turned radio car found
+    if( car_location_string.empty() ) {
         u.add_msg_if_player( m_warning, _( "No radio car connected." ) );
         return;
     }
-    tripoint c;
-    car_location_string >> c.x >> c.y >> c.z;
 
-    auto rc_pairs = m.get_rc_items( c );
-    auto rc_pair = rc_pairs.begin();
-    for( ; rc_pair != rc_pairs.end(); ++rc_pair ) {
-        if( rc_pair->second->typeId() == itype_radio_car_on && rc_pair->second->active ) {
-            break;
-        }
-    }
-    if( rc_pair == rc_pairs.end() ) {
+    tripoint c;
+    deserialize_wrapper( [&]( JsonIn & jsin ) {
+        c.deserialize( jsin );
+    }, car_location_string );
+
+    map_cursor mc( c );
+    std::vector<item *> rc_items = mc.items_with( [&]( const item & it ) {
+        return it.has_flag( "RADIO_CONTROLLED" );
+    } );
+
+    if( rc_items.empty() ) {
         u.add_msg_if_player( m_warning, _( "No radio car connected." ) );
         u.remove_value( "remote_controlling" );
         return;
     }
-    item *rc_car = rc_pair->second;
+    // TODO: keep track of which car is being controlled
+    item *rc_car = rc_items[0];
 
     tripoint dest( c + d );
     if( m.impassable( dest ) || !m.can_put_items_ter_furn( dest ) ||
@@ -407,9 +409,10 @@ inline static void rcdrive( const point &d )
         sounds::sound( src, 6, sounds::sound_t::movement, _( "zzz…" ), true, "misc", "rc_car_drives" );
         u.moves -= 50;
         m.i_rem( src, rc_car );
-        car_location_string.clear();
-        car_location_string << dest.x << ' ' << dest.y << ' ' << dest.z;
-        u.set_value( "remote_controlling", car_location_string.str() );
+
+        u.set_value( "remote_controlling", serialize_wrapper( [&]( JsonOut & jo ) {
+            dest.serialize( jo );
+        } ) );
         return;
     }
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -21,6 +21,7 @@
 #include "activity_actor.h"
 #include "activity_actor_definitions.h"
 #include "active_tile_data_def.h"
+#include "animation.h"
 #include "artifact.h"
 #include "avatar.h"
 #include "bodypart.h"

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8121,33 +8121,15 @@ int iuse::radiocontrol( player *p, item *it, bool t, const tripoint & )
     } else if( choice > 0 ) {
         const std::string signal = "RADIOSIGNAL_" + std::to_string( choice );
 
-        auto item_list = p->get_radio_items();
-        for( auto &elem : item_list ) {
-            if( elem->has_flag( "BOMB" ) && elem->has_flag( signal ) ) {
-                p->add_msg_if_player( m_warning,
-                                      _( "The %s in your inventory would explode on this signal.  Place it down before sending the signal." ),
-                                      elem->display_name() );
-                return 0;
-            }
-        }
-
-        std::vector<item *> radio_containers = p->items_with( []( const item & itm ) {
-            return itm.has_flag( "RADIO_CONTAINER" );
+        std::vector<item *> bombs = p->items_with( [&]( const item & it ) -> bool {
+            return it.has_flag( "RADIO_ACTIVATION" ) && it.has_flag( "BOMB" ) && it.has_flag( signal );
         } );
 
-        if( !radio_containers.empty() ) {
-            for( auto items : radio_containers ) {
-                item *itm = items->contents.get_item_with( [&]( const item & c ) {
-                    return c.has_flag( "BOMB" ) && c.has_flag( signal );
-                } );
-
-                if( itm != nullptr ) {
-                    p->add_msg_if_player( m_warning,
-                                          _( "The %1$s in your %2$s would explode on this signal.  Place it down before sending the signal." ),
-                                          itm->display_name(), items->display_name() );
-                    return 0;
-                }
-            }
+        if( !bombs.empty() ) {
+            p->add_msg_if_player( m_warning,
+                                  _( "The %s in your inventory would explode on this signal.  Place it down before sending the signal." ),
+                                  bombs.front()->display_name() );
+            return 0;
         }
 
         p->add_msg_if_player( _( "Click." ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -14,6 +14,7 @@
 #include "action.h"
 #include "activity_handlers.h"
 #include "ammo.h"
+#include "animation.h"
 #include "assign.h"
 #include "avatar.h"
 #include "bionics.h"

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "animation.h"
 #include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5165,31 +5165,6 @@ std::list<item> map::use_charges( const tripoint &origin, const int range,
     return ret;
 }
 
-std::list<std::pair<tripoint, item *> > map::get_rc_items( const tripoint &p )
-{
-    std::list<std::pair<tripoint, item *> > rc_pairs;
-    tripoint pos;
-    pos.z = abs_sub.z;
-    for( pos.x = 0; pos.x < MAPSIZE_X; pos.x++ ) {
-        if( p.x != -1 && p.x != pos.x ) {
-            continue;
-        }
-        for( pos.y = 0; pos.y < MAPSIZE_Y; pos.y++ ) {
-            if( p.y != -1 && p.y != pos.y ) {
-                continue;
-            }
-            auto items = i_at( pos );
-            for( auto &elem : items ) {
-                if( elem.has_flag( "RADIO_ACTIVATION" ) || elem.has_flag( "RADIO_CONTAINER" ) ) {
-                    rc_pairs.push_back( std::make_pair( pos, &elem ) );
-                }
-            }
-        }
-    }
-
-    return rc_pairs;
-}
-
 bool map::can_see_trap_at( const tripoint &p, const Character &c ) const
 {
     return tr_at( p ).can_see( p, c );

--- a/src/map.h
+++ b/src/map.h
@@ -1285,7 +1285,6 @@ class map
                                      int &quantity, const std::function<bool( const item & )> &filter = return_true<item>,
                                      basecamp *bcp = nullptr );
         /*@}*/
-        std::list<std::pair<tripoint, item *> > get_rc_items( const tripoint &p = { -1, -1, -1 } );
 
         /**
         * Place items from item group in the rectangle f - t. Several items may be spawned

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2381,6 +2381,31 @@ bool monster::check_mech_powered() const
     return true;
 }
 
+static void process_item_valptr( cata::value_ptr<item> &ptr, monster &mon )
+{
+    if( ptr && ptr->needs_processing() && ptr->process( nullptr, mon.pos(), false ) ) {
+        ptr.reset();
+    }
+}
+
+void monster::process_items()
+{
+    for( auto iter = inv.begin(); iter != inv.end(); ) {
+        if( iter->needs_processing() &&
+            iter->process( nullptr, pos(), false )
+          ) {
+            iter = inv.erase( iter );
+            continue;
+        }
+        iter++;
+    }
+
+    process_item_valptr( storage_item, *this );
+    process_item_valptr( armor_item, *this );
+    process_item_valptr( tack_item, *this );
+    process_item_valptr( tied_item, *this );
+}
+
 void monster::drop_items_on_death()
 {
     if( is_hallucination() ) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -95,6 +95,12 @@ class monster : public Creature
         bool is_monster() const override {
             return true;
         }
+        monster *as_monster() override {
+            return this;
+        }
+        const monster *as_monster() const override {
+            return this;
+        }
 
         void poly( const mtype_id &id );
         bool can_upgrade() const;

--- a/src/monster.h
+++ b/src/monster.h
@@ -425,6 +425,8 @@ class monster : public Creature, public visitable<monster>
         bool check_mech_powered() const;
         int mech_str_addition() const;
 
+        void process_items();
+
         /**
          * Makes monster react to heard sound
          *

--- a/src/monster.h
+++ b/src/monster.h
@@ -26,6 +26,7 @@
 #include "type_id.h"
 #include "units.h"
 #include "value_ptr.h"
+#include "visitable.h"
 
 class Character;
 class JsonIn;
@@ -79,7 +80,7 @@ enum monster_horde_attraction {
     NUM_MONSTER_HORDE_ATTRACTION
 };
 
-class monster : public Creature
+class monster : public Creature, public visitable<monster>
 {
         friend class editmap;
     public:

--- a/src/npc.h
+++ b/src/npc.h
@@ -794,6 +794,13 @@ class npc : public player
         bool is_npc() const override {
             return true;
         }
+        npc *as_npc() override {
+            return this;
+        }
+        const npc *as_npc() const override {
+            return this;
+        }
+
         void load_npc_template( const string_id<npc_template> &ident );
         void npc_dismount();
         weak_ptr_fast<monster> chosen_mount;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -713,31 +713,6 @@ std::string player::get_category_dream( const std::string &cat,
     return random_entry( selected_dream.messages() );
 }
 
-std::list<item *> player::get_radio_items()
-{
-    std::list<item *> rc_items;
-    const invslice &stacks = inv.slice();
-    for( auto &stack : stacks ) {
-        item &stack_iter = stack->front();
-        if( stack_iter.has_flag( "RADIO_ACTIVATION" ) ) {
-            rc_items.push_back( &stack_iter );
-        }
-    }
-
-    for( auto &elem : worn ) {
-        if( elem.has_flag( "RADIO_ACTIVATION" ) ) {
-            rc_items.push_back( &elem );
-        }
-    }
-
-    if( is_armed() ) {
-        if( weapon.has_flag( "RADIO_ACTIVATION" ) ) {
-            rc_items.push_back( &weapon );
-        }
-    }
-    return rc_items;
-}
-
 std::list<item *> player::get_artifact_items()
 {
     std::list<item *> art_items;

--- a/src/player.h
+++ b/src/player.h
@@ -308,8 +308,6 @@ class player : public Character
         /** Returns overall % of HP remaining */
         int hp_percentage() const override;
 
-        /** Returns list of rc items in player inventory. **/
-        std::list<item *> get_radio_items();
         /** Returns list of artifacts in player inventory. **/
         std::list<item *> get_artifact_items();
 

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -8,6 +8,7 @@
 #include "avatar.h"
 #include "catch/catch.hpp"
 #include "creature.h"
+#include "explosion_queue.h"
 #include "game.h"
 #include "item.h"
 #include "itype.h"
@@ -28,6 +29,14 @@
 enum class outcome_type {
     Kill, Casualty
 };
+
+static void set_off_explosion( item &explosive, const tripoint &origin )
+{
+    explosion_handler::get_explosion_queue().clear();
+    explosive.charges = 0;
+    explosive.type->invoke( g->u, explosive, origin );
+    explosion_handler::get_explosion_queue().execute();
+}
 
 static void check_lethality( const std::string &explosive_id, const int range, float lethality,
                              float margin, outcome_type expected_outcome )
@@ -54,10 +63,7 @@ static void check_lethality( const std::string &explosive_id, const int range, f
             monster &new_monster = spawn_test_monster( "mon_zombie", monster_position );
             new_monster.no_extra_death_drops = true;
         }
-        // Set off an explosion
-        item grenade( explosive_id );
-        grenade.charges = 0;
-        grenade.type->invoke( g->u, grenade, origin );
+        set_off_explosion( item( explosive_id ), origin );
         // see how many monsters survive
         std::vector<Creature *> survivors = g->get_creatures_if( []( const Creature & critter ) {
             return critter.is_monster();
@@ -118,10 +124,7 @@ static void check_vehicle_damage( const std::string &explosive_id, const std::st
     }
     origin.x += range;
 
-    // Set off an explosion
-    item grenade( explosive_id );
-    grenade.charges = 0;
-    grenade.type->invoke( g->u, grenade, origin );
+    set_off_explosion( item( explosive_id ), origin );
 
     std::vector<int> after_hp = get_part_hp( target_vehicle );
 
@@ -157,7 +160,6 @@ TEST_CASE( "shrapnel behind wall", "[grenade],[explosion],[balance]" )
     tripoint origin( 30, 30, 0 );
 
     item grenade( "can_bomb_act" );
-    grenade.charges = 0;
     REQUIRE( grenade.get_use( "explosion" ) != nullptr );
     const auto *actor = dynamic_cast<const explosion_iuse *>
                         ( grenade.get_use( "explosion" )->get_actor_ptr() );
@@ -176,7 +178,7 @@ TEST_CASE( "shrapnel behind wall", "[grenade],[explosion],[balance]" )
     const monster &m_in_range = spawn_test_monster( "mon_zombie", origin + point_east );
     const monster &m_behind_wall = spawn_test_monster( "mon_zombie", origin + point( 3, 0 ) );
 
-    grenade.type->invoke( g->u, grenade, origin );
+    set_off_explosion( grenade, origin );
 
     CHECK( m_in_range.hp_percentage() < 100 );
     CHECK( m_behind_wall.hp_percentage() == 100 );
@@ -198,7 +200,7 @@ TEST_CASE( "shrapnel at huge range", "[grenade],[explosion]" )
 
     const monster &m = spawn_test_monster( "mon_zombie", tripoint( MAPSIZE_X - 1, MAPSIZE_Y - 1, 0 ) );
 
-    grenade.type->invoke( g->u, grenade, origin );
+    set_off_explosion( grenade, origin );
 
     CHECK( m.is_dead_state() );
 }
@@ -222,8 +224,7 @@ TEST_CASE( "shrapnel at max grenade range", "[grenade],[explosion]" )
         spawn_test_monster( "mon_zombie", pt );
     }
 
-    grenade.charges = 0;
-    grenade.type->invoke( g->u, grenade, origin );
+    set_off_explosion( grenade, origin );
 
     for( const tripoint &pt : closest_points_first( origin, range + 1 ) ) {
         const monster *m = g->critter_at<monster>( pt );

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -63,7 +63,8 @@ static void check_lethality( const std::string &explosive_id, const int range, f
             monster &new_monster = spawn_test_monster( "mon_zombie", monster_position );
             new_monster.no_extra_death_drops = true;
         }
-        set_off_explosion( item( explosive_id ), origin );
+        item explosive( explosive_id );
+        set_off_explosion( explosive, origin );
         // see how many monsters survive
         std::vector<Creature *> survivors = g->get_creatures_if( []( const Creature & critter ) {
             return critter.is_monster();
@@ -124,7 +125,8 @@ static void check_vehicle_damage( const std::string &explosive_id, const std::st
     }
     origin.x += range;
 
-    set_off_explosion( item( explosive_id ), origin );
+    item explosive( explosive_id );
+    set_off_explosion( explosive, origin );
 
     std::vector<int> after_hp = get_part_hp( target_vehicle );
 


### PR DESCRIPTION
#### Purpose of change
1. Fix explosions within vehicles causing segfault (fixes #175)
2. Fix active explosives within monsters not exploding (e.g. when technician pulls an active grenade)
3. Fix radio activation mod having infinite uses 
4. Fix items with `RADIO_ACTIVATION` flag not actually being activated (fixes #1276)
5. Fix active mininuke timer getting reset to 0 on save/load
6. Fix resonance cascade doing nothing
7. Allow RC control to choose which rc car to control, instead of selecting semi-randomly
8. Allow RC control signal to activate items within vehicles or creatures' inventories
9. Allow RC control signal to activate items on all z-levels, remove max range of 30
10. Make radio activation mod easier to craft by allowing more battery variants as components

#### Describe the solution
1. Defer explosions, to avoid modifying data while iterating. This also makes it possible to explode items within monsters inventories. Idea from https://github.com/CleverRaven/Cataclysm-DDA/pull/45693
2. Add code for processing items within monster's inventories
3. Revert item type to TOOL
4. Invoke iuse function if item has `RADIO_ACTIVATION` flag, make `RADIO_INVOKE_PROC` flag set charges of resulting item to 0, so that the next iuse (e.g. explosion) will be invoked when item is processed on next turn.
5. Add arbitrary `max_charges` to the mininuke
6. Fix iterating over area. It seems that the code has not been updated since Whales wrote it, as it still assumes the reality bubble is 3x3 submaps large.
7. Get rid of spaghetti and instead iterate over current z-level looking for items with `RADIO_CONTROLLED` flag
8. Visit all items on map, in vehicles, in monsters and in Characters and check for relevant flags
9. Iterate over all tiles within all active z-levels
10. Add more battery variants as crafting components (cherry-picked from https://github.com/CleverRaven/Cataclysm-DDA/pull/54213)

#### Testing
Mostly for the exact scenarios described in the bugreports and bug descriptions.

#### Additional context
Explosions seem to semi-reliably produce vehicles that have 0 as their cached mass, which results in division by zero and debugmsg informing player of "vehicle with negative drag".