### PR TITLE
Broken Arm Mech Fix ported from DDA.

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1245,7 +1245,8 @@ void Character::dismount()
         remove_effect( effect_riding );
         monster *critter = mounted_creature.get();
         critter->mounted_player_id = character_id();
-        if( critter->has_flag( MF_RIDEABLE_MECH ) && !critter->type->mech_weapon.is_empty() ) {
+        if (critter->has_flag(MF_RIDEABLE_MECH) && !critter->type->mech_weapon.is_empty() &&
+            weapon.typeId() == critter->type->mech_weapon) {
             remove_item( weapon );
         }
         if( is_avatar() && g->u.get_grab_type() != OBJECT_NONE ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1245,8 +1245,8 @@ void Character::dismount()
         remove_effect( effect_riding );
         monster *critter = mounted_creature.get();
         critter->mounted_player_id = character_id();
-        if (critter->has_flag(MF_RIDEABLE_MECH) && !critter->type->mech_weapon.is_empty() &&
-            weapon.typeId() == critter->type->mech_weapon) {
+        if( critter->has_flag( MF_RIDEABLE_MECH ) && !critter->type->mech_weapon.is_empty() &&
+            weapon.typeId() == critter->type->mech_weapon ) {
             remove_item( weapon );
         }
         if( is_avatar() && g->u.get_grab_type() != OBJECT_NONE ) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2571,10 +2571,10 @@ ret_val<bool> player::can_wield( const item &it ) const
                                             weapname(), it.tname() );
     }
 
-    monster* mount = mounted_creature.get();
-    if (it.is_two_handed(*this) && (!has_two_arms() || worn_with_flag(flag_RESTRICT_HAND)) &&
-        !(is_mounted() && mount->has_flag(MF_RIDEABLE_MECH) &&
-            mount->type->mech_weapon && it.typeId() == mount->type->mech_weapon)) {
+    monster *mount = mounted_creature.get();
+    if( it.is_two_handed( *this ) && ( !has_two_arms() || worn_with_flag( flag_RESTRICT_HAND ) ) &&
+        !( is_mounted() && mount->has_flag( MF_RIDEABLE_MECH ) &&
+           mount->type->mech_weapon && it.typeId() == mount->type->mech_weapon ) ) {
         if( worn_with_flag( flag_RESTRICT_HAND ) ) {
             return ret_val<bool>::make_failure(
                        _( "Something you are wearing hinders the use of both hands." ) );
@@ -2586,9 +2586,9 @@ ret_val<bool> player::can_wield( const item &it ) const
                                                 it.tname() );
         }
     }
-    if (is_mounted() && mount->has_flag(MF_RIDEABLE_MECH) &&
-        mount->type->mech_weapon && it.typeId() != mount->type->mech_weapon) {
-        return ret_val<bool>::make_failure(_("You cannot wield anything while piloting a mech."));
+    if( is_mounted() && mount->has_flag( MF_RIDEABLE_MECH ) &&
+        mount->type->mech_weapon && it.typeId() != mount->type->mech_weapon ) {
+        return ret_val<bool>::make_failure( _( "You cannot wield anything while piloting a mech." ) );
     }
 
     return ret_val<bool>::make_success();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -203,6 +203,7 @@ static const trait_id trait_WHISKERS_RAT( "WHISKERS_RAT" );
 static const trait_id trait_WHISKERS( "WHISKERS" );
 
 static const std::string flag_SPLINT( "SPLINT" );
+static const std::string flag_RESTRICT_HAND( "RESTRICT_HANDS" );
 
 static const skill_id skill_dodge( "dodge" );
 static const skill_id skill_gun( "gun" );
@@ -2570,8 +2571,11 @@ ret_val<bool> player::can_wield( const item &it ) const
                                             weapname(), it.tname() );
     }
 
-    if( it.is_two_handed( *this ) && ( !has_two_arms() || worn_with_flag( "RESTRICT_HANDS" ) ) ) {
-        if( worn_with_flag( "RESTRICT_HANDS" ) ) {
+    monster* mount = mounted_creature.get();
+    if (it.is_two_handed(*this) && (!has_two_arms() || worn_with_flag(flag_RESTRICT_HAND)) &&
+        !(is_mounted() && mount->has_flag(MF_RIDEABLE_MECH) &&
+            mount->type->mech_weapon && it.typeId() == mount->type->mech_weapon)) {
+        if( worn_with_flag( flag_RESTRICT_HAND ) ) {
             return ret_val<bool>::make_failure(
                        _( "Something you are wearing hinders the use of both hands." ) );
         } else if( it.has_flag( "ALWAYS_TWOHAND" ) ) {
@@ -2581,6 +2585,10 @@ ret_val<bool> player::can_wield( const item &it ) const
             return ret_val<bool>::make_failure( _( "You are too weak to wield %s with only one arm." ),
                                                 it.tname() );
         }
+    }
+    if (is_mounted() && mount->has_flag(MF_RIDEABLE_MECH) &&
+        mount->type->mech_weapon && it.typeId() != mount->type->mech_weapon) {
+        return ret_val<bool>::make_failure(_("You cannot wield anything while piloting a mech."));
     }
 
     return ret_val<bool>::make_success();


### PR DESCRIPTION

#### Summary

SUMMARY: [Bugfixes] Bugfix

#### Purpose of change

Apparently getting into a mech with a broken arm deletes the mech's weapon.

#### Describe the solution

Was fixed on DDA by adding additional checks to the 'get in mech' checks and the 'wield weapon' checks.

https://github.com/CleverRaven/Cataclysm-DDA/pull/47314/files
 
 And if you ever see this- thanks original author!

#### Testing

![mechfix](https://user-images.githubusercontent.com/72810820/153238149-e3a0a536-4a6d-4d86-8a63-55939924556c.png)