### PR TITLE
Port over island starting location

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -458,7 +458,7 @@
     "points": 0,
     "description": "You find yourself amongst trees.  The screaming and the moaning is fainter this far from civilization, but you'd better know what you're doing out here.",
     "start_name": "Wilderness",
-    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_campsite", "sloc_campground" ],
+    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_campsite", "sloc_campground", "sloc_deserted_island" ],
     "flags": [ "LONE_START" ]
   },
   {

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -233,6 +233,13 @@
   },
   {
     "type": "start_location",
+    "id": "sloc_deserted_island",
+    "name": "Deserted Island",
+    "terrain": [ "island_sand", "island_forest", "island_forest_thick", "island_forest_water", "island_field" ],
+    "flags": [ "ALLOW_OUTSIDE" ]
+  },
+  {
+    "type": "start_location",
     "id": "sloc_lab_escape_cells",
     "name": "Experiment Cell",
     "terrain": [ "lab_escape_cells" ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Content "Port over ability to start on islands from DDA"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I keep getting pestered to add islands to BN's wilderness scenario, turns out this was added to DDA a while back.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Copy over edit to wilderness scenario adding deserted island to starting location options.
2. Copy over added starting location, fixed name from "desert island" to "deserted island" since only one of the allowed island variants is sandy.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding any other island overmap specials we can think of to scenarios.
2. Adding island start location to other innawoods scenarios.
3. Narrowing down what types of islands are valid so that you don't risk getting softlocked on the more useless variants.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked file changes for syntax and lint errors.
2. Ported file changes to a test build.
3. Load-tested and started in wilderness scenario, selecting island as the location.
4. Confirmed you start on an island.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR, by cirops: https://github.com/CleverRaven/Cataclysm-DDA/pull/41269