### PR TITLE
Remove seasonal scaling for fermenting

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5660,7 +5660,7 @@ std::string item::get_pet_armor_bodytype() const
 
 time_duration item::brewing_time() const
 {
-    return is_brewable() ? type->brewable->time * calendar::season_ratio() : 0_turns;
+    return is_brewable() ? type->brewable->time : 0_turns;
 }
 
 const std::vector<itype_id> &item::brewing_results() const


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Fermenting no longer takes longer with longer season length"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Per discussion on an unrelated oddity found while looking into https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1331, it was advised that fermenting vat times should not scale with seasons.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Changed `item::brewing_time()` to not multiply the fermentation time of items by `calendar::season_ratio()`.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Continuing to be mystified by things taking over twice as long to brew up when season length is set to my usual preferred middle ground of 30 days.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested.
2. Started up a world with 30-day seasons.
3. Checked item entry for unfermented vinegar.
4. Observed that the time it said it'd take to ferment when added is 7 hours, instead of 15 hours.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

I haven't checked yet to see if it still scales in DDA or not.

On their end, since they use 91 days as the seasonal default, I would assume that players would see fermentation time get shorter more often, whereas in BN it'd be more common to see fermentation time get longer due to its default being 14 days/