### PR TITLE
Some mapgen fixes for Hub 01

### DIFF
--- a/data/json/mapgen/robofachq_static.json
+++ b/data/json/mapgen/robofachq_static.json
@@ -616,6 +616,7 @@
         "#": "t_rock",
         "6": "t_console"
       },
+      "furniture": { ":": "f_server" },
       "items": {
         "B": [
           { "item": "magazines", "chance": 75, "repeat": [ 1, 5 ] },

--- a/data/json/mapgen/robofachq_static.json
+++ b/data/json/mapgen/robofachq_static.json
@@ -410,6 +410,7 @@
         "&": "t_machinery_electronic"
       },
       "furniture": {
+        ":": "f_server",
         "K": "f_counter",
         "S": "f_table",
         "A": "f_canvas_wall",

--- a/data/json/mapgen/robofachq_static.json
+++ b/data/json/mapgen/robofachq_static.json
@@ -286,7 +286,8 @@
         "#": "t_rock",
         "6": "t_console",
         "R": "t_railing",
-        "W": "t_water_dispenser"
+        "W": "t_water_dispenser",
+        "&": "t_machinery_electronic"
       },
       "furniture": {
         "K": "f_counter",

--- a/data/json/mapgen_palettes/robofachq.json
+++ b/data/json/mapgen_palettes/robofachq.json
@@ -27,13 +27,12 @@
       "<": "t_stairs_up",
       ">": "t_stairs_down",
       "0": "t_window_empty",
-      ":": "t_window_domestic",
       "u": "t_chainfence_h",
       "U": "t_chainfence_v",
       "#": "t_rock"
     },
     "furniture": {
-      "&": "f_toilet",
+      ";": "f_toilet",
       "~": "f_shower",
       "@": "f_bed",
       "a": "f_armchair",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix malformed furniture and terrain placement in Hub 01"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Couple things I spotted borked in Hub 01 thanks to Critsybear's BN playthrough.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Fixed furniture def for toilets using wrong character, causing electronic machinery to spawn with toilets on top of them.
2. Removed terrain def that was placing domestic windows, not something you expect to see in Hub 01, underneath server furniture. When they say they run windows, that's not what they meant.
3. Fixed a case of the server `:` being called for on the map but not having a furniture def.
4. Fixed a case of `&`s being called for without matching terrain def.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Making electronic toilets a feature instead of a bug.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and load errors.
2. Load-tested files in test build.
3. Warped on over to Hub 01 to confirm the place looks more normal.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

I dunno 100% if the canvas walls are intentional or not though. Since they have canvas flaps too, I'm leaning towards assuming it was deliberate.

Numerius bullies Hub 01 and marvels at the electronic toilet: https://www.youtube.com/watch?v=kjDAB6K7RXw