### PR TITLE
Roof buffs

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -2026,7 +2026,7 @@
     "looks_like": "t_wall_metal",
     "color": "cyan",
     "move_cost": 0,
-    "roof": "t_metal_floor",
+    "roof": "t_metal_floor_no_roof",
     "flags": [ "NOITEM", "DOOR", "CONNECT_TO_WALL", "AUTO_WALL_SYMBOL", "MINEABLE" ],
     "open": "t_secretdoor_metal_o",
     "bash": {
@@ -2041,23 +2041,15 @@
   {
     "type": "terrain",
     "id": "t_secretdoor_metal_o",
+    "copy-from": "t_secretdoor_metal_c",
     "name": "open secret door",
     "looks_like": "t_mdoor_frame",
     "description": "This apparently normal segment of metal wall has opened to reveal a secret passage.",
     "symbol": "'",
     "color": "cyan",
     "move_cost": 2,
-    "roof": "t_metal_floor",
     "flags": [ "TRANSPARENT", "FLAT", "CONNECT_TO_WALL", "ROAD", "MINEABLE" ],
-    "close": "t_secretdoor_metal_c",
-    "bash": {
-      "str_min": 80,
-      "str_max": 250,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "ter_set": "t_mdoor_frame",
-      "items": [ { "item": "scrap", "count": [ 12, 24 ] }, { "item": "steel_plate", "prob": 75 } ]
-    }
+    "close": "t_secretdoor_metal_c"
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -124,7 +124,7 @@
     "color": "magenta",
     "looks_like": "t_pit",
     "move_cost": 0,
-    "roof": "t_rock_floor",
+    "roof": "t_rock_floor_no_roof",
     "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL" ],
     "examine_action": "fault"
   },
@@ -161,7 +161,6 @@
     "color": "light_gray",
     "looks_like": "t_rock_floor",
     "move_cost": 2,
-    "roof": "t_open_air",
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
     "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
   },
@@ -294,7 +293,8 @@
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },
         { "item": "scrap", "count": [ 9, 36 ] }
-      ]
+      ],
+      "bash_below": true
     }
   },
   {
@@ -356,7 +356,7 @@
     "color": "green",
     "looks_like": "t_pit",
     "move_cost": 0,
-    "roof": "t_rock_floor",
+    "roof": "t_rock_floor_no_roof",
     "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL" ]
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-floors_indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors_indoor.json
@@ -368,7 +368,15 @@
     "symbol": ".",
     "color": "yellow",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "INDOORS", "FLAT" ]
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "FLAT" ],
+    "bash": {
+      "str_min": 12,
+      "str_max": 150,
+      "sound": "crunch!",
+      "sound_fail": "whump!",
+      "items": [ { "item": "wax", "count": [ 3, 5 ] } ],
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-highways.json
+++ b/data/json/furniture_and_terrain/terrain-highways.json
@@ -14,7 +14,6 @@
       "str_max": 300,
       "sound": "concrete cracking and metal screeching!",
       "sound_fail": "whump!",
-      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 4, 20 ] }, { "item": "rebar", "count": [ 10, 20 ] } ]
     }
   },
@@ -33,7 +32,6 @@
       "str_max": 300,
       "sound": "concrete cracking and metal screeching!",
       "sound_fail": "whump!",
-      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 4, 20 ] }, { "item": "rebar", "count": [ 10, 20 ] } ]
     }
   },
@@ -52,7 +50,6 @@
       "str_max": 300,
       "sound": "concrete cracking and metal screeching!",
       "sound_fail": "whump!",
-      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 4, 20 ] }, { "item": "rebar", "count": [ 10, 20 ] } ]
     }
   }

--- a/data/json/furniture_and_terrain/terrain-migo.json
+++ b/data/json/furniture_and_terrain/terrain-migo.json
@@ -87,14 +87,7 @@
     "looks_like": "t_floor_resin",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "NONFLAMMABLE" ],
-    "bash": {
-      "str_min": 250,
-      "str_max": 700,
-      "sound": "boom!",
-      "sound_fail": "whack!",
-      "ter_set": "t_open_air",
-      "bash_below": true
-    }
+    "bash": { "str_min": 250, "str_max": 700, "sound": "boom!", "sound_fail": "whack!", "bash_below": true }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -29,6 +29,7 @@
     "type": "terrain",
     "id": "t_open_air",
     "name": "open air",
+    "alias": "t_hole",
     "description": "This is open air.",
     "symbol": " ",
     "color": "i_cyan",
@@ -191,14 +192,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT" ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_open_air",
-      "bash_below": true
-    }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "bash_below": true }
   },
   {
     "type": "terrain",
@@ -210,14 +204,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "FLAT" ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_open_air",
-      "bash_below": true
-    }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "bash_below": true }
   },
   {
     "type": "terrain",
@@ -229,14 +216,7 @@
     "color": "green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "FLAT" ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_open_air",
-      "bash_below": true
-    }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "bash_below": true }
   },
   {
     "type": "terrain",
@@ -248,14 +228,7 @@
     "color": "yellow",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE" ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_open_air",
-      "bash_below": true
-    }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "bash_below": true }
   },
   {
     "type": "terrain",
@@ -267,14 +240,7 @@
     "color": "light_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT" ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_open_air",
-      "bash_below": true
-    }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "bash_below": true }
   },
   {
     "type": "terrain",
@@ -286,14 +252,7 @@
     "color": "white",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "FLAMMABLE" ],
-    "bash": {
-      "str_min": 30,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_open_air",
-      "bash_below": true
-    }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "bash_below": true }
   },
   {
     "type": "terrain",
@@ -306,14 +265,7 @@
     "move_cost": 2,
     "trap": "tr_ledge",
     "flags": [ "TRANSPARENT", "NO_FLOOR", "INDOORS" ],
-    "bash": {
-      "str_min": 3,
-      "str_max": 6,
-      "sound": "glass braking!",
-      "sound_fail": "whack!",
-      "ter_set": "t_open_air",
-      "bash_below": true
-    }
+    "bash": { "str_min": 3, "str_max": 6, "sound": "glass braking!", "sound_fail": "whack!", "bash_below": true }
   },
   {
     "type": "terrain",
@@ -325,14 +277,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT" ],
-    "bash": {
-      "str_min": 100,
-      "str_max": 210,
-      "sound": "crash!",
-      "sound_fail": "whump!",
-      "ter_set": "t_open_air",
-      "bash_below": true
-    }
+    "bash": { "str_min": 100, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "bash_below": true }
   },
   {
     "type": "terrain",
@@ -351,7 +296,6 @@
       "sound_fail": "slap!",
       "sound_vol": 8,
       "sound_fail_vol": 4,
-      "ter_set": "t_open_air",
       "bash_below": true
     }
   },
@@ -372,7 +316,6 @@
       "sound_fail": "slap!",
       "sound_vol": 8,
       "sound_fail_vol": 4,
-      "ter_set": "t_open_air",
       "bash_below": true
     }
   }

--- a/data/json/furniture_and_terrain/terrain-traps.json
+++ b/data/json/furniture_and_terrain/terrain-traps.json
@@ -1,17 +1,6 @@
 [
   {
     "type": "terrain",
-    "id": "t_hole",
-    "name": "empty space",
-    "description": "This is empty space.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 2,
-    "trap": "tr_ledge",
-    "flags": [ "TRANSPARENT", "NOITEM", "NO_FLOOR" ]
-  },
-  {
-    "type": "terrain",
     "id": "t_pit_shallow",
     "name": "shallow pit",
     "description": "A pit that could be dug even deeper or filled up.  Also useful as a starting foundation for some constructions.",
@@ -43,8 +32,7 @@
     "color": "green",
     "move_cost": 5,
     "flags": [ "TRANSPARENT", "DIGGABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true },
-    "//": "left diggable to clean out corpses-KA101"
+    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -1130,7 +1130,7 @@
     "move_cost": 0,
     "coverage": 100,
     "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "MINEABLE", "BLOCK_WIND" ],
-    "roof": "t_rock_floor",
+    "roof": "t_rock_floor_no_roof",
     "bash": {
       "str_min": 100,
       "str_max": 400,

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -2847,7 +2847,6 @@
       "sound_fail": "whack!",
       "sound_vol": 12,
       "sound_fail_vol": 8,
-      "ter_set": "t_open_air",
       "items": [ { "item": "2x4", "count": [ 2, 4 ] } ]
     },
     "flags": [ "TRANSPARENT", "FLAMMABLE", "NOITEM", "PERMEABLE" ]

--- a/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
+++ b/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
@@ -13,14 +13,13 @@
       "str_max": 70,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_open_air",
       "items": [
         { "item": "2x4", "count": [ 0, 2 ] },
         { "item": "nail", "charges": [ 0, 5 ] },
         { "item": "splinter", "count": [ 2, 8 ] }
       ]
     },
-    "deconstruct": { "ter_set": "t_open_air", "items": [ { "item": "nail", "charges": [ 4, 8 ] }, { "item": "2x4", "count": [ 0, 4 ] } ] }
+    "deconstruct": { "ter_set": "t_null", "items": [ { "item": "nail", "charges": [ 4, 8 ] }, { "item": "2x4", "count": [ 0, 4 ] } ] }
   },
   {
     "type": "terrain",

--- a/data/mods/Aftershock/maps/terrain.json
+++ b/data/mods/Aftershock/maps/terrain.json
@@ -32,7 +32,6 @@
     "color": "light_blue",
     "looks_like": "t_rock_floor",
     "move_cost": 2,
-    "roof": "t_open_air",
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
     "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 30, "bash_below": true }
   }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9665,31 +9665,6 @@ const pathfinding_settings &Character::get_pathfinding_settings() const
     return *path_settings;
 }
 
-bool Character::crush_frozen_liquid( item_location loc )
-{
-    if( has_quality( quality_id( "HAMMER" ) ) ) {
-        item hammering_item = item_with_best_of_quality( quality_id( "HAMMER" ) );
-        //~ %1$s: item to be crushed, %2$s: hammer name
-        if( query_yn( _( "Do you want to crush up %1$s with your %2$s?\n"
-                         "<color_red>Be wary of fragile items nearby!</color>" ),
-                      loc.get_item()->display_name(), hammering_item.tname() ) ) {
-
-            //Risk smashing tile with hammering tool, risk is lower with higher dex, damage lower with lower strength
-            if( one_in( 1 + dex_cur / 4 ) ) {
-                add_msg_if_player( colorize( _( "You swing your %s wildly!" ), c_red ),
-                                   hammering_item.tname() );
-                int smashskill = str_cur + hammering_item.damage_melee( DT_BASH );
-                g->m.bash( loc.position(), smashskill );
-            }
-            add_msg_if_player( _( "You crush up and gather %s" ), loc.get_item()->display_name() );
-            return true;
-        }
-    } else {
-        popup( _( "You need a hammering tool to crush up frozen liquids!" ) );
-    }
-    return false;
-}
-
 float Character::power_rating() const
 {
     int dmg = std::max( { weapon.damage_melee( DT_BASH ),

--- a/src/character.h
+++ b/src/character.h
@@ -1802,10 +1802,6 @@ class Character : public Creature, public visitable<Character>
         /** Checks to see if the player is using floor items to keep warm, and return the name of one such item if so */
         std::string is_snuggling() const;
 
-        /** Prompts user about crushing item at item_location loc, for harvesting of frozen liquids
-        * @param loc Location for item to crush */
-        bool crush_frozen_liquid( item_location loc );
-
         float power_rating() const override;
         float speed_rating() const override;
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -961,12 +961,13 @@ void complete_construction( player *p )
         debugmsg( "complete_construction called before finalization" );
         return;
     }
-    const tripoint terp = g->m.getlocal( p->activity.placement );
-    partial_con *pc = g->m.partial_con_at( terp );
+    map &here = get_map();
+    const tripoint terp = here.getlocal( p->activity.placement );
+    partial_con *pc = here.partial_con_at( terp );
     if( !pc ) {
         debugmsg( "No partial construction found at activity placement in complete_construction()" );
-        if( g->m.tr_at( terp ).loadid == tr_unfinished_construction ) {
-            g->m.remove_trap( terp );
+        if( here.tr_at( terp ).loadid == tr_unfinished_construction ) {
+            here.remove_trap( terp );
         }
         if( p->is_npc() ) {
             npc *guy = dynamic_cast<npc *>( p );
@@ -999,24 +1000,24 @@ void complete_construction( player *p )
             award_xp( *elem );
         }
     }
-    if( g->m.tr_at( terp ).loadid == tr_unfinished_construction ) {
-        g->m.remove_trap( terp );
+    if( here.tr_at( terp ).loadid == tr_unfinished_construction ) {
+        here.remove_trap( terp );
     }
-    g->m.partial_con_remove( terp );
+    here.partial_con_remove( terp );
     // Some constructions are allowed to have items left on the tile.
     if( built.post_flags.count( "keep_items" ) == 0 ) {
         // Move any items that have found their way onto the construction site.
         std::vector<tripoint> dump_spots;
-        for( const tripoint &pt : g->m.points_in_radius( terp, 1 ) ) {
-            if( g->m.can_put_items( pt ) && pt != terp ) {
+        for( const tripoint &pt : here.points_in_radius( terp, 1 ) ) {
+            if( here.can_put_items( pt ) && pt != terp ) {
                 dump_spots.push_back( pt );
             }
         }
         if( !dump_spots.empty() ) {
             tripoint dump_spot = random_entry( dump_spots );
-            map_stack items = g->m.i_at( terp );
+            map_stack items = here.i_at( terp );
             for( map_stack::iterator it = items.begin(); it != items.end(); ) {
-                g->m.add_item_or_charges( dump_spot, *it );
+                here.add_item_or_charges( dump_spot, *it );
                 it = items.erase( it );
             }
         } else {
@@ -1026,20 +1027,26 @@ void complete_construction( player *p )
     // Make the terrain change
     if( !built.post_terrain.empty() ) {
         if( built.post_is_furniture ) {
-            g->m.furn_set( terp, furn_str_id( built.post_terrain ) );
+            here.furn_set( terp, furn_str_id( built.post_terrain ) );
             active_tile_data *active = active_tiles::furn_at<active_tile_data>(
-                                           tripoint_abs_ms( g->m.getabs( terp ) ) );
+                                           tripoint_abs_ms( here.getabs( terp ) ) );
             if( active != nullptr ) {
                 active->set_last_updated( calendar::turn );
             }
         } else {
-            g->m.ter_set( terp, ter_str_id( built.post_terrain ) );
+            const ter_id new_ter = ter_str_id( built.post_terrain );
+            here.ter_set( terp, new_ter );
+            const tripoint above = terp + tripoint_above;
+            // TODO: What to do if tile above has no floor, but isn't open air?
+            if( new_ter->roof && here.ter( above ) == t_open_air ) {
+                here.ter_set( above, new_ter->roof );
+            }
         }
     }
 
     // Spawn byproducts
     if( built.byproduct_item_group ) {
-        g->m.spawn_items( p->pos(), item_group::items_from( built.byproduct_item_group, calendar::turn ) );
+        here.spawn_items( p->pos(), item_group::items_from( built.byproduct_item_group, calendar::turn ) );
     }
 
     add_msg( m_info, _( "%s finished construction: %s." ), p->disp_name(), _( built.description ) );
@@ -1393,6 +1400,7 @@ void construct::done_mine_upstair( const tripoint &p )
     add_msg( _( "You drill out a passage, heading for the surface." ) );
     g->m.ter_set( p.xy(), t_stairs_up ); // There's the bottom half
     // We need to write to submap-local coordinates.
+    // TODO: Add roof above
     tmpmap.ter_set( local_tmp, t_stairs_down ); // and there's the top half.
     tmpmap.save();
 }
@@ -1400,6 +1408,7 @@ void construct::done_mine_upstair( const tripoint &p )
 void construct::done_wood_stairs( const tripoint &p )
 {
     const tripoint top = p + tripoint_above;
+    // TODO: Add roof above
     g->m.ter_set( top, ter_id( "t_wood_stairs_down" ) );
 }
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1325,7 +1325,7 @@ void construct::done_digormine_stair( const tripoint &p, bool dig )
         } else {
             add_msg( m_warning, _( "You just tunneled into lava!" ) );
             g->events().send<event_type::digs_into_lava>();
-            g->m.ter_set( p, t_hole );
+            g->m.ter_set( p, t_open_air );
         }
 
         return;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -677,7 +677,7 @@ static void smash()
         smashskill = u.str_cur + u.weapon.damage_melee( DT_BASH );
     }
 
-    const bool allow_floor_bash = debug_mode; // Should later become "true"
+    const bool allow_floor_bash = m.has_zlevels();
     const cata::optional<tripoint> smashp_ = choose_adjacent( _( "Smash where?" ), allow_floor_bash );
     if( !smashp_ ) {
         return;
@@ -705,7 +705,7 @@ static void smash()
         if( bash_info.str_min == -1 ) {
             continue;
         }
-        if( smashskill < bash_info.str_min && one_in( 10 ) ) {
+        if( smashskill < bash_info.str_min ) {
             add_msg( m_neutral, _( "You don't seem to be damaging the %s." ), fd_to_smsh.first->get_name() );
             return;
         } else if( smashskill >= rng( bash_info.str_min, bash_info.str_max ) ) {

--- a/src/map.h
+++ b/src/map.h
@@ -161,6 +161,8 @@ struct bash_results {
     bool success = false;
     // Did we bash furniture, terrain or vehicle
     bool bashed_solid = false;
+    // If there was recurrent bashing, it will be here
+    std::vector<bash_results> subresults;
 
     bash_results &operator|=( const bash_results &other );
 };
@@ -1891,6 +1893,8 @@ class map
         std::unique_ptr<vehicle> add_vehicle_to_map( std::unique_ptr<vehicle> veh, bool merge_wrecks );
 
         // Internal methods used to bash just the selected features
+        // "Externaled" for testing, because the interface to bashing is rng dependent
+    public:
         // Information on what to bash/what was bashed is read from/written to the bash_params/bash_results struct
         bash_results bash_ter_furn( const tripoint &p, const bash_params &params );
         bash_results bash_items( const tripoint &p, const bash_params &params );
@@ -1901,6 +1905,7 @@ class map
         bash_results bash_ter_success( const tripoint &p, const bash_params &params );
         bash_results bash_furn_success( const tripoint &p, const bash_params &params );
 
+    private:
         // Gets the roof type of the tile at p
         // Second argument refers to whether we have to get a roof (we're over an unpassable tile)
         // or can just return air because we bashed down an entire floor tile

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -155,19 +155,19 @@ static const std::unordered_map<std::string, ter_bitflags> ter_bitflags_map = { 
         { "FLAMMABLE_HARD",           TFLAG_FLAMMABLE_HARD }, // fire
         { "SEALED",                   TFLAG_SEALED },         // Fire, acid
         { "ALLOW_FIELD_EFFECT",       TFLAG_ALLOW_FIELD_EFFECT }, // Fire, acid
-        { "COLLAPSES",                TFLAG_COLLAPSES },      // building "remodeling"
+        { "COLLAPSES",                TFLAG_COLLAPSES },      // This tile includes a ceiling. If the ceiling drops, this tile is destroyed.
         { "FLAMMABLE",                TFLAG_FLAMMABLE },      // fire bad! fire SLOW!
         { "REDUCE_SCENT",             TFLAG_REDUCE_SCENT },   // ...and the other half is update_scent
         { "INDOORS",                  TFLAG_INDOORS },        // vehicle gain_moves, weather
         { "SHARP",                    TFLAG_SHARP },          // monmove
-        { "SUPPORTS_ROOF",            TFLAG_SUPPORTS_ROOF },  // and by building "remodeling" I mean hulkSMASH
+        { "SUPPORTS_ROOF",            TFLAG_SUPPORTS_ROOF },  // Supports its ceiling and roof above it.
         { "MINEABLE",                 TFLAG_MINEABLE },       // allows mining
         { "SWIMMABLE",                TFLAG_SWIMMABLE },      // monmove, many fields
         { "TRANSPARENT",              TFLAG_TRANSPARENT },    // map::is_transparent / lightmap
         { "NOITEM",                   TFLAG_NOITEM },         // add/spawn_item*()
         { "NO_SIGHT",                 TFLAG_NO_SIGHT },       // Sight reduced to 1 on this tile
         { "FLAMMABLE_ASH",            TFLAG_FLAMMABLE_ASH },  // oh hey fire. again.
-        { "WALL",                     TFLAG_WALL },           // connects to other walls
+        { "WALL",                     TFLAG_WALL },           // Badly defined. Used for roof support, mapgen, and fungalization result.
         { "NO_SCENT",                 TFLAG_NO_SCENT },       // cannot have scent values, which prevents scent diffusion through this tile
         { "DEEP_WATER",               TFLAG_DEEP_WATER },     // Deep enough to submerge things
         { "CURRENT",                  TFLAG_CURRENT },        // Water is flowing.
@@ -621,7 +621,6 @@ bool map_data_common_t::connects( int &ret ) const
 }
 
 ter_id t_null,
-       t_hole, // Real nothingness; makes you fall a z-level
        // Ground
        t_dirt, t_sand, t_clay, t_dirtmound, t_pit_shallow, t_pit, t_grave, t_grave_new,
        t_pit_corpsed, t_pit_covered, t_pit_spiked, t_pit_spiked_covered, t_pit_glass, t_pit_glass_covered,
@@ -742,7 +741,6 @@ ter_id t_null,
 void set_ter_ids()
 {
     t_null = ter_id( "t_null" );
-    t_hole = ter_id( "t_hole" );
     t_dirt = ter_id( "t_dirt" );
     t_sand = ter_id( "t_sand" );
     t_clay = ter_id( "t_clay" );
@@ -1474,18 +1472,31 @@ void ter_t::check() const
     }
     if( ( test_mode || json_report_unused_fields )
         && ( bash.ter_set == t_open_air.id() || bash.ter_set_bashed_from_above == t_open_air.id() ) ) {
-        debugmsg( "%s explicitly turns into \"t_open_air\", but should use \"t_null\" instead",
+        debugmsg( "%s explicitly turns into \"t_open_air\", but \"t_null\" is preferred",
                   id.c_str() );
     }
-    if( roof && !roof->bash.destroy_only ) {
-        const map_bash_info &roof_bash = roof->bash;
-        int roof_bash_min = std::max( roof_bash.str_min, roof_bash.str_min_supported );
-        int roof_bash_max = std::max( roof_bash.str_max, roof_bash.str_max_supported );
-        if( bash.destroy_only || roof_bash_min < bash.str_min || roof_bash_max < bash.str_max ) {
-            debugmsg( "%s has roof %s, which is less resistant to bashing - this can lead to ledges leading to solid tiles!",
-                      id.str(), roof.str() );
-        }
+    if( roof && roof->roof ) {
+        debugmsg( "%s has roof %s, which has its own roof %s",
+                  id.str(), roof.str(), roof->roof.str() );
     }
+    if( roof && !roof->bash.bash_below ) {
+        debugmsg( "%s has roof %s, with \"bash_below\": false",
+                  id.str(), roof.str() );
+    }
+    if( bash.ter_set_bashed_from_above && bash.ter_set_bashed_from_above->movecost == 0 &&
+        !bash.ter_set_bashed_from_above->roof ) {
+        debugmsg( "%s has bash.ter_set_bashed_from_above %s, which is unpassable but has no roof",
+                  id.str(), bash.ter_set_bashed_from_above.str() );
+    }
+    if( deconstruct.ter_set == t_open_air.id() ) {
+        debugmsg( "%s deconstructs into \"t_open_air\", but \"t_null\" is preferred",
+                  id.str() );
+    }
+}
+
+const std::vector<ter_t> &ter_t::get_all()
+{
+    return terrain_data.get_all();
 }
 
 furn_t::furn_t() : open( furn_str_id::NULL_ID() ), close( furn_str_id::NULL_ID() ) {}
@@ -1572,6 +1583,11 @@ void furn_t::check() const
             }
         }
     }
+}
+
+const std::vector<furn_t> &furn_t::get_all()
+{
+    return furniture_data.get_all();
 }
 
 void finalize_furn()

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1488,7 +1488,8 @@ void ter_t::check() const
         debugmsg( "%s has bash.ter_set_bashed_from_above %s, which is unpassable but has no roof",
                   id.str(), bash.ter_set_bashed_from_above.str() );
     }
-    if( deconstruct.ter_set == t_open_air.id() ) {
+    if( ( test_mode || json_report_unused_fields )
+        && deconstruct.ter_set == t_open_air.id() ) {
         debugmsg( "%s deconstructs into \"t_open_air\", but \"t_null\" is preferred",
                   id.str() );
     }

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1466,6 +1466,26 @@ void ter_t::check() const
     if( transforms_into && transforms_into == id ) {
         debugmsg( "%s transforms_into itself", id.c_str() );
     }
+    if( bash.ter_set && bash.ter_set == id ) {
+        debugmsg( "%s turns into itself when bashed", id.c_str() );
+    }
+    if( bash.ter_set_bashed_from_above && bash.ter_set_bashed_from_above == id ) {
+        debugmsg( "%s turns into itself when bashed from above", id.c_str() );
+    }
+    if( ( test_mode || json_report_unused_fields )
+        && ( bash.ter_set == t_open_air.id() || bash.ter_set_bashed_from_above == t_open_air.id() ) ) {
+        debugmsg( "%s explicitly turns into \"t_open_air\", but should use \"t_null\" instead",
+                  id.c_str() );
+    }
+    if( roof && !roof->bash.destroy_only ) {
+        const map_bash_info &roof_bash = roof->bash;
+        int roof_bash_min = std::max( roof_bash.str_min, roof_bash.str_min_supported );
+        int roof_bash_max = std::max( roof_bash.str_max, roof_bash.str_max_supported );
+        if( bash.destroy_only || roof_bash_min < bash.str_min || roof_bash_max < bash.str_max ) {
+            debugmsg( "%s has roof %s, which is less resistant to bashing - this can lead to ledges leading to solid tiles!",
+                      id.str(), roof.str() );
+        }
+    }
 }
 
 furn_t::furn_t() : open( furn_str_id::NULL_ID() ), close( furn_str_id::NULL_ID() ) {}

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -463,6 +463,7 @@ struct ter_t : map_data_common_t {
 
     void load( const JsonObject &jo, const std::string &src ) override;
     void check() const override;
+    static const std::vector<ter_t> &get_all();
 };
 
 void set_ter_ids();
@@ -514,6 +515,7 @@ struct furn_t : map_data_common_t {
 
     void load( const JsonObject &jo, const std::string &src ) override;
     void check() const override;
+    static const std::vector<furn_t> &get_all();
 };
 
 void load_furniture( const JsonObject &jo, const std::string &src );
@@ -532,7 +534,6 @@ t_basalt
 "t_basalt"
 */
 extern ter_id t_null,
-       t_hole, // Real nothingness; makes you fall a z-level
        // Ground
        t_dirt, t_sand, t_clay, t_dirtmound, t_pit_shallow, t_pit, t_grave, t_grave_new,
        t_pit_corpsed, t_pit_covered, t_pit_spiked, t_pit_spiked_covered, t_pit_glass, t_pit_glass_covered,

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1835,14 +1835,16 @@ void monster::stumble()
         return;
     }
 
+    map &here = get_map();
+
     std::vector<tripoint> valid_stumbles;
     valid_stumbles.reserve( 11 );
     const bool avoid_water = has_flag( MF_NO_BREATHE ) && !swims() && !has_flag( MF_AQUATIC );
-    for( const tripoint &dest : g->m.points_in_radius( pos(), 1 ) ) {
+    for( const tripoint &dest : here.points_in_radius( pos(), 1 ) ) {
         if( dest != pos() ) {
-            if( g->m.has_flag( TFLAG_RAMP_DOWN, dest ) ) {
+            if( here.has_flag( TFLAG_RAMP_DOWN, dest ) ) {
                 valid_stumbles.push_back( tripoint( dest.xy(), dest.z - 1 ) );
-            } else  if( g->m.has_flag( TFLAG_RAMP_UP, dest ) ) {
+            } else if( here.has_flag( TFLAG_RAMP_UP, dest ) ) {
                 valid_stumbles.push_back( tripoint( dest.xy(), dest.z + 1 ) );
             } else {
                 valid_stumbles.push_back( dest );
@@ -1850,9 +1852,9 @@ void monster::stumble()
         }
     }
 
-    if( g->m.has_zlevels() ) {
+    if( here.has_zlevels() ) {
         tripoint below( posx(), posy(), posz() - 1 );
-        if( g->m.valid_move( pos(), below, false, true ) ) {
+        if( here.valid_move( pos(), below, false, true ) ) {
             valid_stumbles.push_back( below );
         }
     }
@@ -1863,8 +1865,8 @@ void monster::stumble()
             //(Unless they can swim/are aquatic)
             //But let them wander OUT of water if they are there.
             !( avoid_water &&
-               g->m.has_flag( TFLAG_SWIMMABLE, dest ) &&
-               !g->m.has_flag( TFLAG_SWIMMABLE, pos() ) ) &&
+               here.has_flag( TFLAG_SWIMMABLE, dest ) &&
+               !here.has_flag( TFLAG_SWIMMABLE, pos() ) ) &&
             ( g->critter_at( dest, is_hallucination() ) == nullptr ) ) {
             if( move_to( dest, true, false ) ) {
                 break;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY:  [Bugfixes] "Fix missing roofs and partial roof destruction"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Roofs need pretty specific conditions to work correctly:
1. Have `"bash_below": true`
2. Don't have roofs themselves
3. Were spawned on mapgen or load
4. Z-levels are enabled

The first 3 are improved here:
1. A warning is produced when a tile is a roof, but has no `bash_below`. Some terrains had this problems, fixed now.
2. A warning is produced when a roof has a roof. Terrains with this issue fixed.
3. Constructions now create roofs over them if open air was there before.

Additionally, roof bashing is improved:
* Can bash down with `s->SHIFT+.`
* If a tile has its roof wrecked, it itself is wrecked
* If a `bash_below` tile is wrecked, but is not the roof of the tile above, the roof is placed and then bashed with the same force as the original tile. This can lead to 3 destructions (original floor/roof, roof from tile below, the tile below itself).
* Roof and its replacements drop destruction drops and play sounds in correct order (explosions are still reversed)

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

New checks and changes make it less likely that a roof-less tile with a roof data exists.
Such tiles would get new roofs on reload, so they are in bugged state.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

New warnings:
* Checkout `data` from current `upload` branch, but with `src` from this PR
* Compile and load the game
* See warnings
* Checkout `data` from this PR
* See no warnings

Constructions:
* Build a log wall
* See it has a flat roof above it

Bashing:
* Set character strength to 80 or so
* Spawn many tiles of laminated glass
* Save+reload to spawn roofs (map editor doesn't spawn them yet)
* Get over one
* Bash down until destroyed
* Repeat a few times
* Notice that in no case an unpassable tile without a roof is created, despite laminated glass being more resistant to damage than flat roof

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Limitations:
* Log walls, when destroyed from above, WILL leave unpassable tiles without roofs
* Unpassable tiles without roofs are not fixed here, only tiles with types that should have roofs but have lost them due to their roofs being bashed
* Many strong tiles have weak roofs, which creates sort of an exploit in that you can bash it from above to destroy it much more easily
* Repeating bash command in down direction is mega clunky
