### PR TITLE
Allow moving zone position

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6949,7 +6949,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
 
     cata::optional<tripoint> zone_start;
     cata::optional<tripoint> zone_end;
-    bool zone_blink = true;
+    bool zone_blink = false;
     bool zone_cursor = !is_moving_zone; // Do not draw cursor if moving zone
     shared_ptr_fast<draw_callback_t> zone_cb = create_zone_callback( zone_start, zone_end, zone_blink,
             zone_cursor );
@@ -6976,14 +6976,15 @@ look_around_result game::look_around( bool show_window, tripoint &center,
         if( is_moving_zone ) {
             zone_start = lp;
             zone_end = end_point - start_point + lp;
-            // zone_blink = blink; // Clang-tidy says zone_blink here is never read, emmmmmmm
-            // add_msg( m_info, _( "end_point: %s, start_point: %s, lp: %s, player: %s" ),
-            //          end_point.to_string(), start_point.to_string(), lp.to_string(), u.pos().to_string() );
+            // Actually accessed from the terrain overlay callback `zone_cb` in the
+            // call to `ui_manager::redraw`.
+            //NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+            zone_blink = blink;
         }
         invalidate_main_ui_adaptor();
         ui_manager::redraw();
-
-        if( select_zone && has_first_point ) {
+        // TODO: Enable blinking when moving zone, it's not working right now (simply enable it here will cause weird bugs)
+        if( select_zone && has_first_point /* || is_moving_zone */ ) {
             ctxt.set_timeout( BLINK_SPEED );
         }
 
@@ -7020,7 +7021,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
             add_msg( m_debug, "levx: %d, levy: %d, levz: %d", get_levx(), get_levy(), center.z );
             u.view_offset.z = center.z - u.posz();
             m.invalidate_map_cache( center.z );
-            if( select_zone && has_first_point ) { // is blinking
+            if( select_zone && has_first_point /* || is_moving_zone */) { // is blinking
                 blink = true; // Always draw blink symbols when moving cursor
             }
         } else if( action == "TRAVEL_TO" ) {
@@ -7079,7 +7080,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
                 } else {
                     center += edge_scroll;
                 }
-                if( select_zone && has_first_point ) { // is blinking
+                if( select_zone && has_first_point /* || is_moving_zone */) { // is blinking
                     blink = true; // Always draw blink symbols when moving cursor
                 }
             } else if( action == "MOUSE_MOVE" ) {
@@ -7088,7 +7089,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
                     lx = mouse_pos->x;
                     ly = mouse_pos->y;
                 }
-                if( select_zone && has_first_point ) { // is blinking
+                if( select_zone && has_first_point /* || is_moving_zone */) { // is blinking
                     blink = true; // Always draw blink symbols when moving cursor
                 }
             } else if( action == "TIMEOUT" ) {
@@ -7104,7 +7105,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
             ly = ly + vec->y;
             center.x = center.x + vec->x;
             center.y = center.y + vec->y;
-            if( select_zone && has_first_point ) { // is blinking
+            if( select_zone && has_first_point /* || is_moving_zone */) { // is blinking
                 blink = true; // Always draw blink symbols when moving cursor
             }
         } else if( action == "throw_blind" ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6681,7 +6681,7 @@ void game::zones_manager()
                         ui.mark_resize();
                         static_popup message_pop;
                         message_pop.on_top( true );
-                        message_pop.message( "%s", _( "Moving zone..." ) );
+                        message_pop.message( "%s", _( "Moving zone." ) );
                         const auto zone_local_start_point = m.getlocal( zone.get_start_point() );
                         const auto zone_local_end_point = m.getlocal( zone.get_end_point() );
                         // local position of the zone center, used to calculate the u.view_offset,
@@ -6949,7 +6949,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
 
     cata::optional<tripoint> zone_start;
     cata::optional<tripoint> zone_end;
-    bool zone_blink = false;
+    bool zone_blink = true;
     bool zone_cursor = !is_moving_zone; // Do not draw cursor if moving zone
     shared_ptr_fast<draw_callback_t> zone_cb = create_zone_callback( zone_start, zone_end, zone_blink,
             zone_cursor );
@@ -6976,7 +6976,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
         if( is_moving_zone ) {
             zone_start = lp;
             zone_end = end_point - start_point + lp;
-            zone_blink = blink;
+            // zone_blink = blink; // Clang-tidy says zone_blink here is never read, emmmmmmm
             // add_msg( m_info, _( "end_point: %s, start_point: %s, lp: %s, player: %s" ),
             //          end_point.to_string(), start_point.to_string(), lp.to_string(), u.pos().to_string() );
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7021,7 +7021,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
             add_msg( m_debug, "levx: %d, levy: %d, levz: %d", get_levx(), get_levy(), center.z );
             u.view_offset.z = center.z - u.posz();
             m.invalidate_map_cache( center.z );
-            if( select_zone && has_first_point /* || is_moving_zone */) { // is blinking
+            if( select_zone && has_first_point /* || is_moving_zone */ ) { // is blinking
                 blink = true; // Always draw blink symbols when moving cursor
             }
         } else if( action == "TRAVEL_TO" ) {
@@ -7080,7 +7080,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
                 } else {
                     center += edge_scroll;
                 }
-                if( select_zone && has_first_point /* || is_moving_zone */) { // is blinking
+                if( select_zone && has_first_point /* || is_moving_zone */ ) { // is blinking
                     blink = true; // Always draw blink symbols when moving cursor
                 }
             } else if( action == "MOUSE_MOVE" ) {
@@ -7089,7 +7089,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
                     lx = mouse_pos->x;
                     ly = mouse_pos->y;
                 }
-                if( select_zone && has_first_point /* || is_moving_zone */) { // is blinking
+                if( select_zone && has_first_point /* || is_moving_zone */ ) { // is blinking
                     blink = true; // Always draw blink symbols when moving cursor
                 }
             } else if( action == "TIMEOUT" ) {
@@ -7105,7 +7105,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
             ly = ly + vec->y;
             center.x = center.x + vec->x;
             center.y = center.y + vec->y;
-            if( select_zone && has_first_point /* || is_moving_zone */) { // is blinking
+            if( select_zone && has_first_point /* || is_moving_zone */ ) { // is blinking
                 blink = true; // Always draw blink symbols when moving cursor
             }
         } else if( action == "throw_blind" ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6639,6 +6639,7 @@ void game::zones_manager()
                 as_m.entries.emplace_back( 3, zone.get_options().has_options(), '3',
                                            zone.get_type() == zone_type_id( "LOOT_CUSTOM" ) ? _( "Edit filter" ) : _( "Edit options" ) );
                 as_m.entries.emplace_back( 4, !zone.get_is_vehicle(), '4', _( "Edit position" ) );
+                as_m.entries.emplace_back( 5, !zone.get_is_vehicle(), '5', _( "Move position" ) );
                 as_m.query();
 
                 switch( as_m.ret ) {
@@ -6662,6 +6663,33 @@ void game::zones_manager()
                         if( pos && ( pos->first != zone.get_start_point() ||
                                      pos->second != zone.get_end_point() ) ) {
                             zone.set_position( *pos );
+                            stuff_changed = true;
+                        }
+                        break;
+                    }
+                    case 5: {
+                        restore_on_out_of_scope<bool> show_prev( show );
+                        on_out_of_scope invalidate_current_ui( [&]() {
+                            ui.mark_resize();
+                        } );
+                        show = false;
+                        ui.mark_resize();
+                        static_popup message_pop;
+                        message_pop.on_top( true );
+                        message_pop.message( "%s", _( "Moving zone..." ) );
+                        const auto zone_local_start_point = m.getlocal( zone.get_start_point() );
+                        const auto zone_local_end_point = m.getlocal( zone.get_end_point() );
+                        const look_around_result result_local = look_around( false, zone_local_start_point + tripoint_zero,
+                                                                zone_local_start_point, false, false,
+                                                                false, true, zone_local_end_point );
+                        if( result_local.position ) {
+                            const auto new_start_point = m.getabs( *result_local.position );
+                            if( new_start_point == zone.get_start_point() ) {
+                                break; // Nothing changed, don't save
+                            }
+
+                            const auto new_end_point = zone.get_end_point() - zone.get_start_point() + new_start_point;
+                            zone.set_position( std::pair<tripoint, tripoint>( new_start_point, new_end_point ) );
                             stuff_changed = true;
                         }
                     }
@@ -6770,8 +6798,9 @@ cata::optional<tripoint> game::look_around()
     return result.position;
 }
 
-look_around_result game::look_around( const bool show_window, tripoint &center,
-                                      const tripoint &start_point, bool has_first_point, bool select_zone, bool peeking )
+look_around_result game::look_around( bool show_window, tripoint &center,
+                                      const tripoint &start_point, bool has_first_point, bool select_zone, bool peeking,
+                                      bool is_moving_zone, const tripoint &end_point )
 {
     bVMonsterLookFire = false;
     // TODO: Make this `true`
@@ -6913,7 +6942,7 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
     cata::optional<tripoint> zone_start;
     cata::optional<tripoint> zone_end;
     bool zone_blink = false;
-    bool zone_cursor = true;
+    bool zone_cursor = !is_moving_zone; // Do not draw cursor if moving zone
     shared_ptr_fast<draw_callback_t> zone_cb = create_zone_callback( zone_start, zone_end, zone_blink,
             zone_cursor );
     add_draw_callback( zone_cb );
@@ -6934,6 +6963,14 @@ look_around_result game::look_around( const bool show_window, tripoint &center,
             // call to `ui_manager::redraw`.
             //NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
             zone_blink = blink;
+        }
+
+        if( is_moving_zone ) {
+            zone_start = lp;
+            zone_end = end_point - start_point + lp;
+            zone_blink = blink;
+            add_msg( m_info, _( "end_point: %s, start_point: %s, lp: %s, player: %s" ),
+                     end_point.to_string(), start_point.to_string(), lp.to_string(), u.pos().to_string() );
         }
         invalidate_main_ui_adaptor();
         ui_manager::redraw();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6969,8 +6969,8 @@ look_around_result game::look_around( bool show_window, tripoint &center,
             zone_start = lp;
             zone_end = end_point - start_point + lp;
             zone_blink = blink;
-            add_msg( m_info, _( "end_point: %s, start_point: %s, lp: %s, player: %s" ),
-                     end_point.to_string(), start_point.to_string(), lp.to_string(), u.pos().to_string() );
+            // add_msg( m_info, _( "end_point: %s, start_point: %s, lp: %s, player: %s" ),
+            //          end_point.to_string(), start_point.to_string(), lp.to_string(), u.pos().to_string() );
         }
         invalidate_main_ui_adaptor();
         ui_manager::redraw();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6668,11 +6668,15 @@ void game::zones_manager()
                         break;
                     }
                     case 5: {
-                        restore_on_out_of_scope<bool> show_prev( show );
                         on_out_of_scope invalidate_current_ui( [&]() {
                             ui.mark_resize();
                         } );
+                        restore_on_out_of_scope<bool> show_prev( show );
+                        restore_on_out_of_scope<cata::optional<tripoint>> zone_start_prev( zone_start );
+                        restore_on_out_of_scope<cata::optional<tripoint>> zone_end_prev( zone_end );
                         show = false;
+                        zone_start = cata::nullopt;
+                        zone_end = cata::nullopt;
                         ui.mark_resize();
                         static_popup message_pop;
                         message_pop.on_top( true );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6639,6 +6639,7 @@ void game::zones_manager()
                 as_m.entries.emplace_back( 3, zone.get_options().has_options(), '3',
                                            zone.get_type() == zone_type_id( "LOOT_CUSTOM" ) ? _( "Edit filter" ) : _( "Edit options" ) );
                 as_m.entries.emplace_back( 4, !zone.get_is_vehicle(), '4', _( "Edit position" ) );
+                // TODO: Enable moving vzone after vehicle zone can be bigger than 1*1
                 as_m.entries.emplace_back( 5, !zone.get_is_vehicle(), '5', _( "Move position" ) );
                 as_m.query();
 
@@ -6683,7 +6684,10 @@ void game::zones_manager()
                         message_pop.message( "%s", _( "Moving zone..." ) );
                         const auto zone_local_start_point = m.getlocal( zone.get_start_point() );
                         const auto zone_local_end_point = m.getlocal( zone.get_end_point() );
-                        const look_around_result result_local = look_around( false, zone_local_start_point + tripoint_zero,
+                        // local position of the zone center, used to calculate the u.view_offset,
+                        // could center the screen to the position it represents
+                        auto view_center = m.getlocal( zone.get_center_point() );
+                        const look_around_result result_local = look_around( false, view_center,
                                                                 zone_local_start_point, false, false,
                                                                 false, true, zone_local_end_point );
                         if( result_local.position ) {

--- a/src/game.h
+++ b/src/game.h
@@ -576,7 +576,8 @@ class game
         // Look at nearby terrain ';', or select zone points
         cata::optional<tripoint> look_around();
         look_around_result look_around( bool show_window, tripoint &center,
-                                        const tripoint &start_point, bool has_first_point, bool select_zone, bool peeking );
+                                        const tripoint &start_point, bool has_first_point, bool select_zone, bool peeking,
+                                        bool is_moving_zone = false, const tripoint &end_point = tripoint_zero );
 
         // Shared method to print "look around" info
         void pre_print_all_tile_info( const tripoint &lp, const catacurses::window &w_info,

--- a/src/game.h
+++ b/src/game.h
@@ -575,6 +575,19 @@ class game
 
         // Look at nearby terrain ';', or select zone points
         cata::optional<tripoint> look_around();
+        /**
+         * @brief
+         *
+         * @param show_window display the info window that holds the tile information in the position.
+         * @param center used to calculate the u.view_offset, could center the screen to the position it represents
+         * @param start_point  the start point of the targeting zone, also the initial local position of the cursor
+         * @param has_first_point should be true if the first point has been selected when editing the zone
+         * @param select_zone true if the zone is being edited
+         * @param peeking determines if the player is peeking
+         * @param is_moving_zone true if the zone is being moved, false by default
+         * @param end_point the end point of the targeting zone, only used if is_moving_zone is true, default is tripoint_zero
+         * @return look_around_result
+         */
         look_around_result look_around( bool show_window, tripoint &center,
                                         const tripoint &start_point, bool has_first_point, bool select_zone, bool peeking,
                                         bool is_moving_zone = false, const tripoint &end_point = tripoint_zero );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

SUMMARY: [Features] "Allow moving zone position"

#### Purpose of change

Currently, the only way to change the position of a zone is to re-edit the zone, but in many cases it is more convenient to move the area directly than to re-edit. So it's a good idea to add a feature to move the zone directly.

#### Describe the solution
Add a new option below the option "Edit position", now the window looks like this:
![image](https://user-images.githubusercontent.com/33447021/155622608-126e139b-450f-400f-81fb-c1ad3a06734c.png)

You can then use the keyboard  to move the zone:
![GIF 2022-2-25 8-07-50](https://user-images.githubusercontent.com/33447021/155628545-a40eaef0-1f23-4e55-9f30-47a4372e2212.gif)

 or mouse:
![GIF 2022-2-25 8-14-16](https://user-images.githubusercontent.com/33447021/155629098-253ac08d-3468-479f-b110-f920d2113bac.gif)


If z-levels are enabled, moving zone across z-levels can also function, as shown in the gif above.

#### Describe alternatives you've considered

#### Testing

- Create a new zone, select it and move it around, the zone saves fine.

- Load an old save with existing zones, those zones can also be moved.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
