### PR TITLE
Updates to sod and thatch roofing

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1308,9 +1308,9 @@
     "description": "Build Thatched Roof",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 5 ], [ "survival", 3 ] ],
-    "time": "360 m",
+    "time": "120 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "2x4", 5 ], [ "stick", 10 ] ], [ [ "straw_pile", 60 ], [ "withered", 60 ] ], [ [ "cordage", 8, "LIST" ] ] ],
+    "components": [ [ [ "2x4", 8 ], [ "stick", 8 ] ], [ [ "straw_pile", 24 ], [ "withered", 24 ] ], [ [ "cordage", 2, "LIST" ] ] ],
     "pre_special": "check_support",
     "post_terrain": "t_dirtfloor_thatchroof"
   },
@@ -1324,7 +1324,7 @@
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [
       [ [ "log", 2 ] ],
-      [ [ "stick", 4 ], [ "2x4", 8 ] ],
+      [ [ "stick", 4 ], [ "2x4", 4 ] ],
       [ [ "material_soil", 40 ] ],
       [ [ "birchbark", 12 ], [ "pine_bough", 12 ] ]
     ],

--- a/data/json/recipes/basecamps/recipe_modular_field_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_field_rammed_earth.json
@@ -24,7 +24,7 @@
           [ [ "water", 400 ], [ "water_clean", 400 ] ],
           [ [ "material_sand", 80 ], [ "material_quicklime", 80 ], [ "concrete", 4 ] ],
           [ [ "log", 8 ] ],
-          [ [ "stick", 16 ], [ "2x4", 32 ] ],
+          [ [ "stick", 16 ], [ "2x4", 16 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ]
         ]
       }
@@ -51,7 +51,7 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "log", 12 ] ],
-          [ [ "2x4", 40 ], [ "stick", 20 ] ],
+          [ [ "2x4", 20 ], [ "stick", 20 ] ],
           [ [ "birchbark", 60 ], [ "pine_bough", 60 ] ],
           [ [ "concrete", 3 ], [ "material_quicklime", 60 ], [ "material_sand", 60 ] ],
           [ [ "material_soil", 920 ] ],
@@ -451,7 +451,7 @@
           [ [ "water", 300 ], [ "water_clean", 300 ] ],
           [ [ "material_sand", 60 ], [ "material_quicklime", 60 ], [ "concrete", 3 ] ],
           [ [ "log", 30 ] ],
-          [ [ "stick", 60 ], [ "2x4", 120 ] ],
+          [ [ "stick", 60 ], [ "2x4", 60 ] ],
           [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ]
         ]
       }
@@ -681,7 +681,7 @@
           [ [ "water", 300 ], [ "water_clean", 300 ] ],
           [ [ "material_sand", 60 ], [ "material_quicklime", 60 ], [ "concrete", 3 ] ],
           [ [ "log", 30 ] ],
-          [ [ "stick", 60 ], [ "2x4", 120 ] ],
+          [ [ "stick", 60 ], [ "2x4", 60 ] ],
           [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ]
         ]
       }

--- a/data/json/recipes/basecamps/recipe_modular_field_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_field_rammed_earth.json
@@ -114,7 +114,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 179 ] ],
+          [ [ "2x4", 115 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 34 ], [ "spear_wood", 34 ] ],
           [ [ "material_soil", 4720 ] ],
@@ -148,7 +148,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 211 ] ],
+          [ [ "2x4", 131 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 28 ], [ "spear_wood", 28 ] ],
           [ [ "material_soil", 4160 ] ],
@@ -181,7 +181,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 179 ] ],
+          [ [ "2x4", 115 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 34 ], [ "spear_wood", 34 ] ],
           [ [ "material_soil", 4720 ] ],
@@ -215,7 +215,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 211 ] ],
+          [ [ "2x4", 131 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 26 ], [ "spear_wood", 26 ] ],
           [ [ "material_soil", 3920 ] ],
@@ -248,7 +248,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 105 ] ],
+          [ [ "2x4", 69 ] ],
           [ [ "nail", 54 ] ],
           [ [ "pointy_stick", 28 ], [ "spear_wood", 28 ] ],
           [ [ "material_soil", 3720 ] ],
@@ -281,7 +281,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 179 ] ],
+          [ [ "2x4", 115 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 34 ], [ "spear_wood", 34 ] ],
           [ [ "material_soil", 4720 ] ],
@@ -314,7 +314,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 211 ] ],
+          [ [ "2x4", 131 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 28 ], [ "spear_wood", 28 ] ],
           [ [ "material_soil", 4160 ] ],
@@ -347,7 +347,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 179 ] ],
+          [ [ "2x4", 115 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 34 ], [ "spear_wood", 34 ] ],
           [ [ "material_soil", 4720 ] ],
@@ -380,7 +380,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 211 ] ],
+          [ [ "2x4", 131 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 26 ], [ "spear_wood", 26 ] ],
           [ [ "material_soil", 3920 ] ],
@@ -413,7 +413,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 98 ] ],
+          [ [ "2x4", 58 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 14 ], [ "spear_wood", 14 ] ],
           [ [ "material_soil", 2080 ] ],
@@ -477,7 +477,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 116 ] ],
+          [ [ "2x4", 76 ] ],
           [ [ "nail", 48 ] ],
           [ [ "pointy_stick", 12 ], [ "spear_wood", 12 ] ],
           [ [ "material_soil", 1840 ] ],
@@ -510,7 +510,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 138 ] ],
+          [ [ "2x4", 78 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 4 ], [ "spear_wood", 4 ] ],
           [ [ "material_soil", 1080 ] ],
@@ -543,7 +543,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 258 ] ],
+          [ [ "2x4", 138 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 10 ], [ "spear_wood", 10 ] ],
           [ [ "material_soil", 2400 ] ],
@@ -576,7 +576,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 116 ] ],
+          [ [ "2x4", 76 ] ],
           [ [ "nail", 48 ] ],
           [ [ "pointy_stick", 12 ], [ "spear_wood", 12 ] ],
           [ [ "material_soil", 1840 ] ],
@@ -610,7 +610,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 138 ] ],
+          [ [ "2x4", 78 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 4 ], [ "spear_wood", 4 ] ],
           [ [ "material_soil", 1080 ] ],
@@ -643,7 +643,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 98 ] ],
+          [ [ "2x4", 58 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 14 ], [ "spear_wood", 14 ] ],
           [ [ "material_soil", 2080 ] ],
@@ -712,7 +712,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 258 ] ],
+          [ [ "2x4", 138 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 10 ], [ "spear_wood", 10 ] ],
           [ [ "material_soil", 2400 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_field_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_field_wad.json
@@ -19,7 +19,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 72 ], [ "stick", 96 ] ],
+          [ [ "2x4", 56 ], [ "stick", 96 ] ],
           [ [ "material_quicklime", 32 ], [ "material_limestone", 32 ], [ "clay_lump", 32 ] ],
           [ [ "pebble", 80 ], [ "material_sand", 80 ] ],
           [ [ "straw_pile", 32 ], [ "cattail_stalk", 32 ], [ "dogbane", 32 ], [ "pine_bough", 32 ] ],
@@ -51,7 +51,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 75 ], [ "stick", 90 ] ],
+          [ [ "2x4", 55 ], [ "stick", 90 ] ],
           [ [ "material_quicklime", 28 ], [ "material_limestone", 28 ], [ "clay_lump", 28 ] ],
           [ [ "pebble", 70 ], [ "material_sand", 70 ] ],
           [ [ "straw_pile", 28 ], [ "cattail_stalk", 28 ], [ "dogbane", 28 ], [ "pine_bough", 28 ] ],
@@ -115,7 +115,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 339 ] ],
+          [ [ "2x4", 275 ] ],
           [ [ "nail", 48 ] ],
           [ [ "material_quicklime", 140 ], [ "material_limestone", 140 ], [ "clay_lump", 140 ] ],
           [ [ "pebble", 350 ], [ "material_sand", 350 ] ],
@@ -150,7 +150,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 341 ] ],
+          [ [ "2x4", 261 ] ],
           [ [ "nail", 48 ] ],
           [ [ "material_quicklime", 116 ], [ "material_limestone", 116 ], [ "clay_lump", 116 ] ],
           [ [ "pebble", 290 ], [ "material_sand", 290 ] ],
@@ -184,7 +184,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 339 ] ],
+          [ [ "2x4", 275 ] ],
           [ [ "nail", 48 ] ],
           [ [ "material_quicklime", 140 ], [ "material_limestone", 140 ], [ "clay_lump", 140 ] ],
           [ [ "pebble", 350 ], [ "material_sand", 350 ] ],
@@ -219,7 +219,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 331 ] ],
+          [ [ "2x4", 251 ] ],
           [ [ "nail", 48 ] ],
           [ [ "material_quicklime", 108 ], [ "material_limestone", 108 ], [ "clay_lump", 108 ] ],
           [ [ "pebble", 270 ], [ "material_sand", 270 ] ],
@@ -253,7 +253,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 235 ] ],
+          [ [ "2x4", 199 ] ],
           [ [ "nail", 24 ] ],
           [ [ "material_quicklime", 116 ], [ "material_limestone", 116 ], [ "clay_lump", 116 ] ],
           [ [ "pebble", 290 ], [ "material_sand", 290 ] ],
@@ -287,7 +287,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 339 ] ],
+          [ [ "2x4", 275 ] ],
           [ [ "nail", 48 ] ],
           [ [ "material_quicklime", 140 ], [ "material_limestone", 140 ], [ "clay_lump", 140 ] ],
           [ [ "pebble", 350 ], [ "material_sand", 350 ] ],
@@ -321,7 +321,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 341 ] ],
+          [ [ "2x4", 261 ] ],
           [ [ "nail", 48 ] ],
           [ [ "material_quicklime", 116 ], [ "material_limestone", 116 ], [ "clay_lump", 116 ] ],
           [ [ "pebble", 290 ], [ "material_sand", 290 ] ],
@@ -355,7 +355,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 339 ] ],
+          [ [ "2x4", 275 ] ],
           [ [ "nail", 48 ] ],
           [ [ "material_quicklime", 140 ], [ "material_limestone", 140 ], [ "clay_lump", 140 ] ],
           [ [ "pebble", 350 ], [ "material_sand", 350 ] ],
@@ -389,7 +389,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 331 ] ],
+          [ [ "2x4", 251 ] ],
           [ [ "nail", 48 ] ],
           [ [ "material_quicklime", 108 ], [ "material_limestone", 108 ], [ "clay_lump", 108 ] ],
           [ [ "pebble", 270 ], [ "material_sand", 270 ] ],
@@ -423,7 +423,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 168 ] ],
+          [ [ "2x4", 128 ] ],
           [ [ "nail", 24 ] ],
           [ [ "material_quicklime", 56 ], [ "material_limestone", 56 ], [ "clay_lump", 56 ] ],
           [ [ "pebble", 140 ], [ "material_sand", 140 ] ],
@@ -457,7 +457,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 150 ], [ "stick", 120 ] ],
+          [ [ "2x4", 90 ], [ "stick", 120 ] ],
           [ [ "material_quicklime", 24 ], [ "material_limestone", 24 ], [ "clay_lump", 24 ] ],
           [ [ "pebble", 60 ], [ "material_sand", 60 ] ],
           [ [ "straw_pile", 24 ], [ "cattail_stalk", 24 ], [ "dogbane", 24 ], [ "pine_bough", 24 ] ],
@@ -489,7 +489,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 176 ] ],
+          [ [ "2x4", 136 ] ],
           [ [ "nail", 48 ] ],
           [ [ "material_quicklime", 48 ], [ "material_limestone", 48 ], [ "clay_lump", 48 ] ],
           [ [ "pebble", 120 ], [ "material_sand", 120 ] ],
@@ -523,7 +523,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 158 ] ],
+          [ [ "2x4", 98 ] ],
           [ [ "nail", 24 ] ],
           [ [ "material_quicklime", 16 ], [ "material_limestone", 16 ], [ "clay_lump", 16 ] ],
           [ [ "pebble", 40 ], [ "material_sand", 40 ] ],
@@ -557,7 +557,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 308 ] ],
+          [ [ "2x4", 188 ] ],
           [ [ "nail", 24 ] ],
           [ [ "material_quicklime", 40 ], [ "material_limestone", 40 ], [ "clay_lump", 40 ] ],
           [ [ "pebble", 100 ], [ "material_sand", 100 ] ],
@@ -591,7 +591,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 176 ] ],
+          [ [ "2x4", 136 ] ],
           [ [ "nail", 48 ] ],
           [ [ "material_quicklime", 48 ], [ "material_limestone", 48 ], [ "clay_lump", 48 ] ],
           [ [ "pebble", 120 ], [ "material_sand", 120 ] ],
@@ -626,7 +626,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 158 ] ],
+          [ [ "2x4", 98 ] ],
           [ [ "nail", 24 ] ],
           [ [ "material_quicklime", 16 ], [ "material_limestone", 16 ], [ "clay_lump", 16 ] ],
           [ [ "pebble", 40 ], [ "material_sand", 40 ] ],
@@ -660,7 +660,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 168 ] ],
+          [ [ "2x4", 128 ] ],
           [ [ "nail", 24 ] ],
           [ [ "material_quicklime", 56 ], [ "material_limestone", 56 ], [ "clay_lump", 56 ] ],
           [ [ "pebble", 140 ], [ "material_sand", 140 ] ],
@@ -694,7 +694,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 150 ], [ "stick", 120 ] ],
+          [ [ "2x4", 90 ], [ "stick", 120 ] ],
           [ [ "material_quicklime", 24 ], [ "material_limestone", 24 ], [ "clay_lump", 24 ] ],
           [ [ "pebble", 60 ], [ "material_sand", 60 ] ],
           [ [ "straw_pile", 24 ], [ "cattail_stalk", 24 ], [ "dogbane", 24 ], [ "pine_bough", 24 ] ],
@@ -731,7 +731,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 308 ] ],
+          [ [ "2x4", 188 ] ],
           [ [ "nail", 24 ] ],
           [ [ "material_quicklime", 40 ], [ "material_limestone", 40 ], [ "clay_lump", 40 ] ],
           [ [ "pebble", 100 ], [ "material_sand", 100 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_log.json
@@ -19,7 +19,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 463 ] ],
+          [ [ "2x4", 387 ] ],
           [ [ "nail", 158 ] ],
           [ [ "wood_panel", 6 ] ],
           [ [ "hinge", 2 ] ],
@@ -56,7 +56,7 @@
           [ { "id": "WRENCH" } ]
         ],
         "components": [
-          [ [ "2x4", 274 ] ],
+          [ [ "2x4", 242 ] ],
           [ [ "nail", 164 ] ],
           [ [ "wood_panel", 2 ] ],
           [ [ "hinge", 2 ] ],
@@ -96,7 +96,7 @@
           [ { "id": "WRENCH" } ]
         ],
         "components": [
-          [ [ "2x4", 520 ] ],
+          [ [ "2x4", 424 ] ],
           [ [ "nail", 122 ] ],
           [ [ "wood_panel", 1 ] ],
           [ [ "hinge", 2 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_rammed_earth.json
@@ -24,7 +24,7 @@
           [ [ "water", 1200 ], [ "water_clean", 1200 ] ],
           [ [ "material_sand", 240 ], [ "material_quicklime", 240 ], [ "concrete", 12 ] ],
           [ [ "log", 24 ] ],
-          [ [ "stick", 48 ], [ "2x4", 96 ] ],
+          [ [ "stick", 48 ], [ "2x4", 48 ] ],
           [ [ "birchbark", 144 ], [ "pine_bough", 144 ] ]
         ]
       }
@@ -55,7 +55,7 @@
           [ [ "water", 1200 ], [ "water_clean", 1200 ] ],
           [ [ "material_sand", 240 ], [ "material_quicklime", 240 ], [ "concrete", 12 ] ],
           [ [ "log", 24 ] ],
-          [ [ "stick", 48 ], [ "2x4", 96 ] ],
+          [ [ "stick", 48 ], [ "2x4", 48 ] ],
           [ [ "birchbark", 144 ], [ "pine_bough", 144 ] ]
         ]
       }
@@ -82,7 +82,7 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "log", 10 ] ],
-          [ [ "2x4", 32 ], [ "stick", 16 ] ],
+          [ [ "2x4", 16 ], [ "stick", 16 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
           [ [ "material_soil", 1120 ] ],
@@ -114,7 +114,7 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "log", 10 ] ],
-          [ [ "2x4", 32 ], [ "stick", 16 ] ],
+          [ [ "2x4", 16 ], [ "stick", 16 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
           [ [ "material_soil", 1120 ] ],
@@ -146,7 +146,7 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "log", 10 ] ],
-          [ [ "2x4", 32 ], [ "stick", 16 ] ],
+          [ [ "2x4", 16 ], [ "stick", 16 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
           [ [ "material_soil", 1120 ] ],
@@ -178,7 +178,7 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "log", 10 ] ],
-          [ [ "2x4", 32 ], [ "stick", 16 ] ],
+          [ [ "2x4", 16 ], [ "stick", 16 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
           [ [ "material_soil", 1120 ] ],
@@ -276,7 +276,7 @@
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "log", 120 ] ],
-          [ [ "stick", 240 ], [ "2x4", 480 ] ],
+          [ [ "stick", 240 ], [ "2x4", 240 ] ],
           [ [ "material_soil", 2400 ] ],
           [ [ "birchbark", 720 ], [ "pine_bough", 720 ] ]
         ]

--- a/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_rammed_earth.json
@@ -209,7 +209,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 258 ] ],
+          [ [ "2x4", 162 ] ],
           [ [ "nail", 108 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
           [ [ "material_soil", 1920 ] ],
@@ -242,7 +242,7 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 258 ] ],
+          [ [ "2x4", 162 ] ],
           [ [ "nail", 108 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
           [ [ "material_soil", 1920 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_wad.json
@@ -19,7 +19,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 216 ], [ "stick", 288 ] ],
+          [ [ "2x4", 168 ], [ "stick", 288 ] ],
           [ [ "material_quicklime", 96 ], [ "material_limestone", 96 ], [ "clay_lump", 96 ] ],
           [ [ "pebble", 240 ], [ "material_sand", 240 ] ],
           [ [ "straw_pile", 96 ], [ "cattail_stalk", 96 ], [ "dogbane", 96 ], [ "pine_bough", 96 ] ],
@@ -51,7 +51,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 216 ], [ "stick", 288 ] ],
+          [ [ "2x4", 168 ], [ "stick", 288 ] ],
           [ [ "material_quicklime", 96 ], [ "material_limestone", 96 ], [ "clay_lump", 96 ] ],
           [ [ "pebble", 240 ], [ "material_sand", 240 ] ],
           [ [ "straw_pile", 96 ], [ "cattail_stalk", 96 ], [ "dogbane", 96 ], [ "pine_bough", 96 ] ],
@@ -83,7 +83,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 77 ], [ "stick", 106 ] ],
+          [ [ "2x4", 61 ], [ "stick", 106 ] ],
           [ [ "material_quicklime", 36 ], [ "material_limestone", 36 ], [ "clay_lump", 36 ] ],
           [ [ "pebble", 90 ], [ "material_sand", 90 ] ],
           [ [ "straw_pile", 36 ], [ "cattail_stalk", 36 ], [ "dogbane", 36 ], [ "pine_bough", 36 ] ],
@@ -115,7 +115,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 77 ], [ "stick", 106 ] ],
+          [ [ "2x4", 61 ], [ "stick", 106 ] ],
           [ [ "material_quicklime", 36 ], [ "material_limestone", 36 ], [ "clay_lump", 36 ] ],
           [ [ "pebble", 90 ], [ "material_sand", 90 ] ],
           [ [ "straw_pile", 36 ], [ "cattail_stalk", 36 ], [ "dogbane", 36 ], [ "pine_bough", 36 ] ],
@@ -147,7 +147,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 77 ], [ "stick", 106 ] ],
+          [ [ "2x4", 61 ], [ "stick", 106 ] ],
           [ [ "material_quicklime", 36 ], [ "material_limestone", 36 ], [ "clay_lump", 36 ] ],
           [ [ "pebble", 90 ], [ "material_sand", 90 ] ],
           [ [ "straw_pile", 36 ], [ "cattail_stalk", 36 ], [ "dogbane", 36 ], [ "pine_bough", 36 ] ],
@@ -179,7 +179,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 77 ], [ "stick", 106 ] ],
+          [ [ "2x4", 61 ], [ "stick", 106 ] ],
           [ [ "material_quicklime", 36 ], [ "material_limestone", 36 ], [ "clay_lump", 36 ] ],
           [ [ "pebble", 90 ], [ "material_sand", 90 ] ],
           [ [ "straw_pile", 36 ], [ "cattail_stalk", 36 ], [ "dogbane", 36 ], [ "pine_bough", 36 ] ],
@@ -211,7 +211,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 278 ] ],
+          [ [ "2x4", 182 ] ],
           [ [ "nail", 48 ] ],
           [ [ "material_quicklime", 40 ], [ "material_limestone", 40 ], [ "clay_lump", 40 ] ],
           [ [ "pebble", 100 ], [ "material_sand", 100 ] ],
@@ -245,7 +245,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 278 ] ],
+          [ [ "2x4", 182 ] ],
           [ [ "nail", 48 ] ],
           [ [ "material_quicklime", 40 ], [ "material_limestone", 40 ], [ "clay_lump", 40 ] ],
           [ [ "pebble", 100 ], [ "material_sand", 100 ] ],
@@ -280,7 +280,7 @@
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "log", 120 ] ],
-          [ [ "stick", 240 ], [ "2x4", 480 ] ],
+          [ [ "stick", 240 ], [ "2x4", 240 ] ],
           [ [ "material_soil", 2400 ] ],
           [ [ "birchbark", 720 ], [ "pine_bough", 720 ] ]
         ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Make thatched roof require saner amount of materials relative to sod roof"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Of the two notable ways to build a roof innawoods, the thatched roof option takes a noticeably higher toll in terms of resources. The log and sod roof takes 2 logs (which a single trunk can easily supply), 40 soil (generally less than a shallow pit yields), 12 birchbark or pine boughs (2-3 trees worth in either case), and 4 sticks or 8 planks (if going for sticks, likely a young tree or two at most). So that's roughly 5-7 tiles harvested per 1 tile of roof (not counting potentially needing to cut down a tree).

Thatched roofing meanwhile requires 60 piles of straw (60 long OR grass tiles dug up) or 60 withered plants (rough estimate of 40 underbrush smashed on average), 48 cordage pieces (so 48 grass tiles or average of 32 underbrush smashed), and finally 10 heavy sticks or 5 planks (probably 2-4 young trees bashed, only 1 if extremely lucky). Possible minimum of 73 tiles harvested per 1 tile of roof built, in practice probably over 100.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Reduced straw/withered plant requirement for thatched roof from 60 to 24, i.e. double the pine bough and birchbark requirements needed for sod roof.
2. Reduced cordage requirement to equal 12 short cordage.
3. Set it so sod roofs and thatched roofs don't call for inconsistent amounts of planks vs. sticks. It's probably preferable to start making more constructions call for planks or sticks in equal amounts, which a fair number of newer construction recipes tend to do compared to the really old ones. In this case I went with 4 sticks/planks for the sod roof (since it already calls for logs) and 8 sticks/planks for thatched roofs.
4. Reduced time taken to build thatched roof from 6 hours to 2 hours, identical to log and sod roof for consistency. You've got splitting logs and laying out sod vs. bundling up thatch, I'm not sure if there'd be substantial enough time difference to justify not just using the same time for simplicity

Combined, these changes reduce the potential minimum tiles harvested to 19-20 (12 tall grass for the straw, 6 tall grass for cordage, 1-2 young trees for sticks) per 1 tile of roof, average of 25-26. This makes it 5 to 6 times more foraging and fiddling about to make them, for a construction recipe that takes better skills (fab 5 and surv 3 vs. just fab 3), in exchange for digging up grass being very quick and easier to get started on than starting up a woodcutting operation..

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. We could possibly allow pine boughs, and even birch bark, as options for the thatch material. This would make birch and pine trees even more of a hot-ticket item than they already are to an aspiring innawoods, as they'd be less common than grass as a resource, but have an average of double the yield of tall grass. Pine would make sense given the improvised shelter and related terrains, while birchbark as a roofing material also has historical precedent.
2. Conversely, it'd be just as reasonable to allow straw and withered plants as an alternative to pine boughs and birchbark for the presumed filler material in the sod roof recipe.
3. Making tall grass always return 2 straw piles instead of 1-2, this would make tall grass consistently more desirable for construction that long grass.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and load errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
