### PR TITLE
Fix RECOVER_%i not working

### DIFF
--- a/src/projectile.h
+++ b/src/projectile.h
@@ -24,10 +24,6 @@ struct projectile {
         // TODO: Get rid of this, replace with something sane (or just get rid)
         int speed = 0;
         int range = 0;
-        /**
-         * If !one_in(this_var), the projectile is dropped on hit.
-         */
-        int dont_recover_one_in = 1;
 
         /**
          * Returns an item that should be dropped or an item for which is_null() is true

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1610,8 +1610,10 @@ static projectile make_gun_projectile( const item &gun )
     }
 
     if( gun.ammo_data() ) {
+        assert( gun.ammo_data()->ammo );
+        const islot_ammo &ammo = *gun.ammo_data()->ammo;
         // Some projectiles have a chance of being recoverable
-        bool recover = !one_in( proj.dont_recover_one_in );
+        bool recover = !one_in( ammo.dont_recover_one_in );
 
         if( recover && !fx.has_effect( ammo_effect_IGNITE ) && !fx.has_effect( ammo_effect_EXPLOSIVE ) ) {
             item drop( gun.ammo_current(), calendar::turn, 1 );
@@ -1619,10 +1621,9 @@ static projectile make_gun_projectile( const item &gun )
             proj.set_drop( drop );
         }
 
-        const auto &ammo = gun.ammo_data()->ammo;
-        if( ammo->drop ) {
-            item drop( ammo->drop );
-            if( ammo->drop_active ) {
+        if( ammo.drop ) {
+            item drop( ammo.drop );
+            if( ammo.drop_active ) {
                 drop.activate();
             }
             proj.set_drop( drop );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: [Bugfixes] "Fix RECOVER_%i flags not working"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Make RECOVER_%i flags work again, so that arrows no longer mulch 100% of the time.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

In recent PR, I named two fields the same way and forgot to copy the value from ammo to projectile.
Here I remove the one from `projectile`, since recovery is set on shot, not hit.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
