### PR TITLE
Ask for a retry if game fails to find a suitable starting location

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -667,10 +667,20 @@ bool game::start_game()
 
     const start_location &start_loc = u.random_start_location ? scen->random_start_location().obj() :
                                       u.start_location.obj();
-    const tripoint_abs_omt omtstart = start_loc.find_player_initial_location();
-    if( omtstart == overmap::invalid_tripoint ) {
-        return false;
-    }
+    tripoint_abs_omt omtstart = overmap::invalid_tripoint;
+    do {
+        omtstart = start_loc.find_player_initial_location();
+        if( omtstart == overmap::invalid_tripoint ) {
+            if( query_yn(
+                    _( "Try again?\n\nIt may require several attempts until the game finds a valid starting location." ) ) ) {
+                MAPBUFFER.reset();
+                overmap_buffer.clear();
+            } else {
+                return false;
+            }
+        }
+    } while( omtstart == overmap::invalid_tripoint );
+
     start_loc.prepare_map( omtstart );
 
     // Place vehicles spawned by scenario or profession, has to be placed very early to avoid bugs.


### PR DESCRIPTION
#### Summary
SUMMARY: Features "Ask for a retry if game fails to find a suitable starting location"

#### Purpose of change
* Quality of life stuff for #36. It **doesn't** fix the issue.

#### Describe the solution
Port of my own PRs [#55025](https://github.com/CleverRaven/Cataclysm-DDA/pull/55025) and [#55695](https://github.com/CleverRaven/Cataclysm-DDA/pull/55695).

#### Describe alternatives you've considered
None.

#### Testing
Reduced chance to spawn for one of locations so it has a fairly high chance of fail to find a suitable location, made several retries until game finally found a suitable location.

#### Additional context
None.
