### PR TITLE
Fix bone meal recipe to use human bone with food processor

### DIFF
--- a/data/json/recipes/food/other.json
+++ b/data/json/recipes/food/other.json
@@ -1148,7 +1148,7 @@
     "autolearn": true,
     "batch_time_factors": [ 50, 3 ],
     "tools": [ [ [ "food_processor", 20 ] ] ],
-    "components": [ [ [ "bone", 1 ] ] ]
+    "components": [ [ [ "bone", 1 ], [ "bone_human", 1 ] ] ]
   },
   {
     "result": "meal_bone_tainted",


### PR DESCRIPTION
#### Summary

SUMMARY: [Feature] "Fix bone meal recipe to use human bone with food processor"

#### Purpose of change

Human bone can be made to bone meal with quern / mortars and pestles, but not with food processor.
This will fix it.

#### Describe the solution

Add bone meal's recipe to count human mone as valid material.

#### Describe alternatives you've considered

None.

#### Testing

Tested with current save.
It worked well.

#### Additional context
