### PR TITLE
QoL changes for moving zone

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7006,7 +7006,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
         }
         invalidate_main_ui_adaptor();
         ui_manager::redraw();
-        if( select_zone && has_first_point || is_moving_zone ) {
+        if( ( select_zone && has_first_point ) || is_moving_zone ) {
             ctxt.set_timeout( BLINK_SPEED );
         }
 
@@ -7022,7 +7022,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
             action = ctxt.handle_input();
         }
         if( ( action == "LEVEL_UP" || action == "LEVEL_DOWN" || action == "MOUSE_MOVE" ||
-              ctxt.get_direction( action ) ) && ( select_zone && has_first_point || is_moving_zone ) ) {
+              ctxt.get_direction( action ) ) && ( ( select_zone && has_first_point ) || is_moving_zone ) ) {
             blink = true; // Always draw blink symbols when moving cursor
         } else if( action == "TIMEOUT" ) {
             blink = !blink;


### PR DESCRIPTION
#### Summary

SUMMARY: [Features] "QoL changes for moving zone (blinking, auto zoom and cursor as center)"

#### Purpose of change

To make the operation of moving zone simpler and looks better.

#### Describe the solution

1. Zone is blinking when moving it, and cursor in the center of the zone.
2. Auto zoom out for better observation when moving a large zone.

![GIF 2022-3-6 12-32-55](https://user-images.githubusercontent.com/33447021/156909351-313b5987-f604-45d3-93ab-518a11bb923d.gif)


#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Moving zone around and it looks nice.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
