### PR TITLE
Optimize craft menu performance when there are numerous items around

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -579,6 +579,8 @@ const inventory &Character::crafting_inventory( const tripoint &src_pos, int rad
     cached_moves = moves;
     cached_time = calendar::turn;
     cached_position = inv_pos;
+    // cache the qualities of the items in cached_crafting_inventory
+    cached_crafting_inventory.update_quality_cache();
     return cached_crafting_inventory;
 }
 

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1068,16 +1068,16 @@ enchantment inventory::get_active_enchantment_cache( const Character &owner ) co
 void inventory::update_quality_cache()
 {
     quality_cache.clear();
-    for( const auto &stack : items ) {
-        for( const auto &check_item : stack ) {
-            auto item_qualities = check_item.get_qualities();
-            for( const auto &quality : item_qualities ) {
-                // quality.first is the id of the quality, quality.second is the quality level
-                // the value is the number of items with that quality level
-                ++quality_cache[quality.first][quality.second];
-            }
+    inventory *this_nonconst = const_cast<inventory *>( this );
+    this_nonconst->visit_items( [ this ]( item * e ) {
+        auto item_qualities = e->get_qualities();
+        for( const auto &quality : item_qualities ) {
+            // quality.first is the id of the quality, quality.second is the quality level
+            // the value is the number of items with that quality level
+            ++quality_cache[quality.first][quality.second];
         }
-    }
+        return VisitResponse::NEXT;
+    } );
 }
 
 const std::map<quality_id, std::map<int, int>> &inventory::get_quality_cache() const

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -127,16 +127,18 @@ const std::unordered_map<itype_id, std::string> &invlet_favorites::get_invlets_b
     return invlets_by_id;
 }
 
-invstack::invstack( const invstack &other )
+invstack::invstack( const invstack &other ): std::list<std::list<item>>( other )
 {
-    clear();
-    for( const auto &elem : other ) {
-        push_back( elem );
+    for( auto &elem : *this ) {
+        stacks_by_type[elem.front().typeId()].push_back( &elem );
     }
 }
 
 invstack &invstack::operator=( const invstack &other )
 {
+    if( this == &other ) {
+        return *this;
+    }
     clear();
     for( const auto &elem : other ) {
         push_back( elem );

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -122,10 +122,39 @@ std::string invlet_favorites::invlets_for( const itype_id &id ) const
     return map_iterator->second;
 }
 
-const std::unordered_map<itype_id, std::string> &
-invlet_favorites::get_invlets_by_id() const
+const std::unordered_map<itype_id, std::string> &invlet_favorites::get_invlets_by_id() const
 {
     return invlets_by_id;
+}
+
+invstack::iterator invstack::erase( const const_iterator stack_iter, const itype_id &type )
+{
+    auto &type_stacks = stacks_by_type[type];
+    for( auto iter = type_stacks.begin(); iter != type_stacks.end();  ++iter ) {
+        if( *iter == stack_iter ) {
+            type_stacks.erase( iter );
+            break;
+        }
+    }
+    return std::list<std::list<item> >::erase( stack_iter );
+}
+
+void invstack::push_back( const std::list<item> &new_item_stack )
+{
+    std::list<std::list<item> >::push_back( new_item_stack );
+    stacks_by_type[new_item_stack.front().typeId()].push_back( --end() );
+}
+
+void invstack::clear()
+{
+    stacks_by_type.clear();
+    std::list<std::list<item> >::clear();
+}
+
+
+std::list<invstack::iterator> &invstack::get_stacks_by_type( const itype_id &type )
+{
+    return stacks_by_type[type];
 }
 
 inventory::inventory() = default;
@@ -283,11 +312,11 @@ char inventory::find_usable_cached_invlet( const itype_id &item_type )
 item &inventory::add_item( item newit, bool keep_invlet, bool assign_invlet, bool should_stack )
 {
     binned = false;
-
+    auto type = newit.typeId();
     if( should_stack ) {
         // See if we can't stack this item.
-        for( auto &elem : items ) {
-            std::list<item>::iterator it_ref = elem.begin();
+        for( auto elem : items.get_stacks_by_type( type ) ) {
+            auto it_ref = elem->begin();
             if( it_ref->stacks_with( newit ) ) {
                 if( it_ref->merge_charges( newit ) ) {
                     return *it_ref;
@@ -301,8 +330,8 @@ item &inventory::add_item( item newit, bool keep_invlet, bool assign_invlet, boo
                 } else {
                     newit.invlet = it_ref->invlet;
                 }
-                elem.push_back( newit );
-                return elem.back();
+                elem->push_back( newit );
+                return elem->back();
             } else if( keep_invlet && assign_invlet && it_ref->invlet == newit.invlet &&
                        it_ref->invlet != '\0' ) {
                 // If keep_invlet is true, we'll be forcing other items out of their current invlet.
@@ -317,9 +346,7 @@ item &inventory::add_item( item newit, bool keep_invlet, bool assign_invlet, boo
     }
     update_cache_with_item( newit );
 
-    std::list<item> newstack;
-    newstack.push_back( newit );
-    items.push_back( newstack );
+    items.push_back( { newit } );
     return items.back().back();
 }
 
@@ -376,7 +403,7 @@ void inventory::restack( player &p )
                 } else {
                     iter->splice( iter->begin(), *other );
                 }
-                other = items.erase( other );
+                other = items.erase( other, iter->front().typeId() );
                 --other;
             }
         }
@@ -629,7 +656,7 @@ std::list<item> inventory::reduce_stack( const int position, const int quantity 
             binned = false;
             if( quantity >= static_cast<int>( iter->size() ) || quantity < 0 ) {
                 ret = *iter;
-                items.erase( iter );
+                items.erase( iter, ret.front().typeId() );
             } else {
                 for( int i = 0 ; i < quantity ; i++ ) {
                     ret.push_back( remove_item( &iter->front() ) );
@@ -670,7 +697,7 @@ item inventory::remove_item( const int position )
             item ret = iter->front();
             iter->erase( iter->begin() );
             if( iter->empty() ) {
-                items.erase( iter );
+                items.erase( iter, ret.typeId() );
             }
             return ret;
         }
@@ -706,7 +733,7 @@ std::list<item> inventory::remove_randomly_by_volume( const units::volume &volum
         }
         if( chosen_stack->empty() ) {
             binned = false;
-            items.erase( chosen_stack );
+            items.erase( chosen_stack, chosen_item->typeId() );
         }
     }
     return result;
@@ -782,6 +809,7 @@ std::list<item> inventory::use_amount( itype_id it, int quantity,
     items.sort( stack_compare );
     std::list<item> ret;
     for( invstack::iterator iter = items.begin(); iter != items.end() && quantity > 0; /* noop */ ) {
+        auto type = iter->front().typeId();
         for( std::list<item>::iterator stack_iter = iter->begin();
              stack_iter != iter->end() && quantity > 0;
              /* noop */ ) {
@@ -793,7 +821,7 @@ std::list<item> inventory::use_amount( itype_id it, int quantity,
         }
         if( iter->empty() ) {
             binned = false;
-            iter = items.erase( iter );
+            iter = items.erase( iter, type );
         } else if( iter != items.end() ) {
             ++iter;
         }
@@ -1035,6 +1063,26 @@ enchantment inventory::get_active_enchantment_cache( const Character &owner ) co
         }
     }
     return temp_cache;
+}
+
+void inventory::update_quality_cache()
+{
+    quality_cache.clear();
+    for( const auto &stack : items ) {
+        for( const auto &check_item : stack ) {
+            auto item_qualities = check_item.get_qualities();
+            for( const auto &quality : item_qualities ) {
+                // quality.first is the id of the quality, quality.second is the quality level
+                // the value is the number of items with that quality level
+                ++quality_cache[quality.first][quality.second];
+            }
+        }
+    }
+}
+
+std::map<quality_id, std::map<int, int>> inventory::get_quality_cache() const
+{
+    return quality_cache;
 }
 
 void inventory::assign_empty_invlet( item &it, const Character &p, const bool force )

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -127,9 +127,7 @@ const std::unordered_map<itype_id, std::string> &invlet_favorites::get_invlets_b
     return invlets_by_id;
 }
 
-invstack::invstack()
-{
-}
+invstack::invstack() = default;
 
 invstack::iterator invstack::erase( const const_iterator stack_iter, const itype_id &type )
 {

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1080,7 +1080,7 @@ void inventory::update_quality_cache()
     }
 }
 
-std::map<quality_id, std::map<int, int>> inventory::get_quality_cache() const
+const std::map<quality_id, std::map<int, int>> &inventory::get_quality_cache() const
 {
     return quality_cache;
 }

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -89,6 +89,9 @@ class invstack : private std::list<std::list<item> >
 {
     private:
         std::map<itype_id, std::list<iterator>> stacks_by_type;
+        // Use a menber variable here will cause an "Access violation reading location" error
+        // Don't know why
+        // bool is_valid = false;
 
     public:
         using std::list<std::list<item> >::empty;
@@ -100,11 +103,17 @@ class invstack : private std::list<std::list<item> >
         using std::list<std::list<item> >::sort;
         using std::list<std::list<item> >::iterator;
         using std::list<std::list<item> >::const_iterator;
-        invstack() = default;
-        iterator erase( const const_iterator stack_iter, const itype_id &type ) ;
+        invstack();
+        iterator erase( const_iterator stack_iter, const itype_id &type ) ;
         void push_back( const std::list<item> &new_item_stack ) ;
         void clear() ;
         std::list<iterator> &get_stacks_by_type( const itype_id &type ) ;
+        /**
+         * Init member variable stacks_by_type, make sure the iterator stored is valid.
+         * Guess it could be put into the constructor, but not sure how to do that.
+         *
+         */
+        void init_stacks_by_type() ;
 };
 
 

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -256,7 +256,7 @@ class inventory : public visitable<inventory>
         enchantment get_active_enchantment_cache( const Character &owner ) const;
 
         void update_quality_cache();
-        std::map<quality_id, std::map<int, int>> get_quality_cache() const;
+        const std::map<quality_id, std::map<int, int>> &get_quality_cache() const;
 
     private:
         invlet_favorites invlet_cache;

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -28,7 +28,6 @@ class npc;
 class player;
 struct tripoint;
 
-using invstack = std::list<std::list<item> >;
 using invslice = std::vector<std::list<item> *>;
 using const_invslice = std::vector<const std::list<item> *>;
 using indexed_invslice = std::vector< std::pair<std::list<item>*, int> >;
@@ -85,6 +84,29 @@ class invlet_favorites
         std::unordered_map<itype_id, std::string> invlets_by_id;
         std::array<itype_id, 256> ids_by_invlet;
 };
+
+class invstack : private std::list<std::list<item> >
+{
+    private:
+        std::map<itype_id, std::list<iterator>> stacks_by_type;
+
+    public:
+        using std::list<std::list<item> >::empty;
+        using std::list<std::list<item> >::size;
+        using std::list<std::list<item> >::front;
+        using std::list<std::list<item> >::back;
+        using std::list<std::list<item> >::begin;
+        using std::list<std::list<item> >::end;
+        using std::list<std::list<item> >::sort;
+        using std::list<std::list<item> >::iterator;
+        using std::list<std::list<item> >::const_iterator;
+        invstack() = default;
+        iterator erase( const const_iterator stack_iter, const itype_id &type ) ;
+        void push_back( const std::list<item> &new_item_stack ) ;
+        void clear() ;
+        std::list<iterator> &get_stacks_by_type( const itype_id &type ) ;
+};
+
 
 class inventory : public visitable<inventory>
 {
@@ -233,11 +255,15 @@ class inventory : public visitable<inventory>
         // gets a singular enchantment that is an amalgamation of all items that have active enchantments
         enchantment get_active_enchantment_cache( const Character &owner ) const;
 
+        void update_quality_cache();
+        std::map<quality_id, std::map<int, int>> get_quality_cache() const;
+
     private:
         invlet_favorites invlet_cache;
         char find_usable_cached_invlet( const itype_id &item_type );
 
         invstack items;
+        std::map<quality_id, std::map<int, int>> quality_cache;
 
         mutable bool binned = false;
         /**

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -87,33 +87,30 @@ class invlet_favorites
 
 class invstack : private std::list<std::list<item> >
 {
-    private:
-        std::map<itype_id, std::list<iterator>> stacks_by_type;
-        // Use a menber variable here will cause an "Access violation reading location" error
-        // Don't know why
-        // bool is_valid = false;
-
     public:
-        using std::list<std::list<item> >::empty;
-        using std::list<std::list<item> >::size;
-        using std::list<std::list<item> >::front;
-        using std::list<std::list<item> >::back;
-        using std::list<std::list<item> >::begin;
-        using std::list<std::list<item> >::end;
-        using std::list<std::list<item> >::sort;
-        using std::list<std::list<item> >::iterator;
-        using std::list<std::list<item> >::const_iterator;
-        invstack();
+        using item_stack = std::list<item>;
+        using item_stack_ptr = std::list<item> *;
+
+        using std::list<item_stack>::empty;
+        using std::list<item_stack>::size;
+        using std::list<item_stack>::front;
+        using std::list<item_stack>::back;
+        using std::list<item_stack>::begin;
+        using std::list<item_stack>::end;
+        using std::list<item_stack>::sort;
+        using std::list<item_stack>::iterator;
+        using std::list<item_stack>::const_iterator;
+
+        invstack() = default;
+        invstack( const invstack & );
+        invstack &operator=( const invstack & );
         iterator erase( const_iterator stack_iter, const itype_id &type ) ;
-        void push_back( const std::list<item> &new_item_stack ) ;
+        void push_back( const item_stack &new_item_stack ) ;
         void clear() ;
-        std::list<iterator> &get_stacks_by_type( const itype_id &type ) ;
-        /**
-         * Init member variable stacks_by_type, make sure the iterator stored is valid.
-         * Guess it could be put into the constructor, but not sure how to do that.
-         *
-         */
-        void init_stacks_by_type() ;
+        std::list<item_stack_ptr> &get_stacks_by_type( const itype_id &type ) ;
+
+    private:
+        std::map<itype_id, std::list<item_stack_ptr>> stacks_by_type;
 };
 
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -870,9 +870,9 @@ bool item::display_stacked_with( const item &rhs, bool check_components ) const
     return !count_by_charges() && stacks_with( rhs, check_components );
 }
 
-bool item::stacks_with( const item &rhs, bool check_components ) const
+bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_check ) const
 {
-    if( type != rhs.type ) {
+    if( !skip_type_check && type != rhs.type ) {
         return false;
     }
     if( is_relic() && rhs.is_relic() && !( *relic_data == *rhs.relic_data ) ) {
@@ -5194,6 +5194,15 @@ int item::get_quality( const quality_id &id ) const
     return_quality = std::max( return_quality, contents.best_quality( id ) );
 
     return return_quality;
+}
+
+std::map<quality_id, int> item::get_qualities() const
+{
+    std::map<quality_id, int> qualities;
+    for( const auto &quality : type->qualities ) {
+        qualities[quality.first] = get_quality( quality.first );
+    }
+    return qualities;
 }
 
 bool item::has_technique( const matec_id &tech ) const

--- a/src/item.h
+++ b/src/item.h
@@ -520,7 +520,8 @@ class item : public visitable<item>
          * stacks like "3 items-count-by-charge (5)".
          */
         bool display_stacked_with( const item &rhs, bool check_components = false ) const;
-        bool stacks_with( const item &rhs, bool check_components = false ) const;
+        bool stacks_with( const item &rhs, bool check_components = false,
+                          bool skip_type_check = false ) const;
         /**
          * Merge charges of the other item into this item.
          * @return true if the items have been merged, otherwise false.
@@ -744,6 +745,7 @@ class item : public visitable<item>
         /*@}*/
 
         int get_quality( const quality_id &id ) const;
+        std::map<quality_id, int> get_qualities() const;
         bool count_by_charges() const;
 
         /**

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -174,11 +174,16 @@ template <>
 bool visitable<inventory>::has_quality( const quality_id &qual, int level, int qty ) const
 {
     const inventory *inv = static_cast<const inventory *>( this );
-    std::map<quality_id, std::map<int, int>> inv_qual_cache = inv->get_quality_cache();
-    if( !inv_qual_cache.empty() ) {
-        return inv_qual_cache[qual][level] >= qty;
-    }
+    auto inv_qual_cache = inv->get_quality_cache();
     int res = 0;
+    if( !inv_qual_cache.empty() ) {
+        for( const auto &q : inv_qual_cache[qual] ) {
+            if( q.first >= level ) {
+                res = sum_no_wrap( res, q.second );
+    }
+        }
+        return res >= qty;
+    }
     for( const auto &stack : inv->items ) {
         res += stack.size() * has_quality_internal( stack.front(), qual, level, qty );
         if( res >= qty ) {

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -174,7 +174,7 @@ template <>
 bool visitable<inventory>::has_quality( const quality_id &qual, int level, int qty ) const
 {
     const inventory *inv = static_cast<const inventory *>( this );
-    auto inv_qual_cache = inv->get_quality_cache();
+    std::map<quality_id, std::map<int, int>> inv_qual_cache = inv->get_quality_cache();
     if( !inv_qual_cache.empty() ) {
         return inv_qual_cache[qual][level] >= qty;
     }

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -173,7 +173,7 @@ bool visitable<T>::has_quality( const quality_id &qual, int level, int qty ) con
 template <>
 bool visitable<inventory>::has_quality( const quality_id &qual, int level, int qty ) const
 {
-    auto *inv = static_cast<const inventory *>( this );
+    const inventory *inv = static_cast<const inventory *>( this );
     auto inv_qual_cache = inv->get_quality_cache();
     if( !inv_qual_cache.empty() ) {
         return inv_qual_cache[qual][level] >= qty;

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -180,7 +180,7 @@ bool visitable<inventory>::has_quality( const quality_id &qual, int level, int q
         for( const auto &q : inv_qual_cache[qual] ) {
             if( q.first >= level ) {
                 res = sum_no_wrap( res, q.second );
-    }
+            }
         }
         return res >= qty;
     }


### PR DESCRIPTION
#### Summary

SUMMARY: [Performance] "Optimize craft menu performance when there are numerous items around"

#### Purpose of change

After I happily looted a large shopping center with the help of my recently developed "moving zone" feature, I found that if I tried to open the craft menu with my loot in the craft range, the game would freeze some seconds before the menu finally opened. And it takes really a lot of time to browse the recipes. So I look into the code and try out a solution to increase the performance.

#### Describe the solution

Firstly, when opening the craft menu, I notice that the game does a lot of iterations in `inventory::add_item` function to check whether the new item can be stacked with the existing item, so it takes a lot of time to run `item::stack_with`. One simple approach to improving that is to reduce unnecessary loops. So I group the invstack by item type to realize that.

The game also spends a lot of time checking whether the craft inventory meets the recipe requirement, specifically the tool quality requirements. Since craft inventory is already a cache, a tool quality cache can be built to improve performance.

#### Describe alternatives you've considered

#### Testing

1. Build and run the latest 732d14c version on Windows 11 x64, open the craft menu near numerous items, the VS2022 profiler results are as following screenshots:

- Open craft menu
![inv_add_item_before](https://user-images.githubusercontent.com/33447021/156936784-92ef2dfd-c326-4003-b065-0f01587e8ffd.png)

- Browse all recipe categories
![quality_cache_before](https://user-images.githubusercontent.com/33447021/156936871-dd45284b-5e53-4f04-803e-ae7cac5e5577.png)

2. Build and run 732d14c  + this PR, same approach returns better result:
- Open craft menu
![inv_add_item_after](https://user-images.githubusercontent.com/33447021/156937028-06b5c776-60fb-4f6e-a229-3778f2a2279b.png)

- Browse all recipe categories
![quality_cache_after](https://user-images.githubusercontent.com/33447021/156937042-cd393449-1f0d-49a0-805c-2e35a4bd0912.png)

3. Drop items from character inventory and then pick them up, didn't notice any abnormal. 

#### Additional context

Not fully tested, may have some bugs that I didn't find.

And I have this many items around when I'm testing:
![scene](https://user-images.githubusercontent.com/33447021/156937904-b75e9be1-a8a2-4b04-8b15-7133071c3f12.png)

