### PR TITLE
Allow crafting certain ammo with filthy materials

### DIFF
--- a/data/json/recipes/ammo/arrows.json
+++ b/data/json/recipes/ammo/arrows.json
@@ -15,7 +15,9 @@
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -50,7 +52,9 @@
       [ [ "steel_tiny", 1, "LIST" ], [ "scrap_bronze", 1 ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -71,7 +75,9 @@
       [ [ "steel_tiny", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -92,7 +98,9 @@
       [ [ "steel_tiny", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -110,7 +118,9 @@
       [ [ "adhesive", 1, "LIST" ], [ "filament", 10, "LIST" ] ],
       [ [ "wire", 5 ], [ "pipe", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -128,7 +138,9 @@
       [ [ "adhesive", 1, "LIST" ], [ "filament", 10, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ], [ "arrow_fire_hardened_fletched", 10 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -157,7 +169,9 @@
         [ "sharp_rock", 1 ]
       ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -178,7 +192,9 @@
       [ [ "steel_tiny", 1, "LIST" ], [ "scrap_bronze", 1 ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -199,7 +215,9 @@
       [ [ "steel_tiny", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -220,7 +238,9 @@
       [ [ "steel_tiny", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -238,7 +258,9 @@
       [ [ "adhesive", 1, "LIST" ], [ "filament", 10, "LIST" ] ],
       [ [ "wire", 4 ], [ "pipe", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -270,7 +292,9 @@
       [ [ "adhesive", 1, "LIST" ], [ "filament", 10, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ], [ "bolt_crude", 10 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -288,7 +312,9 @@
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -317,7 +343,9 @@
         [ "sharp_rock", 1 ]
       ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -351,7 +379,9 @@
         [ "diesel", 250, "NO_RECOVER" ],
         [ "biodiesel", 250, "NO_RECOVER" ]
       ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -401,7 +431,9 @@
         [ "shotgun_primer", 1 ]
       ],
       [ [ "gunpowder", 20 ], [ "chem_black_powder", 20 ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -419,6 +451,8 @@
       [ [ "plastic_chunk", 3 ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   }
 ]

--- a/data/json/recipes/ammo/components.json
+++ b/data/json/recipes/ammo/components.json
@@ -67,7 +67,9 @@
         [ "shotgun_primer", 1 ]
       ],
       [ [ "gunpowder", 20 ], [ "chem_black_powder", 20 ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "result": "incendiary",

--- a/data/json/recipes/ammo/other.json
+++ b/data/json/recipes/ammo/other.json
@@ -136,7 +136,9 @@
       [ [ "bleach", 2 ] ],
       [ [ "oxy_powder", 15 ] ],
       [ [ "lye_powder", 15 ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -149,7 +151,9 @@
     "batch_time_factors": [ 80, 5 ],
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "CUT", "level": 1 } ],
     "book_learn": [ [ "textbook_gaswarfare", 2 ], [ "textbook_anarch", 2, "Stuff THE MAN doesn't want you to know" ] ],
-    "components": [ [ [ "gasoline", 100 ] ], [ [ "plastic_chunk", 1 ] ] ]
+    "components": [ [ [ "gasoline", 100 ] ], [ [ "plastic_chunk", 1 ] ] ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",
@@ -218,7 +222,9 @@
       [ [ "chem_thermite", 50 ] ],
       [ [ "plastic_chunk", 5 ] ],
       [ [ "tool_rocket_candy", 2 ], [ "chem_rocket_fuel", 10 ] ]
-    ]
+    ],
+    "delete_flags": [ "FILTHY" ],
+    "flags": [ "ALLOW_FILTHY" ]
   },
   {
     "type": "recipe",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -481,6 +481,10 @@ item::item( const recipe *rec, int qty, std::list<item> items, std::vector<item_
             }
         }
     }
+    // this extra section is so that in-progress crafts will correctly display expected flags.
+    for( const std::string &flag : rec->flags_to_delete ) {
+        unset_flag( flag );
+    }
 }
 
 item::item( const item & ) = default;

--- a/src/item.h
+++ b/src/item.h
@@ -2262,6 +2262,15 @@ inline bool is_crafting_component( const item &component )
            !component.is_filthy();
 }
 
+/**
+ * This is used in recipes, all other cases use is_crafting_component instead. This allows
+ * filthy components to be filtered out in a different manner that allows exceptions.
+ */
+inline bool is_crafting_component_allow_filthy( const item &component )
+{
+    return ( component.allow_crafting_component() || component.count_by_charges() );
+}
+
 namespace charge_removal_blacklist
 {
 const std::set<itype_id> &get();

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -629,10 +629,20 @@ std::function<bool( const item & )> recipe::get_component_filter(
         };
     }
 
-    return [ rotten_filter, magazine_filter ]( const item & component ) {
-        return is_crafting_component( component ) &&
+    // Filter out filthy components here instead of with is_crafting_component
+    // Make an exception for recipes with the ALLOW_FILTHY flag
+    std::function<bool( const item & )> filthy_filter = return_true<item>;
+    if( !has_flag( "ALLOW_FILTHY" ) ) {
+        filthy_filter = []( const item & component ) {
+            return !component.has_flag( "FILTHY" );
+        };
+    }
+
+    return [ rotten_filter, magazine_filter, filthy_filter ]( const item & component ) {
+        return is_crafting_component_allow_filthy( component ) &&
                rotten_filter( component ) &&
-               magazine_filter( component );
+               magazine_filter( component ) &&
+               filthy_filter( component );
     };
 }
 

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -32,6 +32,7 @@
 #include "units.h"
 #include "value_ptr.h"
 
+static const std::string flag_ALLOW_FILTHY( "ALLOW_FILTHY" );
 static const std::string flag_FIT( "FIT" );
 static const std::string flag_VARSIZE( "VARSIZE" );
 
@@ -632,9 +633,9 @@ std::function<bool( const item & )> recipe::get_component_filter(
     // Filter out filthy components here instead of with is_crafting_component
     // Make an exception for recipes with the ALLOW_FILTHY flag
     std::function<bool( const item & )> filthy_filter = return_true<item>;
-    if( !has_flag( "ALLOW_FILTHY" ) ) {
+    if( !has_flag( flag_ALLOW_FILTHY ) ) {
         filthy_filter = []( const item & component ) {
-            return !component.has_flag( "FILTHY" );
+            return !component.is_filthy();
         };
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Implement support for ALLOW_FILTHY recipe flag, use for arrows and certain other ammo"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A suggestion came up in the BN subreddit of letting you use filthy components for items where filthy status should not actually matter, with arrows given as a prominent example. Turns out this would be trivial if not for filthy components being filtered out in an entirely different function, one used by a lot of other functions.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Define a separate function in item.h for finding crafting components for recipes to use, since just removing the check for filthy items would affect a ton of other functions.
2. Add an additional filter in `recipe::get_component_filter` to filter out filthy components by default, unless the recipe has the `ALLOW_FILTHY` flag.
3. Added the ALLOW_FILTHY flag to certain recipes, currently to certain relevant ammo. General trend is for stuff where filthy status for thread or rags doesn't really matter much, and because of the change below also favors stuff where you can't easily get those components back.
4. Set it so filthy flag is removed from output for affected recipes. For this reason I've stuck to recipes that can't be used to easily clean rags this way, not like it would've mattered given how trivial it is to clean things already.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Honestly we could go so far as to just flat-out allow crafting with filthy components full stop, and basically just reserve the above step 4 for stuff where the recipe would most likely destroy filth (like napalm's use of plastic chunks). Only potential issue with that is then filthiness can spread to basically every item used as a component and to its output, and from there filthy status can spread like wildfire if the player isn't careful, plus using just one filthy component in a recipe full of clean items will dirty up the entire output.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Compiled and load tested.
3. Spawned in a bunch of clean rags.
4. Tested I can still make a turban with clean rags, and that it does not inexplicably become filthy in the process.
5. Got rid of the clean rags, spawned in filthy ones, confirmed I can no longer make a turban.
6. Debugged in the remaining items and skills to make flaming arrows (a notable direct use of rags), confirmed I can make them.
7. Confirmed they come out clean as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

There are probably a lot more cases where this can be applied.