### PR TITLE
Improve game performance by adding suspension cache

### DIFF
--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1867,6 +1867,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
             g->m.set_outside_cache_dirty( target.z );
             g->m.set_floor_cache_dirty( target.z );
             g->m.set_pathfinding_cache_dirty( target.z );
+            g->m.set_suspension_cache_dirty( target.z );
 
             g->m.clear_vehicle_cache( target.z );
             g->m.clear_vehicle_list( target.z );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7879,12 +7879,12 @@ void map::update_suspension_cache( const int &z )
     for( auto iter = suspension_cache.begin(); iter != suspension_cache.end(); ) {
         const point absp = *iter;
         const point locp = getlocal( absp );
-        const tripoint loctp( locp.x, locp.y, z );
+        const tripoint loctp( locp, z );
         if( !inbounds( locp ) ) {
             ++iter;
             continue;
         }
-        const submap *cur_submap = get_submap_at( { locp.x, locp.y, z } );
+        const submap *cur_submap = get_submap_at( loctp );
         if( cur_submap == nullptr ) {
             debugmsg( "Tried to run suspension check at (%d,%d,%d) but the submap is not loaded", locp.x,
                       locp.y, z );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6827,6 +6827,7 @@ void map::loadn( const tripoint &grid, const bool update_vehicles )
     set_outside_cache_dirty( grid.z );
     set_floor_cache_dirty( grid.z );
     set_pathfinding_cache_dirty( grid.z );
+    set_suspension_cache_dirty( grid.z );
     setsubmap( gridn, tmpsub );
     if( !tmpsub->active_items.empty() ) {
         submaps_with_active_items.emplace( grid_abs_sub );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7875,17 +7875,19 @@ void map::update_suspension_cache( const int &z )
         ch.suspension_cache_initialized = true;
     }
 
-    for( auto iter = suspension_cache.begin(); iter != suspension_cache.end(); ++iter ) {
+    for( auto iter = suspension_cache.begin(); iter != suspension_cache.end(); ) {
         const point absp = *iter;
         const point locp = getlocal( absp );
         const tripoint loctp( locp.x, locp.y, z );
         if( !inbounds( locp ) ) {
+            ++iter;
             continue;
         }
         const submap *cur_submap = get_submap_at( { locp.x, locp.y, z } );
         if( cur_submap == nullptr ) {
             debugmsg( "Tried to run suspension check at (%d,%d,%d) but the submap is not loaded", locp.x,
                       locp.y, z );
+            ++iter;
             continue;
         }
         const ter_t &terrain = ter( locp ).obj();
@@ -7893,11 +7895,11 @@ void map::update_suspension_cache( const int &z )
             if( !is_suspension_valid( loctp ) ) {
                 support_dirty( loctp );
                 iter = suspension_cache.erase( iter );
-                --iter;
+            } else {
+                ++iter;
             }
         } else {
             iter = suspension_cache.erase( iter );
-            --iter;
         }
     }
     ch.suspension_cache_dirty = false;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1692,6 +1692,15 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain )
         support_cache_dirty.insert( p );
         set_seen_cache_dirty( p );
     }
+
+    if( new_t.has_flag( TFLAG_SUSPENDED ) != old_t.has_flag( TFLAG_SUSPENDED ) ) {
+        set_suspension_cache_dirty( p.z );
+        if( new_t.has_flag( TFLAG_SUSPENDED ) ) {
+            level_cache &ch = get_cache( p.z );
+            ch.suspension_cache.emplace_back( getabs( p ).xy() );
+        }
+    }
+
     invalidate_max_populated_zlev( p.z );
 
     set_memory_seen_cache_dirty( p );
@@ -7832,33 +7841,66 @@ void map::build_floor_caches()
     }
 }
 
-void map::add_susensions_to_cache( const int &z )
+void map::update_suspension_cache( const int &z )
 {
-    for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
-        for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
-            const submap *cur_submap = get_submap_at_grid( { smx, smy, z } );
+    level_cache &ch = get_cache( z );
+    if( !ch.suspension_cache_dirty ) {
+        return;
+    }
+    std::list<point> &suspension_cache = ch.suspension_cache;
+    if( !ch.suspension_cache_initialized ) {
+        for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
+            for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
+                const submap *cur_submap = get_submap_at_grid( { smx, smy, z } );
 
-            if( cur_submap == nullptr ) {
-                debugmsg( "Tried to run suspension check at (%d,%d,%d) but the submap is not loaded", smx, smy,
-                          z );
-                continue;
-            }
+                if( cur_submap == nullptr ) {
+                    debugmsg( "Tried to run suspension check at (%d,%d,%d) but the submap is not loaded", smx, smy,
+                              z );
+                    continue;
+                }
 
-            for( int sx = 0; sx < SEEX; ++sx ) {
-                for( int sy = 0; sy < SEEY; ++sy ) {
-                    point sp( sx, sy );
-                    const ter_t &terrain = cur_submap->get_ter( sp ).obj();
-                    if( terrain.has_flag( TFLAG_SUSPENDED ) ) {
-                        tripoint loc( coords::project_combine( point_om_sm( point( smx, smy ) ), point_sm_ms( sp ) ).raw(),
-                                      z );
-                        if( !is_suspension_valid( loc ) ) {
-                            support_dirty( loc );
+                for( int sx = 0; sx < SEEX; ++sx ) {
+                    for( int sy = 0; sy < SEEY; ++sy ) {
+                        point sp( sx, sy );
+                        const ter_t &terrain = cur_submap->get_ter( sp ).obj();
+                        if( terrain.has_flag( TFLAG_SUSPENDED ) ) {
+                            tripoint loc( coords::project_combine( point_om_sm( point( smx, smy ) ), point_sm_ms( sp ) ).raw(),
+                                          z );
+                            suspension_cache.emplace_back( getabs( loc ).xy() );
                         }
                     }
                 }
             }
         }
+        ch.suspension_cache_initialized = true;
     }
+
+    for( auto iter = suspension_cache.begin(); iter != suspension_cache.end(); ++iter ) {
+        const point absp = *iter;
+        const point locp = getlocal( absp );
+        const tripoint loctp( locp.x, locp.y, z );
+        if( !inbounds( locp ) ) {
+            continue;
+        }
+        const submap *cur_submap = get_submap_at( { locp.x, locp.y, z } );
+        if( cur_submap == nullptr ) {
+            debugmsg( "Tried to run suspension check at (%d,%d,%d) but the submap is not loaded", locp.x,
+                      locp.y, z );
+            continue;
+        }
+        const ter_t &terrain = ter( locp ).obj();
+        if( terrain.has_flag( TFLAG_SUSPENDED ) ) {
+            if( !is_suspension_valid( loctp ) ) {
+                support_dirty( loctp );
+                iter = suspension_cache.erase( iter );
+                --iter;
+            }
+        } else {
+            iter = suspension_cache.erase( iter );
+            --iter;
+        }
+    }
+    ch.suspension_cache_dirty = false;
 }
 
 static void vehicle_caching_internal( level_cache &zch, const vpart_reference &vp, vehicle *v )
@@ -7926,7 +7968,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         const bool affects_seen_cache =  z == zlev || fov_3d;
         build_outside_cache( z );
         build_transparency_cache( z );
-        add_susensions_to_cache( z );
+        update_suspension_cache( z );
         seen_cache_dirty |= ( build_floor_cache( z ) && affects_seen_cache );
         seen_cache_dirty |= get_cache( z ).seen_cache_dirty && affects_seen_cache;
     }

--- a/src/map.h
+++ b/src/map.h
@@ -457,6 +457,7 @@ class map
                 ch.transparency_cache_dirty.set();
                 ch.seen_cache_dirty = true;
                 ch.outside_cache_dirty = true;
+                ch.suspension_cache_dirty = true;
             }
         }
 

--- a/src/map.h
+++ b/src/map.h
@@ -292,6 +292,9 @@ struct level_cache {
     bool outside_cache_dirty = false;
     bool floor_cache_dirty = false;
     bool seen_cache_dirty = false;
+    bool suspension_cache_initialized = false;
+    bool suspension_cache_dirty = false;
+    std::list<point> suspension_cache;
 
     four_quadrants lm[MAPSIZE_X][MAPSIZE_Y];
     float sm[MAPSIZE_X][MAPSIZE_Y];
@@ -428,6 +431,12 @@ class map
         void set_floor_cache_dirty( const int zlev ) {
             if( inbounds_z( zlev ) ) {
                 get_cache( zlev ).floor_cache_dirty = true;
+            }
+        }
+
+        void set_suspension_cache_dirty( const int zlev ) {
+            if( inbounds_z( zlev ) ) {
+                get_cache( zlev ).suspension_cache_dirty = true;
             }
         }
 
@@ -1771,8 +1780,8 @@ class map
         bool build_floor_cache( int zlev );
         // We want this visible in `game`, because we want it built earlier in the turn than the rest
         void build_floor_caches();
-        // Checks all tiles on a z level and adds those that are invalid to the support_dirty_cache */
-        void add_susensions_to_cache( const int &z );
+        // Checks all suspended tiles on a z level and adds those that are invalid to the support_dirty_cache */
+        void update_suspension_cache( const int &z );
     protected:
         void generate_lightmap( int zlev );
         void build_seen_cache( const tripoint &origin, int target_z );


### PR DESCRIPTION
#### Summary

SUMMARY: [Performance] "Improve game performance by adding suspension cache"

#### Purpose of change

People have been complaining for a long time that CBN is running a lot slower than CDDA, so it's the time to look into the code and find out what is the problem.

#### Describe the solution

It turn out that the function `add_susensions_to_cache` brought by #1234 is the culprit of the huge lag, as it keeps iterating over every map tile. Cache it, and the lag should be gone.

#### Describe alternatives you've considered

#### Testing

Waiting for 6h in game:

- Before this PR
![屏幕截图 2022-03-23 011136](https://user-images.githubusercontent.com/33447021/159545308-557f5717-f255-4f87-b90b-f3c6c3f0fe9d.png)

- After
![屏幕截图 2022-03-23 005946](https://user-images.githubusercontent.com/33447021/159545363-dd9ae732-9aa4-48e1-8853-31e99e43720e.png)

Also obtained mutation web bridge, use it and the suspension mechanic works.

#### Additional context

I tested the game time in a basement.
![屏幕截图 2022-03-23 011150](https://user-images.githubusercontent.com/33447021/159546038-674a9f42-c718-4424-8c12-90f28e5e7f46.png)

