### PR TITLE
Revert invstack change and only use the cache when needed

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -122,59 +122,10 @@ std::string invlet_favorites::invlets_for( const itype_id &id ) const
     return map_iterator->second;
 }
 
-const std::unordered_map<itype_id, std::string> &invlet_favorites::get_invlets_by_id() const
+const std::unordered_map<itype_id, std::string> &
+invlet_favorites::get_invlets_by_id() const
 {
     return invlets_by_id;
-}
-
-invstack::invstack( const invstack &other ): std::list<std::list<item>>( other )
-{
-    for( auto &elem : *this ) {
-        stacks_by_type[elem.front().typeId()].push_back( &elem );
-    }
-}
-
-invstack &invstack::operator=( const invstack &other )
-{
-    if( this == &other ) {
-        return *this;
-    }
-    clear();
-    for( const auto &elem : other ) {
-        push_back( elem );
-    }
-    return *this;
-}
-
-invstack::iterator invstack::erase( const const_iterator stack_iter, const itype_id &type )
-{
-    auto &type_stacks = stacks_by_type[type];
-    for( auto iter = type_stacks.begin(); iter != type_stacks.end();  ++iter ) {
-        if( *iter == &*stack_iter ) {
-            type_stacks.erase( iter );
-            break;
-        }
-    }
-    return std::list<std::list<item> >::erase( stack_iter );
-}
-
-void invstack::push_back( const std::list<item> &new_item_stack )
-{
-    std::list<std::list<item> >::push_back( new_item_stack );
-    itype_id type = new_item_stack.front().typeId();
-    stacks_by_type[type].push_back( &back() );
-}
-
-void invstack::clear()
-{
-    stacks_by_type.clear();
-    std::list<std::list<item> >::clear();
-}
-
-
-std::list<invstack::item_stack_ptr> &invstack::get_stacks_by_type( const itype_id &type )
-{
-    return stacks_by_type[type];
 }
 
 inventory::inventory() = default;
@@ -332,13 +283,61 @@ char inventory::find_usable_cached_invlet( const itype_id &item_type )
 item &inventory::add_item( item newit, bool keep_invlet, bool assign_invlet, bool should_stack )
 {
     binned = false;
-    auto type = newit.typeId();
+
     if( should_stack ) {
         // See if we can't stack this item.
-        for( auto &elem : items.get_stacks_by_type( type ) ) {
-            if( !elem || elem->empty() ) {
-                continue;
+        for( auto &elem : items ) {
+            std::list<item>::iterator it_ref = elem.begin();
+            if( it_ref->stacks_with( newit ) ) {
+                if( it_ref->merge_charges( newit ) ) {
+                    return *it_ref;
+                }
+                if( it_ref->invlet == '\0' ) {
+                    if( !keep_invlet ) {
+                        update_invlet( newit, assign_invlet );
+                    }
+                    update_cache_with_item( newit );
+                    it_ref->invlet = newit.invlet;
+                } else {
+                    newit.invlet = it_ref->invlet;
+                }
+                elem.push_back( newit );
+                return elem.back();
+            } else if( keep_invlet && assign_invlet && it_ref->invlet == newit.invlet &&
+                       it_ref->invlet != '\0' ) {
+                // If keep_invlet is true, we'll be forcing other items out of their current invlet.
+                assign_empty_invlet( *it_ref, g->u );
             }
+        }
+    }
+
+    // Couldn't stack the item, proceed.
+    if( !keep_invlet ) {
+        update_invlet( newit, assign_invlet );
+    }
+    update_cache_with_item( newit );
+
+    items.push_back( {newit} );
+    return items.back().back();
+}
+
+void inventory::build_items_type_cache()
+{
+    items_type_cache.clear();
+    for( auto &elem : items ) {
+        itype_id type = elem.front().typeId();
+        items_type_cache[type].push_back( &elem );
+    }
+}
+
+item &inventory::add_item_by_items_type_cache( item newit, bool keep_invlet, bool assign_invlet,
+        bool should_stack )
+{
+    binned = false;
+    itype_id type = newit.typeId();
+    if( should_stack ) {
+        // See if we can't stack this item.
+        for( auto &elem : items_type_cache[type] ) {
             auto it_ref = elem->begin();
             if( it_ref->stacks_with( newit, false, true ) ) {
                 if( it_ref->merge_charges( newit ) ) {
@@ -369,7 +368,8 @@ item &inventory::add_item( item newit, bool keep_invlet, bool assign_invlet, boo
     }
     update_cache_with_item( newit );
 
-    items.push_back( { newit } );
+    items.push_back( {newit} );
+    items_type_cache[type].push_back( &items.back() );
     return items.back().back();
 }
 
@@ -426,7 +426,7 @@ void inventory::restack( player &p )
                 } else {
                     iter->splice( iter->begin(), *other );
                 }
-                other = items.erase( other, iter->front().typeId() );
+                other = items.erase( other );
                 --other;
             }
         }
@@ -501,6 +501,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
 {
     const time_point bday = calendar::start_of_cataclysm;
     items.clear();
+    build_items_type_cache();
     for( const tripoint &p : pts ) {
         if( m.has_furn( p ) ) {
             const furn_t &f = m.furn( p ).obj();
@@ -516,7 +517,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
                 } else {
                     furn_item.charges = ammo ? count_charges_in_list( ammo, m.i_at( p ) ) : 0;
                 }
-                add_item( furn_item );
+                add_item_by_items_type_cache( furn_item );
             }
         }
         if( m.has_items( p ) && m.accessible_items( p ) ) {
@@ -528,7 +529,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
                     continue;
                 }
                 if( allow_liquids || !i.made_of( LIQUID ) ) {
-                    add_item( i, false, assign_invlet );
+                    add_item_by_items_type_cache( i, false, assign_invlet );
                 }
             }
         }
@@ -536,12 +537,12 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
         if( m.has_nearby_fire( p, 0 ) ) {
             item fire( "fire", bday );
             fire.charges = 1;
-            add_item( fire );
+            add_item_by_items_type_cache( fire );
         }
         // Handle any water from infinite map sources.
         item water = m.water_from( p );
         if( !water.is_null() ) {
-            add_item( water );
+            add_item_by_items_type_cache( water );
         }
         // kludge that can probably be done better to check specifically for toilet water to use in
         // crafting
@@ -556,7 +557,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
                 }
             }
             if( water != toilet.end() && water->charges > 0 ) {
-                add_item( *water );
+                add_item_by_items_type_cache( *water );
             }
         }
 
@@ -591,7 +592,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
                 item fuel( it.first, bday );
                 if( fuel.made_of( LIQUID ) ) {
                     fuel.charges = it.second;
-                    add_item( fuel );
+                    add_item_by_items_type_cache( fuel );
                 }
             }
         }
@@ -602,69 +603,69 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
             hotplate.item_tags.insert( "PSEUDO" );
             // TODO: Allow disabling
             hotplate.item_tags.insert( "HEATS_FOOD" );
-            add_item( hotplate );
+            add_item_by_items_type_cache( hotplate );
 
             item pot( "pot", bday );
             pot.set_flag( "PSEUDO" );
-            add_item( pot );
+            add_item_by_items_type_cache( pot );
             item pan( "pan", bday );
             pan.set_flag( "PSEUDO" );
-            add_item( pan );
+            add_item_by_items_type_cache( pan );
         }
         if( weldpart ) {
             item welder( "welder", bday );
             welder.charges = veh->fuel_left( itype_battery, true );
             welder.item_tags.insert( "PSEUDO" );
-            add_item( welder );
+            add_item_by_items_type_cache( welder );
 
             item soldering_iron( "soldering_iron", bday );
             soldering_iron.charges = veh->fuel_left( itype_battery, true );
             soldering_iron.item_tags.insert( "PSEUDO" );
-            add_item( soldering_iron );
+            add_item_by_items_type_cache( soldering_iron );
         }
         if( craftpart ) {
             item vac_sealer( "vac_sealer", bday );
             vac_sealer.charges = veh->fuel_left( itype_battery, true );
             vac_sealer.item_tags.insert( "PSEUDO" );
-            add_item( vac_sealer );
+            add_item_by_items_type_cache( vac_sealer );
 
             item dehydrator( "dehydrator", bday );
             dehydrator.charges = veh->fuel_left( itype_battery, true );
             dehydrator.item_tags.insert( "PSEUDO" );
-            add_item( dehydrator );
+            add_item_by_items_type_cache( dehydrator );
 
             item food_processor( "food_processor", bday );
             food_processor.charges = veh->fuel_left( itype_battery, true );
             food_processor.item_tags.insert( "PSEUDO" );
-            add_item( food_processor );
+            add_item_by_items_type_cache( food_processor );
 
             item press( "press", bday );
             press.charges = veh->fuel_left( itype_battery, true );
             press.set_flag( "PSEUDO" );
-            add_item( press );
+            add_item_by_items_type_cache( press );
         }
         if( forgepart ) {
             item forge( "forge", bday );
             forge.charges = veh->fuel_left( itype_battery, true );
             forge.item_tags.insert( "PSEUDO" );
-            add_item( forge );
+            add_item_by_items_type_cache( forge );
         }
         if( kilnpart ) {
             item kiln( "kiln", bday );
             kiln.charges = veh->fuel_left( itype_battery, true );
             kiln.item_tags.insert( "PSEUDO" );
-            add_item( kiln );
+            add_item_by_items_type_cache( kiln );
         }
         if( chempart ) {
             item chemistry_set( "chemistry_set", bday );
             chemistry_set.charges = veh->fuel_left( itype_battery, true );
             chemistry_set.item_tags.insert( "PSEUDO" );
-            add_item( chemistry_set );
+            add_item_by_items_type_cache( chemistry_set );
 
             item electrolysis_kit( "electrolysis_kit", bday );
             electrolysis_kit.charges = veh->fuel_left( itype_battery, true );
             electrolysis_kit.item_tags.insert( "PSEUDO" );
-            add_item( electrolysis_kit );
+            add_item_by_items_type_cache( electrolysis_kit );
         }
     }
     pts.clear();
@@ -679,7 +680,7 @@ std::list<item> inventory::reduce_stack( const int position, const int quantity 
             binned = false;
             if( quantity >= static_cast<int>( iter->size() ) || quantity < 0 ) {
                 ret = *iter;
-                items.erase( iter, ret.front().typeId() );
+                items.erase( iter );
             } else {
                 for( int i = 0 ; i < quantity ; i++ ) {
                     ret.push_back( remove_item( &iter->front() ) );
@@ -720,7 +721,7 @@ item inventory::remove_item( const int position )
             item ret = iter->front();
             iter->erase( iter->begin() );
             if( iter->empty() ) {
-                items.erase( iter, ret.typeId() );
+                items.erase( iter );
             }
             return ret;
         }
@@ -756,7 +757,7 @@ std::list<item> inventory::remove_randomly_by_volume( const units::volume &volum
         }
         if( chosen_stack->empty() ) {
             binned = false;
-            items.erase( chosen_stack, chosen_item->typeId() );
+            items.erase( chosen_stack );
         }
     }
     return result;
@@ -832,7 +833,6 @@ std::list<item> inventory::use_amount( itype_id it, int quantity,
     items.sort( stack_compare );
     std::list<item> ret;
     for( invstack::iterator iter = items.begin(); iter != items.end() && quantity > 0; /* noop */ ) {
-        auto type = iter->front().typeId();
         for( std::list<item>::iterator stack_iter = iter->begin();
              stack_iter != iter->end() && quantity > 0;
              /* noop */ ) {
@@ -844,7 +844,7 @@ std::list<item> inventory::use_amount( itype_id it, int quantity,
         }
         if( iter->empty() ) {
             binned = false;
-            iter = items.erase( iter, type );
+            iter = items.erase( iter );
         } else if( iter != items.end() ) {
             ++iter;
         }

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -249,6 +249,7 @@ class inventory : public visitable<inventory>
         std::map<itype_id, std::list<std::list<item>*>> items_type_cache;
         std::map<quality_id, std::map<int, int>> quality_cache;
 
+        bool items_type_cached = false;
         mutable bool binned = false;
         /**
          * Items binned by their type.

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -28,6 +28,7 @@ class npc;
 class player;
 struct tripoint;
 
+using invstack = std::list<std::list<item> >;
 using invslice = std::vector<std::list<item> *>;
 using const_invslice = std::vector<const std::list<item> *>;
 using indexed_invslice = std::vector< std::pair<std::list<item>*, int> >;
@@ -85,35 +86,6 @@ class invlet_favorites
         std::array<itype_id, 256> ids_by_invlet;
 };
 
-class invstack : private std::list<std::list<item> >
-{
-    public:
-        using item_stack = std::list<item>;
-        using item_stack_ptr = std::list<item> *;
-
-        using std::list<item_stack>::empty;
-        using std::list<item_stack>::size;
-        using std::list<item_stack>::front;
-        using std::list<item_stack>::back;
-        using std::list<item_stack>::begin;
-        using std::list<item_stack>::end;
-        using std::list<item_stack>::sort;
-        using std::list<item_stack>::iterator;
-        using std::list<item_stack>::const_iterator;
-
-        invstack() = default;
-        invstack( const invstack & );
-        invstack &operator=( const invstack & );
-        iterator erase( const_iterator stack_iter, const itype_id &type ) ;
-        void push_back( const item_stack &new_item_stack ) ;
-        void clear() ;
-        std::list<item_stack_ptr> &get_stacks_by_type( const itype_id &type ) ;
-
-    private:
-        std::map<itype_id, std::list<item_stack_ptr>> stacks_by_type;
-};
-
-
 class inventory : public visitable<inventory>
 {
     public:
@@ -147,6 +119,9 @@ class inventory : public visitable<inventory>
         // returns a reference to the added item
         item &add_item( item newit, bool keep_invlet = false, bool assign_invlet = true,
                         bool should_stack = true );
+        // use item type cache to speed up, remember to run build_items_type_cache() before using it
+        item &add_item_by_items_type_cache( item newit, bool keep_invlet = false, bool assign_invlet = true,
+                                            bool should_stack = true );
         void add_item_keep_invlet( item newit );
         void push_back( item newit );
 
@@ -264,11 +239,14 @@ class inventory : public visitable<inventory>
         void update_quality_cache();
         const std::map<quality_id, std::map<int, int>> &get_quality_cache() const;
 
+        void build_items_type_cache();
+
     private:
         invlet_favorites invlet_cache;
         char find_usable_cached_invlet( const itype_id &item_type );
 
         invstack items;
+        std::map<itype_id, std::list<std::list<item>*>> items_type_cache;
         std::map<quality_id, std::map<int, int>> quality_cache;
 
         mutable bool binned = false;

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -647,6 +647,7 @@ std::list<item> visitable<inventory>::remove_items_with( const
 
     // Invalidate binning cache
     inv->binned = false;
+    inv->items_type_cached = false;
 
     return res;
 }

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -610,7 +610,6 @@ std::list<item> visitable<inventory>::remove_items_with( const
 {
     auto inv = static_cast<inventory *>( this );
     std::list<item> res;
-    itype_id type;
 
     if( count <= 0 ) {
         // nothing to do
@@ -623,7 +622,6 @@ std::list<item> visitable<inventory>::remove_items_with( const
 
         for( auto istack_iter = istack.begin(); istack_iter != istack.end() && count > 0; ) {
             if( filter( *istack_iter ) ) {
-                type = istack_iter->typeId();
                 count--;
                 res.splice( res.end(), istack, istack_iter++ );
                 // The non-first items of a stack may have different invlets, the code
@@ -641,7 +639,7 @@ std::list<item> visitable<inventory>::remove_items_with( const
         }
 
         if( istack.empty() ) {
-            stack = inv->items.erase( stack, type );
+            stack = inv->items.erase( stack );
         } else {
             ++stack;
         }


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Revert invstack change and only use the cache when needed"

#### Purpose of change

The invstack change to add an items type cache in #1386 seems buggy somehow.  Revert!

#### Describe the solution

Revert  invstack change  and only use the cache when the `inventory::add_item` might be called frequently.

#### Describe alternatives you've considered

More cautious check to guarantee the cache to be right.
But, it doesn't appear to be worth the effort and it's difficult to do.

#### Testing

Open the craft menu with numerous items around, and the performance is fine.

#### Additional context

Fix #1416 