### PR TITLE
Change obsolete componets to actual

### DIFF
--- a/data/mods/Aftershock/recipes/recipes.json
+++ b/data/mods/Aftershock/recipes/recipes.json
@@ -13,7 +13,7 @@
     "components": [
       [ [ "chem_sulphuric_acid", 1 ] ],
       [ [ "steel_chunk", 1 ], [ "scrap", 1 ] ],
-      [ [ "can_drink", 1 ], [ "can_food", 1 ], [ "canister_empty", 1 ] ]
+      [ [ "can_drink_unsealed", 1 ], [ "can_food_unsealed", 1 ], [ "canister_empty", 1 ] ]
     ]
   },
   {
@@ -65,7 +65,7 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "steel_chunk", 1 ], [ "scrap", 1 ] ],
-      [ [ "can_drink", 1 ], [ "can_food", 1 ], [ "canister_empty", 1 ] ],
+      [ [ "can_drink_unsealed", 1 ], [ "can_food_unsealed", 1 ], [ "canister_empty", 1 ] ],
       [ [ "plut_cell", 1 ] ]
     ]
   },
@@ -329,7 +329,7 @@
       [ [ "lead", 25 ] ],
       [ [ "plastic_chunk", 5 ] ],
       [ [ "scrap", 5 ] ],
-      [ [ "can_drink", 5 ], [ "can_food", 5 ], [ "canister_empty", 5 ] ]
+      [ [ "can_drink_unsealed", 5 ], [ "can_food_unsealed", 5 ], [ "canister_empty", 5 ] ]
     ]
   },
   {


### PR DESCRIPTION
Fixed components in recipes of light battery and plutonium cell: "can_drink" to "can_drink_unsealed" and "can_food" to "can_food_unsealed" 
