### PR TITLE
Minor bugfix for items type cache

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -594,7 +594,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
         if( cargo ) {
             const auto items = veh->get_items( cargo->part_index() );
             for( const auto &it : items ) {
-                add_item_by_items_type_cache( it );
+                add_item_by_items_type_cache( it, false, false );
             }
         }
 

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -593,7 +593,9 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
 
         if( cargo ) {
             const auto items = veh->get_items( cargo->part_index() );
-            *this += std::list<item>( items.begin(), items.end() );
+            for( const auto &it : items ) {
+                add_item_by_items_type_cache( it );
+            }
         }
 
         if( faupart ) {


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Minor bugfix for items type cache"

#### Purpose of change

To fix #1424

#### Describe the solution

Uses  add_item_by_items_type_cache() instead of '+='

#### Describe alternatives you've considered

#### Testing

- Before this PR, spawn a food truck, examine it, the debug message pop up.
- After this PR,  spawn a food truck, examine it, no debug message pop up.

#### Additional context
