### PR TITLE
Fix windows msvc release

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -69,11 +69,10 @@ jobs:
         # That said, we also have our custom vcpkg_triplets to hash, so we keep everything the same.
         appendedCacheKey: ${{ hashFiles( 'msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/**' ) }}-x64
         vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-        # We have to use at least this version of vcpkg to include fixes for yasm-tool's
-        # availability only as an x86 host tool. Keep it in sync with the builtin-baseline
+        # Keep vcpkg version here in sync with the builtin-baseline
         # field in vcpkg.json. Caching happens as a post-action which runs at the end of
         # the whole workflow, after vcpkg install happens during msbuild run.
-        vcpkgGitCommitId: '49b67d9cb856424ff69f10e7721aec5299624268'
+        vcpkgGitCommitId: '9d9a6f486cc7da7664117a75d01440db0088634a'
 
     - name: Integrate vcpkg
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
           # availability only as an x86 host tool. Keep it in sync with the builtin-baseline
           # field in vcpkg.json. Caching happens as a post-action which runs at the end of
           # the whole workflow, after vcpkg install happens during msbuild run.
-          vcpkgGitCommitId: '49b67d9cb856424ff69f10e7721aec5299624268'
+          vcpkgGitCommitId: '9d9a6f486cc7da7664117a75d01440db0088634a'
       - name: Install dependencies (windows msvc) (3/3)
         if: runner.os == 'Windows'
         run: |

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -10,5 +10,5 @@
         },
         "sdl2-ttf"
     ],
-    "builtin-baseline": "49b67d9cb856424ff69f10e7721aec5299624268"
+    "builtin-baseline": "9d9a6f486cc7da7664117a75d01440db0088634a"
 }


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Fix GH msvc release build"

#### Purpose of change
Fix msvc release build.

#### Describe the solution
The build is failing because `vcpkg` tries to build sdl2 packages using exact version of some msys2 packages that seem to have been removed from https://repo.msys2.org/mingw/i686/ .
As such, update `vcpkg` to the latest version that passes all tests https://github.com/microsoft/vcpkg/commit/9d9a6f486cc7da7664117a75d01440db0088634a which also defines up-to-date msys2 packages (reference: https://github.com/microsoft/vcpkg/commit/897f02781f7724a44f15d26f708fd6a2832422c3).

#### Describe alternatives you've considered
Giving up on GitHub Actions and building releases locally.

#### Testing
Works on my fork: https://github.com/olanti-p/Cataclysm-BN/releases/tag/cbn-experimental-2022-04-03-1739