### PR TITLE
Fix tracking of volume of current music track when changing music volume in settings

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -165,6 +165,8 @@ static void play_music_file( const std::string &filename, int volume )
         return;
     }
 
+    current_music_track_volume = 0;
+
     if( !check_sound( volume ) ) {
         return;
     }
@@ -180,6 +182,7 @@ static void play_music_file( const std::string &filename, int volume )
         dbg( DL::Error ) << "Starting playlist " << path << " failed: " << Mix_GetError();
         return;
     }
+    current_music_track_volume = volume;
     Mix_HookMusicFinished( musicFinished );
 }
 
@@ -249,7 +252,6 @@ void play_music( const std::string &playlist )
     current_playlist_at = playlist_indexes.at( absolute_playlist_at );
 
     const music_playlist::entry &next = list.entries[current_playlist_at];
-    current_music_track_volume = next.volume;
     play_music_file( next.file, next.volume );
 }
 


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed tracking of volume of currently playing music track when changing music volume in settings"

#### Purpose of change
When updating music volume through settings, the game uses `current_music_track_volume` to change volume of currently playing music track. Yet instead of being updated each time new track starts playing, `current_music_track_volume` is updated only once, when the first track in the playlist starts playing.

#### Describe the solution
Update `current_music_track_volume` after starting new music track.

#### Testing
Checked through debugger that `Mix_VolumeMusic` receives proper values based on `MUSIC_VOLUME` and volume of current track defined in json.