### PR TITLE
 Light Turret Recipe change, Turret Chassis recipe addition

### DIFF
--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -297,7 +297,7 @@
     "skills_required": [ "mechanics", 4 ],
     "time": "2 h",
     "reversible": true,
-    "decomp_learn": 7,
+    "decomp_learn": 5,
     "book_learn": [ [ "recipe_lab_elec", 5 ], [ "textbook_robots", 7 ] ],
     "using": [ [ "steel_standard", 1 ], [ "welding_standard", 20 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -300,14 +300,7 @@
     "decomp_learn": 7,
     "book_learn": [ [ "recipe_lab_elec", 5 ], [ "textbook_robots", 7 ] ],
     "using": [ [ "steel_standard", 1 ], [ "welding_standard", 20 ] ],
-    "qualities": [
-      { "id": "SAW_M", "level": 1 },
-      { "id": "SAW_M_FINE", "level": 1 }
-    ],
-    "components": [
-      [ [ "sheet_metal", 2 ] ],
-      [ [ "pipe", 4 ] ],
-      [ [ "spring", 2 ] ]
-    ]
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],
+    "components": [ [ [ "sheet_metal", 2 ] ], [ [ "pipe", 4 ] ], [ [ "spring", 2 ] ] ]
   }
 ]

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -293,14 +293,14 @@
     "category": "CC_ELECTRONIC",
     "subcategory": "CSC_ELECTRONIC_COMPONENTS",
     "skill_used": "fabrication",
-    "difficulty": 6,
+    "difficulty": 4,
     "skills_required": [ "mechanics", 4 ],
-    "time": "5 h",
+    "time": "2 h",
     "reversible": true,
     "decomp_learn": 7,
     "book_learn": [ [ "recipe_lab_elec", 5 ], [ "textbook_robots", 7 ] ],
     "using": [ [ "steel_standard", 1 ], [ "welding_standard", 20 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],
-    "components": [ [ [ "sheet_metal", 2 ] ], [ [ "pipe", 4 ] ], [ [ "spring", 2 ] ] ]
+    "components": [ [ [ "sheet_metal", 2 ] ], [ [ "pipe", 4 ] ], [ [ "spring", 2 ] ], [ [ "material_aluminium_ingot", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/electronic/components.json
+++ b/data/json/recipes/electronic/components.json
@@ -286,5 +286,28 @@
     "using": [ [ "soldering_standard", 15 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "scrap", 8 ] ], [ [ "cable", 10 ] ] ]
+  },
+  {
+    "result": "turret_chassis",
+    "type": "recipe",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_COMPONENTS",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "skills_required": [ "mechanics", 4 ],
+    "time": "5 h",
+    "reversible": true,
+    "decomp_learn": 7,
+    "book_learn": [ [ "recipe_lab_elec", 5 ], [ "textbook_robots", 7 ] ],
+    "using": [ [ "steel_standard", 1 ], [ "welding_standard", 20 ] ],
+    "qualities": [
+      { "id": "SAW_M", "level": 1 },
+      { "id": "SAW_M_FINE", "level": 1 }
+    ],
+    "components": [
+      [ [ "sheet_metal", 2 ] ],
+      [ [ "pipe", 4 ] ],
+      [ [ "spring", 2 ] ]
+    ]
   }
 ]

--- a/data/json/recipes/electronic/other.json
+++ b/data/json/recipes/electronic/other.json
@@ -623,7 +623,7 @@
     "category": "CC_ELECTRONIC",
     "subcategory": "CSC_ELECTRONIC_OTHER",
     "skill_used": "electronics",
-    "skills_required": [ [ "mechanics", 6 ], [ "computer", 6 ] ],
+    "skills_required": [ [ "mechanics", 6 ], [ "computer", 5 ] ],
     "difficulty": 7,
     "time": "30 m",
     "reversible": true,

--- a/data/json/recipes/electronic/other.json
+++ b/data/json/recipes/electronic/other.json
@@ -623,20 +623,18 @@
     "category": "CC_ELECTRONIC",
     "subcategory": "CSC_ELECTRONIC_OTHER",
     "skill_used": "electronics",
-    "skills_required": [ [ "mechanics", 6 ], [ "computer", 6 ], [ "fabrication", 6 ] ],
+    "skills_required": [ [ "mechanics", 6 ], [ "computer", 6 ] ],
     "difficulty": 7,
-    "time": "6 h",
+    "time": "30 m",
     "reversible": true,
     "decomp_learn": 8,
     "book_learn": [ [ "recipe_lab_elec", 7 ], [ "textbook_robots", 9 ] ],
-    "using": [ [ "steel_standard", 1 ], [ "welding_standard", 20 ], [ "soldering_standard", 14 ] ],
+    "using": [ [ "soldering_standard", 14 ] ],
     "qualities": [
       { "id": "SCREW", "level": 1 },
       { "id": "SCREW_FINE", "level": 1 },
       { "id": "WRENCH", "level": 2 },
-      { "id": "WRENCH_FINE", "level": 1 },
-      { "id": "SAW_M", "level": 1 },
-      { "id": "SAW_M_FINE", "level": 1 }
+      { "id": "WRENCH_FINE", "level": 1 }
     ],
     "components": [
       [ [ "ai_module", 1 ] ],
@@ -648,9 +646,7 @@
       [ [ "power_supply", 1 ] ],
       [ [ "robot_controls", 1 ] ],
       [ [ "ksub2000", 1 ] ],
-      [ [ "sheet_metal", 2 ] ],
-      [ [ "pipe", 4 ] ],
-      [ [ "spring", 2 ] ]
+      [ [ "turret_chassis", 1 ] ]
     ]
   },
   {


### PR DESCRIPTION
#### Summary

Added Turret Chassis as an individual component recipe, altered Light Turret recipe to bring balance.

#### Purpose of change

The Light Turret takes 6 hours to craft over the Medium Turrets 30 minutes, owed likely to the section that crafts an entire turret interior chassis for it using springs, steel, pipes and metal sheets. This makes the Light Turret difficult to utilize and also annoying since if a Turret Interior Chassis is found it cannot be used for the Light Turret.

Furthermore, a broken Light Turret takes only 1 hour to deconstruct, and yields Turret Interior Chassis instead of springs, steel, pipes and metal sheets. This makes the recipe even more unintuitive, as if you have several broken Light Turrets, deconstructing them will never give you all the components required for a Light Turret, as Turret Interior Chasses cannot be disassembled into their components. This also means it's faster and more time efficient to hack a Light Turret, activate it, then kill it so you can harvest parts faster, which is unintuitive and illogical. 

#### Describe the solution

Light Turret crafting times were brought in line with Medium Turrets, their Fabrication requirement removed, their Computer's requirement dropped to the same as Medium Turrets (there's no reason it should require higher computer skill), their metal sawing and welding requirements removed, and the extra components (steel standard, springs, pipes and metal sheets) removed from the recipe, replaced with a Turret Interior Chassis.

In exchange, a Turret Interior Chassis recipe was added to the Components section of the Electronics recipe. Can be book learned from the same books at 2 levels lower than the requirements for Light/Medium Turrets. The time was changed to 5 hours as a round number instead of the 5.5 hours that would result if I directly subtracted the time from the Light Turret recipe, mainly because it seemed excessive. Skill requirements were made to be 6 Fabrication (from the original Light Turret recipe, and 4 mechanics (since this seems like it would be required for all the articulation). Tool requirements were inherited from dropped requirements from the Light Turret Recipe.

This effectively decouples the Turret Interior Chassis from the Light Turret, allowing one to craft Turret Interior Chasses for use in the Light Turret (or any other turret, I deemed this to be acceptable as it doesn't really break any balances, you still have to find all the other parts). It also means that the inactive Light Turret doesn't take 1/6th of a day to craft/disassemble.

#### Describe alternatives you've considered

Increase Broken Light Turret disassembly time to 12 hours (as a general rule it seems disassembly of broken robots is double that of crafted variants) and change the Light Turret Chassis dropped into steel, springs, metal sheets and pipes.
I don't like this option, half a day to disassemble Broken Light Turrets is incredibly unfun and doesn't produce any worthwhile materials.

Rebalance the Light Turret Recipe but don't add Turret Interior Chassis recipe.
Would work, I honestly don't know how useful being able to make a Turret Interior Chassis would even be. However, since the original recipe essentially creates a Turret Interior Chassis I didn't see why that functionality should be removed, just expanded upon.

#### Testing

Inactive Light Turret was disassembled then reassembled to check that all parts matched up and nothing extra was spawned. Tested that recipe can be learned from the appropriate book and from disassembly.

#### Additional context

One thing of note is that the disassembly of Broken Light Turrets can produce Sensor Modules instead of Cameras like Inactive Light Turrets. I didn't change that because I don't really see the harm, sort of risk/reward, but that may be a consideration since it'd be more realistic and doesn't actually cause player frustration.