### PR TITLE
Blood Filter CBM update to remove Badly Poisoned status

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -107,6 +107,7 @@ static const efftype_id effect_pkill1( "pkill1" );
 static const efftype_id effect_pkill2( "pkill2" );
 static const efftype_id effect_pkill3( "pkill3" );
 static const efftype_id effect_poison( "poison" );
+static const efftype_id effect_badpoison( "badpoison" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_stung( "stung" );
 static const efftype_id effect_teleglow( "teleglow" );
@@ -705,7 +706,7 @@ bool Character::activate_bionic( int b, bool eff_only )
         add_msg_activate();
         static const std::vector<efftype_id> removable = {{
                 effect_fungus, effect_dermatik, effect_bloodworms,
-                effect_poison, effect_stung,
+                effect_poison, effect_stung, effect_badpoison,
                 effect_pkill1, effect_pkill2, effect_pkill3, effect_pkill_l,
                 effect_drunk, effect_cig, effect_cocaine_high, effect_weed_high,
                 effect_hallu, effect_visuals, effect_pblue, effect_iodine, effect_datura,


### PR DESCRIPTION
#### Summary

Blood Filter now removes Badly Poisoned status.

#### Purpose of change

Didn't seem like there was a good reason to have Badly Poisoned not be affected at all by Blood Filter CBM. It is still a toxin in your bloodstream after all.

#### Describe alternatives you've considered

One of my considerations was that Badly Poisoned could be downgraded to just Poisoned before being removed on the 2nd "flush", this would throw in resource and turn management considerations into avoiding Badly Poisoned to begin with. However I lack the technical knowhow to make this work, so this is what you get.

#### Testing

Walked into Poison Gas, activated Blood Filter CBM, saw poison removed.

#### Additional context

Blood Analysis CBM considers both Badly Poisoned and Poisoned to be separate conditions but simultaneously calls them poisoned. I'd hope that this could be changed later on.
