### PR TITLE
Fix grid minifreezer deconstruction

### DIFF
--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -1126,7 +1126,7 @@
     "coverage": 50,
     "required_str": 5,
     "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MINEABLE", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "fridge", "count": 1 } ] },
+    "deconstruct": { "items": [ { "item": "minifreezer", "count": 1 } ] },
     "max_volume": "75 L",
     "bash": {
       "str_min": 18,


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix grid minifreezer deconstruction"

#### Purpose of change

Gridify-ed minifreezer requires a minifreezer, but if we deconstruct, it leaves a fridge instead of minifreezer. This will fix it.

#### Describe the solution

Changing f_minifreezer's leftover to minifreezer.

#### Describe alternatives you've considered

#### Testing

Tested and worked well.

#### Additional context
