### PR TITLE
Fix construction blueprint not using requirements

### DIFF
--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_common.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_common.json
@@ -210,20 +210,7 @@
           [ [ "wood_sheet", 1 ], [ "wood_panel", 1 ] ],
           [ [ "nail", 8 ] ],
           [ [ "stick_long", 6 ] ],
-          [
-            [ "rope_6", 1 ],
-            [ "vine_6", 1 ],
-            [ "rope_makeshift_6", 1 ],
-            [ "string_36", 2 ],
-            [ "cordage_36", 2 ],
-            [ "string_6", 12 ],
-            [ "cordage_6", 12 ],
-            [ "thread", 600 ],
-            [ "sinew", 600 ],
-            [ "plant_fibre", 600 ],
-            [ "yarn", 600 ],
-            [ "wire", 8 ]
-          ],
+          [ [ "rope_natural_short", 1, "LIST" ], [ "cordage", 2, "LIST" ], [ "wire", 8 ] ],
           [ [ "pointy_stick", 2 ], [ "spike", 2 ] ]
         ]
       }

--- a/data/json/recipes/basecamps/recipe_modular_field_common.json
+++ b/data/json/recipes/basecamps/recipe_modular_field_common.json
@@ -711,20 +711,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "SAW_W" } ], [ { "id": "CUT" } ] ],
         "components": [
-          [
-            [ "cordage_36", 2 ],
-            [ "cordage_6", 12 ],
-            [ "plant_fibre", 600 ],
-            [ "rope_6", 1 ],
-            [ "rope_makeshift_6", 1 ],
-            [ "sinew", 600 ],
-            [ "string_36", 2 ],
-            [ "string_6", 12 ],
-            [ "thread", 600 ],
-            [ "vine_6", 1 ],
-            [ "wire", 8 ],
-            [ "yarn", 600 ]
-          ],
+          [ [ "rope_natural_short", 1, "LIST" ], [ "cordage", 2, "LIST" ], [ "wire", 8 ] ],
           [ [ "pointy_stick", 2 ], [ "spike", 2 ] ],
           [ [ "stick_long", 6 ] ]
         ]

--- a/data/json/recipes/basecamps/recipe_modular_firestation1.json
+++ b/data/json/recipes/basecamps/recipe_modular_firestation1.json
@@ -299,20 +299,7 @@
           [ [ "wood_sheet", 1 ], [ "wood_panel", 1 ] ],
           [ [ "nail", 8 ] ],
           [ [ "stick_long", 6 ] ],
-          [
-            [ "rope_6", 1 ],
-            [ "vine_6", 1 ],
-            [ "rope_makeshift_6", 1 ],
-            [ "string_36", 2 ],
-            [ "cordage_36", 2 ],
-            [ "string_6", 12 ],
-            [ "cordage_6", 12 ],
-            [ "thread", 600 ],
-            [ "sinew", 600 ],
-            [ "plant_fibre", 600 ],
-            [ "yarn", 600 ],
-            [ "wire", 8 ]
-          ],
+          [ [ "rope_natural_short", 1, "LIST" ], [ "cordage", 2, "LIST" ], [ "wire", 8 ] ],
           [ [ "pointy_stick", 2 ], [ "spike", 2 ] ]
         ]
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix construction blueprints not using rope and cordage crafting requirements consistently"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Minor blueprint fix for something that causes minor problems depending on mod selection.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Updated butchering rack blueprints to correctly use the same crafting requirements for its rope/cord component as the construction it's being told to look at. This ensures that anything that changes the `rope_natural_short` or `cordage` requirements won't cause a blueprint error on load. This could include a hypothetical future addition to the types of cord items in the game, or it could be the current known example of loading a mod like MST Extra that edits the cordage crafting requirement for the same reason.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Struggling to find and port over whatever DDA PR makes it not do this when testing the DDA version of MST Extra. There was mention in the BN discord that the PR might have some potential performance impact anyway but no idea.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Ported changes over to test build and made multiple load tests, both vanilla and with MST Extra added, confirming it doesn't complain anymore.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

If there's any other cases where crafting requirements are used in construction entries but not used in relevant blueprints, let me know.