### PR TITLE
Stricter checks on favorite ammo

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8755,6 +8755,24 @@ void game::butcher()
     }
 }
 
+static item::reload_option favorite_ammo_or_select(
+    const player &u, const item &it, bool empty, bool prompt )
+{
+    if( u.ammo_location ) {
+        std::vector<item::reload_option> ammo_list;
+        if( u.list_ammo( *u.ammo_location, ammo_list, empty ) ) {
+            const auto is_favorite_and_compatible = [&it, &u]( const item::reload_option & opt ) {
+                return opt.ammo == u.ammo_location && it.can_reload_with( opt.ammo->typeId() );
+            };
+            auto iter = std::find_if( ammo_list.begin(), ammo_list.end(), is_favorite_and_compatible );
+            if( iter != ammo_list.end() ) {
+                return *iter;
+            }
+        }
+    }
+    return u.select_ammo( it, prompt, empty );
+}
+
 void game::reload( item_location &loc, bool prompt, bool empty )
 {
     item *it = loc.get_item();
@@ -8821,9 +8839,7 @@ void game::reload( item_location &loc, bool prompt, bool empty )
         return;
     }
 
-    item::reload_option opt = u.ammo_location && it->can_reload_with( u.ammo_location->typeId() ) ?
-                              item::reload_option( &u, it, it, u.ammo_location ) :
-                              u.select_ammo( *it, prompt, empty );
+    item::reload_option opt = favorite_ammo_or_select( u, *loc, empty, prompt );
 
     if( opt.ammo.get_item() == nullptr ) {
         return;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Stricter favorite ammo check to fix item reload crash"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fix #1448

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

The bug was caused by favorite ammo being saved as a location and then not checked for viability, allowing things like trying to reload with an item outside bubble or is contained in the reloaded item already.
I changed it from "get ammo under favorite ammo location" to "if there is ammo location like favorite one, use that without prompting". 

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Disabling ammo favoriting for general case.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Load save in #1448
2. Reload UPS
3. Don't get a crash (unlike in latest release)
4. Spawn a bow + 2 stacks of arrows
5. Favorite one stack with "change gun mode"
6. Fire a couple of arrows
7. Don't get a prompt, because favorite ammo is set
8. Favorite second stack by opening inventory menu, selecting the bow, then "reloading" the bow
9. Repeat firing test

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

The favorite ammo feature is not verified well, it can easily cause trouble in the future.