### PR TITLE
Make DEFAULT_HOTKEYS longer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ cata_test
 cata_test-tiles
 cataclysm
 cataclysm-tiles
+cataclysm-tiles.exe.manifest
 cataclysm-vcpkg
 cataclysmdda-*
 chkjson*

--- a/src/player.h
+++ b/src/player.h
@@ -45,7 +45,7 @@ struct requirement_data;
 enum class recipe_filter_flags : int;
 struct itype;
 
-static const std::string DEFAULT_HOTKEYS( "1234567890abcdefghijklmnopqrstuvwxyz" );
+static const std::string DEFAULT_HOTKEYS( "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" );
 
 class recipe_subset;
 


### PR DESCRIPTION
#### Summary

SUMMARY: [Features] "Make DEFAULT_HOTKEYS longer"

#### Purpose of change

Simply make use of upper case hotkeys.

#### Describe the solution

Add capital letters to DEFAULT_HOTKEYS 

#### Describe alternatives you've considered

#### Testing

Now the zone type menu looks like this:
![image](https://user-images.githubusercontent.com/33447021/163562608-81014214-3f87-44da-9402-7642aa154ace.png)

#### Additional context

Not sure if this change will ruin other part of the code, at least it works.

I also add "cataclysm-tiles.exe.manifest" file to the .gitignore since the new msvc build will generate it when I build the project using VS2022 on Windows11 x64.
