### PR TITLE
Optimize electric grid

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11143,7 +11143,6 @@ point game::update_map( int &x, int &y )
         remaining_shift -= this_shift;
     }
 
-    // TODO: Shift, don't reload
     grid_tracker_ptr->load( m );
 
     // Shift monsters

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1686,7 +1686,8 @@ std::set<tripoint_abs_omt> overmapbuffer::electric_grid_at( const tripoint_abs_o
     open.emplace( p );
 
     while( !open.empty() ) {
-        const tripoint_abs_omt elem = open.front();
+        // It's weired that the game takes a lot of time to copy a tripoint_abs_omt, so use reference here.
+        const tripoint_abs_omt &elem = open.front();
         open.pop();
         result.emplace( elem );
         overmap_with_local_coords omc = get_om_global( elem );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1688,7 +1688,6 @@ std::set<tripoint_abs_omt> overmapbuffer::electric_grid_at( const tripoint_abs_o
     while( !open.empty() ) {
         // It's weired that the game takes a lot of time to copy a tripoint_abs_omt, so use reference here.
         const tripoint_abs_omt &elem = open.front();
-        open.pop();
         result.emplace( elem );
         overmap_with_local_coords omc = get_om_global( elem );
         const auto &connections_bitset = omc.om->electric_grid_connections[omc.local];
@@ -1700,6 +1699,7 @@ std::set<tripoint_abs_omt> overmapbuffer::electric_grid_at( const tripoint_abs_o
                 }
             }
         }
+        open.pop();
     }
 
     return result;


### PR DESCRIPTION
#### Summary

SUMMARY: [Performance] "Optimize electric grid"

#### Purpose of change

To fix #1322 

#### Describe the solution

The profiler result in #1322 is rather inaccurate because of the compile options we use, I guess. 
In fact, the major performance eater in `electric_grid_at` is the copy of the `tripoint_abs_omt`, which is weird.
Simply using a reference there solves the lag.

#### Describe alternatives you've considered

#### Testing

Load the save attached in #1322 , then walk around.

- Before this PR
![before](https://user-images.githubusercontent.com/33447021/163570850-acbf7604-4d07-4a34-a13a-139578689a21.png)

- After this PR
![after](https://user-images.githubusercontent.com/33447021/163570862-db30a0ab-a5bc-4077-9fcf-1bb4d57f57e5.png)

#### Additional context

I also made the `distribution_grid_tracker::on_saved()` only reload needed things, but the improvement is not as significant as the reference used in `electric_grid_at`.
