### PR TITLE
Add max duration for several effects lacking it

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -315,6 +315,7 @@
     "desc": [ "Your movement is randomized." ],
     "apply_message": "You're stunned!",
     "rating": "bad",
+    "max_duration": "30 m",
     "show_in_info": true
   },
   {
@@ -325,8 +326,8 @@
     "apply_message": "The scream dazes you!",
     "rating": "bad",
     "max_intensity": 10,
-    "max_duration": "10 m",
     "int_add_val": 2,
+    "max_duration": "10 m",
     "base_mods": { "per_mod": [ -5 ], "dex_mod": [ -2 ] },
     "scaling_mods": { "speed_mod": [ -3 ] },
     "show_in_info": true
@@ -372,6 +373,7 @@
     "apply_message": "You're blinded!",
     "remove_message": "Your sight returns!",
     "rating": "bad",
+    "max_duration": "30 m",
     "show_in_info": true
   },
   {
@@ -396,6 +398,7 @@
     "rating": "bad",
     "max_intensity": 3,
     "int_dur_factor": "100 s",
+    "max_duration": "24 h",
     "base_mods": { "pain_min": [ 1 ], "pain_chance": [ -50 ], "pain_chance_bot": [ 1000 ] },
     "scaling_mods": { "pain_max_val": [ 5 ], "pain_chance": [ 150 ] }
   },
@@ -412,6 +415,7 @@
     "desc": [ "You have been stung!" ],
     "rating": "bad",
     "base_mods": { "pain_min": [ 1 ] },
+    "max_duration": "30 m",
     "show_in_info": true,
     "blood_analysis_description": "Stung"
   },
@@ -426,6 +430,7 @@
     "pain_sizing": true,
     "hurt_sizing": true,
     "main_parts_only": true,
+    "max_duration": "30 m",
     "base_mods": {
       "per_mod": [ -2, -1 ],
       "dex_mod": [ -1, -1 ],
@@ -449,6 +454,7 @@
     "pain_sizing": true,
     "hurt_sizing": true,
     "main_parts_only": true,
+    "max_duration": "30 m",
     "base_mods": {
       "per_mod": [ -2 ],
       "dex_mod": [ -2 ],
@@ -471,6 +477,7 @@
     "miss_messages": [ [ "Your stomach bothers you.", 1 ] ],
     "rating": "bad",
     "resist_traits": [ "POISRESIST" ],
+    "max_duration": "24 h",
     "base_mods": {
       "per_mod": [ -1 ],
       "dex_mod": [ -1 ],
@@ -510,6 +517,7 @@
     "miss_messages": [ [ "You feel stiff.", 3 ] ],
     "rating": "bad",
     "max_intensity": 20,
+    "max_duration": "30 m",
     "resist_traits": [ "POISRESIST" ],
     "int_add_val": 1,
     "int_decay_tick": 600,
@@ -873,6 +881,7 @@
     "max_intensity": 3,
     "int_decay_tick": 720,
     "int_add_val": 1,
+    "max_duration": "60 m",
     "main_parts_only": true,
     "base_mods": { "speed_mod": [ -7 ] },
     "scaling_mods": { "speed_mod": [ -3 ] }
@@ -1092,6 +1101,7 @@
     "desc": [ "You're coated in sap!" ],
     "apply_message": "You're coated in sap!",
     "rating": "bad",
+    "max_duration": "30 m",
     "miss_messages": [ [ "The sap's too sticky for you to fight effectively.", 3 ] ],
     "base_mods": { "speed_mod": [ -25 ], "dex_mod": [ -3 ] }
   },
@@ -1127,7 +1137,8 @@
   },
   {
     "type": "effect_type",
-    "id": "evil"
+    "id": "evil",
+    "max_duration": "48 h"
   },
   {
     "type": "effect_type",
@@ -1392,6 +1403,7 @@
     "apply_message": "You inhale sweetish gas.",
     "remove_message": "The slackness leaves your muscles.",
     "rating": "bad",
+    "max_duration": "30 m",
     "base_mods": { "str_mod": [ -3 ], "dex_mod": [ -3 ], "int_mod": [ -2 ], "per_mod": [ -4 ] }
   },
   {

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -143,6 +143,7 @@
         "effects": [
           {
             "effect_id": "sap",
+            "body_part": "torso",
             "intensity": 1,
             "min_duration": "2 seconds",
             "max_duration": "2 seconds",
@@ -159,6 +160,7 @@
         "effects": [
           {
             "effect_id": "sap",
+            "body_part": "torso",
             "intensity": 1,
             "min_duration": "4 seconds",
             "max_duration": "4 seconds",
@@ -176,6 +178,7 @@
         "effects": [
           {
             "effect_id": "sap",
+            "body_part": "torso",
             "intensity": 1,
             "min_duration": "6 seconds",
             "max_duration": "6 seconds",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Assign max duration to various effects that can easily stack to effectively-infinite duration without them"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

It was brought up on the BN discord that certain effects seem to have uncapped durations, which are kinda infamous for being lethal as hell as a consequence. This also ties in with the infamous "deaf for in-game weeks because big boom" issue, which I recall was fixed in DDA at some point by capping duration.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added placeholder `max_duration` of 30 minutes to the blind, stunned, stun, poison, badpoison, paralyzepoison, sap, relax_gas effects. Most of these are effects that can either hypothetically stack up if a source is able to spam them, or more often gets doled out by a field and can thus easily ramp up to functionally infinite duration in a bad situation.
2. Added a `max_duration` of 23 hours to food poisoning and deafness effects. These are effects meant to be doled out in fairly long durations it seems, but can hypothetically stack up to absurd durations, with deafness being infamous for this in particular. Realistically it seems temporary hearing loss can take 24-48 hours in some cases to clear up so this would be within that range to an acceptable degree.
3. Also added a max duration of 60 minutes to spores. It's one of those effects that can stack up due to a field existing, but seems to favor longer durations and steady checks for whether it wants to convert to fungus, so a longer cap on duration than the above placeholders seemed fitting.
4. Also added max duration of 48 hours to the evil effect. It's another one that can ramp up to uncapped durations (especially since I suspect the effect triggers 6x more often than intended), and while that seems fine for attention and teleglow since their subeffects can shave off parts of the duration, evil has no such ability so the only options are wait it out or use something from a mod.
5. Misc: Fixed sap field complaining about lack of bodypart via having the field apply the effect to the torso. I'd tell it to apply to the feet instead but then we'd need to tweak the effect to account for it being applied twice, and neither of its effects can be neatly divided by two.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

I was tempted to mess with mi-go atmosphere a lil too but I have a separate idea for that I might do in another PR.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for lint and syntax errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
