### PR TITLE
Revive and rebalance royal jelly's curing ability

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -417,12 +417,22 @@
   },
   {
     "type": "effect_type",
+    "id": "antitoxin",
+    "name": [ "Antitoxin" ],
+    "desc": [ "You are temporarily resistant to most poison effects." ],
+    "rating": "good",
+    "max_duration": "60 m",
+    "blood_analysis_description": "Antitoxin"
+  },
+  {
+    "type": "effect_type",
     "id": "poison",
     "name": [ "Poisoned" ],
     "desc": [ "You have been poisoned!" ],
     "miss_messages": [ [ "You feel bad inside.", 1 ] ],
     "rating": "bad",
     "resist_traits": [ "POISRESIST" ],
+    "resist_effects": [ "antitoxin" ],
     "pain_sizing": true,
     "hurt_sizing": true,
     "main_parts_only": true,
@@ -446,6 +456,7 @@
     "miss_messages": [ [ "You feel bad inside.", 2 ] ],
     "rating": "bad",
     "resist_traits": [ "POISRESIST" ],
+    "resist_effects": [ "antitoxin" ],
     "pain_sizing": true,
     "hurt_sizing": true,
     "main_parts_only": true,
@@ -471,6 +482,7 @@
     "miss_messages": [ [ "Your stomach bothers you.", 1 ] ],
     "rating": "bad",
     "resist_traits": [ "POISRESIST" ],
+    "resist_effects": [ "antitoxin" ],
     "base_mods": {
       "per_mod": [ -1 ],
       "dex_mod": [ -1 ],
@@ -511,6 +523,7 @@
     "rating": "bad",
     "max_intensity": 20,
     "resist_traits": [ "POISRESIST" ],
+    "resist_effects": [ "antitoxin" ],
     "int_add_val": 1,
     "int_decay_tick": 600,
     "base_mods": { "dex_mod": [ -0.34, -0.17 ], "speed_mod": [ -5, -3 ] },
@@ -888,7 +901,8 @@
     "max_intensity": 3,
     "permanent": true,
     "resist_traits": [ "POISRESIST" ],
-    "base_mods": { "speed_mod": [ -10 ], "str_mod": [ -1 ], "dex_mod": [ -1 ] },
+    "resist_effects": [ "antitoxin" ],
+    "base_mods": { "speed_mod": [ -10, -5 ], "str_mod": [ -1, 0 ], "dex_mod": [ -1 ] },
     "blood_analysis_description": "Fungal Infection"
   },
   {
@@ -1124,6 +1138,25 @@
       "flu"
     ],
     "base_mods": { "pkill_min": [ 5 ] }
+  },
+  {
+    "type": "effect_type",
+    "id": "cureall_lesser",
+    "removes_effects": [
+      "fungus",
+      "dermatik",
+      "bloodworms",
+      "paincysts",
+      "brainworms",
+      "tapeworm",
+      "blind",
+      "stung",
+      "foodpoison",
+      "infected",
+      "asthma",
+      "common_cold",
+      "flu"
+    ]
   },
   {
     "type": "effect_type",

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -1858,7 +1858,6 @@
       { "item": "mutagen", "prob": 1 },
       { "item": "purifier", "prob": 1 },
       { "item": "yeast", "prob": 3 },
-      { "item": "royal_jelly", "prob": 4 },
       { "item": "superglue", "prob": 30 },
       { "item": "bottle_glass", "prob": 10 },
       { "item": "syringe", "prob": 1 },

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -155,7 +155,6 @@
       { "item": "bleach", "prob": 20, "charges-min": 1 },
       { "item": "ammonia", "prob": 24, "charges-min": 1 },
       { "item": "yeast", "prob": 2 },
-      { "item": "royal_jelly", "prob": 8 },
       { "item": "superglue", "prob": 20 },
       { "item": "bottle_glass", "prob": 10 },
       { "item": "syringe", "prob": 4 },

--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -273,6 +273,7 @@
       [ "lye_powder", 10 ],
       [ "oxy_powder", 12 ],
       [ "chemistry_set", 5 ],
+      [ "royal_jelly", 8 ],
       [ "meat_tainted", 8 ],
       [ "veggy_tainted", 4 ],
       [ "slime_scrap", 8 ],

--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -116,7 +116,7 @@
     "symbol": "%",
     "healthy": 10,
     "calories": 637,
-    "description": "A chunk of meat with a coat of royal jelly over it.  It's a lot like a honey-baked ham.",
+    "description": "A chunk of meat with a coat of honey or royal jelly over it, making it quite rich and savory.",
     "price": 21000,
     "price_postapoc": 4500,
     "material": "flesh",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -77,12 +77,18 @@
     "symbol": "%",
     "healthy": 1,
     "calories": 240,
-    "description": "A translucent hexagonal chunk of wax, filled with dense, milky jelly.  Though some hold it as a panacea, it doesn't have any medical benefit.  Still, it is delicious, and rich with the most beneficial substances the hive can produce.",
+    "description": "A translucent hexagonal chunk of wax, filled with dense, milky jelly.  Rich with the most beneficial substances post-cataclysm hives can produce, it can cure various afflictions and serve as an antitoxin.  However, it's also rich in mutagenic toxins of its own, given the creatures producing it.",
     "price": 20000,
     "price_postapoc": 4000,
     "volume": "250 ml",
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You feel warm inside after eating the royal jelly.",
+      "effects": [ { "id": "antitoxin", "duration": "20 m" }, { "id": "cureall_lesser" } ]
+    },
     "flags": [ "EDIBLE_FROZEN", "NUTRIENT_OVERRIDE" ],
-    "fun": 7
+    "fun": 7,
+    "vitamins": [ [ "mutant_toxin", 100 ] ]
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/recipes/food/meat.json
+++ b/data/json/recipes/food/meat.json
@@ -1466,7 +1466,7 @@
     "batch_time_factors": [ 80, 5 ],
     "qualities": [ { "id": "COOK", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ],
-    "components": [ [ [ "meat_red", 1, "LIST" ] ], [ [ "royal_jelly", 1 ] ] ]
+    "components": [ [ [ "meat_red", 1, "LIST" ] ], [ [ "honey_bottled", 4 ], [ "honey_glassed", 2 ], [ "royal_jelly", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Makes royal jelly useful again, but also possess mutant toxins"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Per discussion on the BN discord, some ideas came up for how to bring back royal jelly as one possible vanilla option for poison and other statuses, with some rebalancing possible now that mutagenic toxins are a thing. Also ties in with my plan to eventually port over DDA's venom and antivenom rework, and a separate idea that'll involve triffid stuff.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Reworked royal jelly to imply it's specifically a post-cataclysm substance mainly made by mutated insects, as fits the majority of its standard spawns. This re-adds a narrower version of the cureall effect to it, plus a separate antitoxin effect. Per feedback from Coolthulhu, it was suggested that royal jelly would be better balanced if it provided a resistance effect for poison instead of curing outright. In addition, it also provides an amount of mutagenic toxin in between mutant offal and mutant tallow.
2. Changed description and recipe of royal beef to let you use honey as the "default" expected ingredient. Recipe still lets you use royal jelly, but this wastes the medical benefit and gives it mutant toxins.
3. Removed royal jelly from `chem_home` and `chem_school` itemgroups, added a spawn to `mut_lab`.
4. Defined the antitoxin and lower-tier cureall effects used by royal jelly. The latter is similar in function to the antivenom effect DDA added with https://github.com/CleverRaven/Cataclysm-DDA/pull/46107, but right now it's generic and applies to every effect that the poison resistance trait interacts with, and has a max duration defined. Separate antivenom I plan to implement when or if I port over the venom overhaul. The latter is cureall except no removal of poison/badpoison/paralyzepoison and no painkilling.
5. Misc, defined resistance effects for fungal infection. It was already set so that poison resistant trait applied to it, but `base_effects` didn't actually care if you resisted it.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making a distinction between regular non-mutant royal jelly and this stuff. Seems pointless since realistic royal jelly would have almost no logical places to spawn, not be producible in any way unless we ported over bee hives from MST Extra, and it would have little real food value anyway.
2. Adding a late-game recipe to purify mutant royal jelly into panacea.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Load tested file changes.
2. Spawned in royal jelly.
3. Confirmed item description shows it has mutagenic toxins.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Related, DDA PR that adds antivenom: https://github.com/CleverRaven/Cataclysm-DDA/pull/46107

Testing to confirm mutagenic toxins both work in medical-type items and pass over to royal beef on hold due to mutagenic toxins appearing to be broken: https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1466