### PR TITLE
Power armour drain fix

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -14,8 +14,8 @@
     "description": "A thin forcefield surrounds your body, continually draining power.  Anything attempting to penetrate this field has a chance of being deflected at the cost of energy, reducing their ability to deal damage.  Bullets will be deflected more than melee weapons and those in turn more than massive objects.",
     "occupied_bodyparts": [ [ "torso", 10 ], [ "head", 1 ], [ "arm_l", 1 ], [ "arm_r", 1 ], [ "leg_l", 2 ], [ "leg_r", 2 ] ],
     "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
-    "act_cost": 10,
-    "react_cost": 10,
+    "act_cost": "10 kJ",
+    "react_cost": "10 kJ",
     "time": 1
   },
   {
@@ -756,7 +756,7 @@
     "description": "Interfaces your power system with the internal charging port on suits of power armor, allowing them to draw from your bionic power banks.",
     "occupied_bodyparts": [ [ "torso", 4 ], [ "head", 1 ] ],
     "flags": [ "BIONIC_ARMOR_INTERFACE", "BIONIC_TOGGLED" ],
-    "react_cost": 1,
+    "react_cost": "1 kJ",
     "time": 1
   },
   {
@@ -766,8 +766,8 @@
     "description": "Interfaces your power system with the internal charging port on suits of power armor, allowing them to draw from your bionic power banks.  Twice as efficient as the Mk. I model.",
     "occupied_bodyparts": [ [ "torso", 3 ], [ "head", 2 ] ],
     "flags": [ "BIONIC_ARMOR_INTERFACE", "BIONIC_TOGGLED" ],
-    "react_cost": 1,
-    "time": 2
+    "react_cost": "500 J",
+    "time": 1
   },
   {
     "id": "bio_power_storage",
@@ -842,8 +842,8 @@
     "description": "EM field generators in your arms double the range and damage of thrown iron and steel objects at a cost of 1 power per throw, causing them to leave a trail of electricity that can cause additional damage.",
     "occupied_bodyparts": [ [ "arm_l", 5 ], [ "arm_r", 5 ], [ "hand_l", 1 ], [ "hand_r", 1 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
-    "act_cost": 1,
-    "react_cost": 1,
+    "act_cost": "1 kJ",
+    "react_cost": "1 kJ",
     "time": 1
   },
   {
@@ -870,7 +870,7 @@
     "description": "A small module connected to your brain allows you to interface with nearby devices with wireless capabilities.",
     "occupied_bodyparts": [ [ "head", 2 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
-    "react_cost": 1,
+    "react_cost": "1 kJ",
     "time": 24
   },
   {
@@ -888,8 +888,8 @@
     "description": "While this system is powered, your body will produce very little odor, making it nearly impossible for creatures to track you by scent.",
     "occupied_bodyparts": [ [ "torso", 3 ], [ "head", 1 ], [ "arm_l", 1 ], [ "arm_r", 1 ], [ "leg_l", 1 ], [ "leg_r", 1 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
-    "act_cost": 1,
-    "react_cost": 1,
+    "act_cost": "1 kJ",
+    "react_cost": "1 kJ,
     "time": 60
   },
   {

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -889,7 +889,7 @@
     "occupied_bodyparts": [ [ "torso", 3 ], [ "head", 1 ], [ "arm_l", 1 ], [ "arm_r", 1 ], [ "leg_l", 1 ], [ "leg_r", 1 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
     "act_cost": "1 kJ",
-    "react_cost": "1 kJ,
+    "react_cost": "1 kJ",
     "time": 60
   },
   {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1480,7 +1480,7 @@ static bool attempt_recharge( Character &p, bionic &bio, units::energy &amount, 
     bool recharged = false;
 
     if( power_cost > 0_kJ ) {
-        if( info.has_flag( STATIC( flag_str_id( "BIO_ARMOR_INTERFACE" ) ) ) ) {
+        if( info.has_flag( STATIC( flag_str_id( "BIONIC_ARMOR_INTERFACE" ) ) ) ) {
             // Don't spend any power on armor interfacing unless we're wearing active powered armor.
             bool powered_armor = std::any_of( p.worn.begin(), p.worn.end(),
             []( const item & w ) {


### PR DESCRIPTION
#### Summary

[Bugfixes]: Fixed code so power armour cost is not subtracted when armour not active, made MkII power armour Interface CBM draw 500J every turn instead of 1kJ every 2 turns which felt kind of weird. Also formatted some of the act/react costs to follow new format.

#### Purpose of change

Power Armour Interfaces drew power even when power armour was at rest, there was already code for this and looking into it showed that the problem lay with a typo.

MkII Interfaces currently draw power at a rate of 1 kJ every 2 turns, instead of 1 kJ every turn as the MkI, I figured this could be made uniform in the interest of more uniform power discharge rates.

Also while I was at it I changed some of the older act/react cost format to the new format in use since bionic power was expressed in J.

#### Describe the solution

Fixed Typo in Bionics.cpp so the code worked smoothly, changed the Mk II interface power draw and rate, and changed the act/react cost format for a few other bionics.

#### Describe alternatives you've considered

Could have left the MkII Power draw alone to be fair.

#### Testing

Spawned character and installed Mk II interface, spawned power armour, wore power armour with Mk II Interface on and noted that power didn't drain until power armour was activated, checked that cost went down at 500J/s

#### Additional context

While fixing the stuff I noted that ADS and Uncanny Dodge will also need work due to jank and misleading descriptions, will wait for [#1458](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1458) to be mainlined before touching that. Uncanny Dodge however will likely need more than my current expertise.
