### PR TITLE
Active defence system rework

### DIFF
--- a/src/bionics.h
+++ b/src/bionics.h
@@ -154,6 +154,8 @@ struct bionic {
         unsigned int         ammo_count = 0;
         /* An amount of time during which this bionic has been rendered inoperative. */
         time_duration        incapacitated_time;
+        /* The amount of energy the Bionic has stored for it's function. [Currently only used for ADS]*/
+        units::energy        energy_stored = 0_kJ;
         bionic()
             : id( "bio_batteries" ), incapacitated_time( 0_turns ) {
         }


### PR DESCRIPTION
#### Summary

Summary: Balance "Makes ADS worth using again."

#### Purpose of change

The ADS CBM is currently pretty bad, it costs 10kJ to maintain every turn and only reduces incoming bash damage by 1-8 points, incoming cut damage by 1-4 points and incoming pierce damage by 1-2 points. It also consumes 24kJ of power every time it does this regardless of damage mitigated.

#### Describe the solution

The ADS was completely reworked. Requiring background work on Bionics.h, Bionics.cpp and Character.cpp to lay down an additional parameter for Bionics. Energy_stored allows a "wind up" effect for bionics, and essentially is an extra reserve specifically for a designated bionic, it could well be possible to adapt this to the Repair Nanobots or any other bionic where thresholds of effects are needed. Many thanks to Coolthulhu for helping me with this.

Anyway, the ADS consumes power from Bionics and converts it into shielding, at a rate of 10kJ per turn. There is currently no upkeep cost to maintain the shield, and if you deactivate it, it will refund whatever is left in the pool, this is subject to change. This shielding currently applies damage mitigation after armour to the designated character, and reduces Bash, Cut or Stab damage by a proportion, with Bashing damage being the least affected and Stab the most.

The cost of shielding consumed is proportional to the damage post-armour, being damage x 400 J. Thus, 25 points of Bashing damage requires 10 kJ shielding, and reduces damage to 20, while Stab damage would be reduced to 12.5 (rounds down?). If you lack the energy to fully block the damage, the system deactivates, and if the attack would deal 25 damage post armour, it shorts out the bionic (duration dependent on damage) You wouldn't believe the amount of work that went into this... thanks Coolthulhu...

The ADS system is currently incomplete, the reason for this being that I'm waiting to integrate the Ballistic Damage type as mentioned in #1458. Once this has been merged, work will go into updating the ADS to work with Ballistic Damage. In order to fulfil the description of the original ADS, the goal will be to have bullets completely deflected when using the ADS, instead of the percentage mitigation the melee component uses. The costs of actual bullet deflection were done based on kinetic energy needed to move a BMG 45 degrees from it's trajectory, but frankly the cost was found to be kind of trivial considering how much bionic power we can accrue, so for balance reasons efficiency will be tweaked.

#### Describe alternatives you've considered

Provide upkeep cost for the ADS, with initial upkeep of 4 kJ per turn after fully charged.
- With the windup, this seemed a bit excessive, but could well be added if the CBM is ultimately adjusted to be stronger than originally intended.

Keep as is/remove the ADS CBM
- I'm half-joking, 80% through the code I considered giving up, but that would've been a waste.

Go back to an RNG flat mitigation of damage.
- Considered but rejected, I wanted less RNG performance from a CBM specifically designed to protect you, and it would be instantly unbalanced in that early characters would be immune to most creatures while late-game characters barely see any benefit against much stronger foes.

#### Testing

_Oh boy the stories I could tell you..._

Debugged a character and installed the CBM, checked that it only drained act_cost and converted Bionic Power into energy_stored. Checked that it didn't go over, checked that it didn't charge bionic power by mistake.

Went outside, found zombies, got hit by zombies, checked that damage was mitigated but not eliminated and also checked that shield could actually be broken. Spawned survivor gear, spawned light turret. Checked that being shot with CBM activated had reduced damage, checked that turret could chew through shielding faster than regen. Checked that getting hit _didn't charge bionic power._

You get the idea. I tested this about 3 hours total and didn't document every test. However, as this is a _very_ big project for me, it is _very likely_ that this is still broken in some way, hence the draft so people can review the code.

#### Additional context

The main goals before I take this out of draft hell follow

- [ ] Balance the mitigation values so that the effects are significant but not overwhelming.
- [ ] Decide on the power cost and whether a maintenance cost should be instituted. Balance the recharge rate.
- [ ] Integrate Ballistic damage into the ADS calculations.
- [ ] _Balance_ the ballistic damage integrations.
- [ ] Bugtest the thing to hell and back so I don't have to comb through the code too often.
