### PR TITLE
Follow-up updates after ballistic damage PR

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -41,10 +41,11 @@
     "id": "bio_armor_arms",
     "type": "bionic",
     "name": { "str": "Alloy Plating - Arms" },
-    "description": "The flesh on your arms has been surgically replaced by alloy plating.  Provides passive protection and can be used in conjunction with bionic martial arts.",
-    "occupied_bodyparts": [ [ "arm_l", 4 ], [ "arm_r", 4 ] ],
-    "bash_protec": [ [ "arm_l", 3 ], [ "arm_r", 3 ] ],
-    "cut_protec": [ [ "arm_l", 3 ], [ "arm_r", 3 ] ],
+    "description": "The flesh on your arms and hands have been surgically replaced by alloy plating.  Provides passive protection and can be used in conjunction with bionic martial arts.",
+    "occupied_bodyparts": [ [ "arm_l", 4 ], [ "arm_r", 4 ], [ "hand_l", 1 ], [ "hand_r", 1 ] ],
+    "bash_protec": [ [ "arm_l", 3 ], [ "arm_r", 3 ], [ "hand_l", 3 ], [ "hand_r", 3 ] ],
+    "cut_protec": [ [ "arm_l", 3 ], [ "arm_r", 3 ], [ "hand_l", 3 ], [ "hand_r", 3 ] ],
+    "bullet_protec": [ [ "arm_l", 3 ], [ "arm_r", 3 ], [ "hand_l", 3 ], [ "hand_r", 3 ] ],
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ]
   },
   {
@@ -64,18 +65,20 @@
     "name": { "str": "Alloy Plating - head" },
     "description": "The flesh on your head has been surgically replaced by alloy plating, protecting both your head and jaw regions.",
     "occupied_bodyparts": [ [ "head", 5 ], [ "mouth", 1 ] ],
-    "bash_protec": [ [ "head", 3 ] ],
-    "cut_protec": [ [ "head", 3 ] ],
+    "bash_protec": [ [ "head", 3 ], [ "mouth", 3 ] ],
+    "cut_protec": [ [ "head", 3 ], [ "mouth", 3 ] ],
+    "bullet_protec": [ [ "head", 3 ], [ "mouth", 3 ] ],
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ]
   },
   {
     "id": "bio_armor_legs",
     "type": "bionic",
     "name": { "str": "Alloy Plating - Legs" },
-    "description": "The flesh on your legs has been surgically replaced by alloy plating.  Provides passive protection and can be used in conjunction with bionic martial arts.",
-    "occupied_bodyparts": [ [ "leg_l", 6 ], [ "leg_r", 6 ] ],
-    "bash_protec": [ [ "leg_l", 3 ], [ "leg_r", 3 ] ],
-    "cut_protec": [ [ "leg_l", 3 ], [ "leg_r", 3 ] ],
+    "description": "The flesh on your legs and feet have been surgically replaced by alloy plating.  Provides passive protection and can be used in conjunction with bionic martial arts.",
+    "occupied_bodyparts": [ [ "leg_l", 6 ], [ "leg_r", 6 ], [ "foot_l", 1 ], [ "foot_r", 1 ] ],
+    "bash_protec": [ [ "leg_l", 3 ], [ "leg_r", 3 ], [ "foot_l", 3 ], [ "foot_r", 3 ] ],
+    "cut_protec": [ [ "leg_l", 3 ], [ "leg_r", 3 ], [ "foot_l", 3 ], [ "foot_r", 3 ] ],
+    "bullet_protec": [ [ "leg_l", 3 ], [ "leg_r", 3 ], [ "foot_l", 3 ], [ "foot_r", 3 ] ],
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ]
   },
   {
@@ -86,6 +89,7 @@
     "occupied_bodyparts": [ [ "torso", 10 ] ],
     "bash_protec": [ [ "torso", 3 ] ],
     "cut_protec": [ [ "torso", 3 ] ],
+    "bullet_protec": [ [ "torso", 3 ] ],
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ]
   },
   {
@@ -186,6 +190,18 @@
       [ "foot_r", 2 ]
     ],
     "cut_protec": [
+      [ "torso", 4 ],
+      [ "head", 4 ],
+      [ "arm_l", 4 ],
+      [ "arm_r", 4 ],
+      [ "hand_l", 4 ],
+      [ "hand_r", 4 ],
+      [ "leg_l", 4 ],
+      [ "leg_r", 4 ],
+      [ "foot_l", 4 ],
+      [ "foot_r", 4 ]
+    ],
+    "bullet_protec": [
       [ "torso", 4 ],
       [ "head", 4 ],
       [ "arm_l", 4 ],

--- a/data/json/clothing_mods.json
+++ b/data/json/clothing_mods.json
@@ -9,6 +9,7 @@
     "mod_value": [
       { "type": "bash", "value": 1, "proportion": [ "thickness" ] },
       { "type": "cut", "value": 1, "proportion": [ "thickness" ] },
+      { "type": "bullet", "value": 1, "proportion": [ "thickness" ] },
       { "type": "encumbrance", "value": 2, "round_up": true, "proportion": [ "thickness", "coverage" ] }
     ]
   },
@@ -23,6 +24,7 @@
     "mod_value": [
       { "type": "bash", "value": 3, "proportion": [ "thickness" ] },
       { "type": "cut", "value": 3, "proportion": [ "thickness" ] },
+      { "type": "bullet", "value": 2, "proportion": [ "thickness" ] },
       { "type": "encumbrance", "value": 5, "round_up": true, "proportion": [ "thickness", "coverage" ] }
     ]
   },
@@ -37,6 +39,7 @@
     "mod_value": [
       { "type": "bash", "value": 3, "proportion": [ "thickness" ] },
       { "type": "cut", "value": 3, "proportion": [ "thickness" ] },
+      { "type": "bullet", "value": 2, "proportion": [ "thickness" ] },
       { "type": "encumbrance", "value": 4, "round_up": true, "proportion": [ "thickness", "coverage" ] }
     ]
   },
@@ -49,7 +52,8 @@
     "destroy_prompt": "Destroy Kevlar padding",
     "mod_value": [
       { "type": "bash", "value": 1, "proportion": [ "thickness" ] },
-      { "type": "cut", "value": 2, "proportion": [ "thickness" ] },
+      { "type": "cut", "value": 1.5, "proportion": [ "thickness" ] },
+      { "type": "bullet", "value": 2.5, "proportion": [ "thickness" ] },
       { "type": "encumbrance", "value": 2, "round_up": true, "proportion": [ "thickness", "coverage" ] }
     ]
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1594,7 +1594,7 @@
       { "part": "hand_r", "ignored": 6 },
       { "part": "torso", "ignored": 60 }
     ],
-    "armor": [ { "parts": "ALL", "cut": 2, "bash": 3 } ],
+    "armor": [ { "parts": "ALL", "cut": 2, "bash": 3, "bullet": 1 } ],
     "speed_modifier": 0.8
   },
   {
@@ -1622,7 +1622,7 @@
       { "part": "hand_r", "ignored": 6 },
       { "part": "torso", "ignored": 60 }
     ],
-    "armor": [ { "parts": "ALL", "cut": 3, "bash": 5 } ],
+    "armor": [ { "parts": "ALL", "cut": 3, "bash": 5, "bullet": 2 } ],
     "speed_modifier": 0.8
   },
   {
@@ -2122,7 +2122,7 @@
       { "part": "hand_r", "neutral": 1 },
       { "part": "torso", "neutral": 10 }
     ],
-    "armor": [ { "parts": "ALL", "cut": 2, "stab": 2 } ],
+    "armor": [ { "parts": "ALL", "cut": 2, "stab": 2, "bullet": 1 } ],
     "thirst_modifier": -0.2
   },
   {
@@ -2148,7 +2148,7 @@
       { "part": "hand_r", "ignored": 4 },
       { "part": "torso", "ignored": 30 }
     ],
-    "armor": [ { "parts": "ALL", "cut": 5, "stab": 5, "heat": 1 } ]
+    "armor": [ { "parts": "ALL", "cut": 5, "stab": 5, "bullet": 4, "heat": 1 } ]
   },
   {
     "type": "mutation",
@@ -5564,7 +5564,7 @@
     "category": [ "CEPHALOPOD" ],
     "wet_protection": [ { "part": "torso", "ignored": 26 } ],
     "restricts_gear": [ "torso" ],
-    "armor": [ { "parts": "torso", "bash": 6, "cut": 14 } ]
+    "armor": [ { "parts": "torso", "bash": 6, "cut": 14, "bullet": 5 } ]
   },
   {
     "type": "mutation",
@@ -5584,7 +5584,7 @@
     "wet_protection": [ { "part": "torso", "ignored": 26 } ],
     "active": true,
     "restricts_gear": [ "torso" ],
-    "armor": [ { "parts": "torso", "bash": 9, "cut": 17 } ]
+    "armor": [ { "parts": "torso", "bash": 9, "cut": 17, "bullet": 5 } ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Add missing ballistic armor to clothing mods, mutations, bionics"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some follow-up updates to the ballistic damage PR, incorporating some stuff that was added later on.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. As promised, I said I'd update clothing mods to add bullet protection when the ballistic damage PR was ported over, so here we be. Notable divergences from DDA's version are that steel padding's bullet resist is closer to the difference the steel material actually has, presence of superalloy padding, 
2. Ported over updates to alloy armor CBMs. Description is closer to the original, and encumbrance not ported over for now (can if requested), but did grab the ballistic protection and the updates making the relevant CBMs cover subordinate bodyparts.
3. Ported over adding ballistic armor to shell mutations. I left chitin mutations untouched for now on testing and confirming that "physical" includes bullet damage.
4. Added bullet values to several cases of mutation armor that don't cite physical damagetype combo.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Could port over encumbrance for armor CBMs if requested.
2. Should we break up all cases of "physical" mutation armor into different amounts of bash/cut/stab/bullet or leave them like they are now?

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Compiled to load test.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Sources:
1. Clothing mod update, by SirPendrak: https://github.com/CleverRaven/Cataclysm-DDA/pull/45713
2. Alloy CBM updates, by anoobindisguise: https://github.com/CleverRaven/Cataclysm-DDA/pull/51578
3. Additional CBM updates, by souricelle: https://github.com/CleverRaven/Cataclysm-DDA/pull/43151
4. Shell mutation update, by souricelle: https://github.com/CleverRaven/Cataclysm-DDA/pull/43212

Stuff I still need to do:
1. Mess around with ballistic damage of materials to make ballistic armor properly more effectively, in line with current plans for the ammo rebalance project.
2. Military robots and zombies generally shouldn't have a ballistic armor value lower than their cut armor value.