### PR TITLE
Rename save dir to cataclysm-bn

### DIFF
--- a/src/path_info.cpp
+++ b/src/path_info.cpp
@@ -55,20 +55,20 @@ void PATH_INFO::init_user_dir( std::string dir )
 #if defined(_WIN32)
         user_dir = getenv( "LOCALAPPDATA" );
         // On Windows userdir without dot
-        dir = std::string( user_dir ) + "/cataclysm-dda/";
+        dir = std::string( user_dir ) + "/cataclysm-bn/";
 #elif defined(MACOSX)
         user_dir = getenv( "HOME" );
-        dir = std::string( user_dir ) + "/Library/Application Support/Cataclysm/";
+        dir = std::string( user_dir ) + "/Library/Application Support/Cataclysm-BN/";
 #elif defined(USE_XDG_DIR)
         if( ( user_dir = getenv( "XDG_DATA_HOME" ) ) ) {
-            dir = std::string( user_dir ) + "/cataclysm-dda/";
+            dir = std::string( user_dir ) + "/cataclysm-bn/";
         } else {
             user_dir = getenv( "HOME" );
-            dir = std::string( user_dir ) + "/.local/share/cataclysm-dda/";
+            dir = std::string( user_dir ) + "/.local/share/cataclysm-bn/";
         }
 #else
         user_dir = getenv( "HOME" );
-        dir = std::string( user_dir ) + "/.cataclysm-dda/";
+        dir = std::string( user_dir ) + "/.cataclysm-bn/";
 #endif
     }
 
@@ -103,10 +103,10 @@ void PATH_INFO::set_standard_filenames()
     const char *user_dir;
     std::string dir;
     if( ( user_dir = getenv( "XDG_CONFIG_HOME" ) ) ) {
-        dir = std::string( user_dir ) + "/cataclysm-dda/";
+        dir = std::string( user_dir ) + "/cataclysm-bn/";
     } else {
         user_dir = getenv( "HOME" );
-        dir = std::string( user_dir ) + "/.config/cataclysm-dda/";
+        dir = std::string( user_dir ) + "/.config/cataclysm-bn/";
     }
     config_dir_value = dir;
 #else


### PR DESCRIPTION
#### Summary: Build "Rename save USE_HOME_DIR save directory to cataclysm-bn"

#### Purpose of change

When building Cataclysm-DDA and Cataclysm-BN both with USE_HOME_DIR, they both use the same directory for saves/config, which are not compatible. This causes game-configuration related errors and could result in accidentally loading the wrong save.

#### Describe the solution

Directory name changed cataclysm-dda to cataclysm-bn.

#### Describe alternatives you've considered

The main problem with this is saves/config would have to be removed manually - for example on Linux the contents from ~/.cataclysm-dda/ to ~/.cataclysm-bn/. This could cause confusion and people may think their saves were deleted after updating. Another option would be to have a make flag to do this / change the path on compile, and leave it to the user to handle it. I did not do this because I think it would be preferable for the default not to conflict with Cataclysm-DDA.

#### Testing

Tested with USE_HOME_DIR on Linux and MacOS.
