### PR TITLE
Don't silently fail when attempting to modify vits

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -542,11 +542,15 @@ time_duration Character::vitamin_rate( const vitamin_id &vit ) const
 
 int Character::vitamin_mod( const vitamin_id &vit, int qty, bool capped )
 {
-    auto it = vitamin_levels.find( vit );
-    if( it == vitamin_levels.end() ) {
+    if( !vit.is_valid() ) {
+        debugmsg( "Vitamin with id %s does not exist, and cannot be modified", vit.str() );
         return 0;
     }
-    const auto &v = it->first.obj();
+    // What's going on here? Emplace returns either an iterator to the inserted
+    // item or, if it already exists, an iterator to the (unchanged) extant item
+    // (Okay, technically it returns a pair<iterator, bool>, the iterator is what we want)
+    auto it = vitamin_levels.emplace( vit, 0 ).first;
+    const vitamin &v = *it->first;
 
     if( qty > 0 ) {
         // Accumulations can never occur from food sources

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -434,9 +434,10 @@ void Character::load( const JsonObject &data )
     JsonObject vits = data.get_object( "vitamin_levels" );
     vits.allow_omitted_members();
     for( const std::pair<const vitamin_id, vitamin> &v : vitamin::all() ) {
-        int lvl = vits.get_int( v.first.str(), 0 );
-        lvl = std::max( std::min( lvl, v.first.obj().max() ), v.first.obj().min() );
-        vitamin_levels[v.first] = lvl;
+        if( vits.has_member( v.first.str() ) ) {
+            int lvl = vits.get_int( v.first.str() );
+            vitamin_levels[v.first] = clamp( lvl, v.first->min(), v.first->max() );
+        }
     }
     data.read( "consumption_history", consumption_history );
     data.read( "activity", activity );


### PR DESCRIPTION
#### Summary

SUMMARY: Fixes vitamin bug that prevents new chars from gaining/losing vitamins.

#### Purpose of change

Fixes #1466 so that newly created characters will have vitamins change, particularly useful in our case for mutagenic toxins.

#### Describe the solution

> Stop silently failing when attempting to modify a vitamin that is not already contained, and instead add it to the vitamin_levels map, and change the character loading function to avoid the behavior that hid this problem in the past - filling out the vitamin map completely even if there was nothing to load for it.

#### Describe alternatives you've considered

#### Testing

Created new custom character, add mutant lard and waited 30 minutes. Checked that mutagenic toxins rose. Saved and loaded char and ensured progression of mutagenic toxins continued.

#### Additional context
