### PR TITLE
Fixed a compiler warnings (which are errors with -WError) of clang 13.

### DIFF
--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -25,10 +25,10 @@ static int cur_season_length = 1;
 const time_point calendar::before_time_starts = time_point::from_turn( -1 );
 const time_point calendar::turn_zero = time_point::from_turn( 0 );
 
-calendar_config calendar::config = calendar_config( calendar::turn_zero,
-                                   calendar::turn_zero,
-                                   SPRING,
-                                   false );
+calendar_config calendar::config( calendar::turn_zero,
+                                  calendar::turn_zero,
+                                  SPRING,
+                                  false );
 
 const time_point &calendar::start_of_cataclysm = calendar::config.start_of_cataclysm();
 const time_point &calendar::start_of_game = calendar::config.start_of_game();

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -551,6 +551,7 @@ class calendar_config
             , _initial_season( initial_season )
             , _eternal_season( eternal_season )
         {}
+        calendar_config( const calendar_config & ) = default;
 
         // TODO: Remove reference bit after testing!
         const time_point &start_of_cataclysm() const {

--- a/src/craft_command.h
+++ b/src/craft_command.h
@@ -44,6 +44,7 @@ struct comp_selection {
         : use_from( use_from ), comp( comp )
     {}
     comp_selection( const comp_selection & ) = default;
+    comp_selection &operator = ( const comp_selection & ) = default;
     /** Tells us where the selected component should be used from. */
     usage use_from = use_from_none;
     CompType comp;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1559,6 +1559,7 @@ struct avail_tool_comp {
         : comp( comp ), charges( charges ), ideal( ideal )
     {}
     avail_tool_comp( const avail_tool_comp & ) = default;
+    avail_tool_comp &operator =( const avail_tool_comp & ) = default;
 
     comp_selection<tool_comp> comp;
     int charges;

--- a/src/faction.h
+++ b/src/faction.h
@@ -70,6 +70,7 @@ class faction_template
 
     public:
         explicit faction_template( const faction_template & ) = default;
+        faction_template &operator = ( const faction_template & ) = default;
         static void load( const JsonObject &jsobj );
         static void check_consistency();
         static void reset();

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4693,7 +4693,6 @@ void iexamine::autodoc( player &p, const tripoint &examp )
 
     bool needs_anesthesia = true;
     std::vector<tool_comp> anesth_kit;
-    int drug_count = 0;
 
     if( patient.has_trait( trait_NOPAIN ) || patient.has_bionic( bio_painkiller ) ||
         amenu.ret > 1 ) {
@@ -4706,7 +4705,6 @@ void iexamine::autodoc( player &p, const tripoint &examp )
         for( const item *anesthesia_item : a_filter ) {
             if( anesthesia_item->ammo_remaining() >= 1 ) {
                 anesth_kit.push_back( tool_comp( anesthesia_item->typeId(), 1 ) );
-                drug_count += anesthesia_item->ammo_remaining();
             }
         }
     }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4753,7 +4753,6 @@ void overmap::add_mon_group( const mongroup &group )
     const int rad = std::max<int>( 0, group.radius );
     const double total_area = group.diffuse ? std::pow( rad + 1, 2 ) : ( rad * rad * M_PI + 1 );
     const double pop = std::max<int>( 0, group.population );
-    int xpop = 0;
     for( int x = -rad; x <= rad; x++ ) {
         for( int y = -rad; y <= rad; y++ ) {
             const int dist = group.diffuse ? square_dist( point( x, y ), point_zero ) : trig_dist( point( x,
@@ -4804,7 +4803,6 @@ void overmap::add_mon_group( const mongroup &group )
             // To avoid this, the overmapbuffer checks the monster groups when loading
             // an overmap and moves groups with out-of-bounds position to another overmap.
             add_mon_group( tmp );
-            xpop += tmp.population;
         }
     }
 }

--- a/src/pathfinding.h
+++ b/src/pathfinding.h
@@ -70,6 +70,7 @@ struct pathfinding_settings {
         : bash_strength( bs ), max_dist( md ), max_length( ml ), climb_cost( cc ),
           allow_open_doors( aod ), avoid_traps( at ), allow_climb_stairs( acs ), avoid_rough_terrain( art ),
           avoid_sharp( as ) {}
+    pathfinding_settings &operator = ( const pathfinding_settings & ) = default;
 };
 
 #endif // CATA_SRC_PATHFINDING_H

--- a/src/ranged_aoe.cpp
+++ b/src/ranged_aoe.cpp
@@ -17,6 +17,7 @@ struct tripoint_distance {
         , distance_squared( distance_squared )
     {}
     tripoint_distance( const tripoint_distance & ) = default;
+    tripoint_distance &operator = ( const tripoint_distance & ) = default;
     tripoint p;
     int distance_squared;
 
@@ -32,6 +33,7 @@ struct aoe_flood_node {
         : parent( parent ), parent_coverage( parent_coverage )
     {}
     aoe_flood_node( const aoe_flood_node & ) = default;
+    aoe_flood_node &operator = ( const aoe_flood_node & ) = default;
     tripoint parent = tripoint_min;
     double parent_coverage = 0.0;
 };

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -367,13 +367,8 @@ void vehicle::control_engines()
     int e_toggle = 0;
     bool dirty = false;
     //count active engines
-    int active_mask = 0;
     int fuel_count = 0;
-    int i = 0;
     for( int e : engines ) {
-        if( is_part_on( e ) ) {
-            active_mask |= 1 << i++;
-        }
         fuel_count += part_info( e ).engine_fuel_opts().size();
     }
 
@@ -389,7 +384,6 @@ void vehicle::control_engines()
                     }
                     return;
                 }
-                i += 1;
             }
         }
     };
@@ -409,11 +403,8 @@ void vehicle::control_engines()
     }
 
     bool engines_were_on = engine_on;
-    int new_active_mask = 0;
-    i = 0;
     for( int e : engines ) {
         engine_on |= is_part_on( e );
-        new_active_mask |= 1 << i++;
     }
 
     // if current velocity greater than new configuration safe speed

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -42,6 +42,7 @@ class vpart_position
     public:
         vpart_position( ::vehicle &v, const size_t part ) : vehicle_( v ), part_index_( part ) { }
         vpart_position( const vpart_position & ) = default;
+        vpart_position &operator = ( const vpart_position & ) = default;
 
         ::vehicle &vehicle() const {
             return vehicle_.get();

--- a/src/vpart_range.h
+++ b/src/vpart_range.h
@@ -49,6 +49,7 @@ class vehicle_part_iterator
             skip_to_next_valid( i );
         }
         vehicle_part_iterator( const vehicle_part_iterator & ) = default;
+        vehicle_part_iterator &operator=( const vehicle_part_iterator & ) = default;
 
         const vpart_reference &operator*() const {
             assert( vp_ );

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -105,7 +105,6 @@ static int can_catch_player( const std::string &monster_type, const tripoint &di
     const int monster_speed = test_monster.get_speed();
     const int target_speed = 100;
 
-    int moves_spent = 0;
     std::vector<track> tracker;
     for( int turn = 0; turn < 1000; ++turn ) {
         test_player.mod_moves( target_speed );
@@ -138,7 +137,6 @@ static int can_catch_player( const std::string &monster_type, const tripoint &di
                                 rl_dist( test_monster.pos(), test_player.pos() ),
                                 test_monster.pos()
                                } );
-            moves_spent += moves_before - test_monster.moves;
             if( rl_dist( test_monster.pos(), test_player.pos() ) == 1 ) {
                 INFO( tracker );
                 clear_map();


### PR DESCRIPTION
#### Summary

SUMMARY: Build "Fixed a compiler warnings (which are errors with -WError) of clang 13."

#### Describe the solution

Most of had default copy constructor explicitly defined but not copy operartor, or vice versa.
There are some examples of variables, only used to assigning.

#### Describe alternatives you've considered

None.

#### Testing

Didn't test, but it compiles.

