### PR TITLE
Add max_pain_val to pain-causing parasites

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -1466,7 +1466,14 @@
     "id": "brainworms",
     "rating": "bad",
     "permanent": true,
-    "base_mods": { "pain_chance": [ 512 ], "pain_min": [ 2 ], "pain_max": [ 8 ], "h_mod_chance": [ 512 ], "h_mod_min": [ -10 ] },
+    "base_mods": {
+      "pain_chance": [ 512 ],
+      "pain_min": [ 2 ],
+      "pain_max": [ 8 ],
+      "pain_max_val": [ 30 ],
+      "h_mod_chance": [ 512 ],
+      "h_mod_min": [ -10 ]
+    },
     "blood_analysis_description": "Intracranial Parasites"
   },
   {
@@ -1474,7 +1481,14 @@
     "id": "paincysts",
     "rating": "bad",
     "permanent": true,
-    "base_mods": { "pain_chance": [ 256 ], "pain_min": [ 1 ], "pain_max": [ 4 ], "fatigue_chance": [ 256 ], "fatigue_min": [ 1 ] },
+    "base_mods": {
+      "pain_chance": [ 256 ],
+      "pain_min": [ 1 ],
+      "pain_max": [ 4 ],
+      "pain_max_val": [ 45 ],
+      "fatigue_chance": [ 256 ],
+      "fatigue_min": [ 1 ]
+    },
     "blood_analysis_description": "Intramuscular Parasites"
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Add pain_max_val to parasites, like all other pain-causing permanent status effects"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

While watching Critybear's latest playthrough he showed me a fun discovery involving effectively infinite pain caused by parasites, which can tank your stats to absurd levels and render your focus effectively zero. This was in his DDA playthrough, but a quick test confirmed that just one of the two pain-causing parasites is enough to cripple you in the same way in BN.

Since these are permanent-until-cured status effects that cause pain, by definition pain will automatically build up uncontrollably over time unless the pain chance is so low that natural pain recovery can outpace it, so the only other potential fix that came to mind was to make use of `pain_max_val`. All other permanent effects that cause pain have caps for them anyway, so adds consistency.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Defined a `pain_max_val` of 30 for brain worms.
2. Defined a `pain_max_val` of 45 for pain cysts.

Pain cysts suggests by its ID that it's supposed to be the most pain-focused parasite effect, but has functionally the same builduo as brain worms (double the chance, half the potential pain per trigger), so making it have a higher cap makes it more meaninfgully different.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Nerfing pain chance of parasites into the ground until pain recovery can actually compete with it, possibly making it intermittent bursts of intense pain to compensate.
2. Avoiding the use of chronic pain for perma-effects entirely just to be safe.
3. Waiting and instead reworking parasite mechanics extensively. Getting parasites would still be functionally a softlock until then however.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked file change for syntax and lint errors.

Combining the two parasites gives you a total potential max pain of 75, which is bad but on its own will still let you retain some amount of focus, while making its stat mods a bit less punishing that if you were hovering near 100 all the time.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Relevant timestamp for aforementioned CritsyBear video: https://youtu.be/V1RaKKecirY?t=290 Relevant section from to 4:50 to 5:40