### PR TITLE
DDA port #53764: Add cursor navigation to the mutations UI

### DIFF
--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -16,56 +16,72 @@
 #include "translations.h"
 #include "ui_manager.h"
 #include "value_ptr.h"
-
-// '!' and '=' are uses as default bindings in the menu
-const invlet_wrapper
-mutation_chars( "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\"#&()*+./:;@[\\]^_{|}" );
-
-static void draw_exam_window( const catacurses::window &win, const int border_y )
-{
-    const int width = getmaxx( win );
-    mvwputch( win, point( 0, border_y ), BORDER_COLOR, LINE_XXXO );
-    mvwhline( win, point( 1, border_y ), LINE_OXOX, width - 2 );
-    mvwputch( win, point( width - 1, border_y ), BORDER_COLOR, LINE_XOXX );
-}
-
-const auto shortcut_desc = []( const std::string &comment, const std::string &keys )
-{
-    return string_format( comment, string_format( "[<color_yellow>%s</color>]", keys ) );
-};
-
-enum class mutation_menu_mode {
+enum mutation_menu_mode {
     activating,
     examining,
     reassigning,
+    hiding
+};
+enum mutation_tab_mode {
+    active,
+    passive
+};
+// '!' and '=' are uses as default bindings in the menu
+static const invlet_wrapper
+mutation_chars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\"#&()*+./:;@[\\]^_{|}");
+
+static void draw_exam_window(const catacurses::window& win, const int border_y)
+{
+    const int width = getmaxx(win);
+    mvwputch(win, point(0, border_y), BORDER_COLOR, LINE_XXXO);
+    mvwhline(win, point(1, border_y), LINE_OXOX, width - 2);
+    mvwputch(win, point(width - 1, border_y), BORDER_COLOR, LINE_XOXX);
+}
+
+static const auto shortcut_desc = [](const std::string& comment, const std::string& keys)
+{
+    return string_format(comment, string_format("[<color_yellow>%s</color>]", keys));
 };
 
-static void show_mutations_titlebar( const catacurses::window &window,
-                                     const mutation_menu_mode menu_mode, const input_context &ctxt )
+// needs extensive improvement
+
+static trait_id GetTrait(std::vector<trait_id> active, std::vector<trait_id> passive, int cursor, mutation_tab_mode tab_mode) {
+    trait_id mut_id;
+    if (tab_mode == mutation_tab_mode::active) {
+        mut_id = active[cursor];
+    }
+    else {
+        mut_id = passive[cursor];
+    }
+    return mut_id;
+}
+
+static void show_mutations_titlebar(const catacurses::window& window,
+    const mutation_menu_mode menu_mode, const input_context& ctxt)
 {
-    werase( window );
+    werase(window);
     std::string desc;
-    if( menu_mode == mutation_menu_mode::reassigning ) {
-        desc += std::string( _( "Reassigning." ) ) + "  " +
-                _( "Select a mutation to reassign or press [<color_yellow>SPACE</color>] to cancel. " );
+    if (menu_mode == mutation_menu_mode::reassigning) {
+        desc += std::string(_("Reassigning.")) + "  " +
+            _("Select a mutation to reassign or press [<color_yellow>SPACE</color>] to cancel. ");
     }
-    if( menu_mode == mutation_menu_mode::activating ) {
-        desc += colorize( _( "Activating" ),
-                          c_green ) + "  " + shortcut_desc( _( "%s to examine mutation, " ),
-                                  ctxt.get_desc( "TOGGLE_EXAMINE" ) );
+    if (menu_mode == mutation_menu_mode::activating) {
+        desc += colorize(_("Activating"),
+            c_green) + "  " + shortcut_desc(_("%s to examine mutation, "),
+                ctxt.get_desc("TOGGLE_EXAMINE"));
     }
-    if( menu_mode == mutation_menu_mode::examining ) {
-        desc += colorize( _( "Examining" ),
-                          c_light_blue ) + "  " + shortcut_desc( _( "%s to activate mutation, " ),
-                                  ctxt.get_desc( "TOGGLE_EXAMINE" ) );
+    if (menu_mode == mutation_menu_mode::examining) {
+        desc += colorize(_("Examining"),
+            c_light_blue) + "  " + shortcut_desc(_("%s to activate mutation, "),
+                ctxt.get_desc("TOGGLE_EXAMINE"));
     }
     if( menu_mode != mutation_menu_mode::reassigning ) {
         desc += shortcut_desc( _( "%s to reassign invlet, " ), ctxt.get_desc( "REASSIGN" ) );
     }
     desc += shortcut_desc( _( "%s to change keybindings." ), ctxt.get_desc( "HELP_KEYBINDINGS" ) );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
-    fold_and_print( window, point( 1, 0 ), getmaxx( window ) - 1, c_white, desc );
-    wnoutrefresh( window );
+    fold_and_print(window, point(1, 0), getmaxx(window) - 1, c_white, desc);
+    wnoutrefresh(window);
 }
 
 void player::power_mutations()
@@ -103,9 +119,9 @@ player::power_mut_ui_result player::power_mutations_ui()
             active.push_back( mut.first );
         }
         // New mutations are initialized with no key at all, so we have to do this here.
-        if( mut.second.key == ' ' ) {
-            for( const auto &letter : mutation_chars ) {
-                if( trait_by_invlet( letter ).is_null() ) {
+        if (mut.second.key == ' ') {
+            for (const auto& letter : mutation_chars) {
+                if (trait_by_invlet(letter).is_null()) {
                     mut.second.key = letter;
                     break;
                 }
@@ -114,9 +130,9 @@ player::power_mut_ui_result player::power_mutations_ui()
     }
 
     // maximal number of rows in both columns
-    const int mutations_count = std::max( passive.size(), active.size() );
-
+    const int mutations_count = std::max(passive.size(), active.size());
     const int TITLE_HEIGHT = 2;
+
     const int DESCRIPTION_HEIGHT = 5;
     // + lines with text in titlebar, local
     const int HEADER_LINE_Y = TITLE_HEIGHT + 1;
@@ -147,150 +163,180 @@ player::power_mut_ui_result player::power_mutations_ui()
     int second_column = 0;
 
     int scroll_position = 0;
+    int cursor = 0;
     int max_scroll_position = 0;
     int list_height = 0;
+    int half_list_view_location = 0;
     mutation_menu_mode menu_mode = mutation_menu_mode::activating;
+    mutation_tab_mode tab_mode = mutation_tab_mode::passive;
     const auto recalc_max_scroll_position = [&]() {
-        list_height = ( menu_mode == mutation_menu_mode::examining ?
-                        DESCRIPTION_LINE_Y : HEIGHT - 1 ) - list_start_y;
+        list_height = (menu_mode == mutation_menu_mode::examining ?
+            DESCRIPTION_LINE_Y : HEIGHT - 1) - list_start_y;
         max_scroll_position = mutations_count - list_height;
-        if( max_scroll_position < 0 ) {
+        half_list_view_location = list_height / 2;
+        if (max_scroll_position < 0) {
             scroll_position = 0;
-        } else if( scroll_position > max_scroll_position ) {
+        }
+        else if (scroll_position > max_scroll_position) {
             scroll_position = max_scroll_position;
         }
     };
 
     ui_adaptor ui;
-    ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        HEIGHT = std::min( TERMY, std::max( FULL_SCREEN_HEIGHT,
-                                            TITLE_HEIGHT + mutations_count + DESCRIPTION_HEIGHT + 5 ) );
-        WIDTH = FULL_SCREEN_WIDTH + ( TERMX - FULL_SCREEN_WIDTH ) / 2;
-        const point START( ( TERMX - WIDTH ) / 2, ( TERMY - HEIGHT ) / 2 );
-        wBio = catacurses::newwin( HEIGHT, WIDTH, START );
+    ui.on_screen_resize([&](ui_adaptor& ui) {
+        HEIGHT = std::min(TERMY, std::max(FULL_SCREEN_HEIGHT,
+            TITLE_HEIGHT + mutations_count + DESCRIPTION_HEIGHT + 5));
+        WIDTH = FULL_SCREEN_WIDTH + (TERMX - FULL_SCREEN_WIDTH) / 2;
+        const point START((TERMX - WIDTH) / 2, (TERMY - HEIGHT) / 2);
+        wBio = catacurses::newwin(HEIGHT, WIDTH, START);
 
         // Description window @ the bottom of the bionic window
         const int DESCRIPTION_START_Y = START.y + HEIGHT - DESCRIPTION_HEIGHT - 1;
         DESCRIPTION_LINE_Y = DESCRIPTION_START_Y - START.y - 1;
-        w_description = catacurses::newwin( DESCRIPTION_HEIGHT, WIDTH - 2,
-                                            point( START.x + 1, DESCRIPTION_START_Y ) );
+        w_description = catacurses::newwin(DESCRIPTION_HEIGHT, WIDTH - 2,
+            point(START.x + 1, DESCRIPTION_START_Y));
 
         // Title window
         const int TITLE_START_Y = START.y + 1;
-        w_title = catacurses::newwin( TITLE_HEIGHT, WIDTH - 2,
-                                      point( START.x + 1, TITLE_START_Y ) );
+        w_title = catacurses::newwin(TITLE_HEIGHT, WIDTH - 2,
+            point(START.x + 1, TITLE_START_Y));
 
         recalc_max_scroll_position();
 
         // X-coordinate of the list of active mutations
-        second_column = 32 + ( TERMX - FULL_SCREEN_WIDTH ) / 4;
+        second_column = 32 + (TERMX - FULL_SCREEN_WIDTH) / 4;
 
-        ui.position_from_window( wBio );
-    } );
+        ui.position_from_window(wBio);
+        });
     ui.mark_resize();
 
-    input_context ctxt( "MUTATIONS" );
+    input_context ctxt("MUTATIONS");
     ctxt.register_updown();
-    ctxt.register_action( "ANY_INPUT" );
-    ctxt.register_action( "TOGGLE_EXAMINE" );
-    ctxt.register_action( "REASSIGN" );
-    ctxt.register_action( "HELP_KEYBINDINGS" );
-    ctxt.register_action( "QUIT" );
+    ctxt.register_action("ANY_INPUT");
+    ctxt.register_action("TOGGLE_EXAMINE");
+    ctxt.register_action("REASSIGN");
+    ctxt.register_action("NEXT_TAB");
+    ctxt.register_action("PREV_TAB");
+    ctxt.register_action("CONFIRM");
+    ctxt.register_action("HELP_KEYBINDINGS");
+    ctxt.register_action("QUIT");
 #if defined(__ANDROID__)
-    for( const auto &p : passive ) {
-        ctxt.register_manual_key( my_mutations[p].key, p.obj().name() );
+    for (const auto& p : passive) {
+        ctxt.register_manual_key(my_mutations[p].key, p.obj().name());
     }
-    for( const auto &a : active ) {
-        ctxt.register_manual_key( my_mutations[a].key, a.obj().name() );
+    for (const auto& a : active) {
+        ctxt.register_manual_key(my_mutations[a].key, a.obj().name());
     }
 #endif
 
     cata::optional<trait_id> examine_id;
 
-    ui.on_redraw( [&]( const ui_adaptor & ) {
-        werase( wBio );
-        draw_border( wBio, BORDER_COLOR, _( " MUTATIONS " ) );
+    ui.on_redraw([&](const ui_adaptor&) {
+        werase(wBio);
+        draw_border(wBio, BORDER_COLOR, _(" MUTATIONS "));
         // Draw line under title
-        mvwhline( wBio, point( 1, HEADER_LINE_Y ), LINE_OXOX, WIDTH - 2 );
+        mvwhline(wBio, point(1, HEADER_LINE_Y), LINE_OXOX, WIDTH - 2);
         // Draw symbols to connect additional lines to border
-        mvwputch( wBio, point( 0, HEADER_LINE_Y ), BORDER_COLOR, LINE_XXXO ); // |-
-        mvwputch( wBio, point( WIDTH - 1, HEADER_LINE_Y ), BORDER_COLOR, LINE_XOXX ); // -|
+        mvwputch(wBio, point(0, HEADER_LINE_Y), BORDER_COLOR, LINE_XXXO); // |-
+        mvwputch(wBio, point(WIDTH - 1, HEADER_LINE_Y), BORDER_COLOR, LINE_XOXX); // -|
 
         // Captions
-        mvwprintz( wBio, point( 2, HEADER_LINE_Y + 1 ), c_light_blue, _( "Passive:" ) );
-        mvwprintz( wBio, point( second_column, HEADER_LINE_Y + 1 ), c_light_blue, _( "Active:" ) );
+        mvwprintz(wBio, point(2, HEADER_LINE_Y + 1), c_light_blue, _("Passive:"));
+        mvwprintz(wBio, point(second_column, HEADER_LINE_Y + 1), c_light_blue, _("Active:"));
 
-        if( menu_mode == mutation_menu_mode::examining ) {
-            draw_exam_window( wBio, DESCRIPTION_LINE_Y );
+        if (menu_mode == mutation_menu_mode::examining) {
+            draw_exam_window(wBio, DESCRIPTION_LINE_Y);
         }
         nc_color type;
-        if( passive.empty() ) {
-            mvwprintz( wBio, point( 2, list_start_y ), c_light_gray, _( "None" ) );
-        } else {
-            for( int i = scroll_position; static_cast<size_t>( i ) < passive.size(); i++ ) {
-                const mutation_branch &md = passive[i].obj();
-                const trait_data &td = my_mutations[passive[i]];
-                if( i - scroll_position == list_height ) {
+        if (passive.empty()) {
+            mvwprintz(wBio, point(2, list_start_y), c_light_gray, _("None"));
+        }
+        else {
+            for (int i = scroll_position; static_cast<size_t>(i) < passive.size(); i++) {
+                const mutation_branch& md = passive[i].obj();
+                const trait_data& td = my_mutations[passive[i]];
+                const bool is_highlighted = cursor == static_cast<int>(i);
+                if (i - scroll_position == list_height) {
                     break;
                 }
-                type = has_base_trait( passive[i] ) ? c_cyan : c_light_cyan;
-                mvwprintz( wBio, point( 2, list_start_y + i - scroll_position ),
-                           type, "%c %s", td.key, md.name() );
+                if (is_highlighted && tab_mode == mutation_tab_mode::passive) {
+                    type = has_base_trait(passive[i]) ? c_cyan_yellow : c_light_cyan_yellow;
+                }
+                else {
+                    type = has_base_trait(passive[i]) ? c_cyan : c_light_cyan;
+                }
+                mvwprintz(wBio, point(2, list_start_y + i - scroll_position),
+                    type, "%c %s", td.key, md.name());
             }
         }
 
-        if( active.empty() ) {
-            mvwprintz( wBio, point( second_column, list_start_y ), c_light_gray, _( "None" ) );
-        } else {
-            for( int i = scroll_position; static_cast<size_t>( i ) < active.size(); i++ ) {
-                const mutation_branch &md = active[i].obj();
-                const trait_data &td = my_mutations[active[i]];
-                if( i - scroll_position == list_height ) {
+        if (active.empty()) {
+            mvwprintz(wBio, point(second_column, list_start_y), c_light_gray, _("None"));
+        }
+        else {
+            for (int i = scroll_position; static_cast<size_t>(i) < active.size(); i++) {
+                const mutation_branch& md = active[i].obj();
+                const trait_data& td = my_mutations[active[i]];
+                const bool is_highlighted = cursor == static_cast<int>(i);
+                if (i - scroll_position == list_height) {
                     break;
                 }
-                if( td.powered ) {
-                    type = has_base_trait( active[i] ) ? c_green : c_light_green;
-                } else {
-                    type = has_base_trait( active[i] ) ? c_red : c_light_red;
+                if (td.powered) {
+                    if (is_highlighted && tab_mode == mutation_tab_mode::active) {
+                        type = has_base_trait(active[i]) ? c_green_yellow : c_light_green_yellow;
+                    }
+                    else {
+                        type = has_base_trait(active[i]) ? c_green : c_light_green;
+                    }
+                }
+                else {
+                    if (is_highlighted && tab_mode == mutation_tab_mode::active) {
+                        type = has_base_trait(active[i]) ? c_red_yellow : c_light_red_yellow;
+                    }
+                    else {
+                        type = has_base_trait(active[i]) ? c_red : c_light_red;
+                    }
                 }
                 // TODO: track resource(s) used and specify
-                mvwputch( wBio, point( second_column, list_start_y + i - scroll_position ),
-                          type, td.key );
+                mvwputch(wBio, point(second_column, list_start_y + i - scroll_position),
+                    type, td.key);
                 std::string mut_desc;
                 mut_desc += md.name();
-                if( md.cost > 0 && md.cooldown > 0 ) {
+                if (md.cost > 0 && md.cooldown > 0) {
                     //~ RU means Resource Units
-                    mut_desc += string_format( _( " - %d RU / %d turns" ),
-                                               md.cost, md.cooldown );
-                } else if( md.cost > 0 ) {
+                    mut_desc += string_format(_(" - %d RU / %d turns"),
+                        md.cost, md.cooldown);
+                }
+                else if (md.cost > 0) {
                     //~ RU means Resource Units
-                    mut_desc += string_format( _( " - %d RU" ), md.cost );
-                } else if( md.cooldown > 0 ) {
-                    mut_desc += string_format( _( " - %d turns" ), md.cooldown );
+                    mut_desc += string_format(_(" - %d RU"), md.cost);
                 }
-                if( td.powered ) {
-                    mut_desc += _( " - Active" );
+                else if (md.cooldown > 0) {
+                    mut_desc += string_format(_(" - %d turns"), md.cooldown);
                 }
-                mvwprintz( wBio, point( second_column + 2, list_start_y + i - scroll_position ),
-                           type, mut_desc );
+                if (td.powered) {
+                    mut_desc += _(" - Active");
+                }
+                mvwprintz(wBio, point(second_column + 2, list_start_y + i - scroll_position),
+                    type, mut_desc);
             }
         }
 
-        draw_scrollbar( wBio, scroll_position, list_height, mutations_count,
-                        point( 0, list_start_y ), c_white, true );
-        wnoutrefresh( wBio );
-        show_mutations_titlebar( w_title, menu_mode, ctxt );
+        draw_scrollbar(wBio, scroll_position, list_height, mutations_count,
+            point(0, list_start_y), c_white, true);
+        wnoutrefresh(wBio);
+        show_mutations_titlebar(w_title, menu_mode, ctxt);
 
-        if( menu_mode == mutation_menu_mode::examining && examine_id.has_value() ) {
-            werase( w_description );
-            fold_and_print( w_description, point_zero, WIDTH - 2, c_light_blue, examine_id.value()->desc() );
-            wnoutrefresh( w_description );
+        if (menu_mode == mutation_menu_mode::examining && examine_id.has_value()) {
+            werase(w_description);
+            fold_and_print(w_description, point_zero, WIDTH - 2, c_light_blue, examine_id.value()->desc());
+            wnoutrefresh(w_description);
         }
-    } );
+        });
 
     power_mut_ui_result ret;
     bool exit = false;
-    while( !exit ) {
+    while (!exit) {
         recalc_max_scroll_position();
         ui_manager::redraw();
         bool handled = false;
@@ -298,53 +344,58 @@ player::power_mut_ui_result player::power_mutations_ui()
         const input_event evt = ctxt.get_raw_input();
         if( evt.type == CATA_INPUT_KEYBOARD && !evt.sequence.empty() ) {
             const int ch = evt.get_first_input();
-            const trait_id mut_id = trait_by_invlet( ch );
-            if( !mut_id.is_null() ) {
-                const mutation_branch &mut_data = mut_id.obj();
-                switch( menu_mode ) {
-                    case mutation_menu_mode::reassigning: {
-                        query_popup pop;
-                        pop.message( _( "%s; enter new letter." ),
-                                     mutation_branch::get_name( mut_id ) )
-                        .context( "POPUP_WAIT" )
-                        .allow_cancel( true )
-                        .allow_anykey( true );
+            if (ch == ' ') { //skip if space is pressed (space is used as an empty hotkey)
+                continue;
+            }
+            const trait_id mut_id = trait_by_invlet(ch);
+            if (!mut_id.is_null()) {
+                const mutation_branch& mut_data = mut_id.obj();
+                switch (menu_mode) {
+                case mutation_menu_mode::reassigning: {
+                    query_popup pop;
+                    pop.message(_("%s; enter new letter."),
+                        mutation_branch::get_name(mut_id))
+                        .context("POPUP_WAIT")
+                        .allow_cancel(true)
+                        .allow_anykey(true);
 
-                        bool pop_exit = false;
-                        while( !pop_exit ) {
-                            const query_popup::result ret = pop.query();
-                            bool pop_handled = false;
-                            if( ret.evt.type == CATA_INPUT_KEYBOARD && !ret.evt.sequence.empty() ) {
-                                const int newch = ret.evt.get_first_input();
-                                if( mutation_chars.valid( newch ) ) {
-                                    const trait_id other_mut_id = trait_by_invlet( newch );
-                                    if( !other_mut_id.is_null() ) {
-                                        std::swap( my_mutations[mut_id].key, my_mutations[other_mut_id].key );
-                                    } else {
-                                        my_mutations[mut_id].key = newch;
-                                    }
-                                    pop_exit = true;
-                                    pop_handled = true;
+                    bool pop_exit = false;
+                    while (!pop_exit) {
+                        const query_popup::result ret = pop.query();
+                        bool pop_handled = false;
+                        if (ret.evt.type == CATA_INPUT_KEYBOARD && !ret.evt.sequence.empty()) {
+                            const int newch = ret.evt.get_first_input();
+                            if (mutation_chars.valid(newch)) {
+                                const trait_id other_mut_id = trait_by_invlet(newch);
+                                if (!other_mut_id.is_null()) {
+                                    std::swap(my_mutations[mut_id].key, my_mutations[other_mut_id].key);
                                 }
-                            }
-                            if( !pop_handled ) {
-                                if( ret.action == "QUIT" ) {
-                                    pop_exit = true;
-                                } else if( ret.action != "HELP_KEYBINDINGS" &&
-                                           ret.evt.type == CATA_INPUT_KEYBOARD ) {
-                                    popup( _( "Invalid mutation letter.  Only those characters are valid:\n\n%s" ),
-                                           mutation_chars.get_allowed_chars() );
+                                else {
+                                    my_mutations[mut_id].key = newch;
                                 }
+                                pop_exit = true;
+                                pop_handled = true;
                             }
                         }
-
-                        menu_mode = mutation_menu_mode::activating;
-                        examine_id = cata::nullopt;
-                        // TODO: show a message like when reassigning a key to an item?
-                        break;
+                        if (!pop_handled) {
+                            if (ret.action == "QUIT") {
+                                pop_exit = true;
+                            }
+                            else if (ret.action != "HELP_KEYBINDINGS" &&
+                                ret.evt.type == CATA_INPUT_KEYBOARD) {
+                                popup(_("Invalid mutation letter.  Only those characters are valid:\n\n%s"),
+                                    mutation_chars.get_allowed_chars());
+                            }
+                        }
                     }
-                    case mutation_menu_mode::activating: {
-                        const cata::value_ptr<mut_transform> &trans = mut_data.transform;
+
+                    menu_mode = mutation_menu_mode::activating;
+                    examine_id = cata::nullopt;
+                    // TODO: show a message like when reassigning a key to an item?
+                    break;
+                }
+                case mutation_menu_mode::activating: {
+                    const cata::value_ptr<mut_transform> &trans = mut_data.transform;
                         if( mut_data.activated || trans ) {
                             if( my_mutations[mut_id].powered ) {
                                 if( trans && !trans->msg_transform.empty() ) {
@@ -368,10 +419,192 @@ player::power_mut_ui_result player::power_mutations_ui()
                                 popup( _( "You feel like using your %s would kill you!" ),
                                        mut_data.name() );
                             }
-                        } else {
-                            popup( _( "You cannot activate %s!  To read a description of "
-                                      "%s, press '!', then '%c'." ),
-                                   mut_data.name(), mut_data.name(), my_mutations[mut_id].key );
+                    }
+                    else {
+                        popup(_("You cannot activate %s!  To read a description of "
+                            "%s, press '!', then '%c'."),
+                            mut_data.name(), mut_data.name(), my_mutations[mut_id].key);
+                    }
+                    break;
+                }
+                case mutation_menu_mode::examining:
+                    // Describing mutations, not activating them!
+                    examine_id = mut_id;
+                    break;
+                }
+                handled = true;
+            }
+            else if (mutation_chars.valid(ch)) {
+                handled = true;
+            }
+        }
+        if (!handled) {
+
+            // Essentially, up-down navigation adapted from the bionics_ui.cpp, with a bunch of extra placeholders to keep functionality
+
+            if (action == "DOWN") {
+
+                int lowerlim;
+
+                if (tab_mode == mutation_tab_mode::passive) {
+                    lowerlim = passive.size() - 1;
+                }
+                else {
+                    lowerlim = active.size() - 1;
+                }
+
+                if (static_cast<size_t>(cursor) < lowerlim) {
+                    cursor++;
+                }
+                else {
+                    cursor = 0;
+                }
+                if (scroll_position < max_scroll_position &&
+                    cursor - scroll_position > list_height - half_list_view_location) {
+                    scroll_position++;
+                }
+                if (scroll_position > 0 && cursor - scroll_position < half_list_view_location) {
+                    scroll_position = std::max(cursor - half_list_view_location, 0);
+                }
+
+                // Draw the description, placeholder
+                examine_id = GetTrait(active, passive, cursor, tab_mode);
+
+            }
+            else if (action == "UP") {
+
+                int lim;
+                if (tab_mode == mutation_tab_mode::passive) {
+                    lim = passive.size() - 1;
+                }
+                else {
+                    lim = active.size() - 1;
+                }
+                if (cursor > 0) {
+                    cursor--;
+                }
+                else {
+                    cursor = lim;
+                }
+                if (scroll_position > 0 && cursor - scroll_position < half_list_view_location) {
+                    scroll_position--;
+                }
+                if (scroll_position < max_scroll_position &&
+                    cursor - scroll_position > list_height - half_list_view_location) {
+                    scroll_position =
+                        std::max(std::min<int>(lim + 1 - list_height,
+                            cursor - half_list_view_location), 0);
+                }
+
+                examine_id = GetTrait(active, passive, cursor, tab_mode);
+            }
+            else if (action == "NEXT_TAB") {
+                scroll_position = 0;
+                cursor = 0;
+                if (tab_mode == mutation_tab_mode::active) {
+                    tab_mode = mutation_tab_mode::passive;
+                }
+                else {
+                    tab_mode = mutation_tab_mode::active;
+                }
+                examine_id = GetTrait(active, passive, cursor, tab_mode);
+            }
+            else if (action == "PREV_TAB") {
+                scroll_position = 0;
+                cursor = 0;
+                if (tab_mode == mutation_tab_mode::active) {
+                    tab_mode = mutation_tab_mode::passive;
+                }
+                else {
+                    tab_mode = mutation_tab_mode::active;
+                }
+                examine_id = GetTrait(active, passive, cursor, tab_mode);
+            }
+            else if (action == "CONFIRM") {
+                trait_id mut_id;
+                if (tab_mode == mutation_tab_mode::active) {
+                    mut_id = active[cursor];
+                }
+                else {
+                    mut_id = passive[cursor];
+                }
+                if (!mut_id.is_null()) {
+                    const mutation_branch& mut_data = mut_id.obj();
+                    switch (menu_mode) {
+                    case mutation_menu_mode::reassigning: {
+                        query_popup pop;
+                        pop.message( _( "%s; enter new letter." ),
+                                     mutation_branch::get_name( mut_id ) )
+                        .context( "POPUP_WAIT" )
+                        .allow_cancel( true )
+                        .allow_anykey( true );
+
+                        bool pop_exit = false;
+                        while (!pop_exit) {
+                            const query_popup::result ret = pop.query();
+                            bool pop_handled = false;
+                            if( ret.evt.type == CATA_INPUT_KEYBOARD && !ret.evt.sequence.empty() ) {
+                                const int newch = ret.evt.get_first_input();
+                                if (mutation_chars.valid(newch)) {
+                                    const trait_id other_mut_id = trait_by_invlet(newch);
+                                    if (!other_mut_id.is_null()) {
+                                        std::swap(my_mutations[mut_id].key, my_mutations[other_mut_id].key);
+                                    }
+                                    else {
+                                        my_mutations[mut_id].key = newch;
+                                    }
+                                    pop_exit = true;
+                                    pop_handled = true;
+                                }
+                                else if (newch == ' ') {
+                                    my_mutations[mut_id].key = newch;
+                                    pop_exit = true;
+                                    pop_handled = true;
+                                }
+                            }
+                            if (!pop_handled) {
+                                if (ret.action == "QUIT") {
+                                    pop_exit = true;
+                                }
+                                else if (ret.action != "HELP_KEYBINDINGS" &&
+                                    ret.evt.type == CATA_INPUT_KEYBOARD) {
+                                    popup(_("Invalid mutation letter.  Only those characters are valid:\n\n%s"),
+                                        mutation_chars.get_allowed_chars());
+                                }
+                            }
+                        }
+
+                        menu_mode = mutation_menu_mode::activating;
+                        examine_id = cata::nullopt;
+                        // TODO: show a message like when reassigning a key to an item?
+                        break;
+                    }
+                    case mutation_menu_mode::activating: {
+                        if (mut_data.activated) {
+                            if (my_mutations[mut_id].powered) {
+                                add_msg_if_player(m_neutral, _("You stop using your %s."), mut_data.name());
+
+                                deactivate_mutation(mut_id);
+                                // Action done, leave screen
+                                exit = true;
+                            }
+                            else if ((!mut_data.hunger || get_kcal_percent() >= 0.8f) &&
+                                (!mut_data.thirst || get_thirst() <= 400) &&
+                                (!mut_data.fatigue || get_fatigue() <= 400)) {
+                                add_msg_if_player(m_neutral, _("You activate your %s."), mut_data.name());
+
+                                activate_mutation(mut_id);
+                                // Action done, leave screen
+                                exit = true;
+                            }
+                            else {
+                                popup(_("You don't have enough in you to activate your %s!"), mut_data.name());
+                            }
+                        }
+                        else {
+                            popup(_("You cannot activate %s!  To read a description of "
+                                "%s, press '!', then '%c'."),
+                                mut_data.name(), mut_data.name(), my_mutations[mut_id].key);
                         }
                         break;
                     }
@@ -380,27 +613,15 @@ player::power_mut_ui_result player::power_mutations_ui()
                         examine_id = mut_id;
                         break;
                 }
-                handled = true;
-            } else if( mutation_chars.valid( ch ) ) {
-                handled = true;
             }
-        }
-        if( !handled ) {
-            if( action == "DOWN" ) {
-                if( scroll_position < max_scroll_position ) {
-                    scroll_position++;
-                }
-            } else if( action == "UP" ) {
-                if( scroll_position > 0 ) {
-                    scroll_position--;
-                }
-            } else if( action == "REASSIGN" ) {
+            else if (action == "REASSIGN") {
                 menu_mode = mutation_menu_mode::reassigning;
                 examine_id = cata::nullopt;
-            } else if( action == "TOGGLE_EXAMINE" ) {
+            }
+            else if (action == "TOGGLE_EXAMINE") {
                 // switches between activation and examination
                 menu_mode = menu_mode == mutation_menu_mode::activating ?
-                            mutation_menu_mode::examining : mutation_menu_mode::activating;
+                    mutation_menu_mode::examining : mutation_menu_mode::activating;
                 examine_id = cata::nullopt;
             } else if( action == "QUIT" ) {
                 ret.cmd = power_mut_ui_cmd::Exit;

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -16,73 +16,74 @@
 #include "translations.h"
 #include "ui_manager.h"
 #include "value_ptr.h"
-enum mutation_menu_mode {
+enum class mutation_menu_mode {
     activating,
     examining,
     reassigning,
     hiding
 };
-enum mutation_tab_mode {
+enum class mutation_tab_mode {
     active,
     passive,
     none
 };
 // '!' and '=' are uses as default bindings in the menu
 static const invlet_wrapper
-mutation_chars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\"#&()*+./:;@[\\]^_{|}");
+mutation_chars( "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\"#&()*+./:;@[\\]^_{|}" );
 
-static void draw_exam_window(const catacurses::window& win, const int border_y)
+static void draw_exam_window( const catacurses::window &win, const int border_y )
 {
-    const int width = getmaxx(win);
-    mvwputch(win, point(0, border_y), BORDER_COLOR, LINE_XXXO);
-    mvwhline(win, point(1, border_y), LINE_OXOX, width - 2);
-    mvwputch(win, point(width - 1, border_y), BORDER_COLOR, LINE_XOXX);
+    const int width = getmaxx( win );
+    mvwputch( win, point( 0, border_y ), BORDER_COLOR, LINE_XXXO );
+    mvwhline( win, point( 1, border_y ), LINE_OXOX, width - 2 );
+    mvwputch( win, point( width - 1, border_y ), BORDER_COLOR, LINE_XOXX );
 }
 
-static const auto shortcut_desc = [](const std::string& comment, const std::string& keys)
+static const auto shortcut_desc = []( const std::string &comment, const std::string &keys )
 {
-    return string_format(comment, string_format("[<color_yellow>%s</color>]", keys));
+    return string_format( comment, string_format( "[<color_yellow>%s</color>]", keys ) );
 };
 
 // needs extensive improvement
 
-static trait_id GetTrait(std::vector<trait_id> active, std::vector<trait_id> passive, int cursor, mutation_tab_mode tab_mode) {
+static trait_id GetTrait( std::vector<trait_id> active, std::vector<trait_id> passive, int cursor,
+                          mutation_tab_mode tab_mode )
+{
     trait_id mut_id;
-    if (tab_mode == mutation_tab_mode::active) {
+    if( tab_mode == mutation_tab_mode::active ) {
         mut_id = active[cursor];
-    }
-    else {
+    } else {
         mut_id = passive[cursor];
     }
     return mut_id;
 }
 
-static void show_mutations_titlebar(const catacurses::window& window,
-    const mutation_menu_mode menu_mode, const input_context& ctxt)
+static void show_mutations_titlebar( const catacurses::window &window,
+                                     const mutation_menu_mode menu_mode, const input_context &ctxt )
 {
-    werase(window);
+    werase( window );
     std::string desc;
-    if (menu_mode == mutation_menu_mode::reassigning) {
-        desc += std::string(_("Reassigning.")) + "  " +
-            _("Select a mutation to reassign or press [<color_yellow>SPACE</color>] to cancel. ");
+    if( menu_mode == mutation_menu_mode::reassigning ) {
+        desc += std::string( _( "Reassigning." ) ) + "  " +
+                _( "Select a mutation to reassign or press [<color_yellow>SPACE</color>] to cancel. " );
     }
-    if (menu_mode == mutation_menu_mode::activating) {
-        desc += colorize(_("Activating"),
-            c_green) + "  " + shortcut_desc(_("%s to examine mutation, "),
-                ctxt.get_desc("TOGGLE_EXAMINE"));
+    if( menu_mode == mutation_menu_mode::activating ) {
+        desc += colorize( _( "Activating" ),
+                          c_green ) + "  " + shortcut_desc( _( "%s to examine mutation, " ),
+                                  ctxt.get_desc( "TOGGLE_EXAMINE" ) );
     }
-    if (menu_mode == mutation_menu_mode::examining) {
-        desc += colorize(_("Examining"),
-            c_light_blue) + "  " + shortcut_desc(_("%s to activate mutation, "),
-                ctxt.get_desc("TOGGLE_EXAMINE"));
+    if( menu_mode == mutation_menu_mode::examining ) {
+        desc += colorize( _( "Examining" ),
+                          c_light_blue ) + "  " + shortcut_desc( _( "%s to activate mutation, " ),
+                                  ctxt.get_desc( "TOGGLE_EXAMINE" ) );
     }
     if( menu_mode != mutation_menu_mode::reassigning ) {
         desc += shortcut_desc( _( "%s to reassign invlet, " ), ctxt.get_desc( "REASSIGN" ) );
     }
     desc += shortcut_desc( _( "%s to change keybindings." ), ctxt.get_desc( "HELP_KEYBINDINGS" ) );
     // NOLINTNEXTLINE(cata-use-named-point-constants)
-    fold_and_print(window, point(1, 0), getmaxx(window) - 1, c_white, desc);
-    wnoutrefresh(window);
+    fold_and_print( window, point( 1, 0 ), getmaxx( window ) - 1, c_white, desc );
+    wnoutrefresh( window );
 }
 
 void player::power_mutations()
@@ -120,9 +121,9 @@ player::power_mut_ui_result player::power_mutations_ui()
             active.push_back( mut.first );
         }
         // New mutations are initialized with no key at all, so we have to do this here.
-        if (mut.second.key == ' ') {
-            for (const auto& letter : mutation_chars) {
-                if (trait_by_invlet(letter).is_null()) {
+        if( mut.second.key == ' ' ) {
+            for( const auto &letter : mutation_chars ) {
+                if( trait_by_invlet( letter ).is_null() ) {
                     mut.second.key = letter;
                     break;
                 }
@@ -131,7 +132,7 @@ player::power_mut_ui_result player::power_mutations_ui()
     }
 
     // maximal number of rows in both columns
-    const int mutations_count = std::max(passive.size(), active.size());
+    const int mutations_count = std::max( passive.size(), active.size() );
     const int TITLE_HEIGHT = 2;
 
     const int DESCRIPTION_HEIGHT = 5;
@@ -170,184 +171,173 @@ player::power_mut_ui_result player::power_mutations_ui()
     int half_list_view_location = 0;
     mutation_menu_mode menu_mode = mutation_menu_mode::activating;
     mutation_tab_mode tab_mode;
-    if (!passive.empty()) {
+    if( !passive.empty() ) {
         tab_mode = mutation_tab_mode::passive;
-    }
-    else if (!active.empty()){
+    } else if( !active.empty() ) {
         tab_mode = mutation_tab_mode::active;
-    }
-    else {
+    } else {
         tab_mode = mutation_tab_mode::none;
     }
 
     const auto recalc_max_scroll_position = [&]() {
-        list_height = (menu_mode == mutation_menu_mode::examining ?
-            DESCRIPTION_LINE_Y : HEIGHT - 1) - list_start_y;
+        list_height = ( menu_mode == mutation_menu_mode::examining ?
+                        DESCRIPTION_LINE_Y : HEIGHT - 1 ) - list_start_y;
         max_scroll_position = mutations_count - list_height;
         half_list_view_location = list_height / 2;
-        if (max_scroll_position < 0) {
+        if( max_scroll_position < 0 ) {
             scroll_position = 0;
-        }
-        else if (scroll_position > max_scroll_position) {
+        } else if( scroll_position > max_scroll_position ) {
             scroll_position = max_scroll_position;
         }
     };
 
     ui_adaptor ui;
-    ui.on_screen_resize([&](ui_adaptor& ui) {
-        HEIGHT = std::min(TERMY, std::max(FULL_SCREEN_HEIGHT,
-            TITLE_HEIGHT + mutations_count + DESCRIPTION_HEIGHT + 5));
-        WIDTH = FULL_SCREEN_WIDTH + (TERMX - FULL_SCREEN_WIDTH) / 2;
-        const point START((TERMX - WIDTH) / 2, (TERMY - HEIGHT) / 2);
-        wBio = catacurses::newwin(HEIGHT, WIDTH, START);
+    ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+        HEIGHT = std::min( TERMY, std::max( FULL_SCREEN_HEIGHT,
+                                            TITLE_HEIGHT + mutations_count + DESCRIPTION_HEIGHT + 5 ) );
+        WIDTH = FULL_SCREEN_WIDTH + ( TERMX - FULL_SCREEN_WIDTH ) / 2;
+        const point START( ( TERMX - WIDTH ) / 2, ( TERMY - HEIGHT ) / 2 );
+        wBio = catacurses::newwin( HEIGHT, WIDTH, START );
 
         // Description window @ the bottom of the bionic window
         const int DESCRIPTION_START_Y = START.y + HEIGHT - DESCRIPTION_HEIGHT - 1;
         DESCRIPTION_LINE_Y = DESCRIPTION_START_Y - START.y - 1;
-        w_description = catacurses::newwin(DESCRIPTION_HEIGHT, WIDTH - 2,
-            point(START.x + 1, DESCRIPTION_START_Y));
+        w_description = catacurses::newwin( DESCRIPTION_HEIGHT, WIDTH - 2,
+                                            point( START.x + 1, DESCRIPTION_START_Y ) );
 
         // Title window
         const int TITLE_START_Y = START.y + 1;
-        w_title = catacurses::newwin(TITLE_HEIGHT, WIDTH - 2,
-            point(START.x + 1, TITLE_START_Y));
+        w_title = catacurses::newwin( TITLE_HEIGHT, WIDTH - 2,
+                                      point( START.x + 1, TITLE_START_Y ) );
 
         recalc_max_scroll_position();
 
         // X-coordinate of the list of active mutations
-        second_column = 32 + (TERMX - FULL_SCREEN_WIDTH) / 4;
+        second_column = 32 + ( TERMX - FULL_SCREEN_WIDTH ) / 4;
 
-        ui.position_from_window(wBio);
-        });
+        ui.position_from_window( wBio );
+    } );
     ui.mark_resize();
 
-    input_context ctxt("MUTATIONS");
+    input_context ctxt( "MUTATIONS" );
     ctxt.register_updown();
-    ctxt.register_action("ANY_INPUT");
-    ctxt.register_action("TOGGLE_EXAMINE");
-    ctxt.register_action("REASSIGN");
-    ctxt.register_action("NEXT_TAB");
-    ctxt.register_action("PREV_TAB");
-    ctxt.register_action("CONFIRM");
-    ctxt.register_action("HELP_KEYBINDINGS");
-    ctxt.register_action("QUIT");
+    ctxt.register_action( "ANY_INPUT" );
+    ctxt.register_action( "TOGGLE_EXAMINE" );
+    ctxt.register_action( "REASSIGN" );
+    ctxt.register_action( "NEXT_TAB" );
+    ctxt.register_action( "PREV_TAB" );
+    ctxt.register_action( "CONFIRM" );
+    ctxt.register_action( "HELP_KEYBINDINGS" );
+    ctxt.register_action( "QUIT" );
 #if defined(__ANDROID__)
-    for (const auto& p : passive) {
-        ctxt.register_manual_key(my_mutations[p].key, p.obj().name());
+    for( const auto &p : passive ) {
+        ctxt.register_manual_key( my_mutations[p].key, p.obj().name() );
     }
-    for (const auto& a : active) {
-        ctxt.register_manual_key(my_mutations[a].key, a.obj().name());
+    for( const auto &a : active ) {
+        ctxt.register_manual_key( my_mutations[a].key, a.obj().name() );
     }
 #endif
 
     cata::optional<trait_id> examine_id;
 
-    ui.on_redraw([&](const ui_adaptor&) {
-        werase(wBio);
-        draw_border(wBio, BORDER_COLOR, _(" MUTATIONS "));
+    ui.on_redraw( [&]( const ui_adaptor & ) {
+        werase( wBio );
+        draw_border( wBio, BORDER_COLOR, _( " MUTATIONS " ) );
         // Draw line under title
-        mvwhline(wBio, point(1, HEADER_LINE_Y), LINE_OXOX, WIDTH - 2);
+        mvwhline( wBio, point( 1, HEADER_LINE_Y ), LINE_OXOX, WIDTH - 2 );
         // Draw symbols to connect additional lines to border
-        mvwputch(wBio, point(0, HEADER_LINE_Y), BORDER_COLOR, LINE_XXXO); // |-
-        mvwputch(wBio, point(WIDTH - 1, HEADER_LINE_Y), BORDER_COLOR, LINE_XOXX); // -|
+        mvwputch( wBio, point( 0, HEADER_LINE_Y ), BORDER_COLOR, LINE_XXXO ); // |-
+        mvwputch( wBio, point( WIDTH - 1, HEADER_LINE_Y ), BORDER_COLOR, LINE_XOXX ); // -|
 
         // Captions
-        mvwprintz(wBio, point(2, HEADER_LINE_Y + 1), c_light_blue, _("Passive:"));
-        mvwprintz(wBio, point(second_column, HEADER_LINE_Y + 1), c_light_blue, _("Active:"));
+        mvwprintz( wBio, point( 2, HEADER_LINE_Y + 1 ), c_light_blue, _( "Passive:" ) );
+        mvwprintz( wBio, point( second_column, HEADER_LINE_Y + 1 ), c_light_blue, _( "Active:" ) );
 
-        if (menu_mode == mutation_menu_mode::examining) {
-            draw_exam_window(wBio, DESCRIPTION_LINE_Y);
+        if( menu_mode == mutation_menu_mode::examining ) {
+            draw_exam_window( wBio, DESCRIPTION_LINE_Y );
         }
         nc_color type;
-        if (passive.empty()) {
-            mvwprintz(wBio, point(2, list_start_y), c_light_gray, _("None"));
-        }
-        else {
-            for (int i = scroll_position; static_cast<size_t>(i) < passive.size(); i++) {
-                const mutation_branch& md = passive[i].obj();
-                const trait_data& td = my_mutations[passive[i]];
-                const bool is_highlighted = cursor == static_cast<int>(i);
-                if (i - scroll_position == list_height) {
+        if( passive.empty() ) {
+            mvwprintz( wBio, point( 2, list_start_y ), c_light_gray, _( "None" ) );
+        } else {
+            for( int i = scroll_position; static_cast<size_t>( i ) < passive.size(); i++ ) {
+                const mutation_branch &md = passive[i].obj();
+                const trait_data &td = my_mutations[passive[i]];
+                const bool is_highlighted = cursor == static_cast<int>( i );
+                if( i - scroll_position == list_height ) {
                     break;
                 }
-                if (is_highlighted && tab_mode == mutation_tab_mode::passive) {
-                    type = has_base_trait(passive[i]) ? c_cyan_yellow : c_light_cyan_yellow;
+                if( is_highlighted && tab_mode == mutation_tab_mode::passive ) {
+                    type = has_base_trait( passive[i] ) ? c_cyan_yellow : c_light_cyan_yellow;
+                } else {
+                    type = has_base_trait( passive[i] ) ? c_cyan : c_light_cyan;
                 }
-                else {
-                    type = has_base_trait(passive[i]) ? c_cyan : c_light_cyan;
-                }
-                mvwprintz(wBio, point(2, list_start_y + i - scroll_position),
-                    type, "%c %s", td.key, md.name());
+                mvwprintz( wBio, point( 2, list_start_y + i - scroll_position ),
+                           type, "%c %s", td.key, md.name() );
             }
         }
 
-        if (active.empty()) {
-            mvwprintz(wBio, point(second_column, list_start_y), c_light_gray, _("None"));
-        }
-        else {
-            for (int i = scroll_position; static_cast<size_t>(i) < active.size(); i++) {
-                const mutation_branch& md = active[i].obj();
-                const trait_data& td = my_mutations[active[i]];
-                const bool is_highlighted = cursor == static_cast<int>(i);
-                if (i - scroll_position == list_height) {
+        if( active.empty() ) {
+            mvwprintz( wBio, point( second_column, list_start_y ), c_light_gray, _( "None" ) );
+        } else {
+            for( int i = scroll_position; static_cast<size_t>( i ) < active.size(); i++ ) {
+                const mutation_branch &md = active[i].obj();
+                const trait_data &td = my_mutations[active[i]];
+                const bool is_highlighted = cursor == static_cast<int>( i );
+                if( i - scroll_position == list_height ) {
                     break;
                 }
-                if (td.powered) {
-                    if (is_highlighted && tab_mode == mutation_tab_mode::active) {
-                        type = has_base_trait(active[i]) ? c_green_yellow : c_light_green_yellow;
+                if( td.powered ) {
+                    if( is_highlighted && tab_mode == mutation_tab_mode::active ) {
+                        type = has_base_trait( active[i] ) ? c_green_yellow : c_light_green_yellow;
+                    } else {
+                        type = has_base_trait( active[i] ) ? c_green : c_light_green;
                     }
-                    else {
-                        type = has_base_trait(active[i]) ? c_green : c_light_green;
-                    }
-                }
-                else {
-                    if (is_highlighted && tab_mode == mutation_tab_mode::active) {
-                        type = has_base_trait(active[i]) ? c_red_yellow : c_light_red_yellow;
-                    }
-                    else {
-                        type = has_base_trait(active[i]) ? c_red : c_light_red;
+                } else {
+                    if( is_highlighted && tab_mode == mutation_tab_mode::active ) {
+                        type = has_base_trait( active[i] ) ? c_red_yellow : c_light_red_yellow;
+                    } else {
+                        type = has_base_trait( active[i] ) ? c_red : c_light_red;
                     }
                 }
                 // TODO: track resource(s) used and specify
-                mvwputch(wBio, point(second_column, list_start_y + i - scroll_position),
-                    type, td.key);
+                mvwputch( wBio, point( second_column, list_start_y + i - scroll_position ),
+                          type, td.key );
                 std::string mut_desc;
                 mut_desc += md.name();
-                if (md.cost > 0 && md.cooldown > 0) {
+                if( md.cost > 0 && md.cooldown > 0 ) {
                     //~ RU means Resource Units
-                    mut_desc += string_format(_(" - %d RU / %d turns"),
-                        md.cost, md.cooldown);
-                }
-                else if (md.cost > 0) {
+                    mut_desc += string_format( _( " - %d RU / %d turns" ),
+                                               md.cost, md.cooldown );
+                } else if( md.cost > 0 ) {
                     //~ RU means Resource Units
-                    mut_desc += string_format(_(" - %d RU"), md.cost);
+                    mut_desc += string_format( _( " - %d RU" ), md.cost );
+                } else if( md.cooldown > 0 ) {
+                    mut_desc += string_format( _( " - %d turns" ), md.cooldown );
                 }
-                else if (md.cooldown > 0) {
-                    mut_desc += string_format(_(" - %d turns"), md.cooldown);
+                if( td.powered ) {
+                    mut_desc += _( " - Active" );
                 }
-                if (td.powered) {
-                    mut_desc += _(" - Active");
-                }
-                mvwprintz(wBio, point(second_column + 2, list_start_y + i - scroll_position),
-                    type, mut_desc);
+                mvwprintz( wBio, point( second_column + 2, list_start_y + i - scroll_position ),
+                           type, mut_desc );
             }
         }
 
-        draw_scrollbar(wBio, scroll_position, list_height, mutations_count,
-            point(0, list_start_y), c_white, true);
-        wnoutrefresh(wBio);
-        show_mutations_titlebar(w_title, menu_mode, ctxt);
+        draw_scrollbar( wBio, scroll_position, list_height, mutations_count,
+                        point( 0, list_start_y ), c_white, true );
+        wnoutrefresh( wBio );
+        show_mutations_titlebar( w_title, menu_mode, ctxt );
 
-        if (menu_mode == mutation_menu_mode::examining && examine_id.has_value()) {
-            werase(w_description);
-            fold_and_print(w_description, point_zero, WIDTH - 2, c_light_blue, examine_id.value()->desc());
-            wnoutrefresh(w_description);
+        if( menu_mode == mutation_menu_mode::examining && examine_id.has_value() ) {
+            werase( w_description );
+            fold_and_print( w_description, point_zero, WIDTH - 2, c_light_blue, examine_id.value()->desc() );
+            wnoutrefresh( w_description );
         }
-        });
+    } );
 
     power_mut_ui_result ret;
     bool exit = false;
-    while (!exit) {
+    while( !exit ) {
         recalc_max_scroll_position();
         ui_manager::redraw();
         bool handled = false;
@@ -355,208 +345,13 @@ player::power_mut_ui_result player::power_mutations_ui()
         const input_event evt = ctxt.get_raw_input();
         if( evt.type == CATA_INPUT_KEYBOARD && !evt.sequence.empty() ) {
             const int ch = evt.get_first_input();
-            if (ch == ' ') { //skip if space is pressed (space is used as an empty hotkey)
+            if( ch == ' ' ) { //skip if space is pressed (space is used as an empty hotkey)
                 continue;
             }
-            const trait_id mut_id = trait_by_invlet(ch);
-            if (!mut_id.is_null()) {
-                const mutation_branch& mut_data = mut_id.obj();
-                switch (menu_mode) {
-                case mutation_menu_mode::reassigning: {
-                    query_popup pop;
-                    pop.message(_("%s; enter new letter."),
-                        mutation_branch::get_name(mut_id))
-                        .context("POPUP_WAIT")
-                        .allow_cancel(true)
-                        .allow_anykey(true);
-
-                    bool pop_exit = false;
-                    while (!pop_exit) {
-                        const query_popup::result ret = pop.query();
-                        bool pop_handled = false;
-                        if (ret.evt.type == CATA_INPUT_KEYBOARD && !ret.evt.sequence.empty()) {
-                            const int newch = ret.evt.get_first_input();
-                            if (mutation_chars.valid(newch)) {
-                                const trait_id other_mut_id = trait_by_invlet(newch);
-                                if (!other_mut_id.is_null()) {
-                                    std::swap(my_mutations[mut_id].key, my_mutations[other_mut_id].key);
-                                }
-                                else {
-                                    my_mutations[mut_id].key = newch;
-                                }
-                                pop_exit = true;
-                                pop_handled = true;
-                            }
-                        }
-                        if (!pop_handled) {
-                            if (ret.action == "QUIT") {
-                                pop_exit = true;
-                            }
-                            else if (ret.action != "HELP_KEYBINDINGS" &&
-                                ret.evt.type == CATA_INPUT_KEYBOARD) {
-                                popup(_("Invalid mutation letter.  Only those characters are valid:\n\n%s"),
-                                    mutation_chars.get_allowed_chars());
-                            }
-                        }
-                    }
-
-                    menu_mode = mutation_menu_mode::activating;
-                    examine_id = cata::nullopt;
-                    // TODO: show a message like when reassigning a key to an item?
-                    break;
-                }
-                case mutation_menu_mode::activating: {
-                    const cata::value_ptr<mut_transform> &trans = mut_data.transform;
-                        if( mut_data.activated || trans ) {
-                            if( my_mutations[mut_id].powered ) {
-                                if( trans && !trans->msg_transform.empty() ) {
-                                    add_msg_if_player( m_neutral, trans->msg_transform );
-                                } else {
-                                    add_msg_if_player( m_neutral, _( "You stop using your %s." ), mut_data.name() );
-                                }
-                                ret.cmd = power_mut_ui_cmd::Deactivate;
-                                ret.mut = mut_id;
-                                exit = true;
-                            } else if( can_use_mutation_warn( mut_id, *this ) ) {
-                                if( trans && !trans->msg_transform.empty() ) {
-                                    add_msg_if_player( m_neutral, trans->msg_transform );
-                                } else {
-                                    add_msg_if_player( m_neutral, _( "You activate your %s." ), mut_data.name() );
-                                }
-                                ret.cmd = power_mut_ui_cmd::Activate;
-                                ret.mut = mut_id;
-                                exit = true;
-                            } else {
-                                popup( _( "You feel like using your %s would kill you!" ),
-                                       mut_data.name() );
-                            }
-                    }
-                    else {
-                        popup(_("You cannot activate %s!  To read a description of "
-                            "%s, press '!', then '%c'."),
-                            mut_data.name(), mut_data.name(), my_mutations[mut_id].key);
-                    }
-                    break;
-                }
-                case mutation_menu_mode::examining:
-                    // Describing mutations, not activating them!
-                    examine_id = mut_id;
-                    break;
-                }
-                handled = true;
-            }
-            else if (mutation_chars.valid(ch)) {
-                handled = true;
-            }
-        }
-        if (!handled) {
-
-            // Essentially, up-down navigation adapted from the bionics_ui.cpp, with a bunch of extra placeholders to keep functionality
-
-            if (action == "DOWN") {
-
-                int lowerlim;
-
-                if (tab_mode == mutation_tab_mode::passive) {
-                    lowerlim = static_cast<int>(passive.size()) - 1;
-                }
-                else if (tab_mode == mutation_tab_mode::active){
-                    lowerlim = static_cast<int>(active.size()) - 1;
-                }
-                else {
-                    continue;
-                }
-
-                if (cursor < lowerlim) {
-                    cursor++;
-                }
-                else {
-                    cursor = 0;
-                }
-                if (scroll_position < max_scroll_position &&
-                    cursor - scroll_position > list_height - half_list_view_location) {
-                    scroll_position++;
-                }
-                if (scroll_position > 0 && cursor - scroll_position < half_list_view_location) {
-                    scroll_position = std::max(cursor - half_list_view_location, 0);
-                }
-
-                // Draw the description, placeholder
-                examine_id = GetTrait(active, passive, cursor, tab_mode);
-
-            }
-            else if (action == "UP") {
-
-                int lim;
-                if (tab_mode == mutation_tab_mode::passive) {
-                    lim = passive.size() - 1;
-                }
-                else if (tab_mode == mutation_tab_mode::active) {
-                    lim = active.size() - 1;
-                }
-                else {
-                    continue;
-                }
-                if (cursor > 0) {
-                    cursor--;
-                }
-                else {
-                    cursor = lim;
-                }
-                if (scroll_position > 0 && cursor - scroll_position < half_list_view_location) {
-                    scroll_position--;
-                }
-                if (scroll_position < max_scroll_position &&
-                    cursor - scroll_position > list_height - half_list_view_location) {
-                    scroll_position =
-                        std::max(std::min<int>(lim + 1 - list_height,
-                            cursor - half_list_view_location), 0);
-                }
-
-                examine_id = GetTrait(active, passive, cursor, tab_mode);
-            }
-            else if (action == "NEXT_TAB") {
-                if (tab_mode == mutation_tab_mode::active && !passive.empty()) {
-                    tab_mode = mutation_tab_mode::passive;
-                }
-                else if (tab_mode == mutation_tab_mode::passive && !active.empty()){
-                    tab_mode = mutation_tab_mode::active;
-                }
-                else {
-                    continue;
-                }
-                examine_id = GetTrait(active, passive, cursor, tab_mode);
-                scroll_position = 0;
-                cursor = 0;
-            }
-            else if (action == "PREV_TAB") {
-                if (tab_mode == mutation_tab_mode::active && !passive.empty()) {
-                    tab_mode = mutation_tab_mode::passive;
-                }
-                else if (tab_mode == mutation_tab_mode::passive && !active.empty()) {
-                    tab_mode = mutation_tab_mode::active;
-                }
-                else {
-                    continue;
-                }
-                examine_id = GetTrait(active, passive, cursor, tab_mode);
-                scroll_position = 0;
-                cursor = 0;
-            }
-            else if (action == "CONFIRM") {
-                trait_id mut_id;
-                if (tab_mode == mutation_tab_mode::active) {
-                    mut_id = active[cursor];
-                }
-                else if (tab_mode == mutation_tab_mode::passive){
-                    mut_id = passive[cursor];
-                }
-                else {
-                    continue;
-                }
-                if (!mut_id.is_null()) {
-                    const mutation_branch& mut_data = mut_id.obj();
-                    switch (menu_mode) {
+            const trait_id mut_id = trait_by_invlet( ch );
+            if( !mut_id.is_null() ) {
+                const mutation_branch &mut_data = mut_id.obj();
+                switch( menu_mode ) {
                     case mutation_menu_mode::reassigning: {
                         query_popup pop;
                         pop.message( _( "%s; enter new letter." ),
@@ -566,36 +361,29 @@ player::power_mut_ui_result player::power_mutations_ui()
                         .allow_anykey( true );
 
                         bool pop_exit = false;
-                        while (!pop_exit) {
+                        while( !pop_exit ) {
                             const query_popup::result ret = pop.query();
                             bool pop_handled = false;
                             if( ret.evt.type == CATA_INPUT_KEYBOARD && !ret.evt.sequence.empty() ) {
                                 const int newch = ret.evt.get_first_input();
-                                if (mutation_chars.valid(newch)) {
-                                    const trait_id other_mut_id = trait_by_invlet(newch);
-                                    if (!other_mut_id.is_null()) {
-                                        std::swap(my_mutations[mut_id].key, my_mutations[other_mut_id].key);
-                                    }
-                                    else {
+                                if( mutation_chars.valid( newch ) ) {
+                                    const trait_id other_mut_id = trait_by_invlet( newch );
+                                    if( !other_mut_id.is_null() ) {
+                                        std::swap( my_mutations[mut_id].key, my_mutations[other_mut_id].key );
+                                    } else {
                                         my_mutations[mut_id].key = newch;
                                     }
                                     pop_exit = true;
                                     pop_handled = true;
                                 }
-                                else if (newch == ' ') {
-                                    my_mutations[mut_id].key = newch;
-                                    pop_exit = true;
-                                    pop_handled = true;
-                                }
                             }
-                            if (!pop_handled) {
-                                if (ret.action == "QUIT") {
+                            if( !pop_handled ) {
+                                if( ret.action == "QUIT" ) {
                                     pop_exit = true;
-                                }
-                                else if (ret.action != "HELP_KEYBINDINGS" &&
-                                    ret.evt.type == CATA_INPUT_KEYBOARD) {
-                                    popup(_("Invalid mutation letter.  Only those characters are valid:\n\n%s"),
-                                        mutation_chars.get_allowed_chars());
+                                } else if( ret.action != "HELP_KEYBINDINGS" &&
+                                           ret.evt.type == CATA_INPUT_KEYBOARD ) {
+                                    popup( _( "Invalid mutation letter.  Only those characters are valid:\n\n%s" ),
+                                           mutation_chars.get_allowed_chars() );
                                 }
                             }
                         }
@@ -606,31 +394,28 @@ player::power_mut_ui_result player::power_mutations_ui()
                         break;
                     }
                     case mutation_menu_mode::activating: {
-                        if (mut_data.activated) {
-                            if (my_mutations[mut_id].powered) {
-                                add_msg_if_player(m_neutral, _("You stop using your %s."), mut_data.name());
+                        if( mut_data.activated ) {
+                            if( my_mutations[mut_id].powered ) {
+                                add_msg_if_player( m_neutral, _( "You stop using your %s." ), mut_data.name() );
 
-                                deactivate_mutation(mut_id);
+                                deactivate_mutation( mut_id );
                                 // Action done, leave screen
                                 exit = true;
-                            }
-                            else if ((!mut_data.hunger || get_kcal_percent() >= 0.8f) &&
-                                (!mut_data.thirst || get_thirst() <= 400) &&
-                                (!mut_data.fatigue || get_fatigue() <= 400)) {
-                                add_msg_if_player(m_neutral, _("You activate your %s."), mut_data.name());
+                            } else if( ( !mut_data.hunger || get_kcal_percent() >= 0.8f ) &&
+                                       ( !mut_data.thirst || get_thirst() <= 400 ) &&
+                                       ( !mut_data.fatigue || get_fatigue() <= 400 ) ) {
+                                add_msg_if_player( m_neutral, _( "You activate your %s." ), mut_data.name() );
 
-                                activate_mutation(mut_id);
+                                activate_mutation( mut_id );
                                 // Action done, leave screen
                                 exit = true;
+                            } else {
+                                popup( _( "You don't have enough in you to activate your %s!" ), mut_data.name() );
                             }
-                            else {
-                                popup(_("You don't have enough in you to activate your %s!"), mut_data.name());
-                            }
-                        }
-                        else {
-                            popup(_("You cannot activate %s!  To read a description of "
-                                "%s, press '!', then '%c'."),
-                                mut_data.name(), mut_data.name(), my_mutations[mut_id].key);
+                        } else {
+                            popup( _( "You cannot activate %s!  To read a description of "
+                                      "%s, press '!', then '%c'." ),
+                                   mut_data.name(), mut_data.name(), my_mutations[mut_id].key );
                         }
                         break;
                     }
@@ -639,18 +424,178 @@ player::power_mut_ui_result player::power_mutations_ui()
                         examine_id = mut_id;
                         break;
                 }
+                handled = true;
+            } else if( mutation_chars.valid( ch ) ) {
+                handled = true;
             }
-            else if (action == "REASSIGN") {
+        }
+        if( !handled ) {
+
+            // Essentially, up-down navigation adapted from the bionics_ui.cpp, with a bunch of extra workarounds to keep functionality
+
+            if( action == "DOWN" ) {
+
+                int lowerlim;
+
+                if( tab_mode == mutation_tab_mode::passive ) {
+                    lowerlim = static_cast<int>( passive.size() ) - 1;
+                } else if( tab_mode == mutation_tab_mode::active ) {
+                    lowerlim = static_cast<int>( active.size() ) - 1;
+                } else {
+                    continue;
+                }
+
+                if( cursor < lowerlim ) {
+                    cursor++;
+                } else {
+                    cursor = 0;
+                }
+                if( scroll_position < max_scroll_position &&
+                    cursor - scroll_position > list_height - half_list_view_location ) {
+                    scroll_position++;
+                }
+                if( scroll_position > 0 && cursor - scroll_position < half_list_view_location ) {
+                    scroll_position = std::max( cursor - half_list_view_location, 0 );
+                }
+
+                // Draw the description, shabby workaround
+                examine_id = GetTrait( active, passive, cursor, tab_mode );
+
+            } else if( action == "UP" ) {
+
+                int lim;
+                if( tab_mode == mutation_tab_mode::passive ) {
+                    lim = passive.size() - 1;
+                } else if( tab_mode == mutation_tab_mode::active ) {
+                    lim = active.size() - 1;
+                } else {
+                    continue;
+                }
+                if( cursor > 0 ) {
+                    cursor--;
+                } else {
+                    cursor = lim;
+                }
+                if( scroll_position > 0 && cursor - scroll_position < half_list_view_location ) {
+                    scroll_position--;
+                }
+                if( scroll_position < max_scroll_position &&
+                    cursor - scroll_position > list_height - half_list_view_location ) {
+                    scroll_position =
+                        std::max( std::min<int>( lim + 1 - list_height,
+                                                 cursor - half_list_view_location ), 0 );
+                }
+
+                examine_id = GetTrait( active, passive, cursor, tab_mode );
+            } else if( action == "NEXT_TAB" || "PREV_TAB" ) {
+                if( tab_mode == mutation_tab_mode::active && !passive.empty() ) {
+                    tab_mode = mutation_tab_mode::passive;
+                } else if( tab_mode == mutation_tab_mode::passive && !active.empty() ) {
+                    tab_mode = mutation_tab_mode::active;
+                } else {
+                    continue;
+                }
+                examine_id = GetTrait( active, passive, cursor, tab_mode );
+                scroll_position = 0;
+                cursor = 0;
+            } else if( action == "CONFIRM" ) {
+                trait_id mut_id;
+                if( tab_mode == mutation_tab_mode::active ) {
+                    mut_id = active[cursor];
+                } else if( tab_mode == mutation_tab_mode::passive ) {
+                    mut_id = passive[cursor];
+                } else {
+                    continue;
+                }
+                if( !mut_id.is_null() ) {
+                    const mutation_branch &mut_data = mut_id.obj();
+                    switch( menu_mode ) {
+                        case mutation_menu_mode::reassigning: {
+                            query_popup pop;
+                            pop.message( _( "%s; enter new letter." ),
+                                         mutation_branch::get_name( mut_id ) )
+                            .context( "POPUP_WAIT" )
+                            .allow_cancel( true )
+                            .allow_anykey( true );
+
+                            bool pop_exit = false;
+                            while( !pop_exit ) {
+                                const query_popup::result ret = pop.query();
+                                bool pop_handled = false;
+                                if( ret.evt.type == CATA_INPUT_KEYBOARD && !ret.evt.sequence.empty() ) {
+                                    const int newch = ret.evt.get_first_input();
+                                    if( mutation_chars.valid( newch ) ) {
+                                        const trait_id other_mut_id = trait_by_invlet( newch );
+                                        if( !other_mut_id.is_null() ) {
+                                            std::swap( my_mutations[mut_id].key, my_mutations[other_mut_id].key );
+                                        } else {
+                                            my_mutations[mut_id].key = newch;
+                                        }
+                                        pop_exit = true;
+                                        pop_handled = true;
+                                    } else if( newch == ' ' ) {
+                                        my_mutations[mut_id].key = newch;
+                                        pop_exit = true;
+                                        pop_handled = true;
+                                    }
+                                }
+                                if( !pop_handled ) {
+                                    if( ret.action == "QUIT" ) {
+                                        pop_exit = true;
+                                    } else if( ret.action != "HELP_KEYBINDINGS" &&
+                                               ret.evt.type == CATA_INPUT_KEYBOARD ) {
+                                        popup( _( "Invalid mutation letter.  Only those characters are valid:\n\n%s" ),
+                                               mutation_chars.get_allowed_chars() );
+                                    }
+                                }
+                            }
+
+                            menu_mode = mutation_menu_mode::activating;
+                            examine_id = cata::nullopt;
+                            // TODO: show a message like when reassigning a key to an item?
+                            break;
+                        }
+                        case mutation_menu_mode::activating: {
+                            if( mut_data.activated ) {
+                                if( my_mutations[mut_id].powered ) {
+                                    add_msg_if_player( m_neutral, _( "You stop using your %s." ), mut_data.name() );
+
+                                    deactivate_mutation( mut_id );
+                                    // Action done, leave screen
+                                    exit = true;
+                                } else if( ( !mut_data.hunger || get_kcal_percent() >= 0.8f ) &&
+                                           ( !mut_data.thirst || get_thirst() <= 400 ) &&
+                                           ( !mut_data.fatigue || get_fatigue() <= 400 ) ) {
+                                    add_msg_if_player( m_neutral, _( "You activate your %s." ), mut_data.name() );
+
+                                    activate_mutation( mut_id );
+                                    // Action done, leave screen
+                                    exit = true;
+                                } else {
+                                    popup( _( "You don't have enough in you to activate your %s!" ), mut_data.name() );
+                                }
+                            } else {
+                                popup( _( "You cannot activate %s!  To read a description of "
+                                          "%s, press '!', then '%c'." ),
+                                       mut_data.name(), mut_data.name(), my_mutations[mut_id].key );
+                            }
+                            break;
+                        }
+                        case mutation_menu_mode::examining:
+                            // Describing mutations, not activating them!
+                            examine_id = mut_id;
+                            break;
+                    }
+                }
+            } else if( action == "REASSIGN" ) {
                 menu_mode = mutation_menu_mode::reassigning;
                 examine_id = cata::nullopt;
-            }
-            else if (action == "TOGGLE_EXAMINE") {
+            } else if( action == "TOGGLE_EXAMINE" ) {
                 // switches between activation and examination
                 menu_mode = menu_mode == mutation_menu_mode::activating ?
-                    mutation_menu_mode::examining : mutation_menu_mode::activating;
+                            mutation_menu_mode::examining : mutation_menu_mode::activating;
                 examine_id = cata::nullopt;
             } else if( action == "QUIT" ) {
-                ret.cmd = power_mut_ui_cmd::Exit;
                 exit = true;
             }
         }

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -458,16 +458,16 @@ player::power_mut_ui_result player::power_mutations_ui()
                 int lowerlim;
 
                 if (tab_mode == mutation_tab_mode::passive) {
-                    lowerlim = passive.size() - 1;
+                    lowerlim = static_cast<int>(passive.size()) - 1;
                 }
                 else if (tab_mode == mutation_tab_mode::active){
-                    lowerlim = active.size() - 1;
+                    lowerlim = static_cast<int>(active.size()) - 1;
                 }
                 else {
                     continue;
                 }
 
-                if (static_cast<size_t>(cursor) < lowerlim) {
+                if (cursor < lowerlim) {
                     cursor++;
                 }
                 else {
@@ -518,19 +518,16 @@ player::power_mut_ui_result player::power_mutations_ui()
             else if (action == "NEXT_TAB") {
                 if (tab_mode == mutation_tab_mode::active && !passive.empty()) {
                     tab_mode = mutation_tab_mode::passive;
-                    examine_id = GetTrait(active, passive, cursor, tab_mode);
-                    scroll_position = 0;
-                    cursor = 0;
                 }
                 else if (tab_mode == mutation_tab_mode::passive && !active.empty()){
                     tab_mode = mutation_tab_mode::active;
-                    examine_id = GetTrait(active, passive, cursor, tab_mode);
-                    scroll_position = 0;
-                    cursor = 0;
                 }
                 else {
                     continue;
                 }
+                examine_id = GetTrait(active, passive, cursor, tab_mode);
+                scroll_position = 0;
+                cursor = 0;
             }
             else if (action == "PREV_TAB") {
                 if (tab_mode == mutation_tab_mode::active && !passive.empty()) {

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -24,7 +24,8 @@ enum mutation_menu_mode {
 };
 enum mutation_tab_mode {
     active,
-    passive
+    passive,
+    none
 };
 // '!' and '=' are uses as default bindings in the menu
 static const invlet_wrapper
@@ -168,7 +169,17 @@ player::power_mut_ui_result player::power_mutations_ui()
     int list_height = 0;
     int half_list_view_location = 0;
     mutation_menu_mode menu_mode = mutation_menu_mode::activating;
-    mutation_tab_mode tab_mode = mutation_tab_mode::passive;
+    mutation_tab_mode tab_mode;
+    if (!passive.empty()) {
+        tab_mode = mutation_tab_mode::passive;
+    }
+    else if (!active.empty()){
+        tab_mode = mutation_tab_mode::active;
+    }
+    else {
+        tab_mode = mutation_tab_mode::none;
+    }
+
     const auto recalc_max_scroll_position = [&]() {
         list_height = (menu_mode == mutation_menu_mode::examining ?
             DESCRIPTION_LINE_Y : HEIGHT - 1) - list_start_y;
@@ -449,8 +460,11 @@ player::power_mut_ui_result player::power_mutations_ui()
                 if (tab_mode == mutation_tab_mode::passive) {
                     lowerlim = passive.size() - 1;
                 }
-                else {
+                else if (tab_mode == mutation_tab_mode::active){
                     lowerlim = active.size() - 1;
+                }
+                else {
+                    continue;
                 }
 
                 if (static_cast<size_t>(cursor) < lowerlim) {
@@ -477,8 +491,11 @@ player::power_mut_ui_result player::power_mutations_ui()
                 if (tab_mode == mutation_tab_mode::passive) {
                     lim = passive.size() - 1;
                 }
-                else {
+                else if (tab_mode == mutation_tab_mode::active) {
                     lim = active.size() - 1;
+                }
+                else {
+                    continue;
                 }
                 if (cursor > 0) {
                     cursor--;
@@ -499,34 +516,49 @@ player::power_mut_ui_result player::power_mutations_ui()
                 examine_id = GetTrait(active, passive, cursor, tab_mode);
             }
             else if (action == "NEXT_TAB") {
-                scroll_position = 0;
-                cursor = 0;
-                if (tab_mode == mutation_tab_mode::active) {
+                if (tab_mode == mutation_tab_mode::active && !passive.empty()) {
                     tab_mode = mutation_tab_mode::passive;
+                    examine_id = GetTrait(active, passive, cursor, tab_mode);
+                    scroll_position = 0;
+                    cursor = 0;
+                }
+                else if (tab_mode == mutation_tab_mode::passive && !active.empty()){
+                    tab_mode = mutation_tab_mode::active;
+                    examine_id = GetTrait(active, passive, cursor, tab_mode);
+                    scroll_position = 0;
+                    cursor = 0;
                 }
                 else {
-                    tab_mode = mutation_tab_mode::active;
+                    continue;
                 }
-                examine_id = GetTrait(active, passive, cursor, tab_mode);
             }
             else if (action == "PREV_TAB") {
-                scroll_position = 0;
-                cursor = 0;
-                if (tab_mode == mutation_tab_mode::active) {
+                if (tab_mode == mutation_tab_mode::active && !passive.empty()) {
                     tab_mode = mutation_tab_mode::passive;
+                    examine_id = GetTrait(active, passive, cursor, tab_mode);
+                    scroll_position = 0;
+                    cursor = 0;
+                }
+                else if (tab_mode == mutation_tab_mode::passive && !active.empty()) {
+                    tab_mode = mutation_tab_mode::active;
+                    examine_id = GetTrait(active, passive, cursor, tab_mode);
+                    scroll_position = 0;
+                    cursor = 0;
                 }
                 else {
-                    tab_mode = mutation_tab_mode::active;
+                    continue;
                 }
-                examine_id = GetTrait(active, passive, cursor, tab_mode);
             }
             else if (action == "CONFIRM") {
                 trait_id mut_id;
                 if (tab_mode == mutation_tab_mode::active) {
                     mut_id = active[cursor];
                 }
-                else {
+                else if (tab_mode == mutation_tab_mode::passive){
                     mut_id = passive[cursor];
+                }
+                else {
+                    continue;
                 }
                 if (!mut_id.is_null()) {
                     const mutation_branch& mut_data = mut_id.obj();

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -532,19 +532,16 @@ player::power_mut_ui_result player::power_mutations_ui()
             else if (action == "PREV_TAB") {
                 if (tab_mode == mutation_tab_mode::active && !passive.empty()) {
                     tab_mode = mutation_tab_mode::passive;
-                    examine_id = GetTrait(active, passive, cursor, tab_mode);
-                    scroll_position = 0;
-                    cursor = 0;
                 }
                 else if (tab_mode == mutation_tab_mode::passive && !active.empty()) {
                     tab_mode = mutation_tab_mode::active;
-                    examine_id = GetTrait(active, passive, cursor, tab_mode);
-                    scroll_position = 0;
-                    cursor = 0;
                 }
                 else {
                     continue;
                 }
+                examine_id = GetTrait(active, passive, cursor, tab_mode);
+                scroll_position = 0;
+                cursor = 0;
             }
             else if (action == "CONFIRM") {
                 trait_id mut_id;


### PR DESCRIPTION
#### Summary

SUMMARY: [Interface] "Add cursor navigation to the mutations UI"

#### Purpose of change

To fix #1479

#### Describe the solution

Cherry-picked from https://github.com/CleverRaven/Cataclysm-DDA/pull/53764

#### Describe alternatives you've considered

#### Testing

Seems working fine.
![GIF 2022-4-24 18-22-46](https://user-images.githubusercontent.com/33447021/164972253-a231b395-df6a-4d3c-a568-6985debfcc4d.gif)


#### Additional context

https://github.com/CleverRaven/Cataclysm-DDA/pull/54204 is also included.
