### PR TITLE
Removed rock_pot References

### DIFF
--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_common.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_common.json
@@ -43,7 +43,7 @@
         "components": [ [ [ "2x4", 2 ] ], [ [ "wood_sheet", 1 ], [ "wood_panel", 2 ] ], [ [ "nail", 8 ] ], [ [ "rock", 80 ] ] ]
       }
     },
-    "components": [ [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ], [ [ "pan", 1 ] ] ]
+    "components": [ [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ], [ [ "pan", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -81,7 +81,7 @@
         ]
       }
     },
-    "components": [ [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ], [ [ "pan", 1 ] ] ]
+    "components": [ [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ], [ [ "pan", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/basecamps/recipe_modular_firestation1.json
+++ b/data/json/recipes/basecamps/recipe_modular_firestation1.json
@@ -195,7 +195,7 @@
         "components": [ [ [ "rock", 40 ] ] ]
       }
     },
-    "components": [ [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
+    "components": [ [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -219,7 +219,7 @@
     ],
     "blueprint_excludes": [ { "id": "fbmc_firestation1_fire" } ],
     "blueprint_resources": [ "fake_fireplace", "pot" ],
-    "components": [ [ [ "brazier", 1 ] ], [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
+    "components": [ [ [ "brazier", 1 ] ], [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -247,7 +247,7 @@
       "skills": [ [ "mechanics", 0 ], [ "fabrication", 4 ] ],
       "inline": { "tools": [  ], "qualities": [ [ { "id": "SAW_M" } ] ], "components": [ [ [ "metal_tank", 1 ] ], [ [ "pipe", 1 ] ] ] }
     },
-    "components": [ [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
+    "components": [ [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/basecamps/recipe_modular_shelter/recipe_modular_shelter_common.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter/recipe_modular_shelter_common.json
@@ -52,7 +52,7 @@
         "components": [ [ [ "2x4", 4 ] ], [ [ "wood_sheet", 1 ], [ "wood_panel", 1 ] ], [ [ "nail", 8 ] ], [ [ "rock", 40 ] ] ]
       }
     },
-    "components": [ [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
+    "components": [ [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -85,7 +85,7 @@
         "components": [ [ [ "2x4", 4 ] ], [ [ "wood_sheet", 1 ], [ "wood_panel", 1 ] ], [ [ "nail", 8 ] ] ]
       }
     },
-    "components": [ [ [ "brazier", 1 ] ], [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
+    "components": [ [ [ "brazier", 1 ] ], [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -123,7 +123,7 @@
         ]
       }
     },
-    "components": [ [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
+    "components": [ [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_common.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_common.json
@@ -52,7 +52,7 @@
         "components": [ [ [ "2x4", 4 ] ], [ [ "wood_sheet", 1 ], [ "wood_panel", 1 ] ], [ [ "nail", 8 ] ], [ [ "rock", 40 ] ] ]
       }
     },
-    "components": [ [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
+    "components": [ [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -85,7 +85,7 @@
         "components": [ [ [ "2x4", 4 ] ], [ [ "wood_sheet", 1 ], [ "wood_panel", 1 ] ], [ [ "nail", 8 ] ] ]
       }
     },
-    "components": [ [ [ "brazier", 1 ] ], [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
+    "components": [ [ [ "brazier", 1 ] ], [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -123,7 +123,7 @@
         ]
       }
     },
-    "components": [ [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
+    "components": [ [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/basecamps/recipe_modular_shelter_2/recipe_modular_shelter_2_common.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_2/recipe_modular_shelter_2_common.json
@@ -52,7 +52,7 @@
         "components": [ [ [ "2x4", 4 ] ], [ [ "nail", 8 ] ], [ [ "rock", 40 ] ], [ [ "wood_panel", 1 ], [ "wood_sheet", 1 ] ] ]
       }
     },
-    "components": [ [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
+    "components": [ [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -85,7 +85,7 @@
         "components": [ [ [ "2x4", 4 ] ], [ [ "wood_sheet", 1 ], [ "wood_panel", 1 ] ], [ [ "nail", 8 ] ] ]
       }
     },
-    "components": [ [ [ "brazier", 1 ] ], [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
+    "components": [ [ [ "brazier", 1 ] ], [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -123,7 +123,7 @@
         ]
       }
     },
-    "components": [ [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
+    "components": [ [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/basecamps/recipe_primitive_field.json
+++ b/data/json/recipes/basecamps/recipe_primitive_field.json
@@ -738,7 +738,7 @@
     "blueprint_resources": [ "fake_fireplace" ],
     "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [
-      [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ],
+      [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ],
       [ [ "log", 92 ] ],
       [ [ "stick", 48 ] ],
       [ [ "2x4", 252 ] ],
@@ -821,7 +821,7 @@
     "blueprint_requires": [ { "id": "faction_base_kitchen_3" } ],
     "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [
-      [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ],
+      [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ],
       [ [ "log", 122 ] ],
       [ [ "stick", 108 ] ],
       [ [ "2x4", 239 ] ],
@@ -871,7 +871,7 @@
     "blueprint_requires": [ { "id": "faction_base_kitchen_5" } ],
     "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "WRENCH", "level": 1 } ], [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [
-      [ [ "pot", 1 ], [ "rock_pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ],
+      [ [ "pot", 1 ], [ "pot_copper", 1 ], [ "clay_pot", 1 ] ],
       [ [ "rock", 40 ] ],
       [ [ "pipe", 42 ] ],
       [ [ "2x4", 4 ] ],


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Removed references to obsoleted item Stone Pot."

#### Purpose of change

While the stone pot is obsoleted, there are still places where it is referenced, misleading players into believing such a recipe exists. [Credit to silverwing235 on the discord for bringing this to my attention]

#### Describe the solution

Removed all remaining references to the stone pot in construction recipes.

#### Describe alternatives you've considered

... Add it back?

#### Testing

#### Additional context

Kind of telling that this hasn't been fixed in so long, we really need to look at the faction camp system at some point.