### PR TITLE
Don't animate if there is nothing to animate

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -283,7 +283,14 @@ input_context game::get_player_input( std::string &action )
             animate_weather = weather_has_anim && get_option<bool>( "ANIMATION_RAIN" );
             animate_sct = !SCT.vSCT.empty() && uquit != QUIT_WATCH && get_option<bool>( "ANIMATION_SCT" );
 
-            return animate_weather || animate_sct;
+#if defined(TILES)
+            // Always animate, minimap and terrain may have animations to run
+            return true;
+#else
+            // Otherwise we need to see if we actually should animate.
+            // Minimap and Terrain never animate in !TILES
+            return animate_weather || animate_sct || uquit == QUIT_WATCH;
+#endif
         }
         return false;
     }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -269,14 +269,28 @@ input_context game::get_player_input( std::string &action )
 
     user_turn current_turn;
 
-    if( get_option<bool>( "ANIMATIONS" ) ) {
-        weather_printable wPrint;
-        const bool weather_has_anim = init_weather_anim( get_weather().weather_id, wPrint );
 
+    // Checking early if we will need to handle animations
+    // If we do not need to handle animations that will not change as long as the user has not selected an action
+    // and we can handle it like we are not animating.
+    weather_printable wPrint;
+    bool animate_weather = false;
+    bool animate_sct = false;
+    bool do_animations = [&]() {
+        if( get_option<bool>( "ANIMATIONS" ) ) {
+            const bool weather_has_anim = init_weather_anim( get_weather().weather_id, wPrint );
+
+            animate_weather = weather_has_anim && get_option<bool>( "ANIMATION_RAIN" );
+            animate_sct = !SCT.vSCT.empty() && uquit != QUIT_WATCH && get_option<bool>( "ANIMATION_SCT" );
+
+            return animate_weather || animate_sct;
+        }
+        return false;
+    }
+    ();
+
+    if( do_animations ) {
         ctxt.set_timeout( 125 );
-
-        bool animate_weather = weather_has_anim && get_option<bool>( "ANIMATION_RAIN" );
-        bool animate_sct = !SCT.vSCT.empty() && uquit != QUIT_WATCH && get_option<bool>( "ANIMATION_SCT" );
 
         shared_ptr_fast<game::draw_callback_t> animation_cb =
         make_shared_fast<game::draw_callback_t>( [&]() {


### PR DESCRIPTION
#### Summary
SUMMARY: Performance "Do not go into animation loop if there is nothing to animate"

#### Purpose of change
When using animations the game will check for user input more quickly so that any active animations can progress. With terminal builds animations are fairly rare. This burns CPU time to do little of importance. A user reported high CPU usage with animations enabled on curses build that disappeared when disabled, even when there was no weather, SCT, nor after-life to animate.

#### Describe the solution
Check early to see if there is anything in need of animation. If there is something that requires we go into the faster animate loop do so. Otherwise treat it like animation is turned off to save some CPU time since new animations won't begin until at least after user input has been obtained.

In the case of TILES builds we will go ahead and enter animation loop anyway because there may be minimap or terrain animations to do and according to the comment these are not cached.

#### Describe alternatives you've considered
Leave it alone. For any recent CPUs the load from getting input isn't going to break anything. It's a minor problem.

#### Testing
Started character with animations off, stood still, observed CPU load for baseline.
Turned animations on with nothing around to animate, observed CPU load was similar.
Changed weather to rain, observed CPU load increase now that it has something to animate
Changed weather to clear, then got into a fight to see SCT animations, observed above baseline CPU load in small spikes
Died and watched the world move on.

Previous functionality remained.

Sent patch to reporting user to see if it helped them, it did.