### PR TITLE
Large and Huge characters and heavy weapons

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1495,7 +1495,7 @@
     "id": "MOUNTED_GUN",
     "type": "json_flag",
     "context": [  ],
-    "info": "This weapon is <bad>too unwieldy</bad> to fire on its own and <info>must be mounted</info> on a vehicle or furniture (window, table, mound of dirt, etc.) before use."
+    "info": "This weapon is <bad>too unwieldy</bad> to fire on its own and <info>must be mounted</info> on a vehicle or furniture (window, table, mound of dirt, etc.) before use, <info>Large or Huge</info> mutants can fire from the hip with <bad>reduced accuracy.</bad>"
   },
   {
     "id": "MYCUS_OK",

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -710,7 +710,7 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - ```FIRE_TWOHAND``` Gun can only be fired if player has two free hands.
 - ```IRREMOVABLE``` Makes so that the gunmod cannot be removed.
 - ```MECH_BAT```    This is an exotic battery designed to power military mechs.
-- ```MOUNTED_GUN``` Gun can only be used on terrain / furniture with the "MOUNTABLE" flag.
+- ```MOUNTED_GUN``` Gun can only be used on terrain / furniture with the "MOUNTABLE" flag, if you're a normal human.  If you're an oversized mutant (Inconveniently Large, Large, Freakishly Huge, Huge), you can fire it regularly in exchange for dispersion and recoil penalties.
 - ```NEVER_JAMS``` Never malfunctions.
 - ```NO_UNLOAD``` Cannot be unloaded.
 - ```PRIMITIVE_RANGED_WEAPON``` Allows using non-gunsmith tools to repair it (but not reinforce).

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -921,6 +921,16 @@ int player::fire_gun( const tripoint &target, const int max_shots, item &gun )
         // Now actually apply recoil for the future shots
         // But only for one shot, because bursts kinda suck
         int gun_recoil = gun.gun_recoil( can_use_bipod( g->m, pos() ) );
+
+        // If user is currently able to fire a mounted gun freely, penalize recoil based on size class.
+        if( gun.has_flag( flag_MOUNTED_GUN ) && !can_use_bipod( g->m, pos() ) ) {
+            if( get_size() == MS_HUGE ) {
+                gun_recoil = gun_recoil * 2;
+            } else {
+                gun_recoil = gun_recoil * 3;
+            }
+        }
+
         recoil += gun_recoil;
         if( is_mech_weapon ) {
             // mechs can handle recoil far better. they are built around their main gun.
@@ -1840,6 +1850,15 @@ dispersion_sources player::get_weapon_dispersion( const item &obj ) const
         // Adding dispersion for additional debuff
         dispersion.add_range( 150 );
         dispersion.add_multiplier( 4 );
+    }
+
+    // If user is currently able to fire a mounted gun freely, penalize dispersion based on size class.
+    if( obj.has_flag( flag_MOUNTED_GUN ) && !can_use_bipod( g->m, pos() ) ) {
+        if( get_size() == MS_HUGE ) {
+            dispersion.add_multiplier( 2 );
+        } else {
+            dispersion.add_multiplier( 3 );
+        }
     }
 
     return dispersion;
@@ -3635,7 +3654,7 @@ bool ranged::gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::
         const bool v_mountable = static_cast<bool>( m.veh_at( you.pos() ).part_with_feature( "MOUNTABLE",
                                  true ) );
         bool t_mountable = m.has_flag_ter_or_furn( flag_MOUNTABLE, you.pos() );
-        if( !t_mountable && !v_mountable ) {
+        if( !t_mountable && !v_mountable && !( you.get_size() > MS_MEDIUM ) ) {
             messages.push_back( string_format(
                                     _( "You must stand near acceptable terrain or furniture to fire the %s.  A table, a mound of dirt, a broken window, etc." ),
                                     gmode->tname() ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Features "Port over canceled DDA PR allowing big mutant characters to fire heavy weapons while dismounted, at penalty"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Revives an old idea that was requested I look into a while back, porting over an idea that was attempted in DDA but closed for realism reasons. Allows abnormally large mutant characters to fire heavy weapons like the M2 Browning without needing terrain, at penalties to dispersion and recoil.

Now that the game UI itself confirms that just getting Large turns a 6-foot character into 7'5" and a Huge character becomes 9'3" it's pretty clear that yes, they are expanding in all dimensions and not merely getting swole.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed the check for firing a mounted weapon in `ranged::gunmode_checks_weapon` to also allow it if the shooter is Large or Huge in size.
2. Changed the dispersion modifiers in `player::get_weapon_dispersion` to multiply dispersion if the shooter is in a state where they're firing a mounted gun dismounted. As in the source PR, Huge sized characters suffering double the dispersion. But in addition, also sets it so Large characters will suffer 3x the dispersion.
3. Changed recoil behavior in `player::fire_gun` so that recoil is doubled if a Huge character fires heavy weapons dismounted, Large characters triple the recoil.
4. Updated description of `MOUNTED_GUN` flag to allude to behavior of size changing.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making the penalty for firing while Large even harsher, like 4x. Either 3x or 4x seems okay to me.
2. Simply restricting it back down to only allowing it if you're Huge. More realistic I guess but I feel that allowing Large characters to also do so (at greater penalty) makes things more interesting, especially since Huge is fully locked behind thresholds while the Inconveniently Large isn't, meaning getting players could accept the penalties for staying at Inconveniently Large as an acceptable price to pay for having pre-thresh access to firing an M2 dismounted.
3. I could also look into also adding the ability for medium-sized characters to fire heavy weapons dismounted if they're wearing active power armor. Either at the sane penalty as Large characters, or even greater penalty.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected JSON for syntax and lint errors.
2. Compiled and load-tested.
3. Confirmed that a normal character can't fire an M2 without standing on mountable terrain.
4. Confirmed that Large and Huge characters can.
5. Edited in message printing to the dispersion and recoil functions temporarily.
6. Confirmed that modifiers for being Large and Huge were printing the expected messages, and that firing while mounted didn't print them.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR, by @Rail-Runner: https://github.com/CleverRaven/Cataclysm-DDA/pull/13173