### PR TITLE
DDA port #46243: Make ACT_FETCH_REQUIRED possible in the dark (fixes game freeze)

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2985,6 +2985,7 @@ bool generic_multi_activity_handler( player_activity &act, player &p, bool check
         // but now we are here, we check
         if( activity_to_restore != ACT_TIDY_UP &&
             activity_to_restore != ACT_MOVE_LOOT &&
+            activity_to_restore != ACT_FETCH_REQUIRED &&
             p.fine_detail_vision_mod( p.pos() ) > 4.0 ) {
             p.add_msg_if_player( m_info, _( "It is too dark to work here." ) );
             return false;


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "ACT_FETCH_REQUIRED is dark capable"

#### Purpose of change

To fix #1500 

#### Describe the solution

Found there is a similar issue in DDA https://github.com/CleverRaven/Cataclysm-DDA/issues/41220
And this is the fix https://github.com/CleverRaven/Cataclysm-DDA/pull/46243
Then cherry-pick! (though I already found the problem by my self)

#### Describe alternatives you've considered

#### Testing

No game freezes anymore after this PR.

#### Additional context
