### PR TITLE
Change highlighting for "Just for Fun" books.

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4119,8 +4119,8 @@ nc_color item::color_in_inventory() const
             ret = c_light_red;
         }
     } else if( is_book() ) {
+        const islot_book &tmp = *type->book;
         if( u.has_identified( typeId() ) ) {
-            const islot_book &tmp = *type->book;
             if( tmp.skill && // Book can improve skill: blue
                 u.get_skill_level_object( tmp.skill ).can_train() &&
                 u.get_skill_level( tmp.skill ) >= tmp.req &&
@@ -4137,8 +4137,12 @@ nc_color item::color_in_inventory() const
                            *type ) ) { // Book can't improve skill anymore, but has more recipes: yellow
                 ret = c_yellow;
             }
+        } else if( tmp.skill || type->can_use( "MA_MANUAL" ) ) {
+            // Book can teach you something and hasn't been identified yet
+            ret = c_red;
         } else {
-            ret = c_red;  // Book hasn't been identified yet: red
+            // "just for fun" book that they haven't read yet
+            ret = c_magenta;
         }
     }
     return ret;


### PR DESCRIPTION
#### Summary

SUMMARY: Interface "Change how books are highlighted to differentiate "Just for Fun" books."

#### Purpose of change

Just for Fun books being highlighted the same as skill books can be somewhat irksome to players, requiring them to either remember the titles (especially in the case of books that might otherwise seem useful, the Merck manual comes to mind.) or just walk up and (R)ead them to remove the highlight.

#### Describe the solution

Adjusted a commit from author Marloss (with a few changes) to make "Just for Fun" books appear on the inventory screen as Magenta when unread.

#### Describe alternatives you've considered

Remove the highlighting for "Just for Fun" books entirely.
- Would be a good update for utilitarian players, but arguably you could just remove all the flavour books entirely. Keeping the highlight but making it different from Skill/Recipe Books would allow players to more easily build a library without keeping a mental or physical list (which is mainly a roleplay feature admittedly.)

Add more highlighting for unread skill/recipe books.
- Would be useful if we had more colours for text, or some other way of combining the highlighting. Right now the only colour I could use that wouldn't be too garish/similar to other colours is green.

Change the highlighting from colours to some form of text.
- Would be quite helpful to the colour-blind. We may/may not want to consider this as a toggleable option of some sort.

#### Testing

Spawned in character and teleported to several different libraries/dojos/churches/cathedrals. Checked that books spawned had appropriate highlighting. Checked that the flavour books like Merck's manual were highlighted properly.

#### Additional context