### PR TITLE
Updates to Probability Travel CBM

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -813,11 +813,11 @@
     "id": "bio_probability_travel",
     "type": "bionic",
     "name": { "str": "Probability Travel" },
-    "description": "Increases your body's wavelength, allowing you to quantum tunnel through walls, reappearing on the other side.  Power drain in standby is minimal, but each tile tunneled through costs 250 bionic power.",
+    "description": "Increases your body's wavelength, allowing you to quantum tunnel through walls, reappearing on the other side.  Power drain in standby is relatively low, but each tile tunneled through costs 90 bionic power.",
     "occupied_bodyparts": [ [ "torso", 20 ], [ "arm_l", 2 ], [ "arm_r", 2 ], [ "leg_l", 3 ], [ "leg_r", 3 ], [ "foot_l", 1 ], [ "foot_r", 1 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
-    "act_cost": "3 J",
-    "react_cost": "3 J",
+    "act_cost": "500 J",
+    "react_cost": "500 J",
     "time": 1
   },
   {

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -709,7 +709,7 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Probability Travel CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "Increases the body's wavelength, allowing the user to quantum tunnel through walls, reappearing on the other side.  Power drain in standby is minimal, but each tile tunneled through costs 250 bionic power.",
+    "description": "Increases the body's wavelength, allowing the user to quantum tunnel through walls, reappearing on the other side.  Power drain in standby is relatively low, but each tile tunneled through costs 90 bionic power.",
     "price": 1400000,
     "difficulty": 11
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Probability Travel less awkward to use, gives better info on why you can't tunnel"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I was reminded once again about Probability Travel being a bit odd behavior-wise. Basically, its cost per tile traveled is pretty massive, and it has an operating cost that is so low as to not even be worth bothering with, but it is exactly enough to screw players over if they have a single mark-2 power storage filled up, and for good measure the function was written such that it bails out early without printing a message, making it hard to tell what's wrong with it.

The idea that came to mind was lower cost per tile to an amount that any amount of power storage would be able to handle a single tile of, while leaving enough power left over to justify bumping up the operating cost. That way it's actually more sensible to turn it on in an "oh shit" situation and discourages leaving it off when not in use, instead of the high tunneling cost and negligible running cost instead meaning that not already having it on before you first get into trouble is a lethal mistake.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Reduced the power cost per tile tunneled through to 90 kJ. Rationale was this makes it so with a single level of power storage being at full power gives you a modest bit of time to reach a wall.
2. Moved the check that bails out early to a separate if function so it can print a message informing you you don't have enough power. The previous check lacked a message presumably because it could hypothetically trigger if you don't even have Probability Travel, if I'm reading it right.
3. Tweaked the dimensional anchor message to better imply the anchor is to blame.
4. Moved the "oops we can't go that far, not enough power" check until after the tunnel distance has been determined. This lets the failure message tell you how much energy you would've needed, or outright tell you if your power capacity isn't enough for it.
5. Per Kheir's suggestion, phasing through more than one tile at a time increases moves taken out afterward, up to a max of 5 seconds.
6. Updated the act and react cost of Probability Travel to 500 joules, so that it actually costs enough to dissuade leaving it on all day.
7. Updated bionic's description.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Having base cost be 200 and just making sure to inform the player that a single Mk 1 power cell won't cut it.
2. Alternatively, setting it to exactly 100 or exactly 250 and removing the operating cost entirely. This would remove deaths from "oh shit" usage but also mean you'd have zero reason to not leave it on 24/7.
3. I went with keeping the 90 kJ punishment for failing to tunnel due to a dimensional anchor or too much thickness, but could be removed if requested.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested.
2. Checked affected JSON for syntax and lint errors.
3. Ran game.cpp through Astyle.
4. Tested bumping into walls with no bionics.
5. Tested bumping into walls with the bionic installed but inactive.
6. Tested walking around and phasing through walls, and what happens once you lack enough power.
7. Tested trying to go through a thick barrier without enough power, and one past the limit.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
