### PR TITLE
Update Repair Nanobots

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1592,7 +1592,12 @@ void Character::process_bionic( int b )
         // The above hack means there's no check for whether the bionic actually has power to run.
         if( get_power_level() < bio.info().power_over_time ) {
             bio.powered = false;
-            add_msg_if_player( m_neutral, _( "Your %s powers down." ), bio.info().name );
+            add_msg_if_player( m_warning, _( "Your %s shut down due to lack of power." ), bio.info().name );
+            deactivate_bionic( b );
+            return;
+        } else if( get_stored_kcal() < 0.85f * max_stored_kcal() ) {
+            bio.powered = false;
+            add_msg_if_player( m_warning, _( "Your %s shut down to conserve calories." ), bio.info().name );
             deactivate_bionic( b );
             return;
         }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfix "Repair Nanobots no longer has the ability to starve you to death in your sleep."

#### Purpose of change

A follow up to my original change to the PR. Since it's now considered "Sleep Friendly" it needs to _actually_ be sleep friendly. Starving you to death in your sleep is the _exact opposite_ of that.

Granted this is an edge case where you go to sleep both hungry and heavily injured, but it should still be considered.

#### Describe the solution

Adjusted the Repair Nanobots to automatically disable if you have less than 85% of your max calories.

#### Describe alternatives you've considered

Have the Repair Nanobots not heal when under 85% max calories, but don't disable.
- I kind of like this idea considering how the Repair Nanobots currently function, I have a draft implementation of this where it only runs the checks when calories are above 85%, printing a message every minute if you don't have enough calories, but I'm not sure if this might be annoying (Do we have something that checks if the character is asleep?).

#### Testing

Spawned in character and installed Repair Nanobots, checked that healing occurred while Calories above requirement, and shut off when below requirement, printing a message.

#### Additional context

I also refined the message it gives when it has no power and shuts off.