### PR TITLE
Consistency updates for bandoliers

### DIFF
--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -169,7 +169,7 @@
     "material_thickness": 1,
     "use_action": {
       "type": "bandolier",
-      "capacity": 10,
+      "capacity": 6,
       "ammo": [
         "22",
         "223",

--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -18,7 +18,7 @@
     "material_thickness": 1,
     "use_action": {
       "type": "bandolier",
-      "capacity": 18,
+      "capacity": 40,
       "ammo": [
         "32",
         "762x25",
@@ -63,7 +63,7 @@
     "material_thickness": 1,
     "use_action": {
       "type": "bandolier",
-      "capacity": 16,
+      "capacity": 25,
       "ammo": [
         "22",
         "223",
@@ -144,7 +144,7 @@
     "material_thickness": 1,
     "use_action": {
       "type": "bandolier",
-      "capacity": 14,
+      "capacity": 20,
       "ammo": [ "flintlock", "36paper", "44paper", "blunderbuss", "shotcanister", "shotpaper" ],
       "draw_cost": 20
     },
@@ -169,7 +169,7 @@
     "material_thickness": 1,
     "use_action": {
       "type": "bandolier",
-      "capacity": 4,
+      "capacity": 10,
       "ammo": [
         "22",
         "223",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -128,13 +128,13 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "flintlock_pouch_reenactor",
-    "entries": [ { "item": "flintlock_ammo", "charges": 14 } ]
+    "entries": [ { "item": "flintlock_ammo", "charges": 20 } ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "bandolier_ww_gunslinger",
-    "entries": [ { "item": "45colt_jhp", "charges": 18 } ]
+    "entries": [ { "item": "45colt_jhp", "charges": 34 } ]
   },
   {
     "type": "profession_item_substitutions",
@@ -3330,7 +3330,7 @@
         "entries": [
           { "item": "rifle_flintlock", "ammo-item": "flintlock_ammo", "charges": 1, "contents-item": "shoulder_strap" },
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_reenactor" },
-          { "item": "flintlock_ammo", "charges": 15 },
+          { "item": "flintlock_ammo", "charges": 9 },
           { "item": "vinegar", "container-item": "bottle_plastic_small" },
           { "item": "lamp_oil", "container-item": "bottle_plastic_small" }
         ]
@@ -3395,7 +3395,7 @@
         "entries": [
           { "item": "rifle_flintlock", "ammo-item": "flintlock_ammo", "charges": 1, "contents-item": "shoulder_strap" },
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_reenactor" },
-          { "item": "flintlock_ammo", "charges": 15 },
+          { "item": "flintlock_ammo", "charges": 9 },
           { "item": "vinegar", "container-item": "bottle_plastic_small" },
           { "item": "lamp_oil", "container-item": "bottle_plastic_small" }
         ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Rebalance bandolier capacity for consistency relative to shotgun bandoliers, based off average volume of ammo used"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Bandoliers are in a bit of a weird niche, their intended main advantage is a reduction in reload time, but with it being 0.8 seconds faster on average that tends to be moot compared to being able to carry extra ammo. I personally feel that these two advantages aren't that great on their own, but are perfectly fine when combined, enough to make for a solid balance against their primary drawback of giving up a fairly valuable torso slot.

For shotgun bandoliers the numbers check out just about right I feel, but the problem is pistol and rifle bandoliers, which hold less of ammo that tends to be smaller than what the player will likely be filling shotgun bandoliers. Moreover, most of these ammo types, especially in the case of pistol ammo, will usually be less damaging than shotshells, so a bandolier's worth of shotshells will already last you longer in a fight than the other bandolier types.

While adjusting reload and draw speed mechanics would be a good long-term solution to making bandoliers more useful for their "main" job of drawing ammo faster, and I don't feel that simply removing them is the best solution either, I feel that it'd fit its current niche (two minor benefits that combined become worth occupying waist or wrist slots) better if the bandoliers for ammo that tends to be smaller and lighter held enough to be worth it relative to the shotgun bandolier at minimum. This is also something that can be hashed out easily without code changes, and would likely be something I'd do anyway alongside a draw cost code change because it's still a major inconsistency.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

There are many ways to potentially determine how much more valuable storage space for each ammo type was, but for this I decided to go with consistency based on the averaged volume of all ammo types usable in a given bandolier, and that would be:

Type | Average volume per round
--- | ---
Pistol | 8 mL
Rifle | 14 mL
Shot | 14 mL

Flintlock was an exception however, its average is 30 mL per shot because blunderbuss rounds are 100 mL per shot, twice that of .700 NX (rifle bandolier's biggest ammo) and four times that of .500 Magnum (pistol bandolier's biggest ammo option). The much lower range of ammotypes also makes its impact that much more disproportionate compared to how the biggest ammo. Ignoring this outlying value instead gives an average of 17.5 mL.

1. Increased capacity of pistol bandolier from 18 to 40 rounds, a few under the 43.5 the above ratio would yield.
2. Increased capacity of rifle bandolier from 16 to 25 rounds, equal to that of shotgun bandolier.
3. Increased capacity of wrist bandolier from 4 to 6 rounds, keeping it ~25% of the rifle bandolier as before.
4. Increased capacity of flintlock pouch from 14 to 20 rounds, in line with the 17.5 mL figure above.
5. Updated professions, moving some of the loose ammo in the reenactor professions to their pouch. Rifle hunter was left untouched because a stack of .270 Winchester is still only 20 rounds, which is why they had no loose ammo to spare (in fact, I'm 90% sure the 16 round capacity was arbitrarily chosen just to allow rifle hunters to hold exactly 1 stack in their gun and bandolier).
6. Gunslinger profession given an actual stack's worth of .45 Colt (40 rounds), 6 in their gun and 34 in their bandolier, for consistency with the above.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Grenade and stone pouches in comparision are a lot harder to balance and were left untouched for now. The former because the values again have a massive disparity but they come out to an average that would justify bumping its ammo capacity up by 1 which is barely a tweak, plus it varies IMMENSELY (arguably far more than any other bandolier type) just how useful those rounds are relative to what other bandoliers can carry. The latter meanwhile because rocks are massive but also easy to scavenge, but also furthermore their damage is pistol-tier. The fact they're belted slot is honestly more tempting to change than their capacity, giving up a backpack for 10 rocks is a bit wacky.

The generic ammo pouch is in a weird position. As a "crappy item that holds a fuckton of ammo" niche it's good, but whereas encumbrance isn't enough of an issue to need any substantial tweaks for bandoliers, 5-11 encumbrance is a lot. 60 of even the biggest ammo you could expect to hold in it won't even really make a dent in your encumbrance in a generic backpack, but it does make up for it by being able to hold some wacky ammo options nothing else can. But on the other hand, it also lacks the ability to hold some things other bandolier-type items can, like blunderbuss rounds.

Other schemes for consistency include:
1. Basing it off a reasonable example of the most common ammo you're likely to carry. That would make pistol bandoliers hold 70 rounds (9x19mm, 5 mL), rifle bandoliers 55-60 rounds (5.56x45mm, 6 mL), and no change for flintlock pouches (paper cartridge, 25 mL).
2. Shaving off the single biggest ammo type for pistol and rifle cartridges, as done with flintlock pouches. This changes far less than what not counting blunderbuss rounds does, to be honest.
3. Instead maintaining the same ratios of ammo capacity except inverted the other way around and shuffled as needed, i.e. multiplying 25 by 25/14, 25,16, 25/18 would give us amounts of roughly 45, 40, and 35 to assign as desired.
4. Saying "fuck it" and just making them all multiples of 15.

Other possible ideas:
1. Making raw cost tend towards zero to make its other main advantage more useful too. 20 centiseconds is infinitely more trivial than "I can't carry anywhere near as many rifle rounds as shotshells" though.
2. Just making (or making a mod for) bandoliers not even counting as being worn on any slot at all, so the player can wear up to 3 of every type without caring about the encumbrance penalties at all.
4. Importing over the hat bandolier idea from Cataclysm++, with or without survivor cowboy hats coming along for the ride.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and load errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

![image](https://user-images.githubusercontent.com/11582235/166841682-5ae2bcdf-11b1-44c8-8b7d-b6a21325e14a.png)