### PR TITLE
Make felt patches from wool staples less of a chore.

### DIFF
--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -7,9 +7,9 @@
     "skill_used": "fabrication",
     "skills_required": [ "tailor", 1 ],
     "difficulty": 1,
-    "time": "15 m",
+    "time": "5 m",
     "autolearn": true,
-    "components": [ [ [ "soap", 5 ] ], [ [ "water_clean", 3 ] ], [ [ "wool_staple", 1 ] ] ]
+    "components": [ [ [ "wool_staple", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary

SUMMARY: Balance "Make felt patches from wool staples less of a chore."
#### Purpose of change
Felt patches are easy to get. Wool is not a very rare resources to get. Making felt patches out of wool staples is a very taxing affair. It took 3 clean water (not normal one), and 5(!) soap charges (no detergent) to make just ONE felt patch, PER 15 MINUTES. It is easier to find a wool clothing than a sheep.

#### Describe the solution

get rid of the insane requirements, just make felt patches out of the staples without any other object.

#### Testing
![image](https://user-images.githubusercontent.com/33199510/166917567-97e1b11e-bdef-49b8-8ff0-ff96c56e0d22.png)
