### PR TITLE
Overhauling Specific Use Storage, part 4

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -3372,7 +3372,7 @@
     ]
   },
   {
-    "id": "wardrode_sporting_misc",
+    "id": "wardrobe_sporting_misc",
     "type": "item_group",
     "//": "Assorted clothing or other wearable items for domestic wardrobes, outdoors and sporting good items.",
     "subtype": "distribution",

--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -3347,5 +3347,50 @@
       { "item": "ring_signet", "prob": 30 },
       { "item": "tie_skinny", "prob": 20 }
     ]
+  },
+  {
+    "id": "wardrode_sporting_misc",
+    "type": "item_group",
+    "//": "Assorted clothing or other wearable items for domestic wardrobes, outdoors and sporting good items.",
+    "subtype": "distribution",
+    "items": [
+      {
+        "distribution": [
+          { "item": "bandolier_pistol", "prob": 10 },
+          { "item": "bandolier_rifle", "prob": 20 },
+          { "item": "bandolier_shotgun", "prob": 10 },
+          { "item": "bandolier_wrist", "prob": 5 },
+          { "item": "quiver", "prob": 30 },
+          { "item": "quiver_large", "prob": 20 },
+          { "item": "torso_bandolier_shotgun", "prob": 5 }
+        ],
+        "prob": 25
+      },
+      {
+        "distribution": [
+          { "item": "fishing_waders", "prob": 25 },
+          { "item": "flotation_vest", "prob": 20 },
+          { "item": "sleeping_bag", "prob": 25 },
+          { "item": "sleeping_bag_roll", "prob": 25 },
+          { "item": "wetsuit", "prob": 5 }
+        ],
+        "prob": 25
+      },
+      {
+        "distribution": [
+          { "item": "armguard_hard", "prob": 5 },
+          { "item": "boxing_gloves", "prob": 20 },
+          { "item": "chestguard_hard", "prob": 5 },
+          { "item": "fencing_jacket", "prob": 5 },
+          { "item": "fencing_mask", "prob": 10 },
+          { "item": "fencing_pants", "prob": 5 },
+          { "item": "football_armor", "prob": 10 },
+          { "item": "golf_bag", "prob": 10 },
+          { "item": "helmet_football", "prob": 20 },
+          { "item": "legguard_hard", "prob": 10 }
+        ],
+        "prob": 50
+      }
+    ]
   }
 ]

--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -3262,13 +3262,16 @@
     "//": "clothing designed to hold a small weapon worn by people.",
     "subtype": "distribution",
     "items": [
-      { "item": "bootstrap", "prob": 20 },
-      { "item": "bootsheath", "prob": 50 },
-      { "item": "sheath", "prob": 80 },
-      { "item": "back_holster", "prob": 10 },
-      { "item": "holster", "prob": 30 },
-      { "item": "sholster", "prob": 10 },
-      { "item": "bholster", "prob": 10 }
+      { "item": "back_holster", "prob": 5 },
+      { "item": "bholster", "prob": 10 },
+      { "item": "bootsheath", "prob": 10 },
+      { "item": "bootstrap", "prob": 5 },
+      { "item": "bow_sling", "prob": 5 },
+      { "item": "bscabbard", "prob": 5 },
+      { "item": "holster", "prob": 20 },
+      { "item": "scabbard", "prob": 10 },
+      { "item": "sheath", "prob": 25 },
+      { "item": "sholster", "prob": 5 }
     ]
   },
   {
@@ -3294,23 +3297,43 @@
     "items": [
       { "group": "clothing_glasses", "prob": 10 },
       { "group": "clothing_watch", "prob": 10 },
-      { "group": "accessory_ring", "prob": 15 },
-      { "group": "accessory_earring" },
-      { "group": "accessory_bracelet", "prob": 15 },
-      { "group": "accessory_teeth", "prob": 15 },
-      { "group": "accessory_necklace", "prob": 15 },
-      { "group": "accessory_cat", "prob": 15 },
-      { "group": "accessory_weaponcarry", "prob": 15 },
-      { "group": "accessory_sportsgear", "prob": 15 },
-      { "item": "folding_poncho", "prob": 10 },
-      { "item": "american_flag", "prob": 2 },
-      { "item": "tool_belt", "prob": 10 },
-      { "item": "leather_belt", "prob": 60 },
-      { "item": "wearable_light", "prob": 30 },
-      { "item": "binoculars", "prob": 10 },
-      { "item": "whistle", "prob": 30 },
-      { "item": "harmonica_holder", "prob": 10 },
-      { "group": "flask_liquor", "prob": 10 }
+      {
+        "distribution": [
+          { "group": "accessory_bracelet", "prob": 20 },
+          { "group": "accessory_earring", "prob": 20 },
+          { "group": "accessory_necklace", "prob": 20 },
+          { "group": "accessory_ring", "prob": 30 },
+          { "group": "accessory_teeth", "prob": 10 }
+        ],
+        "prob": 25
+      },
+      {
+        "distribution": [ { "group": "accessory_sportsgear", "prob": 50 }, { "group": "accessory_weaponcarry", "prob": 50 } ],
+        "prob": 25
+      },
+      {
+        "distribution": [
+          { "group": "accessory_cat", "prob": 10 },
+          { "item": "folding_poncho", "prob": 10 },
+          { "item": "american_flag", "prob": 10 },
+          { "item": "tool_belt", "prob": 10 },
+          { "item": "leather_belt", "prob": 20 },
+          { "item": "wearable_light", "prob": 15 },
+          { "item": "binoculars", "prob": 5 },
+          { "item": "whistle", "prob": 5 },
+          { "item": "harmonica_holder", "prob": 5 },
+          { "group": "flask_liquor", "prob": 10 }
+        ],
+        "prob": 10
+      },
+      {
+        "distribution": [
+          { "group": "everyday_gear", "prob": 75 },
+          { "group": "ammo_common", "prob": 15 },
+          { "item": "condom", "prob": 10, "count": [ 1, 5 ] }
+        ],
+        "prob": 20
+      }
     ]
   },
   {

--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -3293,7 +3293,7 @@
     "id": "accesories_personal_unisex",
     "type": "item_group",
     "//": "unisex personal accessories",
-    "subtype": "collection",
+    "subtype": "distribution",
     "items": [
       { "group": "clothing_glasses", "prob": 10 },
       { "group": "clothing_watch", "prob": 10 },

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -411,19 +411,14 @@
     "//": "clothing found in a man's wardrobe",
     "subtype": "collection",
     "entries": [
-      { "group": "shoes_unisex", "prob": 50 },
-      { "item": "fishing_waders", "prob": 3 },
-      { "item": "kilt", "prob": 10 },
-      { "item": "football_armor", "prob": 10 },
-      { "item": "sleeping_bag", "prob": 10 },
-      { "item": "sleeping_bag_roll", "prob": 10 },
-      { "item": "bscabbard", "prob": 5 },
-      { "item": "kilt_leather", "prob": 5 },
-      { "item": "chaps_leather", "prob": 5 },
+      { "group": "bags_unisex", "prob": 20 },
       { "group": "coats_unisex", "prob": 50 },
-      { "group": "suits_unisex", "prob": 30 },
-      { "group": "suits_mens", "prob": 30 },
-      { "group": "bags_unisex", "prob": 20 }
+      { "group": "shoes_unisex", "prob": 50 },
+      {
+        "distribution": [ { "group": "suits_mens", "prob": 75 }, { "group": "suits_unisex", "prob": 25 } ],
+        "prob": 25
+      },
+      { "group": "wardrode_sporting_misc", "prob": 50 }
     ]
   },
   {
@@ -432,20 +427,17 @@
     "//": "clothing found in a woman's wardrobe",
     "subtype": "collection",
     "entries": [
-      { "group": "shoes_unisex", "prob": 50 },
-      { "group": "shoes_womens", "prob": 60 },
-      { "item": "fishing_waders", "prob": 2 },
-      { "item": "football_armor", "prob": 5 },
-      { "item": "skirt", "prob": 20 },
-      { "item": "skirt_leather", "prob": 10 },
-      { "item": "bscabbard", "prob": 3 },
-      { "item": "sleeping_bag", "prob": 10 },
-      { "item": "sleeping_bag_roll", "prob": 10 },
-      { "item": "chaps_leather", "prob": 5 },
+      { "group": "bags_unisex", "prob": 20 },
       { "group": "coats_unisex", "prob": 50 },
-      { "group": "suits_unisex", "prob": 30 },
-      { "group": "suits_womens", "prob": 40 },
-      { "group": "bags_unisex", "prob": 20 }
+      {
+        "distribution": [ { "group": "shoes_womens", "prob": 10 }, { "group": "shoes_unisex", "prob": 90 } ],
+        "prob": 50
+      },
+      {
+        "distribution": [ { "group": "suits_womens", "prob": 75 }, { "group": "suits_unisex", "prob": 25 } ],
+        "prob": 25
+      },
+      { "group": "wardrode_sporting_misc", "prob": 50 }
     ]
   },
   {
@@ -454,17 +446,23 @@
     "//": "clothing found in a man's dresser",
     "subtype": "collection",
     "entries": [
-      { "group": "accesories_personal_unisex", "prob": 10 },
-      { "group": "accesories_personal_mens", "prob": 10 },
+      {
+        "distribution": [ { "group": "accesories_personal_mens", "prob": 50 }, { "group": "accesories_personal_unisex", "prob": 50 } ],
+        "prob": 10
+      },
+      { "group": "gloves_unisex", "prob": 20 },
       { "group": "masks_unisex", "prob": 5 },
-      { "group": "socks_unisex", "prob": 70 },
+      {
+        "distribution": [ { "group": "pants_mens", "prob": 5 }, { "group": "pants_unisex", "prob": 95 } ],
+        "prob": 50
+      },
       { "group": "scarfs_unisex", "prob": 20 },
       { "group": "shirts_unisex", "prob": 50 },
-      { "group": "underwear_mens", "prob": 80 },
-      { "group": "underwear_unisex", "prob": 80 },
-      { "group": "pants_unisex", "prob": 50 },
-      { "group": "pants_mens", "prob": 60 },
-      { "group": "gloves_unisex", "prob": 20 }
+      { "group": "socks_unisex", "prob": 70 },
+      {
+        "distribution": [ { "group": "underwear_mens", "prob": 50 }, { "group": "underwear_unisex", "prob": 50 } ],
+        "prob": 75
+      }
     ]
   },
   {
@@ -473,19 +471,29 @@
     "//": "clothing found in a woman's dresser",
     "subtype": "collection",
     "entries": [
-      { "group": "accesories_personal_unisex", "prob": 30 },
-      { "group": "accesories_personal_womens", "prob": 5 },
+      {
+        "distribution": [ { "group": "accesories_personal_womens", "prob": 50 }, { "group": "accesories_personal_unisex", "prob": 50 } ],
+        "prob": 10
+      },
+      {
+        "distribution": [ { "group": "gloves_womens", "prob": 5 }, { "group": "gloves_unisex", "prob": 95 } ],
+        "prob": 20
+      },
       { "group": "masks_unisex", "prob": 5 },
+      {
+        "distribution": [ { "group": "pants_womens", "prob": 25 }, { "group": "pants_unisex", "prob": 75 } ],
+        "prob": 50
+      },
+      { "group": "scarfs_unisex", "prob": 20 },
+      {
+        "distribution": [ { "group": "shirts_womens", "prob": 5 }, { "group": "shirts_unisex", "prob": 95 } ],
+        "prob": 50
+      },
       { "group": "socks_unisex", "prob": 70 },
-      { "group": "scarfs_unisex", "prob": 10 },
-      { "group": "shirts_womens", "prob": 60 },
-      { "group": "shirts_unisex", "prob": 50 },
-      { "group": "underwear_womens", "prob": 80 },
-      { "group": "underwear_unisex", "prob": 80 },
-      { "group": "pants_unisex", "prob": 50 },
-      { "group": "pants_womens", "prob": 60 },
-      { "group": "gloves_womens", "prob": 5 },
-      { "group": "gloves_unisex", "prob": 30 }
+      {
+        "distribution": [ { "group": "underwear_womens", "prob": 50 }, { "group": "underwear_unisex", "prob": 50 } ],
+        "prob": 75
+      }
     ]
   }
 ]

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -418,7 +418,7 @@
         "distribution": [ { "group": "suits_mens", "prob": 75 }, { "group": "suits_unisex", "prob": 25 } ],
         "prob": 25
       },
-      { "group": "wardrode_sporting_misc", "prob": 50 }
+      { "group": "wardrobe_sporting_misc", "prob": 50 }
     ]
   },
   {
@@ -437,7 +437,7 @@
         "distribution": [ { "group": "suits_womens", "prob": 75 }, { "group": "suits_unisex", "prob": 25 } ],
         "prob": 25
       },
-      { "group": "wardrode_sporting_misc", "prob": 50 }
+      { "group": "wardrobe_sporting_misc", "prob": 50 }
     ]
   },
   {

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -447,8 +447,8 @@
     "subtype": "collection",
     "entries": [
       {
-        "distribution": [ { "group": "accesories_personal_mens", "prob": 50 }, { "group": "accesories_personal_unisex", "prob": 50 } ],
-        "prob": 10
+        "distribution": [ { "group": "accesories_personal_mens", "prob": 10 }, { "group": "accesories_personal_unisex", "prob": 90 } ],
+        "prob": 50, "count": [ 1, 3 ]
       },
       { "group": "gloves_unisex", "prob": 20 },
       { "group": "masks_unisex", "prob": 5 },
@@ -472,8 +472,8 @@
     "subtype": "collection",
     "entries": [
       {
-        "distribution": [ { "group": "accesories_personal_womens", "prob": 50 }, { "group": "accesories_personal_unisex", "prob": 50 } ],
-        "prob": 10
+        "distribution": [ { "group": "accesories_personal_womens", "prob": 10 }, { "group": "accesories_personal_unisex", "prob": 90 } ],
+        "prob": 50, "count": [ 1, 3 ]
       },
       {
         "distribution": [ { "group": "gloves_womens", "prob": 5 }, { "group": "gloves_unisex", "prob": 95 } ],

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -446,11 +446,8 @@
     "//": "clothing found in a man's dresser",
     "subtype": "collection",
     "entries": [
-      {
-        "distribution": [ { "group": "accesories_personal_mens", "prob": 10 }, { "group": "accesories_personal_unisex", "prob": 90 } ],
-        "prob": 50,
-        "count": [ 1, 3 ]
-      },
+      { "group": "accesories_personal_unisex", "prob": 50, "count": [ 1, 3 ] },
+      { "group": "accesories_personal_mens", "prob": 10 },
       { "group": "gloves_unisex", "prob": 20 },
       { "group": "masks_unisex", "prob": 5 },
       {
@@ -472,11 +469,8 @@
     "//": "clothing found in a woman's dresser",
     "subtype": "collection",
     "entries": [
-      {
-        "distribution": [ { "group": "accesories_personal_womens", "prob": 10 }, { "group": "accesories_personal_unisex", "prob": 90 } ],
-        "prob": 50,
-        "count": [ 1, 3 ]
-      },
+      { "group": "accesories_personal_unisex", "prob": 50, "count": [ 1, 3 ] },
+      { "group": "accesories_personal_womens", "prob": 10 },
       {
         "distribution": [ { "group": "gloves_womens", "prob": 5 }, { "group": "gloves_unisex", "prob": 95 } ],
         "prob": 20

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -448,7 +448,8 @@
     "entries": [
       {
         "distribution": [ { "group": "accesories_personal_mens", "prob": 10 }, { "group": "accesories_personal_unisex", "prob": 90 } ],
-        "prob": 50, "count": [ 1, 3 ]
+        "prob": 50,
+        "count": [ 1, 3 ]
       },
       { "group": "gloves_unisex", "prob": 20 },
       { "group": "masks_unisex", "prob": 5 },
@@ -473,7 +474,8 @@
     "entries": [
       {
         "distribution": [ { "group": "accesories_personal_womens", "prob": 10 }, { "group": "accesories_personal_unisex", "prob": 90 } ],
-        "prob": 50, "count": [ 1, 3 ]
+        "prob": 50,
+        "count": [ 1, 3 ]
       },
       {
         "distribution": [ { "group": "gloves_womens", "prob": 5 }, { "group": "gloves_unisex", "prob": 95 } ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Update Specific Use Storage, dressers and wardrobes"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Part four of overhauling the Specific Use Storage itemgroups. Per discussion on the BN discord, I was reminded that the dresser spawns of the SUS itemgroups were also on the list to be fixed up. As usual it leaned towards massive spawns of relatively identical items, often disproportionately spawning some of the exact same few items, most famously hilarious amounts of kilts.

Part of it is because itemgroups for men-only and women-only items (kilts vs skirts for example) were called about as often as unisex clothing spawns, and since the former has way lower variety of items that meant they'd show up a lot more than expected.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Reworked the dresser itemgroups. Mainly, merge calls for unisex vs. gendered clothing into a single either-or instead of trying to roll to spawn both, and skew the relative weights of unisex vs. gendered items based on how little stuff is in the latter. For example, it'll pick `pants_unisex` over `pants_mens` 95% of the time because `pants_mens` only has kilts in it, `gloves_womens` shows up less often because its only contents are the opera gloves, etc.
2. Also reworked the wardrobe itemgroups. In addition to merging unisex vs. gendered clothing spawns as above, it also does away with the mix of extra random stuff in favor of a new itemgroup for that, `wardrode_sporting_misc`. This is used to spawn the sleeping bags, chaps, football armor etc. Its variety has also been expanded a bit, divided up into hunting gear (quivers and bandoliers), outdoors sporting goods clothing (i.e. camping, fishing, etc), and general sports equipment, focusing on stuff not injected into other dresser/wardrobe clothing itemgroups.
3. Also reworked how accessories spawn to spawn extras less often, but with a better variety of them.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Could look at other dresser itemgroups to see if anything notable is missing.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Load-tested to grab an example item group test.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Example, mens' dresser itemgroup, before:
![dresser_men, before](https://user-images.githubusercontent.com/11582235/167229733-abc839b8-523a-43f1-96da-6d6fa7c3d2b6.png)

Example, mens' dresser itemgroup, after:
![image](https://user-images.githubusercontent.com/11582235/167232668-98372e0d-354e-4b30-98ac-cded2b933a22.png)