### PR TITLE
Fix oddities with generic cooked offal

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -279,7 +279,7 @@
     "type": "COMESTIBLE",
     "name": "raw mutant offal",
     "looks_like": "offal",
-    "description": "Unidentified organs of a mutated animal.  Wildly different between individual specimens, even those otherwise identical.  Many resemble unmutated organs on the outside, but their placement often clearly implies different function.  Weirdly colored fluids and the chemical smell make them unappetizing.",
+    "description": "Unidentified organs of a mutated animal.  Wildly different between individual specimens, even those otherwise identical.  Many resemble unmutated organs on the outside, but their placement often clearly implies different function.  Weirdly colored fluids and the chemical smell make them unappetizing.  Probably much better fried.",
     "price_postapoc": 5,
     "delete": { "flags": [ "SMOKABLE" ] },
     "vitamins": [
@@ -291,17 +291,6 @@
       [ "iron", 4 ],
       [ "mutant_toxin", 50 ]
     ]
-  },
-  {
-    "id": "mutant_offal_cooked",
-    "copy-from": "mutant_offal",
-    "type": "COMESTIBLE",
-    "name": { "str_sp": "cooked mutant offal" },
-    "looks_like": "offal",
-    "description": "Cooked mutant organs.  Color and smell are almost normal, but it still looks weird.",
-    "parasites": 0,
-    "fun": -5,
-    "flags": [ "EATEN_HOT" ]
   },
   {
     "id": "stomach",

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -242,18 +242,6 @@
     "relative": { "vitamins": [ [ "vitA", 5 ], [ "iron", 4 ] ], "fun": -5 }
   },
   {
-    "id": "offal_cooked",
-    "copy-from": "offal",
-    "type": "COMESTIBLE",
-    "name": { "str_sp": "cooked offal" },
-    "description": "This is freshly cooked organ meat and entrails.  It's filled with essential vitamins, but most people consider it a bit gross unless very carefully prepared.",
-    "parasites": 0,
-    "healthy": 1,
-    "price_postapoc": 50,
-    "fun": -5,
-    "flags": [ "EATEN_HOT" ]
-  },
-  {
     "id": "offal_pickled",
     "copy-from": "offal",
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -279,7 +279,7 @@
     "type": "COMESTIBLE",
     "name": "raw mutant offal",
     "looks_like": "offal",
-    "description": "Unidentified organs of a mutated animal.  Wildly different between individual specimens, even those otherwise identical.  Many resemble unmutated organs on the outside, but their placement often clearly implies different function.  Weirdly colored fluids and the chemical smell make them unappetizing.  Probably much better fried.",
+    "description": "Unidentified organs of a mutated animal.  Wildly different between individual specimens, even those otherwise identical.  Many resemble unmutated organs on the outside, but their placement often clearly implies different function.  Weirdly colored fluids and the chemical smell make them unappetizing.",
     "price_postapoc": 5,
     "delete": { "flags": [ "SMOKABLE" ] },
     "vitamins": [

--- a/data/json/items/comestibles/offal_dishes.json
+++ b/data/json/items/comestibles/offal_dishes.json
@@ -292,6 +292,10 @@
     "copy-from": "offal",
     "type": "COMESTIBLE",
     "name": { "str_sp": "fried offal" },
+    "conditional_names": [
+      { "type": "FLAG", "condition": "CANNIBALISM", "name": "fried Frank offal" },
+      { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "fried freak offal" } }
+    ],
     "description": "This is freshly cooked organ meat and entrails.  Deep-frying it makes it more palatable, and while it's probably less healthy it's still filled with essential vitamins.",
     "parasites": 0,
     "quench": -2,

--- a/data/json/items/comestibles/offal_dishes.json
+++ b/data/json/items/comestibles/offal_dishes.json
@@ -286,5 +286,18 @@
     "id": "homemade_hotdogs",
     "name": { "str": "homemade hot dog" },
     "copy-from": "hotdogs_frozen"
+  },
+  {
+    "id": "offal_cooked",
+    "copy-from": "offal",
+    "type": "COMESTIBLE",
+    "name": { "str_sp": "fried offal" },
+    "description": "This is freshly cooked organ meat and entrails.  Deep-frying it makes it more palatable, and while it's probably less healthy it's still filled with essential vitamins.",
+    "parasites": 0,
+    "quench": -2,
+    "fun": 1,
+    "healthy": -2,
+    "price_postapoc": 50,
+    "flags": [ "EATEN_HOT" ]
   }
 ]

--- a/data/json/items/migration.json
+++ b/data/json/items/migration.json
@@ -1660,5 +1660,10 @@
     "id": "reloaded_5x50dart",
     "type": "MIGRATION",
     "replace": "5x50dart"
+  },
+  {
+    "id": "mutant_offal_cooked",
+    "type": "MIGRATION",
+    "replace": "offal_cooked"
   }
 ]

--- a/data/json/obsoletion/recipes.json
+++ b/data/json/obsoletion/recipes.json
@@ -3032,5 +3032,10 @@
     "type": "recipe",
     "result": "reloaded_shot_slug",
     "obsolete": true
+  },
+  {
+    "type": "recipe",
+    "result": "mutant_offal_cooked",
+    "obsolete": true
   }
 ]

--- a/data/json/recipes/food/meat.json
+++ b/data/json/recipes/food/meat.json
@@ -2562,19 +2562,5 @@
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "frying_oil", 1, "LIST" ] ], [ [ "surface_heat", 8, "LIST" ] ] ],
     "components": [ [ [ "offal_raw", 1, "LIST" ] ] ]
-  },
-  {
-    "type": "recipe",
-    "result": "mutant_offal_cooked",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_MEAT",
-    "skill_used": "cooking",
-    "difficulty": 1,
-    "time": "20 m",
-    "autolearn": true,
-    "batch_time_factors": [ 80, 5 ],
-    "qualities": [ { "id": "COOK", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ],
-    "components": [ [ [ "mutant_offal", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/food/meat.json
+++ b/data/json/recipes/food/meat.json
@@ -2560,8 +2560,8 @@
     "autolearn": true,
     "batch_time_factors": [ 80, 5 ],
     "qualities": [ { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "frying_oil", 1, "LIST" ] ] ],
-    "components": [ [ [ "offal", 1 ], [ "mutant_offal", 1 ], [ "liver", 2 ], [ "lung", 2 ], [ "kidney", 2 ] ] ]
+    "tools": [ [ [ "frying_oil", 1, "LIST" ] ], [ [ "surface_heat", 8, "LIST" ] ] ],
+    "components": [ [ [ "offal_raw", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -2574,7 +2574,7 @@
     "autolearn": true,
     "batch_time_factors": [ 80, 5 ],
     "qualities": [ { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "frying_oil", 1, "LIST" ] ] ],
+    "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ],
     "components": [ [ [ "mutant_offal", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/food/meat.json
+++ b/data/json/recipes/food/meat.json
@@ -2573,7 +2573,7 @@
     "time": "20 m",
     "autolearn": true,
     "batch_time_factors": [ 80, 5 ],
-    "qualities": [ { "id": "COOK", "level": 2 } ],
+    "qualities": [ { "id": "COOK", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ],
     "components": [ [ [ "mutant_offal", 1 ] ] ]
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix cooked offal recipes not needing heat to cook, make fried offal actually flavored as such"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So I was gonna make this PR just a bundle of some misc easy fixes that barely warranted a separate PR each, but looking into the issue of cooked offal not using heat to cook actually turned out a lot more complicated than I expected, due to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1371 seeming to intend to reflavor generic cooked offal as fried offal, warranting more involved changes beyond just fixing the bugged recipe.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Reflavored cooked offal as fried offal. This seems to be what the change to recipe and mention of "you can fry them" in the PR OP was talking about, which makes sense because just plain campfire generic offal no longer has any reason to exist now that every offal item has its own cooked variant. Positive enjoyment but much lower than the other more advanced fried offal items, same level of unhealthiness (it's literally just meat and oil). Also moved it to meat dishes since it's no longer just generic cooked item.
2. Fixed cooked/fried offal not having `surface_heat` for its cooking. Used same amount as most other fried meat recipes.
3. Per feedback from Coolthulhu, obsoleted the separate cooked offal item in favor of making it so you have to fry it to make it palatable. Fried offal also gets different name based off components, includes cannibal name in case we add human organs.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Honestly, it's been so long since generic non-mutant offal was functionally dummied out via never spawning anywhere and not being obtainable via harvest that we could likely remove it from recipes too, the odds of a save still have raw generic offal kicking around are fairly low.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
