### PR TITLE
Allow workbenches simple-deconstruct into workbench item

### DIFF
--- a/data/json/furniture_and_terrain/furniture-surfaces.json
+++ b/data/json/furniture_and_terrain/furniture-surfaces.json
@@ -135,14 +135,8 @@
     "move_cost_mod": 2,
     "required_str": 10,
     "looks_like": "f_lab_bench",
-    "flags": [ "TRANSPARENT", "PLACE_ITEM", "MOUNTABLE", "FLAT_SURF" ],
-    "deconstruct": {
-      "items": [
-        { "item": "pipe", "count": [ 6, 8 ] },
-        { "item": "sheet_metal", "count": 2 },
-        { "item": "sheet_metal_small", "count": [ 2, 4 ] }
-      ]
-    },
+    "flags": [ "TRANSPARENT", "PLACE_ITEM", "MOUNTABLE", "FLAT_SURF", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "items": [ { "item": "workbench", "count": 1 } ] },
     "bash": {
       "str_min": 35,
       "str_max": 80,


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Allow workbenches simple-deconstruct into workbench item"

#### Purpose of change

Fixes #1514

#### Describe the solution

Added `EASY_DECONSTRUCT` flag to workbenches, making them able to be deconstructed into `workbench` item without tools

#### Describe alternatives you've considered

> We actually already have this mechanic for Oven implemented, so it just can be applied to other functional furniture that doesn't exist just for scrapping.

Make them not; however this comment from https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1514#issuecomment-1120353082 seems reasonable.

#### Testing

no visible errors after modifying json

#### Additional context
![image](https://user-images.githubusercontent.com/54838975/167459064-b7f43d18-2633-4e42-88b9-41d91eca683b.png)

deconstructing workbench with bare hands yield 1 workbench item.