### PR TITLE
Fix quality-same-as-component not recognizing 2 items of same type

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1107,13 +1107,13 @@ enchantment inventory::get_active_enchantment_cache( const Character &owner ) co
 void inventory::update_quality_cache()
 {
     quality_cache.clear();
-    inventory *this_nonconst = const_cast<inventory *>( this );
-    this_nonconst->visit_items( [ this ]( item * e ) {
-        auto item_qualities = e->get_qualities();
-        for( const auto &quality : item_qualities ) {
+    visit_items( [ this ]( const item * e ) {
+        const std::map<quality_id, int> &item_qualities = e->get_qualities();
+        for( const std::pair<const quality_id, int> &quality : item_qualities ) {
+            const int item_count = e->count_by_charges() ? e->charges : 1;
             // quality.first is the id of the quality, quality.second is the quality level
             // the value is the number of items with that quality level
-            ++quality_cache[quality.first][quality.second];
+            quality_cache[quality.first][quality.second] += item_count;
         }
         return VisitResponse::NEXT;
     } );

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -174,12 +174,15 @@ template <>
 bool visitable<inventory>::has_quality( const quality_id &qual, int level, int qty ) const
 {
     const inventory *inv = static_cast<const inventory *>( this );
-    auto inv_qual_cache = inv->get_quality_cache();
+    const std::map<quality_id, std::map<int, int>> &inv_qual_cache = inv->get_quality_cache();
     int res = 0;
     if( !inv_qual_cache.empty() ) {
-        for( const auto &q : inv_qual_cache[qual] ) {
-            if( q.first >= level ) {
-                res = sum_no_wrap( res, q.second );
+        auto iter = inv_qual_cache.find( qual );
+        if( iter != inv_qual_cache.end() ) {
+            for( const auto &q : iter->second ) {
+                if( q.first >= level ) {
+                    res = sum_no_wrap( res, q.second );
+                }
             }
         }
         return res >= qty;

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -460,6 +460,27 @@ TEST_CASE( "tool_use", "[crafting][tool]" )
     }
 }
 
+TEST_CASE( "Component same as tool", "[crafting][tool]" )
+{
+    SECTION( "primitive_hammer with one rock" ) {
+        std::vector<item> tools;
+        tools.emplace_back( "rock" );
+        tools.emplace_back( "2x4" );
+        tools.emplace_back( "thread", calendar::turn, 100 );
+
+        prep_craft( recipe_id( "primitive_hammer" ), tools, false );
+    }
+    SECTION( "primitive_hammer with two rocks" ) {
+        std::vector<item> tools;
+        tools.emplace_back( "rock" );
+        tools.emplace_back( "rock" );
+        tools.emplace_back( "2x4" );
+        tools.emplace_back( "thread", calendar::turn, 100 );
+
+        prep_craft( recipe_id( "primitive_hammer" ), tools, true );
+    }
+}
+
 // Resume the first in progress craft found in the player's inventory
 static int resume_craft()
 {


### PR DESCRIPTION
AKA Fix stone hammer being uncraftable with 2 rocks

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix quality-same-as-component not recognizing 2 items of same type"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fix #1408 (I hope)

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Seems that rocks are being counted as charges now. The quality cache system didn't handle this edge case and instead counted them as 1, but it's a simple fix, once the reason for the bug is known.

I also added two test cases to ensure it doesn't break in the future:
* Crafting rock hammer with 2 rocks - this one should work
* Crafting rock hammer with 1 rock - this one should fail, because the same rock is "trying" to be both a tool and a component

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Get rid of the requirement to have two items. It's a bit realismic and probably not worth the effort to maintain it.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

* Run the new tests
* Spawn materials for a stone hammer: plank, thread, 2 rocks
* See that stone hammer is craftable
* Remove one rock
* See that stone hammer is uncraftable and the rock component is browned out

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
