### PR TITLE
Fix 60x dupe bug between fertilizer and ammonium nitrate pellet

### DIFF
--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -253,6 +253,7 @@
     "id_suffix": "simple",
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_CHEMICALS",
+    "charges" : 1,
     "time": "5 s",
     "autolearn": true,
     "components": [ [ [ "chem_ammonium_nitrate_pellets", 350 ] ] ]


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix 60x dupe bug between fertilizer and ammonium nitrate pellet"

#### Purpose of change

- 1 charge of `Commercial Fertilzer` (aka fertilizer) can be crafted into 350 `ammonium nitrate pellets` (aka pellets)
- 350 `pellets` can be crafted into 1 `fertilizer`, but with **60 charges** (since its [default chages are 60](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/41ae57c46e67c48dffcb15628371162ea1b61483/data/json/items/chemicals_and_resources.json#L273-L296)), effectively yielding 60x fertilizers per iteration.

related links addressing the issue on korean roguelike forum:
- https://gall.dcinside.com/board/view/?id=rlike&no=408667
- https://gall.dcinside.com/board/view/?id=rlike&no=388068

#### Describe the solution

change the resulting charge of commercial fertilizer to 1, making both recipies even.

#### Describe alternatives you've considered

None

#### Testing

JSON changes only, crafting succeeded

#### Additional context

None