### PR TITLE
Updates pertaining to mag pouches and speedloaders

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -104,7 +104,7 @@
     "id": "chestpouch",
     "type": "ARMOR",
     "name": { "str": "chest ammo pouch", "str_pl": "chest ammo pouches" },
-    "description": "A fabric ammo pouch that can be strapped to your chest which is capable of holding a single magazine close at hand.",
+    "description": "A fabric ammo pouch that can be strapped to your chest which is capable of holding a single magazine or speedloader close at hand.",
     "weight": "140 g",
     "volume": "250 ml",
     "price": 1250,
@@ -123,7 +123,7 @@
       "holster_msg": "You stash your %s.",
       "max_volume": "750 ml",
       "draw_cost": 40,
-      "flags": [ "MAG_COMPACT" ]
+      "flags": [ "MAG_COMPACT", "SPEEDLOADER" ]
     },
     "flags": [ "WATER_FRIENDLY", "BELTED" ]
   },
@@ -131,7 +131,7 @@
     "id": "chestrig",
     "type": "ARMOR",
     "name": { "str_sp": "chest rig" },
-    "description": "Popularized during the Vietnam War, chest rigs like these are typically plain, barebones affairs consisting of three or more pouches in a row, with straps to secure them on your chest.  This one can hold four magazines in its pouches.",
+    "description": "Popularized during the Vietnam War, chest rigs like these are typically plain, barebones affairs consisting of three or more pouches in a row, with straps to secure them on your chest.  This one can hold four magazines or speedloaders in its pouches.",
     "weight": "425 g",
     "volume": "500 ml",
     "price": 3900,
@@ -151,7 +151,7 @@
       "multi": 4,
       "max_volume": "750 ml",
       "draw_cost": 40,
-      "flags": [ "MAG_COMPACT" ]
+      "flags": [ "MAG_COMPACT", "SPEEDLOADER" ]
     },
     "flags": [ "WATER_FRIENDLY", "BELTED" ]
   },
@@ -189,7 +189,7 @@
     "id": "legpouch",
     "type": "ARMOR",
     "name": { "str": "ankle ammo pouch", "str_pl": "ankle ammo pouches" },
-    "description": "A small fabric ammo pouch that can be strapped to your ankle which is capable of holding a single small magazine close at hand.",
+    "description": "A small fabric ammo pouch that can be strapped to your ankle which is capable of holding a single small magazine or speedloader close at hand.",
     "volume": "250 ml",
     "weight": "60 g",
     "price": 2000,
@@ -206,9 +206,10 @@
       "type": "holster",
       "holster_prompt": "Stash ammo",
       "holster_msg": "You stash your %s.",
+      "min_volume": "25 ml",
       "max_volume": "250 ml",
       "draw_cost": 40,
-      "flags": [ "MAG_COMPACT" ]
+      "flags": [ "MAG_COMPACT", "SPEEDLOADER" ]
     },
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ]
   },
@@ -234,9 +235,10 @@
       "holster_prompt": "Stash ammo",
       "holster_msg": "You stash your %s.",
       "multi": 2,
+      "min_volume": "50 ml",
       "max_volume": "500 ml",
       "draw_cost": 40,
-      "flags": [ "MAG_COMPACT" ]
+      "flags": [ "MAG_COMPACT", "SPEEDLOADER" ]
     },
     "flags": [ "WATER_FRIENDLY", "BELTED" ]
   },

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -423,20 +423,12 @@
     "copy-from": "boots",
     "type": "ARMOR",
     "name": { "str": "pair of western boots", "str_pl": "pairs of western boots" },
-    "description": "Stiff leather boots with intricate embroidery and one-inch heels.  They look good, but aren't made for running.  Each boot is large enough to conceal a small holdout pistol or knife.",
+    "description": "Stiff leather boots with intricate embroidery and one-inch heels.  They look good, but aren't made for running.  Each boot is large enough to conceal a small holdout pistol.",
     "price_postapoc": 750,
     "coverage": 95,
     "proportional": { "weight": 1.2, "volume": 1.2, "price": 2, "encumbrance": 2 },
-    "use_action": {
-      "type": "holster",
-      "max_volume": "250 ml",
-      "max_weight": 600,
-      "draw_cost": 80,
-      "multi": 2,
-      "skills": [ "pistol" ],
-      "flags": [ "SHEATH_KNIFE" ]
-    },
-    "extend": { "flags": [ "FANCY", "NO_QUICKDRAW" ] }
+    "use_action": { "type": "holster", "max_volume": "250 ml", "max_weight": 600, "draw_cost": 80, "multi": 2, "skills": [ "pistol" ] },
+    "extend": { "flags": [ "FANCY" ] }
   },
   {
     "id": "boots_winter",

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -423,12 +423,20 @@
     "copy-from": "boots",
     "type": "ARMOR",
     "name": { "str": "pair of western boots", "str_pl": "pairs of western boots" },
-    "description": "Stiff leather boots with intricate embroidery and one-inch heels.  They look good, but aren't made for running.  Each boot is large enough to conceal a small holdout pistol.",
+    "description": "Stiff leather boots with intricate embroidery and one-inch heels.  They look good, but aren't made for running.  Each boot is large enough to conceal a small holdout pistol or knife.",
     "price_postapoc": 750,
     "coverage": 95,
     "proportional": { "weight": 1.2, "volume": 1.2, "price": 2, "encumbrance": 2 },
-    "use_action": { "type": "holster", "max_volume": "250 ml", "max_weight": 600, "draw_cost": 80, "multi": 2, "skills": [ "pistol" ] },
-    "extend": { "flags": [ "FANCY" ] }
+    "use_action": {
+      "type": "holster",
+      "max_volume": "250 ml",
+      "max_weight": 600,
+      "draw_cost": 80,
+      "multi": 2,
+      "skills": [ "pistol" ],
+      "flags": [ "SHEATH_KNIFE" ]
+    },
+    "extend": { "flags": [ "FANCY", "NO_QUICKDRAW" ] }
   },
   {
     "id": "boots_winter",

--- a/data/json/items/battery.json
+++ b/data/json/items/battery.json
@@ -91,7 +91,7 @@
     "ammo_type": "battery",
     "capacity": 100,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE" ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE", "MAG_COMPACT" ]
   },
   {
     "id": "light_plus_battery_cell",
@@ -109,7 +109,7 @@
     "ammo_type": "battery",
     "capacity": 150,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE" ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE", "MAG_COMPACT" ]
   },
   {
     "id": "light_atomic_battery_cell",
@@ -129,7 +129,7 @@
     "count": 1000,
     "capacity": 1000,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "LEAK_DAM", "RADIOACTIVE" ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "LEAK_DAM", "RADIOACTIVE", "MAG_COMPACT" ]
   },
   {
     "id": "light_disposable_cell",
@@ -148,7 +148,7 @@
     "count": 300,
     "capacity": 300,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD" ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "MAG_COMPACT" ]
   },
   {
     "id": "medium_battery_cell",
@@ -167,7 +167,7 @@
     "ammo_type": "battery",
     "capacity": 500,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE" ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE", "MAG_COMPACT" ]
   },
   {
     "id": "medium_plus_battery_cell",
@@ -185,7 +185,7 @@
     "ammo_type": "battery",
     "capacity": 600,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE" ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE", "MAG_COMPACT" ]
   },
   {
     "id": "medium_atomic_battery_cell",
@@ -205,7 +205,7 @@
     "count": 5000,
     "capacity": 5000,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "LEAK_DAM", "RADIOACTIVE" ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "LEAK_DAM", "RADIOACTIVE", "MAG_COMPACT" ]
   },
   {
     "id": "medium_disposable_cell",
@@ -224,7 +224,7 @@
     "count": 1200,
     "capacity": 1200,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD" ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "MAG_COMPACT" ]
   },
   {
     "id": "heavy_battery_cell",
@@ -243,7 +243,7 @@
     "ammo_type": "battery",
     "capacity": 1000,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE" ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE", "MAG_BULKY" ]
   },
   {
     "id": "heavy_plus_battery_cell",
@@ -261,7 +261,7 @@
     "ammo_type": "battery",
     "capacity": 1250,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE" ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE", "MAG_BULKY" ]
   },
   {
     "id": "heavy_atomic_battery_cell",
@@ -281,7 +281,7 @@
     "count": 10000,
     "capacity": 10000,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "LEAK_DAM", "RADIOACTIVE" ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "LEAK_DAM", "RADIOACTIVE", "MAG_BULKY" ]
   },
   {
     "id": "huge_atomic_battery_cell",
@@ -319,6 +319,6 @@
     "count": 2500,
     "capacity": 2500,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD" ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "MAG_BULKY" ]
   }
 ]

--- a/data/json/items/gun/40.json
+++ b/data/json/items/gun/40.json
@@ -228,6 +228,7 @@
     "blackpowder_tolerance": 60,
     "loudness": 25,
     "clip_size": 6,
+    "magazines": [ [ "40", [ "40_speedloader6" ] ] ],
     "reload": 200,
     "valid_mod_locations": [
       [ "accessories", 2 ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Allow storing speedloaders and batteries in relevant mag pouches, related changes"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This is a collection of updates pertaining to storage of items and compatiability between holsters, mag pouches, and the like.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. `MAG_COMPACT` flag added to all light and medium class batteries, and `MAG_BULKY` added to heavy class batteries, allowing them to be stored in relevant mag pouches that will fit them. Ultralight batteries and mech batteries left untouched. Idea is mainly this allows a utility use for magazine storage beyond just firearm magazines, plus utility for mods that add battery-fueled weapons.
2. Allowed small enough mag pouches to also fit items with the `SPEEDLOADER` flag, as it'd make sense to store speedloaders there too, and nothing in-game could actually store them. Favored items that could store `MAG_COMPACT` but not `MAG_BULKY`, with a max volume under 1 liter.
3. Defined `min_volume` of 25 for ankle ammo pouch to ensure it can actually hold magazines that might be too tiny otherwise, and a min volume of 50 for leg ammo pouches.
4. Set it so the handmade six-shooter can make use of the .40 6-round speedloader.
5. Implemented something fun I discovered while adding the survivor's belt rig (https://github.com/Noctifer-de-Mortem/nocts_cata_mod/blob/master/nocts_cata_mod_BN/Surv_help/c_armor.json#L901) to Cataclysm++: in BN, though not in DDA, the holster use_action can accept both `skills` to store guns, and `flags` to store non-gun items, meaning an item can accept both. Set it so that cowboy boots can store boot knives as well as holdout pistols. Left minimum volume unset so that its utility doesn't compete with ankle sheathes as directly, just as the volume range on ankle holsters is different.
6. Added `NO_QUICKDRAW` flag to western boots. The "offer to draw holstered weapon on hitting f" feature does not work right if an item can stow two or more guns in it, so western boots were running into this issue already.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Giving ultralight batteries a higher volume than a single milliliter so there might be some hope of fitting them in any mag pouch.
2. Adding relevant flag to small storage batteries possibly?
3. Adding dedicated speedloader pouch items, i.e. like these:
![image](https://user-images.githubusercontent.com/11582235/167958276-ba0b30ff-f23f-4ddf-8730-ea1f8b9827e5.png)

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled build.
3. Checked that light batteries said they had some pouches they could be stored in.
4. Checked that various speedloaders and clips showed being compatible with ammo pouches.
5. Tested you can indeed stow both a dive knife and a Kel-Tec PF-9 in cowboy boots.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
