### PR TITLE
Misc fixes for funnel, grid batteries, gravel

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2955,6 +2955,19 @@
   },
   {
     "type": "construction",
+    "id": "constr_remove_gravel",
+    "description": "Remove gravel and replace with dirt",
+    "category": "OTHER",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "60 m",
+    "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
+    "byproducts": [ { "item": "pebble", "count": [ 6, 10 ] } ],
+    "pre_terrain": "t_railroad_rubble",
+    "dark_craftable": true,
+    "post_terrain": "t_dirt"
+  },
+  {
+    "type": "construction",
     "id": "constr_kiln_empty",
     "description": "Build Charcoal Kiln",
     "category": "FURN",
@@ -4463,19 +4476,6 @@
     "pre_note": "Must be between brick or (reinforced)concrete walls to function, and at least one wall must have an adjacent mechanical winch.",
     "pre_special": "check_empty",
     "post_terrain": "t_door_metal_locked"
-  },
-  {
-    "type": "construction",
-    "id": "constr_remove_gravel",
-    "description": "Remove gravel and replace with dirt",
-    "category": "CONSTRUCT",
-    "required_skills": [ [ "fabrication", 0 ] ],
-    "time": "60 m",
-    "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
-    "byproducts": [ { "item": "pebble", "count": [ 6, 10 ] } ],
-    "pre_terrain": "t_railroad_rubble",
-    "dark_craftable": true,
-    "post_terrain": "t_dirt"
   },
   {
     "type": "construction",

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -663,7 +663,7 @@
   {
     "type": "furniture",
     "id": "f_battery_large",
-    "looks_like": "f_locker",
+    "looks_like": "f_battery",
     "name": "mounted storage battery",
     "description": "A storage battery mount salvaged from a vehicle, and connected to building's electric grid.",
     "symbol": ":",

--- a/data/json/furniture_and_terrain/terrain-railroads.json
+++ b/data/json/furniture_and_terrain/terrain-railroads.json
@@ -15,14 +15,6 @@
       "sound_fail": "whump!",
       "items": [ { "item": "pebble", "count": [ 1, 3 ] }, { "item": "sharp_rock", "count": [ 0, 1 ] } ]
     },
-    "deconstruct": {
-      "ter_set": "t_pit_shallow",
-      "items": [
-        { "item": "pebble", "count": [ 75, 100 ] },
-        { "item": "sharp_rock", "count": [ 0, 2 ] },
-        { "item": "rock", "count": [ 4, 12 ] }
-      ]
-    },
     "flags": [ "BASHABLE", "TRANSPARENT" ]
   },
   {

--- a/data/json/mapgen/house/house_fortified.json
+++ b/data/json/mapgen/house/house_fortified.json
@@ -51,7 +51,7 @@
       },
       "furniture": { "!": "f_region_flower" },
       "set": [
-        { "point": "trap", "id": "tr_funnel", "x": [ 2, 9 ], "y": 19, "repeat": [ 1, 2 ] },
+        { "point": "trap", "id": "tr_funnel", "x": [ 3, 9 ], "y": 19, "repeat": [ 1, 2 ] },
         { "point": "trap", "id": "tr_cot", "x": [ 2, 9 ], "y": [ 15, 17 ], "repeat": [ 1, 2 ] }
       ],
       "place_loot": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Small fixes for error-inducing funnel placement, looks_like for grid batteries, deconstruction of gravel"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A collection of misc fixes that came up that I felt were each too small to be worth a PR on their own. The first two are things I'd thought I'd fixed but never actually did, both cases of thinking about something and forgetting you hadn't done it, it seems.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Fixed an instance where a house would try to spawn a funnel on top of a gutter downspout.
2. Fixed looks_like of large and huge grid storage batteries to point to the regular battery variant that already has its own sprite in UDP, instead of also looking like lockers.
3. Removed deconstruct entry from gravel due to the existence of an explicit construction for turning gravel back into dirt, and moved its construction entry to the "other" category where most digging-extraction recipes are.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

An alternative would be adding `EASY_DECONSTRUCT` to gravel, updating the deconstruct results instead of removing it, and removing the explicit gravel-removal construction.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1393