### PR TITLE
Fix helicopters silently failing to ascend

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1809,6 +1809,10 @@ bool game::handle_action()
                     vertical_move( 1, false );
                 } else if( veh_ctrl && vp->vehicle().is_rotorcraft() ) {
                     pldrive( tripoint_above );
+                } else if( veh_ctrl && vp->vehicle().has_part( "ROTOR" ) &&
+                           !vp->vehicle().has_sufficient_rotorlift() ) {
+                    add_msg( m_bad, _( "The rotors struggle to generate enough lift!" ) );
+                    break;
                 }
                 break;
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1812,7 +1812,6 @@ bool game::handle_action()
                 } else if( veh_ctrl && vp->vehicle().has_part( "ROTOR" ) &&
                            !vp->vehicle().has_sufficient_rotorlift() ) {
                     add_msg( m_bad, _( "The rotors struggle to generate enough lift!" ) );
-                    break;
                 }
                 break;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Helicopters now print a message on failing to ascend due to lack of engine power, instead of silent failure"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I'd been wanting to figure out how to fix the annoyance where helicopters would fail silently, with no message, if you tried to ascend but couldn't due to lack of power. It took a lot of rooting through a fairly complex chain of functions, giving up, then working through the opposite direction by figuring out what actually happens internally when you press `<`, before I finally found how to fix that.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Updated `game::handle_action` so that triggering the `ACTION_MOVE_UP` will check for if you're in the circumstance of a helicopter trying and failing to ascend, and if so print a message to hint at the problem.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Continue going in circles looking at how the vehicle move functions seem to go back and forth until I go insane.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Spawned in a small helicoper, modified it to have enough cargo space to load the back with a bunch of anvils.
3. Start it up and tried to ascend, observed it failed with an actual message instead of silently.
4. Ditched the anvil collection, observed it ascended as normal.
5. Ran affected file through astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

![image](https://user-images.githubusercontent.com/11582235/168402619-2bddd633-88cb-4a16-837c-fdc877ca4319.png)