### PR TITLE
Port over regen modifiers

### DIFF
--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -1848,6 +1848,7 @@
     "fear_triggers": [ "FIRE" ],
     "death_function": [ "NORMAL" ],
     "regenerates": 10,
+    "regeneration_modifers": [ [ "onfire", -0.2 ], [ "corroding", -0.4 ] ],
     "regen_morale": true,
     "flags": [ "ATTACKMON", "BLEED", "BORES", "CAN_DIG", "HEARS", "KEENNOSE", "PATH_AVOID_DANGER_1", "SMELLS", "WARM" ],
     "//": "Reinsert GOODHEARING when z-level tunneling is possible."

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -1848,7 +1848,7 @@
     "fear_triggers": [ "FIRE" ],
     "death_function": [ "NORMAL" ],
     "regenerates": 10,
-    "regeneration_modifers": [ [ "onfire", -0.2 ], [ "corroding", -0.4 ] ],
+    "regeneration_modifiers": [ [ "onfire", -0.5 ], [ "corroding", -0.4 ] ],
     "regen_morale": true,
     "flags": [ "ATTACKMON", "BLEED", "BORES", "CAN_DIG", "HEARS", "KEENNOSE", "PATH_AVOID_DANGER_1", "SMELLS", "WARM" ],
     "//": "Reinsert GOODHEARING when z-level tunneling is possible."

--- a/data/json/monsters/misc.json
+++ b/data/json/monsters/misc.json
@@ -20,7 +20,7 @@
     "harvest": "exempt",
     "death_function": [ "MELT" ],
     "regenerates": 50,
-    "regeneration_modifers": [ [ "onfire", -0.2 ], [ "corroding", -0.4 ] ],
+    "regeneration_modifiers": [ [ "onfire", -0.5 ], [ "corroding", -0.8 ] ],
     "flags": [ "IMMOBILE", "NOT_HALLUCINATION", "FILTHY" ]
   },
   {

--- a/data/json/monsters/misc.json
+++ b/data/json/monsters/misc.json
@@ -20,6 +20,7 @@
     "harvest": "exempt",
     "death_function": [ "MELT" ],
     "regenerates": 50,
+    "regeneration_modifers": [ [ "onfire", -5 ], [ "corroding", 5 ] ],
     "flags": [ "IMMOBILE", "NOT_HALLUCINATION", "FILTHY" ]
   },
   {

--- a/data/json/monsters/misc.json
+++ b/data/json/monsters/misc.json
@@ -20,7 +20,7 @@
     "harvest": "exempt",
     "death_function": [ "MELT" ],
     "regenerates": 50,
-    "regeneration_modifers": [ [ "onfire", -5 ], [ "corroding", 5 ] ],
+    "regeneration_modifers": [ [ "onfire", 0.5 ], [ "corroding", 1.5 ] ],
     "flags": [ "IMMOBILE", "NOT_HALLUCINATION", "FILTHY" ]
   },
   {

--- a/data/json/monsters/misc.json
+++ b/data/json/monsters/misc.json
@@ -20,7 +20,7 @@
     "harvest": "exempt",
     "death_function": [ "MELT" ],
     "regenerates": 50,
-    "regeneration_modifers": [ [ "onfire", 0.5 ], [ "corroding", 1.5 ] ],
+    "regeneration_modifers": [ [ "onfire", -0.2 ], [ "corroding", -0.4 ] ],
     "flags": [ "IMMOBILE", "NOT_HALLUCINATION", "FILTHY" ]
   },
   {

--- a/data/json/monsters/mutant_human.json
+++ b/data/json/monsters/mutant_human.json
@@ -74,7 +74,7 @@
     "death_drops": "mon_mutant_experimental_death_drops",
     "upgrades": { "half_life": 50, "into": "mon_mutant_evolved" },
     "regenerates": 1,
-    "regeneration_modifers": [ [ "onfire", -1.0 ], [ "corroding", -1.0 ] ],
+    "regeneration_modifiers": [ [ "onfire", -1.0 ], [ "corroding", -1.0 ] ],
     "regen_morale": true,
     "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "WARM", "BLEED", "BASHES", "PATH_AVOID_DANGER_2" ]
   },
@@ -113,7 +113,7 @@
     ],
     "death_drops": "mon_mutant_evolved_death_drops",
     "regenerates": 1,
-    "regeneration_modifers": [ [ "onfire", -1.0 ], [ "corroding", -1.0 ] ],
+    "regeneration_modifiers": [ [ "onfire", -1.0 ], [ "corroding", -1.0 ] ],
     "regen_morale": true,
     "flags": [
       "SEES",

--- a/data/json/monsters/mutant_human.json
+++ b/data/json/monsters/mutant_human.json
@@ -74,6 +74,7 @@
     "death_drops": "mon_mutant_experimental_death_drops",
     "upgrades": { "half_life": 50, "into": "mon_mutant_evolved" },
     "regenerates": 1,
+    "regeneration_modifers": [ [ "onfire", -1.0 ], [ "corroding", -1.0 ] ],
     "regen_morale": true,
     "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "WARM", "BLEED", "BASHES", "PATH_AVOID_DANGER_2" ]
   },
@@ -112,6 +113,7 @@
     ],
     "death_drops": "mon_mutant_evolved_death_drops",
     "regenerates": 1,
+    "regeneration_modifers": [ [ "onfire", -1.0 ], [ "corroding", -1.0 ] ],
     "regen_morale": true,
     "flags": [
       "SEES",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -733,7 +733,7 @@
     "special_attacks": [ [ "PARROT", 40 ] ],
     "death_function": [ "MELT" ],
     "regenerates": 50,
-    "regeneration_modifers": [ [ "onfire", -0.2 ], [ "corroding", -0.4 ] ],
+    "regeneration_modifiers": [ [ "onfire", -0.5 ] ],
     "regen_morale": true,
     "flags": [ "SEES", "SMELLS", "SWIMS", "PLASTIC", "SLUDGEPROOF", "ACID_BLOOD", "ACIDPROOF", "NOHEAD", "ABSORBS_SPLITS", "NOGIB" ]
   },

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -733,6 +733,7 @@
     "special_attacks": [ [ "PARROT", 40 ] ],
     "death_function": [ "MELT" ],
     "regenerates": 50,
+    "regeneration_modifers": [ [ "onfire", -0.2 ], [ "corroding", -0.4 ] ],
     "regen_morale": true,
     "flags": [ "SEES", "SMELLS", "SWIMS", "PLASTIC", "SLUDGEPROOF", "ACID_BLOOD", "ACIDPROOF", "NOHEAD", "ABSORBS_SPLITS", "NOGIB" ]
   },

--- a/data/json/monsters/slugs.json
+++ b/data/json/monsters/slugs.json
@@ -27,7 +27,7 @@
     "harvest": "exempt",
     "death_function": [ "MELT" ],
     "regenerates": 50,
-    "regeneration_modifers": [ [ "onfire", -0.3 ], [ "corroding", -0.3 ] ],
+    "regeneration_modifiers": [ [ "onfire", -0.6 ], [ "corroding", -0.3 ] ],
     "flags": [ "NOHEAD", "SEES", "POISON", "HEARS", "SMELLS", "SLUDGEPROOF", "SLUDGETRAIL", "SWIMS", "FLAMMABLE", "NOGIB" ]
   },
   {

--- a/data/json/monsters/slugs.json
+++ b/data/json/monsters/slugs.json
@@ -26,7 +26,8 @@
     "vision_night": 30,
     "harvest": "exempt",
     "death_function": [ "MELT" ],
-    "regenerates": 50,
+    "regenerates": 50,    
+    "regeneration_modifers": [ [ "onfire", -0.3 ], [ "corroding", -0.3 ] ],
     "flags": [ "NOHEAD", "SEES", "POISON", "HEARS", "SMELLS", "SLUDGEPROOF", "SLUDGETRAIL", "SWIMS", "FLAMMABLE", "NOGIB" ]
   },
   {

--- a/data/json/monsters/slugs.json
+++ b/data/json/monsters/slugs.json
@@ -26,7 +26,7 @@
     "vision_night": 30,
     "harvest": "exempt",
     "death_function": [ "MELT" ],
-    "regenerates": 50,    
+    "regenerates": 50,
     "regeneration_modifers": [ [ "onfire", -0.3 ], [ "corroding", -0.3 ] ],
     "flags": [ "NOHEAD", "SEES", "POISON", "HEARS", "SMELLS", "SLUDGEPROOF", "SLUDGETRAIL", "SWIMS", "FLAMMABLE", "NOGIB" ]
   },

--- a/data/json/monsters/zed_fusion.json
+++ b/data/json/monsters/zed_fusion.json
@@ -60,6 +60,7 @@
     },
     "death_function": [ "NORMAL" ],
     "regenerates": 1,
+    "regeneration_modifers": [ [ "onfire", -0.2 ], [ "corroding", -0.4 ] ],
     "flags": [
       "SEES",
       "HEARS",

--- a/data/json/monsters/zed_fusion.json
+++ b/data/json/monsters/zed_fusion.json
@@ -60,7 +60,7 @@
     },
     "death_function": [ "NORMAL" ],
     "regenerates": 1,
-    "regeneration_modifers": [ [ "onfire", -0.2 ], [ "corroding", -0.4 ] ],
+    "regeneration_modifiers": [ [ "onfire", -1 ], [ "corroding", -1 ] ],
     "flags": [
       "SEES",
       "HEARS",

--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -546,7 +546,7 @@ std::string achievement_tracker::ui_text() const
             achievement_completion::failed,
             achievement_->time_constraint()->target(),
             current_values()
-        } .ui_text( achievement_ );
+        }. ui_text( achievement_ );
     }
 
     // First: the achievement name and description

--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -546,7 +546,7 @@ std::string achievement_tracker::ui_text() const
             achievement_completion::failed,
             achievement_->time_constraint()->target(),
             current_values()
-        }. ui_text( achievement_ );
+        } .ui_text( achievement_ );
     }
 
     // First: the achievement name and description

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1658,6 +1658,9 @@ void map::monster_in_field( monster &z )
                 const int d = rng( cur.get_field_intensity(), cur.get_field_intensity() * 3 );
                 z.deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( DT_ACID, d ) );
                 z.check_dead_state();
+                if( d > 0 ) {
+                    z.add_effect( effect_corroding, 1_turns * rng( dam / 2, dam * 2 ) );
+                }
             }
 
         }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1659,7 +1659,7 @@ void map::monster_in_field( monster &z )
                 z.deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( DT_ACID, d ) );
                 z.check_dead_state();
                 if( d > 0 ) {
-                    z.add_effect( effect_corroding, 1_turns * rng( dam / 2, dam * 2 ) );
+                    z.add_effect( effect_corroding, 1_turns * rng( d / 2, d * 2 ) );
                 }
             }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2523,8 +2523,19 @@ void monster::process_effects_internal()
     }
 
     //If this monster has the ability to heal in combat, do it now.
-    const int healed_amount = heal( type->regenerates );
-    if( healed_amount > 0 && one_in( 2 ) && g->u.sees( *this ) ) {
+    int regeneration_amount = type->regenerates;
+    //Apply effect-triggered regeneartion modifers
+    for( const auto &regeneration_modifier : type->regeneration_modifiers ) {
+        if( has_effect( regeneration_modifier.first ) ) {
+            regeneration_amount += regeneration_modifier.second;
+        }
+    }
+    //Prevent negative regeneration
+    if( regeneration_amount < 0 ) {
+        regeneration_amount = 0;
+    }
+    const int healed_amount = heal( regeneration_amount );
+    if( healed_amount > 0 && one_in( 2 ) ) {
         std::string healing_format_string;
         if( healed_amount >= 50 ) {
             healing_format_string = _( "The %s is visibly regenerating!" );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2527,9 +2527,7 @@ void monster::process_effects_internal()
     //Apply effect-triggered regeneartion modifers
     for( const auto &regeneration_modifier : type->regeneration_modifiers ) {
         if( has_effect( regeneration_modifier.first ) ) {
-            effect &e = get_effect( regeneration_modifier.first );
-            //Effect intensity dictates how many times the regeneration is reduced
-            regeneration_amount *= std::pow( 1 + regeneration_modifier.second, e.get_intensity() );
+            regeneration_amount *= 1 + regeneration_modifier.second;
         }
     }
     //Prevent negative regeneration

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2524,7 +2524,7 @@ void monster::process_effects_internal()
 
     //If this monster has the ability to heal in combat, do it now.
     int regeneration_amount = type->regenerates;
-    //Apply effect-triggered regeneartion modifers
+    //Apply effect-triggered regeneration modifiers
     for( const auto &regeneration_modifier : type->regeneration_modifiers ) {
         if( has_effect( regeneration_modifier.first ) ) {
             regeneration_amount *= 1 + regeneration_modifier.second;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2527,7 +2527,9 @@ void monster::process_effects_internal()
     //Apply effect-triggered regeneartion modifers
     for( const auto &regeneration_modifier : type->regeneration_modifiers ) {
         if( has_effect( regeneration_modifier.first ) ) {
-            regeneration_amount += regeneration_modifier.second;
+            effect &e = get_effect( regeneration_modifier.first );
+            //Effect intensity dictates how many times the regeneration is reduced
+            regeneration_amount *= std::pow( 1 - regeneration_modifier.second, e.get_intensity() );
         }
     }
     //Prevent negative regeneration

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2529,7 +2529,7 @@ void monster::process_effects_internal()
         if( has_effect( regeneration_modifier.first ) ) {
             effect &e = get_effect( regeneration_modifier.first );
             //Effect intensity dictates how many times the regeneration is reduced
-            regeneration_amount *= std::pow( 1 - regeneration_modifier.second, e.get_intensity() );
+            regeneration_amount *= std::pow( 1 + regeneration_modifier.second, e.get_intensity() );
         }
     }
     //Prevent negative regeneration

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1625,7 +1625,7 @@ int monster::heal( const int delta_hp, bool overheal )
     if( hp > maxhp && !overheal ) {
         hp = maxhp;
     }
-    return maxhp - old_hp;
+    return hp - old_hp;
 }
 
 void monster::set_hp( const int hp )

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1166,7 +1166,7 @@ void mtype::add_regeneration_modifier( JsonArray inner, const std::string & )
                       id.c_str(), effect_name );
         }
     }
-    int amount = inner.get_int( 1 );
+    float amount = inner.get_float( 1 );
     regeneration_modifiers.emplace( effect, amount );
 }
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -749,6 +749,24 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "regenerates_in_dark", regenerates_in_dark, false );
     optional( jo, was_loaded, "regen_morale", regen_morale, false );
 
+    if( !was_loaded || jo.has_member( "regeneration_modifers" ) ) {
+        regeneration_modifiers.clear();
+        add_regeneration_modifiers( jo, "regeneration_modifers", src );
+    } else {
+        // Note: regeneration_modifers left as is, new modifiers are added to it!
+        // Note: member name prefixes are compatible with those used by generic_typed_reader
+        if( jo.has_object( "extend" ) ) {
+            JsonObject tmp = jo.get_object( "extend" );
+            tmp.allow_omitted_members();
+            add_regeneration_modifiers( tmp, "regeneration_modifers", src );
+        }
+        if( jo.has_object( "delete" ) ) {
+            JsonObject tmp = jo.get_object( "delete" );
+            tmp.allow_omitted_members();
+            remove_regeneration_modifiers( tmp, "regeneration_modifers", src );
+        }
+    }
+
     optional( jo, was_loaded, "starting_ammo", starting_ammo );
     optional( jo, was_loaded, "luminance", luminance, 0 );
     optional( jo, was_loaded, "revert_to_itype", revert_to_itype, itype_id() );
@@ -1131,6 +1149,52 @@ void mtype::remove_special_attacks( const JsonObject &jo, const std::string &mem
         if( iter != special_attacks_names.end() ) {
             special_attacks_names.erase( iter );
         }
+    }
+}
+
+void mtype::add_regeneration_modifier( JsonArray inner, const std::string & )
+{
+    const std::string effect_name = inner.get_string( 0 );
+    const efftype_id effect( effect_name );
+    //TODO: if invalid effect, throw error
+    //  inner.throw_error( "Invalid regeneration_modifiers" );
+
+    if( regeneration_modifiers.count( effect ) > 0 ) {
+        regeneration_modifiers.erase( effect );
+        if( test_mode ) {
+            debugmsg( "%s specifies more than one regeneration modifer for effect %s, ignoring all but the last",
+                      id.c_str(), effect_name );
+        }
+    }
+    int amount = inner.get_int( 1 );
+    regeneration_modifiers.emplace( effect, amount );
+}
+
+void mtype::add_regeneration_modifiers( const JsonObject &jo, const std::string &member,
+                                        const std::string &src )
+{
+    if( !jo.has_array( member ) ) {
+        return;
+    }
+
+    for( const JsonValue entry : jo.get_array( member ) ) {
+        if( entry.test_array() ) {
+            add_regeneration_modifier( entry.get_array(), src );
+            // TODO: add support for regeneration_modifer objects
+            //} else if ( entry.test_object() ) {
+            //    add_regeneration_modifier( entry.get_object(), src );
+        } else {
+            entry.throw_error( "array element is not an array " );
+        }
+    }
+}
+
+void mtype::remove_regeneration_modifiers( const JsonObject &jo, const std::string &member_name,
+        const std::string & )
+{
+    for( const std::string &name : jo.get_tags( member_name ) ) {
+        const efftype_id effect( name );
+        regeneration_modifiers.erase( effect );
     }
 }
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -749,21 +749,21 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "regenerates_in_dark", regenerates_in_dark, false );
     optional( jo, was_loaded, "regen_morale", regen_morale, false );
 
-    if( !was_loaded || jo.has_member( "regeneration_modifers" ) ) {
+    if( !was_loaded || jo.has_member( "regeneration_modifiers" ) ) {
         regeneration_modifiers.clear();
-        add_regeneration_modifiers( jo, "regeneration_modifers", src );
+        add_regeneration_modifiers( jo, "regeneration_modifiers", src );
     } else {
-        // Note: regeneration_modifers left as is, new modifiers are added to it!
+        // Note: regeneration_modifiers left as is, new modifiers are added to it!
         // Note: member name prefixes are compatible with those used by generic_typed_reader
         if( jo.has_object( "extend" ) ) {
             JsonObject tmp = jo.get_object( "extend" );
             tmp.allow_omitted_members();
-            add_regeneration_modifiers( tmp, "regeneration_modifers", src );
+            add_regeneration_modifiers( tmp, "regeneration_modifiers", src );
         }
         if( jo.has_object( "delete" ) ) {
             JsonObject tmp = jo.get_object( "delete" );
             tmp.allow_omitted_members();
-            remove_regeneration_modifiers( tmp, "regeneration_modifers", src );
+            remove_regeneration_modifiers( tmp, "regeneration_modifiers", src );
         }
     }
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -267,7 +267,7 @@ struct mtype {
         // Number of hitpoints regenerated per turn.
         int regenerates = 0;
         // Effects that can modify regeneration
-        std::map<efftype_id, int> regeneration_modifiers;
+        std::map<efftype_id, float> regeneration_modifiers;
         // Monster regenerates very quickly in poorly lit tiles.
         bool regenerates_in_dark = false;
         // Will stop fleeing if at max hp, and regen anger and morale.

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -224,6 +224,13 @@ struct mtype {
         void add_special_attack( JsonArray inner, const std::string &src );
         void add_special_attack( const JsonObject &obj, const std::string &src );
 
+        void add_regeneration_modifiers( const JsonObject &jo, const std::string &member_name,
+                                         const std::string &src );
+        void remove_regeneration_modifiers( const JsonObject &jo, const std::string &member_name,
+                                            const std::string &src );
+
+        void add_regeneration_modifier( JsonArray inner, const std::string &src );
+
     public:
         mtype_id id;
 
@@ -259,6 +266,8 @@ struct mtype {
 
         // Number of hitpoints regenerated per turn.
         int regenerates = 0;
+        // Effects that can modify regeneration
+        std::map<efftype_id, int> regeneration_modifiers;
         // Monster regenerates very quickly in poorly lit tiles.
         bool regenerates_in_dark = false;
         // Will stop fleeing if at max hp, and regen anger and morale.


### PR DESCRIPTION
#### Summary

SUMMARY: Balance "Allow regeneration to be modified by effects."

#### Purpose of change

Regenerating monsters currently don't push for smart approaches, preferring a more dakka approach that doesn't really encourage any kind of tactics.

#### Describe the solution

Port over [#50439](https://github.com/CleverRaven/Cataclysm-DDA/pull/50439) from DDA which extends regeneration and allows effects like on fire, corroding and the like to modify the amount healed.

Change it to multiply regeneration by specific amount instead, instead of a flat addition/reduction, which should be more comfortable to use.

#### Describe alternatives you've considered

Disable regen entirely under specific effects.
- System as is will allow that, and has more nuance to boot.

#### Testing

Spawned Debug Monster, used molotovs/acid bombs to set them on fire/give them acid burns. Tested that amount of reduction was appropriate, and that multipliers were being used correctly.

#### Additional context

Fixed several issues while I was at it. For one, heal function wasn't returning the amount healed but rather the difference between current hp and max hp. Furthermore, monsters did not suffer from the Corroding condition, meaning I couldn't trigger the effects of regeneration modifiers on them.

Finally, this should allow us to bump up regen on more monsters, like the experimental mutant that only regens 1 HP per turn, or even dissoluted devourers. That said, before we start doing this we need more and _better_ ways to apply burning/corroding to monsters. Incendiary rounds seem somewhat unsatisfactory and acid bombs also make it near impossible to enter the area if you're melee or want to loot the corpse.