### PR TITLE
GO Fix parkings and roads

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -441,6 +441,7 @@
   },
   {
     "type": "overmap_terrain",
+	"copy-from": "generic_parking",
     "id": [
       "parking_2x1_0",
       "parking_2x1_1",
@@ -452,9 +453,9 @@
       "parking_3x1_1",
       "parking_3x1_2"
     ],
-    "name": "parking lot",
-    "sym": "O",
-    "color": "dark_gray",
+    "name": "parking lot"
+	"sym": "0",
+	"color": "dark_gray",
     "see_cost": 2
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -441,7 +441,7 @@
   },
   {
     "type": "overmap_terrain",
-	"copy-from": "generic_parking",
+    "copy-from": "generic_parking",
     "id": [
       "parking_2x1_0",
       "parking_2x1_1",
@@ -453,9 +453,9 @@
       "parking_3x1_1",
       "parking_3x1_2"
     ],
-    "name": "parking lot"
-	"sym": "0",
-	"color": "dark_gray",
+    "name": "parking lot",
+    "sym": "0",
+    "color": "dark_gray",
     "see_cost": 2
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_abstract.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_abstract.json
@@ -108,6 +108,17 @@
     "name": "generic_transportation",
     "land_use_code": "transportation"
   },
+    {
+    "type": "overmap_terrain",
+    "abstract": "generic_road",
+    "name": "generic_road",
+    "land_use_code": "transportation"
+  },
+  {
+    "type": "overmap_terrain",
+    "abstract": "generic_parking",
+    "name": "parking",
+  },
   {
     "type": "overmap_terrain",
     "abstract": "generic_waste_disposal",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_abstract.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_abstract.json
@@ -108,7 +108,7 @@
     "name": "generic_transportation",
     "land_use_code": "transportation"
   },
-    {
+  {
     "type": "overmap_terrain",
     "abstract": "generic_road",
     "name": "generic_road",
@@ -117,7 +117,7 @@
   {
     "type": "overmap_terrain",
     "abstract": "generic_parking",
-    "name": "parking",
+    "name": "parking"
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
@@ -69,6 +69,7 @@
   {
     "type": "overmap_terrain",
     "id": "s_lot",
+	"copy-from": "generic_parking",
     "name": "parking lot",
     "sym": "O",
     "color": "dark_gray",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
@@ -69,7 +69,7 @@
   {
     "type": "overmap_terrain",
     "id": "s_lot",
-	"copy-from": "generic_parking",
+    "copy-from": "generic_parking",
     "name": "parking lot",
     "sym": "O",
     "color": "dark_gray",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
@@ -1147,7 +1147,7 @@
   {
     "type": "overmap_terrain",
     "id": "industrial_center_west_road",
-    "copy-from": "generic_transportation",
+    "copy-from": "generic_road",
     "name": "road",
     "sym": "├",
     "color": "dark_gray",


### PR DESCRIPTION
This small fix along with small tileset update will make internal parkings and roads like Industrial centre and mines show proper tiles. There are more such small things that will need similar fix.
Related tileset PR that will require this to work.
https://github.com/Theawesomeboophis/UndeadPeopleTileset/pull/32
Without it current PR doesn't break anything, we will have to just update ingame tileset from the Boophis one.
Industrial centre
![obraz](https://user-images.githubusercontent.com/37194372/169696311-541133d2-b7a2-472f-8cae-aa191c3c8e81.png)

mines
![obraz](https://user-images.githubusercontent.com/37194372/169696320-965974bd-245b-435d-b18c-fd89f497e9c4.png)

and few others probably too.