### PR TITLE
Fix "bow" gunmod location not working

### DIFF
--- a/data/json/items/gunmod/accessories.json
+++ b/data/json/items/gunmod/accessories.json
@@ -13,7 +13,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "accessories",
-    "mod_targets": [ "bow" ],
+    "mod_targets": [ "archery" ],
     "dispersion_modifier": -100
   },
   {
@@ -29,7 +29,7 @@
     "symbol": ":",
     "color": "brown",
     "location": "stabilizer",
-    "mod_targets": [ "bow" ],
+    "mod_targets": [ "archery" ],
     "dispersion_modifier": -100
   },
   {
@@ -45,7 +45,7 @@
     "symbol": ":",
     "color": "brown",
     "location": "stabilizer",
-    "mod_targets": [ "bow" ],
+    "mod_targets": [ "archery" ],
     "dispersion_modifier": -150,
     "flags": [ "NEEDS_UNFOLD" ]
   },
@@ -62,7 +62,7 @@
     "symbol": ":",
     "color": "brown",
     "location": "dampening",
-    "mod_targets": [ "bow", "crossbow" ],
+    "mod_targets": [ "archery", "crossbow" ],
     "dispersion_modifier": -50,
     "loudness_modifier": -8
   },

--- a/data/json/items/gunmod/grip.json
+++ b/data/json/items/gunmod/grip.json
@@ -33,7 +33,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "grip",
-    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "launcher", "bow" ],
+    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "launcher", "archery" ],
     "handling_modifier": 4
   },
   {

--- a/data/json/items/gunmod/mount.json
+++ b/data/json/items/gunmod/mount.json
@@ -122,7 +122,7 @@
     "symbol": ":",
     "color": "light_gray",
     "location": "underbarrel mount",
-    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "launcher", "bow" ],
+    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "launcher", "archery" ],
     "install_time": "5 m",
     "add_mod": [ [ "underbarrel", 1 ] ],
     "flags": [ "INSTALL_DIFFICULT", "IRREMOVABLE" ]

--- a/data/json/items/gunmod/sights.json
+++ b/data/json/items/gunmod/sights.json
@@ -13,7 +13,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "sights",
-    "mod_targets": [ "bow" ],
+    "mod_targets": [ "archery" ],
     "sight_dispersion": 10,
     "aim_speed": 5
   },
@@ -31,7 +31,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "sights",
-    "mod_targets": [ "bow" ],
+    "mod_targets": [ "archery" ],
     "sight_dispersion": 25,
     "aim_speed": 8
   },
@@ -49,7 +49,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "sights",
-    "mod_targets": [ "bow" ],
+    "mod_targets": [ "archery" ],
     "sight_dispersion": 5,
     "aim_speed": 2,
     "flags": [ "ZOOM" ]

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -225,7 +225,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "underbarrel",
-    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "bow", "launcher" ],
+    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "archery", "launcher" ],
     "sight_dispersion": 30,
     "aim_speed": 9,
     "flags": [ "PUMP_RAIL_COMPATIBLE" ]

--- a/data/mods/Magiclysm/items/enchanted_gunmods.json
+++ b/data/mods/Magiclysm/items/enchanted_gunmods.json
@@ -54,7 +54,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "underbarrel",
-    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "bow", "launcher" ],
+    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "archery", "launcher" ],
     "sight_dispersion": 27,
     "aim_speed": 9,
     "min_skills": [ [ "weapon", 2 ], [ "gun", 2 ] ],

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6926,8 +6926,6 @@ skill_id item::gun_skill() const
 
 gun_type_type item::gun_type() const
 {
-    static skill_id skill_archery( "archery" );
-
     if( !is_gun() ) {
         return gun_type_type( std::string() );
     }
@@ -7503,6 +7501,8 @@ ret_val<bool> item::is_gunmod_compatible( const item &mod ) const
         return ret_val<bool>::make_failure();
     }
     static const gun_type_type pistol_gun_type( translate_marker_context( "gun_type_type", "pistol" ) );
+    static const skill_id skill_archery( "archery" );
+    static const std::string bow_hack_str( "bow" );
 
     if( !is_gun() ) {
         return ret_val<bool>::make_failure( _( "isn't a weapon" ) );
@@ -7520,8 +7520,10 @@ ret_val<bool> item::is_gunmod_compatible( const item &mod ) const
         return ret_val<bool>::make_failure( _( "doesn't have enough room for another %s mod" ),
                                             mod.type->gunmod->location.name() );
 
+        // TODO: Get rid of the "archery"->"bow" hack
     } else if( !mod.type->gunmod->usable.count( gun_type() ) &&
-               !mod.type->gunmod->usable.count( typeId().str() ) ) {
+               !mod.type->gunmod->usable.count( typeId().str() ) &&
+               !( gun_skill() == skill_archery && mod.type->gunmod->usable.count( bow_hack_str ) > 0 ) ) {
         return ret_val<bool>::make_failure( _( "cannot have a %s" ), mod.tname() );
 
     } else if( typeId() == itype_hand_crossbow &&

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1322,7 +1322,7 @@ void Item_factory::check_definitions() const
                 }
 
                 if( json_report_strict && t.name_ == "bow" ) {
-                    msg += string_format( "\"bow\" location is deprecated, use \"archery\" instead" );
+                    msg += string_format( "'bow' location is deprecated, use 'archery' instead" );
                 }
 
                 // We need to check is_skill because something can be both an item and a skill

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1321,6 +1321,10 @@ void Item_factory::check_definitions() const
                     continue;
                 }
 
+                if( json_report_strict && t.name_ == "bow" ) {
+                    msg += string_format( "\"bow\" location is deprecated, use \"archery\" instead" );
+                }
+
                 // We need to check is_skill because something can be both an item and a skill
                 if( !is_skill && is_item ) {
                     const itype *target = &*item_type;


### PR DESCRIPTION
Also add warning in strict json mode

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix 'bow' gunmod location not working"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fix #1526

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

When a gun has skill type "archery", allow gunmods with "bow" as gun type as well.

Added a warning, currently only in strict mode, that "bow" is deprecated. All modders should have strict mode on for warnings like this.
Changed existing entries from "bow" to "archery".

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Rewriting the hacky gunmod location thing to be properly verified and strongly typed.
While this would be a good idea, it would take extra work, then again even more to maintain compatibility with mods.

Dropping the "bow" location altogether and just printing warnings if neither skill nor item for the location exists.

Checking if there is at least one gun with given type which can receive this particular gunmod, warning if there isn't.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

* Spawn recurve bow and arrow rest
* Activate arrow rest
* Should allow installing on bow
* Should install properly on confirm

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
