### PR TITLE
40x46mm M1006 beanbag shells give the wrong casing on disassembly #1565

### DIFF
--- a/data/json/uncraft/ammo/40x46mm.json
+++ b/data/json/uncraft/ammo/40x46mm.json
@@ -6,7 +6,7 @@
     "difficulty": 4,
     "time": "3 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "PULL", "level": 1 } ],
-    "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 35 ] ], [ [ "38_casing", 1 ] ] ],
+    "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 35 ] ], [ [ "40x46mm_m212_casing", 1 ] ] ],
     "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

SUMMARY: [None] "[Fixed 40x46mm M1006 beanbag shells give the wrong casing on disassembly]"

#### Purpose of change

Issue #1565 

#### Describe the solution



#### Describe alternatives you've considered



#### Testing

Changed json in game build, and tested item's disassembly

#### Additional context

