### PR TITLE
Adjust rarity of mechs in finales, fix a spawn

### DIFF
--- a/data/json/mapgen/lab/lab_floorplans_finale1level.json
+++ b/data/json/mapgen/lab/lab_floorplans_finale1level.json
@@ -135,7 +135,7 @@
         { "monster": "mon_secubot", "x": [ 1, 4 ], "y": [ 20, 22 ], "chance": 90 },
         { "monster": "mon_secubot", "x": [ 19, 20 ], "y": [ 20, 22 ], "chance": 90 },
         { "monster": "mon_zombie_scientist", "x": [ 2, 20 ], "y": [ 1, 9 ], "chance": 90, "repeat": [ 1, 2 ] },
-        { "monster": "mon_mech_lifter", "x": 2, "y": 2, "chance": 50 }
+        { "monster": "mon_mech_lifter", "x": 2, "y": 2, "chance": 100 }
       ]
     }
   },
@@ -192,7 +192,7 @@
       "place_monster": [
         { "monster": "mon_hound_tindalos", "x": [ 7, 8 ], "y": [ 17, 18 ], "chance": 90 },
         { "monster": "mon_hound_tindalos", "x": [ 16, 17 ], "y": [ 17, 18 ], "chance": 90 },
-        { "monster": "mon_mech_lifter", "x": 2, "y": 2, "chance": 50 }
+        { "monster": "mon_mech_lifter", "x": 2, "y": 2, "chance": 100 }
       ]
     }
   },
@@ -257,7 +257,7 @@
         { "monster": "mon_secubot", "x": [ 13, 22 ], "y": [ 10, 22 ], "chance": 50, "repeat": 2 },
         { "monster": "mon_secubot", "x": [ 1, 7 ], "y": [ 10, 22 ], "chance": 50, "repeat": 2 },
         { "monster": "mon_secubot", "x": [ 1, 22 ], "y": [ 21, 22 ], "chance": 50 },
-        { "monster": "mon_mech_recon", "x": 3, "y": 21, "chance": 80 }
+        { "monster": "mon_mech_recon", "x": 2, "y": 21, "chance": 100 }
       ],
       "place_loot": [ { "item": "id_science", "x": 6, "y": 14, "chance": 100 } ],
       "place_nested": [
@@ -426,7 +426,7 @@
       "monster": { "7": { "monster": "mon_turret_light" } },
       "place_monster": [
         { "monster": "mon_secubot", "x": [ 1, 22 ], "y": [ 1, 22 ], "chance": 75, "repeat": 2 },
-        { "monster": "mon_mech_combat", "x": 2, "y": 2, "chance": 33 }
+        { "monster": "mon_mech_combat", "x": 2, "y": 2, "chance": 100 }
       ],
       "place_loot": [ { "item": "id_science", "x": 7, "y": 11, "chance": 100 } ],
       "place_nested": [ { "chunks": [ "lab_finale_4x4" ], "x": 10, "y": 10 }, { "chunks": [ "lab_border_walls" ], "x": 0, "y": 0 } ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Mechs in lab finales won't fail to spawn, fix one case of spawning in a wall"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

During Thelonestander's BN stream today he finally ran into a mech lab finale, rare as those are, only to find that it had mech containment with no mech. Given these are fairly rare, burn up fairly rare power cells, and could use some improvements in the future anyway.

Turns out it was not only not a 100% spawn rate, but also that particular variant was set to spawn in a wall, most likely bugging it out.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Fixed broken spawn of recon mech in one lab finale variant.
2. Set spawn changes of mechs in lab finales to 100%, checked the rest will all spawn in actually available space.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. The spawn rate could possibly stay low (or maybe elevated but not 100%) for the lifting mech variants, because those two finales have a nanofab and the phase immersion stuff respectively. In contrast, the recon mech finale has just a keg of mutagen going for it, while the combat mech variant is nearly empty except for a single shot of mutation or more rarely smart shot.
2. Putting this off until he's actually done with the stream.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
