### PR TITLE
Port over crafting UI improvements from DDA

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -490,7 +490,7 @@ const recipe *select_crafting_recipe( int &batch_size )
                 const int makes = current[line]->makes_amount();
                 if( makes > 1 ) {
                     ypos += fold_and_print( w_data, point( xpos, ypos ), pane, col,
-                                            _( "Recipe makes: <color_cyan>%d</color>" ),
+                                            _( "One batch makes: <color_cyan>%d</color>" ),
                                             makes );
                 }
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -20,6 +20,7 @@
 #include "cursesdef.h"
 #include "game.h"
 #include "input.h"
+#include "inventory.h"
 #include "item.h"
 #include "item_contents.h"
 #include "itype.h"
@@ -486,12 +487,34 @@ const recipe *select_crafting_recipe( int &batch_size )
                                         _( "Batch time savings: <color_cyan>%s</color>" ),
                                         current[line]->batch_savings_string() );
 
+                const int makes = current[line]->makes_amount();
+                if( makes > 1 ) {
+                    ypos += fold_and_print( w_data, point( xpos, ypos ), pane, col,
+                                            _( "Recipe makes: <color_cyan>%d</color>" ),
+                                            makes );
+                }
+
                 print_colored_text(
                     w_data, point( xpos, ypos++ ), col, col,
                     string_format( _( "Dark craftable?  <color_cyan>%s</color>" ),
                                    current[line]->has_flag( flag_BLIND_EASY ) ? _( "Easy" ) :
                                    current[line]->has_flag( flag_BLIND_HARD ) ? _( "Hard" ) :
                                    _( "Impossible" ) ) );
+
+                std::string nearby_string;
+                const int nearby_amount = crafting_inv.count_item( current[line]->result() );
+
+                if( nearby_amount == 0 ) {
+                    nearby_string = "<color_light_gray>0</color>";
+                } else if( nearby_amount > 9000 ) {
+                    // at some point you get too many to count at a glance and just know you have a lot
+                    nearby_string = _( "<color_red>It's Over 9000!!!</color>" );
+                } else {
+                    nearby_string = string_format( "<color_yellow>%d</color>", nearby_amount );
+                }
+                ypos += fold_and_print( w_data, point( xpos, ypos ), pane, col,
+                                        _( "Nearby: %s" ), nearby_string );
+
                 if( available[line].can_craft && !available[line].can_craft_non_rotten ) {
                     ypos += fold_and_print( w_data, point( xpos, ypos ), pane, col,
                                             _( "<color_red>Will use rotten ingredients</color>" ) );

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1124,6 +1124,20 @@ const std::map<quality_id, std::map<int, int>> &inventory::get_quality_cache() c
     return quality_cache;
 }
 
+int inventory::count_item( const itype_id &item_type ) const
+{
+    int num = 0;
+    const itype_bin bin = get_binned_items();
+    if( bin.find( item_type ) == bin.end() ) {
+        return num;
+    }
+    const std::list<const item *> items = get_binned_items().find( item_type )->second;
+    for( const item *it : items ) {
+        num += it->count();
+    }
+    return num;
+}
+
 void inventory::assign_empty_invlet( item &it, const Character &p, const bool force )
 {
     const std::string auto_setting = get_option<std::string>( "AUTO_INV_ASSIGN" );

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -236,6 +236,8 @@ class inventory : public visitable<inventory>
         // gets a singular enchantment that is an amalgamation of all items that have active enchantments
         enchantment get_active_enchantment_cache( const Character &owner ) const;
 
+        int count_item( const itype_id &item_type ) const;
+
         void update_quality_cache();
         const std::map<quality_id, std::map<int, int>> &get_quality_cache() const;
 

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -430,7 +430,7 @@ item recipe::create_result() const
     if( !newit.craft_has_charges() ) {
         newit.charges = 0;
     } else if( result_mult != 1 ) {
-        // TODO: Make it work for charge-less items
+        // TODO: Make it work for charge-less items (update makes amount)
         newit.charges *= result_mult;
     }
 
@@ -796,4 +796,16 @@ bool recipe::hot_result() const
         }
     }
     return false;
+}
+
+int recipe::makes_amount() const
+{
+    int makes;
+    if( charges.has_value() ) {
+        makes = charges.value();
+    } else {
+        makes = result_->charges_default();
+    }
+    // return either charges * mult or 1
+    return makes ? makes * result_mult : 1 ;
 }

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -176,6 +176,9 @@ class recipe
 
         bool hot_result() const;
 
+        // Returns the ammount or charges recipe will produce.
+        int makes_amount() const;
+
     private:
         void add_requirements( const std::vector<std::pair<requirement_id, int>> &reqs );
 


### PR DESCRIPTION
Co-Authored-By: Gordon Watt <15700895+Theundyingcode@users.noreply.github.com>

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Interface "Port over changes from DDA allowing crafting menu to show product stack size, amount of product already nearby"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Finally set aside time to port over a thing Lamandus had been asking me about, allowing the crafting UI to show you how many of an object you have nearby, and make it more clear how many items a recipe will make.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/449

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Ported over changes to crafting_gui.cpp, including inventory.h and added if statements to `select_crafting_recipe`.
2. Ported over addition of `inventory::count_item` to inventory.cpp and inventory.h.
3. Ported over addition of `recipe::makes_amount` to recipe.cpp and recipe.h. Converted the function to use BN's handling of item stuff instead of find_type, not sure what DDA PR added that.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making Lamandus cry by putting this off even more.
2. Axing the "how many does this recipe make" feature and only porting over the "how many are already nearby" feature, because the item UI already does it better (see below).

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested.
2. Checked a mundane shelter to see that clean water was reported as being nearby.
3. Spawned in an absurd amount of something craftable, confirmed the UI nopes out if you have over 9000.
4. Also checked that recipes like arrows, fuel, etc show default stack size in the crafting menu too. See below.

One thing I discovered, for example if you select batch crafting pebbles: it still only shows the default amount made per item, not the grand total that instance of batch-crafting will make. I can't actually tell if this is a bug or just an oversight. Pinging @Theundyingcode for clarity, if they'd be able to confirm what's intended behavior here.

I assume this is because either `if( charges.has_value() )` or `makes = charges.value();` is not actually valid in a way that doesn't cause a compile failure, I searched DDA's source code and noticed that the file change from the source PR was the ONLY hit for `charges.value` so I wonder if that's the case. I tested in DDA as well and confirmed that the version as implemented there does this too, so it's not something BN-specific.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source: crafting UI updates, by Theundyingcode: https://github.com/CleverRaven/Cataclysm-DDA/pull/43393

Nearby stuff:
![image](https://user-images.githubusercontent.com/11582235/170564989-128ab2ad-e3f7-4bca-b830-9837c64157eb.png)

What it displays when you almost crash the game attempting to hydrate the gods themselves:
![image](https://user-images.githubusercontent.com/11582235/170565124-8462a77d-1c53-496f-a98f-ee7fc14424c8.png)

Stack size shown in both sections, everything seems normal:
![image](https://user-images.githubusercontent.com/11582235/170566030-a28b2397-904e-4228-8617-a837d04c78e5.png)

And then the part where source PR's implementation does something weird, tested in compiled branch and in DDA:
![image](https://user-images.githubusercontent.com/11582235/170565300-8e50810a-ed63-4694-9767-2a9e712576ef.png)