### PR TITLE
Fix some problems of thievery 

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -884,8 +884,14 @@ void pickup_activity_actor::do_turn( player_activity &, Character &who )
             for( npc &guy : g->all_npcs() ) {
                 if( guy.get_attitude() == NPCATT_RECOVER_GOODS ) {
                     guy.talk_to_u();
+                    // Set the witness to false to avoid more talk
+                    npc::has_thievery_witness = false;
                     break;
                 }
+            }
+            if( npc::has_thievery_witness ) {
+                debugmsg( "Could not find any thievery witness, but there should be one." );
+                npc::has_thievery_witness = false;
             }
         }
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -779,14 +779,6 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
         // Make a copy to be put in the destination location
         item newit = leftovers;
 
-        // Handle charges, quantity == 0 means move all
-        if( quantity != 0 && newit.count_by_charges() ) {
-            newit.charges = std::min( newit.charges, quantity );
-            leftovers.charges -= quantity;
-        } else {
-            leftovers.charges = 0;
-        }
-
         // Check that we can pick it up.
         if( !newit.made_of( LIQUID ) ) {
             // This is for hauling across zlevels, remove when going up and down stairs
@@ -795,6 +787,13 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
                 newit.set_owner( who );
             } else {
                 continue;
+            }
+            // Handle charges, quantity == 0 means move all
+            if( quantity != 0 && newit.count_by_charges() ) {
+                newit.charges = std::min( newit.charges, quantity );
+                leftovers.charges -= quantity;
+            } else {
+                leftovers.charges = 0;
             }
             const tripoint src = target.position();
             const int distance = src.z == dest.z ? std::max( rl_dist( src, dest ), 1 ) : 1;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -867,7 +867,7 @@ void pickup_activity_actor::do_turn( player_activity &, Character &who )
 
     // If there are items left we ran out of moves, so continue the activity
     // Otherwise, we are done.
-    if( !keep_going || target_items.empty() ) {
+    if( !keep_going || target_items.empty() || npc::has_thievery_witness ) {
         who.cancel_activity();
 
         if( who.get_value( "THIEF_MODE_KEEP" ) != "YES" ) {
@@ -879,6 +879,15 @@ void pickup_activity_actor::do_turn( player_activity &, Character &who )
             // AIM might have more pickup activities pending, also cancel them.
             // TODO: Move this to advanced inventory instead of hacking it in here
             cancel_aim_processing();
+        }
+
+        if( npc::has_thievery_witness ) {
+            for( npc &guy : g->all_npcs() ) {
+                if( guy.get_attitude() == NPCATT_RECOVER_GOODS ) {
+                    guy.talk_to_u();
+                    break;
+                }
+            }
         }
     }
 }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -377,6 +377,7 @@ class pickup_activity_actor : public activity_actor
          * if not grabbing from the ground.
          */
         cata::optional<tripoint> starting_pos;
+        bool thievery_checked = false;
 
     public:
         pickup_activity_actor( const std::vector<pickup::pick_drop_selection> &target_items,

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -377,7 +377,6 @@ class pickup_activity_actor : public activity_actor
          * if not grabbing from the ground.
          */
         cata::optional<tripoint> starting_pos;
-        bool thievery_checked = false;
 
     public:
         pickup_activity_actor( const std::vector<pickup::pick_drop_selection> &target_items,

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2261,6 +2261,10 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
             src_veh = &vp->vehicle();
             src_part = vp->part_index();
             for( auto &it : src_veh->get_items( src_part ) ) {
+                if( !it.is_owned_by( p, true ) ) {
+                    continue;
+                }
+                it.set_owner( p );
                 items.push_back( std::make_pair( &it, true ) );
             }
         } else {
@@ -2268,6 +2272,10 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
             src_part = -1;
         }
         for( auto &it : g->m.i_at( src_loc ) ) {
+            if( !it.is_owned_by( p, true ) ) {
+                continue;
+            }
+            it.set_owner( p );
             items.push_back( std::make_pair( &it, false ) );
         }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4281,7 +4281,13 @@ void item::handle_pickup_ownership( Character &c )
             }
             if( !witnesses.empty() ) {
                 set_old_owner( get_owner() );
-                random_entry( witnesses )->witness_thievery();
+                // Make sure there is only one witness
+                for( npc &guy : g->all_npcs() ) {
+                    if( guy.get_attitude() == NPCATT_RECOVER_GOODS ) {
+                        guy.set_attitude( NPCATT_NULL );
+                    }
+                }
+                random_entry( witnesses )->set_attitude( NPCATT_RECOVER_GOODS );
             }
             set_owner( c );
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4281,17 +4281,7 @@ void item::handle_pickup_ownership( Character &c )
             }
             if( !witnesses.empty() ) {
                 set_old_owner( get_owner() );
-                bool guard_chosen = false;
-                for( npc *elem : witnesses ) {
-                    if( elem->myclass == npc_class_id( "NC_BOUNTY_HUNTER" ) ) {
-                        guard_chosen = true;
-                        elem->witness_thievery( &*this );
-                        break;
-                    }
-                }
-                if( !guard_chosen ) {
-                    random_entry( witnesses )->witness_thievery( &*this );
-                }
+                random_entry( witnesses )->witness_thievery( &*this );
             }
             set_owner( c );
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4281,7 +4281,7 @@ void item::handle_pickup_ownership( Character &c )
             }
             if( !witnesses.empty() ) {
                 set_old_owner( get_owner() );
-                random_entry( witnesses )->witness_thievery( &*this );
+                random_entry( witnesses )->witness_thievery();
             }
             set_owner( c );
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -269,6 +269,9 @@ static const std::string flag_WATER_EXTINGUISH( "WATER_EXTINGUISH" );
 static const std::string flag_WET( "WET" );
 static const std::string flag_WIND_EXTINGUISH( "WIND_EXTINGUISH" );
 
+static const std::string has_thievery_witness( "has_thievery_witness" );
+static const activity_id ACT_PICKUP( "ACT_PICKUP" );
+
 static const matec_id rapid_strike( "RAPID" );
 
 class npc_class;
@@ -4288,6 +4291,11 @@ void item::handle_pickup_ownership( Character &c )
                     }
                 }
                 random_entry( witnesses )->set_attitude( NPCATT_RECOVER_GOODS );
+                // Notify the activity that we got a witness
+                if( c.activity && !c.activity.is_null() && c.activity.id() == ACT_PICKUP ) {
+                    c.activity.str_values.clear();
+                    c.activity.str_values.emplace_back( has_thievery_witness );
+                }
             }
             set_owner( c );
         }

--- a/src/npc.h
+++ b/src/npc.h
@@ -1049,8 +1049,6 @@ class npc : public player
         void handle_sound( sounds::sound_t priority, const std::string &description,
                            int heard_volume, const tripoint &spos );
 
-        void witness_thievery();
-
         /* shift() works much like monster::shift(), and is called when the player moves
          * from one submap to an adjacent submap.  It updates our position (shifting by
          * 12 tiles), as well as our plans.
@@ -1340,7 +1338,6 @@ class npc : public player
         static constexpr tripoint_abs_omt no_goal_point{ tripoint_min };
         job_data job;
         time_point last_updated;
-        static bool has_thievery_witness;
         /**
          * Do some cleanup and caching as npc is being unloaded from map.
          */

--- a/src/npc.h
+++ b/src/npc.h
@@ -1305,7 +1305,6 @@ class npc : public player
         tripoint_abs_omt goal;
         tripoint wander_pos = tripoint_min;
         int wander_time = 0;
-        item *known_stolen_item = nullptr; // the item that the NPC wants the player to drop or barter for.
         /**
          * Location and index of the corpse we'd like to pulp (if any).
          */
@@ -1341,6 +1340,7 @@ class npc : public player
         static constexpr tripoint_abs_omt no_goal_point{ tripoint_min };
         job_data job;
         time_point last_updated;
+        static bool has_thievery_witness;
         /**
          * Do some cleanup and caching as npc is being unloaded from map.
          */

--- a/src/npc.h
+++ b/src/npc.h
@@ -1049,7 +1049,7 @@ class npc : public player
         void handle_sound( sounds::sound_t priority, const std::string &description,
                            int heard_volume, const tripoint &spos );
 
-        void witness_thievery( item *it );
+        void witness_thievery();
 
         /* shift() works much like monster::shift(), and is called when the player moves
          * from one submap to an adjacent submap.  It updates our position (shifting by

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1302,8 +1302,14 @@ void npc::execute_action( npc_action action )
     }
 }
 
-void npc::witness_thievery( item *it )
+void npc::witness_thievery()
 {
+    // Make sure there is only one witness
+    for( npc &guy : g->all_npcs() ) {
+        if( guy.get_attitude() == NPCATT_RECOVER_GOODS ) {
+            guy.set_attitude( NPCATT_NULL );
+        }
+    }
     set_attitude( NPCATT_RECOVER_GOODS );
     has_thievery_witness = true;
 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -130,8 +130,6 @@ static constexpr float NPC_DANGER_VERY_LOW = 5.0f;
 static constexpr float NPC_DANGER_MAX = 150.0f;
 static constexpr float MAX_FLOAT = 5000000000.0f;
 
-bool npc::has_thievery_witness = false;
-
 enum npc_action : int {
     npc_undecided = 0,
     npc_pause,
@@ -1300,18 +1298,6 @@ void npc::execute_action( npc_action action )
         add_msg( m_debug, "NPC didn't use its moves.  Action %s (%d).",
                  npc_action_name( action ), action );
     }
-}
-
-void npc::witness_thievery()
-{
-    // Make sure there is only one witness
-    for( npc &guy : g->all_npcs() ) {
-        if( guy.get_attitude() == NPCATT_RECOVER_GOODS ) {
-            guy.set_attitude( NPCATT_NULL );
-        }
-    }
-    set_attitude( NPCATT_RECOVER_GOODS );
-    has_thievery_witness = true;
 }
 
 npc_action npc::method_of_fleeing()

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -841,13 +841,11 @@ void talk_function::drop_stolen_item( npc &p )
         g->u.stop_hauling();
     }
     p.set_attitude( NPCATT_NULL );
-    npc::has_thievery_witness = false;
 }
 
 void talk_function::remove_stolen_status( npc &p )
 {
     p.set_attitude( NPCATT_NULL );
-    npc::has_thievery_witness = false;
 }
 
 void talk_function::start_mugging( npc &p )

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -837,21 +837,17 @@ void talk_function::drop_stolen_item( npc &p )
             g->m.add_item_or_charges( g->u.pos(), to_drop );
         }
     }
-    if( p.known_stolen_item ) {
-        p.known_stolen_item = nullptr;
-    }
     if( g->u.is_hauling() ) {
         g->u.stop_hauling();
     }
     p.set_attitude( NPCATT_NULL );
+    npc::has_thievery_witness = false;
 }
 
 void talk_function::remove_stolen_status( npc &p )
 {
-    if( p.known_stolen_item ) {
-        p.known_stolen_item = nullptr;
-    }
     p.set_attitude( NPCATT_NULL );
+    npc::has_thievery_witness = false;
 }
 
 void talk_function::start_mugging( npc &p )


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Fix some problems of thievery "

#### Purpose of change

Fix #1572 
Fix #1581 
Action "Sort out my loot" does not move items that do not belong to the player faction (no theft).

#### Describe the solution

For #1572, make the NPC talk about thievery immediately once they notice you steal something.
For #1581, move the code to right position (I believe they are placed wrong during the migration).
Add items owner check in move loot action.

#### Describe alternatives you've considered

#### Testing

Tested thievery in refugee center. Works as intended apparently.

#### Additional context
