### PR TITLE
Military helicopter spawns

### DIFF
--- a/data/json/mapgen/helipad.json
+++ b/data/json/mapgen/helipad.json
@@ -125,7 +125,8 @@
         { "vehicle": "flatbed_truck", "x": 11, "y": 4, "chance": 25, "rotation": 270, "status": -1 },
         { "vehicle": "SmallFlier3_Wreck", "x": 9, "y": 42, "chance": 10, "rotation": 90, "status": -1 },
         { "vehicle": "Smallflier1_Wreck", "x": 18, "y": 34, "chance": 10, "rotation": 270, "status": -1 },
-        { "vehicle": "SmallFlier2_Wreck", "x": 39, "y": 42, "chance": 10, "rotation": 90, "status": -1 }
+        { "vehicle": "SmallFlier2_Wreck", "x": 39, "y": 42, "chance": 10, "rotation": 90, "status": -1 },
+        { "vehicle": "mil_helicopters", "x": 18, "y": 34, "chance": 15, "rotation": 180, "status": 1 }
       ]
     }
   },

--- a/data/json/mapgen/military/mil_base/mil_base_z0.json
+++ b/data/json/mapgen/military/mil_base/mil_base_z0.json
@@ -1198,10 +1198,11 @@
       ],
       "place_vehicles": [
         { "vehicle": "ambulance", "x": 37, "y": 18, "chance": 80, "rotation": 180 },
-        { "vehicle": "helicopter_blackhawk_3a", "x": 50, "y": 32, "chance": 5, "rotation": 270 },
+        { "vehicle": "helicopter_blackhawk_3a", "x": 50, "y": 32, "chance": 10, "rotation": 270 },
         { "vehicle": "military_vehicles", "x": 5, "y": 61, "chance": 25, "rotation": 180, "status": 1 },
         { "vehicle": "military_vehicles", "x": 7, "y": 54, "chance": 25, "rotation": 180, "status": 1 },
-        { "vehicle": "portable_generator", "x": 76, "y": 12, "chance": 50, "status": 1 }
+        { "vehicle": "portable_generator", "x": 76, "y": 12, "chance": 50, "status": 1 },
+        { "vehicle": "mil_helicopters", "x": 50, "y": 32, "chance": 15, "rotation": 180, "status": 1 }
       ],
       "computers": {
         "0": {


### PR DESCRIPTION
Summary

SUMMARY: [Content] adds some military helicopter spawns

Purpose of change

There were no military helicopter spawn locations This allows them to spawn in two new places. 

Describe the solution 
 
Made it to where they have an actual spawn point

Describe alternatives you've considered 

 Once more roofs get added I can add more, but some locations I wanted to add didn't have proper roofs, but as it sat in game there were no spawns for other military helicopters. 

Testing

 I loaded into a game with changed spawns went to military helipad Blackhawk was spawned! Could still spawn in weird. Until I see more of them spawn. 

