### PR TITLE
Fix engines being unable to be toggled except first

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -384,6 +384,7 @@ void vehicle::control_engines()
                     }
                     return;
                 }
+                i++;
             }
         }
     };


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix engines being unable to be toggled except first"

#### Purpose of change

Fixes #1552

#### Describe the solution

missing `i++` at the end of loop 
turns out this line was accidently [removed on this commit](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1480/files#diff-078ef22e64ec25788b594c35675260cc1d008bfa08d2a902e5d0c929ff7fe753L392)

#### Describe alternatives you've considered
None

#### Testing
None

#### Additional context
None