### PR TITLE
Fix compilation error about range based for loops

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -976,12 +976,12 @@ bucketed_points bucket_by_distance( const tripoint &origin,
                                     const std::map<tripoint, double> &to_bucket )
 {
     std::map<int, one_bucket> by_distance;
-    for( const std::pair<tripoint, double> &pv : to_bucket ) {
+    for( const std::pair<const tripoint, double> &pv : to_bucket ) {
         int dist = trig_dist_squared( origin, pv.first );
         by_distance[dist].emplace_back( pv.first, pv.second );
     }
     bucketed_points buckets;
-    for( const std::pair<int, one_bucket> &bc : by_distance ) {
+    for( const std::pair<const int, one_bucket> &bc : by_distance ) {
         buckets.emplace_back( bc.second );
     }
     return buckets;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9198,7 +9198,7 @@ static std::map<bodypart_id, int> acc_clothing_warmth( const
         Acc accumulation_function )
 {
     std::map<bodypart_id, int> ret;
-    for( const std::pair<bodypart_id, std::vector<const item *>> &pr : clothing_map ) {
+    for( const std::pair<const bodypart_id, std::vector<const item *>> &pr : clothing_map ) {
         ret[pr.first] = std::accumulate( pr.second.begin(), pr.second.end(), 0,
         [accumulation_function]( int acc, const item * it ) {
             return accumulation_function( acc, it->get_warmth() );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -610,7 +610,7 @@ dealt_damage_instance hit_with_aoe( Creature &target, Creature *source, const da
         return acc + pr.first->hit_size;
     } );
     dealt_damage_instance dealt_damage;
-    for( const std::pair<bodypart_str_id, bodypart> &pr : all_body_parts ) {
+    for( const std::pair<const bodypart_str_id, bodypart> &pr : all_body_parts ) {
         damage_instance impact = di;
         impact.mult_damage( pr.first->hit_size / hit_size_sum );
         dealt_damage_instance bp_damage = target.deal_damage( source, pr.first.id(), impact );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2257,7 +2257,7 @@ drop_locations inventory_drop_selector::execute()
 
     drop_locations dropped_pos_and_qty;
 
-    for( const excluded_stack &drop_pair : dropping ) {
+    for( const std::pair<const item *const, int>  &drop_pair : dropping ) {
         item_location loc( u, const_cast<item *>( drop_pair.first ) );
         // Note: drop_location here contains location of first item in stack,
         // and amount of items to be dropped from the stack.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3272,7 +3272,7 @@ void item::bionic_info( std::vector<iteminfo> &info, const iteminfo_query *parts
     if( !bid->bullet_protec.empty() ) {
         info.push_back( iteminfo( "DESCRIPTION", _( "<bold>Ballistic Protection</bold>: " ),
                                   iteminfo::no_newline ) );
-        for( const std::pair<const bodypart_str_id, size_t > &element : bid->bullet_protec ) {
+        for( const auto &element : bid->bullet_protec ) {
             info.push_back( iteminfo( "CBM", body_part_name_as_heading( element.first->token, 1 ),
                                       " <num> ", iteminfo::no_newline, element.second ) );
         }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3122,7 +3122,7 @@ void target_ui::draw_terrain_overlay()
         }
     } else if( mode == TargetMode::Shape ) {
         drawsq_params params = drawsq_params().highlight( true ).center( center );
-        for( const std::pair<tripoint, double> &pr : shape_coverage ) {
+        for( const std::pair<const tripoint, double> &pr : shape_coverage ) {
             const tripoint &tile = pr.first;
 #ifdef TILES
             if( use_tiles ) {

--- a/src/ranged_aoe.cpp
+++ b/src/ranged_aoe.cpp
@@ -116,7 +116,7 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
 
     // Here and not above because we want the animation first
     // Terrain will be shown damaged, but having it in unknown state would complicate timing the animation
-    for( const std::pair<tripoint, double> &pr : final_coverage ) {
+    for( const std::pair<const tripoint, double> &pr : final_coverage ) {
         Creature *critter = g->critter_at( pr.first );
         if( critter != nullptr ) {
             ranged::hit_with_aoe( *critter, &attacker, proj.impact );

--- a/tests/dependency_tree_test.cpp
+++ b/tests/dependency_tree_test.cpp
@@ -13,7 +13,7 @@ static std::map<mod_id, std::vector<mod_id>> build_map( const t_key_dep_map &m )
 {
     std::map<mod_id, std::vector<mod_id>> ret;
 
-    for( const t_map_entry &entry : m ) {
+    for( const auto &entry : m ) {
         std::vector<mod_id> ids;
         for( t_mod_id elem : entry.second ) {
             ids.emplace_back( elem );


### PR DESCRIPTION
#### Summary

SUMMARY: Build "Fix Compilation error about range based for loops"


#### Purpose of change

compilation was failing because say,
```c++
for( const std::pair<tripoint, double> &pv : to_bucket )
```
wasn't const enough to be referenced.

#### Describe the solution

```c++
for( const std::pair<const tripoint, double> &pv : to_bucket )
```

added some of added missing const qualifier, or changed to auto if it wasn't able to.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
