### PR TITLE
Prevent discharging more power from battery with nearly 0% power

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4974,6 +4974,7 @@ int vehicle::discharge_battery( int amount, bool recurse )
         dischargeable_parts.erase( iter );
         // Calculate number of charges to reach the previous %.
         int prev_charge_level = ( ( charge_level - 1 ) * p->ammo_capacity() ) / 100;
+        prev_charge_level = std::max( 0, prev_charge_level );
         int amount_to_discharge = std::min( p->ammo_remaining() - prev_charge_level, amount );
         p->ammo_consume( amount_to_discharge, global_part_pos3( *p ) );
         amount -= amount_to_discharge;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Prevent discharging too much power from nearly empty batteries"

#### Purpose of change

Consider the situation when charging from large storage battery (80 MJ) with 10 kJ remaining. It would have 0% power level (10*100 / 80_000) so our "prev_charge_level" would `-800` and we would lower `amount` by 810.

Essentially free energy when it shouldn't be so I ensure that we cannot charge more power than remaining.

#### Describe the solution

Just ensure that we never try to lower our power amount more than we have.

#### Describe alternatives you've considered

#### Testing

Only run autotests because change is trivial.

#### Additional context
