### PR TITLE
Make electric engines consume battery power evenly

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4382,13 +4382,25 @@ std::map<itype_id, int> vehicle::fuel_usage() const
 
 double vehicle::drain_energy( const itype_id &ftype, double energy_j )
 {
+    // Consumption of battery power is done differently.
+    // From all batteries at once and doesn't change mass.
+    if( ftype == fuel_type_battery ) {
+        // Batteries stored in kilojoules
+        const int total_kj_to_drain = static_cast<int>( energy_j / 1000.0 );
+        if( total_kj_to_drain <= 0 ) {
+            return 0.0;
+        }
+        const int not_fulfilled = discharge_battery( total_kj_to_drain );
+        return static_cast<double>( total_kj_to_drain - not_fulfilled ) * 1000.0;
+    }
+
     double drained = 0.0f;
     for( auto &p : parts ) {
         if( energy_j <= 0.0f ) {
             break;
         }
 
-        double consumed = p.consume_energy( ftype, energy_j );
+        const double consumed = p.consume_energy( ftype, energy_j );
         drained += consumed;
         energy_j -= consumed;
     }

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -431,7 +431,7 @@ TEST_CASE( "vehicle_efficiency", "[vehicle] [engine]" )
     test_vehicle( "beetle", 815669, 431300, 338700, 95610, 68060 );
     test_vehicle( "car", 1120618, 617500, 386100, 52730, 25170 );
     test_vehicle( "car_sports", 1154214, 352600, 267600, 36790, 22350 );
-    test_vehicle( "electric_car", 1126087, 132700, 72290, 8160, 3390 );
+    test_vehicle( "electric_car", 1126087, 132700, 72290, 8240, 3390 );
     test_vehicle( "suv", 1320286, 1163000, 630000, 85540, 30810 );
     test_vehicle( "motorcycle", 163085, 120300, 99920, 63320, 50810 );
     test_vehicle( "quad_bike", 265345, 116100, 116100, 46770, 46770 );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Make electric engines consume battery power evenly"

#### Purpose of change

Earlier, when riding a car with electric engines and multiple batteries, batteries discharged one after one.
However, they should discharge by similar percent (this is how connected electric grids work).

To reproduce old behaviour, one can do this:
1. Put 2 charged batteries to car.
2. Put electric engine to car.
3. Make car use only electric batteries.
4. Ride the car a while.
5. Notice that one battery is significantly more discharged than another (can be even 0% vs 100%).

#### Describe the solution

Made fuel consumption reuse existing code for utility discharges if fuel type is battery.

#### Describe alternatives you've considered

#### Testing

Ride a car with 1 battery charged to half and another charged fully.
Monitored power level of batteries, noticed that only most charged discharged.
When the second battery meet percentage of another battery, they start to discharge equally and keep same percent +-1.

#### Additional context
