### PR TITLE
Fixed invalid `less` operator implementation for `tripoint_distance`

### DIFF
--- a/src/ranged_aoe.cpp
+++ b/src/ranged_aoe.cpp
@@ -23,7 +23,7 @@ struct tripoint_distance {
 
     // Inverted because it's descending by default
     bool operator<( const tripoint_distance &rhs ) const {
-        return !( distance_squared < rhs.distance_squared );
+        return rhs.distance_squared < this->distance_squared;
     }
 };
 


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix invalid comparator which triggerred debug assertions in STL"

#### Purpose of change

Old implementation have such bad quality:
if a == b, then `a < b` and `b < a` would be both true which is invalid comparator implementation.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

Because running tests in debug build is painful, didn't test lack of assertion firing.
Release build passes tests though.

#### Additional context

Found that when trying running tests in debug build.