### PR TITLE
Vehicle holes

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1025,7 +1025,7 @@ std::vector<tripoint> route_adjacent( const player &p, const tripoint &dest )
     map &here = get_map();
 
     for( const tripoint &tp : here.points_in_radius( dest, 1 ) ) {
-        if( tp != p.pos() && here.passable( tp ) ) {
+        if( tp != p.pos() && here.passable( tp ) && !here.obstructed_by_vehicle_rotation( dest, tp ) ) {
             passable_tiles.emplace( tp );
         }
     }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -250,6 +250,11 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         return false;
     }
 
+    if( m.obstructed_by_vehicle_rotation( you.pos(), dest_loc ) ) {
+        add_msg( _( "You can't walk through that vehicle's wall." ) );
+        return false;
+    }
+
     if( monster *const mon_ptr = g->critter_at<monster>( dest_loc, true ) ) {
         monster &critter = *mon_ptr;
         if( critter.friendly == 0 &&

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -403,6 +403,26 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
                                       critter->ranged_target_size(), 0.4 );
         }
 
+        if( here.obstructed_by_vehicle_rotation( prev_point, tp ) ) {
+            //We're firing through an impassible gap in a rotated vehicle, randomly hit one of the two walls
+            tripoint rand = tp;
+            if( one_in( 2 ) ) {
+                rand.x = prev_point.x;
+            } else {
+                rand.y = prev_point.y;
+            }
+            if( in_veh == nullptr || veh_pointer_or_null( here.veh_at( rand ) ) != in_veh ) {
+                here.shoot( rand, proj, false );
+                if( proj.impact.total_damage() <= 0 ) {
+                    //If the projectile stops here move it back a square so it doesn't end up inside the vehicle
+                    traj_len = i - 1;
+                    tp = prev_point;
+                    break;
+                }
+            }
+        }
+
+
         if( critter != nullptr && cur_missed_by < 1.0 ) {
             if( in_veh != nullptr && veh_pointer_or_null( here.veh_at( tp ) ) == in_veh &&
                 critter->is_player() ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7876,7 +7876,7 @@ tripoint Character::adjacent_tile() const
                 }
             }
 
-            if( dangerous_fields == 0 ) {
+            if( dangerous_fields == 0 && ! get_map().obstructed_by_vehicle_rotation( pos(), p ) ) {
                 ret.push_back( p );
             }
         }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -222,12 +222,15 @@ bool Creature::sees( const Creature &critter ) const
         return ch == nullptr || !ch->is_invisible();
     };
 
+    map &here = get_map();
     const Character *ch = critter.as_character();
     const int wanted_range = rl_dist( pos(), critter.pos() );
-    map &here = get_map();
-    // Can always see adjacent monsters on the same level.
+    // Can always see adjacent monsters on the same level, unless they're through a vehicle wall.
     // We also bypass lighting for vertically adjacent monsters, but still check for floors.
     if( wanted_range <= 1 && ( posz() == critter.posz() || here.sees( pos(), critter.pos(), 1 ) ) ) {
+        if( here.obscured_by_vehicle_rotation( pos(), critter.pos() ) ) {
+            return false;
+        }
         return visible( ch );
     } else if( ( wanted_range > 1 && critter.digging() ) ||
                ( critter.has_flag( MF_NIGHT_INVISIBILITY ) && here.light_at( critter.pos() ) <= lit_level::LOW ) ||

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -618,16 +618,18 @@ static std::map<const Creature *, int> shrapnel( const tripoint &src, const proj
 
     float obstacle_cache[MAPSIZE_X][MAPSIZE_Y] = {};
     float visited_cache[MAPSIZE_X][MAPSIZE_Y] = {};
-    diagonal_blocks blocked_cache[MAPSIZE_X][MAPSIZE_Y] = {};
 
     map &here = get_map();
+
+    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = here.access_cache(
+                src.z ).vehicle_obstructed_cache;
+
     // TODO: Calculate range based on max effective range for projectiles.
     // Basically bisect between 0 and map diameter using shrapnel_calc().
     // Need to update shadowcasting to support limiting range without adjusting initial distance.
     const tripoint_range<tripoint> area = here.points_on_zlevel( src.z );
 
-    here.build_obstacle_cache( area.min(), area.max() + tripoint_south_east, obstacle_cache,
-                               blocked_cache );
+    here.build_obstacle_cache( area.min(), area.max() + tripoint_south_east, obstacle_cache );
 
     // Shadowcasting normally ignores the origin square,
     // so apply it manually to catch monsters standing on the explosive.

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -440,7 +440,7 @@ static std::map<const Creature *, int> do_blast_new( const tripoint &blast_cente
     for( const dist_point_pair &pair : blast_map ) {
         float distance;
         tripoint position;
-        tripoint last_position = position;
+        tripoint last_position = blast_center;
         std::tie( distance, position ) = pair;
 
         const std::vector<tripoint> line_of_movement = line_to( blast_center, position );

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -208,7 +208,8 @@ static std::map<const Creature *, int> do_blast( const tripoint &p, const float 
         // Iterate over all neighbors. Bash all of them, propagate to some
         for( size_t i = 0; i < max_index; i++ ) {
             tripoint dest( pt + tripoint( x_offset[i], y_offset[i], z_offset[i] ) );
-            if( closed.count( dest ) != 0 || !here.inbounds( dest ) ) {
+            if( closed.count( dest ) != 0 || !here.inbounds( dest ) ||
+                here.obstructed_by_vehicle_rotation( pt, dest ) ) {
                 continue;
             }
 
@@ -439,11 +440,16 @@ static std::map<const Creature *, int> do_blast_new( const tripoint &blast_cente
     for( const dist_point_pair &pair : blast_map ) {
         float distance;
         tripoint position;
+        tripoint last_position = position;
         std::tie( distance, position ) = pair;
 
         const std::vector<tripoint> line_of_movement = line_to( blast_center, position );
         const bool has_obstacles = std::any_of( line_of_movement.begin(),
-        line_of_movement.end(), [position]( tripoint ray_position ) {
+        line_of_movement.end(), [position, &last_position]( tripoint ray_position ) {
+            if( get_map().obstructed_by_vehicle_rotation( last_position, ray_position ) ) {
+                return true;
+            }
+            last_position = ray_position;
             return ray_position != position && get_map().impassable( ray_position );
         } );
 
@@ -612,6 +618,7 @@ static std::map<const Creature *, int> shrapnel( const tripoint &src, const proj
 
     float obstacle_cache[MAPSIZE_X][MAPSIZE_Y] = {};
     float visited_cache[MAPSIZE_X][MAPSIZE_Y] = {};
+    diagonal_blocks blocked_cache[MAPSIZE_X][MAPSIZE_Y] = {};
 
     map &here = get_map();
     // TODO: Calculate range based on max effective range for projectiles.
@@ -619,7 +626,8 @@ static std::map<const Creature *, int> shrapnel( const tripoint &src, const proj
     // Need to update shadowcasting to support limiting range without adjusting initial distance.
     const tripoint_range<tripoint> area = here.points_on_zlevel( src.z );
 
-    here.build_obstacle_cache( area.min(), area.max() + tripoint_south_east, obstacle_cache );
+    here.build_obstacle_cache( area.min(), area.max() + tripoint_south_east, obstacle_cache,
+                               blocked_cache );
 
     // Shadowcasting normally ignores the origin square,
     // so apply it manually to catch monsters standing on the explosive.
@@ -631,7 +639,8 @@ static std::map<const Creature *, int> shrapnel( const tripoint &src, const proj
     const int offset_distance = 60 - 1 - fragment.range;
     castLightAll<float, float, shrapnel_calc, shrapnel_check,
                  update_fragment_cloud, accumulate_fragment_cloud>
-                 ( visited_cache, obstacle_cache, src.xy(), offset_distance, fragment.range + 1.0f );
+                 ( visited_cache, obstacle_cache, blocked_cache, src.xy(),
+                   offset_distance, fragment.range + 1.0f );
 
     // Now visited_caches are populated with density and velocity of fragments.
     for( const tripoint &target : area ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10351,7 +10351,7 @@ void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
     tripoint pt = c->pos();
     tripoint prev_point = pt;
     bool force_next = false;
-    tripoint next_forced = tripoint_zero;
+    tripoint next_forced;
     while( range > 0 ) {
         c->underwater = false;
         // TODO: Check whenever it is actually in the viewport

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4604,6 +4604,8 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
     // TODO: make the force parameter actually do something.
     // the header file says higher force causes more damage.
     // perhaps that is what it should do?
+
+    // TODO: refactor this so it's not copy/pasted 3 times
     tripoint tp = traj.front();
     if( !critter_at( tp ) ) {
         debugmsg( _( "Nothing at (%d,%d,%d) to knockback!" ), tp.x, tp.y, tp.z );
@@ -4616,7 +4618,7 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
             add_msg( _( "%s was stunned!" ), targ->name() );
         }
         for( size_t i = 1; i < traj.size(); i++ ) {
-            if( m.impassable( traj[i].xy() ) ) {
+            if( m.impassable( traj[i].xy() ) || m.obstructed_by_vehicle_rotation( tp, traj[i] ) ) {
                 targ->setpos( traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
@@ -4667,6 +4669,7 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
                     add_msg( _( "The %s flops around and dies!" ), targ->name() );
                 }
             }
+            tp = traj[i];
         }
     } else if( npc *const targ = critter_at<npc>( tp ) ) {
         if( stun > 0 ) {
@@ -4674,7 +4677,8 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
             add_msg( _( "%s was stunned!" ), targ->name );
         }
         for( size_t i = 1; i < traj.size(); i++ ) {
-            if( m.impassable( traj[i].xy() ) ) { // oops, we hit a wall!
+            if( m.impassable( traj[i].xy() ) ||
+                m.obstructed_by_vehicle_rotation( tp, traj[i] ) ) {  // oops, we hit a wall!
                 targ->setpos( traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
@@ -4731,6 +4735,7 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
                 break;
             }
             targ->setpos( traj[i] );
+            tp = traj[i];
         }
     } else if( u.pos() == tp ) {
         if( stun > 0 ) {
@@ -4741,7 +4746,8 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
                      stun );
         }
         for( size_t i = 1; i < traj.size(); i++ ) {
-            if( m.impassable( traj[i] ) ) { // oops, we hit a wall!
+            if( m.impassable( traj[i] ) ||
+                m.obstructed_by_vehicle_rotation( tp, traj[i] ) ) { // oops, we hit a wall!
                 u.setpos( traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
@@ -4809,6 +4815,8 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult )
             } else {
                 u.setpos( traj[i] );
             }
+
+            tp = traj[i];
         }
     }
 }
@@ -5931,7 +5939,7 @@ void game::peek()
         return;
     }
 
-    if( m.impassable( u.pos() + *p ) ) {
+    if( m.impassable( u.pos() + *p ) || m.obstructed_by_vehicle_rotation( u.pos(), u.pos() + *p ) ) {
         return;
     }
 
@@ -10331,7 +10339,6 @@ void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
         return;
     }
 
-    int steps = 0;
     bool thru = true;
     const bool is_u = ( c == &u );
     // Don't animate critters getting bashed if animations are off
@@ -10342,15 +10349,35 @@ void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
     tileray tdir( dir );
     int range = flvel / 10;
     tripoint pt = c->pos();
+    tripoint prev_point = pt;
+    bool force_next = false;
+    tripoint next_forced = tripoint_zero;
     while( range > 0 ) {
         c->underwater = false;
         // TODO: Check whenever it is actually in the viewport
         // or maybe even just redraw the changed tiles
         bool seen = is_u || u.sees( *c ); // To avoid redrawing when not seen
-        tdir.advance();
-        pt.x = c->posx() + tdir.dx();
-        pt.y = c->posy() + tdir.dy();
+        if( force_next ) {
+            pt = next_forced;
+            force_next = false;
+        } else {
+            tdir.advance();
+            pt.x = c->posx() + tdir.dx();
+            pt.y = c->posy() + tdir.dy();
+        }
         float force = 0;
+
+        if( m.obstructed_by_vehicle_rotation( prev_point, pt ) ) {
+            //We process the intervening tile on this iteration and then the current tile on the next
+            next_forced = pt;
+            force_next = true;
+            if( one_in( 2 ) ) {
+                pt.x = prev_point.x;
+            } else {
+                pt.y = prev_point.y;
+            }
+        }
+
 
         if( monster *const mon_ptr = critter_at<monster>( pt ) ) {
             monster &critter = *mon_ptr;
@@ -10415,8 +10442,11 @@ void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
             // although at lower velocity
             break;
         }
-        range--;
-        steps++;
+        //Vehicle wall tiles don't count for range
+        if( !force_next ) {
+            range--;
+        }
+        prev_point = pt;
         if( animate && ( seen || u.sees( *c ) ) ) {
             invalidate_main_ui_adaptor();
             ui_manager::redraw_invalidated();

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -683,7 +683,8 @@ int iuse::fungicide( player *p, item *it, bool, const tripoint & )
             if( dest == p->pos() ) {
                 continue;
             }
-            if( g->m.passable( dest ) && x_in_y( spore_count, 8 ) ) {
+            if( g->m.passable( dest ) && !get_map().obstructed_by_vehicle_rotation( p->pos(), dest ) &&
+                x_in_y( spore_count, 8 ) ) {
                 if( monster *const mon_ptr = g->critter_at<monster>( dest ) ) {
                     monster &critter = *mon_ptr;
                     if( g->u.sees( dest ) &&

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -88,6 +88,8 @@ bool map::build_transparency_cache( const int zlev )
         return false;
     }
 
+    std::set<tripoint> vehicles_processed;
+
     // if true, all submaps are invalid (can use batch init)
     bool rebuild_all = map_cache.transparency_cache_dirty.all();
 
@@ -797,6 +799,7 @@ void cast_zlight_segment(
     const array_of_grids_of<T> &output_caches,
     const array_of_grids_of<const T> &input_arrays,
     const array_of_grids_of<const bool> &floor_caches,
+    const array_of_grids_of <const diagonal_blocks> &blocked_caches,
     const tripoint &offset, int offset_distance,
     T numerator = 1.0f, int row = 1,
     float start_major = 0.0f, float end_major = 1.0f,
@@ -811,6 +814,7 @@ void cast_zlight_segment(
     const array_of_grids_of<T> &output_caches,
     const array_of_grids_of<const T> &input_arrays,
     const array_of_grids_of<const bool> &floor_caches,
+    const array_of_grids_of < const diagonal_blocks > &blocked_caches,
     const tripoint &offset, const int offset_distance,
     const T numerator, const int row,
     float start_major, const float end_major,
@@ -820,6 +824,29 @@ void cast_zlight_segment(
     if( start_major >= end_major || start_minor >= end_minor ) {
         return;
     }
+
+    constexpr quadrant quad = quadrant_from_x_y( -xx - xy, -yx - yy );
+
+    const auto check_blocked = [ =, &blocked_caches]( const tripoint & p ) -> bool{
+        switch( quad )
+        {
+            case quadrant::NW:
+                return ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x][p.y].nw;
+                break;
+            case quadrant::NE:
+                return ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x][p.y].ne;
+                break;
+            case quadrant::SE:
+                return ( p.x < MAPSIZE_X - 1 && p.y < MAPSIZE_Y - 1 &&
+                         ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x + 1][p.y + 1].nw );
+                break;
+            case quadrant::SW:
+                return ( p.x > 1 && p.y < MAPSIZE_Y - 1 &&
+                         ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x - 1][p.y + 1].ne );
+                break;
+        }
+    };
+
 
     float radius = 60.0f - offset_distance;
 
@@ -890,7 +917,7 @@ void cast_zlight_segment(
                 const int dist = rl_dist( tripoint_zero, delta ) + offset_distance;
                 last_intensity = calc( numerator, cumulative_transparency, dist );
 
-                if( !floor_block ) {
+                if( !floor_block && !check_blocked( current ) ) {
                     ( *output_caches[z_index] )[current.x][current.y] =
                         std::max( ( *output_caches[z_index] )[current.x][current.y], last_intensity );
                 }
@@ -936,14 +963,14 @@ void cast_zlight_segment(
                     const float trailing_clipped = std::max( trailing_edge_major, start_major );
                     const float major_mid = merge_blocks ? leading_edge_major : trailing_clipped;
                     cast_zlight_segment<xx, xy, xz, yx, yy, yz, zz, T, calc, check, accumulate>(
-                        output_caches, input_arrays, floor_caches,
+                        output_caches, input_arrays, floor_caches, blocked_caches,
                         offset, offset_distance, numerator, distance + 1,
                         start_major, major_mid, start_minor, end_minor,
                         next_cumulative_transparency );
                     if( !merge_blocks ) {
                         // One line that is too short to be part of the rectangle above
                         cast_zlight_segment<xx, xy, xz, yx, yy, yz, zz, T, calc, check, accumulate>(
-                            output_caches, input_arrays, floor_caches,
+                            output_caches, input_arrays, floor_caches, blocked_caches,
                             offset, offset_distance, numerator, distance + 1,
                             major_mid, leading_edge_major, start_minor, trailing_edge_minor,
                             next_cumulative_transparency );
@@ -965,7 +992,7 @@ void cast_zlight_segment(
                 // leading_edge_major plus some epsilon
                 float after_leading_edge_major = ( delta.z + 0.50001f ) / ( delta.y - 0.5f );
                 cast_zlight_segment<xx, xy, xz, yx, yy, yz, zz, T, calc, check, accumulate>(
-                    output_caches, input_arrays, floor_caches,
+                    output_caches, input_arrays, floor_caches, blocked_caches,
                     offset, offset_distance, numerator, distance,
                     after_leading_edge_major, end_major, old_start_minor, start_minor,
                     cumulative_transparency );
@@ -1004,63 +1031,69 @@ void cast_zlight(
     const array_of_grids_of<T> &output_caches,
     const array_of_grids_of<const T> &input_arrays,
     const array_of_grids_of<const bool> &floor_caches,
+    const array_of_grids_of < const diagonal_blocks > &blocked_caches,
     const tripoint &origin, const int offset_distance, const T numerator )
 {
     // Down
     cast_zlight_segment < 0, 1, 0, 1, 0, 0, -1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
     cast_zlight_segment < 1, 0, 0, 0, 1, 0, -1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
 
     cast_zlight_segment < 0, -1, 0, 1, 0, 0, -1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
     cast_zlight_segment < -1, 0, 0, 0, 1, 0, -1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
 
     cast_zlight_segment < 0, 1, 0, -1, 0, 0, -1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
     cast_zlight_segment < 1, 0, 0, 0, -1, 0, -1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
 
     cast_zlight_segment < 0, -1, 0, -1, 0, 0, -1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
     cast_zlight_segment < -1, 0, 0, 0, -1, 0, -1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
 
     // Up
     cast_zlight_segment<0, 1, 0, 1, 0, 0, 1, T, calc, check, accumulate>(
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
     cast_zlight_segment<1, 0, 0, 0, 1, 0, 1, T, calc, check, accumulate>(
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
 
     cast_zlight_segment < 0, -1, 0, 1, 0, 0, 1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
     cast_zlight_segment < -1, 0, 0, 0, 1, 0, 1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
 
     cast_zlight_segment < 0, 1, 0, -1, 0, 0, 1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
     cast_zlight_segment < 1, 0, 0, 0, -1, 0, 1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
 
     cast_zlight_segment < 0, -1, 0, -1, 0, 0, 1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
     cast_zlight_segment < -1, 0, 0, 0, -1, 0, 1, T, calc, check, accumulate > (
-        output_caches, input_arrays, floor_caches, origin, offset_distance, numerator );
+        output_caches, input_arrays, floor_caches, blocked_caches, origin, offset_distance, numerator );
 }
 
 // I can't figure out how to make implicit instantiation work when the parameters of
 // the template-supplied function pointers are involved, so I'm explicitly instantiating instead.
-template void cast_zlight<float, sight_calc, sight_check, accumulate_transparency>(
+template void
+cast_zlight<float, sight_calc, sight_check, accumulate_transparency>(
     const array_of_grids_of<float> &output_caches,
     const array_of_grids_of<const float> &input_arrays,
     const array_of_grids_of<const bool> &floor_caches,
+    const array_of_grids_of < const diagonal_blocks > &blocked_caches,
     const tripoint &origin, int offset_distance, float numerator );
 
-template void cast_zlight<float, shrapnel_calc, shrapnel_check, accumulate_fragment_cloud>(
+template void
+cast_zlight<float, shrapnel_calc, shrapnel_check, accumulate_fragment_cloud>
+(
     const array_of_grids_of<float> &output_caches,
     const array_of_grids_of<const float> &input_arrays,
     const array_of_grids_of<const bool> &floor_caches,
+    const array_of_grids_of < const diagonal_blocks > &blocked_caches,
     const tripoint &origin, int offset_distance, float numerator );
 
 template<int xx, int xy, int yx, int yy, typename T, typename Out,
@@ -1070,6 +1103,7 @@ template<int xx, int xy, int yx, int yy, typename T, typename Out,
          T( *accumulate )( const T &, const T &, const int & )>
 void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                 const T( &input_array )[MAPSIZE_X][MAPSIZE_Y],
+                const diagonal_blocks( &blocked_array )[MAPSIZE_X][MAPSIZE_Y],
                 const point &offset, int offsetDistance,
                 T numerator = VISIBILITY_FULL,
                 int row = 1, float start = 1.0f, float end = 0.0f,
@@ -1082,10 +1116,29 @@ template<int xx, int xy, int yx, int yy, typename T, typename Out,
          T( *accumulate )( const T &, const T &, const int & )>
 void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                 const T( &input_array )[MAPSIZE_X][MAPSIZE_Y],
+                const diagonal_blocks( &blocked_array )[MAPSIZE_X][MAPSIZE_Y],
                 const point &offset, const int offsetDistance, const T numerator,
                 const int row, float start, const float end, T cumulative_transparency )
 {
     constexpr quadrant quad = quadrant_from_x_y( -xx - xy, -yx - yy );
+
+    const auto check_blocked = [ =, &blocked_array]( const point & p ) {
+        switch( quad ) {
+            case quadrant::NW:
+                return blocked_array[p.x][p.y].nw;
+                break;
+            case quadrant::NE:
+                return blocked_array[p.x][p.y].ne;
+                break;
+            case quadrant::SE:
+                return ( p.x < MAPSIZE_X - 1 && p.y < MAPSIZE_Y - 1 && blocked_array[p.x + 1][p.y + 1].nw );
+                break;
+            case quadrant::SW:
+                return ( p.x > 1 && p.y < MAPSIZE_Y - 1 && blocked_array[p.x - 1][p.y + 1].ne );
+                break;
+        }
+    };
+
     float newStart = 0.0f;
     float radius = 60.0f - offsetDistance;
     if( start < end ) {
@@ -1114,6 +1167,10 @@ void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
             } else if( end > trailingEdge ) {
                 break;
             }
+
+            if( check_blocked( current ) ) {
+                continue;
+            }
             if( !started_row ) {
                 started_row = true;
                 current_transparency = input_array[ current.x ][ current.y ];
@@ -1138,7 +1195,7 @@ void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
             // Only cast recursively if previous span was not opaque.
             if( check( current_transparency, last_intensity ) ) {
                 castLight<xx, xy, yx, yy, T, Out, calc, check, update_output, accumulate>(
-                    output_cache, input_array, offset, offsetDistance,
+                    output_cache, input_array, blocked_array, offset, offsetDistance,
                     numerator, distance + 1, start, trailingEdge,
                     accumulate( cumulative_transparency, current_transparency, distance ) );
             }
@@ -1172,33 +1229,35 @@ template<typename T, typename Out, T( *calc )( const T &, const T &, const int &
          T( *accumulate )( const T &, const T &, const int & )>
 void castLightAll( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                    const T( &input_array )[MAPSIZE_X][MAPSIZE_Y],
+                   const diagonal_blocks( &blocked_array )[MAPSIZE_X][MAPSIZE_Y],
                    const point &offset, int offsetDistance, T numerator )
 {
     castLight<0, 1, 1, 0, T, Out, calc, check, update_output, accumulate>(
-        output_cache, input_array, offset, offsetDistance, numerator );
+        output_cache, input_array, blocked_array, offset, offsetDistance, numerator );
     castLight<1, 0, 0, 1, T, Out, calc, check, update_output, accumulate>(
-        output_cache, input_array, offset, offsetDistance, numerator );
+        output_cache, input_array, blocked_array, offset, offsetDistance, numerator );
 
     castLight < 0, -1, 1, 0, T, Out, calc, check, update_output, accumulate > (
-        output_cache, input_array, offset, offsetDistance, numerator );
+        output_cache, input_array, blocked_array, offset, offsetDistance, numerator );
     castLight < -1, 0, 0, 1, T, Out, calc, check, update_output, accumulate > (
-        output_cache, input_array, offset, offsetDistance, numerator );
+        output_cache, input_array, blocked_array, offset, offsetDistance, numerator );
 
     castLight < 0, 1, -1, 0, T, Out, calc, check, update_output, accumulate > (
-        output_cache, input_array, offset, offsetDistance, numerator );
+        output_cache, input_array, blocked_array, offset, offsetDistance, numerator );
     castLight < 1, 0, 0, -1, T, Out, calc, check, update_output, accumulate > (
-        output_cache, input_array, offset, offsetDistance, numerator );
+        output_cache, input_array, blocked_array, offset, offsetDistance, numerator );
 
     castLight < 0, -1, -1, 0, T, Out, calc, check, update_output, accumulate > (
-        output_cache, input_array, offset, offsetDistance, numerator );
+        output_cache, input_array, blocked_array, offset, offsetDistance, numerator );
     castLight < -1, 0, 0, -1, T, Out, calc, check, update_output, accumulate > (
-        output_cache, input_array, offset, offsetDistance, numerator );
+        output_cache, input_array, blocked_array, offset, offsetDistance, numerator );
 }
 
 template void castLightAll<float, four_quadrants, sight_calc, sight_check,
                            update_light_quadrants, accumulate_transparency>(
                                four_quadrants( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                                const float ( &input_array )[MAPSIZE_X][MAPSIZE_Y],
+                               const diagonal_blocks( &blocked_array )[MAPSIZE_X][MAPSIZE_Y],
                                const point &offset, int offsetDistance, float numerator );
 
 template void
@@ -1207,6 +1266,7 @@ castLightAll<float, float, shrapnel_calc, shrapnel_check,
 (
     float( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
     const float( &input_array )[MAPSIZE_X][MAPSIZE_Y],
+    const diagonal_blocks( &blocked_array )[MAPSIZE_X][MAPSIZE_Y],
     const point &offset, int offsetDistance, float numerator );
 
 /**
@@ -1227,6 +1287,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
     float ( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.vision_transparency_cache;
     float ( &seen_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.seen_cache;
     float ( &camera_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.camera_cache;
+    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.blocked_cache;
 
     constexpr float light_transparency_solid = LIGHT_TRANSPARENCY_SOLID;
     constexpr int map_dimensions = MAPSIZE_X * MAPSIZE_Y;
@@ -1245,7 +1306,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
             if( z == target_z ) {
                 seen_cache[origin.x][origin.y] = VISIBILITY_FULL;
                 castLightAll<float, float, sight_calc, sight_check, update_light, accumulate_transparency>(
-                    seen_cache, transparency_cache, origin.xy(), 0 );
+                    seen_cache, transparency_cache, blocked_cache, origin.xy(), 0 );
             }
         }
     } else {
@@ -1253,11 +1314,13 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
         array_of_grids_of<const float> transparency_caches;
         array_of_grids_of<float> seen_caches;
         array_of_grids_of<const bool> floor_caches;
+        array_of_grids_of < const diagonal_blocks > blocked_caches;
         for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
             auto &cur_cache = get_cache( z );
             transparency_caches[z + OVERMAP_DEPTH] = &cur_cache.vision_transparency_cache;
             seen_caches[z + OVERMAP_DEPTH] = &cur_cache.seen_cache;
             floor_caches[z + OVERMAP_DEPTH] = &cur_cache.floor_cache;
+            blocked_caches[z + OVERMAP_DEPTH] = &cur_cache.blocked_cache;
             std::uninitialized_fill_n(
                 &cur_cache.seen_cache[0][0], map_dimensions, light_transparency_solid );
             cur_cache.seen_cache_dirty = false;
@@ -1266,7 +1329,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
             get_cache( origin.z ).seen_cache[origin.x][origin.y] = VISIBILITY_FULL;
         }
         cast_zlight<float, sight_calc, sight_check, accumulate_transparency>(
-            seen_caches, transparency_caches, floor_caches, origin, 0, 1.0 );
+            seen_caches, transparency_caches, floor_caches, blocked_caches, origin, 0, 1.0 );
     }
 
     const optional_vpart_position vp = veh_at( origin );
@@ -1322,7 +1385,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
         // The naive solution of making the mirrors act like a second player
         // at an offset appears to give reasonable results though.
         castLightAll<float, float, sight_calc, sight_check, update_light, accumulate_transparency>(
-            camera_cache, transparency_cache, mirror_pos.xy(), offsetDistance );
+            camera_cache, transparency_cache, blocked_cache, mirror_pos.xy(), offsetDistance );
     }
 }
 
@@ -1363,6 +1426,7 @@ void map::apply_light_source( const tripoint &p, float luminance )
     float ( &sm )[MAPSIZE_X][MAPSIZE_Y] = cache.sm;
     float ( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.transparency_cache;
     float ( &light_source_buffer )[MAPSIZE_X][MAPSIZE_Y] = cache.light_source_buffer;
+    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.blocked_cache;
 
     const point p2( p.xy() );
 
@@ -1402,37 +1466,37 @@ void map::apply_light_source( const tripoint &p, float luminance )
     if( north ) {
         castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
         castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
     }
 
     if( east ) {
         castLight < 0, -1, 1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
         castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
     }
 
     if( south ) {
         castLight<1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency>(
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
         castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
     }
 
     if( west ) {
         castLight<0, 1, 1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency>(
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
         castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
     }
 }
 
@@ -1443,35 +1507,36 @@ void map::apply_directional_light( const tripoint &p, int direction, float lumin
     auto &cache = get_cache( p.z );
     four_quadrants( &lm )[MAPSIZE_X][MAPSIZE_Y] = cache.lm;
     float ( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.transparency_cache;
+    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.blocked_cache;
 
     if( direction == 90 ) {
         castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
         castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
     } else if( direction == 0 ) {
         castLight < 0, -1, 1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
         castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
     } else if( direction == 270 ) {
         castLight<1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency>(
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
         castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
     } else if( direction == 180 ) {
         castLight<0, 1, 1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency>(
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
         castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+                      lm, transparency_cache, blocked_cache, p2, 0, luminance );
     }
 }
 

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -848,38 +848,6 @@ void cast_zlight_segment(
         }
     };
 
-
-    constexpr direction dir = xy < 0 ? direction::EAST :
-                              xy > 0 ? direction::WEST :
-                              yy < 0 ? direction::SOUTH :
-                              direction::NORTH;
-
-    const auto check_blocked_contra = [ =, &blocked_caches]( const tripoint & p ) -> bool{
-        switch( dir )
-        {
-            case direction::EAST:
-                return ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x][p.y].ne ||
-                ( p.x < MAPSIZE_X - 1 && p.y < MAPSIZE_Y - 1 &&
-                  ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x + 1][p.y + 1].nw );
-            case direction::WEST:
-                return ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x][p.y].nw ||
-                ( p.x > 1 && p.y < MAPSIZE_Y - 1 &&
-                  ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x - 1][p.y + 1].ne );
-            case direction::SOUTH:
-                return ( p.x < MAPSIZE_X - 1 && p.y < MAPSIZE_Y - 1 &&
-                         ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x + 1][p.y + 1].nw ) ||
-                ( p.x > 1 && p.y < MAPSIZE_Y - 1 &&
-                  ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x - 1][p.y + 1].ne );
-            case direction::NORTH:
-                return ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x][p.y].nw ||
-                ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x][p.y].ne;
-            default:
-                return false;
-        }
-        return false;
-    };
-
-
     float radius = 60.0f - offset_distance;
 
     constexpr int min_z = -OVERMAP_DEPTH;
@@ -913,7 +881,7 @@ void cast_zlight_segment(
             const int z_index = current.z + OVERMAP_DEPTH;
 
 
-            for( delta.x = 0; delta.x <= distance && !vehicle_blocked; delta.x++ ) {
+            for( delta.x = 0; delta.x <= distance; delta.x++ ) {
                 current.x = offset.x + delta.x * xx + delta.y * xy + delta.z * xz;
                 current.y = offset.y + delta.x * yx + delta.y * yy + delta.z * yz;
                 float trailing_edge_minor = ( delta.x - 0.5f ) / ( delta.y + 0.5f );
@@ -925,13 +893,6 @@ void cast_zlight_segment(
                     continue;
                 } else if( end_minor < trailing_edge_minor ) {
                     break;
-                }
-
-                //This is a nasty hack to work around pillars not casting any shadow when you're adjacent to them
-                if( delta.x == 0 && check_blocked_contra( current ) ) {
-                    //leading edge of previous tile in the y direction with an epsilon
-                    start_minor = ( delta.x + 0.5f ) / ( delta.y - 1.4999f );
-                    continue;
                 }
 
                 T new_transparency = ( *input_arrays[z_index] )[current.x][current.y];
@@ -961,7 +922,7 @@ void cast_zlight_segment(
 
                 if( check_blocked( current ) ) {
                     vehicle_blocked = true;
-                    continue;
+                    break;
                 }
 
                 if( !floor_block ) {

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1287,7 +1287,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
     float ( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.vision_transparency_cache;
     float ( &seen_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.seen_cache;
     float ( &camera_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.camera_cache;
-    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.blocked_cache;
+    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.vehicle_obscured_cache;
 
     constexpr float light_transparency_solid = LIGHT_TRANSPARENCY_SOLID;
     constexpr int map_dimensions = MAPSIZE_X * MAPSIZE_Y;
@@ -1320,7 +1320,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
             transparency_caches[z + OVERMAP_DEPTH] = &cur_cache.vision_transparency_cache;
             seen_caches[z + OVERMAP_DEPTH] = &cur_cache.seen_cache;
             floor_caches[z + OVERMAP_DEPTH] = &cur_cache.floor_cache;
-            blocked_caches[z + OVERMAP_DEPTH] = &cur_cache.blocked_cache;
+            blocked_caches[z + OVERMAP_DEPTH] = &cur_cache.vehicle_obscured_cache;
             std::uninitialized_fill_n(
                 &cur_cache.seen_cache[0][0], map_dimensions, light_transparency_solid );
             cur_cache.seen_cache_dirty = false;
@@ -1426,7 +1426,7 @@ void map::apply_light_source( const tripoint &p, float luminance )
     float ( &sm )[MAPSIZE_X][MAPSIZE_Y] = cache.sm;
     float ( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.transparency_cache;
     float ( &light_source_buffer )[MAPSIZE_X][MAPSIZE_Y] = cache.light_source_buffer;
-    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.blocked_cache;
+    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.vehicle_obscured_cache;
 
     const point p2( p.xy() );
 
@@ -1507,7 +1507,7 @@ void map::apply_directional_light( const tripoint &p, int direction, float lumin
     auto &cache = get_cache( p.z );
     four_quadrants( &lm )[MAPSIZE_X][MAPSIZE_Y] = cache.lm;
     float ( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.transparency_cache;
-    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.blocked_cache;
+    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = cache.vehicle_obscured_cache;
 
     if( direction == 90 ) {
         castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -97,14 +97,16 @@ static bool between_or_on( const point &a0, const point &a1, const point &d, con
 }
 // Builds line until obstructed or outside of region bound by near and far lines. Stores result in set
 static void build_line( spell_detail::line_iterable line, const tripoint &source,
-                        const point &delta, const point &delta_perp, bool ( *test )( const tripoint & ),
+                        const point &delta, const point &delta_perp, bool ( *test )( const tripoint &, const tripoint & ),
                         std::set<tripoint> &result )
 {
+    tripoint last_point = source;
     while( between_or_on( point_zero, delta, delta_perp, line.get() ) ) {
-        if( !test( source + line.get() ) ) {
+        if( !test( source + line.get(), last_point ) ) {
             break;
         }
         result.emplace( source + line.get() );
+        last_point = source + line.get();
         line.next();
     }
 }
@@ -163,10 +165,13 @@ static bool in_spell_aoe( const tripoint &start, const tripoint &end, const int 
         return true;
     }
     const std::vector<tripoint> trajectory = line_to( start, end );
+    tripoint last_point = start;
     for( const tripoint &pt : trajectory ) {
-        if( g->m.impassable( pt ) && !g->m.has_flag( "THIN_OBSTACLE", pt ) ) {
+        if( ( g->m.impassable( pt ) && !g->m.has_flag( "THIN_OBSTACLE", pt ) ) ||
+            g->m.obstructed_by_vehicle_rotation( pt, last_point ) ) {
             return false;
         }
+        last_point = pt;
     }
     return true;
 }
@@ -202,12 +207,15 @@ std::set<tripoint> spell_effect::spell_effect_cone( const spell &sp, const tripo
     }
     for( const tripoint &ep : end_points ) {
         std::vector<tripoint> trajectory = line_to( source, ep );
+        tripoint last_point = source;
         for( const tripoint &tp : trajectory ) {
-            if( ignore_walls || g->m.passable( tp ) || g->m.has_flag( "THIN_OBSTACLE", tp ) ) {
+            if( ignore_walls || ( !g->m.obstructed_by_vehicle_rotation( tp, last_point ) &&
+                                  ( g->m.passable( tp ) || g->m.has_flag( "THIN_OBSTACLE", tp ) ) ) ) {
                 targets.emplace( tp );
             } else {
                 break;
             }
+            last_point = tp;
         }
     }
     // we don't want to hit ourselves in the blast!
@@ -215,13 +223,14 @@ std::set<tripoint> spell_effect::spell_effect_cone( const spell &sp, const tripo
     return targets;
 }
 
-static bool test_always_true( const tripoint & )
+static bool test_always_true( const tripoint &, const tripoint & )
 {
     return true;
 }
-static bool test_passable( const tripoint &p )
+static bool test_passable( const tripoint &p, const tripoint &prev )
 {
-    return ( g->m.passable( p ) || g->m.has_flag( "THIN_OBSTACLE", p ) );
+    return ( !g->m.obstructed_by_vehicle_rotation( prev, p ) && ( g->m.passable( p ) ||
+             g->m.has_flag( "THIN_OBSTACLE", p ) ) );
 }
 
 std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoint &source,
@@ -254,7 +263,8 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
     // is delta aligned with, cw, or ccw of primary axis
     int delta_side = spell_detail::side_of( point_zero, axis_delta, delta );
 
-    bool ( *test )( const tripoint & ) = ignore_walls ? test_always_true : test_passable;
+    bool ( *test )( const tripoint &,
+                    const tripoint & ) = ignore_walls ? test_always_true : test_passable;
 
     // Canonical path from source to target, offset to local space
     std::vector<point> path_to_target = line_to( point_zero, delta );
@@ -273,25 +283,30 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
     // Add cw and ccw legs
     if( delta_side == 0 ) { // delta is already axis aligned, only need straight lines
         // cw leg
+        point prev_point = point_zero;
         for( const point &p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
             base_line.reset( p );
-            if( !test( source + p ) ) {
+            if( !test( source + p, source + prev_point ) ) {
                 break;
             }
 
             spell_detail::build_line( base_line, source, delta, delta_perp, test, result );
+            prev_point = p;
         }
         // ccw leg
+        prev_point = point_zero;
         for( const point &p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
             base_line.reset( p );
-            if( !test( source + p ) ) {
+            if( !test( source + p, source + prev_point ) ) {
                 break;
             }
 
             spell_detail::build_line( base_line, source, delta, delta_perp, test, result );
+            prev_point = p;
         }
     } else if( delta_side == 1 ) { // delta is cw of primary axis
         // ccw leg is behind perp axis
+        point prev_point = point_zero;
         for( const point &p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
             base_line.reset( p );
 
@@ -299,11 +314,13 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
             while( spell_detail::side_of( point_zero, delta_perp, base_line.get() ) == 1 ) {
                 base_line.next();
             }
-            if( !test( source + p ) ) {
+            if( !test( source + p, source + prev_point ) ) {
                 break;
             }
             spell_detail::build_line( base_line, source, delta, delta_perp, test, result );
+            prev_point = p;
         }
+        prev_point = point_zero;
         // cw leg is before perp axis
         for( const point &p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
             base_line.reset( p );
@@ -313,13 +330,15 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
                 base_line.prev();
             }
             base_line.next();
-            if( !test( source + p ) ) {
+            if( !test( source + p, source + prev_point ) ) {
                 break;
             }
             spell_detail::build_line( base_line, source, delta, delta_perp, test, result );
+            prev_point = p;
         }
     } else if( delta_side == -1 ) { // delta is ccw of primary axis
         // ccw leg is before perp axis
+        point prev_point = point_zero;
         for( const point &p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
             base_line.reset( p );
 
@@ -328,11 +347,13 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
                 base_line.prev();
             }
             base_line.next();
-            if( !test( source + p ) ) {
+            if( !test( source + p, source + prev_point ) ) {
                 break;
             }
             spell_detail::build_line( base_line, source, delta, delta_perp, test, result );
+            prev_point = p;
         }
+        prev_point = point_zero;
         // cw leg is behind perp axis
         for( const point &p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
             base_line.reset( p );
@@ -341,10 +362,11 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
             while( spell_detail::side_of( point_zero, delta_perp, base_line.get() ) == 1 ) {
                 base_line.next();
             }
-            if( !test( source + p ) ) {
+            if( !test( source + p, source + prev_point ) ) {
                 break;
             }
             spell_detail::build_line( base_line, source, delta, delta_perp, test, result );
+            prev_point = p;
         }
     }
 
@@ -471,8 +493,10 @@ void spell_effect::projectile_attack( const spell &sp, Creature &caster,
                                       const tripoint &target )
 {
     std::vector<tripoint> trajectory = line_to( caster.pos(), target );
+    tripoint prev_point = caster.pos();
     for( std::vector<tripoint>::iterator iter = trajectory.begin(); iter != trajectory.end(); iter++ ) {
-        if( g->m.impassable( *iter ) && !g->m.has_flag( "THIN_OBSTACLE", *iter ) ) {
+        if( ( g->m.impassable( *iter ) && !g->m.has_flag( "THIN_OBSTACLE", *iter ) ) ||
+            g->m.obstructed_by_vehicle_rotation( prev_point, *iter ) ) {
             if( iter != trajectory.begin() ) {
                 target_attack( sp, caster, *( iter - 1 ) );
             } else {
@@ -480,6 +504,7 @@ void spell_effect::projectile_attack( const spell &sp, Creature &caster,
             }
             return;
         }
+        prev_point = *iter;
     }
     target_attack( sp, caster, trajectory.back() );
 }
@@ -549,6 +574,8 @@ int area_expander::run( const tripoint &center )
     // Number of nodes expanded.
     int expanded = 0;
 
+    map &here = get_map();
+
     while( !frontier.empty() ) {
         int best_index = frontier.top();
         frontier.pop();
@@ -557,7 +584,8 @@ int area_expander::run( const tripoint &center )
         for( size_t i = 0; i < 8; i++ ) {
             tripoint pt = best.position + point( x_offset[ i ], y_offset[ i ] );
 
-            if( g->m.impassable( pt ) && !g->m.has_flag( "THIN_OBSTACLE", pt ) ) {
+            if( ( here.impassable( pt ) && !here.has_flag( "THIN_OBSTACLE", pt ) ) ||
+                here.obstructed_by_vehicle_rotation( best.position, pt ) ) {
                 continue;
             }
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -283,7 +283,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
     // Add cw and ccw legs
     if( delta_side == 0 ) { // delta is already axis aligned, only need straight lines
         // cw leg
-        point prev_point = point_zero;
+        point prev_point;
         for( const point &p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
             base_line.reset( p );
             if( !test( source + p, source + prev_point ) ) {
@@ -306,7 +306,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
         }
     } else if( delta_side == 1 ) { // delta is cw of primary axis
         // ccw leg is behind perp axis
-        point prev_point = point_zero;
+        point prev_point;
         for( const point &p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
             base_line.reset( p );
 
@@ -338,7 +338,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
         }
     } else if( delta_side == -1 ) { // delta is ccw of primary axis
         // ccw leg is before perp axis
-        point prev_point = point_zero;
+        point prev_point;
         for( const point &p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
             base_line.reset( p );
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6437,6 +6437,51 @@ bool map::clear_path( const tripoint &f, const tripoint &t, const int range,
     return is_clear;
 }
 
+bool map::obstructed_by_vehicle_rotation( const tripoint &from, const tripoint &to )
+{
+    const optional_vpart_position vp0 = veh_at( from );
+    vehicle *const veh0 = veh_pointer_or_null( vp0 );
+    const optional_vpart_position vp1 = veh_at( to );
+    vehicle *const veh1 = veh_pointer_or_null( vp1 );
+
+    if( veh1 != nullptr ) {
+        point veh1p = veh1->tripoint_to_mount( from );
+        if( !veh1->allowed_move( veh1p, vp1->mount() ) ) {
+            return true;
+        }
+    }
+    if( veh0 != nullptr && veh1 != veh0 ) {
+        point veh0p = veh0->tripoint_to_mount( to );
+        if( !veh0->allowed_move( vp0->mount(), veh0p ) ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+
+bool map::obscured_by_vehicle_rotation( const tripoint &from, const tripoint &to )
+{
+    const optional_vpart_position vp0 = veh_at( from );
+    vehicle *const veh0 = veh_pointer_or_null( vp0 );
+    const optional_vpart_position vp1 = veh_at( to );
+    vehicle *const veh1 = veh_pointer_or_null( vp1 );
+
+    if( veh1 != nullptr ) {
+        point veh1p = veh1->tripoint_to_mount( from );
+        if( !veh1->allowed_light( veh1p, vp1->mount() ) ) {
+            return true;
+        }
+    }
+    if( veh0 != nullptr && veh1 != veh0 ) {
+        point veh0p = veh0->tripoint_to_mount( to );
+        if( !veh0->allowed_light( vp0->mount(), veh0p ) ) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool map::accessible_items( const tripoint &t ) const
 {
     return !has_flag( "SEALED", t ) || has_flag( "LIQUIDCONT", t );
@@ -7803,8 +7848,68 @@ void map::build_outside_cache( const int zlev )
     ch.outside_cache_dirty = false;
 }
 
+void map::build_vehicle_rotation_obstacles_cache( const tripoint &start, const tripoint &end,
+        diagonal_blocks( & blocked_obstacle_cache )[MAPSIZE_X][MAPSIZE_Y] )
+{
+
+    diagonal_blocks fill = {false, false};
+    std::fill_n( &blocked_obstacle_cache[0][0], MAPSIZE_X * MAPSIZE_Y, fill );
+
+    auto set_blocked = [&blocked_obstacle_cache]( vehicle & veh, const tripoint from ) {
+        auto from_mount = veh.tripoint_to_mount( from );
+        for( int dx = -1; dx <= 1; dx += 2 ) {
+            for( int dy = -1; dy <= 1; dy += 2 ) {
+
+                auto t = veh.tripoint_to_mount( from + point( dx, dy ) );
+
+                if( !veh.allowed_move( from_mount, t ) ) {
+                    if( dy == -1 && dx == -1 ) {
+                        blocked_obstacle_cache[from.x][from.y].nw = true;
+                    } else if( dy == -1 && dx == 1 ) {
+                        blocked_obstacle_cache[from.x][from.y].ne = true;
+                    } else if( dy == 1 && dx == -1 ) {
+                        if( from.x == 0 || from.y == MAPSIZE_Y - 1 ) {
+                            continue;
+                        }
+                        blocked_obstacle_cache[from.x - 1][from.y + 1].ne = true;
+                    } else {
+                        if( from.x == MAPSIZE_X - 1 || from.y == MAPSIZE_Y - 1 ) {
+                            continue;
+                        }
+                        blocked_obstacle_cache[from.x + 1][from.y + 1].nw = true;
+                    }
+                }
+            }
+        }
+    };
+
+
+    VehicleList vehs = get_vehicles( start, end );
+    const inclusive_cuboid<tripoint> bounds( start, end );
+    for( auto &v : vehs ) {
+        for( const vpart_reference &vp : v.v->get_all_parts() ) {
+            tripoint p = v.pos + vp.part().precalc[0];
+            if( p.z != start.z ) {
+                break;
+            }
+            if( !bounds.contains( p ) ) {
+                continue;
+            }
+
+            for( int dx = -1; dx <= 1; dx += 2 ) {
+                set_blocked( *v.v, p + tripoint( dx, 0, 0 ) );
+            }
+
+            for( int dy = -1; dy <= 1; dy += 2 ) {
+                set_blocked( *v.v, p + tripoint( 0, dy, 0 ) );
+            }
+        }
+    }
+}
+
 void map::build_obstacle_cache( const tripoint &start, const tripoint &end,
-                                float( &obstacle_cache )[MAPSIZE_X][MAPSIZE_Y] )
+                                float( &obstacle_cache )[MAPSIZE_X][MAPSIZE_Y],
+                                diagonal_blocks( & blocked_obstacle_cache )[MAPSIZE_X][MAPSIZE_Y] )
 {
     const point min_submap{ std::max( 0, start.x / SEEX ), std::max( 0, start.y / SEEY ) };
     const point max_submap{
@@ -7853,6 +7958,8 @@ void map::build_obstacle_cache( const tripoint &start, const tripoint &end,
             }
         }
     }
+
+    build_vehicle_rotation_obstacles_cache( start, end, blocked_obstacle_cache );
 }
 
 bool map::build_floor_cache( const int zlev )
@@ -7981,6 +8088,7 @@ static void vehicle_caching_internal( level_cache &zch, const vpart_reference &v
     auto &outside_cache = zch.outside_cache;
     auto &transparency_cache = zch.transparency_cache;
     auto &floor_cache = zch.floor_cache;
+    auto &blocked_cache = zch.blocked_cache;
 
     const size_t part = vp.part_index();
     const tripoint &part_pos =  v->global_part_pos3( vp.part() );
@@ -8002,6 +8110,31 @@ static void vehicle_caching_internal( level_cache &zch, const vpart_reference &v
 
     if( vp.has_feature( VPFLAG_BOARDABLE ) && !vp.part().is_broken() ) {
         floor_cache[part_pos.x][part_pos.y] = true;
+    }
+
+    for( int my = -1; my <= 1; my += 2 ) {
+        for( int mx = -1; mx <= 1; mx += 2 ) {
+
+            point t = v->tripoint_to_mount( part_pos + point( mx, my ) );
+
+            if( !v->allowed_light( t, vp.mount() ) ) {
+                if( my == -1 && mx == -1 ) {
+                    blocked_cache[part_pos.x][part_pos.y].nw = true;
+                } else if( my == -1 && mx == 1 ) {
+                    blocked_cache[part_pos.x][part_pos.y].ne = true;
+                } else if( my == 1 && mx == -1 ) {
+                    if( part_pos.x == 0 || part_pos.y == MAPSIZE_Y - 1 ) {
+                        continue;
+                    }
+                    blocked_cache[part_pos.x - 1][part_pos.y + 1].ne = true;
+                } else {
+                    if( part_pos.x == MAPSIZE_X - 1 || part_pos.y == MAPSIZE_Y - 1 ) {
+                        continue;
+                    }
+                    blocked_cache[part_pos.x + 1][part_pos.y + 1].nw = true;
+                }
+            }
+        }
     }
 }
 
@@ -8044,6 +8177,8 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         update_suspension_cache( z );
         seen_cache_dirty |= ( build_floor_cache( z ) && affects_seen_cache );
         seen_cache_dirty |= get_cache( z ).seen_cache_dirty && affects_seen_cache;
+        diagonal_blocks fill = {false, false};
+        std::uninitialized_fill_n( &( get_cache( z ).blocked_cache[0][0] ), MAPSIZE_X * MAPSIZE_Y, fill );
     }
     // needs a separate pass as it changes the caches on neighbour z-levels (e.g. floor_cache);
     // otherwise such changes might be overwritten by main cache-building logic
@@ -8355,9 +8490,9 @@ void map::function_over( const tripoint &start, const tripoint &end, Functor fun
     }
 }
 
-void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &blocks_scent,
-                          std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &reduces_scent,
-                          const point &min, const point &max )
+void map::scent_blockers( std::array<std::array<char, MAPSIZE_X>, MAPSIZE_Y> &scent_transfer,
+                          const point &min, const point &max,
+                          diagonal_blocks( & blocked_obstacle_cache )[MAPSIZE_X][MAPSIZE_Y] )
 {
     auto reduce = TFLAG_REDUCE_SCENT;
     auto block = TFLAG_NO_SCENT;
@@ -8365,15 +8500,12 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
         // We need to generate the x/y coordinates, because we can't get them "for free"
         const point p = lp + sm_to_ms_copy( gp.xy() );
         if( sm->get_ter( lp ).obj().has_flag( block ) ) {
-            blocks_scent[p.x][p.y] = true;
-            reduces_scent[p.x][p.y] = false;
+            scent_transfer[p.x][p.y] = 0;
         } else if( sm->get_ter( lp ).obj().has_flag( reduce ) ||
                    sm->get_furn( lp ).obj().has_flag( reduce ) ) {
-            blocks_scent[p.x][p.y] = false;
-            reduces_scent[p.x][p.y] = true;
+            scent_transfer[p.x][p.y] = 1;
         } else {
-            blocks_scent[p.x][p.y] = false;
-            reduces_scent[p.x][p.y] = false;
+            scent_transfer[p.x][p.y] = 5;
         }
 
         return ITER_CONTINUE;
@@ -8390,8 +8522,8 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
         vehicle &veh = *( wrapped_veh.v );
         for( const vpart_reference &vp : veh.get_any_parts( VPFLAG_OBSTACLE ) ) {
             const tripoint part_pos = vp.pos();
-            if( local_bounds.contains( part_pos.xy() ) ) {
-                reduces_scent[part_pos.x][part_pos.y] = true;
+            if( local_bounds.contains( part_pos.xy() ) && scent_transfer[part_pos.x][part_pos.y] == 5 ) {
+                scent_transfer[part_pos.x][part_pos.y] = 1;
             }
         }
 
@@ -8402,11 +8534,14 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
             }
 
             const tripoint part_pos = vp.pos();
-            if( local_bounds.contains( part_pos.xy() ) ) {
-                reduces_scent[part_pos.x][part_pos.y] = true;
+            if( local_bounds.contains( part_pos.xy() ) && scent_transfer[part_pos.x][part_pos.y] == 5 ) {
+                scent_transfer[part_pos.x][part_pos.y] = 1;
             }
         }
     }
+
+    build_vehicle_rotation_obstacles_cache( tripoint( min, abs_sub.z ), tripoint( max, abs_sub.z ),
+                                            blocked_obstacle_cache );
 }
 
 tripoint_range<tripoint> map::points_in_rectangle( const tripoint &from, const tripoint &to ) const
@@ -8552,6 +8687,8 @@ level_cache::level_cache()
     std::fill_n( &outside_cache[0][0], map_dimensions, false );
     std::fill_n( &floor_cache[0][0], map_dimensions, false );
     std::fill_n( &transparency_cache[0][0], map_dimensions, 0.0f );
+    diagonal_blocks fill = {false, false};
+    std::fill_n( &blocked_cache[0][0], map_dimensions, fill );
     std::fill_n( &vision_transparency_cache[0][0], map_dimensions, 0.0f );
     std::fill_n( &seen_cache[0][0], map_dimensions, 0.0f );
     std::fill_n( &camera_cache[0][0], map_dimensions, 0.0f );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8153,7 +8153,7 @@ void map::do_vehicle_caching( int z )
     for( vehicle *v : ch.vehicle_list ) {
         for( const vpart_reference &vp : v->get_all_parts() ) {
             const tripoint &part_pos = v->global_part_pos3( vp.part() );
-            if( !inbounds( part_pos.xy() ) ) {
+            if( !inbounds( part_pos.xy() ) || vp.part().removed ) {
                 continue;
             }
             vehicle_caching_internal( get_cache( part_pos.z ), vp, v );

--- a/src/map.h
+++ b/src/map.h
@@ -704,12 +704,12 @@ class map
         /**
          * Checks if a rotated vehicle is blocking diagonal movement, tripoints must be adjacent
          */
-        bool obstructed_by_vehicle_rotation( const tripoint &from, const tripoint &to );
+        bool obstructed_by_vehicle_rotation( const tripoint &from, const tripoint &to ) const;
 
         /**
          * Checks if a rotated vehicle is blocking diagonal vision, tripoints must be adjacent
          */
-        bool obscured_by_vehicle_rotation( const tripoint &from, const tripoint &to );
+        bool obscured_by_vehicle_rotation( const tripoint &from, const tripoint &to ) const;
 
         /**
          * Populates a vector of points that are reachable within a number of steps from a

--- a/src/map.h
+++ b/src/map.h
@@ -329,7 +329,10 @@ struct level_cache {
 
     // true when light entering a tile diagonally is blocked by the walls of a turned vehicle. The direction is the direction that the light must be travelling.
     // check the nw value of x+1, y+1 to find the se value of a tile and the ne of x-1, y+1 for sw
-    diagonal_blocks blocked_cache[MAPSIZE_X][MAPSIZE_Y];
+    diagonal_blocks vehicle_obscured_cache[MAPSIZE_X][MAPSIZE_Y];
+
+    // same as above but for obstruction rather than light
+    diagonal_blocks vehicle_obstructed_cache[MAPSIZE_X][MAPSIZE_Y];
 
     // stores "adjusted transparency" of the tiles
     // initial values derived from transparency_cache, uses same units
@@ -1512,8 +1515,7 @@ class map
          * Should be way faster than if done in `game.cpp` using public map functions.
          */
         void scent_blockers( std::array<std::array<char, MAPSIZE_X>, MAPSIZE_Y> &scent_transfer,
-                             const point &min, const point &max,
-                             diagonal_blocks( & blocked_obstacle_cache )[MAPSIZE_X][MAPSIZE_Y] );
+                             const point &min, const point &max );
 
         // Computers
         computer *computer_at( const tripoint &p );
@@ -1594,12 +1596,7 @@ class map
         void build_map_cache( int zlev, bool skip_lightmap = false );
         // Unlike the other caches, this populates a supplied cache instead of an internal cache.
         void build_obstacle_cache( const tripoint &start, const tripoint &end,
-                                   float( &obstacle_cache )[MAPSIZE_X][MAPSIZE_Y],
-                                   diagonal_blocks( &blocked_obstacle_cache )[MAPSIZE_X][MAPSIZE_Y] );
-
-        //populates a supplied cache with diagonal obstructions due to vehicle rotation
-        void build_vehicle_rotation_obstacles_cache( const tripoint &start, const tripoint &end,
-                diagonal_blocks( & blocked_obstacle_cache )[MAPSIZE_X][MAPSIZE_Y] );
+                                   float( &obstacle_cache )[MAPSIZE_X][MAPSIZE_Y] );
 
         vehicle *add_vehicle( const vgroup_id &type, const tripoint &p, units::angle dir,
                               int init_veh_fuel = -1, int init_veh_status = -1,

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -927,7 +927,7 @@ void map::process_fields_in_submap( submap *const current_submap,
                             while( tries < 10 && cur.get_field_age() < 5_minutes && cur.get_field_intensity() > 1 ) {
                                 pnt.x = p.x + rng( -1, 1 );
                                 pnt.y = p.y + rng( -1, 1 );
-                                if( passable( pnt ) ) {
+                                if( passable( pnt ) && !obstructed_by_vehicle_rotation( p, pnt ) ) {
                                     add_field( pnt, fd_electricity, 1, cur.get_field_age() + 1_turns );
                                     cur.set_field_intensity( cur.get_field_intensity() - 1 );
                                     tries = 0;
@@ -947,11 +947,12 @@ void map::process_fields_in_submap( submap *const current_submap,
                             if( valid.empty() ) {
                                 tripoint dst( p + point( rng( -1, 1 ), rng( -1, 1 ) ) );
                                 field_entry *elec = get_field( dst ).find_field( fd_electricity );
-                                if( passable( dst ) && elec != nullptr &&
+                                bool pass = passable( dst ) && !obstructed_by_vehicle_rotation( p, dst );
+                                if( pass && elec != nullptr &&
                                     elec->get_field_intensity() < 3 ) {
                                     elec->set_field_intensity( elec->get_field_intensity() + 1 );
                                     cur.set_field_intensity( cur.get_field_intensity() - 1 );
-                                } else if( passable( dst ) ) {
+                                } else if( pass ) {
                                     add_field( dst, fd_electricity, 1, cur.get_field_age() + 1_turns );
                                 }
                                 cur.set_field_intensity( cur.get_field_intensity() - 1 );
@@ -1996,8 +1997,9 @@ void map::propagate_field( const tripoint &center, const field_type_id &type, in
                     closed.insert( pt );
                     continue;
                 }
-
-                open.push( { static_cast<float>( rl_dist( center, pt ) ), pt } );
+                if( !obstructed_by_vehicle_rotation( gp.second, pt ) ) {
+                    open.push( { static_cast<float>( rl_dist( center, pt ) ), pt } );
+                }
             }
         }
     }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -122,11 +122,13 @@ bool leap_actor::call( monster &z ) const
         bool blocked_path = false;
         // check if monster has a clear path to the proposed point
         std::vector<tripoint> line = here.find_clear_path( z.pos(), dest );
+        tripoint prev_point = z.pos();
         for( auto &i : line ) {
-            if( here.impassable( i ) ) {
+            if( here.impassable( i ) || here.obstructed_by_vehicle_rotation( prev_point, i ) ) {
                 blocked_path = true;
                 break;
             }
+            prev_point = i;
         }
         // don't leap into water if you could drown (#38038)
         if( z.is_aquatic_danger( dest ) ) {

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -47,6 +47,10 @@ static bool is_adjacent( const monster &z, const Creature &target )
         return false;
     }
 
+    if( !z.can_squeeze_to( target.pos() ) ) {
+        return false;
+    }
+
     return z.posz() == target.posz();
 }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -282,6 +282,10 @@ static bool is_adjacent( const monster *z, const Creature *target, const bool al
         return false;
     }
 
+    if( !z->can_squeeze_to( target->pos() ) ) {
+        return false;
+    }
+
     if( z->posz() == target->posz() ) {
         return true;
     }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -853,24 +853,39 @@ bool mattack::boomer( monster *z )
         return false;
     }
 
-    std::vector<tripoint> line = g->m.find_clear_path( z->pos(), target->pos() );
+    map &here = get_map();
+
+    std::vector<tripoint> line = here.find_clear_path( z->pos(), target->pos() );
     // It takes a while
     z->moves -= 250;
     bool u_see = g->u.sees( *z );
     if( u_see ) {
         add_msg( m_warning, _( "The %s spews bile!" ), z->name() );
     }
+    tripoint prev_point = z->pos();
+    bool obstructed = false;
     for( auto &i : line ) {
-        g->m.add_field( i, fd_bile, 1 );
+        if( here.obstructed_by_vehicle_rotation( prev_point, i ) ) {
+            if( one_in( 2 ) ) {
+                i.x = prev_point.x;
+            } else {
+                i.y = prev_point.y;
+            }
+            obstructed = true;
+        }
+
+        here.add_field( i, fd_bile, 1 );
+
         // If bile hit a solid tile, return.
-        if( g->m.impassable( i ) ) {
-            g->m.add_field( i, fd_bile, 3 );
+        if( obstructed || here.impassable( i ) ) {
+            here.add_field( i, fd_bile, 3 );
             if( g->u.sees( i ) ) {
                 add_msg( _( "Bile splatters on the %s!" ),
-                         g->m.tername( i ) );
+                         here.tername( i ) );
             }
             return true;
         }
+        prev_point = i;
     }
     if( !target->uncanny_dodge() ) {
         ///\EFFECT_DODGE increases chance to avoid boomer effect
@@ -897,22 +912,35 @@ bool mattack::boomer_glow( monster *z )
         return false;
     }
 
-    std::vector<tripoint> line = g->m.find_clear_path( z->pos(), target->pos() );
+    map &here = get_map();
+
+    std::vector<tripoint> line = here.find_clear_path( z->pos(), target->pos() );
     // It takes a while
     z->moves -= 250;
     bool u_see = g->u.sees( *z );
     if( u_see ) {
         add_msg( m_warning, _( "The %s spews bile!" ), z->name() );
     }
+    tripoint prev_point = z->pos();
+    bool obstructed = false;
     for( auto &i : line ) {
-        g->m.add_field( i, fd_bile, 1 );
-        if( g->m.impassable( i ) ) {
-            g->m.add_field( i, fd_bile, 3 );
+        if( here.obstructed_by_vehicle_rotation( prev_point, i ) ) {
+            if( one_in( 2 ) ) {
+                i.x = prev_point.x;
+            } else {
+                i.y = prev_point.y;
+            }
+            obstructed = true;
+        }
+        here.add_field( i, fd_bile, 1 );
+        if( obstructed || here.impassable( i ) ) {
+            here.add_field( i, fd_bile, 3 );
             if( g->u.sees( i ) ) {
-                add_msg( _( "Bile splatters on the %s!" ), g->m.tername( i ) );
+                add_msg( _( "Bile splatters on the %s!" ), here.tername( i ) );
             }
             return true;
         }
+        prev_point = i;
     }
     if( !target->uncanny_dodge() ) {
         ///\EFFECT_DODGE increases chance to avoid glowing boomer effect
@@ -2565,16 +2593,20 @@ bool mattack::ranged_pull( monster *z )
         return false;
     }
 
-    player *foe = dynamic_cast< player * >( target );
-    std::vector<tripoint> line = g->m.find_clear_path( z->pos(), target->pos() );
-    bool seen = g->u.sees( *z );
+    map &here = get_map();
 
+    player *foe = dynamic_cast< player * >( target );
+    std::vector<tripoint> line = here.find_clear_path( z->pos(), target->pos() );
+    bool seen = g->u.sees( *z );
+    tripoint prev_point = z->pos();
     for( auto &i : line ) {
         // Player can't be pulled though bars, furniture, cars or creatures
         // TODO: Add bashing? Currently a window is enough to prevent grabbing
-        if( !g->is_empty( i ) && i != z->pos() && i != target->pos() ) {
+        if( ( !g->is_empty( i ) || here.obstructed_by_vehicle_rotation( prev_point, i ) ) &&
+            i != z->pos() && i != target->pos() ) {
             return false;
         }
+        prev_point = i;
     }
 
     z->moves -= 150;
@@ -2613,7 +2645,7 @@ bool mattack::ranged_pull( monster *z )
 
         if( foe != nullptr ) {
             if( foe->in_vehicle ) {
-                g->m.unboard_vehicle( foe->pos() );
+                here.unboard_vehicle( foe->pos() );
             }
 
             if( target->is_player() && ( pt.x < HALF_MAPSIZE_X || pt.y < HALF_MAPSIZE_Y ||
@@ -2632,7 +2664,7 @@ bool mattack::ranged_pull( monster *z )
     }
     // The monster might drag a target that's not on it's z level
     // So if they leave them on open air, make them fall
-    g->m.creature_on_trap( *target );
+    here.creature_on_trap( *target );
     if( seen ) {
         if( z->type->bodytype == "human" || z->type->bodytype == "angel" ) {
             add_msg( _( "The %1$s's arms fly out and pull and grab %2$s!" ), z->name(),
@@ -3662,27 +3694,38 @@ bool mattack::flamethrower( monster *z )
 void mattack::flame( monster *z, Creature *target )
 {
     int dist = rl_dist( z->pos(), target->pos() );
+
+    map &here = get_map();
     if( target != &g->u ) {
         // friendly
         // It takes a while
         z->moves -= 500;
-        if( !g->m.sees( z->pos(), target->pos(), dist ) ) {
+        if( !here.sees( z->pos(), target->pos(), dist ) ) {
             // shouldn't happen
             debugmsg( "mattack::flame invoked on invisible target" );
         }
-        std::vector<tripoint> traj = g->m.find_clear_path( z->pos(), target->pos() );
-
+        std::vector<tripoint> traj = here.find_clear_path( z->pos(), target->pos() );
+        tripoint prev_point = z->pos();
         for( auto &i : traj ) {
+            if( here.obstructed_by_vehicle_rotation( prev_point, i ) ) {
+                if( one_in( 2 ) ) {
+                    i.x = prev_point.x;
+                } else {
+                    i.y = prev_point.y;
+                }
+            }
+
             // break out of attack if flame hits a wall
             // TODO: Z
-            if( g->m.hit_with_fire( tripoint( i.xy(), z->posz() ) ) ) {
+            if( here.hit_with_fire( tripoint( i.xy(), z->posz() ) ) ) {
                 if( g->u.sees( i ) ) {
                     add_msg( _( "The tongue of flame hits the %s!" ),
-                             g->m.tername( i.xy() ) );
+                             here.tername( i.xy() ) );
                 }
                 return;
             }
-            g->m.add_field( i, fd_fire, 1 );
+            here.add_field( i, fd_fire, 1 );
+            prev_point = i;
         }
         target->add_effect( effect_onfire, 8_turns, bp_torso );
 
@@ -3691,22 +3734,38 @@ void mattack::flame( monster *z, Creature *target )
 
     // It takes a while
     z->moves -= 500;
-    if( !g->m.sees( z->pos(), target->pos(), dist + 1 ) ) {
+    if( !here.sees( z->pos(), target->pos(), dist + 1 ) ) {
         // shouldn't happen
         debugmsg( "mattack::flame invoked on invisible target" );
     }
-    std::vector<tripoint> traj = g->m.find_clear_path( z->pos(), target->pos() );
-
+    std::vector<tripoint> traj = here.find_clear_path( z->pos(), target->pos() );
+    tripoint prev_point = z->pos();
     for( auto &i : traj ) {
+        if( here.obstructed_by_vehicle_rotation( prev_point, i ) ) {
+            tripoint intervening = i;
+            if( one_in( 2 ) ) {
+                intervening.x = prev_point.x;
+            } else {
+                intervening.y = prev_point.y;
+            }
+            if( here.hit_with_fire( tripoint( intervening.xy(), z->posz() ) ) ) {
+                if( g->u.sees( i ) ) {
+                    add_msg( _( "The tongue of flame hits the %s!" ),
+                             here.tername( intervening.xy() ) );
+                }
+                return;
+            }
+        }
         // break out of attack if flame hits a wall
-        if( g->m.hit_with_fire( tripoint( i.xy(), z->posz() ) ) ) {
+        if( here.hit_with_fire( tripoint( i.xy(), z->posz() ) ) ) {
             if( g->u.sees( i ) ) {
                 add_msg( _( "The tongue of flame hits the %s!" ),
-                         g->m.tername( i.xy() ) );
+                         here.tername( i.xy() ) );
             }
             return;
         }
-        g->m.add_field( i, fd_fire, 1 );
+        here.add_field( i, fd_fire, 1 );
+        prev_point = i;
     }
     if( !target->uncanny_dodge() ) {
         target->add_effect( effect_onfire, 8_turns, bp_torso );
@@ -4064,14 +4123,27 @@ bool mattack::stretch_bite( monster *z )
 
     z->moves -= 150;
 
+    tripoint prev_point = z->pos();
+    bool obstructed = false;
     for( auto &pnt : g->m.find_clear_path( z->pos(), target->pos() ) ) {
-        if( g->m.impassable( pnt ) ) {
+
+        if( get_map().obstructed_by_vehicle_rotation( prev_point, pnt ) ) {
+            if( one_in( 2 ) ) {
+                pnt.x = prev_point.x;
+            } else {
+                pnt.y = prev_point.y;
+            }
+            obstructed = true;
+        }
+
+        if( obstructed || g->m.impassable( pnt ) ) {
             z->add_effect( effect_stunned, 6_turns );
             target->add_msg_player_or_npc( _( "The %1$s stretches its head at you, but bounces off the %2$s" ),
                                            _( "The %1$s stretches its head at <npcname>, but bounces off the %2$s" ),
                                            z->name(), g->m.obstacle_name( pnt ) );
             return true;
         }
+        prev_point = pnt;
     }
     bool uncanny = target->uncanny_dodge();
     // Can we dodge the attack? Uses player dodge function % chance (melee.cpp)
@@ -4347,19 +4419,33 @@ bool mattack::longswipe( monster *z )
     if( rl_dist( z->pos(), target->pos() ) > 3 || !z->sees( *target ) ) {
         return false;
     }
+    map &here = get_map();
     //Is there something impassable blocking the claw?
-    for( const auto &pnt : g->m.find_clear_path( z->pos(), target->pos() ) ) {
-        if( g->m.impassable( pnt ) ) {
+    tripoint prev_point = z->pos();
+    bool obstructed = false;
+    for( tripoint &pnt : g->m.find_clear_path( z->pos(), target->pos() ) ) {
+
+        if( here.obstructed_by_vehicle_rotation( prev_point, pnt ) ) {
+            if( one_in( 2 ) ) {
+                pnt.x = prev_point.x;
+            } else {
+                pnt.y = prev_point.y;
+            }
+            obstructed = true;
+        }
+
+        if( obstructed || here.impassable( pnt ) ) {
             //If we're here, it's an nonadjacent attack, which is only attempted 1/5 of the time.
             if( !one_in( 5 ) ) {
                 return false;
             }
             target->add_msg_player_or_npc( _( "The %1$s thrusts a claw at you, but it bounces off the %2$s!" ),
                                            _( "The %1$s thrusts a claw at <npcname>, but it bounces off the %2$s!" ),
-                                           z->name(), g->m.obstacle_name( pnt ) );
+                                           z->name(), here.obstacle_name( pnt ) );
             z->mod_moves( -150 );
             return true;
         }
+        prev_point = pnt;
     }
 
     if( !is_adjacent( z, target, true ) ) {
@@ -4642,13 +4728,15 @@ bool mattack::riotbot( monster *z )
         return false;
     }
 
+    map &here = get_map();
+
     player *foe = dynamic_cast<player *>( target );
 
     if( calendar::once_every( 1_minutes ) ) {
-        for( const tripoint &dest : g->m.points_in_radius( z->pos(), 4 ) ) {
-            if( g->m.passable( dest ) &&
-                g->m.clear_path( z->pos(), dest, 3, 1, 100 ) ) {
-                g->m.add_field( dest, fd_relax_gas, rng( 1, 3 ) );
+        for( const tripoint &dest : here.points_in_radius( z->pos(), 4 ) ) {
+            if( here.passable( dest ) &&
+                here.clear_path( z->pos(), dest, 3, 1, 100 ) ) {
+                here.add_field( dest, fd_relax_gas, rng( 1, 3 ) );
             }
         }
     }
@@ -4782,10 +4870,10 @@ bool mattack::riotbot( monster *z )
             add_msg( m_bad, _( "The robot sprays tear gas!" ) );
             z->moves -= 200;
 
-            for( const tripoint &dest : g->m.points_in_radius( z->pos(), 2 ) ) {
-                if( g->m.passable( dest ) &&
-                    g->m.clear_path( z->pos(), dest, 3, 1, 100 ) ) {
-                    g->m.add_field( dest, fd_tear_gas, rng( 1, 3 ) );
+            for( const tripoint &dest : here.points_in_radius( z->pos(), 2 ) ) {
+                if( here.passable( dest ) &&
+                    here.clear_path( z->pos(), dest, 3, 1, 100 ) ) {
+                    here.add_field( dest, fd_tear_gas, rng( 1, 3 ) );
                 }
             }
 
@@ -4819,11 +4907,13 @@ bool mattack::riotbot( monster *z )
         sounds::sound( z->pos(), 3, sounds::sound_t::combat, _( "fzzzzzt" ), false, "misc", "flash" );
 
         std::vector<tripoint> traj = line_to( z->pos(), dest, 0, 0 );
+        tripoint prev_point = z->pos();
         for( auto &elem : traj ) {
-            if( !g->m.is_transparent( elem ) ) {
+            if( !here.is_transparent( elem ) || here.obscured_by_vehicle_rotation( prev_point, elem ) ) {
                 break;
             }
-            g->m.add_field( elem, fd_dazzling, 1 );
+            here.add_field( elem, fd_dazzling, 1 );
+            prev_point = elem;
         }
         return true;
 
@@ -5660,13 +5750,27 @@ bool mattack::stretch_attack( monster *z )
 
     int dam = rng( 5, 10 );
     z->moves -= 100;
+    tripoint prev_point = z->pos();
+    bool bounce = false;
     for( auto &pnt : g->m.find_clear_path( z->pos(), target->pos() ) ) {
-        if( g->m.impassable( pnt ) ) {
+        if( g->m.obstructed_by_vehicle_rotation( prev_point, pnt ) ) {
+            bounce = true;
+            //50% chance of bouncing off each intervening tile
+            if( one_in( 2 ) ) {
+                pnt.x = prev_point.x;
+            } else {
+                pnt.y = prev_point.y;
+            }
+        }
+        if( bounce || g->m.impassable( pnt ) ) {
             target->add_msg_player_or_npc( _( "The %1$s thrusts its arm at you, but bounces off the %2$s." ),
                                            _( "The %1$s thrusts its arm at <npcname>, but bounces off the %2$s." ),
                                            z->name(), g->m.obstacle_name( pnt ) );
             return true;
         }
+
+        prev_point = pnt;
+
     }
 
     auto msg_type = target == &g->u ? m_warning : m_info;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1217,7 +1217,8 @@ tripoint monster::scent_move()
             continue;
         }
         if( g->m.valid_move( pos(), dest, can_bash, true ) &&
-            ( can_move_to( dest ) || ( dest == g->u.pos() ) ||
+            ( ( can_move_to( dest ) && !get_map().obstructed_by_vehicle_rotation( pos(), dest ) ) ||
+              ( dest == g->u.pos() ) ||
               ( can_bash && g->m.bash_rating( bash_estimate(), dest ) > 0 ) ) ) {
             if( ( !fleeing && smell > bestsmell ) || ( fleeing && smell < bestsmell ) ) {
                 smoves.clear();
@@ -1766,7 +1767,7 @@ bool monster::push_to( const tripoint &p, const int boost, const size_t depth )
 
         // Pushing into cars/windows etc. is harder
         const int movecost_penalty = g->m.move_cost( dest ) - 2;
-        if( movecost_penalty <= -2 ) {
+        if( movecost_penalty <= -2 || get_map().obstructed_by_vehicle_rotation( p, dest ) ) {
             // Can't push into unpassable terrain
             continue;
         }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1386,6 +1386,10 @@ void monster::melee_attack( Creature &target, float accuracy )
         return;
     }
 
+    if( !can_squeeze_to( target.pos() ) ) {
+        return;
+    }
+
     if( target.is_player() ||
         ( target.is_npc() && g->u.attitude_to( target ) == A_FRIENDLY ) ) {
         // Make us a valid target for a few turns

--- a/src/monster.h
+++ b/src/monster.h
@@ -186,10 +186,12 @@ class monster : public Creature, public visitable<monster>
          * will_move_to() checks for impassable terrain etc
          * can_reach_to() checks for z-level difference.
          * can_move_to() is a wrapper for both of them.
+         * can_squeeze_to() checks for vehicle holes.
          */
         bool can_move_to( const tripoint &p ) const;
         bool can_reach_to( const tripoint &p ) const;
         bool will_move_to( const tripoint &p ) const;
+        bool can_squeeze_to( const tripoint &p ) const;
 
         bool will_reach( const point &p ); // Do we have plans to get to (x, y)?
         int  turns_to_reach( const point &p ); // How long will it take?

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -208,17 +208,25 @@ bool compare_sound_alert( const dangerous_sound &sound_a, const dangerous_sound 
 static bool clear_shot_reach( const tripoint &from, const tripoint &to, bool check_ally = true )
 {
     std::vector<tripoint> path = line_to( from, to );
+    tripoint target_point = path.back();
     path.pop_back();
+    if( path.empty() ) {
+        return true;
+    }
+    tripoint &last_point = path[0];
     for( const tripoint &p : path ) {
         Creature *inter = g->critter_at( p );
         if( check_ally && inter != nullptr ) {
             return false;
         } else if( get_map().impassable( p ) ) {
             return false;
+        } else if( get_map().obstructed_by_vehicle_rotation( last_point, p ) ) {
+            return false;
         }
+        last_point = p;
     }
 
-    return true;
+    return !get_map().obstructed_by_vehicle_rotation( last_point, target_point );
 }
 
 tripoint npc::good_escape_direction( bool include_pos )

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2252,6 +2252,12 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
         path.clear();
         move_pause();
     }
+
+    if( here.obstructed_by_vehicle_rotation( pos(), p ) ) {
+        move_pause();
+        return;
+    }
+
     bool attacking = false;
     if( g->critter_at<monster>( p ) ) {
         attacking = true;

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -293,6 +293,9 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
         const auto &pf_cache = get_pathfinding_cache_ref( cur.z );
         const auto cur_special = pf_cache.special[cur.x][cur.y];
 
+        int cur_part;
+        const vehicle *cur_veh = veh_at_internal( cur, cur_part );
+
         // 7 3 5
         // 1 . 2
         // 6 4 8
@@ -339,6 +342,18 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
                 if( cost == 0 && rating <= 0 && ( !doors || !terrain.open || !furniture.open ) && veh == nullptr &&
                     climb_cost <= 0 ) {
                     layer.state[index] = ASL_CLOSED; // Close it so that next time we won't try to calculate costs
+                    continue;
+                }
+
+                if( cur_veh &&
+                    !cur_veh->allowed_move( cur_veh->tripoint_to_mount( cur ), cur_veh->tripoint_to_mount( p ) ) ) {
+                    //Trying to squeeze through a vehicle hole, skip this movement but don't close the tile as other paths may lead to it
+                    continue;
+                }
+
+                if( veh && veh != cur_veh &&
+                    !veh->allowed_move( veh->tripoint_to_mount( cur ), veh->tripoint_to_mount( p ) ) ) {
+                    //Same as above but moving into rather than out of a vehicle
                     continue;
                 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1205,6 +1205,21 @@ void player::knock_back_to( const tripoint &to )
         return;
     }
 
+    if( rl_dist( pos(), to ) < 2 && get_map().obstructed_by_vehicle_rotation( pos(), to ) ) {
+        tripoint intervening = to;
+        if( one_in( 2 ) ) {
+            intervening.x = pos().x;
+        } else {
+            intervening.y = pos().y;
+        }
+
+        apply_damage( nullptr, bodypart_id( "torso" ), 3 );
+        add_effect( effect_stunned, 2_turns );
+        add_msg_player_or_npc( _( "You bounce off a %s!" ), _( "<npcname> bounces off a %s!" ),
+                               g->m.obstacle_name( intervening ) );
+        return;
+    }
+
     // First, see if we hit a monster
     if( monster *const critter = g->critter_at<monster>( to ) ) {
         deal_damage( critter, bodypart_id( "torso" ), damage_instance( DT_BASH, critter->type->size ) );

--- a/src/ranged_aoe.cpp
+++ b/src/ranged_aoe.cpp
@@ -59,7 +59,7 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
 
     for( const tripoint &child : here.points_in_radius( origin, 1 ) ) {
         double coverage = sigdist_to_coverage( sh.distance_at( child ) );
-        if( coverage > 0.0 ) {
+        if( coverage > 0.0 && !get_map().obstructed_by_vehicle_rotation( origin, child ) ) {
             open[child] = aoe_flood_node( origin, 1.0 );
             queue.emplace( child, trig_dist_squared( origin, child ) );
         }
@@ -101,7 +101,8 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
         if( current_coverage > 0.0 ) {
             for( const tripoint &child : here.points_in_radius( p, 1 ) ) {
                 double coverage = sigdist_to_coverage( sh.distance_at( child ) );
-                if( coverage > 0.0 && closed.count( child ) == 0 &&
+                if( coverage > 0.0 && !get_map().obstructed_by_vehicle_rotation( p, child ) &&
+                    closed.count( child ) == 0 &&
                     ( open.count( child ) == 0 || open.at( child ).parent_coverage < current_coverage ) ) {
                     open[child] = aoe_flood_node( p, current_coverage );
                     queue.emplace( child, trig_dist_squared( origin, child ) );
@@ -137,7 +138,7 @@ std::map<tripoint, double> expected_coverage( const shape &sh, const map &here, 
 
     for( const tripoint &child : here.points_in_radius( origin, 1 ) ) {
         double coverage = sigdist_to_coverage( sh.distance_at( child ) );
-        if( coverage > 0.0 ) {
+        if( coverage > 0.0 && !get_map().obstructed_by_vehicle_rotation( origin, child ) ) {
             open[child] = aoe_flood_node( origin, 1.0 );
             queue.emplace( child, trig_dist_squared( origin, child ) );
         }
@@ -183,7 +184,8 @@ std::map<tripoint, double> expected_coverage( const shape &sh, const map &here, 
         if( current_coverage > 0.0 ) {
             for( const tripoint &child : here.points_in_radius( p, 1 ) ) {
                 double coverage = sigdist_to_coverage( sh.distance_at( child ) );
-                if( coverage > 0.0 && closed.count( child ) == 0 &&
+                if( coverage > 0.0 && !get_map().obstructed_by_vehicle_rotation( p, child ) &&
+                    closed.count( child ) == 0 &&
                     ( open.count( child ) == 0 || open.at( child ).parent_coverage < current_coverage ) ) {
                     open[child] = aoe_flood_node( p, current_coverage );
                     queue.emplace( child, trig_dist_squared( origin, child ) );

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -166,7 +166,8 @@ void scent_map::update( const tripoint &center, map &m )
     std::array < std::array < int, 3 + SCENT_RADIUS * 2 >, 1 + SCENT_RADIUS * 2 > sum_3_scent_y;
     std::array < std::array < char, 3 + SCENT_RADIUS * 2 >, 1 + SCENT_RADIUS * 2 > squares_used_y;
 
-    diagonal_blocks blocked_cache[MAPSIZE_X][MAPSIZE_Y];
+    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = m.access_cache(
+                center.z ).vehicle_obstructed_cache;
 
     // for loop constants
     const int scentmap_minx = center.x - SCENT_RADIUS;
@@ -176,7 +177,7 @@ void scent_map::update( const tripoint &center, map &m )
 
     // The new scent flag searching function. Should be wayyy faster than the old one.
     m.scent_blockers( scent_transfer, point( scentmap_minx - 1, scentmap_miny - 1 ),
-                      point( scentmap_maxx + 1, scentmap_maxy + 1 ), blocked_cache );
+                      point( scentmap_maxx + 1, scentmap_maxy + 1 ) );
 
     for( int x = 0; x < SCENT_RADIUS * 2 + 3; ++x ) {
         sum_3_scent_y[0][x] = 0;

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -147,7 +147,6 @@ bool scent_map::inbounds( const tripoint &p ) const
 
     return scent_map_boundaries.contains( p.xy() );
 }
-
 void scent_map::update( const tripoint &center, map &m )
 {
     // Stop updating scent after X turns of the player not moving.
@@ -159,17 +158,15 @@ void scent_map::update( const tripoint &center, map &m )
         return;
     }
 
-    // note: the next four intermediate matrices need to be at least
-    // [2*SCENT_RADIUS+3][2*SCENT_RADIUS+1] in size to hold enough data
-    // The code I'm modifying used [MAPSIZE_X]. I'm staying with that to avoid new bugs.
+    //the block and reduce scent properties are folded into a single scent_transfer value here
+    //block=0 reduce=1 normal=5
+    scent_array<char> scent_transfer;
 
-    // These two matrices are transposed so that x addresses are contiguous in memory
-    scent_array<int> sum_3_scent_y;
-    scent_array<int> squares_used_y;
+    std::array < std::array < int, 3 + SCENT_RADIUS * 2 >, 1 + SCENT_RADIUS * 2 > new_scent;
+    std::array < std::array < int, 3 + SCENT_RADIUS * 2 >, 1 + SCENT_RADIUS * 2 > sum_3_scent_y;
+    std::array < std::array < char, 3 + SCENT_RADIUS * 2 >, 1 + SCENT_RADIUS * 2 > squares_used_y;
 
-    // these are for caching flag lookups
-    scent_array<bool> blocks_scent; // currently only TFLAG_NO_SCENT blocks scent
-    scent_array<bool> reduces_scent;
+    diagonal_blocks blocked_cache[MAPSIZE_X][MAPSIZE_Y];
 
     // for loop constants
     const int scentmap_minx = center.x - SCENT_RADIUS;
@@ -177,73 +174,70 @@ void scent_map::update( const tripoint &center, map &m )
     const int scentmap_miny = center.y - SCENT_RADIUS;
     const int scentmap_maxy = center.y + SCENT_RADIUS;
 
-    // decrease this to reduce gas spread. Keep it under 125 for
-    // stability. This is essentially a decimal number * 1000.
-    const int diffusivity = 100;
-
     // The new scent flag searching function. Should be wayyy faster than the old one.
-    m.scent_blockers( blocks_scent, reduces_scent, point( scentmap_minx - 1, scentmap_miny - 1 ),
-                      point( scentmap_maxx + 1, scentmap_maxy + 1 ) );
-    // Sum neighbors in the y direction.  This way, each square gets called 3 times instead of 9
-    // times. This cost us an extra loop here, but it also eliminated a loop at the end, so there
-    // is a net performance improvement over the old code. Could probably still be better.
-    // note: this method needs an array that is one square larger on each side in the x direction
-    // than the final scent matrix. I think this is fine since SCENT_RADIUS is less than
-    // MAPSIZE_X, but if that changes, this may need tweaking.
-    for( int x = scentmap_minx - 1; x <= scentmap_maxx + 1; ++x ) {
-        for( int y = scentmap_miny; y <= scentmap_maxy; ++y ) {
+    m.scent_blockers( scent_transfer, point( scentmap_minx - 1, scentmap_miny - 1 ),
+                      point( scentmap_maxx + 1, scentmap_maxy + 1 ), blocked_cache );
+
+    for( int x = 0; x < SCENT_RADIUS * 2 + 3; ++x ) {
+        sum_3_scent_y[0][x] = 0;
+        squares_used_y[0][x] = 0;
+        sum_3_scent_y[SCENT_RADIUS * 2][x] = 0;
+        squares_used_y[SCENT_RADIUS * 2][x] = 0;
+    }
+
+    for( int x = 0; x < SCENT_RADIUS * 2 + 3; ++x ) {
+        for( int y = 0; y < SCENT_RADIUS * 2 + 1; ++y ) {
+
+            point abs( x + scentmap_minx - 1, y + scentmap_miny );
+
             // remember the sum of the scent val for the 3 neighboring squares that can defuse into
             sum_3_scent_y[y][x] = 0;
             squares_used_y[y][x] = 0;
-            for( int i = y - 1; i <= y + 1; ++i ) {
-                if( !blocks_scent[x][i] ) {
-                    if( reduces_scent[x][i] ) {
-                        // only 20% of scent can diffuse on REDUCE_SCENT squares
-                        sum_3_scent_y[y][x] += 2 * grscent[x][i];
-                        squares_used_y[y][x] += 2;
-                    } else {
-                        sum_3_scent_y[y][x] += 10 * grscent[x][i];
-                        squares_used_y[y][x] += 10;
-                    }
-                }
+            for( int i = abs.y - 1; i <= abs.y + 1; ++i ) {
+                sum_3_scent_y[y][x] += scent_transfer[abs.x][i] * grscent[abs.x][i];
+                squares_used_y[y][x] += scent_transfer[abs.x][i];
             }
         }
     }
 
-    // Rest of the scent map
-    for( int x = scentmap_minx; x <= scentmap_maxx; ++x ) {
-        for( int y = scentmap_miny; y <= scentmap_maxy; ++y ) {
-            int &scent_here = grscent[x][y];
-            if( !blocks_scent[x][y] ) {
-                // to how many neighboring squares do we diffuse out? (include our own square
-                // since we also include our own square when diffusing in)
-                const int squares_used = squares_used_y[y][x - 1]
-                                         + squares_used_y[y][x]
-                                         + squares_used_y[y][x + 1];
+    for( int x = 1; x < SCENT_RADIUS * 2 + 2; ++x ) {
+        for( int y = 0; y < SCENT_RADIUS * 2 + 1; ++y ) {
+            const point abs( x + scentmap_minx - 1, y + scentmap_miny );
 
-                int this_diffusivity;
-                if( !reduces_scent[x][y] ) {
-                    this_diffusivity = diffusivity;
-                } else {
-                    this_diffusivity = diffusivity / 5; //less air movement for REDUCE_SCENT square
-                }
-                // take the old scent and subtract what diffuses out
-                int temp_scent = scent_here * ( 10 * 1000 - squares_used * this_diffusivity );
-                // neighboring REDUCE_SCENT squares absorb some scent
-                temp_scent -= scent_here * this_diffusivity * ( 90 - squares_used ) / 5;
-                // we've already summed neighboring scent values in the y direction in the previous
-                // loop. Now we do it for the x direction, multiply by diffusion, and this is what
-                // diffuses into our current square.
-                scent_here =
-                    ( temp_scent
-                      + this_diffusivity * ( sum_3_scent_y[y][x - 1]
-                                             + sum_3_scent_y[y][x]
-                                             + sum_3_scent_y[y][x + 1] )
-                    ) / ( 1000 * 10 );
-            } else {
-                // this cell blocks scent via NO_SCENT (in json)
-                scent_here = 0;
+            int squares_used = squares_used_y[y][x - 1] + squares_used_y[y][x] + squares_used_y[y][x + 1];
+            int total = sum_3_scent_y[y][x - 1] + sum_3_scent_y[y][x] + sum_3_scent_y[y][x + 1];
+
+            //handle vehicle holes
+            if( blocked_cache[abs.x][abs.y].nw && scent_transfer[abs.x + 1][abs.y + 1] == 5 ) {
+                squares_used -= 4;
+                total -= 4 * grscent[abs.x + 1][abs.y + 1];
             }
+            if( blocked_cache[abs.x][abs.y].ne && scent_transfer[abs.x - 1][abs.y + 1] == 5 ) {
+                squares_used -= 4;
+                total -= 4 * grscent[abs.x - 1][abs.y + 1];
+            }
+            if( blocked_cache[abs.x - 1][abs.y - 1].nw && scent_transfer[abs.x - 1][abs.y - 1] == 5 ) {
+                squares_used -= 4;
+                total -= 4 * grscent[abs.x - 1][abs.y - 1];
+            }
+            if( blocked_cache[abs.x + 1][abs.y - 1].ne && scent_transfer[abs.x + 1][abs.y - 1] == 5 ) {
+                squares_used -= 4;
+                total -= 4 * grscent[abs.x + 1][abs.y - 1];
+            }
+
+            //Lingering scent
+            int temp_scent =  grscent[abs.x][abs.y] * ( 250 - squares_used  *
+                              scent_transfer[abs.x][abs.y] ) ;
+            temp_scent -=  grscent[abs.x][abs.y] * scent_transfer[abs.x][abs.y] *
+                           ( 45 - squares_used ) / 5;
+
+            new_scent[y][x] = ( temp_scent + total * scent_transfer[abs.x][abs.y] ) / 250;
+
+        }
+    }
+    for( int x = 1; x < SCENT_RADIUS * 2 + 2; ++x ) {
+        for( int y = 0; y < SCENT_RADIUS * 2 + 1; ++y ) {
+            grscent[x + scentmap_minx - 1 ][y + scentmap_miny] = new_scent[y][x];
         }
     }
 }

--- a/src/shadowcasting.h
+++ b/src/shadowcasting.h
@@ -12,6 +12,7 @@
 
 struct point;
 struct tripoint;
+struct diagonal_blocks;
 
 // For light we store four values, depending on the direction that the light
 // comes from.  This allows us to determine whether the side of the wall the
@@ -106,9 +107,10 @@ inline float accumulate_transparency( const float &cumulative_transparency,
 template<typename T, typename Out, T( *calc )( const T &, const T &, const int & ),
          bool( *check )( const T &, const T & ),
          void( *update_output )( Out &, const T &, quadrant ),
-         T( *accumulate )( const T &, const T &, const int & )>
+         T( *accumulate )( const T &, const T &, const int & ) >
 void castLightAll( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                    const T( &input_array )[MAPSIZE_X][MAPSIZE_Y],
+                   const diagonal_blocks( &blocked_array )[MAPSIZE_X][MAPSIZE_Y],
                    const point &offset, int offsetDistance = 0,
                    T numerator = 1.0 );
 
@@ -123,6 +125,7 @@ void cast_zlight(
     const array_of_grids_of<T> &output_caches,
     const array_of_grids_of<const T> &input_arrays,
     const array_of_grids_of<const bool> &floor_caches,
+    const array_of_grids_of<const diagonal_blocks> &blocked_caches,
     const tripoint &origin, int offset_distance, T numerator );
 
 #endif // CATA_SRC_SHADOWCASTING_H

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1032,25 +1032,29 @@ static bool sinkhole_safety_roll( player *p, const itype_id &itemname, const int
     ///\EFFECT_DEX increases chance to attach grapnel, bullwhip, or rope when falling into a sinkhole
 
     ///\EFFECT_THROW increases chance to attach grapnel, bullwhip, or rope when falling into a sinkhole
+
+    map &here = get_map();
+
     const int throwing_skill_level = p->get_skill_level( skill_throw );
     const int roll = rng( throwing_skill_level, throwing_skill_level + p->str_cur + p->dex_cur );
     if( roll < diff ) {
         p->add_msg_if_player( m_bad, _( "You fail to attach it…" ) );
         p->use_amount( itemname, 1 );
-        g->m.spawn_item( random_neighbor( p->pos() ), itemname );
+        here.spawn_item( random_neighbor( p->pos() ), itemname );
         return false;
     }
 
     std::vector<tripoint> safe;
     for( const tripoint &tmp : g->m.points_in_radius( p->pos(), 1 ) ) {
-        if( g->m.passable( tmp ) && g->m.tr_at( tmp ).loadid != tr_pit ) {
+        if( here.passable( tmp ) && !here.obstructed_by_vehicle_rotation( p->pos(), tmp ) &&
+            here.tr_at( tmp ).loadid != tr_pit ) {
             safe.push_back( tmp );
         }
     }
     if( safe.empty() ) {
         p->add_msg_if_player( m_bad, _( "There's nowhere to pull yourself to, and you sink!" ) );
         p->use_amount( itemname, 1 );
-        g->m.spawn_item( random_neighbor( p->pos() ), itemname );
+        here.spawn_item( random_neighbor( p->pos() ), itemname );
         return false;
     } else {
         p->add_msg_player_or_npc( m_good, _( "You pull yourself to safety!" ),

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2579,6 +2579,40 @@ bool vehicle::has_part( const tripoint &pos, const std::string &flag, bool enabl
     return false;
 }
 
+int vehicle::obstacle_at_position( const point &pos ) const
+{
+    int i = part_with_feature( pos, "OBSTACLE", true );
+
+    if( i == -1 ) {
+        return -1;
+    }
+
+    auto ref = parts[i];
+
+    if( ref.info().has_flag( VPFLAG_OPENABLE ) && ref.open ) {
+        return -1;
+    }
+
+    return i;
+}
+
+int vehicle::opaque_at_position( const point &pos ) const
+{
+    int i = part_with_feature( pos, "OPAQUE", true );
+
+    if( i == -1 ) {
+        return -1;
+    }
+
+    auto ref = parts[i];
+
+    if( ref.info().has_flag( VPFLAG_OPENABLE ) && ref.open ) {
+        return -1;
+    }
+
+    return i;
+}
+
 std::vector<vehicle_part *> vehicle::get_parts_at( const tripoint &pos, const std::string &flag,
         const part_status_flag condition )
 {
@@ -2994,21 +3028,91 @@ point vehicle::coord_translate( const point &p ) const
     return q.xy();
 }
 
+const struct {
+    float gradient;
+    bool flipH;
+    bool flipV;
+    bool swapXY;
+} rotation_info[24] = {
+    {static_cast<float>( tan( units::to_radians( 0_degrees ) ) ),  false, false,   false}, //0 degrees
+    {static_cast<float>( tan( units::to_radians( 15_degrees ) ) ), false, false,   false},
+    {static_cast<float>( tan( units::to_radians( 30_degrees ) ) ), false, false,   false},
+    {static_cast<float>( -tan( units::to_radians( 45_degrees ) ) ), true,  false, true}, //45 degrees
+    {static_cast<float>( -tan( units::to_radians( 30_degrees ) ) ), true,  false, true},
+    {static_cast<float>( -tan( units::to_radians( 15_degrees ) ) ), true,  false, true},
+    {static_cast<float>( tan( units::to_radians( 0_degrees ) ) ),  true,  false,   true}, //90 degrees
+    {static_cast<float>( tan( units::to_radians( 15_degrees ) ) ), true,  false,   true},
+    {static_cast<float>( tan( units::to_radians( 30_degrees ) ) ), true,  false,   true},
+    {static_cast<float>( tan( units::to_radians( 45_degrees ) ) ), true,  false,   true}, //135 degrees
+    {static_cast<float>( -tan( units::to_radians( 30_degrees ) ) ), true,  true,  false},
+    {static_cast<float>( -tan( units::to_radians( 15_degrees ) ) ), true,  true,  false},
+    {static_cast<float>( tan( units::to_radians( 0_degrees ) ) ),  true,  true,    false}, //180 degrees
+    {static_cast<float>( tan( units::to_radians( 15_degrees ) ) ), true,  true,    false},
+    {static_cast<float>( tan( units::to_radians( 30_degrees ) ) ), true,  true,    false},
+    {static_cast<float>( -tan( units::to_radians( 45_degrees ) ) ), false, true,  true}, //225 degrees
+    {static_cast<float>( -tan( units::to_radians( 30_degrees ) ) ), false, true,  true},
+    {static_cast<float>( -tan( units::to_radians( 15_degrees ) ) ), false, true,  true},
+    {static_cast<float>( tan( units::to_radians( 0_degrees ) ) ),  false,  true,   true}, //270 degrees
+    {static_cast<float>( tan( units::to_radians( 15_degrees ) ) ), false,  true,   true},
+    {static_cast<float>( tan( units::to_radians( 30_degrees ) ) ), false,  true,   true},
+    {static_cast<float>( tan( units::to_radians( 45_degrees ) ) ), false,  true,   true}, //315 degrees
+    {static_cast<float>( -tan( units::to_radians( 30_degrees ) ) ), false,  false, false},
+    {static_cast<float>( -tan( units::to_radians( 15_degrees ) ) ), false,  false, false},
+};
+
 void vehicle::coord_translate( units::angle dir, const point &pivot, const point &p,
                                tripoint &q ) const
 {
-    tileray tdir( dir );
-    tdir.advance( p.x - pivot.x );
-    q.x = tdir.dx() + tdir.ortho_dx( p.y - pivot.y );
-    q.y = tdir.dy() + tdir.ortho_dy( p.y - pivot.y );
+
+    int increment = angle_to_increment( dir );
+    point relative = p - pivot;
+    float skew = std::trunc( relative.x * rotation_info[increment].gradient );
+
+    q.x = relative.x;
+    q.y = relative.y + skew;
+
+    if( rotation_info[increment].swapXY ) {
+        auto swap = q.x;
+        q.x = q.y;
+        q.y = swap;
+    }
+    if( rotation_info[increment].flipH ) {
+        q.x = -q.x;
+    }
+    if( rotation_info[increment].flipV ) {
+        q.y = -q.y;
+    }
 }
 
-void vehicle::coord_translate( tileray tdir, const point &pivot, const point &p, tripoint &q ) const
+void vehicle::coord_translate_reverse( units::angle dir, const point &pivot, const tripoint &p,
+                                       point &q ) const
 {
-    tdir.clear_advance();
-    tdir.advance( p.x - pivot.x );
-    q.x = tdir.dx() + tdir.ortho_dx( p.y - pivot.y );
-    q.y = tdir.dy() + tdir.ortho_dy( p.y - pivot.y );
+    int increment = angle_to_increment( dir );
+
+    q.x = p.x;
+    q.y = p.y;
+
+
+    if( rotation_info[increment].flipV ) {
+        q.y = -q.y;
+    }
+
+    if( rotation_info[increment].flipH ) {
+        q.x = -q.x;
+    }
+
+    if( rotation_info[increment].swapXY ) {
+        auto swap = q.x;
+        q.x = q.y;
+        q.y = swap;
+    }
+
+    float skew = std::trunc( q.x * rotation_info[increment].gradient );
+
+    q.y -= skew;
+
+    q += pivot;
+
 }
 
 tripoint vehicle::mount_to_tripoint( const point &mount ) const
@@ -3023,12 +3127,31 @@ tripoint vehicle::mount_to_tripoint( const point &mount, const point &offset ) c
     return global_pos3() + mnt_translated;
 }
 
+point vehicle::tripoint_to_mount( const tripoint &p ) const
+{
+    tripoint translated = p - global_pos3();
+
+    point result;
+    coord_translate_reverse( pivot_rotation[0], pivot_anchor[0], translated, result );
+
+    return result;
+}
+
+int vehicle::angle_to_increment( units::angle dir )
+{
+    int increment = ( std::lround( to_degrees( dir ) ) % 360 ) / 15;
+    if( increment < 0 ) {
+        increment += 360 / 15;
+    }
+    return increment;
+}
+
+
 void vehicle::precalc_mounts( int idir, units::angle dir, const point &pivot )
 {
     if( idir < 0 || idir > 1 ) {
         idir = 0;
     }
-    tileray tdir( dir );
     std::unordered_map<point, point> mount_to_precalc;
     for( auto &p : parts ) {
         if( p.removed ) {
@@ -3036,7 +3159,7 @@ void vehicle::precalc_mounts( int idir, units::angle dir, const point &pivot )
         }
         auto q = mount_to_precalc.find( p.mount );
         if( q == mount_to_precalc.end() ) {
-            coord_translate( tdir, pivot, p.mount, p.precalc[idir] );
+            coord_translate( dir, pivot, p.mount, p.precalc[idir] );
             p.precalc[idir].z = 0;
             mount_to_precalc.insert( { p.mount, p.precalc[idir].xy() } );
         } else {
@@ -3045,6 +3168,60 @@ void vehicle::precalc_mounts( int idir, units::angle dir, const point &pivot )
     }
     pivot_anchor[idir] = pivot;
     pivot_rotation[idir] = dir;
+}
+
+bool vehicle::check_rotated_intervening( const point &from, const point &to,
+        bool( *check )( const vehicle *, const point & ) ) const
+{
+    point delta = to - from;
+    if( abs( delta.x ) <= 1 && abs( delta.y ) <= 1 ) { //Just a normal move
+        return true;
+    }
+
+    if( !( ( abs( delta.x ) == 2 && abs( delta.y ) == 1 ) || ( abs( delta.x ) == 1 &&
+            abs( delta.y ) == 2 ) ) ) { //Check that we're moving like a knight
+        debugmsg( "Unexpected movement in rotated vehicle vector:%d,%d", delta.x, delta.y );
+        return false;
+    }
+
+    if( abs( delta.x ) == 2 ) { //Mostly horizontal move
+        point t1 = from + point( delta.x / 2, delta.y );
+        if( check( this, t1 ) ) {
+            return true;
+        }
+
+        point t2 = from + point( delta.x / 2, 0 );
+        if( check( this, t2 ) ) {
+            return true;
+        }
+
+    } else { //Mostly vertical move
+        point t1 = from + point( delta.x, delta.y / 2 );
+        if( check( this, t1 ) ) {
+            return true;
+        }
+
+        point t2 = from + point( 0, delta.y / 2 );
+        if( check( this, t2 ) ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool vehicle::allowed_light( const point &from, const point &to ) const
+{
+    return check_rotated_intervening( from, to, []( const vehicle * veh, const point & p ) {
+        return ( veh->opaque_at_position( p ) == -1 );
+    } );
+}
+
+bool vehicle::allowed_move( const point &from, const point &to ) const
+{
+    return check_rotated_intervening( from, to, []( const vehicle * veh, const point & p ) {
+        return ( veh->obstacle_at_position( p ) == -1 );
+    } );
 }
 
 std::vector<int> vehicle::boarded_parts() const

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1001,6 +1001,9 @@ class vehicle
         int avail_part_with_feature( const point &pt, const std::string &f, bool unbroken ) const;
         int avail_part_with_feature( int p, vpart_bitflags f, bool unbroken ) const;
 
+        int obstacle_at_position( const point &pos ) const;
+        int opaque_at_position( const point &pos ) const;
+
         /**
          *  Check if vehicle has at least one unbroken part with specified flag
          *  @param flag Specified flag to search parts for
@@ -1073,12 +1076,16 @@ class vehicle
         // Translate mount coordinates "p" into tile coordinates "q" using given pivot direction and anchor
         void coord_translate( units::angle dir, const point &pivot, const point &p,
                               tripoint &q ) const;
-        // Translate mount coordinates "p" into tile coordinates "q" using given tileray and anchor
-        // should be faster than previous call for repeated translations
-        void coord_translate( tileray tdir, const point &pivot, const point &p, tripoint &q ) const;
+
+        // Translate rotated tile coordinates "p" into mount coordinates "q" using given pivot direction and anchor
+        void coord_translate_reverse( units::angle dir, const point &pivot, const tripoint &p,
+                                      point &q ) const;
 
         tripoint mount_to_tripoint( const point &mount ) const;
         tripoint mount_to_tripoint( const point &mount, const point &offset ) const;
+
+        //Translate tile coordinates into mount coordinates
+        point tripoint_to_mount( const tripoint &p ) const;
 
         // Seek a vehicle part which obstructs tile with given coordinates relative to vehicle position
         int part_at( const point &dp ) const;
@@ -1216,6 +1223,9 @@ class vehicle
          * Mark mass caches and pivot cache as dirty
          */
         void invalidate_mass();
+
+        //Converts angles into turning increments
+        static int angle_to_increment( units::angle dir );
 
         // get the total mass of vehicle, including cargo and passengers
         units::mass total_mass() const;
@@ -1737,6 +1747,16 @@ class vehicle
         void use_harness( int part, const tripoint &pos );
 
         void interact_with( const tripoint &pos, int interact_part );
+
+        //Check if a movement is blocked, must be adjacent points
+        bool allowed_move( const point &from, const point &to ) const;
+
+        //Check if light is blocked, must be adjacent points
+        bool allowed_light( const point &from, const point &to ) const;
+
+        //Checks if the conditional holds for tiles that can be skipped due to rotation
+        bool check_rotated_intervening( const point &from, const point &to, bool( *check )( const vehicle *,
+                                        const point & ) ) const;
 
         std::string disp_name() const;
 

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -577,7 +577,9 @@ void vehicle::autodrive_controller::compute_coordinates()
 vehicle_profile vehicle::autodrive_controller::compute_profile( orientation facing ) const
 {
     vehicle_profile ret;
-    tileray tdir( to_angle( facing ) );
+
+    auto angle = to_angle( facing );
+    tileray tdir( angle );
     ret.tdir = tdir;
     std::map<int, std::pair<int, int>> extent_map;
     const point pivot = driven_veh.pivot_point();
@@ -586,7 +588,7 @@ vehicle_profile vehicle::autodrive_controller::compute_profile( orientation faci
             continue;
         }
         tripoint pos;
-        driven_veh.coord_translate( tdir, pivot, part.mount, pos );
+        driven_veh.coord_translate( angle, pivot, part.mount, pos );
         if( extent_map.find( pos.y ) == extent_map.end() ) {
             extent_map[pos.y] = { pos.x, pos.x };
         } else {
@@ -609,7 +611,7 @@ vehicle_profile vehicle::autodrive_controller::compute_profile( orientation faci
         const int radius = ( diameter + 1 ) / 2;
         if( radius > 0 ) {
             tripoint pos;
-            driven_veh.coord_translate( tdir, pivot, part.mount, pos );
+            driven_veh.coord_translate( angle, pivot, part.mount, pos );
             for( tripoint pt : points_in_radius( pos, radius ) ) {
                 ret.occupied_zone.emplace_back( pt.xy() );
             }

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -253,6 +253,8 @@ TEST_CASE( "rotated_vehicle_walls_block_explosions" )
 
     here.add_vehicle( vproto_id( "apc" ), origin, -45_degrees, 0, 0 );
 
+    here.build_map_cache( 0 );
+
     tripoint mon_origin = origin + tripoint( -2, 1, 0 );
 
     monster &s = spawn_test_monster( "mon_squirrel", mon_origin );

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -241,3 +241,32 @@ TEST_CASE( "shrapnel at max grenade range", "[grenade],[explosion]" )
         }
     }
 }
+
+TEST_CASE( "rotated_vehicle_walls_block_explosions" )
+{
+    clear_map_and_put_player_underground();
+    tripoint origin( 60, 60, 0 );
+
+    item grenade( "can_bomb_act" );
+
+    map &here = get_map();
+
+    here.add_vehicle( vproto_id( "apc" ), origin, -45_degrees, 0, 0 );
+
+    tripoint mon_origin = origin + tripoint( -2, 1, 0 );
+
+    monster &s = spawn_test_monster( "mon_squirrel", mon_origin );
+
+    REQUIRE( veh_pointer_or_null( here.veh_at( mon_origin ) ) != nullptr );
+
+    tripoint explode_at = mon_origin + tripoint_north_west;
+
+    REQUIRE( veh_pointer_or_null( here.veh_at( explode_at ) ) == nullptr );
+
+    set_off_explosion( grenade, explode_at );
+
+    const monster *m = g->critter_at<monster>( mon_origin );
+    REQUIRE( m != nullptr );
+    CHECK( m == &s );
+    CHECK( m->get_hp() == m->get_hp_max() );
+}

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -328,3 +328,22 @@ TEST_CASE( "monster_speed_trig", "[speed]" )
     trigdist = true;
     monster_check();
 }
+
+TEST_CASE( "monster_move_through_vehicle_holes" )
+{
+    clear_map_and_put_player_underground();
+    tripoint origin( 60, 60, 0 );
+
+    get_map().add_vehicle( vproto_id( "apc" ), origin, -45_degrees, 0, 0 );
+
+    tripoint mon_origin = origin + tripoint( -2, 1, 0 );
+    monster &zombie = spawn_test_monster( "mon_zombie", mon_origin );
+    zombie.move_to( mon_origin + tripoint_north_west, false, false, 0.0f );
+
+    const monster *m = g->critter_at<monster>( mon_origin );
+    CHECK( m != nullptr );
+
+    const monster *m2 = g->critter_at<monster>( mon_origin + tripoint_north_west );
+    CHECK( m2 == nullptr );
+
+}

--- a/tests/monster_vision_test.cpp
+++ b/tests/monster_vision_test.cpp
@@ -86,6 +86,7 @@ TEST_CASE( "monsters_dont_see_through_vehicle_holes", "[vision]" )
     tripoint origin( 60, 60, 0 );
 
     get_map().add_vehicle( vproto_id( "apc" ), origin, -45_degrees, 0, 0 );
+    get_map().build_map_cache( 0 );
 
     tripoint mon_origin = origin + tripoint( -2, 1, 0 );
 

--- a/tests/monster_vision_test.cpp
+++ b/tests/monster_vision_test.cpp
@@ -78,3 +78,24 @@ TEST_CASE( "monsters shouldn't see through floors", "[vision]" )
     CHECK( distant.sees( sky ) );
     fov_3d = old_fov_3d;
 }
+
+TEST_CASE( "monsters_dont_see_through_vehicle_holes", "[vision]" )
+{
+    calendar::turn = midday;
+    clear_map_and_put_player_underground();
+    tripoint origin( 60, 60, 0 );
+
+    get_map().add_vehicle( vproto_id( "apc" ), origin, -45_degrees, 0, 0 );
+
+    tripoint mon_origin = origin + tripoint( -2, 1, 0 );
+
+    monster &inside = spawn_test_monster( "mon_zombie", mon_origin );
+
+    tripoint second_origin = mon_origin + tripoint_north_west;
+
+    monster &outside = spawn_test_monster( "mon_zombie", second_origin );
+
+    CHECK( !inside.sees( outside ) );
+    CHECK( !outside.sees( inside ) );
+
+}

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -465,6 +465,7 @@ TEST_CASE( "npc_move_through_vehicle_holes" )
     tripoint origin( 60, 60, 0 );
 
     get_map().add_vehicle( vproto_id( "apc" ), origin, -45_degrees, 0, 0 );
+    get_map().build_map_cache( 0 );
 
     tripoint mon_origin = origin + tripoint( -2, 1, 0 );
 

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -372,6 +372,8 @@ TEST_CASE( "npc-movement" )
                 // the NPC deems themselves to be guarding and stops them
                 // wandering off in search of distant ammo caches, etc.
                 guy->mission = NPC_MISSION_SHOPKEEP;
+                // This prevents npcs occasionally teleporting away
+                guy->assign_activity( activity_id( "ACT_MEDITATE" ) );
                 overmap_buffer.insert_npc( guy );
                 g->load_npcs();
                 guy->set_attitude( ( type == 'M' || type == 'C' ) ? NPCATT_NULL : NPCATT_FOLLOW );
@@ -454,4 +456,32 @@ TEST_CASE( "npc_can_target_player" )
     hostile.regen_ai_cache();
     REQUIRE( hostile.current_target() != nullptr );
     CHECK( hostile.current_target() == static_cast<Creature *>( &player_character ) );
+}
+
+TEST_CASE( "npc_move_through_vehicle_holes" )
+{
+    g->place_player( tripoint( 65, 55, 0 ) );
+    clear_map();
+    tripoint origin( 60, 60, 0 );
+
+    get_map().add_vehicle( vproto_id( "apc" ), origin, -45_degrees, 0, 0 );
+
+    tripoint mon_origin = origin + tripoint( -2, 1, 0 );
+
+    shared_ptr_fast<npc> guy = make_shared_fast<npc>();
+    guy->normalize();
+    guy->randomize();
+    guy->spawn_at_precise( {g->get_levx(), g->get_levy()}, mon_origin );
+
+    overmap_buffer.insert_npc( guy );
+    g->load_npcs();
+
+    guy->move_to( mon_origin + tripoint_north_west, true, nullptr );
+
+    const npc *m = g->critter_at<npc>( mon_origin );
+    CHECK( m != nullptr );
+
+    const npc *m2 = g->critter_at<npc>( mon_origin + tripoint_north_west );
+    CHECK( m2 == nullptr );
+
 }

--- a/tests/player_test.cpp
+++ b/tests/player_test.cpp
@@ -6,6 +6,8 @@
 #include <memory>
 
 #include "avatar.h"
+#include "avatar_action.h"
+#include "catch/catch.hpp"
 #include "player.h"
 #include "weather.h"
 #include "bodypart.h"
@@ -524,4 +526,23 @@ TEST_CASE( "Water hypothermia check.", "[.][bodytemp]" )
     SECTION( "Freezing" ) {
         hypothermia_check( dummy, units::celsius_to_fahrenheit( 0 ), 5_minutes, BODYTEMP_FREEZING );
     }
+}
+
+TEST_CASE( "player_move_through_vehicle_holes" )
+{
+    clear_map();
+    clear_avatar();
+
+    player &dummy = get_avatar();
+
+    const tripoint &pos = dummy.pos();
+
+    get_map().add_vehicle( vproto_id( "apc" ), pos + tripoint( 2, -1, 0 ), -45_degrees, 0, 0 );
+
+    REQUIRE( get_avatar().pos() == pos );
+
+    avatar_action::move( get_avatar(), get_map(), point_north_west );
+
+    CHECK( get_avatar().pos() == pos );
+
 }

--- a/tests/scent_test.cpp
+++ b/tests/scent_test.cpp
@@ -28,9 +28,6 @@ void old_scent_map_update( const tripoint &center, map &m,
 
     std::array<std::array<char, MAPSIZE_Y>, MAPSIZE_X> monkey;
 
-    diagonal_blocks monkey2[MAPSIZE_X][MAPSIZE_Y];
-
-
     // for loop constants
     const int scentmap_minx = center.x - SCENT_RADIUS;
     const int scentmap_maxx = center.x + SCENT_RADIUS;
@@ -43,7 +40,7 @@ void old_scent_map_update( const tripoint &center, map &m,
 
     // The new scent flag searching function. Should be wayyy faster than the old one.
     m.scent_blockers( monkey, point( scentmap_minx - 1, scentmap_miny - 1 ),
-                      point( scentmap_maxx + 1, scentmap_maxy + 1 ), monkey2 );
+                      point( scentmap_maxx + 1, scentmap_maxy + 1 ) );
 
     for( int x = 0; x < MAPSIZE_X; x++ ) {
         for( int y = 0; y < MAPSIZE_Y; y++ ) {

--- a/tests/scent_test.cpp
+++ b/tests/scent_test.cpp
@@ -1,0 +1,174 @@
+
+#include "scent_map.h"
+#include "catch/catch.hpp"
+#include "map.h"
+#include "map_helpers.h"
+#include "game.h"
+void old_scent_map_update( const tripoint &center, map &m,
+                           std::array<std::array<int, MAPSIZE_Y>, MAPSIZE_X> &grscent );
+
+static constexpr int SCENT_RADIUS = 40;
+void old_scent_map_update( const tripoint &center, map &m,
+                           std::array<std::array<int, MAPSIZE_Y>, MAPSIZE_X> &grscent )
+{
+
+    // note: the next four intermediate matrices need to be at least
+    // [2*SCENT_RADIUS+3][2*SCENT_RADIUS+1] in size to hold enough data
+    // The code I'm modifying used [MAPSIZE_X]. I'm staying with that to avoid new bugs.
+
+    // These two matrices are transposed so that x addresses are contiguous in memory
+    std::array<std::array<int, MAPSIZE_Y>, MAPSIZE_X> sum_3_scent_y;
+    std::array<std::array<int, MAPSIZE_Y>, MAPSIZE_X> squares_used_y;
+
+    // these are for caching flag lookups
+    std::array<std::array<bool, MAPSIZE_Y>, MAPSIZE_X>
+    blocks_scent; // currently only TFLAG_NO_SCENT blocks scent
+    std::array<std::array<bool, MAPSIZE_Y>, MAPSIZE_X> reduces_scent;
+
+
+    std::array<std::array<char, MAPSIZE_Y>, MAPSIZE_X> monkey;
+
+    diagonal_blocks monkey2[MAPSIZE_X][MAPSIZE_Y];
+
+
+    // for loop constants
+    const int scentmap_minx = center.x - SCENT_RADIUS;
+    const int scentmap_maxx = center.x + SCENT_RADIUS;
+    const int scentmap_miny = center.y - SCENT_RADIUS;
+    const int scentmap_maxy = center.y + SCENT_RADIUS;
+
+    // decrease this to reduce gas spread. Keep it under 125 for
+    // stability. This is essentially a decimal number * 1000.
+    const int diffusivity = 100;
+
+    // The new scent flag searching function. Should be wayyy faster than the old one.
+    m.scent_blockers( monkey, point( scentmap_minx - 1, scentmap_miny - 1 ),
+                      point( scentmap_maxx + 1, scentmap_maxy + 1 ), monkey2 );
+
+    for( int x = 0; x < MAPSIZE_X; x++ ) {
+        for( int y = 0; y < MAPSIZE_Y; y++ ) {
+            if( monkey[x][y] == 0 ) {
+                blocks_scent[x][y] = true;
+                reduces_scent[x][y] = false;
+            } else if( monkey[x][y] == 1 ) {
+                blocks_scent[x][y] = false;
+                reduces_scent[x][y] = true;
+            } else {
+                blocks_scent[x][y] = false;
+                reduces_scent[x][y] = false;
+            }
+        }
+    }
+    // Sum neighbors in the y direction.  This way, each square gets called 3 times instead of 9
+    // times. This cost us an extra loop here, but it also eliminated a loop at the end, so there
+    // is a net performance improvement over the old code. Could probably still be better.
+    // note: this method needs an array that is one square larger on each side in the x direction
+    // than the final scent matrix. I think this is fine since SCENT_RADIUS is less than
+    // MAPSIZE_X, but if that changes, this may need tweaking.
+    for( int x = scentmap_minx - 1; x <= scentmap_maxx + 1; ++x ) {
+        for( int y = scentmap_miny; y <= scentmap_maxy; ++y ) {
+            // remember the sum of the scent val for the 3 neighboring squares that can defuse into
+            sum_3_scent_y[y][x] = 0;
+            squares_used_y[y][x] = 0;
+            for( int i = y - 1; i <= y + 1; ++i ) {
+                if( !blocks_scent[x][i] ) {
+                    if( reduces_scent[x][i] ) {
+                        // only 20% of scent can diffuse on REDUCE_SCENT squares
+                        sum_3_scent_y[y][x] += 2 * grscent[x][i];
+                        squares_used_y[y][x] += 2;
+                    } else {
+                        sum_3_scent_y[y][x] += 10 * grscent[x][i];
+                        squares_used_y[y][x] += 10;
+                    }
+                }
+            }
+        }
+    }
+
+    // Rest of the scent map
+    for( int x = scentmap_minx; x <= scentmap_maxx; ++x ) {
+        for( int y = scentmap_miny; y <= scentmap_maxy; ++y ) {
+            int &scent_here = grscent[x][y];
+            if( !blocks_scent[x][y] ) {
+                // to how many neighboring squares do we diffuse out? (include our own square
+                // since we also include our own square when diffusing in)
+                const int squares_used = squares_used_y[y][x - 1]
+                                         + squares_used_y[y][x]
+                                         + squares_used_y[y][x + 1];
+
+                int this_diffusivity;
+                if( !reduces_scent[x][y] ) {
+                    this_diffusivity = diffusivity;
+                } else {
+                    this_diffusivity = diffusivity / 5; //less air movement for REDUCE_SCENT square
+                }
+                // take the old scent and subtract what diffuses out
+                int temp_scent = scent_here * ( 10 * 1000 - squares_used * this_diffusivity );
+                // neighboring REDUCE_SCENT squares absorb some scent
+                temp_scent -= scent_here * this_diffusivity * ( 90 - squares_used ) / 5;
+
+                // we've already summed neighboring scent values in the y direction in the previous
+                // loop. Now we do it for the x direction, multiply by diffusion, and this is what
+                // diffuses into our current square.
+                scent_here =
+                    ( temp_scent
+                      + this_diffusivity * ( sum_3_scent_y[y][x - 1]
+                                             + sum_3_scent_y[y][x]
+                                             + sum_3_scent_y[y][x + 1] )
+                    ) / ( 1000 * 10 );
+            } else {
+                // this cell blocks scent via NO_SCENT (in json)
+                scent_here = 0;
+            }
+        }
+    }
+}
+
+TEST_CASE( "scent_matches_old", "[.]" )
+{
+    clear_map();
+
+    tripoint origin( 60, 60, 0 );
+
+    g->place_player( origin );
+
+    map &here = get_map();
+
+    here.ter_set( origin + tripoint_south_west, t_brick_wall );
+    here.ter_set( origin + tripoint_west, t_brick_wall );
+    here.ter_set( origin + tripoint_north, t_rock_wall_half );
+    here.ter_set( origin, t_rock_wall_half );
+    g->scent.reset();
+
+    g->scent.set( origin, 1000, scenttype_id( "sc_human" ) );
+
+    g->scent.update( origin, here );
+    g->scent.update( origin, here );
+    g->scent.update( origin, here );
+
+    std::array<std::array<int, MAPSIZE_Y>, MAPSIZE_X> old_scent;
+    for( auto &elem : old_scent ) {
+        for( auto &val : elem ) {
+            val = 0;
+        }
+    }
+
+    old_scent[origin.x][origin.y] = 1000;
+
+    old_scent_map_update( origin, here, old_scent );
+    old_scent_map_update( origin, here, old_scent );
+    old_scent_map_update( origin, here, old_scent );
+    int x = 0;
+    for( auto &elem : old_scent ) {
+        int y = 0;
+        for( auto &val : elem ) {
+
+            INFO( x );
+            INFO( y );
+            CHECK( val == g->scent.get( {x, y, 0} ) );
+            y++;
+        }
+        x++;
+    }
+}
+

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -100,3 +100,64 @@ TEST_CASE( "overlapping_vehicles_make_wreck" )
     check_wreckage( OVERMAP_HEIGHT );
     check_wreckage( -OVERMAP_DEPTH );
 }
+
+static void test_coord_translate( units::angle dir, const point &pivot, const point &p,
+                                  tripoint &q )
+{
+    tileray tdir( dir );
+    tdir.advance( p.x - pivot.x );
+    q.x = tdir.dx() + tdir.ortho_dx( p.y - pivot.y );
+    q.y = tdir.dy() + tdir.ortho_dy( p.y - pivot.y );
+}
+
+TEST_CASE( "check_vehicle_rotation_against_old", "[.]" )
+{
+    clear_map();
+    const tripoint test_origin( 60, 60, 0 );
+    const tripoint vehicle_origin = test_origin;
+    vehicle *veh_ptr = get_map().add_vehicle( vproto_id( "bicycle" ), vehicle_origin, 0_degrees, 0, 0 );
+    const point pivot;
+
+    for( int dir = 0; dir < 24; dir++ ) {
+        for( int x = -5; x <= 5; x++ ) {
+            for( int y = -5; y <= 5; y++ ) {
+                point p = {x, y};
+                tripoint oldRes;
+                veh_ptr->coord_translate( 15_degrees * dir, pivot, p, oldRes );
+
+                tripoint newRes;
+                test_coord_translate( 15_degrees * dir, pivot, p, newRes );
+
+                CHECK( oldRes.x == newRes.x );
+                CHECK( oldRes.y == newRes.y );
+
+            }
+        }
+    }
+}
+
+TEST_CASE( "vehicle_rotation_reverse" )
+{
+    clear_map();
+    const tripoint test_origin( 60, 60, 0 );
+    const tripoint vehicle_origin = test_origin;
+    vehicle *veh_ptr = get_map().add_vehicle( vproto_id( "bicycle" ), vehicle_origin, 0_degrees, 0, 0 );
+    const point pivot;
+
+    for( int dir = 0; dir < 24; dir++ ) {
+        for( int x = -5; x <= 5; x++ ) {
+            for( int y = -5; y <= 5; y++ ) {
+                point p = {x, y};
+                tripoint result;
+                veh_ptr->coord_translate( 15_degrees * dir, pivot, p, result );
+
+                point reversed;
+                veh_ptr->coord_translate_reverse( 15_degrees * dir, pivot, result, reversed );
+
+                CHECK( reversed.x == p.x );
+                CHECK( reversed.y == p.y );
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Closes the holes created when turning vehicles"

#### Purpose of change

Prevent the integrity of car walls changing when you turn them.

#### Describe the solution

First, the new coord_translate, the first commit contains just this if you want it by itself. It works using a const table describing every rotation in terms of a skew between -45 and 45 degrees (y+=x*tan(a)), followed by transposing and/or mirroring x and/or y. This is roughly 4-5 times faster for a 5x7 vehicle and gets better with bigger sizes. 

The central logic for vehicle holes is that it checks moves against the unrotated version of vehicles to see if they skip any tiles. If they do, it checks the parts on both of the skipped tiles for opacity/obstruction and if they both have it it triggers the handling. I'm sure you know how the holes work in practice, it's only diagonal moves that can trigger this and it's the two tiles you're squeezing between that get checked. 

This does different things depending on where it's triggered. Player movement they're told "You can't squeeze through there." If the player tries to select it as an adjacent tile they're told "You can't reach through there." Pathfinding will not consider it as a path and monsters/npcs that try anyway will fail. Projectiles will be made to hit one of the two tiles randomly before moving on and it suppresses the ability to always see adjacent creatures. 

It also affects shadow casting. This is done with a cache built at the same time as the transparency cache by iterating through all of the vehicles and checking all the diagonal moves that can be made around them. This cache stores 2 bits per tile for if light is blocked entering the square going north west or north east, then adjacent tiles are checked for southern directions. When shadowcasting it just ignores tiles that are blocked from the right direction. 

#### Describe alternatives you've considered

For true alternatives there's the fake parts of course. I really don't mind if you'd rather go with that solution. 

Past that, removing the ability to select adjacent tiles wholesale might be too indiscriminate, it might be better to do specific handling for different cases and while this is ready, it's not finished. There are still things like fields or scent and I'm sure some others that people with a better knowledge of the engine could maybe point me towards, that aren't using it. Explosions are also using opacity rather than obstruction and I'd like to handle automatically opening doors if there's one blocking your way. I hope to look at these things over the next month or so, but for now the most gameplay important ones are there.

#### Testing

I've added the ability to spawn vehicles to the vision tests along with 2 simple tests stood inside and outside of a truck at 45 degrees. There are also tests that the new rotation matches the old and that coord_translate_reverse is a true reverse. I want to do a lot more with at least one test for each of the triggered behaviors. Going through a vehicle hole at all is a weird edge case that probably won't be tested manually so I think it's prudent. 

#### Additional context

View from outside:
![outside](https://user-images.githubusercontent.com/6675689/173786431-4c566f18-105a-44d1-863b-6debec975cd6.jpg)
Lack of view from inside:
![inside](https://user-images.githubusercontent.com/6675689/173786363-7b1527f6-3f50-49e4-a543-7a6da7b31977.jpg)
