### PR TITLE
Stomach data should be saved

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -608,6 +608,7 @@ void Character::load( const JsonObject &data )
         overmap_time_array.read_next( tdr );
         overmap_time[pt] = tdr;
     }
+    data.read( "stomach", stomach );
     data.read( "automoveroute", auto_move_route );
 
     known_traps.clear();
@@ -740,6 +741,7 @@ void Character::store( JsonOut &json ) const
         }
         json.end_array();
     }
+    json.member( "stomach", stomach );
     json.member( "automoveroute", auto_move_route );
     json.member( "known_traps" );
     json.start_array();


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Save stomach data so it won't lost during save/load"

#### Purpose of change

Fix #1615 

#### Describe the solution

Just save/load the stomach data.

#### Describe alternatives you've considered

#### Testing

Do the same thing as #1615 says. After this PR, the character is no more hungry again.

#### Additional context
