### PR TITLE
Sane aft frame folded volume

### DIFF
--- a/data/mods/Aftershock/vehicles/vehicle_parts.json
+++ b/data/mods/Aftershock/vehicles/vehicle_parts.json
@@ -308,7 +308,7 @@
     "color": "light_gray",
     "durability": 75,
     "symbol": "H",
-    "folded_volume": "10 L",
+    "folded_volume": "4 L",
     "description": "An ultralight titanium foldable framework.  Other vehicle components can be mounted on it, and it can be attached to other frames to increase the vehicle's size.",
     "breaks_into": [ { "item": "afs_scrap_titanium", "count": [ 1, 3 ] } ],
     "requirements": {

--- a/data/mods/Aftershock/vehicles/vehicle_parts.json
+++ b/data/mods/Aftershock/vehicles/vehicle_parts.json
@@ -302,7 +302,7 @@
   {
     "abstract": "afs_lightweight_foldable_frame",
     "type": "vehicle_part",
-    "name": { "str": "ultralight foldable frame" },
+    "name": { "str": "foldable ultralight frame" },
     "item": "afs_titanium_foldable_frame",
     "location": "structure",
     "color": "light_gray",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

SUMMARY: Balance "Made the Aftershock foldable ultralight frame a more sane folded volume"

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change

The afs foldable frame folded to 10 L which is far larger than any base foldable frame and is also significantly larger than the item it is installed from. In addition, the name of the part is inconsistent with the other foldable frames.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution

Frame folded volume is now 4 L down from 10. Part name string is now "foldable ultralight frame" to match all the other foldable [material] frames.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

A different volume than 4 L.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Created a new save with a folded ultralight vehicle
- saved & quit
- modified the JSON
- folded ultralight vehicle is same volume as before
- unfolded & refolded vehicle
- it's now the lower volume

So it loads just fine and doesn't seem to break anything, just needs to be recalculated.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
