### PR TITLE
Shots less than 20 damage don't go through cars

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6482,7 +6482,7 @@ int vehicle::damage_direct( int p, int dmg, damage_type type )
             explode_fuel( p, type );
         }
 
-        return dmg;
+        return 0;
     }
 
     dmg -= std::min<int>( dmg, part_info( p ).damage_reduction[ type ] );


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Projectiles that deal less than 20 damage can't go through cars"

#### Purpose of change

Fixes #730

#### Describe the solution

Shots that deal too little damage to do anything to a vehicle part now lose all their momentum when this happens.