### PR TITLE
Allow recipe category merge

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -85,16 +85,19 @@ void load_recipe_category( const JsonObject &jsobj )
     }
 
     if( !is_hidden ) {
-        craft_cat_list.push_back( category );
-
+        if( std::find( craft_cat_list.begin(), craft_cat_list.end(), category ) == craft_cat_list.end() ) {
+            craft_cat_list.push_back( category );
+        }
         const std::string cat_name = get_cat_unprefixed( category );
 
-        craft_subcat_list[category].clear();
         for( const std::string subcat_id : jsobj.get_array( "recipe_subcategories" ) ) {
             if( subcat_id.find( "CSC_" + cat_name + "_" ) != 0 && subcat_id != "CSC_ALL" ) {
                 jsobj.throw_error( "Crafting sub-category id has to be prefixed with CSC_<category_name>_" );
             }
-            craft_subcat_list[category].push_back( subcat_id );
+            if( std::find( craft_subcat_list[category].begin(), craft_subcat_list[category].end(),
+                           subcat_id ) == craft_subcat_list[category].end() ) {
+                craft_subcat_list[category].push_back( subcat_id );
+            }
         }
     }
 }


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Allow recipe category merge"

#### Purpose of change

Some recipe categories added by mods may have same id with the vanilla one, this PR makes them merge together, fix duplicate recipe categories in the crafting gui.

Fix #1607 

#### Describe the solution

Skip duplicate element in `craft_cat_list` and `craft_subcat_list`, `craft_subcat_list` won't clear before adding.
Simple and easy, but not the best solution.

#### Describe alternatives you've considered

I think the best solution is to implement this craft_cat in `generic_factory` way. But seems over complicated? Idk.

#### Testing

Create a new world with DinoMod loaded, no duplicate "Animals category" anymore.

#### Additional context
