### PR TITLE
Updated Github matrix and Makefile to use COMPILER parameter

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -93,10 +93,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install libncursesw5-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
             libsdl2-mixer-dev libpulse-dev ccache gettext parallel
-    - name: install old GCC (ubuntu)
-      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'g++-7' || matrix.compiler == 'g++-8') }}
+    - name: install old compiler (ubuntu)
+      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'g++-7' || matrix.compiler == 'g++-8' || matrix.compiler == 'clang++-9') }}
       run: |
-          sudo apt-get install g++-7 g++-8
+          sudo apt-get install ${{ matrix.compiler }}
     - name: install dependencies (mac)
       if: ${{ env.SKIP == 'false' && runner.os == 'macOS' }}
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Build CBN (osx)
         if: runner.os == 'macOS'
         run: |
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LANGUAGES=all USE_HOME_DIR=1 OSX_MIN=10.12 PCH=0 dmgdist
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LANGUAGES=all USE_HOME_DIR=1 OSX_MIN=10.12 PCH=0 dmgdist COMPILER=clang++
           mv CataclysmBN-unstable.dmg cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Set up JDK 8 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -60,12 +60,15 @@ then
         cmake_extra_opts+=("-DClang_DIR=/usr/lib/llvm-8/lib/cmake/clang")
     fi
 
-    if [ "$COMPILER" = "clang++-8" -a -n "$GITHUB_WORKFLOW" -a -n "$CATA_CLANG_TIDY" ]
+    if echo "$COMPILER" | grep -q "clang"
     then
-        # This is a hacky workaround for the fact that the custom clang-tidy we are
-        # using is built for Travis CI, so it's not using the correct include directories
-        # for GitHub workflows.
-        cmake_extra_opts+=("-DCMAKE_CXX_FLAGS=-isystem /usr/include/clang/8.0.0/include")
+        if [ -n "$GITHUB_WORKFLOW" -a -n "$CATA_CLANG_TIDY" ]
+        then
+            # This is a hacky workaround for the fact that the custom clang-tidy we are
+            # using is built for Travis CI, so it's not using the correct include directories
+            # for GitHub workflows.
+            cmake_extra_opts+=("-DCMAKE_CXX_FLAGS=-isystem /usr/include/clang/8.0.0/include")
+        fi
     fi
 
     mkdir build

--- a/src/simple_pathfinding.cpp
+++ b/src/simple_pathfinding.cpp
@@ -244,7 +244,7 @@ simple_path<tripoint_abs_omt> find_overmap_path( const tripoint_abs_omt &source,
         const tripoint_abs_omt &dest, const int radius, omt_scoring_fn scorer,
         cata::optional<int> max_cost )
 {
-    constexpr int max_search_count = 100000;
+    constexpr size_t max_search_count = 100000;
     simple_path<tripoint_abs_omt> ret;
     bool meet = false;
 

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -948,7 +948,7 @@ cata::optional<std::vector<navigation_step>> vehicle::autodrive_controller::comp
         return cata::nullopt;
     }
     // TODO: tweak this
-    constexpr int max_search_count = 10000;
+    constexpr size_t max_search_count = 10000;
     std::vector<navigation_step> ret;
     // TODO: check simple reachability first and bail out or set upper bound on node score
     std::unordered_map<node_address, navigation_node, node_address_hasher> known_nodes;


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Fix CI builds"

#### Purpose of change

Fixes #1627

#### Describe the solution

Made Makefile look into COMPILER parameter

#### Describe alternatives you've considered

Just remove Makefile and use only cmake.

#### Testing

Not yet

#### Additional context

Found out that we don't actually use compilers from matrix when trying to bump C++ version.
#1624

Also little changes in code and some documenting comments.
