### PR TITLE
Fix turning, interacting with and shifting vehicles on ramps

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2261,7 +2261,7 @@ void activity_handlers::vehicle_finish( player_activity *act, player *p )
     //Grab this now, in case the vehicle gets shifted
     const optional_vpart_position vp = g->m.veh_at( g->m.getlocal( tripoint( act->values[0],
                                        act->values[1],
-                                       p->posz() ) ) );
+                                       act->values[7] ) ) );
     veh_interact::complete_vehicle( *p );
     // complete_vehicle set activity type to NULL if the vehicle
     // was completely dismantled, otherwise the vehicle still exist and
@@ -2275,7 +2275,7 @@ void activity_handlers::vehicle_finish( player_activity *act, player *p )
     }
     act->set_to_null();
     if( !p->is_npc() ) {
-        if( act->values.size() < 7 ) {
+        if( act->values.size() < 8 ) {
             debugmsg( "process_activity invalid ACT_VEHICLE values:%d",
                       act->values.size() );
         } else {

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -678,7 +678,7 @@ void editmap::draw_main_ui_overlay()
         } else {
 #endif
             hilights["mapgentgt"].draw( *this, true );
-            tmpmap.reset_vehicle_cache( target.z );
+            tmpmap.reset_vehicle_cache( );
             drawsq_params params = drawsq_params().center( tripoint( SEEX - 1, SEEY - 1, target.z ) );
             for( const tripoint &p : tmpmap.points_on_zlevel() ) {
                 tmpmap.drawsq( g->w_terrain, p, params );
@@ -1869,7 +1869,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
             g->m.set_pathfinding_cache_dirty( target.z );
             g->m.set_suspension_cache_dirty( target.z );
 
-            g->m.clear_vehicle_cache( target.z );
+            g->m.clear_vehicle_cache( );
             g->m.clear_vehicle_list( target.z );
 
             for( int x = 0; x < 2; x++ ) {
@@ -1903,7 +1903,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
                 }
             }
 
-            g->m.reset_vehicle_cache( target.z );
+            g->m.reset_vehicle_cache( );
         } else if( gpmenu.ret == 3 ) {
             popup( _( "Changed oter_id from '%s' (%s) to '%s' (%s)" ),
                    orig_oters->get_name(), orig_oters.id().str(),
@@ -1976,8 +1976,7 @@ bool editmap::mapgen_veh_destroy( const tripoint_abs_omt &omt_tgt, vehicle *car_
             for( auto &z : destsm->vehicles ) {
                 if( z.get() == car_target ) {
                     std::unique_ptr<vehicle> old_veh = target_bay.detach_vehicle( z.get() );
-                    here.clear_vehicle_cache( omt_tgt.z() );
-                    here.reset_vehicle_cache( omt_tgt.z() );
+                    here.reset_vehicle_cache( );
                     here.clear_vehicle_list( omt_tgt.z() );
                     //Rebuild vehicle_list?
                     return true;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9929,10 +9929,11 @@ void game::place_player_overmap( const tripoint_abs_omt &om_dest )
     if( u.in_vehicle ) {
         m.unboard_vehicle( u.pos() );
     }
+
+    m.clear_vehicle_cache( );
     const int minz = m.has_zlevels() ? -OVERMAP_DEPTH : get_levz();
     const int maxz = m.has_zlevels() ? OVERMAP_HEIGHT : get_levz();
     for( int z = minz; z <= maxz; z++ ) {
-        m.clear_vehicle_cache( z );
         m.clear_vehicle_list( z );
     }
     m.access_cache( get_levz() ).map_memory_seen_cache.reset();
@@ -11065,7 +11066,7 @@ void game::vertical_shift( const int z_after )
     u.setz( z_after );
     const int z_before = get_levz();
     if( !m.has_zlevels() ) {
-        m.clear_vehicle_cache( z_before );
+        m.clear_vehicle_cache( );
         m.access_cache( z_before ).vehicle_list.clear();
         m.access_cache( z_before ).zone_vehicles.clear();
         m.access_cache( z_before ).map_memory_seen_cache.reset();

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -147,6 +147,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
         grabbed_vehicle->turn( mdir.dir() - grabbed_vehicle->face.dir() );
         grabbed_vehicle->face = grabbed_vehicle->turn_dir;
         grabbed_vehicle->precalc_mounts( 1, mdir.dir(), grabbed_vehicle->pivot_point() );
+        grabbed_vehicle->adjust_zlevel( 1, dp );
 
         // Grabbed part has to stay at distance 1 to the player
         // and in roughly the same direction.
@@ -187,7 +188,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
     m.displace_vehicle( *grabbed_vehicle, final_dp_veh );
 
     if( grabbed_vehicle ) {
-        m.level_vehicle( *grabbed_vehicle );
+        grabbed_vehicle->shift_zlevel();
         grabbed_vehicle->check_falling_or_floating();
     } else {
         debugmsg( "Grabbed vehicle disappeared" );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -459,10 +459,6 @@ static void pldrive( const tripoint &p )
         u.in_vehicle = false;
         return;
     }
-    if( veh->is_on_ramp && p.x != 0 ) {
-        add_msg( m_bad, _( "You can't turn the vehicle while on a ramp." ) );
-        return;
-    }
     if( !remote ) {
         static const itype_id fuel_type_animal( "animal" );
         const bool has_animal_controls = veh->part_with_feature( part, "CONTROL_ANIMAL", true ) >= 0;

--- a/src/map.h
+++ b/src/map.h
@@ -740,8 +740,8 @@ class map
         void add_vehicle_to_cache( vehicle * );
         void clear_vehicle_point_from_cache( vehicle *veh, const tripoint &pt );
         void update_vehicle_cache( vehicle *, int old_zlevel );
-        void reset_vehicle_cache( int zlev );
-        void clear_vehicle_cache( int zlev );
+        void reset_vehicle_cache( );
+        void clear_vehicle_cache( );
         void clear_vehicle_list( int zlev );
         void update_vehicle_list( const submap *to, int zlev );
         //Returns true if vehicle zones are dirty and need to be recached
@@ -778,12 +778,10 @@ class map
         void unboard_vehicle( const tripoint &p, bool dead_passenger = false );
         // Change vehicle coordinates and move vehicle's driver along.
         // WARNING: not checking collisions!
-        // optionally: include a list of parts to displace instead of the entire vehicle
-        bool displace_vehicle( vehicle &veh, const tripoint &dp, bool adjust_pos = true,
-                               const std::set<int> &parts_to_move = {} );
-        // make sure a vehicle that is split across z-levels is properly supported
-        // calls displace_vehicle() and shouldn't be called from displace_vehicle
-        void level_vehicle( vehicle &veh );
+        bool displace_vehicle( vehicle &veh, const tripoint &dp );
+
+        // Shift the vehicle's z-level without moving any parts
+        void shift_vehicle_z( vehicle &veh, int z_shift );
         // move water under wheels. true if moved
         bool displace_water( const tripoint &dp );
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -5634,11 +5634,9 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint &p, const units
     veh->sm_pos = ms_to_sm_remain( p_ms );
     veh->pos = p_ms.xy();
     veh->place_spawn_items();
-    veh->face.init( dir );
-    veh->turn_dir = dir;
     // for backwards compatibility, we always spawn with a pivot point of (0,0) so
     // that the mount at (0,0) is located at the spawn position.
-    veh->precalc_mounts( 0, dir, point() );
+    veh->set_facing_and_pivot( dir, point_zero, false );
     //debugmsg("adding veh: %d, sm: %d,%d,%d, pos: %d, %d", veh, veh->smx, veh->smy, veh->smz, veh->posx, veh->posy);
     std::unique_ptr<vehicle> placed_vehicle_up =
         add_vehicle_to_map( std::move( veh ), merge_wrecks );
@@ -5679,6 +5677,9 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
 
     //When hitting a wall, only smash the vehicle once (but walls many times)
     bool needs_smashing = false;
+
+    veh->attach();
+    veh->refresh_position();
 
     for( std::vector<int>::const_iterator part = frame_indices.begin();
          part != frame_indices.end(); part++ ) {
@@ -5854,7 +5855,7 @@ void map::rotate( int turns, const bool setpos_safe )
         }
     }
 
-    clear_vehicle_cache( abs_sub.z );
+    clear_vehicle_cache( );
     clear_vehicle_list( abs_sub.z );
 
     // Move the submaps around.
@@ -5888,7 +5889,7 @@ void map::rotate( int turns, const bool setpos_safe )
             update_vehicle_list( sm, abs_sub.z );
         }
     }
-    reset_vehicle_cache( abs_sub.z );
+    reset_vehicle_cache( );
 
     // rotate zones
     zone_manager &mgr = zone_manager::get_manager();

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -284,12 +284,7 @@ void submap::rotate( int turns )
         const auto new_pos = rotate_point( elem->pos );
 
         elem->pos = new_pos;
-        // turn the steering wheel, vehicle::turn does not actually
-        // move the vehicle.
-        elem->turn( turns * 90_degrees );
-        // The facing direction and recalculate the positions of the parts
-        elem->face = elem->turn_dir;
-        elem->precalc_mounts( 0, elem->turn_dir, elem->pivot_anchor[0] );
+        elem->set_facing( turns * 90_degrees );
     }
 
     std::map<point, computer> rot_comp;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1913,7 +1913,7 @@ void vehicle::use_bike_rack( int part )
     }
     if( success ) {
         get_map().invalidate_map_cache( g->get_levz() );
-        get_map().reset_vehicle_cache( g->get_levz() );
+        get_map().reset_vehicle_cache( );
     }
 }
 

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -73,3 +73,27 @@ TEST_CASE( "add_item_to_broken_vehicle_part" )
     const item itm2 = item( "jeans" );
     REQUIRE( !veh_ptr->add_item( *cargo_part, itm2 ) );
 }
+
+static void check_wreckage( int zlevel )
+{
+    clear_map();
+    const tripoint test_origin( 60, 60, zlevel );
+    const tripoint vehicle_origin = test_origin;
+
+    vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "bicycle" ), vehicle_origin, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+
+    vehicle *veh_ptr2 = g->m.add_vehicle( vproto_id( "car" ), vehicle_origin + tripoint_north_west,
+                                          0_degrees, 0, 0 );
+    REQUIRE( veh_ptr2 != nullptr );
+
+    INFO( veh_ptr2->name );
+    CHECK( veh_ptr2->name == "Wreckage" );
+}
+
+TEST_CASE( "overlapping_vehicles_make_wreck" )
+{
+    check_wreckage( 0 );
+    check_wreckage( OVERMAP_HEIGHT );
+    check_wreckage( -OVERMAP_DEPTH );
+}


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Allow turning on ramps, interacting with vehicles across z-levels and prevent disappearing parts"

#### Purpose of change

Fixes #1212 by reallowing turning on ramps. It also fixes two other problems mentioned in that issue. Attempting to interact with vehicle parts on a different z level to the player won't cause an error and vehicles on ramps will no longer half disappear when loading or shifting submaps.

#### Describe the solution

Currently the code checks every part to see if it's on a ramp and move it up or down accordingly. Turning could cause parts to skip the ramp and collide with the floor or float and there was a lot of code accounting for the fact that the precalc z level wasn't correct until one of the last steps of movement. 

With this, we update the z levels at the same time as the rest of the movement, prior to collisions etc. Rather than keep track of every part going over the ramp, we only track the center part. For other parts we draw a line from the center to the part and look at any ramps that line crosses. There's a check at the start to skip the process if the vehicle isn't touching a ramp. 

Interacting across z levels just needed the part's z level passing through rather than using the player's. The disappearing vehicles is done by making vehicle cache resets always full resets rather than single z level resets, similar to DDA's solution. 

#### Describe alternatives you've considered

I considered using collisions and falling to handle the ramp skipping after it happened, but each system would have been more complicated, only handled one direction and not given me a chance to remove all the ad-hoc z level adjustments.

I've also had vehicles check their z levels when a vehicle cache reset is done. This is mostly a defensive measure, I'm not sure it's needed. It's done there to be sure it's done every time something is loaded but things should already have the correct z levels when they're loaded. That said, for most vehicles all it will involve is checking they don't touch a ramp and it means you can do things like spawn vehicles on a ramp without worry. 

#### Testing

Just manual testing. I gave the steering a good wiggle going back and forth and checked that stuff didn't disappear when I crossed submaps and that it let me remove a part across z levels. It might be that it's still possible to skip the ramp with the center tile, but I was unable to get this to happen when trying. If it does we'll need to use the rotation pivot rather than the center but that's extra complexity that I don't think is needed. 