### PR TITLE
Adding magiclysm spellbook category for ease of sorting

### DIFF
--- a/data/json/item_category.json
+++ b/data/json/item_category.json
@@ -64,59 +64,66 @@
     "sort_rank": -15
   },
   {
+    "id": "spellbooks",
+    "type": "ITEM_CATEGORY",
+    "name": { "str": "SPELLBOOKS" },
+    "zone": "LOOT_SPELLBOOKS",
+    "sort_rank": -14
+  },
+  {
     "id": "maps",
     "type": "ITEM_CATEGORY",
     "name": { "str": "MAPS" },
-    "sort_rank": -14
+    "sort_rank": -13
   },
   {
     "id": "mods",
     "type": "ITEM_CATEGORY",
     "name": { "str": "MODS" },
     "zone": "LOOT_MODS",
-    "sort_rank": -13
+    "sort_rank": -12
   },
   {
     "id": "mutagen",
     "type": "ITEM_CATEGORY",
     "name": { "str": "MUTAGENS" },
     "zone": "LOOT_MUTAGENS",
-    "sort_rank": -12
+    "sort_rank": -11
   },
   {
     "id": "bionics",
     "type": "ITEM_CATEGORY",
     "name": { "str": "BIONICS" },
     "zone": "LOOT_BIONICS",
-    "sort_rank": -12
+    "sort_rank": -10
   },
   {
     "id": "veh_parts",
     "type": "ITEM_CATEGORY",
     "name": { "str": "VEHICLE PARTS" },
     "zone": "LOOT_VEHICLE_PARTS",
-    "sort_rank": -10
+    "sort_rank": -9
   },
   {
     "id": "other",
     "type": "ITEM_CATEGORY",
     "name": { "str": "OTHER" },
     "zone": "LOOT_OTHER",
-    "sort_rank": -9
+    "sort_rank": -8
   },
   {
     "id": "fuel",
     "type": "ITEM_CATEGORY",
     "name": { "str": "FUEL" },
     "zone": "LOOT_FUEL",
-    "sort_rank": -8
+    "sort_rank": -7
   },
   {
     "id": "seeds",
     "type": "ITEM_CATEGORY",
     "name": { "str": "SEEDS" },
     "zone": "LOOT_SEEDS",
-    "sort_rank": -7
+    "sort_rank": -6
   },
   {
     "id": "chems",

--- a/data/json/loot_zones.json
+++ b/data/json/loot_zones.json
@@ -96,6 +96,12 @@
     "description": "Destination for books and magazines."
   },
   {
+    "id": "LOOT_SPELLBOOKS",
+    "type": "LOOT_ZONE",
+    "name": "Loot: Spellbooks",
+    "description": "Destination for spellbooks and scrolls."
+  },
+  {
     "id": "LOOT_MODS",
     "type": "LOOT_ZONE",
     "name": "Loot: Mods",

--- a/data/mods/Magiclysm/items/spell_scrolls.json
+++ b/data/mods/Magiclysm/items/spell_scrolls.json
@@ -3,6 +3,7 @@
     "abstract": "spell_scroll",
     "name": { "str": "Spell Scroll" },
     "type": "GENERIC",
+    "category": "spellbooks",
     "weight": "475 g",
     "volume": "500 ml",
     "price": 4000,

--- a/data/mods/Magiclysm/items/spellbooks.json
+++ b/data/mods/Magiclysm/items/spellbooks.json
@@ -2,6 +2,7 @@
   {
     "id": "DEBUG_spellbook",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "A Technomancer's Guide to Debugging C:DDA", "str_pl": "copies of A Technomancer's Guide to Debugging C:DDA" },
     "description": "static std::string description( spell sp ) const;",
     "weight": "1 g",
@@ -29,6 +30,7 @@
   {
     "id": "wizard_beginner",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "A Beginner's Guide to Magic", "str_pl": "copies of A Beginner's Guide to Magic" },
     "//": "2 Magus, 1 classless spell",
     "description": "You would describe this as more like a pamphlet than a spellbook, but it seems to have at least one interesting spell you can use.",
@@ -42,6 +44,7 @@
   {
     "id": "wizard_utility",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "Wizarding Guide to Backpacking", "str_pl": "copies of Wizarding Guide to Backpacking" },
     "//": "1 Magus, 1 Biomancer, 1, Kelvinist, 1 classless spell",
     "description": "This appears to be the spell version of a guide for what things to take with you when backpacking.  It's a little bulky, but will certainly prove useful.",
@@ -55,6 +58,7 @@
   {
     "id": "pyro",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "Pyromancy for Heretics", "str_pl": "copies of Pyromancy for Heretics" },
     "//": "4 Kelvinist spells",
     "description": "This charred husk of a book still contains many ways to light things aflame.",
@@ -68,6 +72,7 @@
   {
     "id": "wizard_advanced",
     "type": "GENERIC",
+    "category": "spellbooks",
     "//": "1 Magus, 1 biomancer, 2 kelvinist spells",
     "name": { "str": "A Treatise on Magical Elements", "str_pl": "copies of A Treatise on Magical Elements" },
     "description": "This details complex diagrams, rituals, and choreography that describes various spells.",
@@ -81,6 +86,7 @@
   {
     "id": "priest_beginner",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "Introduction to the Divine", "str_pl": "copies of Introduction to the Divine" },
     "//": "1 technomancer, 1 biomancer, 1 classless spells",
     "description": "This appears to mostly be a religious text, but it does have some notes on healing.",
@@ -94,6 +100,7 @@
   {
     "id": "priest_advanced",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": {
       "str": "The Paladin's Guide to Modern Spellcasting",
       "str_pl": "copies of The Paladin's Guide to Modern Spellcasting"
@@ -110,6 +117,7 @@
   {
     "id": "winter_grasp",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "Winter's Eternal Grasp", "str_pl": "copies of Winter's Eternal Grasp" },
     "//": "5 Kelvinist spells",
     "description": "This slim book almost seems to be made from ice, it's cold to the touch.",
@@ -123,6 +131,7 @@
   {
     "id": "tome_of_storms",
     "type": "GENERIC",
+    "category": "spellbooks",
     "//": "6 Stormshaper spells",
     "name": { "str": "The Tome of The Oncoming Storm", "str_pl": "copies of The Tome of The Oncoming Storm" },
     "description": "A large book embossed with crossed lightning bolts and storm clouds, it tingles to the touch.",
@@ -139,6 +148,7 @@
   {
     "id": "generic_spellbook",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "Nondescript Spellbook", "str_pl": "copies of Nondescript Spellbook" },
     "//": "1 technomancer, 1 earthshaper, 1 classless spell",
     "description": "A small book, containing spells created by a novice magician.",
@@ -151,6 +161,7 @@
   {
     "id": "light_manipulation_spellbook",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "Of Light and Falsehoods", "str_pl": "copies of Of Light and Falsehoods" },
     "//": "3 technomancer, 4 classless spell",
     "description": "A small white book, it subtly amplifies the ambient light around it.",
@@ -175,6 +186,7 @@
   {
     "id": "biomancer_spellbook",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "The Tome of Flesh", "str_pl": "copies of The Tome of Flesh" },
     "//": "5 Biomancer spells",
     "description": "A small tome, seemingly covered in tanned human skin.",
@@ -190,6 +202,7 @@
   {
     "id": "druid_spellbook",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "The Book of Trees", "str_pl": "copies of The Book of Trees" },
     "//": "4 Druid spells",
     "description": "A bark covered book.",
@@ -202,6 +215,7 @@
   {
     "id": "recovery_spellbook",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "The Utility of Mana as an Energy Source", "str_pl": "copies of The Utility of Mana as an Energy Source" },
     "description": "This book details spells that use your mana to recover various physiological effects.",
     "//": "1 technomancer, 2 animist, 1 druid, 1 earthshaper spell",
@@ -217,6 +231,7 @@
   {
     "id": "magus_spellbook",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "The Tome of The Battle Mage", "str_pl": "copies of The Tome of The Battle Mage" },
     "//": "3 Magus spells",
     "description": "Your standard wizardy looking spellbook, filled with Magus combat spells.  You sure lucked out!",
@@ -229,6 +244,7 @@
   {
     "id": "eshaper_spellbook",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "The Tome of the Hollow Earth", "str_pl": "copies of The Tome of the Hollow Earth" },
     "//": "4 earthshaper spells",
     "description": "This large dusty spellbook seems perpetually, well, dusty.  It contains the power of the earth.",
@@ -244,6 +260,7 @@
   {
     "id": "magus_spellbook_move",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "The Tome of Magical Movement", "str_pl": "copies of The Tome of Magical Movement" },
     "//": "3 Magus spells",
     "description": "This small lightweight book seems to almost not entirely exist, let's say it 97% does.  It contains Magus spells focused on movement.",
@@ -256,6 +273,7 @@
   {
     "id": "summon_scroll_smudged",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "Smudged Scroll" },
     "//": "Druid spell",
     "description": "This looks like someone was designing a new spell, but spilled a mug of coffee on it and crumpled it up in anger.  You can tell that it will definitely cast something, but you can't be sure that it will work very well.",
@@ -268,6 +286,7 @@
   {
     "id": "summon_undead_spellbook",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "Necromantic Minions for Dummies", "str_pl": "copies of Necromantic Minions for Dummies" },
     "//": "3 Animist spells",
     "description": "This book details various ways of summoning an undead minion to fight for you.  They all appear to disappear after a short time, crumbling to dust.",
@@ -280,6 +299,7 @@
   {
     "id": "techno_fundamentals",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "Fundamentals of Technomancy", "str_pl": "copies of Fundamentals of Technomancy" },
     "//": "3 Technomancer spells",
     "description": "This thick manual instructs the spellcaster on manipulating and empowering various forms of matter and energy.",
@@ -292,6 +312,7 @@
   {
     "id": "techno_idiots",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "Complete Idiot's Guide to Technomancy", "str_pl": "copies of Complete Idiot's Guide to Technomancy" },
     "description": "This colorful guide, full of diagrams and cartoons, teaches a couple of very basic Technomancy spells for the not-so-bright pupils.",
     "//": "2 Technomancer spells",
@@ -304,6 +325,7 @@
   {
     "id": "techno_em",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": {
       "str": "Technomancy and the Electromagnetic Spectrum",
       "str_pl": "copies of Technomancy and the Electromagnetic Spectrum"
@@ -319,6 +341,7 @@
   {
     "id": "translocate_spellbook",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "Geospatial Systems: The Lie Of Linearity", "str_pl": "copies of Geospatial Systems: The Lie Of Linearity" },
     "//": "1 classless spell",
     "description": "This book outlines in great detail how time and space are wibbly-wobbly and non-Euclidean.  It also appears to have a dozen different coordinate systems that it uses nearly interchangeably, which makes it hard to follow.  There's lots of jargon, but with intense study you can probably learn a thing or two about portals.",
@@ -331,6 +354,7 @@
   {
     "id": "stat_up_spellbook",
     "type": "GENERIC",
+    "category": "spellbooks",
     "name": { "str": "Transcendence of the Human Condition", "str_pl": "copies of Transcendence of the Human Condition" },
     "//": "4 Magus spells",
     "description": "The Human is the only creature that seeks to improve himself.  This study examines different spells that can heighten various senses temporarily, in hopes to discover a more permanent solution.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

SUMMARY: Interface "Adds spellbook item category and loot zone"


#### Purpose of change

Magiclysm spellbooks and scrolls are difficult to sort and search for because they are categorized as "other"

#### Describe the solution

Adds a new item category "spellbooks" to spellbooks and scrolls and an associated loot zone so they can be easily prioritized and searched for.

#### Describe alternatives you've considered

Making them categorized as normal books. Also, putting a space between "spell" and "book"

#### Testing

Dropped the edited JSONs in a fresh copy of the game and everything worked as expected.

#### Additional context

![image](https://user-images.githubusercontent.com/77130566/175181796-dff70260-e6e6-4246-967e-7e6f82db82fb.png)
