### PR TITLE
Add colony.h to precompiled headers

### DIFF
--- a/msvc-full-features/stdafx.h
+++ b/msvc-full-features/stdafx.h
@@ -74,6 +74,7 @@
 #include <vector>
 
 #include "../src/platform_win.h"
+#include "../src/colony.h"
 
 #if defined(TILES)
 #   if defined(_MSC_VER) && defined(USE_VCPKG)

--- a/pch/main-pch.hpp
+++ b/pch/main-pch.hpp
@@ -53,3 +53,5 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+
+#include "../src/colony.h"


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Add colony.h to precompiled headers for a small build speedup"

#### Purpose of change
`colony.h` is the largest extensively used header file in the project. It's essentially third-party code, and it makes its way into over 160 compilation units. A prime candidate for precompilation.

#### Describe the solution
Add `colony.h` to the list of precompiled headers.

#### Describe alternatives you've considered
Implementing an opaque wrapper over `colony<item>` so that `colony.h` gets included only once, in wrapper's `.cpp` file, and the rest of the code uses the wrapper defined in a lightweight header, but testing showed there to be too little build time improvement over the current solution to justify spaghettification.

#### Testing
Compiled with `time make -j4 -k COMPILER=clang++-12 TILES=1`.

Before:
```
real    20m22,521s
user    75m19,058s
sys     1m47,387s
```
After:
```
real    19m56.946s
user    75m6.086s
sys     1m45.102s
```

#### Additional context
Under 20 minutes, yay!