### PR TITLE
[DDA Port] Fix screenshot feature in debug menu

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1960,33 +1960,8 @@ void debug()
         }
         break;
 
-        case DEBUG_SAVE_SCREENSHOT: {
-#if defined(TILES)
-            // check that the current '<world>/screenshots' directory exists
-            std::stringstream map_directory;
-            map_directory << g->get_world_base_save_path() << "/screenshots/";
-            assure_dir_exist( map_directory.str() );
-
-            // build file name: <map_dir>/screenshots/[<character_name>]_<date>.png
-            // Date format is a somewhat ISO-8601 compliant GMT time date (except for some characters that wouldn't pass on most file systems like ':').
-            std::time_t time = std::time( nullptr );
-            std::stringstream date_buffer;
-            date_buffer << std::put_time( std::gmtime( &time ), "%F_%H-%M-%S_%z" );
-            const auto tmp_file_name = string_format( "[%s]_%s.png", g->u.get_name(), date_buffer.str() );
-
-            std::string file_name = ensure_valid_file_name( tmp_file_name );
-            auto current_file_path = map_directory.str() + file_name;
-
-            // Take a screenshot of the viewport.
-            if( g->take_screenshot( current_file_path ) ) {
-                popup( _( "Successfully saved your screenshot to: %s" ), map_directory.str() );
-            } else {
-                popup( _( "An error occurred while trying to save the screenshot." ) );
-            }
-#else
-            popup( _( "This binary was not compiled with tiles support." ) );
-#endif
-        }
+        case DEBUG_SAVE_SCREENSHOT:
+            g->queue_screenshot = true;
         break;
 
         case DEBUG_GAME_REPORT: {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1525,6 +1525,8 @@ bool game::do_turn()
                 }
 
                 if( queue_screenshot ) {
+                    invalidate_main_ui_adaptor();
+                    ui_manager::redraw();
                     take_screenshot();
                     queue_screenshot = false;
                 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12,6 +12,7 @@
 #include <ctime>
 #include <cwctype>
 #include <exception>
+#include <iomanip>
 #include <iostream>
 #include <iterator>
 #include <limits>
@@ -1521,6 +1522,11 @@ bool game::do_turn()
                 if( !u.activity && !u.has_distant_destination() && uquit != QUIT_WATCH && wait_popup ) {
                     wait_popup.reset();
                     ui_manager::redraw();
+                }
+
+                if( queue_screenshot ) {
+                    take_screenshot();
+                    queue_screenshot = false;
                 }
 
                 if( handle_action() ) {
@@ -7348,9 +7354,43 @@ bool game::take_screenshot( const std::string &path ) const
 {
     return save_screenshot( path );
 }
+
+bool game::take_screenshot() const
+{
+    // check that the current '<world>/screenshots' directory exists
+    std::stringstream map_directory;
+    map_directory << get_world_base_save_path() << "/screenshots/";
+    assure_dir_exist( map_directory.str() );
+
+    // build file name: <map_dir>/screenshots/[<character_name>]_<date>.png
+    // Date format is a somewhat ISO-8601 compliant GMT time date (except for some characters that wouldn't pass on most file systems like ':').
+    std::time_t time = std::time( nullptr );
+    std::stringstream date_buffer;
+    date_buffer << std::put_time( std::gmtime( &time ), "%F_%H-%M-%S_%z" );
+    const auto tmp_file_name = string_format( "[%s]_%s.png", get_player_character().get_name(),
+                               date_buffer.str() );
+
+    std::string file_name = ensure_valid_file_name( tmp_file_name );
+    auto current_file_path = map_directory.str() + file_name;
+
+    // Take a screenshot of the viewport.
+    if( take_screenshot( current_file_path ) ) {
+        popup( _( "Successfully saved your screenshot to: %s" ), map_directory.str() );
+        return true;
+    } else {
+        popup( _( "An error occurred while trying to save the screenshot." ) );
+        return false;
+    }
+}
 #else
 bool game::take_screenshot( const std::string &/*path*/ ) const
 {
+    return false;
+}
+
+bool game::take_screenshot() const
+{
+    popup( _( "This binary was not compiled with tiles support." ) );
     return false;
 }
 #endif

--- a/src/game.h
+++ b/src/game.h
@@ -649,6 +649,11 @@ class game
         * @returns `true` if the screenshot generation was successful, `false` otherwise.
         */
         bool take_screenshot( const std::string &file_path ) const;
+        /** Saves a screenshot of the current viewport, as a PNG file. Filesystem location is derived from the current world and character.
+        * @note: Only works for SDL/TILES (otherwise the function returns `false`). A window (more precisely, a viewport) must already exist and the SDL renderer must be valid.
+        * @returns `true` if the screenshot generation was successful, `false` otherwise.
+        */
+        bool take_screenshot() const;
 
         /**
          * The top left corner of the reality bubble (in submaps coordinates). This is the same
@@ -1059,6 +1064,7 @@ class game
         bool fullscreen = false;
         bool was_fullscreen = false;
         bool auto_travel_mode = false;
+        bool queue_screenshot = false;
         safe_mode_type safe_mode;
         int turnssincelastmon = 0; // needed for auto run mode
 


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "[DDA Port] Fixed screenshot feature in debug menu"

#### Purpose of change
Fix debug screenshot feature so it's not completely useless (see #1365 for example).

#### Describe the solution
This is a cherry-pick of https://github.com/CleverRaven/Cataclysm-DDA/commit/f6422ec29ce6fbc97f8cea78b6b6b7f7832a214d with some BN-specific fixes

#### Describe alternatives you've considered
Getting rid of it, but it's still good as backup to screenshot functionality provided by the os.

#### Testing
Took some screenshots on Windows with different renderers.
