### PR TITLE
Fix water cannons

### DIFF
--- a/data/core/basic.json
+++ b/data/core/basic.json
@@ -20,7 +20,7 @@
     "phase": "liquid",
     "container": "bottle_plastic",
     "quench": 50,
-    "ammo_data": { "ammo_type": "water" },
+    "ammo_data": { "ammo_type": "water", "effects": [ "RECOVER_10" ] },
     "flags": [ "EATEN_COLD", "UNSAFE_CONSUME" ],
     "use_action": "BLECH_BECAUSE_UNCLEAN"
   }

--- a/data/json/items/gunmod/bionicmods.json
+++ b/data/json/items/gunmod/bionicmods.json
@@ -16,7 +16,7 @@
       "skill": "rifle",
       "range": 30,
       "ranged_damage": { "damage_type": "bullet", "amount": 1 },
-      "ammo_effects": [ "PLASMA", "EXPLOSIVE", "FLAME", "NPC_AVOID" ],
+      "ammo_effects": [ "PLASMA", "EXPLOSIVE", "FLAME" ],
       "durability": 10
     },
     "flags": [ "IRREMOVABLE" ]

--- a/data/json/items/ranged/launchers.json
+++ b/data/json/items/ranged/launchers.json
@@ -103,7 +103,7 @@
     "price": 50000,
     "material": "steel",
     "flags": [ "NEVER_JAMS", "MOUNTED_GUN", "NO_RELOAD", "NON-FOULING" ],
-    "ammo_effects": [ "JET", "BEANBAG", "NEVER_MISFIRES", "RECOVER_10" ],
+    "ammo_effects": [ "JET", "BEANBAG", "NEVER_MISFIRES" ],
     "skill": "launcher",
     "ammo": "water",
     "weight": "24500 g",

--- a/data/json/not_really_obsolete.json
+++ b/data/json/not_really_obsolete.json
@@ -187,8 +187,8 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "ammo_effects": [ "PLASMA", "EXPLOSIVE", "FLAME", "NEVER_JAMS" ],
-    "flags": [ "NO_UNLOAD" ]
+    "ammo_effects": [ "PLASMA", "EXPLOSIVE", "FLAME" ],
+    "flags": [ "NO_UNLOAD", "NEVER_JAMS" ]
   },
   {
     "id": "ftk93",

--- a/data/mods/Aftershock/items/bioparts.json
+++ b/data/mods/Aftershock/items/bioparts.json
@@ -102,7 +102,7 @@
     "durability": 7,
     "loudness": 4,
     "clip_size": 80,
-    "ammo_effects": "ACID",
+    "ammo_effects": "ACIDBOMB",
     "flags": [ "NO_UNLOAD", "NON-FOULING" ]
   }
 ]

--- a/data/mods/No_Hope/Items/guns.json
+++ b/data/mods/No_Hope/Items/guns.json
@@ -89,8 +89,8 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "ammo_effects": [ "PLASMA", "EXPLOSIVE", "FLAME", "NEVER_JAMS" ],
-    "flags": [ "NO_UNLOAD", "PYROMANIAC_WEAPON" ]
+    "ammo_effects": [ "PLASMA", "EXPLOSIVE", "FLAME" ],
+    "flags": [ "NO_UNLOAD", "PYROMANIAC_WEAPON", "NEVER_JAMS" ]
   },
   {
     "id": "l_sp_45",

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -292,6 +292,23 @@ void Item_factory::finalize_pre( itype &obj )
             }
         }
     }
+    const auto check_ammo_effects = []( const itype_id & id, std::set<ammo_effect_str_id> &effects ) {
+        for( auto iter = effects.begin(); iter != effects.end(); ) {
+            const ammo_effect_str_id &ae_id = *iter;
+            if( ae_id.is_valid() ) {
+                iter++;
+            } else {
+                debugmsg( "%s has unknown ammo_effect %s, removing", id, ae_id );
+                iter = effects.erase( iter );
+            }
+        }
+    };
+    if( obj.gun ) {
+        check_ammo_effects( obj.id, obj.gun->ammo_effects );
+    }
+    if( obj.gunmod ) {
+        check_ammo_effects( obj.id, obj.gunmod->ammo_effects );
+    }
 
     // Helper for ammo migration in following sections
     auto migrate_ammo_set = [&]( std::set<ammotype> &ammoset ) {


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed debugmsg when firing water cannons"

#### Purpose of change
Fix #1638 

#### Describe the solution
Move the flag from water cannon to water.
Validate gun (and gunmod) ammo effects on load.

#### Describe alternatives you've considered
Something more complex that allows gun(mods) to alter ammo recovery rates, but upon searching through BN repo and Kenan's modpack there seemed to be no cases of that actually being used in some meaningful way.

#### Testing
Loaded a random world, spawned fire engine, fired the water cannons.
Before fix: a debugmsg, no puddles.
After fix: a puddle, no debugmsgs.