### PR TITLE
Fix smash_fail sound not playing

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3368,9 +3368,11 @@ bash_results map::bash_ter_furn( const tripoint &p, const bash_params &params )
 
     if( furn_obj.id && furn_obj.bash.str_max != -1 ) {
         bash = &furn_obj.bash;
+        soundfxvariant = furn_obj.id.str();
     } else if( ter_obj.bash.str_max != -1 ) {
         bash = &ter_obj.bash;
         smash_ter = true;
+        soundfxvariant = ter_obj.id.str();
     }
 
     // Floor bashing check


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed smash_fail sound not playing"

#### Purpose of change
Fix #1579

#### Describe the solution
`smash_fail` variant initialization seems to have been accidentally removed in #1307, added the code back in.

#### Testing
Before: smashing walls and furniture results in no sound unless they break.
After: smashing walls and furniture always produces sound.
