### PR TITLE
Book selection menu: filter by name by default

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1072,22 +1072,6 @@ class read_inventory_preset final: public inventory_selector_preset
             return entry.any_item()->color_in_inventory( p );
         }
 
-        std::function<bool( const inventory_entry & )> get_filter( const std::string &filter ) const
-        override {
-            return [this, filter]( const inventory_entry & e ) {
-                if( !is_known( e.any_item() ) ) {
-                    return false;
-                }
-
-                const islot_book &book = get_book( e.any_item() );
-                if( book.skill && p.get_skill_level_object( book.skill ).can_train() ) {
-                    return lcmatch( book.skill->name(), filter );
-                }
-
-                return false;
-            };
-        }
-
         /** Splits books into groups: Unknown, CanTrainSkill, CanNotTrainSkillAnymore, ForFun.
         * 1. Unknown sorted by default algorithm.
         * 2. CanTrainSkill grouped by skill and sorted by time to read

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -6,8 +6,10 @@
 #include "cata_utility.h"
 #include "item.h"
 #include "item_category.h"
+#include "item_factory.h"
 #include "material.h"
 #include "requirements.h"
+#include "skill.h"
 #include "string_id.h"
 #include "type_id.h"
 
@@ -68,6 +70,15 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
             return [filter]( const item & i ) {
                 const std::string note = i.get_var( "item_note" );
                 return !note.empty() && lcmatch( note, filter );
+            };
+        // skill taught
+        case 'k':
+            return [filter]( const item & i ) {
+                if( i.is_book() ) {
+                    const islot_book &book = *i.type->book;
+                    return lcmatch( book.skill->name(), filter );
+                }
+                return false;
             };
         // by name
         default:


### PR DESCRIPTION
#### Summary
SUMMARY: Interface "Book selection menu: filter by name by default"

#### Purpose of change
Book selection menu is searching by skill name, not item name, which is counter-intuitive as it does not adhere to behavior of other similar menus.
Closes #1191

#### Describe the solution
Filter by item name instead, and add special `k:` prefix for searching by skill name.

#### Testing
Spawned a bunch of books, tried searching using different terms.
Also tested that search works with localized item and skill names.