### PR TITLE
Add separate keybind for selecting which gun ammo is used by default

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1815,6 +1815,13 @@
   },
   {
     "type": "keybinding",
+    "name": "Select default ammo for Wielded Item",
+    "category": "DEFAULTMODE",
+    "id": "select_default_ammo",
+    "bindings": [ { "input_method": "keyboard", "key": "{" } ]
+  },
+  {
+    "type": "keybinding",
     "name": "Drop Item",
     "category": "DEFAULTMODE",
     "id": "drop",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -197,6 +197,8 @@ std::string action_ident( action_id act )
             return "cast_spell";
         case ACTION_SELECT_FIRE_MODE:
             return "select_fire_mode";
+        case ACTION_SELECT_DEFAULT_AMMO:
+            return "select_default_ammo";
         case ACTION_DROP:
             return "drop";
         case ACTION_DIR_DROP:
@@ -846,6 +848,7 @@ action_id handle_action_menu()
             REGISTER_ACTION( ACTION_RELOAD_WIELDED );
             REGISTER_ACTION( ACTION_CAST_SPELL );
             REGISTER_ACTION( ACTION_SELECT_FIRE_MODE );
+            REGISTER_ACTION( ACTION_SELECT_DEFAULT_AMMO );
             REGISTER_ACTION( ACTION_THROW );
             REGISTER_ACTION( ACTION_FIRE_BURST );
             REGISTER_ACTION( ACTION_PICK_STYLE );

--- a/src/action.h
+++ b/src/action.h
@@ -173,6 +173,8 @@ enum action_id : int {
     ACTION_FIRE_BURST,
     /** Change fire mode of the current weapon */
     ACTION_SELECT_FIRE_MODE,
+    /** Change default ammo for current weapon */
+    ACTION_SELECT_DEFAULT_AMMO,
     /** Cast a spell (only if any spells are known) */
     ACTION_CAST_SPELL,
     /** Open the drop-item menu */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -130,6 +130,7 @@
 #include "player_activity.h"
 #include "point_float.h"
 #include "popup.h"
+#include "ranged.h"
 #include "recipe.h"
 #include "recipe_dictionary.h"
 #include "ret_val.h"
@@ -2467,6 +2468,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "cast_spell" );
     ctxt.register_action( "fire_burst" );
     ctxt.register_action( "select_fire_mode" );
+    ctxt.register_action( "select_default_ammo" );
     ctxt.register_action( "drop" );
     ctxt.register_action( "drop_adj" );
     ctxt.register_action( "bionics" );
@@ -8781,14 +8783,7 @@ void game::reload( item_location &loc, bool prompt, bool empty )
 
     // bows etc. do not need to reload. select favorite ammo for them instead
     if( it->has_flag( "RELOAD_AND_SHOOT" ) ) {
-        item::reload_option opt = u.select_ammo( *it, prompt );
-        if( !opt ) {
-            return;
-        } else if( u.ammo_location && opt.ammo == u.ammo_location ) {
-            u.ammo_location = item_location();
-        } else {
-            u.ammo_location = opt.ammo;
-        }
+        ranged::prompt_select_default_ammo_for( u, *it );
         return;
     }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2043,19 +2043,18 @@ bool game::handle_action()
             }
 
             case ACTION_SELECT_FIRE_MODE:
-                if( u.is_armed() ) {
-                    if( u.weapon.is_gun() && !u.weapon.is_gunmod() && u.weapon.gun_all_modes().size() > 1 ) {
+                if( u.is_armed() && u.weapon.is_gun() && !u.weapon.is_gunmod() ) {
+                    if( u.weapon.gun_all_modes().size() > 1 ) {
                         u.weapon.gun_cycle_mode();
-                    } else if( u.weapon.has_flag( flag_RELOAD_ONE ) || u.weapon.has_flag( flag_RELOAD_AND_SHOOT ) ) {
-                        item::reload_option opt = u.select_ammo( u.weapon, false );
-                        if( !opt ) {
-                            break;
-                        } else if( u.ammo_location && opt.ammo == u.ammo_location ) {
-                            u.ammo_location = item_location();
-                        } else {
-                            u.ammo_location = opt.ammo;
-                        }
+                    } else {
+                        add_msg( m_info, _( "Your %s has only one firing mode." ), u.weapon.display_name() );
                     }
+                }
+                break;
+
+            case ACTION_SELECT_DEFAULT_AMMO:
+                if( u.is_armed() && u.weapon.is_gun() && !u.weapon.is_gunmod() ) {
+                    ranged::prompt_select_default_ammo_for( u, u.weapon );
                 }
                 break;
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -118,8 +118,6 @@ static const std::string flag_LITCIG( "LITCIG" );
 static const std::string flag_LOCKED( "LOCKED" );
 static const std::string flag_MAGIC_FOCUS( "MAGIC_FOCUS" );
 static const std::string flag_NO_QUICKDRAW( "NO_QUICKDRAW" );
-static const std::string flag_RELOAD_AND_SHOOT( "RELOAD_AND_SHOOT" );
-static const std::string flag_RELOAD_ONE( "RELOAD_ONE" );
 
 static const std::string flag_SLEEP_IGNORE( "SLEEP_IGNORE" );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6647,12 +6647,16 @@ bool item::is_reloadable_helper( const itype_id &ammo, bool now ) const
     if( !is_reloadable() ) {
         return false;
     } else if( is_watertight_container() ) {
-        return ( ( now ? !is_container_full() : true ) && ( ammo.is_empty()
-                 || ( ammo->phase == LIQUID && ( is_container_empty()
-                         || contents.front().typeId() == ammo ) ) ) );
+        if( ammo.is_empty() ) {
+            return now ? !is_container_full() : true;
+        } else if( ammo->phase != LIQUID ) {
+            return false;
+        } else {
+            return now ? ( is_container_empty() || contents.front().typeId() == ammo ) : true;
+        }
     } else if( magazine_integral() ) {
         if( !ammo.is_empty() ) {
-            if( ammo_data() ) {
+            if( now && ammo_data() ) {
                 if( ammo_current() != ammo ) {
                     return false;
                 }

--- a/src/item.h
+++ b/src/item.h
@@ -1208,7 +1208,10 @@ class item : public visitable<item>
          * @see player::can_reload()
          */
         bool is_reloadable() const;
-        /** Returns true if this item can be reloaded with specified ammo type, ignoring capacity. */
+        /**
+         * Returns true if this item can be reloaded with specified ammo type,
+         * ignoring currently loaded ammo.
+         */
         bool can_reload_with( const itype_id &ammo ) const;
         /** Returns true if this item can be reloaded with specified ammo type at this moment. */
         bool is_reloadable_with( const itype_id &ammo ) const;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2433,7 +2433,7 @@ item::reload_option player::select_ammo( const item &base,
 }
 
 bool player::list_ammo( const item &base, std::vector<item::reload_option> &ammo_list,
-                        bool empty ) const
+                        bool empty_mags, bool include_potential ) const
 {
     auto opts = base.gunmods();
     opts.push_back( &base );
@@ -2451,7 +2451,7 @@ bool player::list_ammo( const item &base, std::vector<item::reload_option> &ammo
     bool ammo_match_found = false;
     int ammo_search_range = is_mounted() ? -1 : 1;
     for( const auto e : opts ) {
-        for( item_location &ammo : find_ammo( *e, empty, ammo_search_range ) ) {
+        for( item_location &ammo : find_ammo( *e, empty_mags, ammo_search_range ) ) {
             // don't try to unload frozen liquids
             if( ammo->is_watertight_container() && ammo->contents_made_of( SOLID ) ) {
                 continue;
@@ -2461,7 +2461,7 @@ bool player::list_ammo( const item &base, std::vector<item::reload_option> &ammo
                       : ammo->typeId();
             if( e->can_reload_with( id ) ) {
                 // Speedloaders require an empty target.
-                if( !ammo->has_flag( "SPEEDLOADER" ) || e->ammo_remaining() < 1 ) {
+                if( include_potential || !ammo->has_flag( "SPEEDLOADER" ) || e->ammo_remaining() < 1 ) {
                     ammo_match_found = true;
                 }
             }
@@ -2473,10 +2473,11 @@ bool player::list_ammo( const item &base, std::vector<item::reload_option> &ammo
     return ammo_match_found;
 }
 
-item::reload_option player::select_ammo( const item &base, bool prompt, bool empty ) const
+item::reload_option player::select_ammo( const item &base, bool prompt, bool empty_mags,
+        bool include_potential ) const
 {
     std::vector<item::reload_option> ammo_list;
-    bool ammo_match_found = list_ammo( base, ammo_list, empty );
+    bool ammo_match_found = list_ammo( base, ammo_list, empty_mags, include_potential );
 
     if( ammo_list.empty() ) {
         if( !is_npc() ) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2433,7 +2433,7 @@ item::reload_option player::select_ammo( const item &base,
 }
 
 bool player::list_ammo( const item &base, std::vector<item::reload_option> &ammo_list,
-                        bool empty_mags, bool include_potential ) const
+                        bool include_empty_mags, bool include_potential ) const
 {
     auto opts = base.gunmods();
     opts.push_back( &base );
@@ -2451,7 +2451,7 @@ bool player::list_ammo( const item &base, std::vector<item::reload_option> &ammo
     bool ammo_match_found = false;
     int ammo_search_range = is_mounted() ? -1 : 1;
     for( const auto e : opts ) {
-        for( item_location &ammo : find_ammo( *e, empty_mags, ammo_search_range ) ) {
+        for( const item_location &ammo : find_ammo( *e, include_empty_mags, ammo_search_range ) ) {
             // don't try to unload frozen liquids
             if( ammo->is_watertight_container() && ammo->contents_made_of( SOLID ) ) {
                 continue;
@@ -2459,7 +2459,7 @@ bool player::list_ammo( const item &base, std::vector<item::reload_option> &ammo
             auto id = ( ammo->is_ammo_container() || ammo->is_container() )
                       ? ammo->contents.front().typeId()
                       : ammo->typeId();
-            bool can_reload_with = e->can_reload_with( id );
+            const bool can_reload_with = e->can_reload_with( id );
             if( can_reload_with ) {
                 // Speedloaders require an empty target.
                 if( include_potential || !ammo->has_flag( "SPEEDLOADER" ) || e->ammo_remaining() < 1 ) {
@@ -2468,18 +2468,18 @@ bool player::list_ammo( const item &base, std::vector<item::reload_option> &ammo
             }
             if( ( include_potential && can_reload_with )
                 || can_reload( *e, id ) || e->has_flag( "RELOAD_AND_SHOOT" ) ) {
-                ammo_list.emplace_back( this, e, &base, std::move( ammo ) );
+                ammo_list.emplace_back( this, e, &base, ammo );
             }
         }
     }
     return ammo_match_found;
 }
 
-item::reload_option player::select_ammo( const item &base, bool prompt, bool empty_mags,
-        bool include_potential ) const
+item::reload_option player::select_ammo( const item &base, bool prompt,
+        bool include_empty_mags, bool include_potential ) const
 {
     std::vector<item::reload_option> ammo_list;
-    bool ammo_match_found = list_ammo( base, ammo_list, empty_mags, include_potential );
+    const bool ammo_match_found = list_ammo( base, ammo_list, include_empty_mags, include_potential );
 
     if( ammo_list.empty() ) {
         if( !is_npc() ) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2459,13 +2459,15 @@ bool player::list_ammo( const item &base, std::vector<item::reload_option> &ammo
             auto id = ( ammo->is_ammo_container() || ammo->is_container() )
                       ? ammo->contents.front().typeId()
                       : ammo->typeId();
-            if( e->can_reload_with( id ) ) {
+            bool can_reload_with = e->can_reload_with( id );
+            if( can_reload_with ) {
                 // Speedloaders require an empty target.
                 if( include_potential || !ammo->has_flag( "SPEEDLOADER" ) || e->ammo_remaining() < 1 ) {
                     ammo_match_found = true;
                 }
             }
-            if( can_reload( *e, id ) || e->has_flag( "RELOAD_AND_SHOOT" ) ) {
+            if( ( include_potential && can_reload_with )
+                || can_reload( *e, id ) || e->has_flag( "RELOAD_AND_SHOOT" ) ) {
                 ammo_list.emplace_back( this, e, &base, std::move( ammo ) );
             }
         }

--- a/src/player.h
+++ b/src/player.h
@@ -333,16 +333,16 @@ class player : public Character
         int get_lift_assist() const;
 
         bool list_ammo( const item &base, std::vector<item::reload_option> &ammo_list,
-                        bool empty_mags = true, bool include_potential = false ) const;
+                        bool include_empty_mags = true, bool include_potential = false ) const;
         /**
          * Select suitable ammo with which to reload the item
          * @param base Item to select ammo for
          * @param prompt Force display of the menu even if only one choice
-         * @param empty_mags Allow selection of empty magazines
-         * @param include_potential Also include ammo that can potentially be used, but not right now
+         * @param include_empty_mags Allow selection of empty magazines
+         * @param include_potential Include ammo that can potentially be used, but not right now
          */
         item::reload_option select_ammo( const item &base, bool prompt = false,
-                                         bool empty_mags = true, bool include_potential = false ) const;
+                                         bool include_empty_mags = true, bool include_potential = false ) const;
 
         /** Select ammo from the provided options */
         item::reload_option select_ammo( const item &base, std::vector<item::reload_option> opts ) const;

--- a/src/player.h
+++ b/src/player.h
@@ -333,15 +333,16 @@ class player : public Character
         int get_lift_assist() const;
 
         bool list_ammo( const item &base, std::vector<item::reload_option> &ammo_list,
-                        bool empty = true ) const;
+                        bool empty_mags = true, bool include_potential = false ) const;
         /**
          * Select suitable ammo with which to reload the item
          * @param base Item to select ammo for
-         * @param prompt force display of the menu even if only one choice
-         * @param empty allow selection of empty magazines
+         * @param prompt Force display of the menu even if only one choice
+         * @param empty_mags Allow selection of empty magazines
+         * @param include_potential Also include ammo that can potentially be used, but not right now
          */
         item::reload_option select_ammo( const item &base, bool prompt = false,
-                                         bool empty = true ) const;
+                                         bool empty_mags = true, bool include_potential = false ) const;
 
         /** Select ammo from the provided options */
         item::reload_option select_ammo( const item &base, std::vector<item::reload_option> opts ) const;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2433,7 +2433,11 @@ void target_ui::init_window_and_input()
     }
     if( mode == TargetMode::Fire || mode == TargetMode::TurretManual ) {
         ctxt.register_action( "SWITCH_MODE" );
-        ctxt.register_action( "SWITCH_AMMO" );
+        if( mode == TargetMode::TurretManual || relevant->has_flag( flag_RELOAD_AND_SHOOT ) ) {
+            // Turrets may support multiple ammo types.
+            // RELOAD_AND_SHOOT weapons use whatever ammo is favorite.
+            ctxt.register_action( "SWITCH_AMMO" );
+        }
     }
     if( mode == TargetMode::Fire ) {
         ctxt.register_action( "AIM" );
@@ -3374,7 +3378,7 @@ void target_ui::draw_controls_list( int text_y )
     if( mode == TargetMode::Fire || mode == TargetMode::TurretManual ) {
         lines.push_back( { 5, colored( col_enabled, string_format( _( "[%c] to switch firing modes." ),
                                        bound_key( "SWITCH_MODE" ) ) ) } );
-        lines.push_back( { 6, colored( col_enabled, string_format( _( "[%c] to reload/switch ammo." ),
+        lines.push_back( { 6, colored( col_enabled, string_format( _( "[%c] to switch ammo." ),
                                        bound_key( "SWITCH_AMMO" ) ) ) } );
     }
     if( mode == TargetMode::Turrets ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3738,3 +3738,15 @@ bool ranged::gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::
 
     return result;
 }
+
+void ranged::prompt_select_default_ammo_for( avatar &u, const item &w )
+{
+    item::reload_option opt = u.select_ammo( w, false, true, true );
+    if( opt ) {
+        if( u.ammo_location && opt.ammo == u.ammo_location ) {
+            u.ammo_location = item_location();
+        } else {
+            u.ammo_location = opt.ammo;
+        }
+    }
+}

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -114,6 +114,11 @@ enum class hit_tier : int {
 void print_dmg_msg( Creature &target, Creature *source, const dealt_damage_instance &dealt_dam,
                     hit_tier ht = hit_tier::normal );
 
+/**
+ * Prompts to select default ammo compatible with provided gun.
+ */
+void prompt_select_default_ammo_for( avatar &u, const item &w );
+
 } // namespace ranged
 
 #endif // CATA_SRC_RANGED_H


### PR DESCRIPTION
#### Summary
SUMMARY: Interface "Add separate keybind for selecting which gun ammo is used by default"

#### Purpose of change
Fixes #1352
When pressing `F` to change gun mode if the gun has only 1 mode, and it's either `RELOAD_AND_SHOOT` (slings, bows) or `RELOAD_ONE` (shotguns, revolvers), the game will instead try to select default ammo to use.

There are a couple problems with this:
1. If none of the loading options are available (e.g. shotgun is loaded with regular shot, but you only have dragon breath left), the game will show a erroneous "You don't have any X to reload your Y" message.
2. If the shotgun has a second magazine (e.g. `Kel-Tec KSG`), it has a second firing mode, so the player loses ability to select default ammo.

#### Describe the solution
1. Add a separate keybind for changing default gun ammo, and remove default ammo selection fallback from `F` key.
    Now, if the player tries to switch firing mode, and the gun has only 1 mode, it'll say so.
2. Make "select default ammo" menu ignore current state of the gun and allow any compatible ammo to be marked as default.

#### Describe alternatives you've considered
Not adding yet another keybind, and instead do either of:
1. Restrict default ammo feature to `RELOAD_AND_SHOOT` guns, as they are the main use case.
    * Might be inconvenient when (or if) weapons start supporting mixed ammo as the player would need to re-select which shot to load each time they want to load one.
    * Might be inconvenient for people that rely on this feature to skip ammo selection when loading in first shot.
2. Don't change firing mode for `RELOAD_ONE` guns and instead go straight to default ammo selection menu.
    * Will make it impossible to switch firing mode for these guns outside target selection ui, which would be inconsistent with many other guns (rifles, pistols).
    * Will need to allow entering target selection ui with currently selected gun mode being empty (it's disallowed right now).

#### Testing
Marked some ammo as default using the new key or from target ui, tried reloading various shotguns and firing bows.