### PR TITLE
Include effects from gunmods when displaying gun damage in item info

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1988,7 +1988,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
         debugmsg( "curammo is nullptr in item::gun_info()" );
         return;
     }
-    damage_unit gun_du = gun.damage.damage_units.front();
+    damage_unit gun_du = gun_damage( false ).damage_units.front();
 
     gun_du.damage_multiplier *= ranged::str_draw_damage_modifier( *mod, viewer );
 


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Include effects from gunmods when displaying gun damage in item info"

#### Purpose of change
Fix #1566

#### Describe the solution
Use damage from gun with all gunmods rather than raw gun damage. Range display already does this.

#### Testing
Repeated repro steps from the issue, item info screen now displays increasing gun damage.

#### Additional context
Also works in "compare before/after installation of gunmod" screen.