### PR TITLE
Fix crash in lightmap generation after debug long teleport

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -319,6 +319,8 @@ void map::clear_vehicle_list( const int zlev )
     auto &ch = get_cache( zlev );
     ch.vehicle_list.clear();
     ch.zone_vehicles.clear();
+
+    last_full_vehicle_list_dirty = true;
 }
 
 void map::update_vehicle_list( const submap *const to, const int zlev )


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed crash in lightmap generation after debug long teleport"

#### Purpose of change
Fixes #725

#### Describe the solution
Add full vehicle list invalidation to `map::clear_vehicle_list`

#### Describe alternatives you've considered
Sticking it in `map::load` that's called on long teleport, but I'm paranoid.

#### Testing
1. Bind quicksave key
2. Move mouse cursor outside game window
3. Find (or spawn) a vehicle
4. Enter debug menu -> teleport -> long range -> any destination more than 2 overmap tiles away
5. Hit quicksave key
6. Before fix: CTD
    After fix: game quicksaves with no issues

#### Additional context
Somehow I've encountered this "rare" crash dozens of times, got fed up with it.