### PR TITLE
Fix crash picking up liquids

### DIFF
--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -219,11 +219,13 @@ static bool get_liquid_target( item &liquid, item *const source, const int radiu
     std::set<vehicle *> opts;
     for( const auto &e : g->m.points_in_radius( g->u.pos(), 1 ) ) {
         auto veh = veh_pointer_or_null( g->m.veh_at( e ) );
-        vehicle_part_range vpr = veh->get_all_parts();
-        if( veh && std::any_of( vpr.begin(), vpr.end(), [&liquid]( const vpart_reference & pt ) {
-        return pt.part().can_reload( liquid );
-        } ) ) {
-            opts.insert( veh );
+        if( veh ) {
+            vehicle_part_range vpr = veh->get_all_parts();
+            if( veh && std::any_of( vpr.begin(), vpr.end(), [&liquid]( const vpart_reference & pt ) {
+            return pt.part().can_reload( liquid );
+            } ) ) {
+                opts.insert( veh );
+            }
         }
     }
     for( auto veh : opts ) {


### PR DESCRIPTION
#### Summary

[Bugfixes] Fix a crash when picking up liquids

#### Purpose of change

This is the weirdest bug. The actual problem is simple, it's missing a null pointer check when looking for adjacent vehicles when you're picking up liquids from the ground. What I really don't understand about it is that the crash appears and disappears depending on your compile flags. With O3 or O2 it crashes, with Os it doesn't. It seems like it should just crash consistently.

#### Describe the solution

Null pointer check.

#### Describe alternatives you've considered

Exorcising my compiler.