### PR TITLE
Boulders drop more rocks port from DDA

### DIFF
--- a/data/json/furniture_and_terrain/furniture-terrains.json
+++ b/data/json/furniture_and_terrain/furniture-terrains.json
@@ -619,7 +619,7 @@
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "thump.",
-      "items": [ { "item": "rock", "count": [ 1, 6 ] }, { "item": "sharp_rock", "count": [ 0, 2 ] } ]
+      "items": [ { "item": "rock", "count": [ 16, 32 ] }, { "item": "sharp_rock", "count": [ 0, 6 ] } ]
     }
   },
   {
@@ -639,7 +639,7 @@
       "str_max": 80,
       "sound": "smash!",
       "sound_fail": "thump.",
-      "items": [ { "item": "rock", "count": [ 5, 11 ] }, { "item": "sharp_rock", "count": [ 1, 4 ] } ]
+      "items": [ { "item": "rock", "count": [ 35, 50 ] }, { "item": "sharp_rock", "count": [ 3, 7 ] } ]
     }
   },
   {
@@ -659,8 +659,8 @@
       "sound": "smash!",
       "sound_fail": "thump.",
       "items": [
-        { "item": "rock", "count": [ 10, 22 ] },
-        { "item": "sharp_rock", "count": [ 3, 7 ] },
+        { "item": "rock", "count": [ 65, 85 ] },
+        { "item": "sharp_rock", "count": [ 5, 9 ] },
         { "item": "material_limestone", "charges": [ 2, 5 ], "prob": 30 },
         { "item": "material_rocksalt", "count": [ 0, 1 ], "prob": 10 },
         { "item": "material_rhodonite", "count": [ 0, 1 ], "prob": 1 },


### PR DESCRIPTION
From here https://github.com/CleverRaven/Cataclysm-DDA/pull/52861

Co-Authored-By: StringhamEthan <69316833+StringhamEthan@users.noreply.github.com>

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary


SUMMARY: Balance "Port increased boulder rock drops from DDA"


#### Purpose of change

Boulders drop very few rocks, seems like a whole boulder should drop more.

#### Describe the solution

Make them drop more by copying commit were somebody fixed the same problem in DDA.

#### Describe alternatives you've considered

Do basically the same thing but with different numbers.
#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
