### PR TITLE
Add workflow to deploy documentation on github page

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,41 @@
+name: Generate Documentation
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches: [upload]
+  workflow_dispatch:
+
+jobs:
+  documentation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+
+      - name: cache css
+        id: cache-css
+        uses: actions/cache@v3
+        with:
+          key: doxygen-css-cache
+          path: ./doxygen_doc/doxygen-awesome-css
+
+      - if: ${{ steps.cache-css.outputs.cache-hit != 'true' }}
+        name: download css
+        run: |
+          git clone https://github.com/jothepro/doxygen-awesome-css ./doxygen_doc/doxygen-awesome-css
+      - name: run doxygen
+        uses: mattnotmitt/doxygen-action@v1.9.2
+        with:
+          working-directory: .
+          doxyfile-path: ./doxygen_doc/Doxyfile
+          # additional-packages: font-fira-code
+
+      - name: deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doxygen_doc/html/


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Add workflow to deploy documentation on github page"

#### Purpose of change

for some reason removed github action yml last commit in #1603, so it doesn't do much.

#### Describe the solution

reverts the github workflow in question.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

at least it works on my machi... fork

- [workflow run result](https://github.com/scarf005/Cataclysm-BN/actions/runs/2478209181)
- [deployed gh pages in fork](https://www.maribel.dev/Cataclysm-BN/)

#### Additional context

this is a follow-up PR to #1603, please also check here
