### PR TITLE
Aftershock doesn't interfere in base game autodoc uninstallation

### DIFF
--- a/data/mods/Aftershock/maps/furniture.json
+++ b/data/mods/Aftershock/maps/furniture.json
@@ -110,7 +110,7 @@
   {
     "type": "furniture",
     "id": "f_autodoc",
-    "name": "Autodoc Mk. XVI",
+    "name": "Autodoc Mk. XI",
     "symbol": "&",
     "color": "light_red",
     "copy-from": "f_autodoc",
@@ -118,19 +118,7 @@
     "flags": [ "TRANSPARENT", "AUTODOC", "CONTAINER" ],
     "examine_action": "autodoc",
     "surgery_skill_multiplier": 1.6,
-    "deconstruct": {
-      "items": [
-        { "item": "afs_circuitry_3", "count": [ 1, 2 ] },
-        { "item": "afs_circuitry_2", "count": [ 4, 8 ] },
-        { "item": "cable", "charges": [ 4, 6 ] },
-        { "item": "small_lcd_screen", "count": [ 1, 2 ] },
-        { "item": "afs_material_2", "count": [ 6, 10 ] },
-        { "item": "afs_energy_storage_2", "count": [ 1, 2 ] },
-        { "item": "afs_energy_storage_3", "count": [ 0, 1 ] },
-        { "item": "plastic_chunk", "count": [ 10, 12 ] },
-        { "item": "afs_material_2", "count": [ 6, 8 ] }
-      ]
-    },
+    "deconstruct": { "items": [ { "item": "autodoc", "count": 1 } ] },
     "bash": {
       "str_min": 8,
       "str_max": 150,

--- a/data/mods/Aftershock/recipes/deconstruction/deconstruction_overrides.json
+++ b/data/mods/Aftershock/recipes/deconstruction/deconstruction_overrides.json
@@ -1,0 +1,22 @@
+[
+  {
+    "result": "autodoc",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "difficulty": 4,
+    "time": "1 h",
+    "using": [ [ "soldering_standard", 10 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "afs_circuitry_3", 2 ] ],
+      [ [ "afs_circuitry_2", 6 ] ],
+      [ [ "cable", 6 ] ],
+      [ [ "small_lcd_screen", 2 ] ],
+      [ [ "afs_material_2", 8 ] ],
+      [ [ "afs_energy_storage_2", 2 ] ],
+      [ [ "afs_energy_storage_3", 1 ] ],
+      [ [ "plastic_chunk", 10 ] ],
+      [ [ "afs_material_2", 6 ] ]
+    ]
+  }
+]

--- a/data/mods/Aftershock/recipes/deconstruction/deconstruction_overrides.json
+++ b/data/mods/Aftershock/recipes/deconstruction/deconstruction_overrides.json
@@ -6,7 +6,12 @@
     "difficulty": 4,
     "time": "1 h",
     "using": [ [ "soldering_standard", 10 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "qualities": [
+      { "id": "SCREW", "level": 1 },
+      { "id": "SCREW_FINE", "level": 1 },
+      { "id": "WRENCH", "level": 2 },
+      { "id": "WRENCH_FINE", "level": 1 }
+    ],
     "components": [
       [ [ "afs_circuitry_3", 2 ] ],
       [ [ "afs_circuitry_2", 6 ] ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary



SUMMARY: Bugfixes "fixes #1675"


#### Purpose of change

Autodocs deconstruct into parts instead of autodoc item like in base game

#### Describe the solution

Autodoc deconstructs to item, item disassembles to parts.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded it up, worked great.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
