### PR TITLE
Make milling results definable in JSON (#41174)

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -558,6 +558,7 @@
     "price": 0,
     "price_postapoc": 10,
     "material": "bone",
+    "milling": { "into": "meal_bone", "conversion_rate": 4 },
     "volume": "250 ml",
     "vitamins": [ [ "calcium", 96 ] ]
   },

--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -15,7 +15,8 @@
     "price_postapoc": 250,
     "material": "veggy",
     "volume": "1 L",
-    "flags": [ "EDIBLE_FROZEN", "MILLABLE", "RAW" ],
+    "milling": { "into": "flour", "conversion_rate": 15 },
+    "flags": [ "EDIBLE_FROZEN", "RAW" ],
     "charges": 4,
     "vitamins": [ [ "calcium", 6 ], [ "iron", 29 ] ],
     "fun": -15
@@ -73,7 +74,8 @@
     "price_postapoc": 400,
     "material": "veggy",
     "volume": "500 ml",
-    "flags": [ "EDIBLE_FROZEN", "MILLABLE", "RAW" ],
+    "milling": { "into": "flour", "conversion_rate": 15 },
+    "flags": [ "EDIBLE_FROZEN", "RAW" ],
     "charges": 2,
     "vitamins": [ [ "calcium", 3 ], [ "iron", 22 ] ],
     "fun": -10

--- a/data/json/items/comestibles/wheat.json
+++ b/data/json/items/comestibles/wheat.json
@@ -37,8 +37,9 @@
     "price": 120,
     "price_postapoc": 100,
     "material": "wheat",
+    "milling": { "into": "flour", "conversion_rate": 15 },
     "volume": "250 ml",
-    "flags": [ "EDIBLE_FROZEN", "MILLABLE", "RAW" ],
+    "flags": [ "EDIBLE_FROZEN", "RAW" ],
     "vitamins": [ [ "calcium", 4 ], [ "iron", 40 ] ],
     "fun": -10
   },
@@ -203,7 +204,8 @@
     "price_postapoc": 100,
     "material": "wheat",
     "volume": "250 ml",
-    "flags": [ "EDIBLE_FROZEN", "MILLABLE", "RAW" ],
+    "milling": { "into": "flour", "conversion_rate": 3.75 },
+    "flags": [ "EDIBLE_FROZEN", "RAW" ],
     "vitamins": [ [ "calcium", 3 ], [ "iron", 20 ] ],
     "fun": -10
   },

--- a/data/json/items/comestibles/wheat.json
+++ b/data/json/items/comestibles/wheat.json
@@ -204,7 +204,7 @@
     "price_postapoc": 100,
     "material": "wheat",
     "volume": "250 ml",
-    "milling": { "into": "flour", "conversion_rate": 3.75 },
+    "milling": { "into": "flour", "conversion_rate": 4 },
     "flags": [ "EDIBLE_FROZEN", "RAW" ],
     "vitamins": [ [ "calcium", 3 ], [ "iron", 20 ] ],
     "fun": -10

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -312,6 +312,7 @@
     "price_postapoc": 25,
     "material": "chitin",
     "flags": [ "NO_SALVAGE" ],
+    "milling": { "into": "meal_chitin_piece", "conversion_rate": 4 },
     "weight": "89 g",
     "volume": "250 ml",
     "bashing": 1,

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -1636,8 +1636,8 @@ See also VEHICLE_JSON.md
     [ "45", [ "m1911mag", "m1911bigmag" ] ],
 ],
 "milling": {                                 // Optional. If given, the item can be milled in a water/wind mill.
-  "into": "flour",                           // The item id of the result of the milling.
-  "conversion_rate": 1.0                     // Conversion of number of items that are milled (e.g. with a rate of 2, 10 input items will yield 20 milled items).
+  "into": "flour",                           // The item id of the product.
+  "conversion_rate": 4                       // Number of products per item consumed. At a conversion_rate of 4, 1 item is milled into 4 product. Only accepts integers.
 },
 "explode_in_fire": true,                     // Should the item explode if set on fire
 "explosion": {                               // Physical explosion data

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -1635,6 +1635,10 @@ See also VEHICLE_JSON.md
     [ "9mm", [ "glockmag" ] ]                // The first magazine specified for each ammo type is the default
     [ "45", [ "m1911mag", "m1911bigmag" ] ],
 ],
+"milling": {                                 // Optional. If given, the item can be milled in a water/wind mill.
+  "into": "flour",                           // The item id of the result of the milling.
+  "conversion_rate": 1.0                     // Conversion of number of items that are milled (e.g. with a rate of 2, 10 input items will yield 20 milled items).
+},
 "explode_in_fire": true,                     // Should the item explode if set on fire
 "explosion": {                               // Physical explosion data
   "damage": 10,                              // Damage the explosion deals to player at epicenter. Damage is halved above 50% radius.

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -28,6 +28,7 @@
 #include "catacharset.h"
 #include "character.h"
 #include "colony.h"
+#include "flag.h"
 #include "color.h"
 #include "construction.h"
 #include "coordinate_conversions.h"
@@ -133,7 +134,6 @@ static const itype_id itype_fake_milling_item( "fake_milling_item" );
 static const itype_id itype_fake_smoke_plume( "fake_smoke_plume" );
 static const itype_id itype_fertilizer( "fertilizer" );
 static const itype_id itype_fire( "fire" );
-static const itype_id itype_flour( "flour" );
 static const itype_id itype_fungal_seeds( "fungal_seeds" );
 static const itype_id itype_grapnel( "grapnel" );
 static const itype_id itype_hickory_root( "hickory_root" );
@@ -218,7 +218,6 @@ static const std::string flag_FIRE( "FIRE" );
 static const std::string flag_FIRESTARTER( "FIRESTARTER" );
 static const std::string flag_GROWTH_HARVEST( "GROWTH_HARVEST" );
 static const std::string flag_IN_CBM( "IN_CBM" );
-static const std::string flag_MILLABLE( "MILLABLE" );
 static const std::string flag_NO_CVD( "NO_CVD" );
 static const std::string flag_NO_PACKED( "NO_PACKED" );
 static const std::string flag_NO_STERILE( "NO_STERILE" );
@@ -234,6 +233,9 @@ static const std::string flag_VARSIZE( "VARSIZE" );
 static const std::string flag_WALL( "WALL" );
 static const std::string flag_WRITE_MESSAGE( "WRITE_MESSAGE" );
 static const std::string flag_ELEVATOR( "ELEVATOR" );
+
+// @TODO maybe make this a property of the item (depend on volume/type)
+static const time_duration milling_time = 6_hours;
 
 /**
  * Nothing player can interact with here.
@@ -5137,23 +5139,16 @@ static void mill_activate( player &p, const tripoint &examp )
     units::volume food_volume = 0_ml;
 
     for( item &it : items ) {
-        if( it.typeId() == itype_flour ) {
-            add_msg( _( "This mill already contains flour." ) );
-            add_msg( _( "Remove it before starting the mill again." ) );
-            return;
-        }
-        if( it.has_flag( flag_MILLABLE ) ) {
+        if( it.type->milling_data ) {
             food_present = true;
             food_volume += it.volume();
             continue;
-        }
-        if( !it.has_flag( flag_MILLABLE ) ) {
-            add_msg( m_bad, _( "This rack contains %s, which can't be milled!" ), it.tname( 1,
-                     false ) );
+        } else {
+            add_msg( m_bad, _( "This mill contains %s, which can't be milled!" ), it.tname( 1, false ) );
             add_msg( _( "You remove the %s from the mill." ), it.tname() );
             g->m.add_item_or_charges( p.pos(), it );
-            g->m.i_rem( examp, &it );
             p.mod_moves( -p.item_handling_cost( it ) );
+            g->m.i_rem( examp, &it );
             return;
         }
     }
@@ -5170,7 +5165,7 @@ static void mill_activate( player &p, const tripoint &examp )
     }
 
     for( auto &it : g->m.i_at( examp ) ) {
-        if( it.has_flag( flag_MILLABLE ) ) {
+        if( it.type->milling_data ) {
             // Do one final rot check before milling, then apply the PROCESSING flag to prevent further checks.
             it.process_rot( 1, false, examp, nullptr );
             it.set_flag( flag_PROCESSING );
@@ -5178,7 +5173,7 @@ static void mill_activate( player &p, const tripoint &examp )
     }
     g->m.furn_set( examp, next_mill_type );
     item result( "fake_milling_item", calendar::turn );
-    result.item_counter = to_turns<int>( 6_hours );
+    result.item_counter = to_turns<int>( milling_time );
     result.activate();
     g->m.add_item( examp, result );
     add_msg( _( "You remove the brake on the millstone and it slowly starts to turn." ) );
@@ -5310,9 +5305,18 @@ void iexamine::mill_finalize( player &, const tripoint &examp, const time_point 
     }
 
     for( item &it : items ) {
-        if( it.has_flag( flag_MILLABLE ) && it.get_comestible() ) {
-            it.calc_rot_while_processing( 6_hours );
-            item result( "flour", start_time + 6_hours, it.charges * 15 );
+        if( it.type->milling_data ) {
+            it.calc_rot_while_processing( milling_time );
+            const islot_milling &mdata = *it.type->milling_data;
+            item result( mdata.into_, start_time + milling_time, it.charges * mdata.conversion_rate_ );
+            result.components.push_back( it );
+            // copied from item::inherit_flags, which can not be called here because it requires a recipe.
+            for( const std::string &f : it.type->item_tags ) {
+                if( json_flag::get( f ).craft_inherit() ) {
+                    result.set_flag( f );
+                }
+            }
+            result.recipe_charges = result.charges;
             // Set flag to tell set_relative_rot() to calc from bday not now
             result.set_flag( flag_PROCESSING_RESULT );
             result.set_relative_rot( it.get_relative_rot() );
@@ -5502,7 +5506,7 @@ static void mill_load_food( player &p, const tripoint &examp,
         return it.rotten();
     } );
     std::vector<const item *> filtered = p.crafting_inventory().items_with( []( const item & it ) {
-        return it.has_flag( flag_MILLABLE );
+        return static_cast<bool>( it.type->milling_data );
     } );
 
     uilist smenu;
@@ -5642,20 +5646,16 @@ void iexamine::quern_examine( player &p, const tripoint &examp )
     }
 
     time_duration time_left = 0_turns;
-    int hours_left = 0;
-    int minutes_left = 0;
     units::volume f_volume = 0_ml;
     bool f_check = false;
 
     for( const item &it : items_here ) {
-        if( it.is_food() ) {
+        if( it.typeId() != itype_fake_milling_item ) {
             f_check = true;
             f_volume += it.volume();
         }
         if( active && it.typeId() == itype_fake_milling_item ) {
             time_left = time_duration::from_turns( it.item_counter );
-            hours_left = to_hours<int>( time_left );
-            minutes_left = to_minutes<int>( time_left ) + 1;
         }
     }
 
@@ -5673,7 +5673,8 @@ void iexamine::quern_examine( player &p, const tripoint &examp )
         smenu.addentry_desc( 1, !empty, 'r',
                              empty ?  _( "Remove brake and start milling… insert some products for milling first" ) :
                              _( "Remove brake and start milling" ),
-                             _( "Remove brake and start milling, milling will take about 6 hours." ) );
+                             string_format( _( "Remove brake and start milling, milling will take about %s." ),
+                                            to_string( milling_time ) ) );
 
         smenu.addentry_desc( 2, !full, 'p',
                              full ? _( "Insert products for milling… mill is full" ) :
@@ -5699,15 +5700,8 @@ void iexamine::quern_examine( player &p, const tripoint &examp )
             if( active ) {
                 pop = colorize( _( "There's a mill here.  It is turning and milling." ), c_green ) + "\n";
                 if( time_left > 0_turns ) {
-                    if( minutes_left > 60 ) {
-                        pop += string_format( vgettext( "It will finish milling in about %d hour.",
-                                                        "It will finish milling in about %d hours.",
-                                                        hours_left ), hours_left ) + "\n\n";
-                    } else if( minutes_left > 30 ) {
-                        pop += _( "It will finish milling in less than an hour." );
-                    } else {
-                        pop += string_format( _( "It should take about %d minutes to finish milling." ), minutes_left );
-                    }
+                    pop += string_format( _( "It should take about %s to finish milling." ),
+                                          to_string_clipped( time_left ) ) + "\n";
                 }
             } else {
                 pop += colorize( _( "There's a mill here." ), c_green ) + "\n";
@@ -5743,7 +5737,7 @@ void iexamine::quern_examine( player &p, const tripoint &examp )
         case 3:
             // remove food
             for( map_stack::iterator it = items_here.begin(); it != items_here.end(); ) {
-                if( it->is_food() ) {
+                if( it->typeId() != itype_fake_milling_item ) {
                     // get handling cost before the item reference is invalidated
                     const int handling_cost = -p.item_handling_cost( *it );
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1253,6 +1253,11 @@ void Item_factory::check_definitions() const
         if( type->can_use( "MA_MANUAL" ) && !type->book ) {
             msg += "has use_action MA_MANUAL but is not a book\n";
         }
+        if( type->milling_data ) {
+            if( !has_template( type->milling_data->into_ ) ) {
+                msg += "type to mill into is invalid: " + type->milling_data->into_.str() + "\n";
+            }
+        }
         if( type->ammo ) {
             if( !type->ammo->type && type->ammo->type != ammotype( "NULL" ) ) {
                 msg += "must define at least one ammo type\n";
@@ -1660,6 +1665,12 @@ void Item_factory::load( islot_artifact &slot, const JsonObject &jo, const std::
     load_optional_enum_array( slot.effects_activated, jo, "effects_activated" );
     load_optional_enum_array( slot.effects_carried, jo, "effects_carried" );
     load_optional_enum_array( slot.effects_worn, jo, "effects_worn" );
+}
+
+void Item_factory::load( islot_milling &slot, const JsonObject &jo, const std::string & )
+{
+    assign( jo, "into", slot.into_ );
+    assign( jo, "conversion_rate", slot.conversion_rate_ );
 }
 
 void islot_ammo::load( const JsonObject &jo )
@@ -2607,6 +2618,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     load_slot_optional( def.brewable, jo, "brewable", src );
     load_slot_optional( def.fuel, jo, "fuel", src );
     load_slot_optional( def.relic_data, jo, "relic_data", src );
+    load_slot_optional( def.milling_data, jo, "milling", src );
 
     // optional gunmod slot may also specify mod data
     if( jo.has_member( "gunmod_data" ) ) {

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -302,6 +302,7 @@ class Item_factory
         void load( islot_seed &slot, const JsonObject &jo, const std::string &src );
         void load( islot_artifact &slot, const JsonObject &jo, const std::string &src );
         void load( relic &slot, const JsonObject &jo, const std::string &src );
+        void load( islot_milling &slot, const JsonObject &jo, const std::string &src );
 
         //json data handlers
         void emplace_usage( std::map<std::string, use_function> &container, const std::string &iuse_id );

--- a/src/itype.h
+++ b/src/itype.h
@@ -838,7 +838,7 @@ class islot_milling
 {
     public:
         itype_id into_;
-        double conversion_rate_;
+        int conversion_rate_;
 };
 
 struct itype {

--- a/src/itype.h
+++ b/src/itype.h
@@ -834,6 +834,13 @@ struct conditional_name {
     translation name;
 };
 
+class islot_milling
+{
+    public:
+        itype_id into_;
+        double conversion_rate_;
+};
+
 struct itype {
         friend class Item_factory;
 
@@ -864,6 +871,7 @@ struct itype {
         cata::value_ptr<islot_seed> seed;
         cata::value_ptr<islot_artifact> artifact;
         cata::value_ptr<relic> relic_data;
+        cata::value_ptr<islot_milling> milling_data;
         /*@}*/
 
     private:


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Ports over jsonized milling results"

#### Purpose of change

Port over [41174](https://github.com/CleverRaven/Cataclysm-DDA/pull/41174) from DDA repo that allows one to define items as millable and define their results outside of hardcode.

Converted their implementation to use int values so as to prevent products being made out of thin air.

#### Describe the solution

> Removes the (undocumented) flag "MILLABLE".
> 
> Adds an item slot that defines what an item can be milled into (e.g. for "wheat" that would be "flour").
> 
> Fixes mills to produces flour at the same conversion rate as manual crafting. Mills used to give 15 flour for 1 input item. But crafting it with a quern requires different amounts of input items to get the same 15 flour as result. For example it takes four oats to craft 15 flour. This has been fixed (80 oats give only 300 flout, 80 wheat give 1200 flour).
> 
> Fixes the product to have the same properties as if crafted by hand (inheriting flags and components). This makes flour milled from oats contain different vitamins than when milled from wheat, just like you would get if you had crafted it manually.
> 
> Makes chitin pieces and bone (human as well) millable. The result is chitin powder and bone meal.
> 
> Fixes a crash (see commit).

#### Describe alternatives you've considered

#### Testing

#### Additional context

In the future we'd probably want scaling changes to time based on materials in the mill, and if at all possible have it process in increments, so that stopping the mill halfway has half of the millable items changed to products. But this system is one step in the right direction for now.