### PR TITLE
Missing uncraft recipes for armored armor

### DIFF
--- a/data/json/uncraft/armor/armored.json
+++ b/data/json/uncraft/armor/armored.json
@@ -1,0 +1,47 @@
+[
+  {
+    "result": "jacket_leather_mod",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "3 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 18 ] ], [ [ "scrap", 24 ] ] ]
+  },
+  {
+    "result": "vest_leather_mod",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "2 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 10 ] ], [ [ "scrap", 5 ] ] ]
+  },
+  {
+    "result": "gloves_fingerless_mod",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "1 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 2 ] ], [ [ "scrap", 2 ] ] ]
+  },
+  {
+    "result": "boots_plate",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "5 m",
+    "qualities": [ [ { "id": "CUT", "level": 1 } ], [ { "id": "SAW_M", "level": 1 } ] ],
+    "components": [ [ [ "fur", 16 ] ], [ [ "leather", 16 ] ], [ [ "scrap", 6 ] ] ]
+  },
+  {
+    "result": "gloves_plate",
+    "type": "uncraft",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "4 m",
+    "qualities": [ [ { "id": "CUT", "level": 1 } ], [ { "id": "SAW_M", "level": 1 } ] ],
+    "components": [ [ [ "fur", 10 ] ], [ [ "leather", 10 ] ], [ [ "scrap", 8 ] ] ]
+  }
+]


### PR DESCRIPTION
#### Summary

SUMMARY: Content "Missing uncraft recipes for armored armor"

#### Purpose of change

Resolves #1595 
and a little more.

#### Describe the solution

Allows to cut armored jackets into leather and scrap. Also allows same thing for armored leather vests, fingerless gloves, armored boots and gauntlets. The latter requires something to saw the metal, too.

#### Describe alternatives you've considered

None.

#### Testing

Debug spawn above-mentioned armor, try to butcher or disassemble it. It just works.

![изображение](https://user-images.githubusercontent.com/60776130/176939668-324cbae0-2d94-46b3-8772-890466d7d0bd.png)

#### Additional context

Look out for more missing uncraft recipes, report them to the guards!