### PR TITLE
Make mine_downstair work on rock floors without roof

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2599,6 +2599,24 @@
   },
   {
     "type": "construction",
+    "id": "constr_mine_downstair_no_roof",
+    "description": "Mine Downstair",
+    "category": "DIG",
+    "required_skills": [ [ "fabrication", 6 ] ],
+    "time": "480 m",
+    "qualities": [
+      [ { "id": "AXE", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
+      [ { "id": "HAMMER", "level": 2 } ],
+      [ { "id": "DIG", "level": 2 } ]
+    ],
+    "tools": [ [ [ "pickaxe", -1 ], [ "jackhammer", 160 ], [ "elec_jackhammer", 7000 ] ] ],
+    "components": [ [ [ "2x4", 12 ], [ "log", 12 ] ], [ [ "rope_makeshift_30", 1 ], [ "rope_30", 1 ], [ "vine_30", 1 ] ] ],
+    "pre_special": "check_down_OK",
+    "pre_terrain": "t_rock_floor_no_roof",
+    "post_special": "done_mine_downstair"
+  },
+  {
+    "type": "construction",
     "id": "constr_repair_wood_stairs_up",
     "description": "Repair Wooden Staircase",
     "//": "Fix the broken back to normal",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

SUMMARY: Bugfixes "Can't mine down through roofless rock floor"


#### Purpose of change

Only `t_rock_floor` and not `t_rock_floor_no_roof` can be mined down through via the "mine downstair" construction.

#### Describe the solution

Copy of original construction but with `t_rock_floor_no_roof` prerequisite.

#### Describe alternatives you've considered

Make rock walls mine into the roofed version, or use a terrain tag to allow mining down instead of a specific terrain match.

#### Testing

Dropped the change in, it worked.

#### Additional context

![image](https://user-images.githubusercontent.com/77130566/176982625-c3b5270f-d664-4327-9884-44cba663b02a.png)

(construction time sped up via options menu for testing purposes)