### PR TITLE
Cargo weight modifier update

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -1488,7 +1488,6 @@ Vehicle components when installed on a vehicle.
 "durability": 200,            // How much damage the part can take before breaking
 "description": "A wheel."     // A description of this vehicle part when installing it
 "size": 2000                  // If vehicle part has flag "FLUIDTANK" then capacity in mLs, else divide by 4 for volume on space
-"cargo_weight_modifier": 100  // Special function to multiplicatively modify item weight on space. Divide by 100 for ratio.
 "wheel_width": 9,             /* (Optional, default = 0)
                                * SPECIAL: A part may have at most ONE of the following fields:
                                *    wheel_width = base wheel width in inches

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6809,7 +6809,7 @@ void vehicle::calc_mass_center( bool use_precalc ) const
             m_part_items += j.weight();
         }
         if( vp.part().info().cargo_weight_modifier != 100 ) {
-            m_part_items *= vp.part().info().cargo_weight_modifier / 100;
+            m_part_items *= static_cast<float>( vp.part().info().cargo_weight_modifier ) / 100.0f;
         }
         m_part += m_part_items;
 


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Cargo Weight Modifiers rounding to 0/100/200, etc"

#### Purpose of change

`cargo_weight_modifier` currently works weirdly, with anything below 100 turning to 0 and anything above 100 incrementing to the nearest 100. This prevents it from working as intended.

#### Describe the solution

Ports over [53811](https://github.com/CleverRaven/Cataclysm-DDA/pull/53812) from DDA. Also amends the documentation which had a duplicated entry for `cargo_weight_modifier`.

#### Describe alternatives you've considered

#### Testing

Made bicycle baskets have 10 `cargo_weight_modifier`, added items to the basket and observed weight increase from vehicle menu.

#### Additional context

Since we don't want negative mass, we might want to sanity check the calculations so any `cargo_weight_modifiers` below 0 become 0.

Aside from that perhaps we might benefit from giving decimal places to vehicle weight displays, though this is of questionable use.