### PR TITLE
Allows the use of bandages for players with traits like Made of Sugar

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -715,7 +715,7 @@ ret_val<edible_rating> Character::can_eat( const item &food ) const
     }
 
     for( const trait_id &mut : get_mutations() ) {
-        if( !food.made_of_any( mut.obj().can_only_eat ) && !mut.obj().can_only_eat.empty() ) {
+        if( !food.made_of_any( mut.obj().can_only_eat ) && !mut.obj().can_only_eat.empty() && !food.has_flag( flag_NO_INGEST ) ) {
             return ret_val<edible_rating>::make_failure( edible_rating::inedible_mutation,
                     _( "You can't eat this." ) );
         }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -715,7 +715,8 @@ ret_val<edible_rating> Character::can_eat( const item &food ) const
     }
 
     for( const trait_id &mut : get_mutations() ) {
-        if( !food.made_of_any( mut.obj().can_only_eat ) && !mut.obj().can_only_eat.empty() && !food.has_flag( flag_NO_INGEST ) ) {
+        if( !food.made_of_any( mut.obj().can_only_eat ) && !mut.obj().can_only_eat.empty() &&
+            !food.has_flag( flag_NO_INGEST ) ) {
             return ret_val<edible_rating>::make_failure( edible_rating::inedible_mutation,
                     _( "You can't eat this." ) );
         }


### PR DESCRIPTION
Linted


#### Summary Bugfix "Follow up to #1207"


#### Purpose of change

A follow up Pr for #1207. 


#### Describe the solution

This allows non-food comestibles to also be usable by players with traits that limit food types in the same way the Made of Sugar trait does.

#### Describe alternatives you've considered

N/A

#### Testing

Compiled and tested, works great!

#### Additional context


