### PR TITLE
Magazine Weight Fix

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4914,6 +4914,10 @@ units::mass item::weight( bool include_contents, bool integral ) const
         ret += links.weight();
     }
 
+    if( magazine_current() != nullptr ) {
+        ret += std::max( magazine_current()->weight(), 0_gram );
+    }
+
     // reduce weight for sawn-off weapons capped to the apportioned weight of the barrel
     if( gunmod_find( itype_barrel_small ) ) {
         const units::volume b = type->gun->barrel_length;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Magazine weight was not being added to items with a magazine."

#### Purpose of change

Fixes #1677.

#### Describe the solution

Item weight code lacked a check for whether an item had a magazine, and thus did not add the relevant weight to the gun.

#### Describe alternatives you've considered

Ignore for another 2 months

#### Testing

Spawn M4A1, 10 round STANAG magazine and SIG 552. Record all weights, unload both bullets and magazines from all 3. Checked both guns without magazine, with empty magazine, and with full 10 round STANAG magazine. Confirmed numbers are as expected.

#### Additional context