### PR TITLE
Rework Morale Display

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -986,7 +986,7 @@ void avatar::disp_morale()
 {
     int equilibrium = calc_focus_equilibrium();
 
-    int fatigue_cap = calc_fatigue_cap();
+    int fatigue_cap = calc_fatigue_cap( *this );
 
     int pain_penalty = has_trait( trait_CENOBITE ) ? 0 : get_perceived_pain();
 

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -986,27 +986,11 @@ void avatar::disp_morale()
 {
     int equilibrium = calc_focus_equilibrium();
 
-    int fatigue_penalty = 0;
-    if( get_fatigue() >= fatigue_levels::massive && equilibrium > 20 ) {
-        fatigue_penalty = equilibrium - 20;
-        equilibrium = 20;
-    } else if( get_fatigue() >= fatigue_levels::exhausted && equilibrium > 40 ) {
-        fatigue_penalty = equilibrium - 40;
-        equilibrium = 40;
-    } else if( get_fatigue() >= fatigue_levels::dead_tired && equilibrium > 60 ) {
-        fatigue_penalty = equilibrium - 60;
-        equilibrium = 60;
-    } else if( get_fatigue() >= fatigue_levels::tired && equilibrium > 80 ) {
-        fatigue_penalty = equilibrium - 80;
-        equilibrium = 80;
-    }
+    int fatigue_cap = calc_fatigue_cap();
 
-    int pain_penalty = 0;
-    if( get_perceived_pain() && !has_trait( trait_CENOBITE ) ) {
-        pain_penalty = calc_focus_equilibrium( true ) - equilibrium - fatigue_penalty;
-    }
+    int pain_penalty = has_trait( trait_CENOBITE ) ? 0 : get_perceived_pain();
 
-    morale->display( equilibrium, pain_penalty, fatigue_penalty );
+    morale->display( equilibrium, pain_penalty, fatigue_cap );
 }
 
 int avatar::get_str_base() const

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -530,7 +530,7 @@ void player_morale::decay( const time_duration &ticks )
     invalidate();
 }
 
-void player_morale::display( int focus_eq, int pain_penalty, int fatigue_penalty )
+void player_morale::display( int focus_eq, int pain_penalty, int fatigue_cap )
 {
     /*calculates the percent contributions of the morale points,
      * must be done before anything else in this method
@@ -720,11 +720,11 @@ void player_morale::display( int focus_eq, int pain_penalty, int fatigue_penalty
             morale_line::line_color::green_gray_red
         );
     }
-    if( fatigue_penalty != 0 ) {
+    if( fatigue_cap ) {
         bottom_lines.emplace_back(
-            _( "Fatigue level:" ), -fatigue_penalty,
-            morale_line::number_format::signed_or_dash,
-            morale_line::line_color::green_gray_red
+            _( "Fatigue Morale Cap:" ), fatigue_cap,
+            morale_line::number_format::normal,
+            morale_line::line_color::red_gray_green
         );
     }
     bottom_lines.emplace_back(

--- a/src/morale.h
+++ b/src/morale.h
@@ -70,7 +70,7 @@ class player_morale
         /** Ticks down morale counters and removes them */
         void decay( const time_duration &ticks = 1_turns );
         /** Displays morale screen */
-        void display( int focus_eq, int pain_penalty, int fatigue_penalty );
+        void display( int focus_eq, int pain_penalty, int fatigue_cap );
         /** Returns false whether morale is inconsistent with the argument.
          *  Only permanent morale is checked */
         bool consistent_with( const player_morale &morale ) const;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4407,15 +4407,15 @@ bool player::query_yn( const std::string &mes ) const
     return ::query_yn( mes );
 }
 
-int player::calc_fatigue_cap() const
+int calc_fatigue_cap( const player &p )
 {
-    if( get_fatigue() >= fatigue_levels::massive ) {
+    if( p.get_fatigue() >= fatigue_levels::massive ) {
         return 20;
-    } else if( get_fatigue() >= fatigue_levels::exhausted ) {
+    } else if( p.get_fatigue() >= fatigue_levels::exhausted ) {
         return 40;
-    } else if( get_fatigue() >= fatigue_levels::dead_tired ) {
+    } else if( p.get_fatigue() >= fatigue_levels::dead_tired ) {
         return 60;
-    } else if( get_fatigue() >= fatigue_levels::tired ) {
+    } else if( p.get_fatigue() >= fatigue_levels::tired ) {
         return 80;
     }
     return 0;
@@ -4445,8 +4445,8 @@ int player::calc_focus_equilibrium() const
     }
 
     // as baseline morale is 100, calc_fatigue_cap() has to -100 to apply accurate penalties.
-    if( calc_fatigue_cap() != 0 && eff_morale > calc_fatigue_cap() - 100 ) {
-        eff_morale = calc_fatigue_cap() - 100;
+    if( calc_fatigue_cap( *this ) != 0 && eff_morale > calc_fatigue_cap( *this ) - 100 ) {
+        eff_morale = calc_fatigue_cap( *this ) - 100;
     }
 
     if( eff_morale < -99 ) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4407,7 +4407,21 @@ bool player::query_yn( const std::string &mes ) const
     return ::query_yn( mes );
 }
 
-int player::calc_focus_equilibrium( bool ignore_pain ) const
+int player::calc_fatigue_cap() const
+{
+    if( get_fatigue() >= fatigue_levels::massive ) {
+        return 20;
+    } else if( get_fatigue() >= fatigue_levels::exhausted ) {
+        return 40;
+    } else if( get_fatigue() >= fatigue_levels::dead_tired ) {
+        return 60;
+    } else if( get_fatigue() >= fatigue_levels::tired ) {
+        return 80;
+    }
+    return 0;
+}
+
+int player::calc_focus_equilibrium() const
 {
     int focus_equilibrium = 100;
 
@@ -4426,8 +4440,13 @@ int player::calc_focus_equilibrium( bool ignore_pain ) const
     int eff_morale = get_morale_level();
     // Factor in perceived pain, since it's harder to rest your mind while your body hurts.
     // Cenobites don't mind, though
-    if( !ignore_pain && !has_trait( trait_CENOBITE ) ) {
+    if( !has_trait( trait_CENOBITE ) ) {
         eff_morale = eff_morale - get_perceived_pain();
+    }
+
+    // as baseline morale is 100, calc_fatigue_cap() has to -100 to apply accurate penalties.
+    if( calc_fatigue_cap() != 0 && eff_morale > calc_fatigue_cap() - 100 ) {
+        eff_morale = calc_fatigue_cap() - 100;
     }
 
     if( eff_morale < -99 ) {
@@ -4492,14 +4511,6 @@ int player::calc_focus_change() const
 
     gain *= base_change;
 
-    // Fatigue will incrementally decrease any focus above related cap
-    if( ( get_fatigue() >= fatigue_levels::tired && focus_pool > 100 ) ||
-        ( get_fatigue() >= fatigue_levels::dead_tired && focus_pool > 75 ) ||
-        ( get_fatigue() >= fatigue_levels::exhausted && focus_pool > 50 ) ||
-        ( get_fatigue() >= fatigue_levels::massive && focus_pool > 25 ) ) {
-
-        gain = std::min( gain, -1 );
-    }
     return gain;
 }
 

--- a/src/player.h
+++ b/src/player.h
@@ -456,8 +456,10 @@ class player : public Character
         /** Checked each turn during "lying_down", returns true if the player falls asleep */
         bool can_sleep();
 
-        /** Uses morale and other factors to return the player's focus target goto value */
-        int calc_focus_equilibrium( bool ignore_pain = false ) const;
+        /** Calculates the player's morale cap due to fatigue */
+        int calc_fatigue_cap() const;
+        /** Uses morale, pain and fatigue to return the player's focus target goto value */
+        int calc_focus_equilibrium() const;
         /** Calculates actual focus gain/loss value from focus equilibrium*/
         int calc_focus_change() const;
         /** Uses calc_focus_change to update the player's current focus */

--- a/src/player.h
+++ b/src/player.h
@@ -456,8 +456,6 @@ class player : public Character
         /** Checked each turn during "lying_down", returns true if the player falls asleep */
         bool can_sleep();
 
-        /** Calculates the player's morale cap due to fatigue */
-        int calc_fatigue_cap() const;
         /** Uses morale, pain and fatigue to return the player's focus target goto value */
         int calc_focus_equilibrium() const;
         /** Calculates actual focus gain/loss value from focus equilibrium*/
@@ -778,5 +776,8 @@ class player : public Character
         /** Stamp of skills. @ref learned_recipes are valid only with this set of skills. */
         mutable decltype( _skills ) valid_autolearn_skills;
 };
+
+/** Calculates the player's morale cap due to fatigue */
+int calc_fatigue_cap( const player &p );
 
 #endif // CATA_SRC_PLAYER_H


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix Morale Calculations."

#### Purpose of change

Originally this PR was to fix a display oddity, as fatigue would display on the morale screen as a penalty when in reality it capped the focus equilibrium display and increased/decreased fatigue penalties accordingly. Leading to unintuitive situations where the more you tried to increase your morale the higher the penalty became.

While converting it to display as a cap. It was found that morale calculations were broken. Fatigue itself did not affect the focus equilibrium, but rather applied extra per tick decrements directly to focus change calculations. Furthermore, the caps for each tier of fatigue were different from the player side display.  

#### Describe the solution

Created new function `calc_fatigue_cap()` to unify the calculations, so that only one calculation needs to be altered to affect both the display and the effect on focus.

Removed direct effect on focus change calculations and applied the fatigue cap to effective morale when calculating focus equilibrium, as I assume was intended.

Changed the display to show the fatigue cap instead of fatigue penalties, and show regardless of whether morale is below or above cap to prevent player confusion.

Streamlined the pain_penalty display so it didn't call the _entire_ focus equilibrium calculation.

#### Describe alternatives you've considered

- Run away and live with the knowledge that morale and focus calculations are wrong.
- Use `calc_fatigue_cap()` to affect the focus equilibrium directly instead of the `eff_morale` int.
This could probably be done and would allow me to remove the `- 100` from the calculations, but I'm on the fence.

#### Testing

Added pain to character, checked that it displayed properly. Added Fatigue to character, checked that cap was enforced but did not interfere with pain. (20 pain and tired level fatigue is still 80 morale, while increasing pain beyond the threshold decreases morale accordingly.) Check that fatigue cap was displayed so long as fatigue thresholds were reached.

#### Additional context