### PR TITLE
[DDA Port] Map reference migration part 1

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -543,7 +543,7 @@ bool can_butcher_at( const tripoint &p )
     // TODO: unify this with game::butcher
     const int factor = g->u.max_quality( qual_BUTCHER );
     const int factorD = g->u.max_quality( qual_CUT_FINE );
-    map_stack items = g->m.i_at( p );
+    map_stack items = get_map().i_at( p );
     bool has_item = false;
     bool has_corpse = false;
 
@@ -562,8 +562,9 @@ bool can_butcher_at( const tripoint &p )
 
 bool can_move_vertical_at( const tripoint &p, int movez )
 {
+    map &here = get_map();
     // TODO: unify this with game::move_vertical
-    if( g->m.has_flag( flag_SWIMMABLE, p ) && g->m.has_flag( TFLAG_DEEP_WATER, p ) ) {
+    if( here.has_flag( flag_SWIMMABLE, p ) && here.has_flag( TFLAG_DEEP_WATER, p ) ) {
         if( movez == -1 ) {
             return !g->u.is_underwater() && !g->u.worn_with_flag( flag_FLOTATION );
         } else {
@@ -572,9 +573,9 @@ bool can_move_vertical_at( const tripoint &p, int movez )
     }
 
     if( movez == -1 ) {
-        return g->m.has_flag( flag_GOES_DOWN, p );
+        return here.has_flag( flag_GOES_DOWN, p );
     } else {
-        return g->m.has_flag( flag_GOES_UP, p );
+        return here.has_flag( flag_GOES_UP, p );
     }
 }
 
@@ -611,25 +612,27 @@ bool can_examine_at( const tripoint &p )
 static bool can_pickup_at( const tripoint &p )
 {
     bool veh_has_items = false;
-    const optional_vpart_position vp = g->m.veh_at( p );
+    map &here = get_map();
+    const optional_vpart_position vp = here.veh_at( p );
     if( vp ) {
         const int cargo_part = vp->vehicle().part_with_feature( vp->part_index(), "CARGO", false );
         veh_has_items = cargo_part >= 0 && !vp->vehicle().get_items( cargo_part ).empty();
     }
-    return g->m.has_items( p ) || veh_has_items;
+    return here.has_items( p ) || veh_has_items;
 }
 
 bool can_interact_at( action_id action, const tripoint &p )
 {
+    map &here = get_map();
     switch( action ) {
         case ACTION_OPEN:
-            return g->m.open_door( p, !g->m.is_outside( g->u.pos() ), true );
+            return here.open_door( p, !here.is_outside( g->u.pos() ), true );
         case ACTION_CLOSE: {
-            const optional_vpart_position vp = g->m.veh_at( p );
+            const optional_vpart_position vp = here.veh_at( p );
             return ( vp &&
                      vp->vehicle().next_part_to_close( vp->part_index(),
-                             veh_pointer_or_null( g->m.veh_at( g->u.pos() ) ) != &vp->vehicle() ) >= 0 ) ||
-                   g->m.close_door( p, !g->m.is_outside( g->u.pos() ), true );
+                             veh_pointer_or_null( here.veh_at( g->u.pos() ) ) != &vp->vehicle() ) >= 0 ) ||
+                   here.close_door( p, !here.is_outside( g->u.pos() ), true );
         }
         case ACTION_BUTCHER:
             return can_butcher_at( p );
@@ -685,15 +688,16 @@ action_id handle_action_menu()
         action_weightings[ACTION_TOGGLE_CROUCH] = 300;
     }
 
+    map &here = get_map();
     // Check if we're on a vehicle, if so, vehicle controls should be top.
-    if( g->m.veh_at( g->u.pos() ) ) {
+    if( here.veh_at( g->u.pos() ) ) {
         // Make it 300 to prioritize it before examining the vehicle.
         action_weightings[ACTION_CONTROL_VEHICLE] = 300;
     }
 
     // Check if we can perform one of our actions on nearby terrain. If so,
     // display that action at the top of the list.
-    for( const tripoint &pos : g->m.points_in_radius( g->u.pos(), 1 ) ) {
+    for( const tripoint &pos : here.points_in_radius( g->u.pos(), 1 ) ) {
         if( pos != g->u.pos() ) {
             // Check for actions that work on nearby tiles
             if( can_interact_at( ACTION_OPEN, pos ) ) {
@@ -1026,8 +1030,9 @@ cata::optional<tripoint> choose_adjacent_highlight( const std::string &message,
         const bool allow_vertical )
 {
     std::vector<tripoint> valid;
+    map &here = get_map();
     if( allowed ) {
-        for( const tripoint &pos : g->m.points_in_radius( g->u.pos(), 1 ) ) {
+        for( const tripoint &pos : here.points_in_radius( g->u.pos(), 1 ) ) {
             if( allowed( pos ) ) {
                 valid.emplace_back( pos );
             }
@@ -1046,7 +1051,7 @@ cata::optional<tripoint> choose_adjacent_highlight( const std::string &message,
     if( !valid.empty() ) {
         hilite_cb = make_shared_fast<game::draw_callback_t>( [&]() {
             for( const tripoint &pos : valid ) {
-                g->m.drawsq( g->w_terrain, pos, drawsq_params().highlight( true ) );
+                here.drawsq( g->w_terrain, pos, drawsq_params().highlight( true ) );
             }
         } );
         g->add_draw_callback( hilite_cb );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -440,24 +440,25 @@ void activity_handlers::burrow_do_turn( player_activity *act, player * )
 void activity_handlers::burrow_finish( player_activity *act, player *p )
 {
     tripoint pos = act->placement; // make a copy to avoid use-after-free
+    map &here = get_map();
     act->set_to_null(); // kill activity before inflicting pain
-    if( g->m.is_bashable( pos ) && g->m.has_flag( flag_SUPPORTS_ROOF, pos ) &&
-        g->m.ter( pos ) != t_tree ) {
+    if( here.is_bashable( pos ) && here.has_flag( flag_SUPPORTS_ROOF, pos ) &&
+        here.ter( pos ) != t_tree ) {
         // Tunneling through solid rock is hungry, sweaty, tiring, backbreaking work
         // Not quite as bad as the pickaxe, though
         p->mod_stored_nutr( 10 );
         p->mod_thirst( 10 );
         p->mod_fatigue( 15 );
         p->mod_pain( 3 * rng( 1, 3 ) );
-    } else if( g->m.move_cost( pos ) == 2 && g->get_levz() == 0 &&
-               g->m.ter( pos ) != t_dirt && g->m.ter( pos ) != t_grass ) {
+    } else if( here.move_cost( pos ) == 2 && g->get_levz() == 0 &&
+               here.ter( pos ) != t_dirt && here.ter( pos ) != t_grass ) {
         //Breaking up concrete on the surface? not nearly as bad
         p->mod_stored_nutr( 5 );
         p->mod_thirst( 5 );
         p->mod_fatigue( 10 );
     }
     p->add_msg_if_player( m_good, _( "You finish burrowing." ) );
-    g->m.destroy( pos, true );
+    here.destroy( pos, true );
 }
 
 static bool check_butcher_cbm( const int roll )
@@ -530,6 +531,7 @@ enum class butcherable_rating : int {
 
 butchery_setup consider_butchery( const item &corpse_item, player &u, butcher_type action )
 {
+    map &here = get_map();
     butchery_setup setup;
     setup.can_do = butchery_possibility::yes;
     setup.type = action;
@@ -587,15 +589,15 @@ butchery_setup consider_butchery( const item &corpse_item, player &u, butcher_ty
     }
 
     bool has_tree_nearby = false;
-    for( const tripoint &pt : g->m.points_in_radius( u.pos(), PICKUP_RANGE ) ) {
-        if( g->m.has_flag( flag_TREE, pt ) ) {
+    for( const tripoint &pt : here.points_in_radius( u.pos(), PICKUP_RANGE ) ) {
+        if( here.has_flag( flag_TREE, pt ) ) {
             has_tree_nearby = true;
             break;
         }
     }
     bool b_rack_present = false;
-    for( const tripoint &pt : g->m.points_in_radius( u.pos(), PICKUP_RANGE ) ) {
-        if( g->m.has_flag_furn( flag_BUTCHER_EQ, pt ) ) {
+    for( const tripoint &pt : here.points_in_radius( u.pos(), PICKUP_RANGE ) ) {
+        if( here.has_flag_furn( flag_BUTCHER_EQ, pt ) ) {
             b_rack_present = true;
             break;
         }
@@ -625,7 +627,7 @@ butchery_setup consider_butchery( const item &corpse_item, player &u, butcher_ty
                     _( "To perform a full butchery on a corpse this big, you need either a butchering rack, a nearby hanging meathook, or both a long rope in your inventory and a nearby tree to hang the corpse from." ),
                     butcherable_rating::no_tree_rope_rack );
             }
-            if( !( g->m.has_nearby_table( u.pos(), PICKUP_RANGE ) || inv.has_item_with( []( const item & it ) {
+            if( !( here.has_nearby_table( u.pos(), PICKUP_RANGE ) || inv.has_item_with( []( const item & it ) {
             return it.has_flag( "FLAT_SURFACE" );
             } ) ) ) {
                 not_this_one(
@@ -890,6 +892,7 @@ static void butchery_drops_harvest( item *corpse_item, const mtype &mt, player &
         return;
     }
 
+    map &here = get_map();
     for( const harvest_entry &entry : *mt.harvest ) {
         const int butchery = roll_butchery();
         const float min_num = entry.base_num.first + butchery * entry.scale_num.first;
@@ -1080,7 +1083,7 @@ static void butchery_drops_harvest( item *corpse_item, const mtype &mt, player &
                 if( !p.backlog.empty() && p.backlog.front().id() == ACT_MULTIPLE_BUTCHER ) {
                     obj.set_var( "activity_var", p.name );
                 }
-                g->m.add_item_or_charges( p.pos(), obj );
+                here.add_item_or_charges( p.pos(), obj );
             } else {
                 item obj( drop, calendar::turn );
                 obj.set_mtype( &mt );
@@ -1097,7 +1100,7 @@ static void butchery_drops_harvest( item *corpse_item, const mtype &mt, player &
                     obj.set_var( "activity_var", p.name );
                 }
                 for( int i = 0; i != roll; ++i ) {
-                    g->m.add_item_or_charges( p.pos(), obj );
+                    here.add_item_or_charges( p.pos(), obj );
                 }
             }
             p.add_msg_if_player( m_good, _( "You harvest: %s" ), drop->nname( roll ) );
@@ -1117,9 +1120,10 @@ static void butchery_quarter( item *corpse_item, const player &p )
     p.add_msg_if_player( m_good,
                          _( "You roughly slice the corpse of %s into four parts and set them aside." ),
                          corpse_item->get_mtype()->nname() );
+    map &here = get_map();
     // 4 quarters (one exists, add 3, flag does the rest)
     for( int i = 1; i <= 3; i++ ) {
-        g->m.add_item_or_charges( p.pos(), *corpse_item, true );
+        here.add_item_or_charges( p.pos(), *corpse_item, true );
     }
 }
 
@@ -1132,6 +1136,7 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
         return;
     }
 
+    map &here = get_map();
     item_location target = act->targets.back();
     const inventory &inv = p->crafting_inventory();
 
@@ -1204,7 +1209,7 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
     };
 
     if( action == DISMEMBER ) {
-        g->m.add_splatter( type_gib, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
+        here.add_splatter( type_gib, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
     }
 
     //all BUTCHERY types - FATAL FAILURE
@@ -1228,12 +1233,12 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
         target.remove_item();
         act->targets.pop_back();
 
-        g->m.add_splatter( type_gib, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
-        g->m.add_splatter( type_blood, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
+        here.add_splatter( type_gib, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
+        here.add_splatter( type_blood, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
         for( int i = 1; i <= corpse->size; i++ ) {
-            g->m.add_splatter_trail( type_gib, p->pos(), random_entry( g->m.points_in_radius( p->pos(),
+            here.add_splatter_trail( type_gib, p->pos(), random_entry( here.points_in_radius( p->pos(),
                                      corpse->size + 1 ) ) );
-            g->m.add_splatter_trail( type_blood, p->pos(), random_entry( g->m.points_in_radius( p->pos(),
+            here.add_splatter_trail( type_blood, p->pos(), random_entry( here.points_in_radius( p->pos(),
                                      corpse->size + 1 ) ) );
         }
 
@@ -1315,12 +1320,12 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
                 }
                 corpse_item.set_flag( "FIELD_DRESS_FAILED" );
 
-                g->m.add_splatter( type_gib, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
-                g->m.add_splatter( type_blood, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
+                here.add_splatter( type_gib, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
+                here.add_splatter( type_blood, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
                 for( int i = 1; i <= corpse->size; i++ ) {
-                    g->m.add_splatter_trail( type_gib, p->pos(), random_entry( g->m.points_in_radius( p->pos(),
+                    here.add_splatter_trail( type_gib, p->pos(), random_entry( here.points_in_radius( p->pos(),
                                              corpse->size + 1 ) ) );
-                    g->m.add_splatter_trail( type_blood, p->pos(), random_entry( g->m.points_in_radius( p->pos(),
+                    here.add_splatter_trail( type_blood, p->pos(), random_entry( here.points_in_radius( p->pos(),
                                              corpse->size + 1 ) ) );
                 }
 
@@ -1341,12 +1346,12 @@ void activity_handlers::butcher_finish( player_activity *act, player *p )
                 }
                 corpse_item.set_flag( flag_FIELD_DRESS );
 
-                g->m.add_splatter( type_gib, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
-                g->m.add_splatter( type_blood, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
+                here.add_splatter( type_gib, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
+                here.add_splatter( type_blood, p->pos(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
                 for( int i = 1; i <= corpse->size; i++ ) {
-                    g->m.add_splatter_trail( type_gib, p->pos(), random_entry( g->m.points_in_radius( p->pos(),
+                    here.add_splatter_trail( type_gib, p->pos(), random_entry( here.points_in_radius( p->pos(),
                                              corpse->size + 1 ) ) );
-                    g->m.add_splatter_trail( type_blood, p->pos(), random_entry( g->m.points_in_radius( p->pos(),
+                    here.add_splatter_trail( type_blood, p->pos(), random_entry( here.points_in_radius( p->pos(),
                                              corpse->size + 1 ) ) );
                 }
 
@@ -1426,7 +1431,8 @@ void activity_handlers::shear_finish( player_activity *act, player *p )
         debugmsg( "shearing item location lost" );
         return;
     }
-    const tripoint source_pos = g->m.getlocal( act->coords.at( 0 ) );
+    map &here = get_map();
+    const tripoint source_pos = here.getlocal( act->coords.at( 0 ) );
     monster *source_mon = g->critter_at<monster>( source_pos );
     if( source_mon == nullptr ) {
         debugmsg( "could not find source creature for shearing" );
@@ -1435,7 +1441,7 @@ void activity_handlers::shear_finish( player_activity *act, player *p )
     // 22 wool staples corresponds to an average wool-producing sheep yield of 10 lbs or so
     for( int i = 0; i != 22; ++i ) {
         item wool_staple( itype_wool_staple, calendar::turn );
-        g->m.add_item_or_charges( p->pos(), wool_staple );
+        here.add_item_or_charges( p->pos(), wool_staple );
     }
     source_mon->add_effect( effect_sheared, calendar::season_length() );
     if( !act->str_values.empty() && act->str_values[0] == "temp_tie" ) {
@@ -1453,7 +1459,8 @@ void activity_handlers::milk_finish( player_activity *act, player *p )
         debugmsg( "milking activity with no position of monster stored" );
         return;
     }
-    const tripoint source_pos = g->m.getlocal( act->coords.at( 0 ) );
+    map &here = get_map();
+    const tripoint source_pos = here.getlocal( act->coords.at( 0 ) );
     monster *source_mon = g->critter_at<monster>( source_pos );
     if( source_mon == nullptr ) {
         debugmsg( "could not find source creature for liquid transfer" );
@@ -1492,7 +1499,8 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, player *p )
         // 1. Gather the source item.
         vehicle *source_veh = nullptr;
         const tripoint source_pos = act_ref.coords.at( 0 );
-        map_stack source_stack = g->m.i_at( source_pos );
+        map &here = get_map();
+        map_stack source_stack = here.i_at( source_pos );
         map_stack::iterator on_ground;
         monster *source_mon = nullptr;
         item liquid;
@@ -1501,7 +1509,7 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, player *p )
         int veh_charges = 0;
         switch( source_type ) {
             case LST_VEHICLE:
-                source_veh = veh_pointer_or_null( g->m.veh_at( source_pos ) );
+                source_veh = veh_pointer_or_null( here.veh_at( source_pos ) );
                 if( source_veh == nullptr ) {
                     throw std::runtime_error( "could not find source vehicle for liquid transfer" );
                 }
@@ -1541,7 +1549,7 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, player *p )
         // 2. Transfer charges.
         switch( static_cast<liquid_target_type>( act_ref.values.at( 2 ) ) ) {
             case LTT_VEHICLE:
-                if( const optional_vpart_position vp = g->m.veh_at( act_ref.coords.at( 1 ) ) ) {
+                if( const optional_vpart_position vp = here.veh_at( act_ref.coords.at( 1 ) ) ) {
                     p->pour_into( vp->vehicle(), liquid );
                 } else {
                     throw std::runtime_error( "could not find target vehicle for liquid transfer" );
@@ -1554,7 +1562,7 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, player *p )
                 if( iexamine::has_keg( act_ref.coords.at( 1 ) ) ) {
                     iexamine::pour_into_keg( act_ref.coords.at( 1 ), liquid );
                 } else {
-                    g->m.add_item_or_charges( act_ref.coords.at( 1 ), liquid );
+                    here.add_item_or_charges( act_ref.coords.at( 1 ), liquid );
                     p->add_msg_if_player( _( "You pour %1$s onto the ground." ), liquid.tname() );
                     liquid.charges = 0;
                 }
@@ -1600,15 +1608,15 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, player *p )
                 on_ground->charges -= removed_charges;
                 if( on_ground->charges <= 0 ) {
                     source_stack.erase( on_ground );
-                    if( g->m.ter( source_pos ).obj().examine == &iexamine::gaspump ) {
+                    if( here.ter( source_pos ).obj().examine == &iexamine::gaspump ) {
                         add_msg( _( "With a clang and a shudder, the %s pump goes silent." ),
                                  liquid.type_name( 1 ) );
-                    } else if( g->m.furn( source_pos ).obj().examine == &iexamine::fvat_full ) {
+                    } else if( here.furn( source_pos ).obj().examine == &iexamine::fvat_full ) {
                         add_msg( _( "You squeeze the last drops of %s from the vat." ),
                                  liquid.type_name( 1 ) );
-                        map_stack items_here = g->m.i_at( source_pos );
+                        map_stack items_here = here.i_at( source_pos );
                         if( items_here.empty() ) {
-                            g->m.furn_set( source_pos, f_fvat_empty );
+                            here.furn_set( source_pos, f_fvat_empty );
                         }
                     }
                     act_ref.set_to_null();
@@ -1672,8 +1680,9 @@ void activity_handlers::forage_finish( player_activity *act, player *p )
 {
     // Don't forage if we aren't next to the bush - otherwise we get weird bugs
     bool next_to_bush = false;
-    for( const tripoint &pnt : g->m.points_in_radius( p->pos(), 1 ) ) {
-        if( g->m.getabs( pnt ) == act->placement ) {
+    map &here = get_map();
+    for( const tripoint &pnt : here.points_in_radius( p->pos(), 1 ) ) {
+        if( here.getabs( pnt ) == act->placement ) {
             next_to_bush = true;
             break;
         }
@@ -1711,7 +1720,7 @@ void activity_handlers::forage_finish( player_activity *act, player *p )
             debugmsg( "Invalid season" );
     }
 
-    g->m.ter_set( g->m.getlocal( act->placement ), next_ter );
+    here.ter_set( here.getlocal( act->placement ), next_ter );
 
     // Survival gives a bigger boost, and Perception is leveled a bit.
     // Both survival and perception affect time to forage
@@ -1719,7 +1728,7 @@ void activity_handlers::forage_finish( player_activity *act, player *p )
     ///\EFFECT_PER slightly increases forage success chance
     ///\EFFECT_SURVIVAL increases forage success chance
     if( veggy_chance < p->get_skill_level( skill_survival ) * 3 + p->per_cur - 2 ) {
-        const std::vector<item *> dropped = g->m.put_items_from_loc( loc, p->pos(), calendar::turn );
+        const std::vector<item *> dropped = here.put_items_from_loc( loc, p->pos(), calendar::turn );
         for( item *it : dropped ) {
             add_msg( m_good, _( "You found: %s!" ), it->tname() );
             found_something = true;
@@ -1734,7 +1743,7 @@ void activity_handlers::forage_finish( player_activity *act, player *p )
     }
     // 10% to drop a item/items from this group.
     if( one_in( 10 ) ) {
-        const std::vector<item *> dropped = g->m.put_items_from_loc( item_group_id( "trash_forest" ),
+        const std::vector<item *> dropped = here.put_items_from_loc( item_group_id( "trash_forest" ),
                                             p->pos(),
                                             calendar::turn );
         for( item * const &it : dropped ) {
@@ -1818,7 +1827,8 @@ void activity_handlers::longsalvage_finish( player_activity *act, player *p )
 {
     static const std::string salvage_string = "salvage";
     item &main_tool = p->i_at( act->index );
-    map_stack items = g->m.i_at( p->pos() );
+    map &here = get_map();
+    map_stack items = here.i_at( p->pos() );
     item *salvage_tool = main_tool.get_usable_item( salvage_string );
     if( salvage_tool == nullptr ) {
         debugmsg( "Lost tool used for long salvage" );
@@ -1971,7 +1981,8 @@ void activity_handlers::pickaxe_finish( player_activity *act, player *p )
 
 void activity_handlers::pulp_do_turn( player_activity *act, player *p )
 {
-    const tripoint &pos = g->m.getlocal( act->placement );
+    map &here = get_map();
+    const tripoint &pos = here.getlocal( act->placement );
 
     // Stabbing weapons are a lot less effective at pulping
     const int cut_power = std::max( p->weapon.damage_melee( DT_CUT ),
@@ -1989,7 +2000,7 @@ void activity_handlers::pulp_do_turn( player_activity *act, player *p )
     int moves = 0;
     // use this to collect how many corpse are pulped
     int &num_corpses = act->index;
-    map_stack corpse_pile = g->m.i_at( pos );
+    map_stack corpse_pile = here.i_at( pos );
     for( item &corpse : corpse_pile ) {
         const mtype *corpse_mtype = corpse.get_mtype();
         if( !corpse.is_corpse() || !corpse_mtype->has_flag( MF_REVIVES ) ||
@@ -2016,7 +2027,7 @@ void activity_handlers::pulp_do_turn( player_activity *act, player *p )
                 const field_type_id type_blood = ( mess_radius > 1 && x_in_y( pulp_power, 10000 ) ) ?
                                                  corpse.get_mtype()->gibType() :
                                                  corpse.get_mtype()->bloodType();
-                g->m.add_splatter_trail( type_blood, pos, dest );
+                here.add_splatter_trail( type_blood, pos, dest );
             }
 
             p->mod_stamina( -pulp_effort );
@@ -2158,9 +2169,10 @@ void activity_handlers::start_fire_finish( player_activity *act, player *p )
 
 void activity_handlers::start_fire_do_turn( player_activity *act, player *p )
 {
-    if( !g->m.is_flammable( act->placement ) ) {
+    map &here = get_map();
+    if( !here.is_flammable( act->placement ) ) {
         try_fuel_fire( *act, *p, true );
-        if( !g->m.is_flammable( act->placement ) ) {
+        if( !here.is_flammable( act->placement ) ) {
             p->add_msg_if_player( m_info, _( "There's nothing to light there." ) );
             p->cancel_activity();
             return;
@@ -2169,7 +2181,7 @@ void activity_handlers::start_fire_do_turn( player_activity *act, player *p )
 
     item &firestarter = *act->targets.front();
     if( firestarter.has_flag( flag_REQUIRES_TINDER ) ) {
-        if( !g->m.tinder_at( act->placement ) ) {
+        if( !here.tinder_at( act->placement ) ) {
             p->add_msg_if_player( m_info, _( "This item requires tinder to light." ) );
             p->cancel_activity();
             return;
@@ -2258,8 +2270,9 @@ void activity_handlers::train_finish( player_activity *act, player *p )
 
 void activity_handlers::vehicle_finish( player_activity *act, player *p )
 {
+    map &here = get_map();
     //Grab this now, in case the vehicle gets shifted
-    const optional_vpart_position vp = g->m.veh_at( g->m.getlocal( tripoint( act->values[0],
+    const optional_vpart_position vp = here.veh_at( here.getlocal( tripoint( act->values[0],
                                        act->values[1],
                                        p->posz() ) ) );
     veh_interact::complete_vehicle( *p );
@@ -2280,7 +2293,7 @@ void activity_handlers::vehicle_finish( player_activity *act, player *p )
                       act->values.size() );
         } else {
             if( vp ) {
-                g->m.invalidate_map_cache( g->get_levz() );
+                here.invalidate_map_cache( g->get_levz() );
                 // TODO: Z (and also where the activity is queued)
                 // Or not, because the vehicle coordinates are dropped anyway
                 if( !resume_for_multi_activities( *p ) ) {
@@ -2358,9 +2371,10 @@ void activity_handlers::start_engines_finish( player_activity *act, player *p )
     act->set_to_null();
     // Find the vehicle by looking for a remote vehicle first, then by player relative coordinates
     vehicle *veh = g->remoteveh();
+    map &here = get_map();
     if( !veh ) {
         const tripoint pos = act->placement + g->u.pos();
-        veh = veh_pointer_or_null( g->m.veh_at( pos ) );
+        veh = veh_pointer_or_null( here.veh_at( pos ) );
         if( !veh ) {
             return;
         }
@@ -2447,59 +2461,60 @@ void activity_handlers::oxytorch_do_turn( player_activity *act, player *p )
 void activity_handlers::oxytorch_finish( player_activity *act, player *p )
 {
     act->set_to_null();
+    map &here = get_map();
     const tripoint &pos = act->placement;
-    const ter_id ter = g->m.ter( pos );
+    const ter_id ter = here.ter( pos );
 
     // fast players might still have some charges left to be consumed
     act->targets.front()->ammo_consume( act->values[0], p->pos() );
 
-    if( g->m.furn( pos ) == f_rack ) {
-        g->m.furn_set( pos, f_null );
-        g->m.spawn_item( p->pos(), itype_steel_chunk, rng( 2, 6 ) );
+    if( here.furn( pos ) == f_rack ) {
+        here.furn_set( pos, f_null );
+        here.spawn_item( p->pos(), itype_steel_chunk, rng( 2, 6 ) );
     } else if( ter == t_chainfence || ter == t_chaingate_c || ter == t_chaingate_l ) {
-        g->m.ter_set( pos, t_dirt );
-        g->m.spawn_item( pos, itype_pipe, rng( 1, 4 ) );
-        g->m.spawn_item( pos, itype_wire, rng( 4, 16 ) );
+        here.ter_set( pos, t_dirt );
+        here.spawn_item( pos, itype_pipe, rng( 1, 4 ) );
+        here.spawn_item( pos, itype_wire, rng( 4, 16 ) );
     } else if( ter == t_chainfence_posts ) {
-        g->m.ter_set( pos, t_dirt );
-        g->m.spawn_item( pos, itype_pipe, rng( 1, 4 ) );
+        here.ter_set( pos, t_dirt );
+        here.spawn_item( pos, itype_pipe, rng( 1, 4 ) );
     } else if( ter == t_door_metal_locked || ter == t_door_metal_c || ter == t_door_bar_c ||
                ter == t_door_bar_locked || ter == t_door_metal_pickable ) {
-        g->m.ter_set( pos, t_mdoor_frame );
-        g->m.spawn_item( pos, itype_steel_plate, rng( 0, 1 ) );
-        g->m.spawn_item( pos, itype_steel_chunk, rng( 3, 8 ) );
+        here.ter_set( pos, t_mdoor_frame );
+        here.spawn_item( pos, itype_steel_plate, rng( 0, 1 ) );
+        here.spawn_item( pos, itype_steel_chunk, rng( 3, 8 ) );
     } else if( ter == t_window_enhanced || ter == t_window_enhanced_noglass ) {
-        g->m.ter_set( pos, t_window_empty );
-        g->m.spawn_item( pos, itype_steel_plate, rng( 0, 1 ) );
-        g->m.spawn_item( pos, itype_sheet_metal, rng( 1, 3 ) );
+        here.ter_set( pos, t_window_empty );
+        here.spawn_item( pos, itype_steel_plate, rng( 0, 1 ) );
+        here.spawn_item( pos, itype_sheet_metal, rng( 1, 3 ) );
     } else if( ter == t_reb_cage ) {
-        g->m.ter_set( pos, t_pit );
-        g->m.spawn_item( pos, itype_spike, rng( 1, 19 ) );
-        g->m.spawn_item( pos, itype_scrap, rng( 1, 8 ) );
+        here.ter_set( pos, t_pit );
+        here.spawn_item( pos, itype_spike, rng( 1, 19 ) );
+        here.spawn_item( pos, itype_scrap, rng( 1, 8 ) );
     } else if( ter == t_bars ) {
-        if( g->m.ter( pos + point_east ) == t_sewage || g->m.ter( pos + point_south ) ==
+        if( here.ter( pos + point_east ) == t_sewage || here.ter( pos + point_south ) ==
             t_sewage ||
-            g->m.ter( pos + point_west ) == t_sewage || g->m.ter( pos + point_north ) ==
+            here.ter( pos + point_west ) == t_sewage || here.ter( pos + point_north ) ==
             t_sewage ) {
-            g->m.ter_set( pos, t_sewage );
-            g->m.spawn_item( p->pos(), itype_pipe, rng( 1, 2 ) );
+            here.ter_set( pos, t_sewage );
+            here.spawn_item( p->pos(), itype_pipe, rng( 1, 2 ) );
         } else {
-            g->m.ter_set( pos, t_floor );
-            g->m.spawn_item( p->pos(), itype_pipe, rng( 1, 2 ) );
+            here.ter_set( pos, t_floor );
+            here.spawn_item( p->pos(), itype_pipe, rng( 1, 2 ) );
         }
     } else if( ter == t_window_bars_alarm ) {
-        g->m.ter_set( pos, t_window_alarm );
-        g->m.spawn_item( p->pos(), itype_pipe, rng( 1, 2 ) );
+        here.ter_set( pos, t_window_alarm );
+        here.spawn_item( p->pos(), itype_pipe, rng( 1, 2 ) );
     } else if( ter == t_window_bars ) {
-        g->m.ter_set( pos, t_window_empty );
-        g->m.spawn_item( p->pos(), itype_pipe, rng( 1, 2 ) );
+        here.ter_set( pos, t_window_empty );
+        here.spawn_item( p->pos(), itype_pipe, rng( 1, 2 ) );
     }
 }
 
 void activity_handlers::cracking_finish( player_activity *act, player *p )
 {
     p->add_msg_if_player( m_good, _( "With a satisfying click, the lock on the safe opens!" ) );
-    g->m.furn_set( act->placement, f_safe_c );
+    get_map().furn_set( act->placement, f_safe_c );
     act->set_to_null();
 }
 
@@ -3100,9 +3115,10 @@ void activity_handlers::toolmod_add_finish( player_activity *act, player *p )
 void activity_handlers::clear_rubble_finish( player_activity *act, player *p )
 {
     const tripoint &pos = act->placement;
+    map &here = get_map();
     p->add_msg_if_player( m_info, _( "You clear up the %s." ),
-                          g->m.furnname( pos ) );
-    g->m.furn_set( pos, f_null );
+                          here.furnname( pos ) );
+    here.furn_set( pos, f_null );
 
     act->set_to_null();
 }
@@ -3177,13 +3193,13 @@ void activity_handlers::travel_do_turn( player_activity *act, player *p )
         if( !here.passable( centre_sub ) ) {
             tripoint_range<tripoint> candidates = here.points_in_radius( centre_sub, 2 );
             for( const tripoint &elem : candidates ) {
-                if( g->m.passable( elem ) ) {
+                if( here.passable( elem ) ) {
                     centre_sub = elem;
                     break;
                 }
             }
         }
-        const std::vector<tripoint> route_to = g->m.route( p->pos(), centre_sub,
+        const std::vector<tripoint> route_to = here.route( p->pos(), centre_sub,
                                                p->get_pathfinding_settings(),
                                                p->get_path_avoid() );
         if( !route_to.empty() ) {
@@ -3212,12 +3228,13 @@ void activity_handlers::atm_do_turn( player_activity *, player *p )
 // fish-with-rod fish catching function.
 static void rod_fish( player *p, const std::vector<monster *> &fishables )
 {
+    map &here = get_map();
     //if the vector is empty (no fish around) the player is still given a small chance to get a (let us say it was hidden) fish
     if( fishables.empty() ) {
         const std::vector<mtype_id> fish_group = MonsterGroupManager::GetMonstersFromGroup(
                     mongroup_id( "GROUP_FISH" ) );
         const mtype_id fish_mon = random_entry_ref( fish_group );
-        g->m.add_item_or_charges( p->pos(), item::make_corpse( fish_mon, calendar::turn + rng( 0_turns,
+        here.add_item_or_charges( p->pos(), item::make_corpse( fish_mon, calendar::turn + rng( 0_turns,
                                   3_hours ) ) );
         p->add_msg_if_player( m_good, _( "You caught a %s." ), fish_mon.obj().nname() );
     } else {
@@ -3226,13 +3243,13 @@ static void rod_fish( player *p, const std::vector<monster *> &fishables )
         if( chosen_fish->fish_population <= 0 ) {
             g->catch_a_monster( chosen_fish, p->pos(), p, 50_hours );
         } else {
-            g->m.add_item_or_charges( p->pos(), item::make_corpse( chosen_fish->type->id,
+            here.add_item_or_charges( p->pos(), item::make_corpse( chosen_fish->type->id,
                                       calendar::turn + rng( 0_turns,
                                               3_hours ) ) );
             p->add_msg_if_player( m_good, _( "You caught a %s." ), chosen_fish->type->nname() );
         }
     }
-    for( item &elem : g->m.i_at( p->pos() ) ) {
+    for( item &elem : here.i_at( p->pos() ) ) {
         if( elem.is_corpse() && !elem.has_var( "activity_var" ) ) {
             elem.set_var( "activity_var", p->name );
         }
@@ -3532,11 +3549,12 @@ void activity_handlers::operation_do_turn( player_activity *act, player *p )
     const time_duration message_freq = difficulty * 2_minutes;
     time_duration time_left = time_duration::from_turns( act->moves_left / 100 );
 
-    if( autodoc && g->m.inbounds( p->pos() ) ) {
-        const std::list<tripoint> autodocs = g->m.find_furnitures_with_flag_in_radius( p->pos(), 1,
+    map &here = get_map();
+    if( autodoc && here.inbounds( p->pos() ) ) {
+        const std::list<tripoint> autodocs = here.find_furnitures_with_flag_in_radius( p->pos(), 1,
                                              flag_AUTODOC );
 
-        if( !g->m.has_flag_furn( flag_AUTODOC_COUCH, p->pos() ) || autodocs.empty() ) {
+        if( !here.has_flag_furn( flag_AUTODOC_COUCH, p->pos() ) || autodocs.empty() ) {
             p->remove_effect( effect_under_op );
             act->set_to_null();
 
@@ -3662,11 +3680,12 @@ void activity_handlers::try_sleep_finish( player_activity *act, player *p )
 
 void activity_handlers::operation_finish( player_activity *act, player *p )
 {
+    map &here = get_map();
     if( act->str_values[3] == "true" ) {
         if( act->values[1] > 0 ) {
             add_msg( m_good,
                      _( "The Autodoc returns to its resting position after successfully performing the operation." ) );
-            const std::list<tripoint> autodocs = g->m.find_furnitures_with_flag_in_radius( p->pos(), 1,
+            const std::list<tripoint> autodocs = here.find_furnitures_with_flag_in_radius( p->pos(), 1,
                                                  flag_AUTODOC );
             sounds::sound( autodocs.front(), 10, sounds::sound_t::music,
                            _( "a short upbeat jingle: \"Operation successful\"" ), true,
@@ -3676,7 +3695,7 @@ void activity_handlers::operation_finish( player_activity *act, player *p )
             if( act->str_values[0] == "install" ) {
                 add_msg( m_warning,
                          _( "The Autodoc completes installation and activates bionic but reports about complications during operation." ) );
-                const std::list<tripoint> autodocs = g->m.find_furnitures_with_flag_in_radius( p->pos(), 1,
+                const std::list<tripoint> autodocs = here.find_furnitures_with_flag_in_radius( p->pos(), 1,
                                                      flag_AUTODOC );
                 sounds::sound( autodocs.front(), 10, sounds::sound_t::music,
                                _( "a sad beeping noise: \"Complications detected!  Report to medical personnel immediately!\"" ),
@@ -3686,7 +3705,7 @@ void activity_handlers::operation_finish( player_activity *act, player *p )
             } else {
                 add_msg( m_bad,
                          _( "The Autodoc jerks back to its resting position after failing the operation." ) );
-                const std::list<tripoint> autodocs = g->m.find_furnitures_with_flag_in_radius( p->pos(), 1,
+                const std::list<tripoint> autodocs = here.find_furnitures_with_flag_in_radius( p->pos(), 1,
                                                      flag_AUTODOC );
                 sounds::sound( autodocs.front(), 10, sounds::sound_t::music,
                                _( "a sad beeping noise: \"Operation failed\"" ), true,
@@ -3716,8 +3735,9 @@ void activity_handlers::operation_finish( player_activity *act, player *p )
 
 void activity_handlers::churn_finish( player_activity *act, player *p )
 {
+    map &here = get_map();
     p->add_msg_if_player( _( "You finish churning up the earth here." ) );
-    g->m.ter_set( g->m.getlocal( act->placement ), t_dirtmound );
+    here.ter_set( here.getlocal( act->placement ), t_dirtmound );
     // Go back to what we were doing before
     // could be player zone activity, or could be NPC multi-farming
     act->set_to_null();
@@ -3726,7 +3746,8 @@ void activity_handlers::churn_finish( player_activity *act, player *p )
 
 void activity_handlers::plant_seed_finish( player_activity *act, player *p )
 {
-    tripoint examp = g->m.getlocal( act->placement );
+    map &here = get_map();
+    tripoint examp = here.getlocal( act->placement );
     const itype_id seed_id( act->str_values[0] );
     std::list<item> used_seed;
     if( item::count_by_charges( seed_id ) ) {
@@ -3740,11 +3761,11 @@ void activity_handlers::plant_seed_finish( player_activity *act, player *p )
             used_seed.front().erase_var( "activity_var" );
         }
         used_seed.front().set_flag( flag_HIDDEN_ITEM );
-        g->m.add_item_or_charges( examp, used_seed.front() );
-        if( g->m.has_flag_furn( flag_PLANTABLE, examp ) ) {
-            g->m.furn_set( examp, furn_str_id( g->m.furn( examp )->plant->transform ) );
+        here.add_item_or_charges( examp, used_seed.front() );
+        if( here.has_flag_furn( flag_PLANTABLE, examp ) ) {
+            here.furn_set( examp, furn_str_id( here.furn( examp )->plant->transform ) );
         } else {
-            g->m.set( examp, t_dirt, f_plant_seed );
+            here.set( examp, t_dirt, f_plant_seed );
         }
         p->add_msg_player_or_npc( _( "You plant some %s." ), _( "<npcname> plants some %s." ),
                                   item::nname( seed_id ) );
@@ -3757,7 +3778,8 @@ void activity_handlers::plant_seed_finish( player_activity *act, player *p )
 
 void activity_handlers::build_do_turn( player_activity *act, player *p )
 {
-    partial_con *pc = g->m.partial_con_at( g->m.getlocal( act->placement ) );
+    map &here = get_map();
+    partial_con *pc = here.partial_con_at( here.getlocal( act->placement ) );
     // Maybe the player and the NPC are working on the same construction at the same time
     if( !pc ) {
         if( p->is_npc() ) {
@@ -4007,49 +4029,50 @@ void activity_handlers::hacksaw_do_turn( player_activity *act, player * )
 void activity_handlers::hacksaw_finish( player_activity *act, player *p )
 {
     const tripoint &pos = act->placement;
-    const ter_id ter = g->m.ter( pos );
+    map &here = get_map();
+    const ter_id ter = here.ter( pos );
 
-    if( g->m.furn( pos ) == f_rack ) {
-        g->m.furn_set( pos, f_null );
-        g->m.spawn_item( p->pos(), itype_pipe, rng( 1, 3 ) );
-        g->m.spawn_item( p->pos(), itype_steel_chunk );
+    if( here.furn( pos ) == f_rack ) {
+        here.furn_set( pos, f_null );
+        here.spawn_item( p->pos(), itype_pipe, rng( 1, 3 ) );
+        here.spawn_item( p->pos(), itype_steel_chunk );
     } else if( ter == t_chainfence || ter == t_chaingate_c || ter == t_chaingate_l ) {
-        g->m.ter_set( pos, t_dirt );
-        g->m.spawn_item( p->pos(), itype_pipe, 6 );
-        g->m.spawn_item( p->pos(), itype_wire, 20 );
+        here.ter_set( pos, t_dirt );
+        here.spawn_item( p->pos(), itype_pipe, 6 );
+        here.spawn_item( p->pos(), itype_wire, 20 );
     } else if( ter == t_chainfence_posts ) {
-        g->m.ter_set( pos, t_dirt );
-        g->m.spawn_item( p->pos(), itype_pipe, 6 );
+        here.ter_set( pos, t_dirt );
+        here.spawn_item( p->pos(), itype_pipe, 6 );
     } else if( ter == t_window_bars_alarm ) {
-        g->m.ter_set( pos, t_window_alarm );
-        g->m.spawn_item( p->pos(), itype_pipe, 6 );
+        here.ter_set( pos, t_window_alarm );
+        here.spawn_item( p->pos(), itype_pipe, 6 );
     } else if( ter == t_window_bars ) {
-        g->m.ter_set( pos, t_window_empty );
-        g->m.spawn_item( p->pos(), itype_pipe, 6 );
+        here.ter_set( pos, t_window_empty );
+        here.spawn_item( p->pos(), itype_pipe, 6 );
     } else if( ter == t_window_enhanced ) {
-        g->m.ter_set( pos, t_window_reinforced );
-        g->m.spawn_item( p->pos(), itype_spike, rng( 1, 4 ) );
+        here.ter_set( pos, t_window_reinforced );
+        here.spawn_item( p->pos(), itype_spike, rng( 1, 4 ) );
     } else if( ter == t_window_enhanced_noglass ) {
-        g->m.ter_set( pos, t_window_reinforced_noglass );
-        g->m.spawn_item( p->pos(), itype_spike, rng( 1, 4 ) );
+        here.ter_set( pos, t_window_reinforced_noglass );
+        here.spawn_item( p->pos(), itype_spike, rng( 1, 4 ) );
     } else if( ter == t_reb_cage ) {
-        g->m.ter_set( pos, t_pit );
-        g->m.spawn_item( p->pos(), itype_spike, 19 );
-        g->m.spawn_item( p->pos(), itype_scrap, 8 );
+        here.ter_set( pos, t_pit );
+        here.spawn_item( p->pos(), itype_spike, 19 );
+        here.spawn_item( p->pos(), itype_scrap, 8 );
     } else if( ter == t_bars ) {
-        if( g->m.ter( pos + point_east ) == t_sewage || g->m.ter( pos + point_south )
+        if( here.ter( pos + point_east ) == t_sewage || here.ter( pos + point_south )
             == t_sewage ||
-            g->m.ter( pos + point_west ) == t_sewage || g->m.ter( pos + point_north ) ==
+            here.ter( pos + point_west ) == t_sewage || here.ter( pos + point_north ) ==
             t_sewage ) {
-            g->m.ter_set( pos, t_sewage );
-            g->m.spawn_item( p->pos(), itype_pipe, 3 );
+            here.ter_set( pos, t_sewage );
+            here.spawn_item( p->pos(), itype_pipe, 3 );
         } else {
-            g->m.ter_set( pos, t_floor );
-            g->m.spawn_item( p->pos(), itype_pipe, 3 );
+            here.ter_set( pos, t_floor );
+            here.spawn_item( p->pos(), itype_pipe, 3 );
         }
     } else if( ter == t_door_bar_c || ter == t_door_bar_locked ) {
-        g->m.ter_set( pos, t_mdoor_frame );
-        g->m.spawn_item( p->pos(), itype_pipe, 12 );
+        here.ter_set( pos, t_mdoor_frame );
+        here.spawn_item( p->pos(), itype_pipe, 12 );
     }
 
     p->mod_stored_nutr( 5 );
@@ -4068,7 +4091,8 @@ void activity_handlers::pry_nails_do_turn( player_activity *act, player * )
 void activity_handlers::pry_nails_finish( player_activity *act, player *p )
 {
     const tripoint &pnt = act->placement;
-    const ter_id type = g->m.ter( pnt );
+    map &here = get_map();
+    const ter_id type = here.ter( pnt );
 
     int nails = 0;
     int boards = 0;
@@ -4109,18 +4133,19 @@ void activity_handlers::pry_nails_finish( player_activity *act, player *p )
         p->add_msg_if_player( _( "You pry the boards from the door." ) );
     }
     p->practice( skill_fabrication, 1, 1 );
-    g->m.spawn_item( p->pos(), itype_nail, 0, nails );
-    g->m.spawn_item( p->pos(), itype_2x4, boards );
-    g->m.ter_set( pnt, newter );
+    here.spawn_item( p->pos(), itype_nail, 0, nails );
+    here.spawn_item( p->pos(), itype_2x4, boards );
+    here.ter_set( pnt, newter );
     act->set_to_null();
 }
 
 void activity_handlers::chop_tree_do_turn( player_activity *act, player *p )
 {
-    sfx::play_activity_sound( "tool", "axe", sfx::get_heard_volume( g->m.getlocal( act->placement ) ) );
+    map &here = get_map();
+    sfx::play_activity_sound( "tool", "axe", sfx::get_heard_volume( here.getlocal( act->placement ) ) );
     if( calendar::once_every( 1_minutes ) ) {
         //~ Sound of a wood chopping tool at work!
-        sounds::sound( g->m.getlocal( act->placement ), 15, sounds::sound_t::activity, _( "CHK!" ) );
+        sounds::sound( here.getlocal( act->placement ), 15, sounds::sound_t::activity, _( "CHK!" ) );
     }
     if( calendar::once_every( 6_minutes ) ) {
         p->mod_fatigue( 1 );
@@ -4133,7 +4158,8 @@ void activity_handlers::chop_tree_do_turn( player_activity *act, player *p )
 
 void activity_handlers::chop_tree_finish( player_activity *act, player *p )
 {
-    const tripoint &pos = g->m.getlocal( act->placement );
+    map &here = get_map();
+    const tripoint &pos = here.getlocal( act->placement );
 
     tripoint direction;
     if( !p->is_npc() ) {
@@ -4148,7 +4174,7 @@ void activity_handlers::chop_tree_finish( player_activity *act, player *p )
             }
         }
     } else {
-        for( const tripoint &elem : g->m.points_in_radius( pos, 1 ) ) {
+        for( const tripoint &elem : here.points_in_radius( pos, 1 ) ) {
             bool cantuse = false;
             tripoint direc = elem - pos;
             tripoint proposed_to = pos + point( 3 * direction.x, 3 * direction.y );
@@ -4168,30 +4194,31 @@ void activity_handlers::chop_tree_finish( player_activity *act, player *p )
     const tripoint to = pos + 3 * direction.xy() + point( rng( -1, 1 ), rng( -1, 1 ) );
     std::vector<tripoint> tree = line_to( pos, to, rng( 1, 8 ) );
     for( const tripoint &elem : tree ) {
-        g->m.batter( elem, 300, 5 );
-        g->m.ter_set( elem, t_trunk );
+        here.batter( elem, 300, 5 );
+        here.ter_set( elem, t_trunk );
     }
 
-    g->m.ter_set( pos, t_stump );
+    here.ter_set( pos, t_stump );
     p->add_msg_if_player( m_good, _( "You finish chopping down a tree." ) );
     // sound of falling tree
     sfx::play_variant_sound( "misc", "timber",
-                             sfx::get_heard_volume( g->m.getlocal( act->placement ) ) );
+                             sfx::get_heard_volume( here.getlocal( act->placement ) ) );
     act->set_to_null();
     resume_for_multi_activities( *p );
 }
 
 void activity_handlers::chop_logs_finish( player_activity *act, player *p )
 {
-    const tripoint &pos = g->m.getlocal( act->placement );
+    map &here = get_map();
+    const tripoint &pos = here.getlocal( act->placement );
     int log_quan;
     int stick_quan;
     int splint_quan;
-    if( g->m.ter( pos ) == t_trunk ) {
+    if( here.ter( pos ) == t_trunk ) {
         log_quan = rng( 2, 3 );
         stick_quan = rng( 0, 1 );
         splint_quan = 0;
-    } else if( g->m.ter( pos ) == t_stump ) {
+    } else if( here.ter( pos ) == t_stump ) {
         log_quan = rng( 0, 2 );
         stick_quan = 0;
         splint_quan = rng( 5, 15 );
@@ -4203,19 +4230,19 @@ void activity_handlers::chop_logs_finish( player_activity *act, player *p )
     for( int i = 0; i != log_quan; ++i ) {
         item obj( itype_log, calendar::turn );
         obj.set_var( "activity_var", p->name );
-        g->m.add_item_or_charges( pos, obj );
+        here.add_item_or_charges( pos, obj );
     }
     for( int i = 0; i != stick_quan; ++i ) {
         item obj( itype_stick_long, calendar::turn );
         obj.set_var( "activity_var", p->name );
-        g->m.add_item_or_charges( pos, obj );
+        here.add_item_or_charges( pos, obj );
     }
     for( int i = 0; i != splint_quan; ++i ) {
         item obj( itype_splinter, calendar::turn );
         obj.set_var( "activity_var", p->name );
-        g->m.add_item_or_charges( pos, obj );
+        here.add_item_or_charges( pos, obj );
     }
-    g->m.ter_set( pos, t_dirt );
+    here.ter_set( pos, t_dirt );
     const int helpersize = p->get_crafting_helpers( 3 ).size();
     p->mod_stored_nutr( 5 - helpersize );
     p->mod_thirst( 5 - helpersize );
@@ -4235,12 +4262,13 @@ void activity_handlers::chop_planks_finish( player_activity *act, player *p )
     int scraps = rng( wasted_planks, wasted_planks * 3 );
     planks = std::min( planks, max_planks );
 
+    map &here = get_map();
     if( planks > 0 ) {
-        g->m.spawn_item( g->m.getlocal( act->placement ), itype_2x4, planks, 0, calendar::turn );
+        here.spawn_item( here.getlocal( act->placement ), itype_2x4, planks, 0, calendar::turn );
         p->add_msg_if_player( m_good, _( "You produce %d planks." ), planks );
     }
     if( scraps > 0 ) {
-        g->m.spawn_item( g->m.getlocal( act->placement ), itype_splinter, scraps, 0, calendar::turn );
+        here.spawn_item( here.getlocal( act->placement ), itype_splinter, scraps, 0, calendar::turn );
         p->add_msg_if_player( m_good, _( "You produce %d splinters." ), scraps );
     }
     if( planks < max_planks / 2 ) {
@@ -4252,10 +4280,11 @@ void activity_handlers::chop_planks_finish( player_activity *act, player *p )
 
 void activity_handlers::jackhammer_do_turn( player_activity *act, player * )
 {
+    map &here = get_map();
     sfx::play_activity_sound( "tool", "jackhammer",
-                              sfx::get_heard_volume( g->m.getlocal( act->placement ) ) );
+                              sfx::get_heard_volume( here.getlocal( act->placement ) ) );
     if( calendar::once_every( 1_minutes ) ) {
-        sounds::sound( g->m.getlocal( act->placement ), 15, sounds::sound_t::destructive_activity,
+        sounds::sound( here.getlocal( act->placement ), 15, sounds::sound_t::destructive_activity,
                        //~ Sound of a jackhammer at work!
                        _( "TATATATATATATAT!" ) );
     }
@@ -4263,9 +4292,10 @@ void activity_handlers::jackhammer_do_turn( player_activity *act, player * )
 
 void activity_handlers::jackhammer_finish( player_activity *act, player *p )
 {
-    const tripoint &pos = g->m.getlocal( act->placement );
+    map &here = get_map();
+    const tripoint &pos = here.getlocal( act->placement );
 
-    g->m.destroy( pos, true );
+    here.destroy( pos, true );
 
     if( p->is_avatar() ) {
         const int helpersize = g->u.get_crafting_helpers( 3 ).size();
@@ -4284,7 +4314,7 @@ void activity_handlers::jackhammer_finish( player_activity *act, player *p )
         debugmsg( "jackhammer activity targets empty" );
     }
     if( resume_for_multi_activities( *p ) ) {
-        for( item &elem : g->m.i_at( pos ) ) {
+        for( item &elem : here.i_at( pos ) ) {
             elem.set_var( "activity_var", p->name );
         }
     }
@@ -4302,14 +4332,15 @@ void activity_handlers::fill_pit_do_turn( player_activity *act, player * )
 void activity_handlers::fill_pit_finish( player_activity *act, player *p )
 {
     const tripoint &pos = act->placement;
-    const ter_id ter = g->m.ter( pos );
+    map &here = get_map();
+    const ter_id ter = here.ter( pos );
     const ter_id old_ter = ter;
 
     if( ter == t_pit || ter == t_pit_spiked || ter == t_pit_glass ||
         ter == t_pit_corpsed ) {
-        g->m.ter_set( pos, t_pit_shallow );
+        here.ter_set( pos, t_pit_shallow );
     } else {
-        g->m.ter_set( pos, t_dirt );
+        here.ter_set( pos, t_dirt );
     }
     const int helpersize = g->u.get_crafting_helpers( 3 ).size();
     p->mod_stored_nutr( 5 - helpersize );
@@ -4362,10 +4393,11 @@ template<typename fn>
 static void cleanup_tiles( std::unordered_set<tripoint> &tiles, fn &cleanup )
 {
     auto it = tiles.begin();
+    map &here = get_map();
     while( it != tiles.end() ) {
         auto current = it++;
 
-        const tripoint &tile_loc = g->m.getlocal( *current );
+        const tripoint &tile_loc = here.getlocal( *current );
 
         if( cleanup( tile_loc ) ) {
             tiles.erase( current );
@@ -4380,7 +4412,8 @@ static void perform_zone_activity_turn( player *p,
                                         const std::string &finished_msg )
 {
     const zone_manager &mgr = zone_manager::get_manager();
-    const tripoint abspos = g->m.getabs( p->pos() );
+    map &here = get_map();
+    const tripoint abspos = here.getabs( p->pos() );
     std::unordered_set<tripoint> unsorted_tiles = mgr.get_near( ztype, abspos );
 
     cleanup_tiles( unsorted_tiles, tile_filter );
@@ -4389,9 +4422,9 @@ static void perform_zone_activity_turn( player *p,
     const std::vector<tripoint> &tiles = get_sorted_tiles_by_distance( abspos, unsorted_tiles );
 
     for( const tripoint &tile : tiles ) {
-        const tripoint &tile_loc = g->m.getlocal( tile );
+        const tripoint &tile_loc = here.getlocal( tile );
 
-        std::vector<tripoint> route = g->m.route( p->pos(), tile_loc, p->get_pathfinding_settings(),
+        std::vector<tripoint> route = here.route( p->pos(), tile_loc, p->get_pathfinding_settings(),
                                       p->get_path_avoid() );
         if( route.size() > 1 ) {
             route.pop_back();

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -165,13 +165,14 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
     }
 
     const tripoint where = veh.global_part_pos3( part );
-    const std::string ter_name = g->m.name( where );
+    map &here = get_map();
+    const std::string ter_name = here.name( where );
     int fallen_count = 0;
     int into_vehicle_count = 0;
 
     // can't use constant reference here because of the spill_contents()
     for( auto it : items ) {
-        if( pickup::handle_spillable_contents( c, it, g->m ) ) {
+        if( pickup::handle_spillable_contents( c, it, here ) ) {
             continue;
         }
         if( veh.add_item( part, it ) ) {
@@ -183,7 +184,7 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
                 it.mod_charges( -charges_added );
                 into_vehicle_count += charges_added;
             }
-            g->m.add_item_or_charges( where, it );
+            here.add_item_or_charges( where, it );
             fallen_count += it.count();
         }
         it.handle_pickup_ownership( c );
@@ -279,16 +280,17 @@ static void stash_on_pet( const std::list<item> &items, monster &pet, Character 
 {
     units::volume remaining_volume = pet.storage_item->get_storage() - pet.get_carried_volume();
     units::mass remaining_weight = pet.weight_capacity() - pet.get_carried_weight();
+    map &here = get_map();
 
     for( const item &it : items ) {
         if( it.volume() > remaining_volume ) {
             add_msg( m_bad, _( "%1$s did not fit and fell to the %2$s." ), it.display_name(),
-                     g->m.name( pet.pos() ) );
-            g->m.add_item_or_charges( pet.pos(), it );
+                     here.name( pet.pos() ) );
+            here.add_item_or_charges( pet.pos(), it );
         } else if( it.weight() > remaining_weight ) {
             add_msg( m_bad, _( "%1$s is too heavy and fell to the %2$s." ), it.display_name(),
-                     g->m.name( pet.pos() ) );
-            g->m.add_item_or_charges( pet.pos(), it );
+                     here.name( pet.pos() ) );
+            here.add_item_or_charges( pet.pos(), it );
         } else {
             pet.add_item( it );
             remaining_volume -= it.volume();
@@ -305,8 +307,9 @@ void drop_on_map( Character &c, item_drop_reason reason, const std::list<item> &
     if( items.empty() ) {
         return;
     }
-    const std::string ter_name = g->m.name( where );
-    const bool can_move_there = g->m.passable( where );
+    map &here = get_map();
+    const std::string ter_name = here.name( where );
+    const bool can_move_there = here.passable( where );
 
     if( same_type( items ) ) {
         const item &it = items.front();
@@ -381,7 +384,7 @@ void drop_on_map( Character &c, item_drop_reason reason, const std::list<item> &
         }
     }
     for( auto &it : items ) {
-        g->m.add_item_or_charges( where, it );
+        here.add_item_or_charges( where, it );
         pass_to_ownership_handling( it, c );
     }
 }
@@ -394,7 +397,8 @@ void put_into_vehicle_or_drop( Character &c, item_drop_reason reason, const std:
 void put_into_vehicle_or_drop( Character &c, item_drop_reason reason, const std::list<item> &items,
                                const tripoint &where, bool force_ground )
 {
-    const cata::optional<vpart_reference> vp = g->m.veh_at( where ).part_with_feature( "CARGO", false );
+    map &here = get_map();
+    const cata::optional<vpart_reference> vp = here.veh_at( where ).part_with_feature( "CARGO", false );
     if( vp && !force_ground ) {
         put_into_vehicle( c, reason, items, vp->vehicle(), vp->part_index() );
         return;
@@ -890,7 +894,7 @@ static int move_cost( const item &it, const tripoint &src, const tripoint &dest 
     if( g->u.get_grab_type() == OBJECT_VEHICLE ) {
         tripoint cart_position = g->u.pos() + g->u.grab_point;
 
-        if( const cata::optional<vpart_reference> vp = g->m.veh_at(
+        if( const cata::optional<vpart_reference> vp = get_map().veh_at(
                     cart_position ).part_with_feature( "CARGO", false ) ) {
             const vehicle &veh = vp->vehicle();
             size_t vstor = vp->part_index();
@@ -907,7 +911,8 @@ static int move_cost( const item &it, const tripoint &src, const tripoint &dest 
 // return false if it was not possible.
 static bool vehicle_activity( player &p, const tripoint &src_loc, int vpindex, char type )
 {
-    vehicle *veh = veh_pointer_or_null( g->m.veh_at( src_loc ) );
+    map &here = get_map();
+    vehicle *veh = veh_pointer_or_null( here.veh_at( src_loc ) );
     if( !veh ) {
         return false;
     }
@@ -936,12 +941,12 @@ static bool vehicle_activity( player &p, const tripoint &src_loc, int vpindex, c
     // for someone else who stored that position at the start of their activity.
     // so we may need to go looking a bit further afield to find it , at activities end.
     for( const auto pt : veh->get_points( true ) ) {
-        p.activity.coord_set.insert( g->m.getabs( pt ) );
+        p.activity.coord_set.insert( here.getabs( pt ) );
     }
     // values[0]
-    p.activity.values.push_back( g->m.getabs( src_loc ).x );
+    p.activity.values.push_back( here.getabs( src_loc ).x );
     // values[1]
-    p.activity.values.push_back( g->m.getabs( src_loc ).y );
+    p.activity.values.push_back( here.getabs( src_loc ).y );
     // values[2]
     p.activity.values.push_back( point_zero.x );
     // values[3]
@@ -956,7 +961,7 @@ static bool vehicle_activity( player &p, const tripoint &src_loc, int vpindex, c
     // this would only be used for refilling tasks
     item_location target;
     p.activity.targets.emplace_back( std::move( target ) );
-    p.activity.placement = g->m.getabs( src_loc );
+    p.activity.placement = here.getabs( src_loc );
     p.activity_vehicle_part_index = -1;
     return true;
 }
@@ -977,6 +982,7 @@ static void move_item( player &p, item &it, const int quantity, const tripoint &
         leftovers.charges = 0;
     }
 
+    map &here = get_map();
     // Check that we can pick it up.
     if( !it.made_of( LIQUID ) ) {
         p.mod_moves( -move_cost( it, src, dest ) );
@@ -990,7 +996,7 @@ static void move_item( player &p, item &it, const int quantity, const tripoint &
         if( src_veh ) {
             src_veh->remove_item( src_part, &it );
         } else {
-            g->m.i_rem( src, &it );
+            here.i_rem( src, &it );
         }
     }
 
@@ -1001,7 +1007,7 @@ static void move_item( player &p, item &it, const int quantity, const tripoint &
                 debugmsg( "SortLoot: Source vehicle failed to receive leftover charges." );
             }
         } else {
-            g->m.add_item_or_charges( src, leftovers );
+            here.add_item_or_charges( src, leftovers );
         }
     }
 }
@@ -1009,9 +1015,10 @@ static void move_item( player &p, item &it, const int quantity, const tripoint &
 std::vector<tripoint> route_adjacent( const player &p, const tripoint &dest )
 {
     auto passable_tiles = std::unordered_set<tripoint>();
+    map &here = get_map();
 
-    for( const tripoint &tp : g->m.points_in_radius( dest, 1 ) ) {
-        if( tp != p.pos() && g->m.passable( tp ) ) {
+    for( const tripoint &tp : here.points_in_radius( dest, 1 ) ) {
+        if( tp != p.pos() && here.passable( tp ) ) {
             passable_tiles.emplace( tp );
         }
     }
@@ -1020,7 +1027,7 @@ std::vector<tripoint> route_adjacent( const player &p, const tripoint &dest )
 
     const auto &avoid = p.get_path_avoid();
     for( const tripoint &tp : sorted ) {
-        auto route = g->m.route( p.pos(), tp, p.get_pathfinding_settings(), avoid );
+        auto route = here.route( p.pos(), tp, p.get_pathfinding_settings(), avoid );
 
         if( !route.empty() ) {
             return route;
@@ -1041,8 +1048,9 @@ static activity_reason_info find_base_construction(
 {
     const construction &build = idx.obj();
     //already done?
-    const furn_id furn = g->m.furn( loc );
-    const ter_id ter = g->m.ter( loc );
+    map &here = get_map();
+    const furn_id furn = here.furn( loc );
+    const ter_id ter = here.ter( loc );
     if( !build.post_terrain.empty() ) {
         if( build.post_is_furniture ) {
             if( furn_id( build.post_terrain ) == furn ) {
@@ -1199,6 +1207,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
         }
         temp_inv += *elem;
     }
+    map &here = get_map();
     for( const tripoint &elem : loot_spots ) {
         // if we are searching for things to fetch, we can skip certain things.
         // if, however they are already near the work spot, then the crafting / inventory functions will have their own method to use or discount them.
@@ -1206,13 +1215,13 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
             // skip tiles in IGNORE zone and tiles on fire
             // (to prevent taking out wood off the lit brazier)
             // and inaccessible furniture, like filled charcoal kiln
-            if( mgr.has( zone_type_LOOT_IGNORE, g->m.getabs( elem ) ) ||
-                g->m.dangerous_field_at( elem ) ||
-                !g->m.can_put_items_ter_furn( elem ) ) {
+            if( mgr.has( zone_type_LOOT_IGNORE, here.getabs( elem ) ) ||
+                here.dangerous_field_at( elem ) ||
+                !here.can_put_items_ter_furn( elem ) ) {
                 continue;
             }
         }
-        for( const auto &elem2 : g->m.i_at( elem ) ) {
+        for( const auto &elem2 : here.i_at( elem ) ) {
             if( in_loot_zones && elem2.made_of( LIQUID ) ) {
                 continue;
             }
@@ -1226,7 +1235,7 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
             temp_inv += elem2;
         }
         if( !in_loot_zones ) {
-            if( const cata::optional<vpart_reference> vp = g->m.veh_at( elem ).part_with_feature( "CARGO",
+            if( const cata::optional<vpart_reference> vp = here.veh_at( elem ).part_with_feature( "CARGO",
                     false ) ) {
                 vehicle &src_veh = vp->vehicle();
                 int src_part = vp->part_index();
@@ -1238,8 +1247,8 @@ static bool are_requirements_nearby( const std::vector<tripoint> &loot_spots,
     }
     // use nearby welding rig without needing to drag it or position yourself on the right side of the vehicle.
     if( !found_welder ) {
-        for( const tripoint &elem : g->m.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
-            const optional_vpart_position vp = g->m.veh_at( elem );
+        for( const tripoint &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
+            const optional_vpart_position vp = here.veh_at( elem );
             if( vp ) {
                 vehicle &veh = vp->vehicle();
                 const cata::optional<vpart_reference> weldpart = vp.part_with_feature( "WELDRIG", true );
@@ -1277,10 +1286,11 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
     p.invalidate_crafting_inventory();
     zone_manager &mgr = zone_manager::get_manager();
     std::vector<zone_data> zones;
+    map &here = get_map();
     if( act == ACT_VEHICLE_DECONSTRUCTION ||
         act == ACT_VEHICLE_REPAIR ) {
         std::vector<int> already_working_indexes;
-        vehicle *veh = veh_pointer_or_null( g->m.veh_at( src_loc ) );
+        vehicle *veh = veh_pointer_or_null( here.veh_at( src_loc ) );
         if( !veh ) {
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
@@ -1295,16 +1305,16 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
             // If the NPC has an activity - make sure they're not duplicating work.
             tripoint guy_work_spot;
             if( guy.has_player_activity() && guy.activity.placement != tripoint_min ) {
-                guy_work_spot = g->m.getlocal( guy.activity.placement );
+                guy_work_spot = here.getlocal( guy.activity.placement );
             }
             // If their position or intended position or player position/intended position
             // then discount, don't need to move each other out of the way.
-            if( g->m.getlocal( g->u.activity.placement ) == src_loc ||
+            if( here.getlocal( g->u.activity.placement ) == src_loc ||
                 guy_work_spot == src_loc || guy.pos() == src_loc || ( p.is_npc() && g->u.pos() == src_loc ) ) {
                 return activity_reason_info::fail( do_activity_reason::ALREADY_WORKING );
             }
             if( guy_work_spot != tripoint_zero ) {
-                vehicle *other_veh = veh_pointer_or_null( g->m.veh_at( guy_work_spot ) );
+                vehicle *other_veh = veh_pointer_or_null( here.veh_at( guy_work_spot ) );
                 // working on same vehicle - store the index to check later.
                 if( other_veh && other_veh == veh && guy.activity_vehicle_part_index != -1 ) {
                     already_working_indexes.push_back( guy.activity_vehicle_part_index );
@@ -1395,7 +1405,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
         return activity_reason_info::fail( do_activity_reason::NO_ZONE );
     }
     if( act == ACT_MULTIPLE_MINE ) {
-        if( !g->m.has_flag( "MINEABLE", src_loc ) ) {
+        if( !here.has_flag( "MINEABLE", src_loc ) ) {
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
         std::vector<item *> mining_inv = p.items_with( []( const item & itm ) {
@@ -1409,7 +1419,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
         }
     }
     if( act == ACT_MULTIPLE_FISH ) {
-        if( !g->m.has_flag( flag_FISHABLE, src_loc ) ) {
+        if( !here.has_flag( flag_FISHABLE, src_loc ) ) {
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
         std::vector<item *> rod_inv = p.items_with( []( const item & itm ) {
@@ -1422,8 +1432,8 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
         }
     }
     if( act == ACT_MULTIPLE_CHOP_TREES ) {
-        if( g->m.has_flag( flag_TREE, src_loc ) || g->m.ter( src_loc ) == t_trunk ||
-            g->m.ter( src_loc ) == t_stump ) {
+        if( here.has_flag( flag_TREE, src_loc ) || here.ter( src_loc ) == t_trunk ||
+            here.ter( src_loc ) == t_stump ) {
             if( p.has_quality( qual_AXE ) ) {
                 return activity_reason_info::ok( do_activity_reason::NEEDS_TREE_CHOPPING );
             } else {
@@ -1437,7 +1447,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
         std::vector<item> corpses;
         int big_count = 0;
         int small_count = 0;
-        for( const auto &i : g->m.i_at( src_loc ) ) {
+        for( const auto &i : here.i_at( src_loc ) ) {
             // make sure nobody else is working on that corpse right now
             if( i.is_corpse() && !i.has_var( "activity_var" ) ) {
                 const mtype corpse = *i.get_mtype();
@@ -1450,9 +1460,9 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
             }
         }
         bool b_rack_present = false;
-        for( const tripoint &pt : g->m.points_in_radius( src_loc, 2 ) ) {
+        for( const tripoint &pt : here.points_in_radius( src_loc, 2 ) ) {
             const inventory &inv = p.crafting_inventory();
-            if( g->m.has_flag_furn( flag_BUTCHER_EQ, pt ) || inv.has_item_with( []( const item & it ) {
+            if( here.has_flag_furn( flag_BUTCHER_EQ, pt ) || inv.has_item_with( []( const item & it ) {
             return it.has_flag( "BUTCHER_RACK" );
             } ) ) {
                 b_rack_present = true;
@@ -1461,7 +1471,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
         if( !corpses.empty() ) {
             if( big_count > 0 && small_count == 0 ) {
                 const inventory &inv = p.crafting_inventory();
-                if( !b_rack_present || !( g->m.has_nearby_table( src_loc, PICKUP_RANGE ) ||
+                if( !b_rack_present || !( here.has_nearby_table( src_loc, PICKUP_RANGE ) ||
                 inv.has_item_with( []( const item & it ) {
                 return it.has_flag( "FLAT_SURFACE" );
                 } ) ) ) {
@@ -1486,7 +1496,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
     }
     if( act == ACT_MULTIPLE_CHOP_PLANKS ) {
         //are there even any logs there?
-        for( auto &i : g->m.i_at( src_loc ) ) {
+        for( auto &i : here.i_at( src_loc ) ) {
             if( i.typeId() == itype_log ) {
                 // do we have an axe?
                 if( p.has_quality( qual_AXE, 1 ) ) {
@@ -1499,8 +1509,8 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
         return activity_reason_info::fail( do_activity_reason::NO_ZONE );
     }
     if( act == ACT_TIDY_UP ) {
-        if( mgr.has_near( zone_type_LOOT_UNSORTED, g->m.getabs( src_loc ), distance ) ||
-            mgr.has_near( z_camp_storage, g->m.getabs( src_loc ), distance ) ) {
+        if( mgr.has_near( zone_type_LOOT_UNSORTED, here.getabs( src_loc ), distance ) ||
+            mgr.has_near( z_camp_storage, here.getabs( src_loc ), distance ) ) {
             return activity_reason_info::ok( do_activity_reason::CAN_DO_FETCH );
         }
         return activity_reason_info::fail( do_activity_reason::NO_ZONE );
@@ -1508,13 +1518,13 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
     if( act == ACT_MULTIPLE_CONSTRUCTION ) {
         const std::vector<construction> &list_constructions = get_constructions();
         zones = mgr.get_zones( zone_type_CONSTRUCTION_BLUEPRINT,
-                               g->m.getabs( src_loc ) );
-        const partial_con *part_con = g->m.partial_con_at( src_loc );
+                               here.getabs( src_loc ) );
+        const partial_con *part_con = here.partial_con_at( src_loc );
         cata::optional<construction_id> part_con_idx;
         if( part_con ) {
             part_con_idx = part_con->id;
         }
-        const map_stack stuff_there = g->m.i_at( src_loc );
+        const map_stack stuff_there = here.i_at( src_loc );
 
         // PICKUP_RANGE -1 because we will be adjacent to the spot when arriving.
         const inventory pre_inv = p.crafting_inventory( src_loc, PICKUP_RANGE - 1 );
@@ -1531,12 +1541,12 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
         }
     } else if( act == ACT_MULTIPLE_FARM ) {
         zones = mgr.get_zones( zone_type_FARM_PLOT,
-                               g->m.getabs( src_loc ) );
+                               here.getabs( src_loc ) );
         for( const zone_data &zone : zones ) {
-            if( g->m.has_flag_furn( flag_GROWTH_HARVEST, src_loc ) ) {
+            if( here.has_flag_furn( flag_GROWTH_HARVEST, src_loc ) ) {
                 // simple work, pulling up plants, nothing else required.
                 return activity_reason_info::ok( do_activity_reason::NEEDS_HARVESTING );
-            } else if( g->m.has_flag( flag_PLOWABLE, src_loc ) && !g->m.has_furn( src_loc ) ) {
+            } else if( here.has_flag( flag_PLOWABLE, src_loc ) && !here.has_furn( src_loc ) ) {
                 if( p.has_quality( qual_DIG, 1 ) ) {
                     // we have a shovel/hoe already, great
                     return activity_reason_info::ok( do_activity_reason::NEEDS_TILLING );
@@ -1544,9 +1554,9 @@ static activity_reason_info can_do_activity_there( const activity_id &act, playe
                     // we need a shovel/hoe
                     return activity_reason_info::fail( do_activity_reason::NEEDS_TILLING );
                 }
-            } else if( g->m.has_flag_ter_or_furn( flag_PLANTABLE, src_loc ) &&
+            } else if( here.has_flag_ter_or_furn( flag_PLANTABLE, src_loc ) &&
                        warm_enough_to_plant( src_loc ) ) {
-                if( g->m.has_items( src_loc ) ) {
+                if( here.has_items( src_loc ) ) {
                     return activity_reason_info::fail( do_activity_reason::BLOCKING_TILE );
                 } else {
                     // do we have the required seed on our person?
@@ -1592,13 +1602,14 @@ static void add_basecamp_storage_to_loot_zone_list( zone_manager &mgr, const tri
         player &p, std::vector<tripoint> &loot_zone_spots, std::vector<tripoint> &combined_spots )
 {
     if( npc *const guy = dynamic_cast<npc *>( &p ) ) {
+        map &here = get_map();
         if( guy->assigned_camp &&
-            mgr.has_near( z_camp_storage, g->m.getabs( src_loc ), ACTIVITY_SEARCH_DISTANCE ) ) {
+            mgr.has_near( z_camp_storage, here.getabs( src_loc ), ACTIVITY_SEARCH_DISTANCE ) ) {
             std::unordered_set<tripoint> bc_storage_set = mgr.get_near( zone_type_id( "CAMP_STORAGE" ),
-                    g->m.getabs( src_loc ), ACTIVITY_SEARCH_DISTANCE );
+                    here.getabs( src_loc ), ACTIVITY_SEARCH_DISTANCE );
             for( const tripoint &elem : bc_storage_set ) {
-                loot_zone_spots.push_back( g->m.getlocal( elem ) );
-                combined_spots.push_back( g->m.getlocal( elem ) );
+                loot_zone_spots.push_back( here.getlocal( elem ) );
+                combined_spots.push_back( here.getlocal( elem ) );
             }
         }
     }
@@ -1633,13 +1644,14 @@ static std::vector<std::tuple<tripoint, itype_id, int>> requirements_map( player
     std::vector<tripoint> already_there_spots;
     std::vector<tripoint> combined_spots;
     std::map<itype_id, int> total_map;
-    tripoint src_loc = g->m.getlocal( p.backlog.front().placement );
-    for( const tripoint &elem : g->m.points_in_radius( src_loc,
+    map &here = get_map();
+    tripoint src_loc = here.getlocal( p.backlog.front().placement );
+    for( const tripoint &elem : here.points_in_radius( src_loc,
             PICKUP_RANGE - 1 ) ) {
         already_there_spots.push_back( elem );
         combined_spots.push_back( elem );
     }
-    for( const tripoint &elem : mgr.get_point_set_loot( g->m.getabs( p.pos() ), distance,
+    for( const tripoint &elem : mgr.get_point_set_loot( here.getabs( p.pos() ), distance,
             p.is_npc() ) ) {
         // if there is a loot zone that's already near the work spot, we don't want it to be added twice.
         if( std::find( already_there_spots.begin(), already_there_spots.end(),
@@ -1673,7 +1685,7 @@ static std::vector<std::tuple<tripoint, itype_id, int>> requirements_map( player
     // will be filtered for amounts/charges afterwards.
     for( const tripoint &point_elem : pickup_task ? loot_spots : combined_spots ) {
         std::map<itype_id, int> temp_map;
-        for( const item &stack_elem : g->m.i_at( point_elem ) ) {
+        for( const item &stack_elem : here.i_at( point_elem ) ) {
             for( std::vector<item_comp> &elem : req_comps ) {
                 for( item_comp &comp_elem : elem ) {
                     if( comp_elem.type == stack_elem.typeId() ) {
@@ -1901,9 +1913,10 @@ static bool construction_activity( player &p, const zone_data * /*zone*/, const 
     partial_con pc;
     pc.id = built_chosen.id;
     pc.counter = 0;
+    map &here = get_map();
     // Set the trap that has the examine function
-    if( g->m.tr_at( src_loc ).loadid == tr_null ) {
-        g->m.trap_set( src_loc, tr_unfinished_construction );
+    if( here.tr_at( src_loc ).loadid == tr_null ) {
+        here.trap_set( src_loc, tr_unfinished_construction );
     }
     // Use up the components
     for( const std::vector<item_comp> &it : built_chosen.requirements->get_components() ) {
@@ -1911,13 +1924,13 @@ static bool construction_activity( player &p, const zone_data * /*zone*/, const 
         used.splice( used.end(), tmp );
     }
     pc.components = used;
-    g->m.partial_con_set( src_loc, pc );
+    here.partial_con_set( src_loc, pc );
     for( const std::vector<tool_comp> &it : built_chosen.requirements->get_tools() ) {
         p.consume_tools( it );
     }
     p.backlog.push_front( activity_to_restore );
     p.assign_activity( ACT_BUILD );
-    p.activity.placement = g->m.getabs( src_loc );
+    p.activity.placement = here.getabs( src_loc );
     return true;
 }
 
@@ -1925,27 +1938,28 @@ static bool tidy_activity( player &p, const tripoint &src_loc,
                            const activity_id &activity_to_restore, const int distance = ACTIVITY_SEARCH_DISTANCE )
 {
     auto &mgr = zone_manager::get_manager();
-    tripoint loot_abspos = g->m.getabs( src_loc );
+    map &here = get_map();
+    tripoint loot_abspos = here.getabs( src_loc );
     tripoint loot_src_lot;
     const auto &zone_src_set = mgr.get_near( zone_type_LOOT_UNSORTED, loot_abspos, distance );
     if( !zone_src_set.empty() ) {
         const auto &zone_src_sorted = get_sorted_tiles_by_distance( loot_abspos, zone_src_set );
         // Find the nearest unsorted zone to dump objects at
         for( auto &src_elem : zone_src_sorted ) {
-            if( !g->m.can_put_items_ter_furn( g->m.getlocal( src_elem ) ) ) {
+            if( !here.can_put_items_ter_furn( here.getlocal( src_elem ) ) ) {
                 continue;
             }
-            loot_src_lot = g->m.getlocal( src_elem );
+            loot_src_lot = here.getlocal( src_elem );
             break;
         }
     }
     if( loot_src_lot == tripoint_zero ) {
         return false;
     }
-    auto items_there = g->m.i_at( src_loc );
+    auto items_there = here.i_at( src_loc );
     vehicle *dest_veh;
     int dest_part;
-    if( const cata::optional<vpart_reference> vp = g->m.veh_at(
+    if( const cata::optional<vpart_reference> vp = here.veh_at(
                 loot_src_lot ).part_with_feature( "CARGO",
                         false ) ) {
         dest_veh = &vp->vehicle();
@@ -1962,7 +1976,7 @@ static bool tidy_activity( player &p, const tripoint &src_loc,
         }
     }
     // we are adjacent to an unsorted zone, we came here to just drop items we are carrying
-    if( mgr.has( zone_type_LOOT_UNSORTED, g->m.getabs( src_loc ) ) ) {
+    if( mgr.has( zone_type_LOOT_UNSORTED, here.getabs( src_loc ) ) ) {
         for( item *inv_elem : p.inv_dump() ) {
             if( inv_elem->has_var( "activity_var" ) ) {
                 inv_elem->erase_var( "activity_var" );
@@ -1977,16 +1991,17 @@ static bool tidy_activity( player &p, const tripoint &src_loc,
 static bool fetch_activity( player &p, const tripoint &src_loc,
                             const activity_id &activity_to_restore, const int distance = ACTIVITY_SEARCH_DISTANCE )
 {
-    if( !g->m.can_put_items_ter_furn( g->m.getlocal( p.backlog.front().coords.back() ) ) ) {
+    map &here = get_map();
+    if( !here.can_put_items_ter_furn( here.getlocal( p.backlog.front().coords.back() ) ) ) {
         return false;
     }
     const std::vector<std::tuple<tripoint, itype_id, int>> mental_map_2 = requirements_map( p,
             distance );
     int pickup_count = 1;
-    auto items_there = g->m.i_at( src_loc );
+    auto items_there = here.i_at( src_loc );
     vehicle *src_veh = nullptr;
     int src_part = 0;
-    if( const cata::optional<vpart_reference> vp = g->m.veh_at( src_loc ).part_with_feature( "CARGO",
+    if( const cata::optional<vpart_reference> vp = here.veh_at( src_loc ).part_with_feature( "CARGO",
             false ) ) {
         src_veh = &vp->vehicle();
         src_part = vp->part_index();
@@ -2000,7 +2015,7 @@ static bool fetch_activity( player &p, const tripoint &src_loc,
                 if( std::get<0>( elem ) == src_loc && veh_elem.typeId() == std::get<1>( elem ) ) {
                     if( !p.backlog.empty() && p.backlog.front().id() == ACT_MULTIPLE_CONSTRUCTION ) {
                         move_item( p, veh_elem, veh_elem.count_by_charges() ? std::get<2>( elem ) : 1, src_loc,
-                                   g->m.getlocal( p.backlog.front().coords.back() ), src_veh, src_part, activity_to_restore );
+                                   here.getlocal( p.backlog.front().coords.back() ), src_veh, src_part, activity_to_restore );
                         return true;
                     }
                 }
@@ -2014,7 +2029,7 @@ static bool fetch_activity( player &p, const tripoint &src_loc,
                 // construction/crafting tasks want the required item moved near the work spot.
                 if( !p.backlog.empty() && p.backlog.front().id() == ACT_MULTIPLE_CONSTRUCTION ) {
                     move_item( p, it, it.count_by_charges() ? std::get<2>( elem ) : 1, src_loc,
-                               g->m.getlocal( p.backlog.front().coords.back() ), src_veh, src_part, activity_to_restore );
+                               here.getlocal( p.backlog.front().coords.back() ), src_veh, src_part, activity_to_restore );
                     return true;
                     // other tasks want the tool picked up
                 } else if( !p.backlog.empty() && ( p.backlog.front().id() == ACT_MULTIPLE_FARM ||
@@ -2051,7 +2066,7 @@ static bool fetch_activity( player &p, const tripoint &src_loc,
                     items_there.erase( item_iter );
                     // If we didn't pick up a whole stack, put the remainder back where it came from.
                     if( leftovers.charges > 0 ) {
-                        g->m.add_item_or_charges( src_loc, leftovers );
+                        here.add_item_or_charges( src_loc, leftovers );
                     }
                     return true;
                 }
@@ -2070,7 +2085,8 @@ static bool fetch_activity( player &p, const tripoint &src_loc,
 static bool butcher_corpse_activity( player &p, const tripoint &src_loc,
                                      const do_activity_reason &reason )
 {
-    map_stack items = g->m.i_at( src_loc );
+    map &here = get_map();
+    map_stack items = here.i_at( src_loc );
     for( auto &elem : items ) {
         if( elem.is_corpse() && !elem.has_var( "activity_var" ) ) {
             const mtype corpse = *elem.get_mtype();
@@ -2080,7 +2096,7 @@ static bool butcher_corpse_activity( player &p, const tripoint &src_loc,
             elem.set_var( "activity_var", p.name );
             p.assign_activity( ACT_BUTCHER_FULL, 0, true );
             p.activity.targets.emplace_back( map_cursor( src_loc ), &elem );
-            p.activity.placement = g->m.getabs( src_loc );
+            p.activity.placement = here.getabs( src_loc );
             return true;
         }
     }
@@ -2096,13 +2112,14 @@ static bool chop_plank_activity( player &p, const tripoint &src_loc )
     if( best_qual->type->can_have_charges() ) {
         p.consume_charges( *best_qual, best_qual->type->charges_to_use() );
     }
-    for( auto &i : g->m.i_at( src_loc ) ) {
+    map &here = get_map();
+    for( auto &i : here.i_at( src_loc ) ) {
         if( i.typeId() == itype_log ) {
-            g->m.i_rem( src_loc, &i );
+            here.i_rem( src_loc, &i );
             int moves = to_moves<int>( 20_minutes );
             p.add_msg_if_player( _( "You cut the log into planks." ) );
             p.assign_activity( ACT_CHOP_PLANKS, moves, -1 );
-            p.activity.placement = g->m.getabs( src_loc );
+            p.activity.placement = here.getabs( src_loc );
             return true;
         }
     }
@@ -2129,9 +2146,10 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
     }
     int &num_processed = act.values[ 0 ];
 
-    const auto abspos = g->m.getabs( p.pos() );
+    map &here = get_map();
+    const auto abspos = here.getabs( p.pos() );
     auto &mgr = zone_manager::get_manager();
-    if( g->m.check_vehicle_zones( g->get_levz() ) ) {
+    if( here.check_vehicle_zones( g->get_levz() ) ) {
         mgr.cache_vzones();
     }
 
@@ -2151,9 +2169,9 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
             act.placement = src;
             act.coord_set.erase( src );
 
-            const auto &src_loc = g->m.getlocal( src );
-            if( !g->m.inbounds( src_loc ) ) {
-                if( !g->m.inbounds( p.pos() ) ) {
+            const auto &src_loc = here.getlocal( src );
+            if( !here.inbounds( src_loc ) ) {
+                if( !here.inbounds( p.pos() ) ) {
                     // p is implicitly an NPC that has been moved off the map, so reset the activity
                     // and unload them
                     p.cancel_activity();
@@ -2163,7 +2181,7 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
                     return;
                 }
                 std::vector<tripoint> route;
-                route = g->m.route( p.pos(), src_loc, p.get_pathfinding_settings(),
+                route = here.route( p.pos(), src_loc, p.get_pathfinding_settings(),
                                     p.get_path_avoid() );
                 if( route.empty() ) {
                     // can't get there, can't do anything, skip it
@@ -2179,16 +2197,16 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
             // (to prevent taking out wood off the lit brazier)
             // and inaccessible furniture, like filled charcoal kiln
             if( mgr.has( zone_type_LOOT_IGNORE, src ) ||
-                g->m.get_field( src_loc, fd_fire ) != nullptr ||
-                !g->m.can_put_items_ter_furn( src_loc ) ) {
+                here.get_field( src_loc, fd_fire ) != nullptr ||
+                !here.can_put_items_ter_furn( src_loc ) ) {
                 continue;
             }
 
             //nothing to sort?
-            const cata::optional<vpart_reference> vp = g->m.veh_at( src_loc ).part_with_feature( "CARGO",
+            const cata::optional<vpart_reference> vp = here.veh_at( src_loc ).part_with_feature( "CARGO",
                     false );
             if( ( !vp || vp->vehicle().get_items( vp->part_index() ).empty() )
-                && g->m.i_at( src_loc ).empty() ) {
+                && here.i_at( src_loc ).empty() ) {
                 continue;
             }
 
@@ -2201,8 +2219,8 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
 
                 // get either direct route or route to nearest adjacent tile if
                 // source tile is impassable
-                if( g->m.passable( src_loc ) ) {
-                    route = g->m.route( p.pos(), src_loc, p.get_pathfinding_settings(),
+                if( here.passable( src_loc ) ) {
+                    route = here.route( p.pos(), src_loc, p.get_pathfinding_settings(),
                                         p.get_path_avoid() );
                 } else {
                     // impassable source tile (locker etc.),
@@ -2238,7 +2256,7 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
     }
     if( stage == DO ) {
         const tripoint &src = act.placement;
-        const tripoint &src_loc = g->m.getlocal( src );
+        const tripoint &src_loc = here.getlocal( src );
 
         bool is_adjacent_or_closer = square_dist( p.pos(), src_loc ) <= 1;
         // before we move any item, check if player is at or
@@ -2256,7 +2274,7 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
         //Check source for cargo part
         //map_stack and vehicle_stack are different types but inherit from item_stack
         // TODO: use one for loop
-        if( const cata::optional<vpart_reference> vp = g->m.veh_at( src_loc ).part_with_feature( "CARGO",
+        if( const cata::optional<vpart_reference> vp = here.veh_at( src_loc ).part_with_feature( "CARGO",
                 false ) ) {
             src_veh = &vp->vehicle();
             src_part = vp->part_index();
@@ -2271,7 +2289,7 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
             src_veh = nullptr;
             src_part = -1;
         }
-        for( auto &it : g->m.i_at( src_loc ) ) {
+        for( auto &it : here.i_at( src_loc ) ) {
             if( !it.is_owned_by( p, true ) ) {
                 continue;
             }
@@ -2311,10 +2329,10 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
             const std::unordered_set<tripoint> &dest_set = mgr.get_near( id, abspos, ACTIVITY_SEARCH_DISTANCE,
                     &thisitem );
             for( const tripoint &dest : dest_set ) {
-                const tripoint &dest_loc = g->m.getlocal( dest );
+                const tripoint &dest_loc = here.getlocal( dest );
 
                 //Check destination for cargo part
-                if( const cata::optional<vpart_reference> vp = g->m.veh_at( dest_loc ).part_with_feature( "CARGO",
+                if( const cata::optional<vpart_reference> vp = here.veh_at( dest_loc ).part_with_feature( "CARGO",
                         false ) ) {
                     dest_veh = &vp->vehicle();
                     dest_part = vp->part_index();
@@ -2324,8 +2342,8 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
                 }
 
                 // skip tiles with inaccessible furniture, like filled charcoal kiln
-                if( !g->m.can_put_items_ter_furn( dest_loc ) ||
-                    static_cast<int>( g->m.i_at( dest_loc ).size() ) >= MAX_ITEM_IN_SQUARE ) {
+                if( !here.can_put_items_ter_furn( dest_loc ) ||
+                    static_cast<int>( here.i_at( dest_loc ).size() ) >= MAX_ITEM_IN_SQUARE ) {
                     continue;
                 }
 
@@ -2334,7 +2352,7 @@ void activity_on_turn_move_loot( player_activity &act, player &p )
                 if( dest_veh ) {
                     free_space = dest_veh->free_volume( dest_part );
                 } else {
-                    free_space = g->m.free_volume( dest_loc );
+                    free_space = here.free_volume( dest_loc );
                 }
                 // check free space at destination
                 if( free_space >= thisitem.volume() ) {
@@ -2423,14 +2441,15 @@ static bool chop_tree_activity( player &p, const tripoint &src_loc )
     if( best_qual->type->can_have_charges() ) {
         p.consume_charges( *best_qual, best_qual->type->charges_to_use() );
     }
-    const ter_id ter = g->m.ter( src_loc );
-    if( g->m.has_flag( flag_TREE, src_loc ) ) {
+    map &here = get_map();
+    const ter_id ter = here.ter( src_loc );
+    if( here.has_flag( flag_TREE, src_loc ) ) {
         p.assign_activity( ACT_CHOP_TREE, moves, -1, p.get_item_position( best_qual ) );
-        p.activity.placement = g->m.getabs( src_loc );
+        p.activity.placement = here.getabs( src_loc );
         return true;
     } else if( ter == t_trunk || ter == t_stump ) {
         p.assign_activity( ACT_CHOP_LOGS, moves, -1, p.get_item_position( best_qual ) );
-        p.activity.placement = g->m.getabs( src_loc );
+        p.activity.placement = here.getabs( src_loc );
         return true;
     }
     return false;
@@ -2478,7 +2497,7 @@ static zone_type_id get_zone_for_act( const tripoint &src_loc, const zone_manage
         ret = zone_type_MINING;
     }
     if( src_loc != tripoint_zero && act_id == ACT_FETCH_REQUIRED ) {
-        const zone_data *zd = mgr.get_zone_at( g->m.getabs( src_loc ) );
+        const zone_data *zd = mgr.get_zone_at( get_map().getabs( src_loc ) );
         if( zd ) {
             ret = zd->get_type();
         }
@@ -2496,18 +2515,19 @@ static std::unordered_set<tripoint> generic_multi_activity_locations( player &p,
 
     zone_manager &mgr = zone_manager::get_manager();
     const tripoint localpos = p.pos();
-    const tripoint abspos = g->m.getabs( localpos );
+    map &here = get_map();
+    const tripoint abspos = here.getabs( localpos );
     if( act_id == ACT_TIDY_UP ) {
         dark_capable = true;
         tripoint unsorted_spot;
         std::unordered_set<tripoint> unsorted_set = mgr.get_near( zone_type_LOOT_UNSORTED, abspos,
                 ACTIVITY_SEARCH_DISTANCE );
         if( !unsorted_set.empty() ) {
-            unsorted_spot = g->m.getlocal( random_entry( unsorted_set ) );
+            unsorted_spot = here.getlocal( random_entry( unsorted_set ) );
         }
         bool found_one_point = false;
         bool found_route = true;
-        for( const tripoint &elem : g->m.points_in_radius( localpos,
+        for( const tripoint &elem : here.points_in_radius( localpos,
                 ACTIVITY_SEARCH_DISTANCE ) ) {
             // There's no point getting the entire list of all items to tidy up now.
             // the activity will run again after pathing to the first tile anyway.
@@ -2522,11 +2542,11 @@ static std::unordered_set<tripoint> generic_multi_activity_locations( player &p,
             if( found_one_point ) {
                 break;
             }
-            for( const item &stack_elem : g->m.i_at( elem ) ) {
+            for( const item &stack_elem : here.i_at( elem ) ) {
                 if( stack_elem.has_var( "activity_var" ) && stack_elem.get_var( "activity_var", "" ) == p.name ) {
-                    const furn_t &f = g->m.furn( elem ).obj();
+                    const furn_t &f = here.furn( elem ).obj();
                     if( !f.has_flag( flag_PLANT ) ) {
-                        src_set.insert( g->m.getabs( elem ) );
+                        src_set.insert( here.getabs( elem ) );
                         found_one_point = true;
                         // only check for a valid path, as that is all that is needed to tidy something up.
                         if( square_dist( p.pos(), elem ) > 1 ) {
@@ -2544,7 +2564,7 @@ static std::unordered_set<tripoint> generic_multi_activity_locations( player &p,
             for( const item *inv_elem : p.inv_dump() ) {
                 if( inv_elem->has_var( "activity_var" ) ) {
                     // we've gone to tidy up all the things lying around, now tidy up the things we picked up.
-                    src_set.insert( g->m.getabs( unsorted_spot ) );
+                    src_set.insert( here.getabs( unsorted_spot ) );
                     break;
                 }
             }
@@ -2554,10 +2574,10 @@ static std::unordered_set<tripoint> generic_multi_activity_locations( player &p,
         src_set = mgr.get_near( zone_type_id( zone_type ), abspos, ACTIVITY_SEARCH_DISTANCE );
         // multiple construction will form a list of targets based on blueprint zones and unfinished constructions
         if( act_id == ACT_MULTIPLE_CONSTRUCTION ) {
-            for( const tripoint &elem : g->m.points_in_radius( localpos, ACTIVITY_SEARCH_DISTANCE ) ) {
-                partial_con *pc = g->m.partial_con_at( elem );
+            for( const tripoint &elem : here.points_in_radius( localpos, ACTIVITY_SEARCH_DISTANCE ) ) {
+                partial_con *pc = here.partial_con_at( elem );
                 if( pc ) {
-                    src_set.insert( g->m.getabs( elem ) );
+                    src_set.insert( here.getabs( elem ) );
                 }
             }
             // farming activities encompass tilling, planting, harvesting.
@@ -2573,21 +2593,21 @@ static std::unordered_set<tripoint> generic_multi_activity_locations( player &p,
                 ACTIVITY_SEARCH_DISTANCE );
         for( const auto &elem : mental_map ) {
             const tripoint &elem_point = std::get<0>( elem );
-            src_set.insert( g->m.getabs( elem_point ) );
+            src_set.insert( here.getabs( elem_point ) );
         }
     }
     // prune the set to remove tiles that are never gonna work out.
     const bool pre_dark_check = src_set.empty();
     for( auto it2 = src_set.begin(); it2 != src_set.end(); ) {
         // remove dangerous tiles
-        const tripoint set_pt = g->m.getlocal( *it2 );
-        if( g->m.dangerous_field_at( set_pt ) ) {
+        const tripoint set_pt = here.getlocal( *it2 );
+        if( here.dangerous_field_at( set_pt ) ) {
             it2 = src_set.erase( it2 );
             // remove tiles in darkness, if we aren't lit-up ourselves
         } else if( !dark_capable && p.fine_detail_vision_mod( set_pt ) > 4.0 ) {
             it2 = src_set.erase( it2 );
         } else if( act_id == ACT_MULTIPLE_FISH ) {
-            const ter_id terrain_id = g->m.ter( set_pt );
+            const ter_id terrain_id = here.ter( set_pt );
             if( !terrain_id.obj().has_flag( TFLAG_DEEP_WATER ) ) {
                 it2 = src_set.erase( it2 );
             } else {
@@ -2610,7 +2630,8 @@ static requirement_check_result generic_multi_activity_check_requirement( player
         const tripoint &src, const tripoint &src_loc, const std::unordered_set<tripoint> &src_set,
         const bool check_only = false )
 {
-    const tripoint abspos = g->m.getabs( p.pos() );
+    map &here = get_map();
+    const tripoint abspos = here.getabs( p.pos() );
     zone_manager &mgr = zone_manager::get_manager();
 
     bool &can_do_it = act_info.can_do;
@@ -2627,7 +2648,7 @@ static requirement_check_result generic_multi_activity_check_requirement( player
                                      act_id == ACT_MULTIPLE_FISH ||
                                      act_id == ACT_MULTIPLE_MINE ||
                                      ( act_id == ACT_MULTIPLE_CONSTRUCTION &&
-                                       !g->m.partial_con_at( src_loc ) );
+                                       !here.partial_con_at( src_loc ) );
     // some activities require the target tile to be part of a zone.
     // tidy up activity doesn't - it wants things that may not be in a zone already - things that may have been left lying around.
     if( needs_to_be_in_zone && !zone ) {
@@ -2671,7 +2692,7 @@ static requirement_check_result generic_multi_activity_check_requirement( player
             loot_zone_spots.push_back( elem );
             combined_spots.push_back( elem );
         }
-        for( const tripoint &elem : g->m.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
+        for( const tripoint &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
             combined_spots.push_back( elem );
         }
         add_basecamp_storage_to_loot_zone_list( mgr, src_loc, p, loot_zone_spots, combined_spots );
@@ -2689,7 +2710,7 @@ static requirement_check_result generic_multi_activity_check_requirement( player
             what_we_need = built_chosen.requirements;
         } else if( reason == do_activity_reason::NEEDS_VEH_DECONST ||
                    reason == do_activity_reason::NEEDS_VEH_REPAIR ) {
-            const vehicle *veh = veh_pointer_or_null( g->m.veh_at( src_loc ) );
+            const vehicle *veh = veh_pointer_or_null( here.veh_at( src_loc ) );
             // we already checked this in can_do_activity() but check again just incase.
             if( !veh ) {
                 p.activity_vehicle_part_index = 1;
@@ -2775,13 +2796,13 @@ static requirement_check_result generic_multi_activity_check_requirement( player
                 if( act_prev.coords.empty() ) {
                     std::vector<tripoint> local_src_set;
                     for( const tripoint &elem : src_set ) {
-                        local_src_set.push_back( g->m.getlocal( elem ) );
+                        local_src_set.push_back( here.getlocal( elem ) );
                     }
                     std::vector<tripoint> candidates;
-                    for( const tripoint &point_elem : g->m.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
+                    for( const tripoint &point_elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
                         // we don't want to place the components where they could interfere with our ( or someone else's ) construction spots
                         if( !p.sees( point_elem ) || ( std::find( local_src_set.begin(), local_src_set.end(),
-                                                       point_elem ) != local_src_set.end() ) || !g->m.can_put_items_ter_furn( point_elem ) ) {
+                                                       point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {
                             continue;
                         }
                         candidates.push_back( point_elem );
@@ -2792,7 +2813,7 @@ static requirement_check_result generic_multi_activity_check_requirement( player
                         check_npc_revert( p );
                         return SKIP_LOCATION;
                     }
-                    act_prev.coords.push_back( g->m.getabs( candidates[std::max( 0,
+                    act_prev.coords.push_back( here.getabs( candidates[std::max( 0,
                                                                       static_cast<int>( candidates.size() / 2 ) )] ) );
                 }
                 act_prev.placement = src;
@@ -2815,21 +2836,22 @@ static bool generic_multi_activity_do( player &p, const activity_id &act_id,
 
     const do_activity_reason &reason = act_info.reason;
     const zone_data *zone = mgr.get_zone_at( src, get_zone_for_act( src_loc, mgr, act_id ) );
+    map &here = get_map();
     // something needs to be done, now we are there.
     // it was here earlier, in the space of one turn, maybe it got harvested by someone else.
     if( reason == do_activity_reason::NEEDS_HARVESTING &&
-        g->m.has_flag_furn( flag_GROWTH_HARVEST, src_loc ) ) {
+        here.has_flag_furn( flag_GROWTH_HARVEST, src_loc ) ) {
         iexamine::harvest_plant( p, src_loc, true );
-    } else if( reason == do_activity_reason::NEEDS_TILLING && g->m.has_flag( flag_PLOWABLE, src_loc ) &&
-               p.has_quality( qual_DIG, 1 ) && !g->m.has_furn( src_loc ) ) {
+    } else if( reason == do_activity_reason::NEEDS_TILLING && here.has_flag( flag_PLOWABLE, src_loc ) &&
+               p.has_quality( qual_DIG, 1 ) && !here.has_furn( src_loc ) ) {
         p.assign_activity( ACT_CHURN, 18000, -1 );
         p.backlog.push_front( act_id );
         p.activity.placement = src;
         return false;
     } else if( reason == do_activity_reason::NEEDS_PLANTING &&
-               g->m.has_flag_ter_or_furn( flag_PLANTABLE, src_loc ) ) {
+               here.has_flag_ter_or_furn( flag_PLANTABLE, src_loc ) ) {
         std::vector<zone_data> zones = mgr.get_zones( zone_type_FARM_PLOT,
-                                       g->m.getabs( src_loc ) );
+                                       here.getabs( src_loc ) );
         for( const zone_data &zone : zones ) {
             const itype_id seed =
                 dynamic_cast<const plot_options &>( zone.get_options() ).get_seed();
@@ -2858,7 +2880,7 @@ static bool generic_multi_activity_do( player &p, const activity_id &act_id,
         }
     } else if( reason == do_activity_reason::CAN_DO_CONSTRUCTION ||
                reason == do_activity_reason::CAN_DO_PREREQ ) {
-        if( g->m.partial_con_at( src_loc ) ) {
+        if( here.partial_con_at( src_loc ) ) {
             p.backlog.push_front( act_id );
             p.assign_activity( ACT_BUILD );
             p.activity.placement = src;
@@ -2919,7 +2941,8 @@ static bool generic_multi_activity_do( player &p, const activity_id &act_id,
 
 bool generic_multi_activity_handler( player_activity &act, player &p, bool check_only )
 {
-    const tripoint abspos = g->m.getabs( p.pos() );
+    map &here = get_map();
+    const tripoint abspos = here.getabs( p.pos() );
     // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     activity_id activity_to_restore = act.id();
     // Nuke the current activity, leaving the backlog alone
@@ -2934,9 +2957,9 @@ bool generic_multi_activity_handler( player_activity &act, player &p, bool check
     // now loop through the work-spot tiles and judge whether its worth traveling to it yet
     // or if we need to fetch something first.
     for( const tripoint &src : src_sorted ) {
-        const tripoint &src_loc = g->m.getlocal( src );
-        if( !g->m.inbounds( src_loc ) && !check_only ) {
-            if( !g->m.inbounds( p.pos() ) ) {
+        const tripoint &src_loc = here.getlocal( src );
+        if( !here.inbounds( src_loc ) && !check_only ) {
+            if( !here.inbounds( p.pos() ) ) {
                 // p is implicitly an NPC that has been moved off the map, so reset the activity
                 // and unload them
                 p.assign_activity( activity_to_restore );
@@ -3035,10 +3058,11 @@ static cata::optional<tripoint> find_best_fire( const std::vector<tripoint> &fro
 {
     cata::optional<tripoint> best_fire;
     time_duration best_fire_age = 1_days;
+    map &here = get_map();
     for( const tripoint &pt : from ) {
-        field_entry *fire = g->m.get_field( pt, fd_fire );
+        field_entry *fire = here.get_field( pt, fd_fire );
         if( fire == nullptr || fire->get_field_intensity() > 1 ||
-            !g->m.clear_path( center, pt, PICKUP_RANGE, 1, 100 ) ) {
+            !here.clear_path( center, pt, PICKUP_RANGE, 1, 100 ) ) {
             continue;
         }
         time_duration fire_age = fire->get_field_age();
@@ -3048,7 +3072,7 @@ static cata::optional<tripoint> find_best_fire( const std::vector<tripoint> &fro
             best_fire_age = fire_age;
         }
         // If a contained fire exists, ignore any other fires
-        if( g->m.has_flag_furn( TFLAG_FIRE_CONTAINER, pt ) ) {
+        if( here.has_flag_furn( TFLAG_FIRE_CONTAINER, pt ) ) {
             return pt;
         }
     }
@@ -3058,15 +3082,17 @@ static cata::optional<tripoint> find_best_fire( const std::vector<tripoint> &fro
 
 static inline bool has_clear_path_to_pickup_items( const tripoint &from, const tripoint &to )
 {
-    return g->m.has_items( to ) &&
-           g->m.accessible_items( to ) &&
-           g->m.clear_path( from, to, PICKUP_RANGE, 1, 100 );
+    map &here = get_map();
+    return here.has_items( to ) &&
+           here.accessible_items( to ) &&
+           here.clear_path( from, to, PICKUP_RANGE, 1, 100 );
 }
 
 static cata::optional<tripoint> find_refuel_spot_zone( const tripoint &center )
 {
     const zone_manager &mgr = zone_manager::get_manager();
-    const tripoint center_abs = g->m.getabs( center );
+    map &here = get_map();
+    const tripoint center_abs = here.getabs( center );
 
     const std::unordered_set<tripoint> &tiles_abs_unordered =
         mgr.get_near( zone_type_source_firewood, center_abs, PICKUP_RANGE );
@@ -3074,7 +3100,7 @@ static cata::optional<tripoint> find_refuel_spot_zone( const tripoint &center )
         get_sorted_tiles_by_distance( center_abs, tiles_abs_unordered );
 
     for( const tripoint &tile_abs : tiles_abs ) {
-        const tripoint tile = g->m.getlocal( tile_abs );
+        const tripoint tile = here.getlocal( tile_abs );
         if( has_clear_path_to_pickup_items( center, tile ) ) {
             return tile;
         }
@@ -3088,7 +3114,7 @@ static cata::optional<tripoint> find_refuel_spot_trap( const std::vector<tripoin
 {
     const auto tile = std::find_if( from.begin(), from.end(), [center]( const tripoint & pt ) {
         // Hacky - firewood spot is a trap and it's ID-checked
-        return g->m.tr_at( pt ).id == tr_firewood_source
+        return get_map().tr_at( pt ).id == tr_firewood_source
                && has_clear_path_to_pickup_items( center, pt );
     } );
 
@@ -3111,6 +3137,7 @@ bool find_auto_consume( player &p, const bool food )
     static const std::string flag_MELTS( "MELTS" );
     static const std::string flag_EDIBLE_FROZEN( "EDIBLE_FROZEN" );
     const tripoint pos = p.pos();
+    map &here = get_map();
     zone_manager &mgr = zone_manager::get_manager();
     zone_type_id consume_type_zone( "" );
     if( food ) {
@@ -3118,10 +3145,10 @@ bool find_auto_consume( player &p, const bool food )
     } else {
         consume_type_zone = zone_type_id( "AUTO_DRINK" );
     }
-    if( g->m.check_vehicle_zones( g->get_levz() ) ) {
+    if( here.check_vehicle_zones( g->get_levz() ) ) {
         mgr.cache_vzones();
     }
-    const std::unordered_set<tripoint> &dest_set = mgr.get_near( consume_type_zone, g->m.getabs( pos ),
+    const std::unordered_set<tripoint> &dest_set = mgr.get_near( consume_type_zone, here.getabs( pos ),
             ACTIVITY_SEARCH_DISTANCE );
     if( dest_set.empty() ) {
         return false;
@@ -3131,7 +3158,7 @@ bool find_auto_consume( player &p, const bool food )
             continue;
         }
 
-        const optional_vpart_position vp = g->m.veh_at( g->m.getlocal( loc ) );
+        const optional_vpart_position vp = here.veh_at( g->m.getlocal( loc ) );
         std::vector<item *> items_here;
         if( vp ) {
             vehicle &veh = vp->vehicle();
@@ -3143,7 +3170,7 @@ bool find_auto_consume( player &p, const bool food )
                 }
             }
         } else {
-            map_stack mapitems = g->m.i_at( g->m.getlocal( loc ) );
+            map_stack mapitems = here.i_at( here.getlocal( loc ) );
             for( item &it : mapitems ) {
                 items_here.push_back( &it );
             }
@@ -3185,12 +3212,12 @@ bool find_auto_consume( player &p, const bool food )
             }
 
             p.mod_moves( -pickup::cost_to_move_item( p, *it ) * std::max( rl_dist( p.pos(),
-                         g->m.getlocal( loc ) ), 1 ) );
+                         here.getlocal( loc ) ), 1 ) );
             item_location item_loc;
             if( vp ) {
                 item_loc = item_location( vehicle_cursor( vp->vehicle(), vp->part_index() ), &comest );
             } else {
-                item_loc = item_location( map_cursor( g->m.getlocal( loc ) ), &comest );
+                item_loc = item_location( map_cursor( here.getlocal( loc ) ), &comest );
             }
             avatar_action::eat( g->u, item_loc );
             // eat() may have removed the item, so check its still there.
@@ -3212,7 +3239,8 @@ void try_fuel_fire( player_activity &act, player &p, const bool starting_fire )
     cata::optional<tripoint> best_fire = starting_fire ? act.placement : find_best_fire( adjacent,
                                          pos );
 
-    if( !best_fire || !g->m.accessible_items( *best_fire ) ) {
+    map &here = get_map();
+    if( !best_fire || !here.accessible_items( *best_fire ) ) {
         return;
     }
 
@@ -3225,13 +3253,13 @@ void try_fuel_fire( player_activity &act, player &p, const bool starting_fire )
     }
 
     // Special case: fire containers allow burning logs, so use them as fuel if fire is contained
-    bool contained = g->m.has_flag_furn( TFLAG_FIRE_CONTAINER, *best_fire );
+    bool contained = here.has_flag_furn( TFLAG_FIRE_CONTAINER, *best_fire );
     fire_data fd( 1, contained );
-    time_duration fire_age = g->m.get_field_age( *best_fire, fd_fire );
+    time_duration fire_age = here.get_field_age( *best_fire, fd_fire );
 
     // Maybe TODO: - refueling in the rain could use more fuel
     // First, simulate expected burn per turn, to see if we need more fuel
-    map_stack fuel_on_fire = g->m.i_at( *best_fire );
+    map_stack fuel_on_fire = here.i_at( *best_fire );
     for( item &it : fuel_on_fire ) {
         it.simulate_burn( fd );
         // Unconstrained fires grow below -50_minutes age
@@ -3251,7 +3279,7 @@ void try_fuel_fire( player_activity &act, player &p, const bool starting_fire )
     }
 
     // We need to move fuel from stash to fire
-    map_stack potential_fuel = g->m.i_at( *refuel_spot );
+    map_stack potential_fuel = here.i_at( *refuel_spot );
     for( item &it : potential_fuel ) {
         if( it.made_of( LIQUID ) ) {
             continue;


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "[DDA Port] Port code to use global getters instead of g->u and g->m"

#### Purpose of change
Reducing dependency on `game.h` and `game` class.

#### Describe the solution
This and following PRs are cherry-picks of corresponding DDA PRs.
This one is https://github.com/CleverRaven/Cataclysm-DDA/pull/41358
The idea is to use `get_map()`, `get_avatar()` and `get_player_character()` instead of including `game.h` just for `g->m` or `g->u`.
Cherry-picks are done somewhat loosely (parts of commits are dropped, parts are adapted for BN) since the divergence is quite noticeable at this point, so some usages of `g->u` or `g->m` may remain in the changed files.

#### Describe alternatives you've considered
Doing this manually, but that would produce even more merge conflicts down the line.

#### Testing
Compiles locally. No behavior changes intended.

#### Additional context
These are bound to cause merge conflicts with other open PRs, so in case they're interfering I'm fine with these being put off in favor of other changes.