### PR TITLE
everburning torch substitutes for torch

### DIFF
--- a/data/mods/Magiclysm/items/enchanted_misc.json
+++ b/data/mods/Magiclysm/items/enchanted_misc.json
@@ -92,6 +92,7 @@
     "name": { "str": "everburning torch", "str_pl": "everburning torches" },
     "copy-from": "mtorch_everburning",
     "revert_to": "mtorch_everburning",
+    "sub": "torch",
     "use_action": [
       { "type": "firestarter", "moves": 30 },
       {

--- a/data/mods/Magiclysm/items/enchanted_misc.json
+++ b/data/mods/Magiclysm/items/enchanted_misc.json
@@ -92,7 +92,7 @@
     "name": { "str": "everburning torch", "str_pl": "everburning torches" },
     "copy-from": "mtorch_everburning",
     "revert_to": "mtorch_everburning",
-    "sub": "torch",
+    "sub": "torch_lit",
     "use_action": [
       { "type": "firestarter", "moves": 30 },
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary


SUMMARY: Bugfixes "Everburning torch can substitute for a regular torch"


#### Purpose of change

The everburning torch can't be used as a torch/fire in crafting recipes right now, but it's a torch though so it should.

#### Describe the solution

Make it a substitute

#### Describe alternatives you've considered

Ignore it I guess

#### Testing

didn't bother, it's one very simple line

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
