### PR TITLE
Draw lower z levels

### DIFF
--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -11,6 +11,7 @@ int message_ttl;
 int message_cooldown;
 bool trigdist;
 bool fov_3d;
+bool static_z_effect = false;
 int fov_3d_z_range;
 bool tile_iso;
 bool pixel_minimap_option = false;

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -64,6 +64,9 @@ extern int fov_3d_z_range;
 /** Using isometric tileset. */
 extern bool tile_iso;
 
+/** Static z level effect. */
+extern bool static_z_effect;
+
 /**
  * Whether to show the pixel minimap. Always false for ncurses build,
  * but can be toggled during game in sdl build.

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1482,7 +1482,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
     for( decltype( &cata_tiles::draw_furniture ) f : final_drawing_layers ) {
         for( tile_render_info &p : draw_points ) {
-            ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, 0 );
+            ( this->*f )( {p.pos.xy(), center.z}, p.ll, p.height_3d, p.invisible, 0 );
         }
     }
     // display number of monsters to spawn in mapgen preview

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -456,11 +456,12 @@ bool tileset_loader::create_textures_from_tile_atlas( const SDL_Surface_Ptr &til
 
     /** perform color filter conversion here */
     using tiles_pixel_color_entry = std::tuple<std::vector<texture>*, std::string>;
-    std::array<tiles_pixel_color_entry, 5> tile_values_data = {{
+    std::array<tiles_pixel_color_entry, 6> tile_values_data = {{
             { std::make_tuple( &ts.tile_values, "color_pixel_none" ) },
             { std::make_tuple( &ts.shadow_tile_values, "color_pixel_grayscale" ) },
             { std::make_tuple( &ts.night_tile_values, "color_pixel_nightvision" ) },
             { std::make_tuple( &ts.overexposed_tile_values, "color_pixel_overexposed" ) },
+            { std::make_tuple( &ts.z_overlay_values, "color_pixel_zoverlay" ) },
             { std::make_tuple( &ts.memory_tile_values, tilecontext->memory_map_mode ) }
         }
     };
@@ -559,6 +560,7 @@ void tileset_loader::load_tileset( const std::string &img_path )
     extend_vector_by( ts.shadow_tile_values, expected_tilecount );
     extend_vector_by( ts.night_tile_values, expected_tilecount );
     extend_vector_by( ts.overexposed_tile_values, expected_tilecount );
+    extend_vector_by( ts.z_overlay_values, expected_tilecount );
     extend_vector_by( ts.memory_tile_values, expected_tilecount );
 
     for( const SDL_Rect sub_rect : output_range ) {
@@ -1075,7 +1077,7 @@ void tileset_loader::load_tile_spritelists( const JsonObject &entry,
 }
 
 struct tile_render_info {
-    const tripoint pos{};
+    tripoint pos{};
     // accumulator for 3d tallness of sprites rendered here so far;
     int height_3d = 0;
     lit_level ll;
@@ -1152,8 +1154,6 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     const int max_visible_x = ( g->u.posx() % SEEX ) + ( MAPSIZE - 1 ) * SEEX;
     const int max_visible_y = ( g->u.posy() % SEEY ) + ( MAPSIZE - 1 ) * SEEY;
 
-    const auto &ch = here.access_cache( center.z );
-
     // Map memory should be at least the size of the view range
     // so that new tiles can be memorized, and at least the size of the display
     // since at farthest zoom displayed area may be bigger than view range.
@@ -1166,8 +1166,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                                  std::max( s.y + o.y, max_visible_y )
                              );
     g->u.prepare_map_memory_region(
-        g->m.getabs( tripoint( min_mm_reg, center.z ) ),
-        g->m.getabs( tripoint( max_mm_reg, center.z ) )
+        here.getabs( tripoint( min_mm_reg, center.z ) ),
+        here.getabs( tripoint( max_mm_reg, center.z ) )
     );
 
     idle_animations.set_enabled( get_option<bool>( "ANIMATIONS" ) );
@@ -1209,9 +1209,11 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             }
         }
     }
+
+    std::vector<tile_render_info> draw_points;
+    int min_z = OVERMAP_HEIGHT;
+
     for( int row = min_row; row < max_row; row ++ ) {
-        std::vector<tile_render_info> draw_points;
-        draw_points.reserve( max_col );
         for( int col = min_col; col < max_col; col ++ ) {
             int temp_x;
             int temp_y;
@@ -1227,69 +1229,52 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 temp_x = col + o.x;
                 temp_y = row + o.y;
             }
-            const tripoint pos( temp_x, temp_y, center.z );
-            const int &x = pos.x;
-            const int &y = pos.y;
 
-            lit_level ll;
-            // invisible to normal eyes
-            bool invisible[5];
-            invisible[0] = false;
+            bool invis = ( temp_y < min_visible_y || temp_y > max_visible_y || temp_x < min_visible_x ||
+                           temp_x > max_visible_x ) &&
+                         ( has_memory_at( {temp_x, temp_y, center.z} ) || has_draw_override( {temp_x, temp_y, center.z} ) );
 
-            if( y < min_visible_y || y > max_visible_y || x < min_visible_x || x > max_visible_x ) {
-                if( has_memory_at( pos ) ) {
-                    ll = lit_level::MEMORIZED;
-                    invisible[0] = true;
-                } else if( has_draw_override( pos ) ) {
-                    ll = lit_level::DARK;
-                    invisible[0] = true;
-                } else {
-                    apply_vision_effects( pos, offscreen_type );
-                    continue;
-                }
-            } else {
-                ll = ch.visibility_cache[x][y];
-            }
+
 
             // Add scent value to the overlay_strings list for every visible tile when displaying scent
-            if( g->display_overlay_state( ACTION_DISPLAY_SCENT ) && !invisible[0] ) {
-                const int scent_value = g->scent.get( pos );
+            if( g->display_overlay_state( ACTION_DISPLAY_SCENT ) && !invis ) {
+                const int scent_value = g->scent.get( {temp_x, temp_y, center.z} );
                 if( scent_value > 0 ) {
-                    overlay_strings.emplace( player_to_screen( point( x, y ) ) + point( tile_width / 2, 0 ),
+                    overlay_strings.emplace( player_to_screen( point( temp_x, temp_y ) ) + point( tile_width / 2, 0 ),
                                              formatted_text( std::to_string( scent_value ), 8 + catacurses::yellow,
                                                      direction::NORTH ) );
                 }
             }
 
             // Add scent type to the overlay_strings list for every visible tile when displaying scent
-            if( g->display_overlay_state( ACTION_DISPLAY_SCENT_TYPE ) && !invisible[0] ) {
-                const scenttype_id scent_type = g->scent.get_type( pos );
+            if( g->display_overlay_state( ACTION_DISPLAY_SCENT_TYPE ) && !invis ) {
+                const scenttype_id scent_type = g->scent.get_type( {temp_x, temp_y, center.z} );
                 if( !scent_type.is_empty() ) {
-                    overlay_strings.emplace( player_to_screen( point( x, y ) ) + point( tile_width / 2, 0 ),
+                    overlay_strings.emplace( player_to_screen( point( temp_x, temp_y ) ) + point( tile_width / 2, 0 ),
                                              formatted_text( scent_type.c_str(), 8 + catacurses::yellow,
                                                      direction::NORTH ) );
                 }
             }
 
             if( g->display_overlay_state( ACTION_DISPLAY_RADIATION ) ) {
-                const auto rad_override = radiation_override.find( pos );
+                const auto rad_override = radiation_override.find( {temp_x, temp_y, center.z} );
                 const bool rad_overridden = rad_override != radiation_override.end();
-                if( rad_overridden || !invisible[0] ) {
-                    const int rad_value = rad_overridden ? rad_override->second : here.get_radiation( pos );
+                if( rad_overridden || !invis ) {
+                    const int rad_value = rad_overridden ? rad_override->second : here.get_radiation( {temp_x, temp_y, center.z} );
                     catacurses::base_color col;
                     if( rad_value > 0 ) {
                         col = catacurses::green;
                     } else {
                         col = catacurses::cyan;
                     }
-                    overlay_strings.emplace( player_to_screen( point( x, y ) ) + point( tile_width / 2, 0 ),
+                    overlay_strings.emplace( player_to_screen( point( temp_x, temp_y ) ) + point( tile_width / 2, 0 ),
                                              formatted_text( std::to_string( rad_value ), 8 + col, direction::NORTH ) );
                 }
             }
 
             // Add temperature value to the overlay_strings list for every visible tile when displaying temperature
-            if( g->display_overlay_state( ACTION_DISPLAY_TEMPERATURE ) && !invisible[0] ) {
-                int temp_value = get_weather().get_temperature( pos );
+            if( g->display_overlay_state( ACTION_DISPLAY_TEMPERATURE ) && !invis ) {
+                int temp_value = get_weather().get_temperature( {temp_x, temp_y, center.z} );
                 int ctemp = units::fahrenheit_to_celsius( temp_value );
                 short color;
                 const short bold = 8;
@@ -1312,25 +1297,25 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     temp_value = units::fahrenheit_to_kelvin( temp_value );
 
                 }
-                overlay_strings.emplace( player_to_screen( point( x, y ) ) + point( tile_width / 2, 0 ),
+                overlay_strings.emplace( player_to_screen( point( temp_x, temp_y ) ) + point( tile_width / 2, 0 ),
                                          formatted_text( std::to_string( temp_value ), color,
                                                  direction::NORTH ) );
             }
 
             if( g->display_overlay_state( ACTION_DISPLAY_VISIBILITY ) &&
-                g->displaying_visibility_creature && !invisible[0] ) {
-                const bool visibility = g->displaying_visibility_creature->sees( pos );
+                g->displaying_visibility_creature && !invis ) {
+                const bool visibility = g->displaying_visibility_creature->sees( {temp_x, temp_y, center.z} );
 
                 // color overlay.
                 auto block_color = visibility ? windowsPalette[catacurses::green] : SDL_Color{ 192, 192, 192, 255 };
                 block_color.a = 100;
                 color_blocks.first = SDL_BLENDMODE_BLEND;
-                color_blocks.second.emplace( player_to_screen( point( x, y ) ), block_color );
+                color_blocks.second.emplace( player_to_screen( point( temp_x, temp_y ) ), block_color );
 
                 // overlay string
                 std::string visibility_str = visibility ? "+" : "-";
                 overlay_strings.emplace(
-                    player_to_screen( point( x, y ) ) + point( tile_width / 4, tile_height / 4 ),
+                    player_to_screen( point( temp_x, temp_y ) ) + point( tile_width / 4, tile_height / 4 ),
                     formatted_text( visibility_str, catacurses::black, direction::NORTH ) );
             }
 
@@ -1342,7 +1327,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     SDL_Color blue = { 0, 0, 255, 255 };
                     lighting_colors = color_linear_interpolate( white, blue, 9 );
                 }
-                point tile_pos = player_to_screen( point( x, y ) );
+                point tile_pos = player_to_screen( point( temp_x, temp_y ) );
 
                 // color overlay
                 SDL_Color color = lighting_colors[std::min( std::max( 0, color_hue ), 10 )];
@@ -1357,7 +1342,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
             if( g->display_overlay_state( ACTION_DISPLAY_LIGHTING ) ) {
                 if( g->displaying_lighting_condition == 0 ) {
-                    const float light = here.ambient_light_at( {x, y, center.z} );
+                    const float light = here.ambient_light_at( {temp_x, temp_y, center.z} );
                     // note: lighting will be constrained in the [1.0, 11.0] range.
                     int intensity = static_cast<int>( std::max( 1.0, LIGHT_AMBIENT_LIT - light + 1.0 ) ) - 1;
                     draw_debug_tile( intensity, string_format( "%.1f", light ) );
@@ -1365,65 +1350,143 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             }
 
             if( g->display_overlay_state( ACTION_DISPLAY_TRANSPARENCY ) ) {
-                const float tr = here.light_transparency( {x, y, center.z} );
+                const float tr = here.light_transparency( {temp_x, temp_y, center.z} );
                 int intensity =  tr <= LIGHT_TRANSPARENCY_SOLID ? 10 :  static_cast<int>
                                  ( ( tr - LIGHT_TRANSPARENCY_OPEN_AIR ) * 8 );
                 draw_debug_tile( intensity, string_format( "%.2f", tr ) );
             }
 
-            if( !invisible[0] && apply_vision_effects( pos, here.get_visibility( ll, cache ) ) ) {
-                const Creature *critter = g->critter_at( pos, true );
-                if( has_draw_override( pos ) || has_memory_at( pos ) ||
-                    ( critter && ( g->u.sees_with_infrared( *critter ) || g->u.sees_with_specials( *critter ) ) ) ) {
+            lit_level ll = lit_level::BLANK;
+            for( int z = center.z; z > -OVERMAP_DEPTH; z-- ) {
+                const auto &ch = here.access_cache( z );
 
-                    invisible[0] = true;
-                } else {
-                    continue;
+                const tripoint pos( temp_x, temp_y, z );
+                const int &x = pos.x;
+                const int &y = pos.y;
+
+                bool in_vis_bounds = ( y >= min_visible_y && y <= max_visible_y && x >= min_visible_x &&
+                                       x <= max_visible_x );
+
+                bool in_map_bounds = here.inbounds( pos );
+
+                if( ( fov_3d || z == center.z ) && in_map_bounds ) {
+                    ll = ch.visibility_cache[x][y];
                 }
-            }
-            for( int i = 0; i < 4; i++ ) {
-                const tripoint np = pos + neighborhood[i];
-                invisible[1 + i] = np.y < min_visible_y || np.y > max_visible_y ||
-                                   np.x < min_visible_x || np.x > max_visible_x ||
-                                   would_apply_vision_effects( here.get_visibility( ch.visibility_cache[np.x][np.y], cache ) );
-            }
 
-            int height_3d = 0;
+                const auto low_override = draw_below_override.find( pos );
+                const bool low_overridden = low_override != draw_below_override.end();
+                if( low_overridden ? !low_override->second :
+                    ( ( ( in_map_bounds && here.dont_draw_lower_floor( pos ) )
+                        || ( !in_map_bounds && ( has_memory_at( pos ) || pos.z <= 0 ) ) )
+                      || ( fov_3d && in_map_bounds && ll != lit_level::BLANK
+                           && here.access_cache( z - 1 ).visibility_cache[pos.x][pos.y] == lit_level::BLANK ) ) ) {
+                    // invisible to normal eyes
+                    bool invisible[5];
+                    invisible[0] = false;
 
-            // light level is now used for choosing between grayscale filter and normal lit tiles.
-            draw_terrain( pos, ll, height_3d, invisible );
-
-            draw_points.emplace_back( pos, height_3d, ll, invisible );
-        }
-        const std::array<decltype( &cata_tiles::draw_furniture ), 11> drawing_layers = {{
-                &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap,
-                &cata_tiles::draw_field_or_item, &cata_tiles::draw_vpart_below,
-                &cata_tiles::draw_critter_at_below, &cata_tiles::draw_terrain_below,
-                &cata_tiles::draw_vpart, &cata_tiles::draw_critter_at,
-                &cata_tiles::draw_zone_mark, &cata_tiles::draw_zombie_revival_indicators
-            }
-        };
-        // for each of the drawing layers in order, back to front ...
-        for( auto f : drawing_layers ) {
-            // ... draw all the points we drew terrain for, in the same order
-            for( auto &p : draw_points ) {
-                ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible );
-            }
-        }
-        // display number of monsters to spawn in mapgen preview
-        for( const auto &p : draw_points ) {
-            const auto mon_override = monster_override.find( p.pos );
-            if( mon_override != monster_override.end() ) {
-                const int count = std::get<1>( mon_override->second );
-                const bool more = std::get<2>( mon_override->second );
-                if( count > 1 || more ) {
-                    std::string text = "x" + std::to_string( count );
-                    if( more ) {
-                        text += "+";
+                    if( !in_vis_bounds ) {
+                        if( has_memory_at( pos ) ) {
+                            ll = lit_level::MEMORIZED;
+                            invisible[0] = true;
+                        } else if( has_draw_override( pos ) ) {
+                            ll = lit_level::DARK;
+                            invisible[0] = true;
+                        } else {
+                            apply_vision_effects( pos, offscreen_type );
+                            break;
+                        }
                     }
-                    overlay_strings.emplace( player_to_screen( p.pos.xy() ) + point( tile_width / 2, 0 ),
-                                             formatted_text( text, catacurses::red, direction::NORTH ) );
+
+                    int height_3d = 0;
+
+                    for( int i = 0; i < 4; i++ ) {
+                        const tripoint np = pos + neighborhood[i];
+                        invisible[1 + i] = np.y < min_visible_y || np.y > max_visible_y ||
+                                           np.x < min_visible_x || np.x > max_visible_x ||
+                                           would_apply_vision_effects( here.get_visibility( ch.visibility_cache[np.x][np.y], cache ) );
+                    }
+
+                    if( !invisible[0] && apply_vision_effects( pos, here.get_visibility( ll, cache ) ) ) {
+                        if( has_draw_override( pos ) || has_memory_at( pos ) ) {
+                            invisible[0] = true;
+                        }
+                        for( int cz = pos.z; !invisible[0] && cz <= -center.z; cz++ ) {
+                            const Creature *critter = g->critter_at( {pos.xy(), cz}, true );
+                            if( critter && ( g->u.sees_with_infrared( *critter ) ||
+                                             g->u.sees_with_specials( *critter ) ) ) {
+                                invisible[0] = true;
+                            }
+                        }
+                        if( invisible[0] ) {
+                            min_z = std::min( pos.z, min_z );
+                            draw_points.emplace_back( pos, height_3d, ll, invisible );
+                        }
+
+                    } else {
+                        min_z = std::min( pos.z, min_z );
+                        draw_points.emplace_back( pos, height_3d, ll, invisible );
+                    }
+                    break;
                 }
+            }
+        }
+    }
+
+    const std::array<decltype( &cata_tiles::draw_furniture ), 4> base_drawing_layers = {{
+            &cata_tiles::draw_terrain, &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap
+        }
+    };
+    const std::array<decltype( &cata_tiles::draw_furniture ), 3> zlevel_drawing_layers = {{
+            &cata_tiles::draw_field_or_item, &cata_tiles::draw_vpart, &cata_tiles::draw_critter_at
+        }
+    };
+    const std::array<decltype( &cata_tiles::draw_furniture ), 2> final_drawing_layers = {{
+            &cata_tiles::draw_zone_mark, &cata_tiles::draw_zombie_revival_indicators
+        }
+    };
+
+    auto compare_z = [&]( tile_render_info a, tile_render_info b ) -> bool {
+        return ( a.pos.z < b.pos.z );
+    };
+
+    std::stable_sort( draw_points.begin(), draw_points.end(), compare_z );
+
+    for( decltype( &cata_tiles::draw_furniture ) f : base_drawing_layers ) {
+        for( auto &p : draw_points ) {
+            ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, center.z - p.pos.z );
+        }
+    }
+
+    for( int z = min_z; z <= center.z; z++ ) {
+        for( decltype( &cata_tiles::draw_furniture ) f : zlevel_drawing_layers ) {
+            for( auto &p : draw_points ) {
+                if( p.pos.z > z ) {
+                    break;
+                }
+
+                ( this->*f )( {p.pos.xy(), z}, p.ll, p.height_3d, p.invisible, center.z - z );
+            }
+        }
+    }
+
+    for( decltype( &cata_tiles::draw_furniture ) f : final_drawing_layers ) {
+        for( auto &p : draw_points ) {
+            ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible, 0 );
+        }
+    }
+    // display number of monsters to spawn in mapgen preview
+    for( const auto &p : draw_points ) {
+        const auto mon_override = monster_override.find( p.pos );
+        if( mon_override != monster_override.end() ) {
+            const int count = std::get<1>( mon_override->second );
+            const bool more = std::get<2>( mon_override->second );
+            if( count > 1 || more ) {
+                std::string text = "x" + std::to_string( count );
+                if( more ) {
+                    text += "+";
+                }
+                overlay_strings.emplace( player_to_screen( p.pos.xy() ) + point( tile_width / 2, 0 ),
+                                         formatted_text( text, catacurses::red, direction::NORTH ) );
             }
         }
     }
@@ -1470,8 +1533,27 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     continue;
                 }
             }
-            const tripoint p( mem_x, mem_y, center.z );
-            lit_level lighting = ch.visibility_cache[p.x][p.y];
+
+            lit_level lighting = here.access_cache( center.z ).visibility_cache[mem_x][mem_y];
+
+            int z = center.z;
+            for( ;  z > -OVERMAP_DEPTH; z-- ) {
+                const auto low_override = draw_below_override.find( {mem_x, mem_y, z} );
+                const bool low_overridden = low_override != draw_below_override.end();
+                if( low_overridden ? !low_override->second : ( here.dont_draw_lower_floor( {mem_x, mem_y, z} )
+                        || ( fov_3d && lighting != lit_level::BLANK &&
+                             here.access_cache( z - 1 ).visibility_cache[mem_x][mem_y] == lit_level::BLANK ) ) ) {
+                    if( fov_3d ) {
+                        lighting = here.access_cache( z ).visibility_cache[mem_x][mem_y];
+                    }
+                    break;
+                }
+            }
+
+
+            const auto &ch = here.access_cache( z );
+            const tripoint p( mem_x, mem_y, z );
+
             if( apply_vision_effects( p, here.get_visibility( lighting, cache ) ) ) {
                 continue;
             }
@@ -1486,11 +1568,11 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             }
             //calling draw to memorize everything.
             //bypass cache check in case we learn something new about the terrain's connections
-            draw_terrain( p, lighting, height_3d, invisible );
+            draw_terrain( p, lighting, height_3d, invisible, 0 );
             if( here.check_seen_cache( p ) ) {
-                draw_furniture( p, lighting, height_3d, invisible );
-                draw_trap( p, lighting, height_3d, invisible );
-                draw_vpart( p, lighting, height_3d, invisible );
+                draw_furniture( p, lighting, height_3d, invisible, 0 );
+                draw_trap( p, lighting, height_3d, invisible, 0 );
+                draw_vpart( p, lighting, height_3d, invisible, 0 );
                 here.check_and_set_seen_cache( p );
             }
         }
@@ -1547,23 +1629,23 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         // check to see if player is located at ter
         draw_from_id_string( "cursor", C_NONE, empty_string,
                              tripoint( g->ter_view_p.xy(), center.z ), 0, 0, lit_level::LIT,
-                             false );
+                             false, 0 );
     }
     if( g->u.controlling_vehicle ) {
         if( cata::optional<tripoint> indicator_offset = g->get_veh_dir_indicator_location( true ) ) {
             draw_from_id_string( "cursor", C_NONE, empty_string, indicator_offset->xy() + tripoint( g->u.posx(),
                                  g->u.posy(), center.z ),
-                                 0, 0, lit_level::LIT, false );
+                                 0, 0, lit_level::LIT, false, 0 );
         }
     }
 
     if( g->debug_submap_grid_overlay && !iso_mode ) {
-        point sm_start = ms_to_sm_copy( g->m.getabs( point( min_col, min_row ) + o ) );
-        point sm_end = ms_to_sm_copy( g->m.getabs( point( max_col, max_row ) + o ) );
+        point sm_start = ms_to_sm_copy( here.getabs( point( min_col, min_row ) + o ) );
+        point sm_end = ms_to_sm_copy( here.getabs( point( max_col, max_row ) + o ) );
 
-        bool zlevs = g->m.has_zlevels();
-        int mapsize = g->m.getmapsize();
-        tripoint mappos = g->m.get_abs_sub();
+        bool zlevs = here.has_zlevels();
+        int mapsize = here.getmapsize();
+        tripoint mappos = here.get_abs_sub();
         half_open_rectangle<point> maprect( mappos.xy(), mappos.xy() + point( mapsize, mapsize ) );
 
         const auto is_map = [mappos, zlevs, maprect]( const tripoint & p ) {
@@ -1586,8 +1668,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             for( int sm_y = sm_start.y; sm_y <= sm_end.y; sm_y++ ) {
                 point sm_p = point( sm_x, sm_y );
                 tripoint sm_tp = tripoint( sm_x, sm_y, center.z );
-                point p1 = player_to_screen( g->m.getlocal( sm_to_ms_copy( sm_p ) ) );
-                point p3 = player_to_screen( g->m.getlocal( sm_to_ms_copy( sm_p + point_south_east ) ) );
+                point p1 = player_to_screen( here.getlocal( sm_to_ms_copy( sm_p ) ) );
+                point p3 = player_to_screen( here.getlocal( sm_to_ms_copy( sm_p + point_south_east ) ) );
                 p3 -= point( THICC, THICC ); // Don't draw over other lines
 
                 // Leave a small gap to indicate omt boundaries
@@ -1648,27 +1730,27 @@ void cata_tiles::get_window_tile_counts( const int width, const int height, int 
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, const tripoint &pos, int subtile,
-                                      int rota, lit_level ll, bool apply_night_vision_goggles )
+                                      int rota, lit_level ll, bool apply_night_vision_goggles, int overlay_count )
 {
     int nullint = 0;
     return cata_tiles::draw_from_id_string( id, C_NONE, empty_string, pos, subtile, rota,
-                                            ll, apply_night_vision_goggles, nullint );
+                                            ll, apply_night_vision_goggles, nullint, overlay_count );
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                       const std::string &subcategory, const tripoint &pos,
-                                      int subtile, int rota, lit_level ll, bool apply_night_vision_goggles )
+                                      int subtile, int rota, lit_level ll, bool apply_night_vision_goggles, int overlay_count )
 {
     int nullint = 0;
     return cata_tiles::draw_from_id_string( id, category, subcategory, pos, subtile, rota,
-                                            ll, apply_night_vision_goggles, nullint );
+                                            ll, apply_night_vision_goggles, nullint, overlay_count );
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, const tripoint &pos, int subtile,
-                                      int rota, lit_level ll, bool apply_night_vision_goggles, int &height_3d )
+                                      int rota, lit_level ll, bool apply_night_vision_goggles, int &height_3d, int overlay_count )
 {
     return cata_tiles::draw_from_id_string( id, C_NONE, empty_string, pos, subtile, rota,
-                                            ll, apply_night_vision_goggles, height_3d );
+                                            ll, apply_night_vision_goggles, height_3d, overlay_count );
 }
 
 cata::optional<tile_lookup_res>
@@ -1816,7 +1898,7 @@ bool cata_tiles::find_overlay_looks_like( const bool male, const std::string &ov
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                       const std::string &subcategory, const tripoint &pos,
                                       int subtile, int rota, lit_level ll,
-                                      bool apply_night_vision_goggles, int &height_3d )
+                                      bool apply_night_vision_goggles, int &height_3d, int overlay_count )
 {
     // If the ID string does not produce a drawable tile
     // it will revert to the "unknown" tile.
@@ -1979,13 +2061,13 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
             }
             if( tileset_ptr->find_tile_type( generic_id ) ) {
                 return draw_from_id_string( generic_id, pos, subtile, rota,
-                                            ll, apply_night_vision_goggles );
+                                            ll, apply_night_vision_goggles, overlay_count );
             }
             // Try again without color this time (using default color).
             generic_id = get_ascii_tile_id( sym, -1, -1 );
             if( tileset_ptr->find_tile_type( generic_id ) ) {
                 return draw_from_id_string( generic_id, pos, subtile, rota,
-                                            ll, apply_night_vision_goggles );
+                                            ll, apply_night_vision_goggles, overlay_count );
             }
         }
     }
@@ -2025,7 +2107,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
             // append subtile name to tile and re-find display_tile
             return draw_from_id_string( found_id + "_" + multitile_keys[subtile],
                                         category, subcategory, pos, -1, rota, ll, apply_night_vision_goggles,
-                                        height_3d );
+                                        height_3d, overlay_count );
         }
     }
 
@@ -2183,7 +2265,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
 
     //draw it!
     draw_tile_at( display_tile, screen_pos, loc_rand, rota, ll,
-                  apply_night_vision_goggles, height_3d );
+                  apply_night_vision_goggles, height_3d, overlay_count );
 
     return true;
 }
@@ -2191,17 +2273,17 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
 bool cata_tiles::draw_sprite_at(
     const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
     const point &p, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-    bool apply_night_vision_goggles )
+    bool apply_night_vision_goggles, int overlay_count )
 {
     int nullint = 0;
     return cata_tiles::draw_sprite_at( tile, svlist, p, loc_rand, rota_fg, rota, ll,
-                                       apply_night_vision_goggles, nullint );
+                                       apply_night_vision_goggles, nullint, overlay_count );
 }
 
 bool cata_tiles::draw_sprite_at(
     const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
     const point &p, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-    bool apply_night_vision_goggles, int &height_3d )
+    bool apply_night_vision_goggles, int &height_3d, int overlay_count )
 {
     auto picked = svlist.pick( loc_rand );
     if( !picked ) {
@@ -2251,11 +2333,17 @@ bool cata_tiles::draw_sprite_at(
                 sprite_tex = ptr;
             }
         }
+    } else if( overlay_count > 0 && static_z_effect ) {
+        if( const auto ptr = tileset_ptr->get_z_overlay( spritelist[sprite_num] ) ) {
+            sprite_tex = ptr;
+        }
     } else if( ll == lit_level::LOW ) {
         if( const auto ptr = tileset_ptr->get_shadow_tile( spritelist[sprite_num] ) ) {
             sprite_tex = ptr;
         }
     }
+
+    const auto overlay = tileset_ptr->get_z_overlay( spritelist[sprite_num] );
 
     int width = 0;
     int height = 0;
@@ -2267,49 +2355,56 @@ bool cata_tiles::draw_sprite_at(
     destination.w = width * tile_width / tileset_ptr->get_tile_width();
     destination.h = height * tile_height / tileset_ptr->get_tile_height();
 
+    auto render = [&]( const int rotation, const SDL_RendererFlip flip ) {
+        int ret = sprite_tex->render_copy_ex( renderer, &destination, rotation, nullptr, flip );
+        if( !static_z_effect && overlay && overlay_count > 0 ) {
+            overlay->set_alpha_mod( std::min( 192, ( 1 + overlay_count ) * 24 ) );
+            overlay->render_copy_ex( renderer, &destination, rotation, nullptr, flip );
+        }
+        return ret;
+    };
+
     if( rotate_sprite ) {
         switch( rota ) {
             default:
             case 0:
                 // unrotated (and 180, with just two sprites)
-                ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr, SDL_FLIP_NONE );
+                ret = render( 0, SDL_FLIP_NONE );
                 break;
             case 1:
                 // 90 degrees (and 270, with just two sprites)
                 if( !tile_iso ) {
                     // never rotate isometric tiles
-                    ret = sprite_tex->render_copy_ex( renderer, &destination, -90, nullptr, SDL_FLIP_NONE );
+                    ret = render( -90, SDL_FLIP_NONE );
                 } else {
-                    ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr, SDL_FLIP_NONE );
+                    ret = render( 0, SDL_FLIP_NONE );
                 }
                 break;
             case 2:
                 // 180 degrees, implemented with flips instead of rotation
                 if( !tile_iso ) {
                     // never flip isometric tiles vertically
-                    ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
-                                                      static_cast<SDL_RendererFlip>( SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL ) );
+                    ret = render( 0, static_cast<SDL_RendererFlip>( SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL ) );
                 } else {
-                    ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr, SDL_FLIP_NONE );
+                    ret = render( 0, SDL_FLIP_NONE );
                 }
                 break;
             case 3:
                 // 270 degrees
                 if( !tile_iso ) {
                     // never rotate isometric tiles
-                    ret = sprite_tex->render_copy_ex( renderer, &destination, 90, nullptr, SDL_FLIP_NONE );
+                    ret = render( 90, SDL_FLIP_NONE );
                 } else {
-                    ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr, SDL_FLIP_NONE );
+                    ret = render( 0, SDL_FLIP_NONE );
                 }
                 break;
             case 4:
                 // flip horizontally
-                ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
-                                                  static_cast<SDL_RendererFlip>( SDL_FLIP_HORIZONTAL ) );
+                ret = render( 0, SDL_FLIP_HORIZONTAL );
         }
     } else {
         // don't rotate, same as case 0 above
-        ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr, SDL_FLIP_NONE );
+        ret = render( 0, SDL_FLIP_NONE );
     }
 
     printErrorIf( ret != 0, "SDL_RenderCopyEx() failed" );
@@ -2322,12 +2417,12 @@ bool cata_tiles::draw_sprite_at(
 
 bool cata_tiles::draw_tile_at(
     const tile_type &tile, const point &p, unsigned int loc_rand, int rota,
-    lit_level ll, bool apply_night_vision_goggles, int &height_3d )
+    lit_level ll, bool apply_night_vision_goggles, int &height_3d, int overlay_count )
 {
     draw_sprite_at( tile, tile.bg, p, loc_rand, /*fg:*/ false, rota, ll,
-                    apply_night_vision_goggles );
+                    apply_night_vision_goggles, overlay_count );
     draw_sprite_at( tile, tile.fg, p, loc_rand, /*fg:*/ true, rota, ll,
-                    apply_night_vision_goggles, height_3d );
+                    apply_night_vision_goggles, height_3d, overlay_count );
     return true;
 }
 
@@ -2365,83 +2460,47 @@ bool cata_tiles::apply_vision_effects( const tripoint &pos,
     }
 
     // lighting is never rotated, though, could possibly add in random rotation?
-    draw_from_id_string( light_name, C_LIGHTING, empty_string, pos, 0, 0, lit_level::LIT, false );
+    draw_from_id_string( light_name, C_LIGHTING, empty_string, pos, 0, 0, lit_level::LIT, false, 0 );
 
     return true;
 }
 
-bool cata_tiles::draw_terrain_below( const tripoint &p, const lit_level, int &,
-                                     const bool ( &invisible )[5] )
+bool cata_tiles::draw_block( const tripoint &p, SDL_Color color, int scale )
 {
-    map &here = get_map();
-    const auto low_override = draw_below_override.find( p );
-    const bool low_overridden = low_override != draw_below_override.end();
-    if( low_overridden ? !low_override->second : ( invisible[0] ||
-            here.dont_draw_lower_floor( p ) ) ) {
-        return false;
-    }
+    SDL_Rect rect;
+    rect.h = tile_width / scale;
+    rect.w = tile_height / scale;
 
-    tripoint pbelow = tripoint( p.xy(), p.z - 1 );
-    SDL_Color tercol = curses_color_to_SDL( c_dark_gray );
-
-    const ter_t &curr_ter = here.ter( pbelow ).obj();
-    const furn_t &curr_furn = here.furn( pbelow ).obj();
-    int part_below;
-    int sizefactor = 2;
-    const vehicle *veh;
-    //        const vehicle *veh;
-    if( curr_furn.has_flag( TFLAG_SEEN_FROM_ABOVE ) ) {
-        tercol = curses_color_to_SDL( curr_furn.color() );
-    } else if( curr_furn.movecost < 0 ) {
-        tercol = curses_color_to_SDL( curr_furn.color() );
-    } else if( ( veh = here.veh_at_internal( pbelow, part_below ) ) != nullptr ) {
-        const int roof = veh->roof_at_part( part_below );
-        const auto vpobst = vpart_position( const_cast<vehicle &>( *veh ), part_below ).obstacle_at_part();
-        tercol = curses_color_to_SDL( ( roof >= 0 ||
-                                        vpobst ) ? c_light_gray : c_magenta );
-        sizefactor = ( roof >= 0 || vpobst ) ? 4 : 2;
-    } else if( curr_ter.has_flag( TFLAG_SEEN_FROM_ABOVE ) || curr_ter.movecost == 0 ) {
-        tercol = curses_color_to_SDL( curr_ter.color() );
-    } else if( !curr_ter.has_flag( TFLAG_NO_FLOOR ) ) {
-        sizefactor = 4;
-        tercol = curses_color_to_SDL( curr_ter.color() );
-    } else {
-        tercol = curses_color_to_SDL( curr_ter.color() );
-    }
-
-    SDL_Rect belowRect;
-    belowRect.h = tile_width / sizefactor;
-    belowRect.w = tile_height / sizefactor;
     if( tile_iso ) {
-        belowRect.h = ( belowRect.h * 2 ) / 3;
-        belowRect.w = ( belowRect.w * 3 ) / 4;
+        rect.h = ( rect.h * 2 ) / 3;
+        rect.w = ( rect.w * 3 ) / 4;
     }
     // translate from player-relative to screen relative tile position
     point screen;
     if( tile_iso ) {
-        screen.x = ( ( pbelow.x - o.x ) - ( o.y - pbelow.y ) + screentile_width - 2 ) * tile_width / 2 +
+        screen.x = ( ( p.x - o.x ) - ( o.y - p.y ) + screentile_width - 2 ) * tile_width / 2 +
                    op.x;
         // y uses tile_width because width is definitive for iso tiles
         // tile footprints are half as tall as wide, arbitrarily tall
-        screen.y = ( ( pbelow.y - o.y ) - ( pbelow.x - o.x ) - 4 ) * tile_width / 4 +
+        screen.y = ( ( p.y - o.y ) - ( p.x - o.x ) - 4 ) * tile_width / 4 +
                    screentile_height * tile_height / 2 + // TODO: more obvious centering math
                    op.y;
     } else {
-        screen.x = ( pbelow.x - o.x ) * tile_width + op.x;
-        screen.y = ( pbelow.y - o.y ) * tile_height + op.y;
+        screen.x = ( p.x - o.x ) * tile_width + op.x;
+        screen.y = ( p.y - o.y ) * tile_height + op.y;
     }
-    belowRect.x = screen.x + ( tile_width - belowRect.w ) / 2;
-    belowRect.y = screen.y + ( tile_height - belowRect.h ) / 2;
+    rect.x = screen.x + ( tile_width - rect.w ) / 2;
+    rect.y = screen.y + ( tile_height - rect.h ) / 2;
     if( tile_iso ) {
-        belowRect.y += tile_height / 8;
+        rect.y += tile_height / 8;
     }
-    geometry->rect( renderer, belowRect, tercol );
 
+    geometry->rect( renderer, rect,  color );
     return true;
 }
 
 bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &height_3d,
-                               const bool ( &invisible )[5] )
+                               const bool ( &invisible )[5], int z_drop )
 {
     map &here = get_map();
     const auto override = terrain_override.find( p );
@@ -2470,13 +2529,18 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             // do something to get other terrain orientation values
         }
         const std::string &tname = t.id().str();
-        if( here.check_seen_cache( p ) ) {
+        if( here.check_seen_cache( p ) && t != t_open_air ) {
             g->u.memorize_tile( here.getabs( p ), tname, subtile, rotation );
         }
         // draw the actual terrain if there's no override
         if( !neighborhood_overridden ) {
-            return draw_from_id_string( tname, C_TERRAIN, empty_string, p, subtile, rotation, ll,
-                                        nv_goggles_activated, height_3d );
+            //If it's open air just draw a flat color
+            if( t == t_open_air ) {
+                return draw_block( p, curses_color_to_SDL( c_cyan ), 4 );
+            } else {
+                return draw_from_id_string( tname, C_TERRAIN, empty_string, p, subtile, rotation, ll,
+                                            nv_goggles_activated, height_3d, z_drop );
+            }
         }
     }
     if( invisible[0] ? overridden : neighborhood_overridden ) {
@@ -2499,13 +2563,14 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             const lit_level lit = overridden ? lit_level::LIT : ll;
             const bool nv = overridden ? false : nv_goggles_activated;
             return draw_from_id_string( tname, C_TERRAIN, empty_string, p, subtile, rotation, lit, nv,
-                                        height_3d );
+                                        height_3d, z_drop );
         }
     } else if( invisible[0] && has_terrain_memory_at( p ) ) {
         // try drawing memory if invisible and not overridden
         const auto &t = get_terrain_memory_at( p );
+
         return draw_from_id_string( t.tile, C_TERRAIN, empty_string, p, t.subtile, t.rotation,
-                                    lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+                                    lit_level::MEMORIZED, nv_goggles_activated, height_3d, z_drop );
     }
     return false;
 }
@@ -2608,7 +2673,7 @@ memorized_terrain_tile cata_tiles::get_vpart_memory_at( const tripoint &p ) cons
 }
 
 bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &height_3d,
-                                 const bool ( &invisible )[5] )
+                                 const bool ( &invisible )[5], int z_drop )
 {
     const auto override = furniture_override.find( p );
     const bool overridden = override != furniture_override.end();
@@ -2641,7 +2706,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         // draw the actual furniture if there's no override
         if( !neighborhood_overridden ) {
             return draw_from_id_string( fname, C_FURNITURE, empty_string, p, subtile, rotation, ll,
-                                        nv_goggles_activated, height_3d );
+                                        nv_goggles_activated, height_3d, z_drop );
         }
     }
     if( invisible[0] ? overridden : neighborhood_overridden ) {
@@ -2670,19 +2735,19 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
             const lit_level lit = overridden ? lit_level::LIT : ll;
             const bool nv = overridden ? false : nv_goggles_activated;
             return draw_from_id_string( fname, C_FURNITURE, empty_string, p, subtile, rotation, lit, nv,
-                                        height_3d );
+                                        height_3d, z_drop );
         }
     } else if( invisible[0] && has_furniture_memory_at( p ) ) {
         // try drawing memory if invisible and not overridden
         const auto &t = get_furniture_memory_at( p );
         return draw_from_id_string( t.tile, C_FURNITURE, empty_string, p, t.subtile, t.rotation,
-                                    lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+                                    lit_level::MEMORIZED, nv_goggles_activated, height_3d, z_drop );
     }
     return false;
 }
 
 bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3d,
-                            const bool ( &invisible )[5] )
+                            const bool ( &invisible )[5], int z_drop )
 {
     const auto override = trap_override.find( p );
     const bool overridden = override != trap_override.end();
@@ -2716,7 +2781,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
         // draw the actual trap if there's no override
         if( !neighborhood_overridden ) {
             return draw_from_id_string( trname, C_TRAP, empty_string, p, subtile, rotation, ll,
-                                        nv_goggles_activated, height_3d );
+                                        nv_goggles_activated, height_3d, z_drop );
         }
     }
     if( overridden || ( !invisible[0] && neighborhood_overridden && tr.obj().can_see( p, g->u ) ) ) {
@@ -2745,19 +2810,19 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
             const lit_level lit = overridden ? lit_level::LIT : ll;
             const bool nv = overridden ? false : nv_goggles_activated;
             return draw_from_id_string( trname, C_TRAP, empty_string, p, subtile, rotation, lit, nv,
-                                        height_3d );
+                                        height_3d, z_drop );
         }
     } else if( invisible[0] && has_trap_memory_at( p ) ) {
         // try drawing memory if invisible and not overridden
         const auto &t = get_trap_memory_at( p );
         return draw_from_id_string( t.tile, C_TRAP, empty_string, p, t.subtile, t.rotation,
-                                    lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+                                    lit_level::MEMORIZED, nv_goggles_activated, height_3d, z_drop );
     }
     return false;
 }
 
 bool cata_tiles::draw_graffiti( const tripoint &p, const lit_level ll, int &height_3d,
-                                const bool ( &invisible )[5] )
+                                const bool ( &invisible )[5], int z_drop )
 {
     const auto override = graffiti_override.find( p );
     const bool overridden = override != graffiti_override.end();
@@ -2765,11 +2830,12 @@ bool cata_tiles::draw_graffiti( const tripoint &p, const lit_level ll, int &heig
         return false;
     }
     const lit_level lit = overridden ? lit_level::LIT : ll;
-    return draw_from_id_string( "graffiti", C_NONE, empty_string, p, 0, 0, lit, false, height_3d );
+    return draw_from_id_string( "graffiti", C_NONE, empty_string, p, 0, 0, lit, false, height_3d,
+                                z_drop );
 }
 
 bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int &height_3d,
-                                     const bool ( &invisible )[5] )
+                                     const bool ( &invisible )[5], int z_drop )
 {
     const auto fld_override = field_override.find( p );
     const bool fld_overridden = fld_override != field_override.end();
@@ -2800,7 +2866,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
         get_tile_values( fld.to_i(), neighborhood, subtile, rotation );
 
         ret_draw_field = draw_from_id_string( fld.id().str(), C_FIELD, empty_string, p, subtile,
-                                              rotation, lit, nv );
+                                              rotation, lit, nv, z_drop );
     }
     if( fld.obj().display_items ) {
         const auto it_override = item_override.find( p );
@@ -2834,7 +2900,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
             const bool nv = it_overridden ? false : nv_goggles_activated;
 
             ret_draw_items = draw_from_id_string( disp_id, C_ITEM, it_category, p, 0, 0, lit,
-                                                  nv, height_3d );
+                                                  nv, height_3d, z_drop );
             if( ret_draw_items && hilite ) {
                 draw_item_highlight( p );
             }
@@ -2843,24 +2909,8 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
     return ret_draw_field && ret_draw_items;
 }
 
-bool cata_tiles::draw_vpart_below( const tripoint &p, const lit_level /*ll*/, int &/*height_3d*/,
-                                   const bool ( &invisible )[5] )
-{
-    const auto low_override = draw_below_override.find( p );
-    const bool low_overridden = low_override != draw_below_override.end();
-    if( low_overridden ? !low_override->second : ( invisible[0] ||
-            get_map().dont_draw_lower_floor( p ) ) ) {
-        return false;
-    }
-    tripoint pbelow( p.xy(), p.z - 1 );
-    int height_3d_below = 0;
-    bool below_invisible[5];
-    std::fill( below_invisible, below_invisible + 5, false );
-    return draw_vpart( pbelow, lit_level::LOW, height_3d_below, below_invisible );
-}
-
 bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
-                             const bool ( &invisible )[5] )
+                             const bool ( &invisible )[5], int z_drop )
 {
     const auto override = vpart_override.find( p );
     const bool overridden = override != vpart_override.end();
@@ -2869,11 +2919,13 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
     const optional_vpart_position vp = here.veh_at( p );
     if( vp && !invisible[0] ) {
         const vehicle &veh = vp->vehicle();
-        const int veh_part = vp->part_index();
+        int veh_part = vp->part_index();
+
         // Gets the visible part, should work fine once tileset vp_ids are updated to work with the vehicle part json ids
         // get the vpart_id
         char part_mod = 0;
-        const vpart_id &vp_id = veh.part_id_string( veh_part, part_mod );
+        const Creature *critter = g->critter_at( p, true );
+        const vpart_id &vp_id = veh.part_id_string( veh_part, z_drop > 0 && critter == nullptr, part_mod );
         const int subtile = part_mod == 1 ? open_ : part_mod == 2 ? broken : 0;
         const int rotation = std::round( to_degrees( veh.face.dir() ) );
         const std::string vpname = "vp_" + vp_id.str();
@@ -2886,7 +2938,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             const cata::optional<vpart_reference> cargopart = vp.part_with_feature( "CARGO", true );
             const bool draw_highlight = cargopart && !veh.get_items( cargopart->part_index() ).empty();
             const bool ret = draw_from_id_string( vpname, C_VEHICLE_PART, empty_string, p, subtile, rotation,
-                                                  ll, nv_goggles_activated, height_3d );
+                                                  ll, nv_goggles_activated, height_3d, z_drop );
             if( ret && draw_highlight ) {
                 draw_item_highlight( p );
             }
@@ -2906,7 +2958,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             // tile overrides are always shown with full visibility
             const bool ret = draw_from_id_string( vpname, C_VEHICLE_PART, empty_string, p,
                                                   subtile, to_degrees( rotation ), lit_level::LIT,
-                                                  false, height_3d );
+                                                  false, height_3d, z_drop );
             if( ret && draw_highlight ) {
                 draw_item_highlight( p );
             }
@@ -2916,67 +2968,13 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
         // try drawing memory if invisible and not overridden
         const auto &t = get_vpart_memory_at( p );
         return draw_from_id_string( t.tile, C_VEHICLE_PART, empty_string, p, t.subtile, t.rotation,
-                                    lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+                                    lit_level::MEMORIZED, nv_goggles_activated, height_3d, z_drop );
     }
     return false;
 }
 
-bool cata_tiles::draw_critter_at_below( const tripoint &p, const lit_level, int &,
-                                        const bool ( &invisible )[5] )
-{
-    // Check if we even need to draw below. If not, bail.
-    const auto low_override = draw_below_override.find( p );
-    const bool low_overridden = low_override != draw_below_override.end();
-    if( low_overridden ? !low_override->second : ( invisible[0] ||
-            get_map().dont_draw_lower_floor( p ) ) ) {
-        return false;
-    }
-
-    tripoint pbelow( p.xy(), p.z - 1 );
-
-    // Get the critter at the location below. If there isn't one,
-    // we can bail.
-    const Creature *critter = g->critter_at( pbelow, true );
-    if( critter == nullptr ) {
-        return false;
-    }
-
-    // Check if the player can actually see the critter. We don't care if
-    // it's via infrared or not, just whether or not they're seen. If not,
-    // we can bail.
-    if( !g->u.sees( *critter ) && !( g->u.sees_with_infrared( *critter ) ||
-                                     g->u.sees_with_specials( *critter ) ) ) {
-        return false;
-    }
-
-    const point screen_point = player_to_screen( pbelow.xy() );
-
-    SDL_Color tercol = curses_color_to_SDL( c_red );
-    const int sizefactor = 2;
-
-    SDL_Rect belowRect;
-    belowRect.h = tile_width / sizefactor;
-    belowRect.w = tile_height / sizefactor;
-
-    if( tile_iso ) {
-        belowRect.h = ( belowRect.h * 2 ) / 3;
-        belowRect.w = ( belowRect.w * 3 ) / 4;
-    }
-
-    belowRect.x = screen_point.x + ( tile_width - belowRect.w ) / 2;
-    belowRect.y = screen_point.y + ( tile_height - belowRect.h ) / 2;
-
-    if( tile_iso ) {
-        belowRect.y += tile_height / 8;
-    }
-
-    geometry->rect( renderer, belowRect, tercol );
-
-    return true;
-}
-
 bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3d,
-                                  const bool ( &invisible )[5] )
+                                  const bool ( &invisible )[5], int z_drop )
 {
     bool result;
     bool is_player;
@@ -2995,7 +2993,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
         const std::string &ent_subcategory = id.obj().species.empty() ?
                                              empty_string : id.obj().species.begin()->str();
         result = draw_from_id_string( chosen_id, C_MONSTER, ent_subcategory, p, corner, 0,
-                                      lit_level::LIT, false, height_3d );
+                                      lit_level::LIT, false, height_3d, z_drop );
     } else if( !invisible[0] ) {
         const Creature *pcritter = g->critter_at( p, true );
         if( pcritter == nullptr ) {
@@ -3003,10 +3001,10 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
         }
         const Creature &critter = *pcritter;
 
-        if( !g->u.sees( critter ) ) {
+        if( fov_3d && !g->u.sees( critter ) ) {
             if( g->u.sees_with_infrared( critter ) || g->u.sees_with_specials( critter ) ) {
                 return draw_from_id_string( "infrared_creature", C_NONE, empty_string, p, 0, 0,
-                                            lit_level::LIT, false, height_3d );
+                                            lit_level::LIT, false, height_3d, z_drop );
             }
             return false;
         }
@@ -3046,7 +3044,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
                     }
                 }
                 result = draw_from_id_string( chosen_id, ent_category, ent_subcategory, p, subtile, rot_facing,
-                                              ll, false, height_3d );
+                                              ll, false, height_3d, z_drop );
                 sees_player = m->sees( g->u );
                 attitude = m->attitude_to( g-> u );
             }
@@ -3069,7 +3067,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
             // try drawing infrared creature if invisible and not overridden
             // return directly without drawing overlay
             return draw_from_id_string( "infrared_creature", C_NONE, empty_string, p, 0, 0,
-                                        lit_level::LIT, false, height_3d );
+                                        lit_level::LIT, false, height_3d, z_drop );
         } else {
             return false;
         }
@@ -3081,14 +3079,16 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
             draw_id += "_sees_player";
         }
         if( tileset_ptr->find_tile_type( draw_id ) ) {
-            draw_from_id_string( draw_id, C_NONE, empty_string, p, 0, 0, lit_level::LIT, false, height_3d );
+            draw_from_id_string( draw_id, C_NONE, empty_string, p, 0, 0, lit_level::LIT, false, height_3d,
+                                 z_drop );
         }
     }
     return result;
+
 }
 
 bool cata_tiles::draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d,
-                                 const bool ( &invisible )[5] )
+                                 const bool ( &invisible )[5], int z_drop )
 {
     if( invisible[0] ) {
         return false;
@@ -3107,7 +3107,7 @@ bool cata_tiles::draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d
 
         if( option && !option->get_mark().empty() ) {
             return draw_from_id_string( option->get_mark(), C_NONE, empty_string, p, 0, 0, ll,
-                                        nv_goggles_activated, height_3d );
+                                        nv_goggles_activated, height_3d, z_drop );
         }
     }
 
@@ -3115,7 +3115,7 @@ bool cata_tiles::draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d
 }
 
 bool cata_tiles::draw_zombie_revival_indicators( const tripoint &pos, const lit_level /*ll*/,
-        int &/*height_3d*/, const bool ( &invisible )[5] )
+        int &/*height_3d*/, const bool ( &invisible )[5], int z_drop )
 {
     map &here = get_map();
     if( tileset_ptr->find_tile_type( ZOMBIE_REVIVAL_INDICATOR ) && !invisible[0] &&
@@ -3123,7 +3123,7 @@ bool cata_tiles::draw_zombie_revival_indicators( const tripoint &pos, const lit_
         for( auto &i : here.i_at( pos ) ) {
             if( i.can_revive() ) {
                 return draw_from_id_string( ZOMBIE_REVIVAL_INDICATOR, C_NONE, empty_string, pos, 0, 0,
-                                            lit_level::LIT, false );
+                                            lit_level::LIT, false, z_drop );
             }
         }
     }
@@ -3146,9 +3146,9 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
 
     // depending on the toggle flip sprite left or right
     if( ch.facing == FD_RIGHT ) {
-        draw_from_id_string( ent_name, C_NONE, "", p, corner, 0, ll, false, height_3d );
+        draw_from_id_string( ent_name, C_NONE, "", p, corner, 0, ll, false, height_3d, 0 );
     } else if( ch.facing == FD_LEFT ) {
-        draw_from_id_string( ent_name, C_NONE, "", p, corner, 4, ll, false, height_3d );
+        draw_from_id_string( ent_name, C_NONE, "", p, corner, 4, ll, false, height_3d, 0 );
     }
 
     // next up, draw all the overlays
@@ -3158,9 +3158,9 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
         if( find_overlay_looks_like( ch.male, overlay, draw_id ) ) {
             int overlay_height_3d = prev_height_3d;
             if( ch.facing == FD_RIGHT ) {
-                draw_from_id_string( draw_id, C_NONE, "", p, corner, /*rota:*/ 0, ll, false, overlay_height_3d );
+                draw_from_id_string( draw_id, C_NONE, "", p, corner, /*rota:*/ 0, ll, false, overlay_height_3d, 0 );
             } else if( ch.facing == FD_LEFT ) {
-                draw_from_id_string( draw_id, C_NONE, "", p, corner, /*rota:*/ 4, ll, false, overlay_height_3d );
+                draw_from_id_string( draw_id, C_NONE, "", p, corner, /*rota:*/ 4, ll, false, overlay_height_3d, 0 );
             }
             // the tallest height-having overlay is the one that counts
             height_3d = std::max( height_3d, overlay_height_3d );
@@ -3171,7 +3171,7 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
 bool cata_tiles::draw_item_highlight( const tripoint &pos )
 {
     return draw_from_id_string( ITEM_HIGHLIGHT, C_NONE, empty_string, pos, 0, 0,
-                                lit_level::LIT, false );
+                                lit_level::LIT, false, 0 );
 }
 
 void tileset_loader::ensure_default_item_highlight()
@@ -3425,27 +3425,27 @@ void cata_tiles::draw_explosion_frame()
         rotation = 0;
 
         draw_from_id_string( exp_name, exp_pos + point( -i, -i ),
-                             subtile, rotation++, lit_level::LIT, nv_goggles_activated );
+                             subtile, rotation++, lit_level::LIT, nv_goggles_activated, 0 );
         draw_from_id_string( exp_name, exp_pos + point( -i, i ),
-                             subtile, rotation++, lit_level::LIT, nv_goggles_activated );
+                             subtile, rotation++, lit_level::LIT, nv_goggles_activated, 0 );
         draw_from_id_string( exp_name, exp_pos + point( i, i ),
-                             subtile, rotation++, lit_level::LIT, nv_goggles_activated );
+                             subtile, rotation++, lit_level::LIT, nv_goggles_activated, 0 );
         draw_from_id_string( exp_name, exp_pos + point( i, -i ),
-                             subtile, rotation, lit_level::LIT, nv_goggles_activated );
+                             subtile, rotation, lit_level::LIT, nv_goggles_activated, 0 );
 
         subtile = edge;
         for( int j = 1 - i; j < 0 + i; j++ ) {
             rotation = 0;
             draw_from_id_string( exp_name, exp_pos + point( j, -i ),
-                                 subtile, rotation, lit_level::LIT, nv_goggles_activated );
+                                 subtile, rotation, lit_level::LIT, nv_goggles_activated, 0 );
             draw_from_id_string( exp_name, exp_pos + point( j, i ),
-                                 subtile, rotation, lit_level::LIT, nv_goggles_activated );
+                                 subtile, rotation, lit_level::LIT, nv_goggles_activated, 0 );
 
             rotation = 1;
             draw_from_id_string( exp_name, exp_pos + point( -i, j ),
-                                 subtile, rotation, lit_level::LIT, nv_goggles_activated );
+                                 subtile, rotation, lit_level::LIT, nv_goggles_activated, 0 );
             draw_from_id_string( exp_name, exp_pos + point( i, j ),
-                                 subtile, rotation, lit_level::LIT, nv_goggles_activated );
+                                 subtile, rotation, lit_level::LIT, nv_goggles_activated, 0 );
         }
     }
 }
@@ -3512,7 +3512,7 @@ void cata_tiles::draw_custom_explosion_frame()
         }
 
         const tripoint &p = pr.first;
-        draw_from_id_string( exp_name, p, subtile, rotation, lit_level::LIT, nv_goggles_activated );
+        draw_from_id_string( exp_name, p, subtile, rotation, lit_level::LIT, nv_goggles_activated, 0 );
         // Used to be divided into explosion_weak/explosion_medium/explosion.
     }
 }
@@ -3530,7 +3530,7 @@ void cata_tiles::draw_cone_aoe_frame()
         };
 
         size_t intensity = ( pv.val >= 1.0 ) + ( pv.val >= 0.5 );
-        draw_from_id_string( sprite_ids[intensity], pv.pt, 0, rotation, lit_level::LIT, false );
+        draw_from_id_string( sprite_ids[intensity], pv.pt, 0, rotation, lit_level::LIT, false, 0 );
     }
 }
 void cata_tiles::void_cone_aoe()
@@ -3542,15 +3542,15 @@ void cata_tiles::void_cone_aoe()
 
 void cata_tiles::draw_bullet_frame()
 {
-    draw_from_id_string( bul_id, C_BULLET, empty_string, bul_pos, 0, 0, lit_level::LIT, false );
+    draw_from_id_string( bul_id, C_BULLET, empty_string, bul_pos, 0, 0, lit_level::LIT, false, 0 );
 }
 void cata_tiles::draw_hit_frame()
 {
     std::string hit_overlay = "animation_hit";
 
     draw_from_id_string( hit_entity_id, C_HIT_ENTITY, empty_string, hit_pos, 0, 0,
-                         lit_level::LIT, false );
-    draw_from_id_string( hit_overlay, hit_pos, 0, 0, lit_level::LIT, false );
+                         lit_level::LIT, false, 0 );
+    draw_from_id_string( hit_overlay, hit_pos, 0, 0, lit_level::LIT, false, 0 );
 }
 void cata_tiles::draw_line()
 {
@@ -3560,22 +3560,22 @@ void cata_tiles::draw_line()
     static std::string line_overlay = "animation_line";
     if( !is_target_line || g->u.sees( line_pos ) ) {
         for( auto it = line_trajectory.begin(); it != line_trajectory.end() - 1; ++it ) {
-            draw_from_id_string( line_overlay, *it, 0, 0, lit_level::LIT, false );
+            draw_from_id_string( line_overlay, *it, 0, 0, lit_level::LIT, false, 0 );
         }
     }
 
-    draw_from_id_string( line_endpoint_id, line_trajectory.back(), 0, 0, lit_level::LIT, false );
+    draw_from_id_string( line_endpoint_id, line_trajectory.back(), 0, 0, lit_level::LIT, false, 0 );
 }
 void cata_tiles::draw_cursor()
 {
     for( const tripoint &p : cursors ) {
-        draw_from_id_string( "cursor", p, 0, 0, lit_level::LIT, false );
+        draw_from_id_string( "cursor", p, 0, 0, lit_level::LIT, false, 0 );
     }
 }
 void cata_tiles::draw_highlight()
 {
     for( const tripoint &p : highlights ) {
-        draw_from_id_string( "highlight", p, 0, 0, lit_level::LIT, false );
+        draw_from_id_string( "highlight", p, 0, 0, lit_level::LIT, false, 0 );
     }
 }
 void cata_tiles::draw_weather_frame()
@@ -3589,7 +3589,7 @@ void cata_tiles::draw_weather_frame()
             p += o;
         }
         draw_from_id_string( weather_name, C_WEATHER, empty_string, p, 0, 0,
-                             lit_level::LIT, nv_goggles_activated );
+                             lit_level::LIT, nv_goggles_activated, 0 );
     }
 }
 
@@ -3624,7 +3624,7 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
 
                     if( tileset_ptr->find_tile_type( generic_id ) ) {
                         draw_from_id_string( generic_id, C_NONE, empty_string,
-                                             iD + tripoint( iOffsetX, iOffsetY, g->u.pos().z ), 0, 0, lit_level::LIT, false );
+                                             iD + tripoint( iOffsetX, iOffsetY, g->u.pos().z ), 0, 0, lit_level::LIT, false, 0 );
                     }
 
                     if( tile_iso ) {
@@ -3643,7 +3643,7 @@ void cata_tiles::draw_zones_frame()
         for( int iX = zone_start.x; iX <= zone_end.x; ++iX ) {
             draw_from_id_string( "highlight", C_NONE, empty_string,
                                  zone_offset.xy() + tripoint( iX, iY, g->u.pos().z ),
-                                 0, 0, lit_level::LIT, false );
+                                 0, 0, lit_level::LIT, false, 0 );
         }
     }
 
@@ -3657,11 +3657,11 @@ void cata_tiles::draw_footsteps_frame( const tripoint &center )
 
     for( const tripoint &pos : sounds::get_footstep_markers() ) {
         if( pos.z == center.z ) {
-            draw_from_id_string( id_footstep, pos, 0, 0, lit_level::LIT, false );
+            draw_from_id_string( id_footstep, pos, 0, 0, lit_level::LIT, false, 0 );
         } else if( pos.z > center.z ) {
-            draw_from_id_string( id_footstep_above, pos, 0, 0, lit_level::LIT, false );
+            draw_from_id_string( id_footstep_above, pos, 0, 0, lit_level::LIT, false, 0 );
         } else {
-            draw_from_id_string( id_footstep_below, pos, 0, 0, lit_level::LIT, false );
+            draw_from_id_string( id_footstep_below, pos, 0, 0, lit_level::LIT, false, 0 );
         }
     }
 }

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -102,6 +102,10 @@ class texture
             return SDL_RenderCopyEx( renderer.get(), sdl_texture_ptr.get(), &srcrect, dstrect, angle, center,
                                      flip );
         }
+
+        int set_alpha_mod( int mod ) const {
+            return SDL_SetTextureAlphaMod( sdl_texture_ptr.get(), mod );
+        }
 };
 
 class tileset
@@ -125,6 +129,7 @@ class tileset
         std::vector<texture> night_tile_values;
         std::vector<texture> overexposed_tile_values;
         std::vector<texture> memory_tile_values;
+        std::vector<texture> z_overlay_values;
 
         std::unordered_map<std::string, tile_type> tile_ids;
         // caches both "default" and "_season_XXX" tile variants (to reduce the number of lookups)
@@ -166,6 +171,9 @@ class tileset
         }
         const texture *get_memory_tile( const size_t index ) const {
             return get_if_available( index, memory_tile_values );
+        }
+        const texture *get_z_overlay( const size_t index ) const {
+            return get_if_available( index, z_overlay_values );
         }
 
         tile_type &create_tile_type( const std::string &id, tile_type &&new_tile_type );
@@ -372,25 +380,25 @@ class cata_tiles
         bool find_overlay_looks_like( bool male, const std::string &overlay, std::string &draw_id );
 
         bool draw_from_id_string( const std::string &id, const tripoint &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles );
+                                  lit_level ll, bool apply_night_vision_goggles, int overlay_count );
         bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                   const std::string &subcategory, const tripoint &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles );
+                                  lit_level ll, bool apply_night_vision_goggles, int overlay_count );
         bool draw_from_id_string( const std::string &id, const tripoint &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d );
+                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d, int overlay_count );
         bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                   const std::string &subcategory, const tripoint &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d );
+                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d, int overlay_count );
         bool draw_sprite_at(
             const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
             const point &, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-            bool apply_night_vision_goggles );
+            bool apply_night_vision_goggles, int overlay_count );
         bool draw_sprite_at(
             const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
             const point &, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-            bool apply_night_vision_goggles, int &height_3d );
+            bool apply_night_vision_goggles, int &height_3d, int overlay_count );
         bool draw_tile_at( const tile_type &tile, const point &, unsigned int loc_rand, int rota,
-                           lit_level ll, bool apply_night_vision_goggles, int &height_3d );
+                           lit_level ll, bool apply_night_vision_goggles, int &height_3d, int overlay_count );
 
         /* Tile Picking */
         void get_tile_values( int t, const int *tn, int &subtile, int &rotation );
@@ -415,32 +423,30 @@ class cata_tiles
         /** Drawing Layers */
         bool would_apply_vision_effects( visibility_type visibility ) const;
         bool apply_vision_effects( const tripoint &pos, visibility_type visibility );
+
+        bool draw_block( const tripoint &p, SDL_Color color, int scale );
+
         bool draw_terrain( const tripoint &p, lit_level ll, int &height_3d,
-                           const bool ( &invisible )[5] );
-        bool draw_terrain_below( const tripoint &p, lit_level ll, int &height_3d,
-                                 const bool ( &invisible )[5] );
+                           const bool ( &invisible )[5], int z_drop );
         bool draw_furniture( const tripoint &p, lit_level ll, int &height_3d,
-                             const bool ( &invisible )[5] );
+                             const bool ( &invisible )[5], int z_drop );
         bool draw_graffiti( const tripoint &p, lit_level ll, int &height_3d,
-                            const bool ( &invisible )[5] );
+                            const bool ( &invisible )[5], int z_drop );
         bool draw_trap( const tripoint &p, lit_level ll, int &height_3d,
-                        const bool ( &invisible )[5] );
+                        const bool ( &invisible )[5], int z_drop );
         bool draw_field_or_item( const tripoint &p, lit_level ll, int &height_3d,
-                                 const bool ( &invisible )[5] );
+                                 const bool ( &invisible )[5], int z_drop );
         bool draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
-                         const bool ( &invisible )[5] );
-        bool draw_vpart_below( const tripoint &p, lit_level ll, int &height_3d,
-                               const bool ( &invisible )[5] );
+                         const bool ( &invisible )[5], int z_drop );
         bool draw_critter_at( const tripoint &p, lit_level ll, int &height_3d,
-                              const bool ( &invisible )[5] );
-        bool draw_critter_at_below( const tripoint &p, lit_level ll, int &height_3d,
-                                    const bool ( &invisible )[5] );
+                              const bool ( &invisible )[5], int z_drop );
         bool draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d,
-                             const bool ( &invisible )[5] );
+                             const bool ( &invisible )[5], int z_drop );
         bool draw_zombie_revival_indicators( const tripoint &pos, lit_level ll, int &height_3d,
-                                             const bool ( &invisible )[5] );
+                                             const bool ( &invisible )[5], int z_drop );
         void draw_entity_with_overlays( const Character &ch, const tripoint &p, lit_level ll,
                                         int &height_3d );
+
 
         bool draw_item_highlight( const tripoint &pos );
 

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -640,7 +640,7 @@ void editmap::draw_main_ui_overlay()
                         const vehicle &veh = vp->vehicle();
                         const int veh_part = vp->part_index();
                         char part_mod = 0;
-                        const vpart_id &vp_id = veh.part_id_string( veh_part, part_mod );
+                        const vpart_id &vp_id = veh.part_id_string( veh_part, false, part_mod );
                         const cata::optional<vpart_reference> cargopart = vp.part_with_feature( "CARGO", true );
                         bool draw_highlight = cargopart && !veh.get_items( cargopart->part_index() ).empty();
                         units::angle veh_dir = veh.face.dir();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7004,20 +7004,26 @@ std::vector<map_item_stack> game::find_nearby_items( int iRadius )
         return ret;
     }
 
-    for( auto &points_p_it : closest_points_first( u.pos(), iRadius ) ) {
-        if( points_p_it.y >= u.posy() - iRadius && points_p_it.y <= u.posy() + iRadius &&
-            u.sees( points_p_it ) &&
-            m.sees_some_items( points_p_it, u ) ) {
+    int range = fov_3d ? fov_3d_z_range : 0;
+    int center_z = u.pos().z;
 
-            for( auto &elem : m.i_at( points_p_it ) ) {
-                const std::string name = elem.tname();
-                const tripoint relative_pos = points_p_it - u.pos();
+    for( int i = 0; i <= range * 2; i++ ) {
+        int z = i % 2 ? center_z - i / 2 : center_z + i / 2;
+        for( auto &points_p_it : closest_points_first( {u.pos().xy(), z}, iRadius ) ) {
+            if( points_p_it.y >= u.posy() - iRadius && points_p_it.y <= u.posy() + iRadius &&
+                u.sees( points_p_it ) &&
+                m.sees_some_items( points_p_it, u ) ) {
 
-                if( std::find( item_order.begin(), item_order.end(), name ) == item_order.end() ) {
-                    item_order.push_back( name );
-                    temp_items[name] = map_item_stack( &elem, relative_pos );
-                } else {
-                    temp_items[name].add_at_pos( &elem, relative_pos );
+                for( auto &elem : m.i_at( points_p_it ) ) {
+                    const std::string name = elem.tname();
+                    const tripoint relative_pos = points_p_it - u.pos();
+
+                    if( std::find( item_order.begin(), item_order.end(), name ) == item_order.end() ) {
+                        item_order.push_back( name );
+                        temp_items[name] = map_item_stack( &elem, relative_pos );
+                    } else {
+                        temp_items[name].add_at_pos( &elem, relative_pos );
+                    }
                 }
             }
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5599,17 +5599,25 @@ void map::update_visibility_cache( const int zlev )
     int sm_squares_seen[MAPSIZE][MAPSIZE];
     std::memset( sm_squares_seen, 0, sizeof( sm_squares_seen ) );
 
-    auto &visibility_cache = get_cache( zlev ).visibility_cache;
+    int min_z = fov_3d ? -OVERMAP_DEPTH : zlev;
+    int max_z = fov_3d ? OVERMAP_HEIGHT : zlev;
 
-    tripoint p;
-    p.z = zlev;
-    int &x = p.x;
-    int &y = p.y;
-    for( x = 0; x < MAPSIZE_X; x++ ) {
-        for( y = 0; y < MAPSIZE_Y; y++ ) {
-            lit_level ll = apparent_light_at( p, visibility_variables_cache );
-            visibility_cache[x][y] = ll;
-            sm_squares_seen[ x / SEEX ][ y / SEEY ] += ( ll == lit_level::BRIGHT || ll == lit_level::LIT );
+    for( int z = min_z; z <= max_z; z++ ) {
+
+        auto &visibility_cache = get_cache( z ).visibility_cache;
+
+        tripoint p;
+        p.z = z;
+        int &x = p.x;
+        int &y = p.y;
+        for( x = 0; x < MAPSIZE_X; x++ ) {
+            for( y = 0; y < MAPSIZE_Y; y++ ) {
+                lit_level ll = apparent_light_at( p, visibility_variables_cache );
+                visibility_cache[x][y] = ll;
+                if( z == zlev ) {
+                    sm_squares_seen[ x / SEEX ][ y / SEEY ] += ( ll == lit_level::BRIGHT || ll == lit_level::LIT );
+                }
+            }
         }
     }
 
@@ -8193,8 +8201,9 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     for( int z = minz; z <= maxz; z++ ) {
         do_vehicle_caching( z );
     }
-
-    seen_cache_dirty |= build_vision_transparency_cache( zlev );
+    for( int z = minz; z <= maxz; z++ ) {
+        seen_cache_dirty |= build_vision_transparency_cache( z );
+    }
 
     if( seen_cache_dirty ) {
         skew_vision_cache.clear();

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -8,8 +8,8 @@
 #include "game.h"
 #include "line.h"
 #include "translations.h"
-
-const memorized_terrain_tile mm_submap::default_tile{ "", 0, 0 };
+#include "map.h"
+const memorized_terrain_tile mm_submap::default_tile { "", 0, 0 };
 const int mm_submap::default_symbol = 0;
 
 #define MM_SIZE (MAPSIZE * 2)
@@ -128,7 +128,9 @@ bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )
     tripoint sm_pos = sm_p1;
     point sm_size = sm_p2.xy() - sm_p1.xy();
 
-    if( sm_pos.z == cache_pos.z ) {
+    bool z_levels = get_map().has_zlevels();
+
+    if( sm_pos.z == cache_pos.z || z_levels ) {
         inclusive_rectangle<point> rect( cache_pos.xy(), cache_pos.xy() + cache_size );
         if( rect.contains( sm_p1.xy() ) && rect.contains( sm_p2.xy() ) ) {
             return false;
@@ -137,13 +139,21 @@ bool map_memory::prepare_region( const tripoint &p1, const tripoint &p2 )
 
     dbg( DL::Info ) << "Preparing memory map for area: pos: " << sm_pos << " size: " << sm_size;
 
+
+    int minz = z_levels ? -OVERMAP_DEPTH : p1.z;
+    int maxz = z_levels ? OVERMAP_HEIGHT : p1.z;
+
     cache_pos = sm_pos;
     cache_size = sm_size;
+
     cached.clear();
-    cached.reserve( cache_size.x * cache_size.y );
-    for( int dy = 0; dy < cache_size.y; dy++ ) {
-        for( int dx = 0; dx < cache_size.x; dx++ ) {
-            cached.push_back( fetch_submap( cache_pos + point( dx, dy ) ) );
+    cached.reserve( cache_size.x * cache_size.y * ( maxz - minz + 1 ) );
+
+    for( int z = minz; z <= maxz; z++ ) {
+        for( int dy = 0; dy < cache_size.y; dy++ ) {
+            for( int dx = 0; dx < cache_size.x; dx++ ) {
+                cached.push_back( fetch_submap( tripoint( cache_pos.xy(), z ) + point( dx, dy ) ) );
+            }
         }
     }
     return true;
@@ -195,6 +205,25 @@ shared_ptr_fast<mm_submap> map_memory::find_submap( const tripoint &sm_pos )
     }
 }
 
+//FIXME: This is to fix old (mid 2022) saves. It can be removed at some point.
+static void temp_remove_open_air( shared_ptr_fast<mm_submap> sm )
+{
+
+    if( sm->is_empty() ) {
+        return;
+    }
+    for( int x = 0; x < SEEX; x++ ) {
+        for( int y = 0; y < SEEY; y++ ) {
+            const memorized_terrain_tile &t = sm->tile( {x, y} );
+
+            if( !t.tile.empty() && t.tile == "t_open_air" ) {
+                sm->set_tile( {x, y}, mm_submap::default_tile );
+            }
+        }
+    }
+
+}
+
 shared_ptr_fast<mm_submap> map_memory::load_submap( const tripoint &sm_pos )
 {
     if( test_mode ) {
@@ -237,6 +266,9 @@ shared_ptr_fast<mm_submap> map_memory::load_submap( const tripoint &sm_pos )
             if( pos == sm_pos ) {
                 ret = sm;
             }
+
+            temp_remove_open_air( mmr.submaps[x][y] );
+
             submaps.insert( std::make_pair( pos, sm ) );
         }
     }
@@ -253,9 +285,12 @@ const mm_submap &map_memory::get_submap( const tripoint &sm_pos ) const
         debugmsg( "Called map_memory::get_submap() before initializing map memory region." );
         return invalid_mz_submap;
     }
+
+    int zoffset = get_map().has_zlevels() ? ( sm_pos.z + OVERMAP_DEPTH ) * cache_size.y * cache_size.x :
+                  0;
     const point idx = ( sm_pos - cache_pos ).xy();
     if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y ) {
-        return *cached[idx.y * cache_size.x + idx.x];
+        return *cached[idx.y * cache_size.x + idx.x + zoffset];
     } else {
         return null_mz_submap;
     }
@@ -266,9 +301,12 @@ mm_submap &map_memory::get_submap( const tripoint &sm_pos )
     if( cache_pos == tripoint_min ) {
         return invalid_mz_submap;
     }
+
+    int zoffset = get_map().has_zlevels() ? ( sm_pos.z + OVERMAP_DEPTH ) * cache_size.y * cache_size.x :
+                  0;
     const point idx = ( sm_pos - cache_pos ).xy();
     if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y ) {
-        return *cached[idx.y * cache_size.x + idx.x];
+        return *cached[idx.y * cache_size.x + idx.x + zoffset];
     } else {
         return null_mz_submap;
     }

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -29,6 +29,7 @@ struct memorized_terrain_tile {
 /** Represent a submap-sized chunk of tile memory. */
 struct mm_submap {
     public:
+        friend class map_memory;
         static const memorized_terrain_tile default_tile;
         static const int default_symbol;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1909,10 +1909,15 @@ void options_manager::add_options_graphics()
     add_empty_line();
 
     add( "MEMORY_MAP_MODE", "graphics", translate_marker( "Memory map drawing mode" ),
-    translate_marker( "Specified the mode in which the memory map is drawn.  Requires restart." ), {
+    translate_marker( "Specified the mode in which the memory map is drawn." ), {
         { "color_pixel_darken", translate_marker( "Darkened" ) },
         { "color_pixel_sepia", translate_marker( "Sepia" ) }
     }, "color_pixel_sepia", COPT_CURSES_HIDE
+       );
+
+    add( "STATICZEFFECT", "graphics", translate_marker( "Static z level effect" ),
+         translate_marker( "If true, lower z levels will look the same no matter how far down they are.  Increases rendering performance." ),
+         false, COPT_CURSES_HIDE
        );
 
     add_empty_line();
@@ -2610,13 +2615,14 @@ void options_manager::add_options_android()
 
 #if defined(TILES)
 // Helper method to isolate #ifdeffed tiles code.
-static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_changed, bool ingame )
+static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_changed, bool ingame,
+                           bool force_tile_change )
 {
     if( used_tiles_changed ) {
         //try and keep SDL calls limited to source files that deal specifically with them
         try {
             tilecontext->reinit();
-            tilecontext->load_tileset( get_option<std::string>( "TILES" ) );
+            tilecontext->load_tileset( get_option<std::string>( "TILES" ), false, force_tile_change );
             //game_ui::init_ui is called when zoom is changed
             g->reset_zoom();
             g->mark_main_ui_adaptor_resize();
@@ -2631,7 +2637,7 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
     }
 }
 #else
-static void refresh_tiles( bool, bool, bool )
+static void refresh_tiles( bool, bool, bool, bool )
 {
 }
 #endif // TILES
@@ -3125,6 +3131,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
     bool used_tiles_changed = false;
     bool pixel_minimap_changed = false;
     bool terminal_size_changed = false;
+    bool force_tile_change = false;
 
     for( auto &iter : OPTIONS_OLD ) {
         if( iter.second != OPTIONS[iter.first] ) {
@@ -3140,9 +3147,12 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
                 || iter.first == "PIXEL_MINIMAP_SCALE_TO_FIT" ) {
                 pixel_minimap_changed = true;
 
-            } else if( iter.first == "TILES" || iter.first == "USE_TILES" ) {
+            } else if( iter.first == "TILES" || iter.first == "USE_TILES" || iter.first == "STATICZEFFECT" ||
+                       iter.first == "MEMORY_MAP_MODE" ) {
                 used_tiles_changed = true;
-
+                if( iter.first == "STATICZEFFECT" || iter.first == "MEMORY_MAP_MODE" ) {
+                    force_tile_change = true;
+                }
             } else if( iter.first == "USE_LANG" ) {
                 lang_changed = true;
 
@@ -3206,7 +3216,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only,
     ( void ) terminal_size_changed;
 #endif
 
-    refresh_tiles( used_tiles_changed, pixel_minimap_changed, ingame );
+    refresh_tiles( used_tiles_changed, pixel_minimap_changed, ingame, force_tile_change );
 
     return "";
 }
@@ -3298,6 +3308,7 @@ void options_manager::cache_to_globals()
     message_cooldown = ::get_option<int>( "MESSAGE_COOLDOWN" );
     fov_3d = ::get_option<bool>( "FOV_3D" );
     fov_3d_z_range = ::get_option<int>( "FOV_3D_Z_RANGE" );
+    static_z_effect = ::get_option<bool>( "STATICZEFFECT" );
     PICKUP_RANGE = ::get_option<int>( "PICKUP_RANGE" );
 #if defined(SDL_SOUND)
     sounds::sound_enabled = ::get_option<bool>( "SOUND_ENABLED" );

--- a/src/sdl_utils.cpp
+++ b/src/sdl_utils.cpp
@@ -18,6 +18,7 @@ color_pixel_function_map builtin_color_pixel_functions = {
     { "color_pixel_grayscale", color_pixel_grayscale },
     { "color_pixel_nightvision", color_pixel_nightvision },
     { "color_pixel_overexposed", color_pixel_overexposed },
+    { "color_pixel_zoverlay", color_pixel_z_overlay },
 };
 
 color_pixel_function_pointer get_color_pixel_function( const std::string &name )

--- a/src/sdl_utils.h
+++ b/src/sdl_utils.h
@@ -10,6 +10,7 @@
 
 #include "color.h"
 #include "sdl_wrappers.h"
+#include "cached_options.h"
 
 using color_pixel_function_pointer = SDL_Color( * )( const SDL_Color &color );
 using color_pixel_function_map = std::unordered_map<std::string, color_pixel_function_pointer>;
@@ -143,6 +144,14 @@ inline SDL_Color color_pixel_sepia( const SDL_Color &color )
         std::min( static_cast<int>( std::round( std::pow( pv, gammav ) * 150 ) ), 100 );
 
     return mix_colors( sepia_dark, sepia_light, finalv );
+}
+
+inline SDL_Color color_pixel_z_overlay( const SDL_Color &color )
+{
+    if( static_z_effect ) {
+        return mix_colors( color, {128, 255, 255, color.a}, color.a / 8 );
+    }
+    return { 128, 255, 255, color.a };
 }
 
 SDL_Color curses_color_to_SDL( const nc_color &color );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -915,7 +915,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
             // light level is now used for choosing between grayscale filter and normal lit tiles.
             draw_from_id_string( id, TILE_CATEGORY::C_OVERMAP_TERRAIN, "overmap_terrain", omp.raw(),
-                                 subtile, rotation, ll, false, height_3d );
+                                 subtile, rotation, ll, false, height_3d, 0 );
 
             if( see ) {
                 if( blink && uistate.overmap_debug_mongroup ) {
@@ -924,7 +924,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                         auto mgroup_iter = mgroups.begin();
                         std::advance( mgroup_iter, rng( 0, mgroups.size() - 1 ) );
                         draw_from_id_string( ( *mgroup_iter )->type->defaultMonster.str(),
-                                             omp.raw(), 0, 0, lit_level::LIT, false );
+                                             omp.raw(), 0, 0, lit_level::LIT, false, 0 );
                     }
                 }
                 const int horde_size = overmap_buffer.get_horde_size( omp );
@@ -932,32 +932,32 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                     // a little bit of hardcoded fallbacks for hordes
                     if( find_tile_with_season( id ) ) {
                         draw_from_id_string( string_format( "overmap_horde_%d", horde_size ),
-                                             omp.raw(), 0, 0, lit_level::LIT, false );
+                                             omp.raw(), 0, 0, lit_level::LIT, false, 0 );
                     } else {
                         switch( horde_size ) {
                             case HORDE_VISIBILITY_SIZE:
                                 draw_from_id_string( "mon_zombie", omp.raw(), 0, 0, lit_level::LIT,
-                                                     false );
+                                                     false, 0 );
                                 break;
                             case HORDE_VISIBILITY_SIZE + 1:
                                 draw_from_id_string( "mon_zombie_tough", omp.raw(), 0, 0,
-                                                     lit_level::LIT, false );
+                                                     lit_level::LIT, false, 0 );
                                 break;
                             case HORDE_VISIBILITY_SIZE + 2:
                                 draw_from_id_string( "mon_zombie_brute", omp.raw(), 0, 0,
-                                                     lit_level::LIT, false );
+                                                     lit_level::LIT, false, 0 );
                                 break;
                             case HORDE_VISIBILITY_SIZE + 3:
                                 draw_from_id_string( "mon_zombie_hulk", omp.raw(), 0, 0,
-                                                     lit_level::LIT, false );
+                                                     lit_level::LIT, false, 0 );
                                 break;
                             case HORDE_VISIBILITY_SIZE + 4:
                                 draw_from_id_string( "mon_zombie_necro", omp.raw(), 0, 0,
-                                                     lit_level::LIT, false );
+                                                     lit_level::LIT, false, 0 );
                                 break;
                             default:
                                 draw_from_id_string( "mon_zombie_master", omp.raw(), 0, 0,
-                                                     lit_level::LIT, false );
+                                                     lit_level::LIT, false, 0 );
                                 break;
                         }
                     }
@@ -968,17 +968,17 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                 // Highlight areas that already have been generated
                 // TODO: fix point types
                 if( MAPBUFFER.lookup_submap( project_to<coords::sm>( omp ).raw() ) ) {
-                    draw_from_id_string( "highlight", omp.raw(), 0, 0, lit_level::LIT, false );
+                    draw_from_id_string( "highlight", omp.raw(), 0, 0, lit_level::LIT, false, 0 );
                 }
             }
 
             if( blink && overmap_buffer.has_vehicle( omp ) ) {
                 if( find_tile_looks_like( "overmap_remembered_vehicle", TILE_CATEGORY::C_OVERMAP_NOTE ) ) {
                     draw_from_id_string( "overmap_remembered_vehicle", TILE_CATEGORY::C_OVERMAP_NOTE,
-                                         "overmap_note", omp.raw(), 0, 0, lit_level::LIT, false );
+                                         "overmap_note", omp.raw(), 0, 0, lit_level::LIT, false, 0 );
                 } else {
                     draw_from_id_string( "note_c_cyan", TILE_CATEGORY::C_OVERMAP_NOTE,
-                                         "overmap_note", omp.raw(), 0, 0, lit_level::LIT, false );
+                                         "overmap_note", omp.raw(), 0, 0, lit_level::LIT, false, 0 );
                 }
             }
 
@@ -992,7 +992,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
                 std::string note_name = "note_" + ter_sym + "_" + string_from_color( ter_color );
                 draw_from_id_string( note_name, TILE_CATEGORY::C_OVERMAP_NOTE, "overmap_note",
-                                     omp.raw(), 0, 0, lit_level::LIT, false );
+                                     omp.raw(), 0, 0, lit_level::LIT, false, 0 );
             }
         }
     }
@@ -1005,7 +1005,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         int subtile;
         terrain.get_rotation_and_subtile( rotation, subtile );
         draw_from_id_string( id, global_omt_to_draw_position( center_abs_omt ), subtile, rotation,
-                             lit_level::LOW, true );
+                             lit_level::LOW, true, 0 );
     }
     if( uistate.place_special ) {
         for( const overmap_special_terrain &s_ter : uistate.place_special->terrains ) {
@@ -1020,7 +1020,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                 terrain.get_rotation_and_subtile( rotation, subtile );
 
                 draw_from_id_string( id, TILE_CATEGORY::C_OVERMAP_TERRAIN, "overmap_terrain",
-                                     global_omt_to_draw_position( center_abs_omt + rp ), 0, rotation, lit_level::LOW, true );
+                                     global_omt_to_draw_position( center_abs_omt + rp ), 0, rotation, lit_level::LOW, true, 0 );
             }
         }
     }
@@ -1041,7 +1041,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                                    lit_level::LIT, height_3d );
     }
     draw_from_id_string( "cursor", global_omt_to_draw_position( center_abs_omt ), 0, 0, lit_level::LIT,
-                         false );
+                         false, 0 );
 
     if( blink ) {
         // Draw path for auto-travel
@@ -1054,7 +1054,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             } else {
                 id = "overmap_path_below";
             }
-            draw_from_id_string( id, global_omt_to_draw_position( pos ), 0, 0, lit_level::LIT, false );
+            draw_from_id_string( id, global_omt_to_draw_position( pos ), 0, 0, lit_level::LIT, false, 0 );
         }
 
         // reduce the area where the map cursor is drawn so it doesn't get cut off
@@ -1064,7 +1064,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                     get_mission_arrow( map_cursor_area, center_abs_omt );
         if( mission_arrow ) {
             draw_from_id_string( mission_arrow->second, global_omt_to_draw_position( mission_arrow->first ), 0,
-                                 0, lit_level::LIT, false );
+                                 0, lit_level::LIT, false, 0 );
         }
     }
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1097,7 +1097,7 @@ class vehicle
 
         // get symbol for map
         char part_sym( int p, bool exact = false ) const;
-        vpart_id part_id_string( int p, char &part_mod ) const;
+        vpart_id part_id_string( int p, bool roof, char &part_mod ) const;
 
         // get color for map
         nc_color part_color( int p, bool exact = false ) const;

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -52,14 +52,22 @@ char vehicle::part_sym( const int p, const bool exact ) const
 // similar to part_sym(int p) but for use when drawing SDL tiles. Called only by cata_tiles
 // during draw_vpart vector returns at least 1 element, max of 2 elements. If 2 elements the
 // second denotes if it is open or damaged
-vpart_id vehicle::part_id_string( const int p, char &part_mod ) const
+vpart_id vehicle::part_id_string( const int p, bool roof, char &part_mod ) const
 {
     part_mod = 0;
     if( p < 0 || p >= static_cast<int>( parts.size() ) || parts[p].removed ) {
         return vpart_id::NULL_ID();
     }
 
-    int displayed_part = part_displayed_at( parts[p].mount );
+    int displayed_part = -1;
+
+    if( roof ) {
+        displayed_part = roof_at_part( p );
+    }
+    if( displayed_part < 0 || displayed_part >= static_cast<int>( parts.size() ) ||
+        parts[ displayed_part ].removed ) {
+        displayed_part = part_displayed_at( parts[p].mount );
+    }
     if( displayed_part < 0 || displayed_part >= static_cast<int>( parts.size() ) ||
         parts[ displayed_part ].removed ) {
         return vpart_id::NULL_ID();

--- a/tests/map_memory_test.cpp
+++ b/tests/map_memory_test.cpp
@@ -30,7 +30,7 @@ TEST_CASE( "map_memory_keeps_region", "[map_memory]" )
     CHECK( !memory.prepare_region( p2, p3 ) );
     CHECK( memory.prepare_region( p1, p4 ) );
     CHECK( !memory.prepare_region( p2, p3 ) );
-    CHECK( memory.prepare_region(
+    CHECK( get_map().has_zlevels() == !memory.prepare_region(
                tripoint( p2.xy(), -p2.z ),
                tripoint( p3.xy(), -p3.z )
            ) );


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Draw in lower z levels."

#### Purpose of change

Fixes #1728. Draws in the contents of lower z levels with a visual effect. 

#### Describe the solution

When drawing tiles previously each row would be collected and then drawn in turn. Now the whole map is collected first. It's during this collection that the searching down to lower z levels happens and only the lowest tile is collected. Collected tiles are sorted by z level, then the terrain, furniture, graffiti and trap layers are drawn for each collected tile in turn. Then starting at the lowest z level and working up, the fields, items, vehicles and creatures are drawn for each collected tile and the tiles above them. Lastly the zone markers and revival indicators are drawn. 

Things being drawn on lower z levels have an effect applied to them. Similar to the greyscale and nightvision versions of sprites, a filter is applied that maintains the alpha channel and sets the color to a light cyan. When drawing the sprite this texture is drawn over the top of it using SDL_SetTextureAlphaMod to control transparency based on z level. There's an option to use a prebaked version of this with a fixed transparency instead. 

When 3d field of view is turned on it takes into account visibility when looking downwards. If you don't have visibility on the tile below it will draw a small square like it does currently. This is also the case if you turn z levels off. When vehicles are being viewed from above like this they will prefer to show their roof part unless they have a creature in them.

#### Describe alternatives you've considered

Porting to UE5.

#### Testing

There are some cases that don't layer nicely. If a large sprite like a hulk is stood one tile south and down from a vehicle the hulk will be rendered below the vehicle making it look like it's shoved its head beneath it. I don't think this is easily resolved though. In this case the hulk should be on top, but if the vehicle covered a tile south as well, then it should be underneath as the vehicle should hide it entirely. 

I'm not too happy with the way 3d fov looks, I think the squares look a bit out of place but flat cyan doesn't look any better. It also doesn't show car roofs as you can't see the tile with the part in it. 

#### Additional context

Landed on a roof:
![chopnoz](https://user-images.githubusercontent.com/6675689/179667274-f121a285-5ecf-4903-a0ea-ca15d6031058.jpg)

Same with 3d fov on:
![chopz](https://user-images.githubusercontent.com/6675689/179667598-dc02c410-2c6a-491f-bd4c-9cc86be49a6c.jpg)
