### PR TITLE
Mapgen crash fix

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2351,8 +2351,9 @@ bool map::has_flag_ter_or_furn( const ter_bitflags flag, const tripoint &p ) con
     point l;
     submap *const current_submap = get_submap_at( p, l );
 
-    return current_submap->get_ter( l ).obj().has_flag( flag ) ||
-           current_submap->get_furn( l ).obj().has_flag( flag );
+    return current_submap && //FIXME: can be null during mapgen
+           ( current_submap->get_ter( l ).obj().has_flag( flag ) ||
+             current_submap->get_furn( l ).obj().has_flag( flag ) );
 }
 
 // End of 3D flags

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -83,11 +83,11 @@ static void check_wreckage( int zlevel )
     const tripoint test_origin( 60, 60, zlevel );
     const tripoint vehicle_origin = test_origin;
 
-    vehicle *veh_ptr = g->m.add_vehicle( vproto_id( "bicycle" ), vehicle_origin, 0_degrees, 0, 0 );
+    vehicle *veh_ptr = get_map().add_vehicle( vproto_id( "bicycle" ), vehicle_origin, 0_degrees, 0, 0 );
     REQUIRE( veh_ptr != nullptr );
 
-    vehicle *veh_ptr2 = g->m.add_vehicle( vproto_id( "car" ), vehicle_origin + tripoint_north_west,
-                                          0_degrees, 0, 0 );
+    vehicle *veh_ptr2 = get_map().add_vehicle( vproto_id( "car" ), vehicle_origin + tripoint_north_west,
+                        0_degrees, 0, 0 );
     REQUIRE( veh_ptr2 != nullptr );
 
     INFO( veh_ptr2->name );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fixes crash during mapgen"

#### Purpose of change

No more segfaults.

#### Describe the solution

More null pointer checks on submaps.

#### Describe alternatives you've considered

I'm going to actually look at this and work out why they're null in the first place. I'm adding checks to the specific part that the ramp code triggers but those checks are missing everywhere because it's meant to be that they're initialized by that point. 

#### Testing

Not enough apparently. 

#### Additional context

Also changes g->m to get_map in the tests because it wasn't compiling. 