### PR TITLE
Refactor calc_fatigue_cap()

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -986,7 +986,7 @@ void avatar::disp_morale()
 {
     int equilibrium = calc_focus_equilibrium();
 
-    int fatigue_cap = calc_fatigue_cap( *this );
+    int fatigue_cap = calc_fatigue_cap( this->get_fatigue() );
 
     int pain_penalty = has_trait( trait_CENOBITE ) ? 0 : get_perceived_pain();
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4407,7 +4407,7 @@ bool player::query_yn( const std::string &mes ) const
     return ::query_yn( mes );
 }
 
-int calc_fatigue_cap( const int &fatigue )
+int calc_fatigue_cap( int fatigue )
 {
     if( fatigue >= fatigue_levels::massive ) {
         return 20;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4407,15 +4407,15 @@ bool player::query_yn( const std::string &mes ) const
     return ::query_yn( mes );
 }
 
-int calc_fatigue_cap( const player &p )
+int calc_fatigue_cap( const int &fatigue )
 {
-    if( p.get_fatigue() >= fatigue_levels::massive ) {
+    if( fatigue >= fatigue_levels::massive ) {
         return 20;
-    } else if( p.get_fatigue() >= fatigue_levels::exhausted ) {
+    } else if( fatigue >= fatigue_levels::exhausted ) {
         return 40;
-    } else if( p.get_fatigue() >= fatigue_levels::dead_tired ) {
+    } else if( fatigue >= fatigue_levels::dead_tired ) {
         return 60;
-    } else if( p.get_fatigue() >= fatigue_levels::tired ) {
+    } else if( fatigue >= fatigue_levels::tired ) {
         return 80;
     }
     return 0;
@@ -4445,8 +4445,9 @@ int player::calc_focus_equilibrium() const
     }
 
     // as baseline morale is 100, calc_fatigue_cap() has to -100 to apply accurate penalties.
-    if( calc_fatigue_cap( *this ) != 0 && eff_morale > calc_fatigue_cap( *this ) - 100 ) {
-        eff_morale = calc_fatigue_cap( *this ) - 100;
+    if( calc_fatigue_cap( this->get_fatigue() ) != 0 &&
+        eff_morale > calc_fatigue_cap( this->get_fatigue() ) - 100 ) {
+        eff_morale = calc_fatigue_cap( this->get_fatigue() ) - 100;
     }
 
     if( eff_morale < -99 ) {

--- a/src/player.h
+++ b/src/player.h
@@ -778,6 +778,6 @@ class player : public Character
 };
 
 /** Calculates the player's morale cap due to fatigue */
-int calc_fatigue_cap( const player &p );
+int calc_fatigue_cap( const int &fatigue );
 
 #endif // CATA_SRC_PLAYER_H

--- a/src/player.h
+++ b/src/player.h
@@ -778,6 +778,6 @@ class player : public Character
 };
 
 /** Calculates the player's morale cap due to fatigue */
-int calc_fatigue_cap( const int &fatigue );
+int calc_fatigue_cap( int fatigue );
 
 #endif // CATA_SRC_PLAYER_H


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Refactor `calc_fatigue_cap()"

#### Purpose of change

Was suggested in #1708 to convert `calc_fatigue_cap()` to use int instead of accepting the entire character class.

#### Describe the solution

Converts `calc_fatigue_cap()` to use int argument instead of character argument. Adjusted code accordingly.

#### Describe alternatives you've considered

#### Testing

Started new character, applied fatigue, applied pain, tested that morale displayed and changed appropriately.

#### Additional context