### PR TITLE
Gaming Device update

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1764,26 +1764,29 @@ void activity_handlers::forage_finish( player_activity *act, player *p )
 void activity_handlers::generic_game_do_turn( player_activity *act, player *p )
 {
     item &game_item = *act->targets.front();
-    int energy = 0;
 
     // Consume battery charges for every minute spent playing
     if( calendar::once_every( 1_minutes ) ) {
         if( game_item.ammo_required() ) {
-            energy = game_item.ammo_required();
+            int energy = game_item.ammo_required();
             energy -= game_item.ammo_consume( energy, p->pos() );
             if( energy > 0 && game_item.has_flag( flag_USE_UPS ) ) {
                 if( p->use_charges_if_avail( itype_UPS, energy ) ) {
                     energy = 0;
                 }
             }
-        }
-        if( !energy ) {
-            // In practice this grants a 32 point morale bonus due to decay
-            p->add_morale( MORALE_GAME, 8, 60 );
+            if( !energy ) {
+                // In practice this grants a 32 point morale bonus due to decay
+                p->add_morale( MORALE_GAME, 8, 60 );
+                return;
+            }
         } else {
-            act->moves_left = 0;
-            add_msg( m_info, _( "The %s runs out of batteries." ), game_item.tname() );
+            // In practice this grants an 18 point morale bonus due to decay
+            p->add_morale( MORALE_GAME, 6, 60 );
+            return;
         }
+        act->moves_left = 0;
+        add_msg( m_info, _( "The %s runs out of batteries." ), game_item.tname() );
     }
 }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1761,11 +1761,11 @@ void activity_handlers::forage_finish( player_activity *act, player *p )
     act->set_to_null();
 }
 
-void activity_handlers::generic_game_do_turn( player_activity *act, player *p )
+void activity_handlers::generic_game_do_turn( player_activity * /*act*/, player *p )
 {
     if( calendar::once_every( 1_minutes ) ) {
-        // So 15 points per play
-        p->add_morale( MORALE_GAME, 1, 30, 2_hours, 30_minutes, true );
+        // So 30 points per play
+        p->add_morale( MORALE_GAME, 2, 60, 2_hours, 30_minutes, true );
         return;
     }
 }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1764,14 +1764,17 @@ void activity_handlers::forage_finish( player_activity *act, player *p )
 void activity_handlers::generic_game_do_turn( player_activity *act, player *p )
 {
     item &game_item = *act->targets.front();
+    int energy = 0;
 
     // Consume battery charges for every minute spent playing
     if( calendar::once_every( 1_minutes ) ) {
-        int energy = game_item.ammo_required();
-        energy -= game_item.ammo_consume( energy, p->pos() );
-        if( energy > 0 && game_item.has_flag( flag_USE_UPS ) ) {
-            if( p->use_charges_if_avail( itype_UPS, energy ) ) {
-                energy = 0;
+        if( game_item.ammo_required() ) {
+            energy = game_item.ammo_required();
+            energy -= game_item.ammo_consume( energy, p->pos() );
+            if( energy > 0 && game_item.has_flag( flag_USE_UPS ) ) {
+                if( p->use_charges_if_avail( itype_UPS, energy ) ) {
+                    energy = 0;
+                }
             }
         }
         if( !energy ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1763,30 +1763,10 @@ void activity_handlers::forage_finish( player_activity *act, player *p )
 
 void activity_handlers::generic_game_do_turn( player_activity *act, player *p )
 {
-    item &game_item = *act->targets.front();
-
-    // Consume battery charges for every minute spent playing
     if( calendar::once_every( 1_minutes ) ) {
-        if( game_item.ammo_required() ) {
-            int energy = game_item.ammo_required();
-            energy -= game_item.ammo_consume( energy, p->pos() );
-            if( energy > 0 && game_item.has_flag( flag_USE_UPS ) ) {
-                if( p->use_charges_if_avail( itype_UPS, energy ) ) {
-                    energy = 0;
-                }
-            }
-            if( !energy ) {
-                // In practice this grants a 32 point morale bonus due to decay
-                p->add_morale( MORALE_GAME, 8, 60 );
-                return;
-            }
-        } else {
-            // In practice this grants an 18 point morale bonus due to decay
-            p->add_morale( MORALE_GAME, 6, 60 );
-            return;
-        }
-        act->moves_left = 0;
-        add_msg( m_info, _( "The %s runs out of batteries." ), game_item.tname() );
+        // So 15 points per play
+        p->add_morale( MORALE_GAME, 1, 30, 2_hours, 30_minutes, true );
+        return;
     }
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4432,8 +4432,9 @@ int iuse::portable_game( player *p, item *it, bool t, const tripoint & )
 
         p->add_msg_if_player( _( "You play on your %s for a while." ), it->tname() );
         if( loaded_software == "null" ) {
-            p->assign_activity( ACT_GENERIC_GAME, to_moves<int>( 1_hours ), -1,
-                                p->get_item_position( it ), "gaming" );
+            p->assign_activity( ACT_GENERIC_GAME, to_moves<int>( 30_minutes ), -1,
+                                0, "gaming" );
+            p->activity.targets.push_back( item_location( *p, it ) );
             return 0;
         }
         p->assign_activity( ACT_GAME, moves, -1, 0, "gaming" );
@@ -9729,7 +9730,7 @@ int iuse::play_game( player *p, item *it, bool t, const tripoint & )
 
     if( query_yn( _( "Play a game with the %s?" ), it->tname() ) ) {
         p->add_msg_if_player( _( "You start playing." ) );
-        p->assign_activity( ACT_GENERIC_GAME, to_moves<int>( 1_hours ), -1,
+        p->assign_activity( ACT_GENERIC_GAME, to_moves<int>( 30_minutes ), -1,
                             p->get_item_position( it ), "gaming" );
     }
     return 0;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9715,7 +9715,7 @@ int iuse::play_game( player *p, item *it, bool t, const tripoint & )
 
     if( query_yn( _( "Play a game with the %s?" ), it->tname() ) ) {
         p->add_msg_if_player( _( "You start playing." ) );
-        p->assign_activity( ACT_GENERIC_GAME, to_moves<int>( 15_minutes ), -1,
+        p->assign_activity( ACT_GENERIC_GAME, to_moves<int>( 30_minutes ), -1,
                             p->get_item_position( it ), "gaming" );
     }
     return 0;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9732,6 +9732,7 @@ int iuse::play_game( player *p, item *it, bool t, const tripoint & )
         p->add_msg_if_player( _( "You start playing." ) );
         p->assign_activity( ACT_GENERIC_GAME, to_moves<int>( 30_minutes ), -1,
                             p->get_item_position( it ), "gaming" );
+        p->activity.targets.push_back( item_location( *p, it ) );
     }
     return 0;
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4387,9 +4387,8 @@ int iuse::portable_game( player *p, item *it, bool t, const tripoint & )
     if( p->has_trait( trait_ILLITERATE ) ) {
         p->add_msg_if_player( m_info, _( "You're illiterate!" ) );
         return 0;
-    } else if( it->units_remaining( *p ) < it->ammo_required() ) {
-        p->add_msg_if_player( m_info, _( "The %s's batteries are dead." ), it->tname() );
-        return 0;
+    } else if( it->units_remaining( *p ) < ( it->ammo_required() * 15 ) ) {
+        p->add_msg_if_player( m_info, _( "You don't have enough charges to play." ) );
     } else {
         std::string loaded_software = "robot_finds_kitten";
 
@@ -4431,35 +4430,21 @@ int iuse::portable_game( player *p, item *it, bool t, const tripoint & )
         const int moves = to_moves<int>( 15_minutes );
 
         p->add_msg_if_player( _( "You play on your %s for a while." ), it->tname() );
-        if( loaded_software == "null" ) {
-            p->assign_activity( ACT_GENERIC_GAME, to_moves<int>( 30_minutes ), -1,
-                                0, "gaming" );
-            p->activity.targets.push_back( item_location( *p, it ) );
-            return 0;
-        }
         p->assign_activity( ACT_GAME, moves, -1, 0, "gaming" );
         p->activity.targets.push_back( item_location( *p, it ) );
-        std::map<std::string, std::string> game_data;
-        game_data.clear();
+        std::string end_message;
+        end_message.clear();
         int game_score = 0;
 
-        play_videogame( loaded_software, game_data, game_score );
+        play_videogame( loaded_software, end_message, game_score );
 
-        if( game_data.find( "end_message" ) != game_data.end() ) {
-            p->add_msg_if_player( game_data["end_message"] );
+        if( !end_message.empty() ) {
+            p->add_msg_if_player( end_message );
         }
 
         if( game_score != 0 ) {
-            if( game_data.find( "moraletype" ) != game_data.end() ) {
-                std::string moraletype = game_data.find( "moraletype" )->second;
-                if( moraletype == "MORALE_GAME_FOUND_KITTEN" ) {
-                    p->add_morale( MORALE_GAME_FOUND_KITTEN, game_score, 110 );
-                } /*else if ( ...*/
-            } else {
-                p->add_morale( MORALE_GAME, game_score, 110 );
-            }
+            p->add_morale( MORALE_GAME, game_score, 60, 2_hours, 30_minutes, true );
         }
-
     }
     return 0;
 }
@@ -9730,9 +9715,8 @@ int iuse::play_game( player *p, item *it, bool t, const tripoint & )
 
     if( query_yn( _( "Play a game with the %s?" ), it->tname() ) ) {
         p->add_msg_if_player( _( "You start playing." ) );
-        p->assign_activity( ACT_GENERIC_GAME, to_moves<int>( 30_minutes ), -1,
+        p->assign_activity( ACT_GENERIC_GAME, to_moves<int>( 15_minutes ), -1,
                             p->get_item_position( it ), "gaming" );
-        p->activity.targets.push_back( item_location( *p, it ) );
     }
     return 0;
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4389,6 +4389,7 @@ int iuse::portable_game( player *p, item *it, bool t, const tripoint & )
         return 0;
     } else if( it->units_remaining( *p ) < ( it->ammo_required() * 15 ) ) {
         p->add_msg_if_player( m_info, _( "You don't have enough charges to play." ) );
+        return 0;
     } else {
         std::string loaded_software = "robot_finds_kitten";
 

--- a/src/iuse_software.cpp
+++ b/src/iuse_software.cpp
@@ -16,19 +16,18 @@
 #include "translations.h"
 
 bool play_videogame( const std::string &function_name,
-                     std::map<std::string, std::string> &game_data,
+                     std::string &end_message,
                      int &score )
 {
-    if( function_name.empty() ) {
-        score = 15;
+    if( function_name == "null" ) {
+        score = 30;
         return true; // generic game
     }
     if( function_name == "robot_finds_kitten" ) {
         robot_finds_kitten findkitten;
         bool foundkitten = findkitten.ret;
         if( foundkitten ) {
-            game_data["end_message"] = _( "You found kitten!" );
-            game_data["moraletype"] = "MORALE_GAME_FOUND_KITTEN";
+            end_message = _( "You found kitten!" );
             score = 30;
         }
 
@@ -71,12 +70,8 @@ bool play_videogame( const std::string &function_name,
 
         return true;
     } else {
-        score = -5;
-        /* morale/activity workaround >.> */
-        game_data["end_message"] = string_format(
-                                       _( "You struggle to get '%s' working, and finally give up to play minesweeper." ),
-                                       function_name );
-        // TODO: better messages in morale system //  game_data["moraletype"]="MORALE_GAME_SOFTWARE_PROBLEM";
+        debugmsg( "Invalid function_name for play_videogame." );
+        score = 0;
         return false;
     }
 }

--- a/src/iuse_software.h
+++ b/src/iuse_software.h
@@ -6,7 +6,7 @@
 #include <string>
 
 bool play_videogame( const std::string &function_name,
-                     std::map<std::string, std::string> &game_data,
+                     std::string &end_message,
                      int &score );
 
 #endif // CATA_SRC_IUSE_SOFTWARE_H

--- a/src/morale_types.cpp
+++ b/src/morale_types.cpp
@@ -69,7 +69,6 @@ const morale_type MORALE_PERM_OPTIMIST( "morale_perm_optimist" );
 const morale_type MORALE_PERM_BADTEMPER( "morale_perm_badtemper" );
 const morale_type MORALE_PERM_CONSTRAINED( "morale_perm_constrained" );
 const morale_type MORALE_PERM_NOMAD( "morale_perm_nomad" );
-const morale_type MORALE_GAME_FOUND_KITTEN( "morale_game_found_kitten" );
 const morale_type MORALE_HAIRCUT( "morale_haircut" );
 const morale_type MORALE_SHAVE( "morale_shave" );
 const morale_type MORALE_CHAT( "morale_chat" );

--- a/src/morale_types.h
+++ b/src/morale_types.h
@@ -95,7 +95,6 @@ extern const morale_type MORALE_PERM_OPTIMIST;
 extern const morale_type MORALE_PERM_BADTEMPER;
 extern const morale_type MORALE_PERM_CONSTRAINED;
 extern const morale_type MORALE_PERM_NOMAD;
-extern const morale_type MORALE_GAME_FOUND_KITTEN;
 extern const morale_type MORALE_HAIRCUT;
 extern const morale_type MORALE_SHAVE;
 extern const morale_type MORALE_CHAT;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfix "Rebalance gaming machines and fix power consumption"

#### Purpose of change

Fix #1751.

Also found out that morale bonus from `game_do_turn` is actually pointless as 99% of the morale boost is handled in `iuse::portable_game`.

In the same vein, `generic_game_do_turn` ultimately granted 8 morale only despite using an entire hour due to ~morale decay~ unintuitive code. It also did not have _any_ checks for consuming charges. Furthermore, routing through `generic_game_do_turn ` instead of `play_videogame` was unnecessary, as that function already has a check for if the game is a generic game.

#### Describe the solution

First, changed the way `game_do_turn` processed such that it would use the item charges first, and only look for UPS if the charges were used up.

Then, ripped out the morale bonus in `game_do_turn` because it ultimately granted only 1 morale per session. Changed the morale code for the `iuse` so that it would stack properly, and only stack to a maximum of 60 to prevent shenanigans where you play games for 6 hours to try and maximize the bonus to 110 which lasts only an hour. Removed the unique morale identifier `FOUND_KITTEN` as it would allow players to stack both Robot finds Kitten and any other game for a total buff of 120 morale.

Added a check so that you couldn't play a video game session unless you had enough charges. As a game is either played or it is not, it would be both cruel and unintuitive for the player to spend 10 minutes farming 10k points in Snake only to lose a portion of it because the computer ran out of power.

~Copied most of the code over to `generic_game_do_turn` so that it would consume charges, bumped up the morale bonus so it would build to a total of 30 per session (equal to that of a game of robot finds kitten), and reduced the session to 15 minutes from an hour (as playing an actual game only uses 15 minutes, using an hour for generic games seems like a pointless punishment)~

Reduced `generic_game_do_turn` duration to 30 minutes, and bumped up the morale to match that of `portable_game` iuse. This allows a deck of cards to still be useful in comparison to laptops and game_watches by not requiring charges, and providing the same amount of morale boost with a greater investment in time.

~Additionally, added a consideration I'd missed. `generic_game_do_turn` is also used for playing cards, reduced morale bonuses such that it grants 15 morale total per use for such a game item without charge requirements (max stack 30. (If anyone makes an atomic gaming machine this will need to be adjusted as if it doesn't use charges it will default to the so-so morale bonus).~

#### Describe alternatives you've considered

- Keep morale bonus in `game_do_turn` and adjust it upward to matter.
Rejected on the basis that the main meat of the morale bonus is currently scaled off game score. Adding a second source has no meaning.
- Further reduce generic game session duration to 15 minutes to match with specific game session, reduce max and per session morale instead.
Considering that playing cards are not much more common than laptops and other gaming devices, this seems to be too heavy a penalty.

#### Testing

Spawned laptop, played robot finds kitten, checked morale gain and power consumption. Played generic game, checked morale gain and power consumption.

Spawned playing cards, played game.

#### Additional context

~It's worth noting that there's a niche exploit here. Due to how morale decays, it may actually be beneficial if you can somehow control the number of charges a laptop or gaming machine has. Ending the session 15 to 20 minutes early grants the same amount of morale for less charges used and less time used.~ Fixed.

The scoring for the games are a bit out of whack, requiring for instance 10,000 points in Snake to match the morale bonus of playing Robot finds Kitten. The other games are likely similar and may need to be rebalanced so that the player's time investment isn't disproportionate to the morale buff (Alternatively we can remove the scoring scale, but that would make some games much more desirable, I'd just propose changing it so that each game takes on average similar amounts of time to complete for max bonuses.)