### PR TITLE
Vanilla Ups Changes

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "adv_UPS_off",
-    "type": "TOOL",
+    "type": "TOOL_ARMOR",
     "category": "tools",
     "name": { "str": "advanced UPS", "str_pl": "advanced UPS's" },
     "description": "This is an advanced version of the unified power supply, or UPS.  Designed for military use to power advanced weapons, it uses plutonium fuel cells which provide better efficiency, but are not rechargeable.  It can power many household electronics as well.",
@@ -14,9 +14,12 @@
     "material": [ "aluminum", "plastic" ],
     "symbol": ";",
     "color": "light_green",
+    "coverage": 5,
+    "encumbrance": 2,
+    "covers": [ "leg_either" ],
     "ammo": "plutonium",
     "max_charges": 2500,
-    "flags": [ "IS_UPS" ]
+    "flags": [ "IS_UPS", "WAIST", "FRAGILE", "OVERSIZE" ]
   },
   {
     "id": "camera",
@@ -501,7 +504,7 @@
   },
   {
     "id": "UPS_off",
-    "type": "TOOL",
+    "type": "TOOL_ARMOR",
     "category": "tools",
     "name": { "str": "UPS", "str_pl": "UPS's" },
     "description": "This is a unified power supply, or UPS.  It is a civilian evolution of a military project.  Designed to power advanced weapons and armor, the civilian version serves as a portable power bank and inverter for many household electronics.",
@@ -514,12 +517,15 @@
     "material": [ "aluminum", "plastic" ],
     "symbol": ";",
     "color": "light_gray",
+    "coverage": 5,
+    "encumbrance": 2,
+    "covers": [ "leg_either" ],
     "ammo": "battery",
     "magazines": [
       [ "battery", [ "heavy_plus_battery_cell", "heavy_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ] ]
     ],
     "magazine_well": "1500 ml",
-    "flags": [ "IS_UPS" ]
+    "flags": [ "IS_UPS", "WAIST", "FRAGILE", "OVERSIZE" ]
   },
   {
     "id": "vibrator",

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -1,27 +1,5 @@
 [
   {
-    "id": "adv_UPS_off",
-    "type": "TOOL_ARMOR",
-    "category": "tools",
-    "name": { "str": "advanced UPS", "str_pl": "advanced UPS's" },
-    "description": "This is an advanced version of the unified power supply, or UPS.  Designed for military use to power advanced weapons, it uses plutonium fuel cells which provide better efficiency, but are not rechargeable.  It can power many household electronics as well.",
-    "weight": "453 g",
-    "volume": "2 L",
-    "price": 560000,
-    "price_postapoc": 3000,
-    "to_hit": -1,
-    "bashing": 8,
-    "material": [ "aluminum", "plastic" ],
-    "symbol": ";",
-    "color": "light_green",
-    "coverage": 5,
-    "encumbrance": 2,
-    "covers": [ "leg_either" ],
-    "ammo": "plutonium",
-    "max_charges": 2500,
-    "flags": [ "IS_UPS", "WAIST", "FRAGILE", "OVERSIZE" ]
-  },
-  {
     "id": "camera",
     "type": "TOOL",
     "category": "tools",
@@ -503,31 +481,6 @@
     "flags": [ "WATCH", "LIGHT_20", "TRADER_AVOID", "ALARMCLOCK", "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {
-    "id": "UPS_off",
-    "type": "TOOL_ARMOR",
-    "category": "tools",
-    "name": { "str": "UPS", "str_pl": "UPS's" },
-    "description": "This is a unified power supply, or UPS.  It is a civilian evolution of a military project.  Designed to power advanced weapons and armor, the civilian version serves as a portable power bank and inverter for many household electronics.",
-    "weight": "680 g",
-    "volume": "2500 ml",
-    "price": 280000,
-    "price_postapoc": 1500,
-    "to_hit": -1,
-    "bashing": 8,
-    "material": [ "aluminum", "plastic" ],
-    "symbol": ";",
-    "color": "light_gray",
-    "coverage": 5,
-    "encumbrance": 2,
-    "covers": [ "leg_either" ],
-    "ammo": "battery",
-    "magazines": [
-      [ "battery", [ "heavy_plus_battery_cell", "heavy_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ] ]
-    ],
-    "magazine_well": "1500 ml",
-    "flags": [ "IS_UPS", "WAIST", "FRAGILE", "OVERSIZE" ]
-  },
-  {
     "id": "vibrator",
     "type": "TOOL",
     "category": "tools",
@@ -612,5 +565,52 @@
     "use_action": "NOTE_BIONICS",
     "revert_to": "bionic_scanner",
     "revert_msg": "The %s shuts down."
+  },
+  {
+    "id": "adv_UPS_off",
+    "type": "TOOL_ARMOR",
+    "category": "tools",
+    "name": { "str": "advanced UPS", "str_pl": "advanced UPS's" },
+    "description": "This is an advanced version of the unified power supply, or UPS.  Designed for military use to power advanced weapons, it uses plutonium fuel cells which provide better efficiency, but are not rechargeable.  It can power many household electronics as well.",
+    "weight": "453 g",
+    "volume": "2 L",
+    "price": 560000,
+    "price_postapoc": 3000,
+    "to_hit": -1,
+    "bashing": 8,
+    "material": [ "aluminum", "plastic" ],
+    "symbol": ";",
+    "color": "light_green",
+    "coverage": 5,
+    "encumbrance": 2,
+    "covers": [ "leg_either" ],
+    "ammo": "plutonium",
+    "max_charges": 2500,
+    "flags": [ "IS_UPS", "WAIST", "FRAGILE", "OVERSIZE" ]
+  },
+  {
+    "id": "UPS_off",
+    "type": "TOOL_ARMOR",
+    "category": "tools",
+    "name": { "str": "UPS", "str_pl": "UPS's" },
+    "description": "This is a unified power supply, or UPS.  It is a civilian evolution of a military project.  Designed to power advanced weapons and armor, the civilian version serves as a portable power bank and inverter for many household electronics.",
+    "weight": "680 g",
+    "volume": "2500 ml",
+    "price": 280000,
+    "price_postapoc": 1500,
+    "to_hit": -1,
+    "bashing": 8,
+    "material": [ "aluminum", "plastic" ],
+    "symbol": ";",
+    "color": "light_gray",
+    "coverage": 5,
+    "encumbrance": 2,
+    "covers": [ "leg_either" ],
+    "ammo": "battery",
+    "magazines": [
+      [ "battery", [ "heavy_plus_battery_cell", "heavy_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ] ]
+    ],
+    "magazine_well": "1500 ml",
+    "flags": [ "IS_UPS", "WAIST", "FRAGILE", "OVERSIZE" ]
   }
 ]

--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -215,32 +215,6 @@
     "looks_like": "rope_30"
   },
   {
-    "id": "UPS_off",
-    "type": "TOOL_ARMOR",
-    "copy-from": "UPS_off",
-    "name": { "str": "UPS", "str_pl": "UPS's" },
-    "description": "This is a unified power supply, or UPS.  It is a device developed jointly by military and scientific interests for use in combat and the field.  The UPS is designed to power armor and some guns, but drains batteries quickly.  It can be worn around to either leg for ease of access, and it's been waterproofed to protect the delicate electronics.  Has it's own custom battery, with higher capacity and rechargeable, but not removeable",
-    "coverage": 5,
-    "ammo": "battery",
-    "initial_charges": 1000,
-    "max_charges": 1500,
-    "encumbrance": 2,
-    "covers": [ "leg_either" ],
-    "flags": [ "RECHARGE", "WAIST", "FRAGILE", "OVERSIZE", "WATERPROOF", "IS_UPS", "NO_RELOAD", "NO_UNLOAD" ],
-    "magazines": [  ]
-  },
-  {
-    "id": "adv_UPS_off",
-    "type": "TOOL_ARMOR",
-    "copy-from": "adv_UPS_off",
-    "name": { "str": "advanced UPS", "str_pl": "advanced UPS's" },
-    "description": "This is an advanced version of the unified power supply, or UPS.  This device has been significantly redesigned to provide better efficiency as well as to consume plutonium fuel cells rather than batteries, and is both slimmer and lighter to wear.  Sadly, its plutonium reactor can't be charged in UPS charging station.",
-    "coverage": 5,
-    "encumbrance": 1,
-    "covers": [ "leg_either" ],
-    "flags": [ "WAIST", "FRAGILE", "OVERSIZE", "IS_UPS" ]
-  },
-  {
     "id": "bionic_maintenance_toolkit",
     "copy-from": "screwdriver_set",
     "type": "TOOL",


### PR DESCRIPTION
UPS can now be worn in vanilla! You can also re load regular UPS with batteries as well. Advanced UPS stays the same just now is wearable!


#### Summary Features/Balance "Allows vanilla UPS to be wearable and reloadable" 



#### Purpose of change

This change will allow UPS to be wearable like in the mod "Aftershock" but with the added ability to reload regular UPS. I find this change will be nice, and allow UPS to be more viable, and have more uses then just carrying in your inventory. 

#### Describe the solution

I took aftershocks UPS code and modified it a bit. This is the end product. 

#### Describe alternatives you've considered

Keeping it as it is. (but why?) 
I have plans to further this eventually but more on that later. 


#### Testing

Tested in game with no mods active. UPS reloads and can accept batteries and is wearable! 

#### Additional context

![Screenshot (716)](https://user-images.githubusercontent.com/82045140/181515572-28d91859-cd3d-4781-a92c-d9e1da769eb2.png)

![Screenshot (717)](https://user-images.githubusercontent.com/82045140/181515591-de0390ee-282a-4a5b-b9b2-9e5d438f4c05.png)

![Screenshot (720)](https://user-images.githubusercontent.com/82045140/181515631-3df89813-15a1-4c2d-a827-5e33a943b73d.png)

![Screenshot (719)](https://user-images.githubusercontent.com/82045140/181515651-f97fccce-ca8c-40a4-b809-5f96dede582c.png)

