### PR TITLE
Fix CTD when trying to drop worn NO_TAKEOFF items, other related fixes

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -599,14 +599,19 @@ std::list<item> obtain_and_tokenize_items( player &p, std::list<act_item> &items
 
         if( !try_rebuild_if_needed( ait.loc ) ) {
             debugmsg( "Lost target item of ACT_DROP" );
-            items.pop_back();
+            items.pop_front();
             return res;
         }
 
         p.mod_moves( -ait.consumed_moves );
 
         if( p.is_worn( *ait.loc ) ) {
-            p.takeoff( *ait.loc, &res );
+            if( !p.takeoff( *ait.loc, &res ) ) {
+                // Skip item if failed to take it off
+                debugmsg( "Failed to obtain worn target item of ACT_DROP" );
+                items.pop_front();
+                continue;
+            }
         } else if( ait.loc->count_by_charges() ) {
             res.push_back( p.reduce_charges( const_cast<item *>( &*ait.loc ), ait.count ) );
         } else {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2471,12 +2471,12 @@ bool Character::i_add_or_drop( item &it, int qty )
     return retval;
 }
 
-std::list<item *> Character::get_dependent_worn_items( const item &it )
+std::list<item *> Character::get_dependent_worn_items( const item &it ) const
 {
     std::list<item *> dependent;
     // Adds dependent worn items recursively
     const std::function<void( const item &it )> add_dependent = [&]( const item & it ) {
-        for( item &wit : worn ) {
+        for( const item &wit : worn ) {
             if( &wit == &it || !wit.is_worn_only_with( it ) ) {
                 continue;
             }
@@ -2486,7 +2486,7 @@ std::list<item *> Character::get_dependent_worn_items( const item &it )
             } );
             if( iter == dependent.end() ) { // Not in the list yet
                 add_dependent( wit );
-                dependent.push_back( &wit );
+                dependent.push_back( const_cast<item *>( & wit ) );
             }
         }
     };
@@ -2503,6 +2503,13 @@ void Character::drop( item_location loc, const tripoint &where )
     item &oThisItem = *loc;
     if( is_wielding( oThisItem ) ) {
         const auto ret = can_unwield( *loc );
+
+        if( !ret.success() ) {
+            add_msg( m_info, "%s", ret.c_str() );
+            return;
+        }
+    } else if( is_wearing( oThisItem ) ) {
+        const auto ret = as_player()->can_takeoff( *loc );
 
         if( !ret.success() ) {
             add_msg( m_info, "%s", ret.c_str() );
@@ -3224,6 +3231,16 @@ bool Character::has_artifact_with( const art_effect_passive effect ) const
 bool Character::is_wielding( const item &target ) const
 {
     return &weapon == &target;
+}
+
+bool Character::is_wearing( const item &itm ) const
+{
+    for( auto &i : worn ) {
+        if( &i == &itm ) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool Character::is_wearing( const itype_id &it ) const

--- a/src/character.h
+++ b/src/character.h
@@ -1396,7 +1396,7 @@ class Character : public Creature, public visitable<Character>
 
         void drop_invalid_inventory();
         /** Returns all items that must be taken off before taking off this item */
-        std::list<item *> get_dependent_worn_items( const item &it );
+        std::list<item *> get_dependent_worn_items( const item &it ) const;
         /** Drops an item to the specified location */
         void drop( item_location loc, const tripoint &where );
         virtual void drop( const drop_locations &what, const tripoint &target, bool stash = false );
@@ -1412,6 +1412,8 @@ class Character : public Creature, public visitable<Character>
 
         // --------------- Clothing Stuff ---------------
         /** Returns true if the player is wearing the item. */
+        bool is_wearing( const item &itm ) const;
+        /** Returns true if the player is wearing an item of this type. */
         bool is_wearing( const itype_id &it ) const;
         /** Returns true if the player is wearing the item on the given body part. */
         bool is_wearing_on_bp( const itype_id &it, const bodypart_id &bp ) const;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1473,7 +1473,14 @@ drop_locations game_menus::inv::multidrop( player &p )
     p.inv.restack( p );
 
     const inventory_filter_preset preset( [ &p ]( const item_location & location ) {
-        return p.can_unwield( *location ).success();
+        const item &itm = *location;
+        if( p.is_wielding( itm ) ) {
+            return p.can_unwield( itm ).success();
+        } else if( p.is_wearing( itm ) ) {
+            return p.can_takeoff( itm ).success();
+        } else {
+            return true;
+        }
     } );
 
     inventory_drop_selector inv_s( p, preset );

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2926,7 +2926,7 @@ hint_rating player::rate_action_takeoff( const item &it ) const
         return hint_rating::cant;
     }
 
-    if( is_worn( it ) ) {
+    if( is_worn( it ) && can_takeoff( it ).success() ) {
         return hint_rating::good;
     }
 
@@ -2950,7 +2950,7 @@ bool player::can_lift( int lift_strength_required ) const
     return str + npc_str >= lift_strength_required;
 }
 
-ret_val<bool> player::can_takeoff( const item &it, const std::list<item> *res )
+ret_val<bool> player::can_takeoff( const item &it, const std::list<item> *res ) const
 {
     auto iter = std::find_if( worn.begin(), worn.end(), [ &it ]( const item & wit ) {
         return &it == &wit;

--- a/src/player.h
+++ b/src/player.h
@@ -354,7 +354,7 @@ class player : public Character
          * Check player capable of taking off an item.
          * @param it Thing to be taken off
          */
-        ret_val<bool> can_takeoff( const item &it, const std::list<item> *res = nullptr );
+        ret_val<bool> can_takeoff( const item &it, const std::list<item> *res = nullptr ) const;
 
         /**
          * Check player capable of wielding an item.


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed CTD when trying to drop worn NO_TAKEOFF items, other related fixes"

#### Purpose of change
Fix #1475, improve NO_TAKEOFF handling in some other cases

#### Describe the solution
1. In dropping activity, show debugmsg and skip item if failed to drop it
2. Add message when failing to drop the item through item overview screen (`i`->select item->`Enter`)
3. Don't show worn NO_TAKEOFF items in multidrop menu
4. In item overview screen, fix colors of drop & wield options for worn NO_TAKEOFF items
5. In AIM, check whether can drop item before starting activity

#### Testing
Tried to drop active worn foodperson mask via multidrop screen, AIM and via item overview screen, all failed.