### PR TITLE
Fix automatic sprite rotation for non-linear overmap tiles

### DIFF
--- a/src/om_direction.h
+++ b/src/om_direction.h
@@ -29,6 +29,7 @@ const size_t size = all.size();
 const std::array<std::string, 4> all_suffixes = {{ "_north", "_east", "_south", "_west" }};
 const std::string invalid_dir_suffix;
 const std::array<int, 4> all_cw_rotations = {{ 0, 1, 2, 3 }};
+const std::array<int, 4> all_ccw_rotations = { { 0, 3, 2, 1 } };
 const int invalid_dir_rotations = 0;
 
 /** Returns directional suffix associated with the value, e.g. _north or _west. */
@@ -48,6 +49,16 @@ constexpr int get_num_cw_rotations( type dir )
         return invalid_dir_rotations;
     } else {
         return all_cw_rotations[static_cast<size_t>( dir )];
+    }
+}
+
+/** Returns number of counterclockwise rotations needed to reach this direction from 'north'. */
+constexpr int get_num_ccw_rotations( type dir )
+{
+    if( dir == type::invalid ) {
+        return invalid_dir_rotations;
+    } else {
+        return all_ccw_rotations[static_cast<size_t>( dir )];
     }
 }
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -791,7 +791,7 @@ void oter_t::get_rotation_and_subtile( int &rotation, int &subtile ) const
         rotation = t.rotation;
         subtile = t.subtile;
     } else if( is_rotatable() ) {
-        rotation = static_cast<int>( get_dir() );
+        rotation = om_direction::get_num_ccw_rotations( get_dir() );
         subtile = -1;
     } else {
         rotation = 0;


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed automatic sprite rotation for non-linear overmap tiles"

#### Purpose of change
If overmap terrain is rotatable, and the tileset has no explicitly defined rotations for the corresponding tile which is also marked as rotatable, then the game would try to automatically rotate that single tile to match rotation of the omt. Except the rotation direction is wrong (screenshot of `ws_regional_dump` found in latest unpacked UDP version):
![image](https://user-images.githubusercontent.com/60584843/181599183-9c09736b-90c7-4937-ab92-0c918f9a0e38.png)

This PR fixes this bug.

#### Describe the solution
Turns out `rotations` for omts are clockwise rotations, and `rotations` for tileset sprites are counterclockwise rotations. This PR adds proper conversion from omt rotation to sprite rotation.

#### Describe alternatives you've considered
Rewriting the renderer.

#### Testing
![image](https://user-images.githubusercontent.com/60584843/181598869-c8f0eefb-8ec3-4c06-b8e0-d15419e97590.png)

#### Additional context
Re-packed UDP with the aforementioned `ws_regional_dump` for testing:
[UDP_REPACK.zip](https://github.com/cataclysmbnteam/Cataclysm-BN/files/9212937/UDP_REPACK.zip)
