### PR TITLE
Translate prying messages

### DIFF
--- a/lang/extract_json_strings.py
+++ b/lang/extract_json_strings.py
@@ -1064,6 +1064,23 @@ def extract(state, item):
         if "sound_fail" in bash:
             writestr(state, bash["sound_fail"])
             wrote = True
+    if "pry" in item:
+        pry = item["pry"]
+        if "sound" in pry:
+            writestr(state, pry["sound"])
+            wrote = True
+        if "break_sound" in pry:
+            writestr(state, pry["break_sound"])
+            wrote = True
+        if "success_message" in pry:
+            writestr(state, pry["success_message"])
+            wrote = True
+        if "fail_message" in pry:
+            writestr(state, pry["fail_message"])
+            wrote = True
+        if "break_message" in pry:
+            writestr(state, pry["break_message"])
+            wrote = True
     if "seed_data" in item:
         seed_data = item["seed_data"]
         writestr(state, seed_data["plant_name"])

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -194,9 +194,9 @@ struct pry_result {
     // sound message made on breakage, if breakable is true
     translation break_sound;
     // Messages for succeeding or failing pry attempt, and breakage
-    std::string success_message;
-    std::string fail_message;
-    std::string break_message;
+    translation success_message;
+    translation fail_message;
+    translation break_message;
     pry_result();
     enum map_object_type {
         furniture = 0,


### PR DESCRIPTION
#### Summary
SUMMARY: I18N "Translate prying messages"

#### Purpose of change
Fix #1721

#### Describe the solution
Extract prying messages in `lang/extract_json_strings.py`.
Switch relevant message members in `map_data.h` to use `translation` class so that they're actually translated in-game.

#### Testing
Locally ran `lang/extract_json_strings.py`, saw the new messages in the POT.
Compiled a MO with translated prying messages, saw them appear in-game.