### PR TITLE
Update placement of labs, fix lab cell start

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -638,9 +638,9 @@
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "lab_stairs" } ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 10, -1 ],
-    "occurrences": [ 30, 100 ],
-    "flags": [ "LAB", "UNIQUE" ]
+    "city_distance": [ 4, -1 ],
+    "occurrences": [ 0, 2 ],
+    "flags": [ "LAB" ]
   },
   {
     "type": "overmap_special",
@@ -648,8 +648,8 @@
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "lab_stairs" }, { "point": [ 3, 1, 0 ], "overmap": "anthill" } ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 10, -1 ],
-    "occurrences": [ 10, 100 ],
+    "city_distance": [ 4, -1 ],
+    "occurrences": [ 30, 100 ],
     "flags": [ "ANT", "UNIQUE" ],
     "spawns": { "group": "GROUP_ANT", "population": [ 1000, 2000 ], "radius": [ 10, 30 ] }
   },
@@ -711,8 +711,8 @@
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
-    "occurrences": [ 10, 100 ],
-    "flags": [ "LAB", "UNIQUE" ]
+    "occurrences": [ 0, 2 ],
+    "flags": [ "LAB" ]
   },
   {
     "type": "overmap_special",
@@ -992,7 +992,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 10, 100 ],
+    "occurrences": [ 30, 100 ],
     "flags": [ "LAB", "UNIQUE" ]
   },
   {

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -639,8 +639,8 @@
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 4, -1 ],
-    "occurrences": [ 0, 2 ],
-    "flags": [ "LAB" ]
+    "occurrences": [ 50, 100 ],
+    "flags": [ "LAB", "UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -711,8 +711,8 @@
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
-    "occurrences": [ 0, 2 ],
-    "flags": [ "LAB" ]
+    "occurrences": [ 50, 100 ],
+    "flags": [ "LAB", "UNIQUE" ]
   },
   {
     "type": "overmap_special",

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3510,8 +3510,8 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
         }
     }
 
-    // 4th story of labs is a candidate for lab escape, as long as there's no train or finale.
-    if( prefix.empty() && p.z() == -4 && train_odds == 0 && numstairs > 0 ) {
+    // 4th story of labs and down are candidates for lab escape, as long as there's no train or finale.
+    if( prefix.empty() && p.z() <= -4 && train_odds == 0 && numstairs > 0 ) {
         tripoint_om_omt cell;
         int tries = 0;
         int adjacent_labs = 0;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Audit occurrences and spawning of labs vs. microlabs, fix weird spawning of experiment cell mapgen"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A complaint I'd seen a few times has been that microlabs seem to be vastly more common than regular labs overall, which is presently a problem given the microlabs are currently effectively filler, at least until I can do some work on https://github.com/cataclysmbnteam/Cataclysm-BN/issues/971.

Per feedback, this in itself isn't a massive problem, though personally if I could make regular labs equally as common as microlabs I'd like to, but worldgen likes to bundle overmap specials into the same general patches of similarly-compatible city distances. However, the low occurrence rates of the unique lab variants does have a magifying effect on regular labs being proportionately less common.

In addition, it came up that the lab scenario's "experiment cell" starting location is dangerously prone to failing to generate after several attempts in a row, so giving that a look over in the process would be good too.

On looking at the current overmap special entries, I made note of the maximum possible occurrences per general type of lab, not counting the endgame. The following tallies count unique lab specials as 1 potential occurrence each, and did not count `lab_subway_vent_shaft` as being worth 1 on the microlab counter since it's just a subway connector it seems. This had barely any impact on the total as seen below:

Type | Maximum Occurrences
--- | ---
Normal lab | 3
Ice lab | 1
Microlab | 4
Double microlab | 2

Office tower labs and lab basements were not counted since those are city buildings, meaning their occurrences are up to the whims of city generation and thus vastly more fiddly and impossible to predict than overmap specials. This does mean that regular labs have some potential bonus occurrences from those city buildings but they were evidently uncommon enough for this to have no appreciable impact on the failure-to-start issue reported to me on the discord.

My initial plan was to add more potential maximum spawns of the relevant regular lab types to make them closer to 50/50, but worldgen issues means I'd be better off just making their spawning less finicky as a starting point.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

C++ changes:
1. Changed the placement of experimental cells in labs to occur at level -4 and below, not ONLY -4.

JSON changes:
1. Adjusted the occurrence percentages of the standard lab and ice lab from 30% to 50%.
2. Elevated all other standard lab variants to a minimum of 30% instead of only 10%
3. Set all specials that can spawn the bog-standard lab_stairs to have a minimum city size of 4 instead of 10, matching that of prison labs. This should reduce vulnerability to generation failures depending on world settings.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Reducing the total number of microlabs slightly via making underground-only microlabs unique instead of 0-2.
2. Adding at least one more type of overmap special that can generate labs or ice labs under them, ideally something that covers a city distance/size niche that neither the existing specials nor the city building labs cover. 
3. Submitting to the heretical impulse to make at least one normal lab special mandatory.
4. Reworking bio-weapon labs over in Cata++ to be more lab-like and not just a single bunker level so third-party mods can pick up at least some of the slack of making lab spawns less microlab-y.
5. Dummying out microlabs entirely until I can get around to making their contents less bland.
6. Finally ceasing my endless procrastination and focusing on making their contents less bland ASAP.
7. Trying to further tweak placement of experimental cells so that it isn't locked into being on the north edge of the lab generation, per Kheir's suggestion. Might be a useful follow-up, but for now the current C++ change seems to be a big help so far.
8. Unhardcoding standard labs so that we have a concrete and adjustable set of occurrences for the experiment cells, and suffering the agony of trying to get its very fancy room generation to produce something that looks even remotely sane as an overmap special of fixed layout, without its map profile becoming too bland and blocky.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected JSON file for syntax and lint errors, and affected C++ file for astyle.
2. Compiled and load-tested, creating a world with default city size and distance.
3. Started in lab scenario with the experiment cell starting location.
4. Confirmed it spawned instead of failing to start 10 times in a row.
5. Repeated this test about half a dozen times, found no failures to start so far, also checked each time to ensure the cells never stepped out directly into a finale.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/343