### PR TITLE
Print a message when NPC takes aim at the player, some aim behavior/message tweaks

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1396,16 +1396,6 @@ npc_action npc::method_of_attack()
         }
     }
 
-    // TODO: Needs a check for transparent but non-passable tiles on the way
-    if( !modes.empty() && sees( *critter ) && aim_per_move( weapon, recoil ) > 0 &&
-        confident_shoot_range( weapon, get_most_accurate_sight( weapon ) ) >= dist ) {
-        add_msg( m_debug, "%s is aiming", disp_name() );
-        if( critter->is_player() && player_character.sees( *this ) ) {
-            add_msg( m_bad, _( "%s takes aim at you!" ), disp_name() );
-        }
-        return npc_aim;
-    }
-
     // if the best mode is within the confident range try for a shot
     if( !modes.empty() && sees( *critter ) && has_los &&
         confident_gun_mode_range( modes[ 0 ].second, cur_recoil ) >= dist ) {
@@ -1446,6 +1436,15 @@ npc_action npc::method_of_attack()
         }
     }
 
+    // TODO: Needs a check for transparent but non-passable tiles on the way
+    if( !modes.empty() && sees( *critter ) && aim_per_move( weapon, recoil ) > 0 &&
+        confident_shoot_range( weapon, get_most_accurate_sight( weapon ) ) >= dist ) {
+        add_msg( m_debug, "%s is aiming", disp_name() );
+        if( critter->is_player() && player_character.sees( *this ) ) {
+            add_msg( m_bad, _( "%s takes aim at you!" ), disp_name() );
+        }
+        return npc_aim;
+    }
     add_msg( m_debug, "%s can't figure out what to do", disp_name() );
     return ( dont_move || !same_z ) ? npc_undecided : npc_melee;
 }
@@ -2656,7 +2655,6 @@ void npc::worker_downtime()
 void npc::move_pause()
 
 {
-    recoil = MAX_RECOIL;
 
     // make sure we're using the best weapon
     if( calendar::once_every( 1_hours ) ) {
@@ -2674,6 +2672,8 @@ void npc::move_pause()
         pause();
         return;
     }
+
+    recoil = MAX_RECOIL;
 
     // Stop, drop, and roll
     if( has_effect( effect_onfire ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2655,7 +2655,6 @@ void npc::worker_downtime()
 void npc::move_pause()
 
 {
-
     // make sure we're using the best weapon
     if( calendar::once_every( 1_hours ) ) {
         deactivate_bionic_by_id( bio_soporific );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1310,6 +1310,7 @@ npc_action npc::method_of_fleeing()
 
 npc_action npc::method_of_attack()
 {
+    Character &player_character = get_player_character();
     Creature *critter = current_target();
     if( critter == nullptr ) {
         // This function shouldn't be called...
@@ -1437,7 +1438,10 @@ npc_action npc::method_of_attack()
     // TODO: Needs a check for transparent but non-passable tiles on the way
     if( !modes.empty() && sees( *critter ) && aim_per_move( weapon, recoil ) > 0 &&
         confident_shoot_range( weapon, get_most_accurate_sight( weapon ) ) >= dist ) {
-        add_msg( m_debug, "%s is aiming" );
+        add_msg( m_debug, "%s is aiming", disp_name() );
+        if ( critter->is_player() && player_character.sees( *this ) ) {
+            add_msg( m_bad, _( "%s takes aim at you!" ), disp_name() );
+        }
         return npc_aim;
     }
     add_msg( m_debug, "%s can't figure out what to do", disp_name() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2672,8 +2672,6 @@ void npc::move_pause()
         return;
     }
 
-    recoil = MAX_RECOIL;
-
     // Stop, drop, and roll
     if( has_effect( effect_onfire ) ) {
         pause();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Make NPCs a bit better about remembering to aim, improve debug messages for aiming and firing a bit, add a visible warning when a player is being aimed at by an NPC"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I recently had the idea of rigging it so that hostile NPCs will print a message when aiming at you, to give the player some degree of fair warning that they're about to be shot. This is in line with turrets and robots generally audibly announcing their action beforehand.

This also should help make it easier to judge when an NPC is actually bothering to aim their shots and when they're making snapshots, which should in the future make it easier to figure out when they're actually playing by the same rules as the player. Having the player also see a non-debug message when the NPC's aiming at them will also make it easier for players who get shot to death by NPCs to tell whether the NPC actually took time to aim or whether they got insta-sniped.

Along the way this led to a few added tweaks that might hopefully improve the behavior of NPCs when they have a gun, make them a bit more consistent about actually aiming, and some improvements to debug messages to make it easier to track what they're up to.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Updated `npc::method_of_attack()` to be able to get the player character, and set it so that when an NPC chooses to take aim at the player specifically, if they can see the offending NPC a message is printed to confirm visually that they're being aimed at.
2. Moved the aim part of `npc::method_of_attack()` up a bit to before the fire section. I'm not 100% sure if this will reduce cases where an NPC forgets to aim their shot when they're supposed to, but better safe than sorry in case the NPC finds a way to smuggle recoil they were supposed to shake off into the firing stage.
3. Fixed the debug message that prints when an NPC is aiming in general so that it actually uses their name in the `%s` keyword, since
4. Added a debug message to right before an NPC actually fires to print how much recoil they have beforehand, for further testing purposes.
5. Added an additional instance of "max out recoil" to `npc::move_pause()`, as I noticed that the player's pause action maxes out recoil but this one doesn't seem to. Far as I can tell by my understanding, instances where move_pause are called from `npc::move_to` will correctly already max out recoil because the movement function calls it too, but cases where the pause function is called elsewhere may allow the NPC to evade the wrath of recoil in cases where the player would not be able to escape it.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Trying to further tackle some of the other problems I keep intermittently running into, as mentioned in testing section below.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for astyling.
2. Compiled and load-tested, turning debug mode on.
3. Spawned in and repeatedly tormented the ensuring starter NPC by throwing a rock at them, debugging various guns into their hands when necessary.

![image](https://user-images.githubusercontent.com/11582235/181853978-08f8d63e-7779-4943-8b2f-1c390794086d.png)

Two problems I noticed:
1. A lot of times, a pissed-off NPC will show the red ! indicating they can see you, but they don't make a move towards you or try to shoot you unless you get closer. Debug says their action taken tends to be go to goal with no destination.
2. Very often, an armed NPC will say in debug they failed to decide what to do and chose action melee. This would be why NPCs with guns often choose to run up and smack you with them instead. It doesn't happen every time but often enough to be really goddamn annoying while testing, and sometimes once they do get in close they'll snap out of it after slapping you a few times, but a lot of times they're just constantly unable to figure out how to do anything but fall back on melee and I can't even remotely figure out what the root cause of this.

When the lil bastards do actually bother to use their guns as intended, the right messages successfully print in the right contexts. My changes so far seem to have also made it so the NPC is less likely to skip straight to a snapshot when they haven't had any chance to aim.

Prior to this I noticed that often the very first shots tended to be snapshots, then after they reloaded they'd start actually bothering to aim, most easily seen should you get an NPC with a single-shot weapon like a crossbow. Now they seem to be more reliable about wanting to aim from the get-go, at least when they don't break and decide their weapon is better for smacking you with.

The new recoil message indicated that often recoil was above zero when they did fire, I'm not sure if that's intentional or not.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Tested what NPCs do when ticked off in DDA and found most of the same flaws. Only discernible difference is the NPC seems to actually choose action "attack" instead of failing to decide and defaulting to melee, but the net result is the same in that an NPC that can and should just shoot you is prone to just walking up and clobbering you with their gun instead.

They seemed slightly better at wandering over towards you when you're more than five steps away, but in exchange they were very prone to losing sight of you outright even with a clear LoS. Otherwise they seemed to share most of the same problems of very rarely being able to figure out how to use their guns at all, preferring to shoot you in melee range the few times they do figure out how to pull the trigger, and being prone to skipping the aiming step.