### PR TITLE
Modernize oms connections JSON, deprecate autoguessing from "terrain"

### DIFF
--- a/data/json/overmap/overmap_connections.json
+++ b/data/json/overmap/overmap_connections.json
@@ -2,6 +2,7 @@
   {
     "type": "overmap_connection",
     "id": "local_road",
+    "default_terrain": "road",
     "subtypes": [
       { "terrain": "road", "locations": [ "field", "road" ] },
       { "terrain": "road", "locations": [ "forest_without_trail" ], "basic_cost": 20 },
@@ -14,16 +15,19 @@
   {
     "type": "overmap_connection",
     "id": "sewer_tunnel",
+    "default_terrain": "sewer",
     "subtypes": [ { "terrain": "sewer", "locations": [ "subterranean" ], "flags": [ "ORTHOGONAL" ] } ]
   },
   {
     "type": "overmap_connection",
     "id": "subway_tunnel",
+    "default_terrain": "subway",
     "subtypes": [ { "terrain": "subway", "locations": [ "subterranean_subway" ], "flags": [ "ORTHOGONAL" ] } ]
   },
   {
     "type": "overmap_connection",
     "id": "forest_trail",
+    "default_terrain": "forest_trail",
     "subtypes": [
       { "terrain": "forest_trail", "locations": [ "forest_trail" ], "basic_cost": 0 },
       { "terrain": "forest_trail", "locations": [ "forest_edge" ], "basic_cost": 100 },
@@ -34,6 +38,7 @@
   {
     "type": "overmap_connection",
     "id": "local_railroad",
+    "default_terrain": "railroad",
     "subtypes": [
       { "terrain": "railroad", "locations": [ "railroad" ], "basic_cost": 1, "flags": [ "ORTHOGONAL" ] },
       { "terrain": "railroad", "locations": [ "wilderness" ], "basic_cost": 1, "flags": [ "ORTHOGONAL" ] },

--- a/data/json/overmap/overmap_special/mine.json
+++ b/data/json/overmap/overmap_special/mine.json
@@ -15,8 +15,8 @@
       { "point": [ 1, 1, -2 ], "overmap": "mine_shaft_lower_east_north" }
     ],
     "connections": [
-      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] },
-      { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] }
+      { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] },
+      { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] }
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
@@ -55,8 +55,8 @@
       { "point": [ -1, 2, -4 ], "overmap": "mine_spiral_finale_se_north" }
     ],
     "connections": [
-      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] },
-      { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] }
+      { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] },
+      { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] }
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
@@ -89,8 +89,8 @@
       { "point": [ -3, 1, -4 ], "overmap": "mine_amigara_finale_west_north" }
     ],
     "connections": [
-      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] },
-      { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] }
+      { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] },
+      { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] }
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
@@ -118,8 +118,8 @@
       { "point": [ -3, 1, -3 ], "overmap": "mine_wyrms_finale_north" }
     ],
     "connections": [
-      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] },
-      { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] }
+      { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] },
+      { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] }
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -17,8 +17,8 @@
       { "point": [ 0, 0, 1 ], "overmap": "motel_twd_second_floor_north" }
     ],
     "connections": [
-      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] },
-      { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] }
+      { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] },
+      { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] }
     ],
     "locations": [ "land" ],
     "city_distance": [ 8, 30 ],
@@ -39,7 +39,7 @@
       { "point": [ 0, 1, 0 ], "overmap": "motel_3_north" },
       { "point": [ 0, 1, 1 ], "overmap": "motel_3_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 8, 30 ],
     "occurrences": [ 0, 2 ],
@@ -49,7 +49,7 @@
     "type": "overmap_special",
     "id": "Boat Rental",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "boat_rental_north" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "water" ],
     "city_distance": [ 5, 15 ],
     "occurrences": [ 0, 5 ],
@@ -94,7 +94,7 @@
       { "point": [ -1, -5, 5 ], "overmap": "radio_tower_odd_north" },
       { "point": [ -1, -5, 6 ], "overmap": "radio_tower_top_north" }
     ],
-    "connections": [ { "point": [ -1, -6, 0 ], "terrain": "road" }, { "point": [ 0, -5, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ -1, -6, 0 ], "connection": "local_road" }, { "point": [ 0, -5, 0 ], "connection": "local_road" } ],
     "locations": [ "forest" ],
     "city_distance": [ 12, -1 ],
     "occurrences": [ 30, 100 ],
@@ -131,7 +131,7 @@
       { "point": [ 1, 1, -1 ], "overmap": "office_tower_collapse_b_b1_north" },
       { "point": [ 2, 1, -1 ], "overmap": "office_tower_collapse_b_b2_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" }, { "point": [ 2, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" }, { "point": [ 2, -1, 0 ], "connection": "local_road" } ],
     "city_distance": [ 0, 25 ],
     "locations": [ "land" ],
     "city_sizes": [ 0, 16 ],
@@ -174,11 +174,11 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ 0, -2, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, -1, 0 ] },
-      { "point": [ -1, 0, -1 ], "terrain": "sewer", "connection": "sewer_tunnel", "from": [ 0, 0, -1 ] },
-      { "point": [ 1, -1, -1 ], "terrain": "sewer", "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] },
-      { "point": [ 3, 0, -1 ], "terrain": "sewer", "connection": "sewer_tunnel", "from": [ 2, 0, -1 ] },
-      { "point": [ 1, 2, -1 ], "terrain": "sewer", "connection": "sewer_tunnel", "from": [ 1, 1, -1 ] }
+      { "point": [ 0, -2, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] },
+      { "point": [ -1, 0, -1 ], "connection": "sewer_tunnel", "from": [ 0, 0, -1 ] },
+      { "point": [ 1, -1, -1 ], "connection": "sewer_tunnel", "from": [ 1, 0, -1 ] },
+      { "point": [ 3, 0, -1 ], "connection": "sewer_tunnel", "from": [ 2, 0, -1 ] },
+      { "point": [ 1, 2, -1 ], "connection": "sewer_tunnel", "from": [ 1, 1, -1 ] }
     ],
     "city_distance": [ 5, 25 ],
     "city_sizes": [ 4, -1 ],
@@ -213,7 +213,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "s_gas_rural_north" },
       { "point": [ 0, 0, 1 ], "overmap": "s_gas_rural_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ 20, -1 ],
     "occurrences": [ 0, 2 ],
@@ -223,7 +223,7 @@
     "type": "overmap_special",
     "id": "Gas Station",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "s_gas_north" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ 5, -1 ],
     "occurrences": [ 0, 2 ],
@@ -342,7 +342,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "sugar_house_north" },
       { "point": [ 0, 0, 1 ], "overmap": "sugar_house_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "forest" ],
     "city_distance": [ 5, 60 ],
     "occurrences": [ 0, 10 ],
@@ -379,7 +379,7 @@
       { "point": [ 2, 4, 0 ], "overmap": "2farm_14_north" },
       { "point": [ 3, 4, 0 ], "overmap": "2farm_13_north" }
     ],
-    "connections": [ { "point": [ 1, 2, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 1, 2, 0 ], "connection": "local_road" } ],
     "locations": [ "field" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
@@ -402,7 +402,7 @@
       { "point": [ 0, 0, 1 ], "overmap": "farm_3_roof_north" },
       { "point": [ 1, 0, 1 ], "overmap": "farm_2_roof_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "field" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
@@ -426,7 +426,7 @@
       { "point": [ 2, 2, 0 ], "overmap": "farm_stills_10_north" },
       { "point": [ 3, 2, 0 ], "overmap": "farm_stills_9_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "field" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
@@ -461,7 +461,7 @@
       { "point": [ 2, 3, 0 ], "overmap": "horse_farm_15_north" },
       { "point": [ 3, 3, 0 ], "overmap": "horse_farm_16_north" }
     ],
-    "connections": [ { "point": [ 1, 4, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 3, 0 ] } ],
+    "connections": [ { "point": [ 1, 4, 0 ], "connection": "local_road", "from": [ 1, 3, 0 ] } ],
     "locations": [ "field" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
@@ -484,7 +484,7 @@
       { "point": [ -1, -1, 0 ], "overmap": "farm_lot_wire_turn_v_open_west" },
       { "point": [ 0, -1, 0 ], "overmap": "dirt_road_3way_east" }
     ],
-    "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, -1, 0 ] } ],
+    "connections": [ { "point": [ 0, 0, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] } ],
     "locations": [ "field" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
@@ -507,7 +507,7 @@
       { "point": [ -1, -1, 0 ], "overmap": "farm_lot_M1_east" },
       { "point": [ 0, -1, 0 ], "overmap": "dirt_road_3way_east" }
     ],
-    "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, -1, 0 ] } ],
+    "connections": [ { "point": [ 0, 0, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] } ],
     "locations": [ "field" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
@@ -539,7 +539,7 @@
       { "point": [ 0, -2, 0 ], "overmap": "dirt_road_turn_forest_north" },
       { "point": [ 0, -1, 0 ], "overmap": "dirt_road_forest_north" }
     ],
-    "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, -1, 0 ] } ],
+    "connections": [ { "point": [ 0, 0, 0 ], "connection": "local_road", "from": [ 0, -1, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
@@ -567,7 +567,7 @@
       { "point": [ 2, 4, 0 ], "overmap": "farm_lot_wire_turn_v_west" },
       { "point": [ 1, 4, 0 ], "overmap": "farm_lot_wire_turn_h_north" }
     ],
-    "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 1, 0 ] } ],
+    "connections": [ { "point": [ 0, 0, 0 ], "connection": "local_road", "from": [ 0, 1, 0 ] } ],
     "locations": [ "field" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
@@ -598,7 +598,7 @@
       { "point": [ 1, 1, 1 ], "overmap": "farm_dairy_twd_second_floor_6_north" },
       { "point": [ 3, 2, 1 ], "overmap": "farm_dairy_twd_second_floor_12_north" }
     ],
-    "connections": [ { "point": [ 2, 3, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 2, 0 ] } ],
+    "connections": [ { "point": [ 2, 3, 0 ], "connection": "local_road", "from": [ 2, 2, 0 ] } ],
     "locations": [ "field" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
@@ -636,7 +636,7 @@
     "type": "overmap_special",
     "id": "Lab",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "lab_stairs" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
     "occurrences": [ 30, 100 ],
@@ -646,7 +646,7 @@
     "type": "overmap_special",
     "id": "Lab with Anthill",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "lab_stairs" }, { "point": [ 3, 1, 0 ], "overmap": "anthill" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
     "occurrences": [ 10, 100 ],
@@ -708,7 +708,7 @@
     "type": "overmap_special",
     "id": "Ice Lab",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "ice_lab_stairs" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
     "occurrences": [ 10, 100 ],
@@ -729,7 +729,7 @@
       { "point": [ 1, 2, 0 ], "overmap": "fema_3_2_north" },
       { "point": [ 2, 2, 0 ], "overmap": "fema_3_3_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ] } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 20 ],
     "city_sizes": [ 4, -1 ],
@@ -751,7 +751,7 @@
       { "point": [ 2, 2, 0 ], "overmap": "FEMA_brc_north" },
       { "point": [ 1, 3, 0 ], "overmap": "road_end_south" }
     ],
-    "connections": [ { "point": [ 1, 3, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 1, 3, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 20 ],
     "city_sizes": [ 4, -1 ],
@@ -766,7 +766,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "bunker_south" },
       { "point": [ 0, 0, -1 ], "overmap": "bunker_basement" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "from": [ 0, 0, 0 ], "connection": "local_road" } ],
     "locations": [ "forest" ],
     "city_distance": [ 20, -1 ],
     "occurrences": [ 0, 2 ],
@@ -793,7 +793,7 @@
       { "point": [ 0, 0, -4 ], "overmap": "silo_4" },
       { "point": [ 0, 0, -5 ], "overmap": "silo_finale" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 30, -1 ],
     "city_sizes": [ -1, 4 ],
@@ -812,7 +812,7 @@
       { "point": [ 0, 0, 5 ], "overmap": "radio_tower_odd_north" },
       { "point": [ 0, 0, 6 ], "overmap": "radio_tower_top_north" }
     ],
-    "connections": [ { "point": [ 0, 1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, 1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 0, 20 ],
     "occurrences": [ 0, 5 ],
@@ -830,7 +830,7 @@
       { "point": [ 0, 0, 5 ], "overmap": "radio_tower_odd_north" },
       { "point": [ 0, 0, 6 ], "overmap": "radio_tower_top_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 0, 20 ],
     "occurrences": [ 0, 5 ],
@@ -878,7 +878,7 @@
       { "point": [ 0, 2, 2 ], "overmap": "prison_1_3f_8_north" },
       { "point": [ 1, 2, 2 ], "overmap": "prison_1_3f_7_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "land" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 4, -1 ],
@@ -988,7 +988,7 @@
       { "point": [ 0, 2, 2 ], "overmap": "prison_1_3f_8_north" },
       { "point": [ 1, 2, 2 ], "overmap": "prison_1_3f_7_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],
@@ -1097,7 +1097,7 @@
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_north" },
       { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 3, 15 ],
     "city_sizes": [ 4, -1 ],
@@ -1112,7 +1112,7 @@
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_north" },
       { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 2, 14 ],
     "city_sizes": [ 4, -1 ],
@@ -1127,7 +1127,7 @@
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_north" },
       { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_2_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 2, 14 ],
     "city_sizes": [ 4, -1 ],
@@ -1142,7 +1142,7 @@
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_north" },
       { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 2, 14 ],
     "city_sizes": [ 4, -1 ],
@@ -1157,7 +1157,7 @@
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_north" },
       { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 2, 14 ],
     "city_sizes": [ 4, -1 ],
@@ -1172,7 +1172,7 @@
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_north" },
       { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_2_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 2, 14 ],
     "city_sizes": [ 4, -1 ],
@@ -1225,7 +1225,7 @@
       { "point": [ 1, 1, -2 ], "overmap": "haz_sar_b_3_north" },
       { "point": [ 0, 1, -2 ], "overmap": "haz_sar_b_4_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ] } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 15, -1 ],
     "city_sizes": [ 6, -1 ],
@@ -1562,9 +1562,9 @@
       { "point": [ 8, 8, -3 ], "overmap": "necropolis_d_81_north" }
     ],
     "connections": [
-      { "point": [ 5, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 5, 0, 0 ] },
-      { "point": [ -1, 7, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 7, 0 ] },
-      { "point": [ 4, 9, 0 ], "terrain": "road", "connection": "local_road", "from": [ 4, 8, 0 ] }
+      { "point": [ 5, -1, 0 ], "connection": "local_road", "from": [ 5, 0, 0 ] },
+      { "point": [ -1, 7, 0 ], "connection": "local_road", "from": [ 0, 7, 0 ] },
+      { "point": [ 4, 9, 0 ], "connection": "local_road", "from": [ 4, 8, 0 ] }
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 12, -1 ],
@@ -3152,7 +3152,7 @@
       { "point": [ 14, 14, -4 ], "overmap": "refctr_SE5e_z-4_north" },
       { "point": [ 7, 15, 0 ], "overmap": "road_end_south" }
     ],
-    "connections": [ { "point": [ 7, 15, 0 ] } ],
+    "connections": [ { "point": [ 7, 15, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 4, -1 ],
@@ -3188,7 +3188,7 @@
     "type": "overmap_special",
     "id": "sai",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "sai_north" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 8, -1 ],
@@ -3199,7 +3199,7 @@
     "type": "overmap_special",
     "id": "power_station_small",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "pwr_sub_s_north" }, { "point": [ 0, 0, 1 ], "overmap": "pwr_sub_s_roof_north" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 10 ],
     "city_sizes": [ 4, -1 ],
@@ -3218,7 +3218,7 @@
       { "point": [ -1, 0, 0 ], "overmap": "pwr_large_3_north" },
       { "point": [ 0, 0, 0 ], "overmap": "pwr_large_4_north" }
     ],
-    "connections": [ { "point": [ 0, 2, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, 2, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 30 ],
     "city_sizes": [ 6, -1 ],
@@ -3230,7 +3230,7 @@
     "type": "overmap_special",
     "id": "warehouse",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "warehouse_north" }, { "point": [ 0, 0, 1 ], "overmap": "warehouse_roof_north" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "land" ],
     "city_distance": [ 6, 15 ],
     "city_sizes": [ 4, -1 ],
@@ -3333,7 +3333,7 @@
       { "point": [ 8, 8, 0 ], "overmap": "ranch_camp_81_north" },
       { "point": [ 4, 9, 0 ], "overmap": "road_end_south" }
     ],
-    "connections": [ { "point": [ 4, 9, 0 ] } ],
+    "connections": [ { "point": [ 4, 9, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
     "rotate": false,
@@ -3394,7 +3394,7 @@
     "type": "overmap_special",
     "id": "rest_stop",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "roadstop_north" }, { "point": [ 0, 0, 1 ], "overmap": "roadstop_roof_north" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ 10, 200 ],
     "occurrences": [ 0, 4 ],
@@ -3407,7 +3407,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "roadstop_a_north" },
       { "point": [ 0, 0, 1 ], "overmap": "roadstop_a_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ 10, 200 ],
     "occurrences": [ 0, 4 ],
@@ -3420,7 +3420,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "roadstop_b_north" },
       { "point": [ 0, 0, 1 ], "overmap": "roadstop_b_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ 10, 200 ],
     "occurrences": [ 0, 4 ],
@@ -3439,10 +3439,10 @@
       { "point": [ 0, 1, -1 ], "overmap": "pump_station_5_north" }
     ],
     "connections": [
-      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] },
-      { "point": [ 1, -1, -1 ], "terrain": "sewer", "connection": "sewer_tunnel", "from": [ 0, -1, -1 ] },
-      { "point": [ -1, -1, -1 ], "terrain": "sewer", "connection": "sewer_tunnel", "from": [ 0, -1, -1 ] },
-      { "point": [ -1, 1, -1 ], "terrain": "sewer", "connection": "sewer_tunnel", "from": [ 0, 1, -1 ] }
+      { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] },
+      { "point": [ 1, -1, -1 ], "connection": "sewer_tunnel", "from": [ 0, -1, -1 ] },
+      { "point": [ -1, -1, -1 ], "connection": "sewer_tunnel", "from": [ 0, -1, -1 ] },
+      { "point": [ -1, 1, -1 ], "connection": "sewer_tunnel", "from": [ 0, 1, -1 ] }
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 1, 12 ],
@@ -3461,9 +3461,9 @@
       { "point": [ 2, 0, 1 ], "overmap": "garage_gas_roof_3_north" }
     ],
     "connections": [
-      { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true },
-      { "point": [ 1, -1, 0 ], "terrain": "road", "existing": true },
-      { "point": [ 2, -1, 0 ], "terrain": "road", "existing": true }
+      { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true },
+      { "point": [ 1, -1, 0 ], "connection": "local_road", "existing": true },
+      { "point": [ 2, -1, 0 ], "connection": "local_road", "existing": true }
     ],
     "locations": [ "land" ],
     "city_distance": [ -1, 100 ],
@@ -3480,7 +3480,7 @@
       { "point": [ 1, 1, 0 ], "overmap": "cemetery_4square_11_north" },
       { "point": [ 0, 2, 0 ], "overmap": "road_end_south" }
     ],
-    "connections": [ { "point": [ 0, 2, 0 ] } ],
+    "connections": [ { "point": [ 0, 2, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 2, 5 ],
     "city_sizes": [ 4, -1 ],
@@ -3559,7 +3559,7 @@
       { "point": [ 2, 3, 0 ], "overmap": "orchard_tree_apple_north" },
       { "point": [ 3, 3, 0 ], "overmap": "orchard_tree_apple_north" }
     ],
-    "connections": [ { "point": [ -1, 1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 1, 0 ] } ],
+    "connections": [ { "point": [ -1, 1, 0 ], "connection": "local_road", "from": [ 0, 1, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 40 ],
     "occurrences": [ 0, 5 ],
@@ -3576,7 +3576,7 @@
       { "point": [ 1, 1, 0 ], "overmap": "dairy_farm_SE_north" },
       { "point": [ 1, 1, 1 ], "overmap": "dairy_farm_SE_roof_north" }
     ],
-    "connections": [ { "point": [ 0, 2, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, 2, 0 ], "connection": "local_road" } ],
     "locations": [ "field" ],
     "city_distance": [ 5, 60 ],
     "occurrences": [ 0, 3 ],
@@ -3592,7 +3592,7 @@
       { "point": [ 0, 1, 0 ], "overmap": "state_park_0_1_north" },
       { "point": [ 1, 1, 0 ], "overmap": "state_park_1_1_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "forest" ],
     "city_distance": [ 15, -1 ],
     "city_sizes": [ 4, -1 ],
@@ -3609,7 +3609,7 @@
       { "point": [ 0, 1, 0 ], "overmap": "fishing_pond_0_1_north" },
       { "point": [ 1, 1, 0 ], "overmap": "fishing_pond_1_1_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "field" ],
     "city_distance": [ 3, 10 ],
     "city_sizes": [ 4, -1 ],
@@ -3675,7 +3675,7 @@
       { "point": [ 1, 2, -1 ], "overmap": "mansion_t7d_north" },
       { "point": [ 2, 2, -1 ], "overmap": "mansion_c1d_south" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 0, 10 ],
     "city_sizes": [ 6, -1 ],
@@ -3723,7 +3723,7 @@
       { "point": [ 1, 2, -1 ], "overmap": "mansion_t1d_north" },
       { "point": [ 2, 2, -1 ], "overmap": "mansion_c4d_south" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 0, 10 ],
     "city_sizes": [ 6, -1 ],
@@ -3833,7 +3833,7 @@
       { "point": [ 0, 1, 0 ], "overmap": "junkyard_2a_north" },
       { "point": [ 1, 1, 0 ], "overmap": "junkyard_2b_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" }, { "point": [ 1, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" }, { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ -1, 10 ],
     "city_sizes": [ 8, -1 ],
@@ -3844,7 +3844,7 @@
     "type": "overmap_special",
     "id": "dumpsite",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "dumpsite_north" } ],
-    "connections": [ { "point": [ 0, 1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, 1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ 5, 20 ],
     "city_sizes": [ 4, -1 ],
@@ -3858,7 +3858,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "NatureTrail_1a_north" },
       { "point": [ 1, 0, 0 ], "overmap": "NatureTrail_1b_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "forest" ],
     "city_distance": [ 3, 8 ],
     "city_sizes": [ 4, -1 ],
@@ -3872,7 +3872,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "PublicPond_1a_north" },
       { "point": [ 1, 0, 0 ], "overmap": "PublicPond_1b_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "land" ],
     "city_distance": [ 1, 6 ],
     "city_sizes": [ 4, -1 ],
@@ -3883,7 +3883,7 @@
     "type": "overmap_special",
     "id": "cemetery",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "Cemetery_1a_north" }, { "point": [ 1, 0, 0 ], "overmap": "Cemetery_1b_north" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 2, 5 ],
     "city_sizes": [ 4, -1 ],
@@ -3894,7 +3894,7 @@
     "type": "overmap_special",
     "id": "tree farm",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "TreeFarm_1a_north" }, { "point": [ 1, 0, 0 ], "overmap": "TreeFarm_1b_north" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "forest" ],
     "city_distance": [ 5, 40 ],
     "occurrences": [ 0, 5 ],
@@ -3908,7 +3908,7 @@
       { "point": [ 0, 0, 1 ], "overmap": "shootingrange_1a_roof_north" },
       { "point": [ 0, 1, 0 ], "overmap": "shootingrange_2a_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 1, 10 ],
     "city_sizes": [ 4, -1 ],
@@ -3925,7 +3925,7 @@
       { "point": [ 1, 1, 0 ], "overmap": "campground_2b_north" },
       { "point": [ 1, 0, 1 ], "overmap": "campground_roof_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "forest" ],
     "city_distance": [ 20, -1 ],
     "occurrences": [ 0, 3 ],
@@ -3948,7 +3948,7 @@
       { "point": [ 1, 0, 0 ], "overmap": "bandit_garage_2_north" }
     ],
     "locations": [ "forest" ],
-    "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ -1, 0, 0 ], "connection": "local_road" } ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 50, 100 ],
@@ -3973,7 +3973,7 @@
       { "point": [ 3, 1, 2 ], "overmap": "golfcourse_31_roof_north" },
       { "point": [ 3, 2, 0 ], "overmap": "golfcourse_32_north" }
     ],
-    "connections": [ { "point": [ 3, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 3, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 20 ],
     "city_sizes": [ 8, -1 ],
@@ -3992,8 +3992,8 @@
       { "point": [ 1, 1, 1 ], "overmap": "s_reststop_2_roof_north" }
     ],
     "connections": [
-      { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true },
-      { "point": [ 1, -1, 0 ], "terrain": "road", "existing": true }
+      { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true },
+      { "point": [ 1, -1, 0 ], "connection": "local_road", "existing": true }
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 15, 150 ],
@@ -4023,7 +4023,7 @@
       { "point": [ 2, 2, 0 ], "overmap": "movietheater_2_2_north" },
       { "point": [ 2, 2, 1 ], "overmap": "movietheater_roof_2_2_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "field" ],
     "city_distance": [ 0, 6 ],
     "city_sizes": [ 6, -1 ],
@@ -4038,7 +4038,7 @@
       { "point": [ 1, 0, 0 ], "overmap": "trailerparksmall1_north" },
       { "point": [ 2, 0, 0 ], "overmap": "trailerparksmall2_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 4, 15 ],
     "city_sizes": [ -1, 12 ],
@@ -4064,7 +4064,7 @@
       { "point": [ 0, 3, 0 ], "overmap": "house_farm_north" },
       { "point": [ 0, 3, 1 ], "overmap": "house_farm_roof_north" }
     ],
-    "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 1, 0 ] } ],
+    "connections": [ { "point": [ 0, 0, 0 ], "connection": "local_road", "from": [ 0, 1, 0 ] } ],
     "locations": [ "forest" ],
     "city_distance": [ 5, 40 ],
     "occurrences": [ 0, 3 ],
@@ -4079,7 +4079,7 @@
       { "point": [ 1, 2, 0 ], "overmap": "house_farm_west" },
       { "point": [ 1, 2, 1 ], "overmap": "house_farm_roof_west" }
     ],
-    "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 1, 0 ] } ],
+    "connections": [ { "point": [ 0, 0, 0 ], "connection": "local_road", "from": [ 0, 1, 0 ] } ],
     "locations": [ "forest" ],
     "city_distance": [ 5, 40 ],
     "occurrences": [ 0, 3 ],
@@ -4096,7 +4096,7 @@
       { "point": [ 1, 3, 0 ], "overmap": "house_farm_west" },
       { "point": [ 1, 3, 1 ], "overmap": "house_farm_roof_west" }
     ],
-    "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 1, 0 ] } ],
+    "connections": [ { "point": [ 0, 0, 0 ], "connection": "local_road", "from": [ 0, 1, 0 ] } ],
     "locations": [ "forest" ],
     "city_distance": [ 5, 40 ],
     "occurrences": [ 0, 3 ],
@@ -4163,7 +4163,7 @@
       { "point": [ 1, 2, -1 ], "overmap": "railroad_station_under_1_2_north" },
       { "point": [ 1, 3, -1 ], "overmap": "railroad_station_under_1_3_north" }
     ],
-    "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road" }, { "point": [ 2, 5, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 2, 0, 0 ], "connection": "local_road" }, { "point": [ 2, 5, 0 ], "connection": "local_road" } ],
     "locations": [ "land", "forest" ],
     "city_distance": [ -1, 20 ],
     "city_sizes": [ 3, 12 ],
@@ -4186,7 +4186,7 @@
       { "point": [ -1, 1, 2 ], "overmap": "2fmotel_2_r_north" },
       { "point": [ 0, 1, 2 ], "overmap": "2fmotel_3_r_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 8, 40 ],
     "occurrences": [ 0, 2 ],
@@ -4217,9 +4217,9 @@
       { "point": [ 10, 2, 6 ], "overmap": "radio_tower_top_north" }
     ],
     "connections": [
-      { "point": [ 10, 1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 10, 2, 0 ] },
-      { "point": [ 2, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 0, 0 ] },
-      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] }
+      { "point": [ 10, 1, 0 ], "connection": "local_road", "from": [ 10, 2, 0 ] },
+      { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 2, 0, 0 ] },
+      { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] }
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
@@ -4316,7 +4316,7 @@
       { "point": [ 3, 4, -2 ], "overmap": "microlab_rock_border" },
       { "point": [ 4, 4, -2 ], "overmap": "microlab_rock_border" }
     ],
-    "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 1, 0 ] } ],
+    "connections": [ { "point": [ 2, 0, 0 ], "connection": "local_road", "from": [ 2, 1, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
     "occurrences": [ 30, 100 ],
@@ -4569,7 +4569,7 @@
       { "point": [ 2, 3, 0 ], "overmap": "ws_regional_dump_2_3_north" },
       { "point": [ 3, 3, 0 ], "overmap": "ws_regional_dump_3_3_north" }
     ],
-    "connections": [ { "point": [ 2, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 2, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 20 ],
     "city_sizes": [ 8, -1 ],
@@ -4731,7 +4731,7 @@
       { "point": [ 3, 4, 4 ], "overmap": "lab_surface_brick_block5D4_north" },
       { "point": [ 4, 4, 4 ], "overmap": "lab_surface_brick_block5E4_north" }
     ],
-    "connections": [ { "point": [ 2, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 0, 0 ] } ],
+    "connections": [ { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 2, 0, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 120 ],
     "city_sizes": [ 4, -1 ],
@@ -4763,9 +4763,9 @@
     ],
     "locations": [ "wilderness" ],
     "connections": [
-      { "point": [ 0, 3, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 2, 0 ] },
-      { "point": [ 1, 3, 0 ], "terrain": "road" },
-      { "point": [ 2, 3, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 2, 0 ] }
+      { "point": [ 0, 3, 0 ], "connection": "local_road", "from": [ 0, 2, 0 ] },
+      { "point": [ 1, 3, 0 ], "connection": "local_road" },
+      { "point": [ 2, 3, 0 ], "connection": "local_road", "from": [ 2, 2, 0 ] }
     ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 6, -1 ],
@@ -4805,7 +4805,7 @@
       { "point": [ 5, 0, 0 ], "overmap": "fuel_station_north" },
       { "point": [ 5, 0, 1 ], "overmap": "fuel_station_roof_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 8, -1 ],
@@ -4836,7 +4836,7 @@
       { "point": [ 1, 3, 0 ], "overmap": "lumbermill_dforest_north" },
       { "point": [ 2, 3, 0 ], "overmap": "lumbermill_dforest_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" }, { "point": [ 1, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" }, { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "forest" ],
     "city_distance": [ 5, 60 ],
     "city_sizes": [ 4, -1 ],
@@ -4865,7 +4865,7 @@
       { "point": [ 2, 3, 0 ], "overmap": "ws_biker_dump_2_3_north" },
       { "point": [ 3, 3, 0 ], "overmap": "ws_biker_dump_3_3_north" }
     ],
-    "connections": [ { "point": [ 2, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 0, 0 ] } ],
+    "connections": [ { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 2, 0, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 20 ],
     "city_sizes": [ 6, -1 ],
@@ -4892,7 +4892,7 @@
     "type": "overmap_special",
     "id": "trailhead_basic",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "trailhead_north" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "city_sizes": [ 1, -1 ],
     "//": "These actually get placed by some C++ trailhead placement code, so [0, 0] occurrences is deliberate.",
     "occurrences": [ 0, 0 ],
@@ -4905,7 +4905,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "trailhead_outhouse_z0_north" },
       { "point": [ 0, 0, 1 ], "overmap": "trailhead_outhouse_z1_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "city_sizes": [ 1, -1 ],
     "//": "These actually get placed by some C++ trailhead placement code, so [0, 0] occurrences is deliberate.",
     "occurrences": [ 0, 0 ],
@@ -4918,7 +4918,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "trailhead_shack_z0_north" },
       { "point": [ 0, 0, 1 ], "overmap": "trailhead_shack_z1_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "city_sizes": [ 1, -1 ],
     "//": "These actually get placed by some C++ trailhead placement code, so [0, 0] occurrences is deliberate.",
     "occurrences": [ 0, 0 ],
@@ -5516,7 +5516,7 @@
     ],
     "city_sizes": [ 4, 20 ],
     "occurrences": [ 0, 1 ],
-    "connections": [ { "point": [ 2, 4, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 3, 0 ] } ],
+    "connections": [ { "point": [ 2, 4, 0 ], "connection": "local_road", "from": [ 2, 3, 0 ] } ],
     "flags": [ "LAKE" ]
   },
   {
@@ -6591,7 +6591,7 @@
       { "point": [ 0, 3, 2 ], "overmap": "cground_1_2_north" }
     ],
     "locations": [ "forest" ],
-    "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ -1, 1, 0 ] } ],
+    "connections": [ { "point": [ -1, 0, 0 ], "connection": "local_road", "from": [ -1, 1, 0 ] } ],
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 3, 20 ],
     "occurrences": [ 0, 0 ],
@@ -6663,7 +6663,7 @@
       { "point": [ 3, 4, 2 ], "overmap": "steel_mill_rail_2_3_north" }
     ],
     "locations": [ "wilderness" ],
-    "connections": [ { "point": [ 2, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 0, 0 ] } ],
+    "connections": [ { "point": [ 2, -1, 0 ], "connection": "local_road", "from": [ 2, 0, 0 ] } ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 75, 100 ],
@@ -6684,7 +6684,7 @@
       { "point": [ 1, 1, 1 ], "overmap": "miniaturerailway_1_1_1_north" }
     ],
     "locations": [ "wilderness" ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 1, 0 ] } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 1, 0 ] } ],
     "city_distance": [ 10, 30 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 30, 100 ],
@@ -6708,7 +6708,7 @@
       { "point": [ 2, 1, 1 ], "overmap": "luna_park_2_1_1_north" }
     ],
     "locations": [ "wilderness" ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 1, 0 ] } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 1, 0 ] } ],
     "city_distance": [ 10, 30 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 30, 100 ],
@@ -6751,10 +6751,7 @@
       { "point": [ 1, 2, 2 ], "overmap": "p_resort_rss_north" },
       { "point": [ 2, 2, 2 ], "overmap": "p_resort_rse_north" }
     ],
-    "connections": [
-      { "point": [ 1, 4, 0 ], "terrain": "road", "connection": "local_road" },
-      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" }
-    ],
+    "connections": [ { "point": [ 1, 4, 0 ], "connection": "local_road" }, { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 8, 40 ],
     "city_sizes": [ 6, -1 ],
@@ -6776,7 +6773,7 @@
       { "point": [ 1, 1, 1 ], "overmap": "helipad2f_se_north" }
     ],
     "locations": [ "land" ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "city_distance": [ 10, -1 ],
     "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "MILITARY", "ELECTRIC_GRID" ]
@@ -7019,7 +7016,7 @@
       { "point": [ 2, 8, 4 ], "overmap": "mil_base_3i4_north" }
     ],
     "locations": [ "field" ],
-    "connections": [ { "point": [ 3, -2, 0 ] } ],
+    "connections": [ { "point": [ 3, -2, 0 ], "connection": "local_road" } ],
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 45, 100 ],
@@ -7052,9 +7049,9 @@
       { "point": [ 5, 1, 0 ], "overmap": "s_air_runway_l_south" }
     ],
     "connections": [
-      { "point": [ -1, -1, 0 ], "terrain": "road" },
-      { "point": [ 0, -1, 0 ], "terrain": "road" },
-      { "point": [ 1, -1, 0 ], "terrain": "road", "from": [ 1, 0, 0 ] }
+      { "point": [ -1, -1, 0 ], "connection": "local_road" },
+      { "point": [ 0, -1, 0 ], "connection": "local_road" },
+      { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] }
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 40 ],
@@ -7094,8 +7091,8 @@
     ],
     "locations": [ "land" ],
     "connections": [
-      { "point": [ 1, 4, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 3, 0 ] },
-      { "point": [ 2, -1, -1 ], "terrain": "sewer", "connection": "sewer_tunnel", "from": [ 2, 0, -1 ] }
+      { "point": [ 1, 4, 0 ], "connection": "local_road", "from": [ 1, 3, 0 ] },
+      { "point": [ 2, -1, -1 ], "connection": "sewer_tunnel", "from": [ 2, 0, -1 ] }
     ],
     "city_distance": [ 4, 25 ],
     "city_sizes": [ 3, -1 ],

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -29,7 +29,6 @@
     "type": "overmap_special",
     "id": "Motel",
     "overmaps": [
-      { "point": [ 0, -1, 0 ], "overmap": "road_end_north" },
       { "point": [ 0, 0, 0 ], "overmap": "motel_entrance_north" },
       { "point": [ 0, 0, 1 ], "overmap": "motel_entrance_roof_north" },
       { "point": [ -1, 0, 0 ], "overmap": "motel_1_north" },
@@ -718,7 +717,6 @@
     "type": "overmap_special",
     "id": "FEMA Camp",
     "overmaps": [
-      { "point": [ 1, -1, 0 ], "overmap": "road_end_north" },
       { "point": [ 0, 0, 0 ], "overmap": "fema_north" },
       { "point": [ 1, 0, 0 ], "overmap": "fema_entrance_north" },
       { "point": [ 2, 0, 0 ], "overmap": "fema_1_3_north" },
@@ -729,7 +727,7 @@
       { "point": [ 1, 2, 0 ], "overmap": "fema_3_2_north" },
       { "point": [ 2, 2, 0 ], "overmap": "fema_3_3_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "from": [ 1, 0, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 20 ],
     "city_sizes": [ 4, -1 ],
@@ -748,10 +746,9 @@
       { "point": [ 2, 1, 0 ], "overmap": "FEMA_re_north" },
       { "point": [ 0, 2, 0 ], "overmap": "FEMA_blc_north" },
       { "point": [ 1, 2, 0 ], "overmap": "FEMA_entrance_north" },
-      { "point": [ 2, 2, 0 ], "overmap": "FEMA_brc_north" },
-      { "point": [ 1, 3, 0 ], "overmap": "road_end_south" }
+      { "point": [ 2, 2, 0 ], "overmap": "FEMA_brc_north" }
     ],
-    "connections": [ { "point": [ 1, 3, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 1, 3, 0 ], "from": [ 1, 2, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 20 ],
     "city_sizes": [ 4, -1 ],
@@ -761,11 +758,7 @@
   {
     "type": "overmap_special",
     "id": "Military Bunker",
-    "overmaps": [
-      { "point": [ 0, -1, 0 ], "overmap": "road_end_north" },
-      { "point": [ 0, 0, 0 ], "overmap": "bunker_south" },
-      { "point": [ 0, 0, -1 ], "overmap": "bunker_basement" }
-    ],
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "bunker_south" }, { "point": [ 0, 0, -1 ], "overmap": "bunker_basement" } ],
     "connections": [ { "point": [ 0, -1, 0 ], "from": [ 0, 0, 0 ], "connection": "local_road" } ],
     "locations": [ "forest" ],
     "city_distance": [ 20, -1 ],
@@ -785,7 +778,6 @@
     "type": "overmap_special",
     "id": "Missile Silo",
     "overmaps": [
-      { "point": [ 0, -1, 0 ], "overmap": "road_end_north" },
       { "point": [ 0, 0, 0 ], "overmap": "silo" },
       { "point": [ 0, 0, -1 ], "overmap": "silo_1" },
       { "point": [ 0, 0, -2 ], "overmap": "silo_2" },
@@ -793,7 +785,7 @@
       { "point": [ 0, 0, -4 ], "overmap": "silo_4" },
       { "point": [ 0, 0, -5 ], "overmap": "silo_finale" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "from": [ 0, 0, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 30, -1 ],
     "city_sizes": [ -1, 4 ],
@@ -840,7 +832,6 @@
     "type": "overmap_special",
     "id": "Prison",
     "overmaps": [
-      { "point": [ 0, -1, 0 ], "overmap": "road_end_north" },
       { "point": [ -1, 0, 0 ], "overmap": "prison_1_3_north" },
       { "point": [ 0, 0, 0 ], "overmap": "prison_1_2_north" },
       { "point": [ 1, 0, 0 ], "overmap": "prison_1_1_north" },
@@ -878,7 +869,7 @@
       { "point": [ 0, 2, 2 ], "overmap": "prison_1_3f_8_north" },
       { "point": [ 1, 2, 2 ], "overmap": "prison_1_3f_7_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "from": [ 0, 0, 0 ], "connection": "local_road" } ],
     "locations": [ "land" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 4, -1 ],
@@ -950,7 +941,6 @@
     "type": "overmap_special",
     "id": "Prison Hidden Lab",
     "overmaps": [
-      { "point": [ 0, -1, 0 ], "overmap": "road_end_north" },
       { "point": [ -1, 0, 0 ], "overmap": "prison_1_3_north" },
       { "point": [ 0, 0, 0 ], "overmap": "prison_1_2_north" },
       { "point": [ 1, 0, 0 ], "overmap": "prison_1_1_north" },
@@ -988,7 +978,7 @@
       { "point": [ 0, 2, 2 ], "overmap": "prison_1_3f_8_north" },
       { "point": [ 1, 2, 2 ], "overmap": "prison_1_3f_7_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "from": [ 0, 0, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],
@@ -1215,7 +1205,6 @@
     "type": "overmap_special",
     "id": "Hazardous Waste Sarcophagus",
     "overmaps": [
-      { "point": [ 1, -1, 0 ], "overmap": "road_end_north" },
       { "point": [ 1, 0, 0 ], "overmap": "haz_sar_1_1_north" },
       { "point": [ 0, 0, 0 ], "overmap": "haz_sar_1_2_north" },
       { "point": [ 1, 1, 0 ], "overmap": "haz_sar_1_3_north" },
@@ -1225,7 +1214,7 @@
       { "point": [ 1, 1, -2 ], "overmap": "haz_sar_b_3_north" },
       { "point": [ 0, 1, -2 ], "overmap": "haz_sar_b_4_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "from": [ 1, 0, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 15, -1 ],
     "city_sizes": [ 6, -1 ],
@@ -3149,10 +3138,9 @@
       { "point": [ 11, 14, -4 ], "overmap": "refctr_SE2e_z-4_north" },
       { "point": [ 12, 14, -4 ], "overmap": "refctr_SE3e_z-4_north" },
       { "point": [ 13, 14, -4 ], "overmap": "refctr_SE4e_z-4_north" },
-      { "point": [ 14, 14, -4 ], "overmap": "refctr_SE5e_z-4_north" },
-      { "point": [ 7, 15, 0 ], "overmap": "road_end_south" }
+      { "point": [ 14, 14, -4 ], "overmap": "refctr_SE5e_z-4_north" }
     ],
-    "connections": [ { "point": [ 7, 15, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 7, 15, 0 ], "from": [ 7, 14, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 4, -1 ],
@@ -3330,10 +3318,9 @@
       { "point": [ 5, 8, 0 ], "overmap": "ranch_camp_78_north" },
       { "point": [ 6, 8, 0 ], "overmap": "ranch_camp_79_north" },
       { "point": [ 7, 8, 0 ], "overmap": "ranch_camp_80_north" },
-      { "point": [ 8, 8, 0 ], "overmap": "ranch_camp_81_north" },
-      { "point": [ 4, 9, 0 ], "overmap": "road_end_south" }
+      { "point": [ 8, 8, 0 ], "overmap": "ranch_camp_81_north" }
     ],
-    "connections": [ { "point": [ 4, 9, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 4, 9, 0 ], "from": [ 4, 8, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
     "rotate": false,
@@ -3477,10 +3464,9 @@
       { "point": [ 0, 0, 0 ], "overmap": "cemetery_4square_00_north" },
       { "point": [ 1, 0, 0 ], "overmap": "cemetery_4square_10_north" },
       { "point": [ 0, 1, 0 ], "overmap": "cemetery_4square_01_north" },
-      { "point": [ 1, 1, 0 ], "overmap": "cemetery_4square_11_north" },
-      { "point": [ 0, 2, 0 ], "overmap": "road_end_south" }
+      { "point": [ 1, 1, 0 ], "overmap": "cemetery_4square_11_north" }
     ],
-    "connections": [ { "point": [ 0, 2, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 0, 2, 0 ], "from": [ 0, 1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 2, 5 ],
     "city_sizes": [ 4, -1 ],
@@ -3586,13 +3572,12 @@
     "type": "overmap_special",
     "id": "State Park",
     "overmaps": [
-      { "point": [ 1, -1, 0 ], "overmap": "road_end_north" },
       { "point": [ 0, 0, 0 ], "overmap": "state_park_0_0_north" },
       { "point": [ 1, 0, 0 ], "overmap": "state_park_1_0_north" },
       { "point": [ 0, 1, 0 ], "overmap": "state_park_0_1_north" },
       { "point": [ 1, 1, 0 ], "overmap": "state_park_1_1_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "from": [ 1, 0, 0 ], "connection": "local_road" } ],
     "locations": [ "forest" ],
     "city_distance": [ 15, -1 ],
     "city_sizes": [ 4, -1 ],
@@ -3603,13 +3588,12 @@
     "id": "Fishing Pond",
     "type": "overmap_special",
     "overmaps": [
-      { "point": [ 1, -1, 0 ], "overmap": "road_end_north" },
       { "point": [ 0, 0, 0 ], "overmap": "fishing_pond_0_0_north" },
       { "point": [ 1, 0, 0 ], "overmap": "fishing_pond_1_0_north" },
       { "point": [ 0, 1, 0 ], "overmap": "fishing_pond_0_1_north" },
       { "point": [ 1, 1, 0 ], "overmap": "fishing_pond_1_1_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "from": [ 1, 0, 0 ], "connection": "local_road" } ],
     "locations": [ "field" ],
     "city_distance": [ 3, 10 ],
     "city_sizes": [ 4, -1 ],
@@ -4150,12 +4134,10 @@
       { "point": [ 1, 2, 0 ], "overmap": "railroad_station_1_2_north" },
       { "point": [ 1, 3, 0 ], "overmap": "railroad_station_1_3_north" },
       { "point": [ 1, 4, 0 ], "overmap": "railroad_station_1_4_north" },
-      { "point": [ 2, 0, 0 ], "overmap": "road_end_north" },
       { "point": [ 2, 1, 0 ], "overmap": "railroad_station_2_1_north" },
       { "point": [ 2, 2, 0 ], "overmap": "railroad_station_2_2_north" },
       { "point": [ 2, 3, 0 ], "overmap": "railroad_station_2_3_north" },
       { "point": [ 2, 4, 0 ], "overmap": "railroad_station_2_4_north" },
-      { "point": [ 2, 5, 0 ], "overmap": "road_end_south" },
       { "point": [ 0, 1, -1 ], "overmap": "railroad_station_under_0_1_north" },
       { "point": [ 0, 2, -1 ], "overmap": "railroad_station_under_0_2_north" },
       { "point": [ 0, 3, -1 ], "overmap": "railroad_station_under_0_3_north" },
@@ -4163,7 +4145,10 @@
       { "point": [ 1, 2, -1 ], "overmap": "railroad_station_under_1_2_north" },
       { "point": [ 1, 3, -1 ], "overmap": "railroad_station_under_1_3_north" }
     ],
-    "connections": [ { "point": [ 2, 0, 0 ], "connection": "local_road" }, { "point": [ 2, 5, 0 ], "connection": "local_road" } ],
+    "connections": [
+      { "point": [ 2, 0, 0 ], "from": [ 2, 1, 0 ], "connection": "local_road" },
+      { "point": [ 2, 5, 0 ], "from": [ 2, 4, 0 ], "connection": "local_road" }
+    ],
     "locations": [ "land", "forest" ],
     "city_distance": [ -1, 20 ],
     "city_sizes": [ 3, 12 ],
@@ -4777,7 +4762,6 @@
     "type": "overmap_special",
     "id": "regional_airport",
     "overmaps": [
-      { "point": [ 1, -1, 0 ], "overmap": "road_end_north" },
       { "point": [ 0, 0, 0 ], "overmap": "airport_lot_0_north" },
       { "point": [ 1, 0, 0 ], "overmap": "airport_lot_1_north" },
       { "point": [ 2, 0, 0 ], "overmap": "waiting_area_north" },
@@ -4805,7 +4789,7 @@
       { "point": [ 5, 0, 0 ], "overmap": "fuel_station_north" },
       { "point": [ 5, 0, 1 ], "overmap": "fuel_station_roof_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "from": [ 1, 0, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 8, -1 ],
@@ -6782,7 +6766,6 @@
     "type": "overmap_special",
     "id": "mil_base",
     "overmaps": [
-      { "point": [ 3, -2, 0 ], "overmap": "road_end_north" },
       { "point": [ 0, 0, 0 ], "overmap": "mil_base_1a_north" },
       { "point": [ 1, 0, 0 ], "overmap": "mil_base_2a_north" },
       { "point": [ 2, 0, 0 ], "overmap": "mil_base_3a_north" },
@@ -7016,7 +6999,7 @@
       { "point": [ 2, 8, 4 ], "overmap": "mil_base_3i4_north" }
     ],
     "locations": [ "field" ],
-    "connections": [ { "point": [ 3, -2, 0 ], "connection": "local_road" } ],
+    "connections": [ { "point": [ 3, -2, 0 ], "from": [ 3, -1, 0 ], "connection": "local_road" } ],
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 45, 100 ],

--- a/data/mods/Aftershock/maps/overmap_specials.json
+++ b/data/mods/Aftershock/maps/overmap_specials.json
@@ -3,7 +3,7 @@
     "type": "overmap_special",
     "id": "prepnet_orchard",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "prepnet_orchard_north" } ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "land" ],
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 2, -1 ],
@@ -13,7 +13,7 @@
   {
     "id": "municipal_reactor",
     "type": "overmap_special",
-    "connections": [ { "point": [ -1, 1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ -1, 1, 0 ], "from": [ 0, 1, 0 ], "connection": "local_road" } ],
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "municipal_reactor_north" },
       { "point": [ 0, 0, -1 ], "overmap": "municipal_reactor_b_north" },
@@ -21,7 +21,6 @@
       { "point": [ 0, 0, -3 ], "overmap": "municipal_reactor_b3_north" },
       { "point": [ 1, 0, 0 ], "overmap": "municipal_reactor_ware_north" },
       { "point": [ 1, 0, -1 ], "overmap": "municipal_reactor_ware_b_north" },
-      { "point": [ -1, 1, 0 ], "overmap": "road_ew" },
       { "point": [ 0, 1, 0 ], "overmap": "road_ew" },
       { "point": [ 1, 1, 0 ], "overmap": "road_end_east" },
       { "point": [ 0, 2, 0 ], "overmap": "park_north" },
@@ -55,7 +54,7 @@
       { "point": [ 0, 0, -1 ], "overmap": "mortuary_basement_north" },
       { "point": [ 0, 0, 2 ], "overmap": "mortuary_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "land" ],
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 2, -1 ],

--- a/data/mods/DinoMod/overmap/overmap_specials.json
+++ b/data/mods/DinoMod/overmap/overmap_specials.json
@@ -6,7 +6,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "dinoexhibit_north" },
       { "point": [ 0, 0, 1 ], "overmap": "dinoexhibit_roof_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 0, 20 ],
@@ -57,7 +57,7 @@
       { "point": [ 3, 4, -2 ], "overmap": "microlab_rock_border" },
       { "point": [ 4, 4, -2 ], "overmap": "microlab_rock_border" }
     ],
-    "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 1, 0 ] } ],
+    "connections": [ { "point": [ 2, 0, 0 ], "connection": "local_road", "from": [ 2, 1, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
     "occurrences": [ 30, 100 ],

--- a/data/mods/Fuji_Structures/worldgen/overmap_specials.json
+++ b/data/mods/Fuji_Structures/worldgen/overmap_specials.json
@@ -11,8 +11,8 @@
       { "point": [ 0, 1, 0 ], "overmap": "s_lightindustry_11_south" }
     ],
     "connections": [
-      { "point": [ -1, 0, 0 ], "terrain": "road", "existing": false },
-      { "point": [ -2, 0, 0 ], "terrain": "road", "existing": true }
+      { "point": [ -1, 0, 0 ], "connection": "local_road", "existing": false },
+      { "point": [ -2, 0, 0 ], "connection": "local_road", "existing": true }
     ],
     "locations": [ "land", "swamp" ],
     "city_distance": [ 0, -1 ],
@@ -31,7 +31,7 @@
       { "point": [ 0, 0, -2 ], "overmap": "s_gas_b20_south" },
       { "point": [ 0, 1, -2 ], "overmap": "s_gas_b21_south" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land", "swamp" ],
     "city_distance": [ 0, -1 ],
     "city_sizes": [ 1, 12 ],
@@ -46,7 +46,7 @@
       { "point": [ 0, 0, 0 ], "overmap": "s_bunker_shop_g_south" },
       { "point": [ 0, 0, -1 ], "overmap": "s_bunker_shop_b_south" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land", "swamp" ],
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 1, 12 ],

--- a/data/mods/More_Locations/bandit_tower/overmap_specials.json
+++ b/data/mods/More_Locations/bandit_tower/overmap_specials.json
@@ -108,7 +108,7 @@
       { "point": [ 2, 3, -1 ], "overmap": "bandit_tower_ublc_north" },
       { "point": [ 3, 3, -1 ], "overmap": "bandit_tower_ubrc_north" }
     ],
-    "connections": [ { "point": [ 0, -2, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -2, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 1, -1 ],
     "city_sizes": [ 1, 20 ],

--- a/data/mods/More_Locations/estate/overmap_specials.json
+++ b/data/mods/More_Locations/estate/overmap_specials.json
@@ -93,7 +93,7 @@
       { "point": [ 1, 4, -1 ], "overmap": "estate_ube_north" },
       { "point": [ 5, 4, -1 ], "overmap": "estate_ube_north" }
     ],
-    "connections": [ { "point": [ 3, -1, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 3, -1, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 1, 20 ],

--- a/data/mods/More_Locations/factory/overmap_specials.json
+++ b/data/mods/More_Locations/factory/overmap_specials.json
@@ -29,7 +29,7 @@
       { "point": [ 3, 4, 0 ], "overmap": "factory_be_north" },
       { "point": [ 4, 4, 0 ], "overmap": "factory_brc_north" }
     ],
-    "connections": [ { "point": [ 2, 5, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 2, 5, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 1, 12 ],

--- a/data/mods/More_Locations/military_outpost/overmap_specials.json
+++ b/data/mods/More_Locations/military_outpost/overmap_specials.json
@@ -77,7 +77,7 @@
       { "point": [ 2, 3, -4 ], "overmap": "mil_outpost_ubeb_north" },
       { "point": [ 3, 3, -4 ], "overmap": "mil_outpost_ubrc_north" }
     ],
-    "connections": [ { "point": [ 2, 5, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 2, 5, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 1, 12 ],

--- a/data/mods/More_Locations/multistory_houses/overmap_specials.json
+++ b/data/mods/More_Locations/multistory_houses/overmap_specials.json
@@ -9,7 +9,7 @@
       { "point": [ 0, 0, 3 ], "overmap": "3storyA_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "3storyA_basement_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -26,7 +26,7 @@
       { "point": [ 0, 0, 3 ], "overmap": "3storyB_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "3storyB_basement_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -43,7 +43,7 @@
       { "point": [ 0, 0, 3 ], "overmap": "3storyC_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "3storyC_basement_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -60,7 +60,7 @@
       { "point": [ 0, 0, 3 ], "overmap": "3storyD_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "3storyD_basement_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -77,7 +77,7 @@
       { "point": [ 0, 0, 3 ], "overmap": "3storyE_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "3storyE_basement_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -94,7 +94,7 @@
       { "point": [ 0, 0, 3 ], "overmap": "3storyF_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "3storyF_basement_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -110,7 +110,7 @@
       { "point": [ 0, 0, 2 ], "overmap": "2storyA_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "2storyA_basement_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -126,7 +126,7 @@
       { "point": [ 0, 0, 2 ], "overmap": "2storyB_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "2storyB_basement_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -142,7 +142,7 @@
       { "point": [ 0, 0, 2 ], "overmap": "2storyC_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "2storyC_basement_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -158,7 +158,7 @@
       { "point": [ 0, 0, 2 ], "overmap": "2storyD_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "2storyD_basement_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -174,7 +174,7 @@
       { "point": [ 0, 0, 2 ], "overmap": "2storyE_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "2storyE_basement_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -190,7 +190,7 @@
       { "point": [ 0, 0, 2 ], "overmap": "2storyF_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "2storyF_basement_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -209,7 +209,7 @@
       { "point": [ 1, 0, 2 ], "overmap": "combogarageA_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "combohouseA_basement_north" }
     ],
-    "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 2, 0, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],
@@ -228,7 +228,7 @@
       { "point": [ 1, 0, 2 ], "overmap": "combogarageB_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "combohouseB_basement_north" }
     ],
-    "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 2, 0, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 1 ],
     "city_sizes": [ 1, 12 ],
@@ -247,7 +247,7 @@
       { "point": [ 1, 0, 2 ], "overmap": "combogarageC_roof_north" },
       { "point": [ 0, 0, -1 ], "overmap": "combohouseC_basement_north" }
     ],
-    "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 2, 0, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 1, 12 ],

--- a/data/mods/More_Locations/refugee_tower/overmap_specials.json
+++ b/data/mods/More_Locations/refugee_tower/overmap_specials.json
@@ -120,7 +120,7 @@
       { "point": [ 2, 3, -1 ], "overmap": "refugee_tower_ublc_north" },
       { "point": [ 3, 3, -1 ], "overmap": "refugee_tower_ubrc_north" }
     ],
-    "connections": [ { "point": [ 0, -2, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -2, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 1, -1 ],
     "city_sizes": [ 1, 20 ],

--- a/data/mods/More_Locations/tri_tower/overmap_specials.json
+++ b/data/mods/More_Locations/tri_tower/overmap_specials.json
@@ -108,7 +108,7 @@
       { "point": [ 2, 3, -1 ], "overmap": "tri_tower_ublc_north" },
       { "point": [ 3, 3, -1 ], "overmap": "tri_tower_ubrc_north" }
     ],
-    "connections": [ { "point": [ 0, -2, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 0, -2, 0 ], "connection": "local_road" } ],
     "locations": [ "land" ],
     "city_distance": [ 1, -1 ],
     "city_sizes": [ 1, 20 ],

--- a/data/mods/National_Guard_Camp/overmap_specials.json
+++ b/data/mods/National_Guard_Camp/overmap_specials.json
@@ -433,7 +433,7 @@
       { "point": [ 4, 9, -1 ], "overmap": "national_guard_camp_b1_203_north" },
       { "point": [ 5, 9, -1 ], "overmap": "national_guard_camp_b1_204_north" }
     ],
-    "connections": [ { "point": [ 8, 11, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ 8, 11, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 1, 5 ],
     "city_sizes": [ 1, 12 ],

--- a/data/mods/No_Rail_Stations/overmap_specials.json
+++ b/data/mods/No_Rail_Stations/overmap_specials.json
@@ -1,34 +1,8 @@
 [
   {
-    "id": "Railroad Station",
     "type": "overmap_special",
-    "overmaps": [
-      { "point": [ 0, 1, 0 ], "overmap": "railroad_station_0_1_north" },
-      { "point": [ 0, 2, 0 ], "overmap": "railroad_station_0_2_north" },
-      { "point": [ 0, 3, 0 ], "overmap": "railroad_station_0_3_north" },
-      { "point": [ 0, 4, 0 ], "overmap": "railroad_station_0_4_north" },
-      { "point": [ 1, 1, 0 ], "overmap": "railroad_station_1_1_north" },
-      { "point": [ 1, 2, 0 ], "overmap": "railroad_station_1_2_north" },
-      { "point": [ 1, 3, 0 ], "overmap": "railroad_station_1_3_north" },
-      { "point": [ 1, 4, 0 ], "overmap": "railroad_station_1_4_north" },
-      { "point": [ 2, 0, 0 ], "overmap": "road_end_north" },
-      { "point": [ 2, 1, 0 ], "overmap": "railroad_station_2_1_north" },
-      { "point": [ 2, 2, 0 ], "overmap": "railroad_station_2_2_north" },
-      { "point": [ 2, 3, 0 ], "overmap": "railroad_station_2_3_north" },
-      { "point": [ 2, 4, 0 ], "overmap": "railroad_station_2_4_north" },
-      { "point": [ 2, 5, 0 ], "overmap": "road_end_south" },
-      { "point": [ 0, 1, -1 ], "overmap": "railroad_station_under_0_1_north" },
-      { "point": [ 0, 2, -1 ], "overmap": "railroad_station_under_0_2_north" },
-      { "point": [ 0, 3, -1 ], "overmap": "railroad_station_under_0_3_north" },
-      { "point": [ 1, 1, -1 ], "overmap": "railroad_station_under_1_1_north" },
-      { "point": [ 1, 2, -1 ], "overmap": "railroad_station_under_1_2_north" },
-      { "point": [ 1, 3, -1 ], "overmap": "railroad_station_under_1_3_north" }
-    ],
-    "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road" }, { "point": [ 2, 5, 0 ], "terrain": "road" } ],
-    "locations": [ "land", "forest" ],
-    "city_distance": [ -1, 20 ],
-    "city_sizes": [ 3, 12 ],
-    "occurrences": [ 0, 0 ],
-    "flags": [ "CLASSIC" ]
+    "id": "Railroad Station",
+    "overmaps": [  ],
+    "occurrences": [ 0, 0 ]
   }
 ]

--- a/data/mods/Salvaged_Robots/robot_additions/overmap_special.json
+++ b/data/mods/Salvaged_Robots/robot_additions/overmap_special.json
@@ -10,6 +10,6 @@
       { "point": [ 0, 0, 0 ], "overmap": "robot_dispatch_first_north" },
       { "point": [ 0, 0, 1 ], "overmap": "robot_dispatch_second_north" }
     ],
-    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road" } ]
+    "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road" } ]
   }
 ]

--- a/data/mods/desert_region/desert_overmap_connections.json
+++ b/data/mods/desert_region/desert_overmap_connections.json
@@ -2,6 +2,7 @@
   {
     "type": "overmap_connection",
     "id": "local_road",
+    "default_terrain": "road",
     "subtypes": [
       { "terrain": "road", "locations": [ "field", "road", "desert" ] },
       { "terrain": "road", "locations": [ "forest_without_trail" ], "basic_cost": 20 },

--- a/data/mods/mapspecials_demo/megastore/overmap_specials.json
+++ b/data/mods/mapspecials_demo/megastore/overmap_specials.json
@@ -42,7 +42,7 @@
       { "point": [ 1, 2, 2 ], "overmap": "mega_3be_north" },
       { "point": [ 2, 2, 2 ], "overmap": "mega_3brc_north" }
     ],
-    "connections": [ { "point": [ 1, 5, 0 ], "terrain": "road", "existing": true } ],
+    "connections": [ { "point": [ 1, 5, 0 ], "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ 8, 20 ],
     "city_sizes": [ 1, 12 ],

--- a/data/mods/mapspecials_demo/missile_silo/overmap_specials.json
+++ b/data/mods/mapspecials_demo/missile_silo/overmap_specials.json
@@ -32,7 +32,7 @@
       { "point": [ 0, 1, -6 ], "overmap": "silo_fblc_north" },
       { "point": [ 1, 1, -6 ], "overmap": "silo_fbrc_north" }
     ],
-    "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road" } ],
+    "connections": [ { "point": [ -1, 0, 0 ], "connection": "local_road" } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 1, 12 ],

--- a/doc/JSON Mapping Guides/Guide for beginning mapgen.md
+++ b/doc/JSON Mapping Guides/Guide for beginning mapgen.md
@@ -433,10 +433,10 @@ Example:
       { "point": [ 0, 1, -1 ], "overmap": "pump_station_5_north" }
     ],
     "connections": [
-      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] },
-      { "point": [ 1, -1, -1 ], "terrain": "sewer", "connection": "sewer_tunnel", "from": [ 0, -1, -1 ] },
-      { "point": [ -1, -1, -1 ], "terrain": "sewer", "connection": "sewer_tunnel", "from": [ 0, -1, -1 ] },
-      { "point": [ -1, 1, -1 ], "terrain": "sewer", "connection": "sewer_tunnel", "from": [ 0, 1, -1 ] }
+      { "point": [ 0, -1, 0 ], "connection": "local_road", "from": [ 0, 0, 0 ] },
+      { "point": [ 1, -1, -1 ], "connection": "sewer_tunnel", "from": [ 0, -1, -1 ] },
+      { "point": [ -1, -1, -1 ], "connection": "sewer_tunnel", "from": [ 0, -1, -1 ] },
+      { "point": [ -1, 1, -1 ], "connection": "sewer_tunnel", "from": [ 0, 1, -1 ] }
     ],
     "locations": [ "land" ],
     "city_distance": [ 1, 4 ],

--- a/doc/OVERMAP.md
+++ b/doc/OVERMAP.md
@@ -302,7 +302,7 @@ level value and then only specify it for individual entries that differ.
       { "point": [ 0, 1, 0 ], "overmap": "campground_2a_north" },
       { "point": [ 1, 1, 0 ], "overmap": "campground_2b_north" }
     ],
-    "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
+    "connections": [ { "point": [ 1, -1, 0 ], "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "forest" ],
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 3, 12 ],
@@ -326,8 +326,7 @@ level value and then only specify it for individual entries that differ.
 |  Identifier  |                                           Description                                              |
 | ------------ | -------------------------------------------------------------------------------------------------- |
 | `point`      | `[ x, y, z]` of the connection end point. Cannot overlap an overmap terrain entry for the special. |
-| `terrain`    | Will go away in favor of `connection` eventually. Use `road`, `subway`, `sewer`, etc.              |
-| `connection` | Id of the `overmap_connection` to build. Optional for now, but you should specify it explicitly.   |
+| `connection` | Id of the `overmap_connection` to build.                                                           |
 | `from`       | Optional point `[ x, y, z]` within the special to treat as the origin of the connection.           |
 
 ## City Building

--- a/doc/OVERMAP.md
+++ b/doc/OVERMAP.md
@@ -382,11 +382,12 @@ by the frequency assigned to the city building within the `region_settings`. Con
 
 ### Fields
 
-| Identifier |                                           Description                                           |
-| ---------- | ----------------------------------------------------------------------------------------------- |
-| `type`     | Must be "overmap_connection".                                                                   |
-| `id`       | Unique id.                                                                                      |
-| `subtypes` | List of entries used to determine valid locations, terrain cost, and resulting overmap terrain. |
+|     Identifier    |                                           Description                                           |
+| ----------------- | ----------------------------------------------------------------------------------------------- |
+| `type`            | Must be "overmap_connection".                                                                   |
+| `id`              | Unique id.                                                                                      |
+| `default_terrain` | Default `overmap_terrain` to use for undirected connections and existance checks.               |
+| `subtypes`        | List of entries used to determine valid locations, terrain cost, and resulting overmap terrain. |
 
 
 ### Example

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -31,10 +31,6 @@ struct MonsterGroup;
 
 using overmap_land_use_code_id = string_id<overmap_land_use_code>;
 class JsonObject;
-class overmap_special_batch;
-class overmap_special;
-
-using overmap_special_id = string_id<overmap_special>;
 
 static const overmap_land_use_code_id land_use_code_forest( "forest" );
 static const overmap_land_use_code_id land_use_code_wetland( "wetland" );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -437,8 +437,33 @@ void overmap_special_terrain::deserialize( const JsonObject &jo )
 void overmap_special_connection::deserialize( const JsonObject &jo )
 {
     mandatory( jo, false, "point", p );
-    optional( jo, false, "connection", connection );
-    optional( jo, false, "terrain", terrain );
+    if( jo.has_string( "terrain" ) ) {
+        // Legacy migration.
+        // TODO: remove after BN 0.F or 0.E (or whatever it's gonna be)
+        if( json_report_strict ) {
+            try {
+                jo.throw_error( "Defining connection by terrain is deprecated, use explicit 'connection' instead.",
+                                "terrain" );
+            } catch( const JsonError &e ) {
+                debugmsg( "%s", e.what() );
+            }
+        }
+
+        if( !jo.has_member( "connection" ) ) {
+            std::string t = jo.get_string( "terrain" );
+            if( t == "sewer" ) {
+                connection = overmap_connection_id( "sewer_tunnel" );
+            } else if( t == "subway" ) {
+                connection = overmap_connection_id( "subway_tunnel" );
+            } else if( t == "forest_trail" ) {
+                connection = overmap_connection_id( "forest_trail" );
+            } else {
+                connection = overmap_connection_id( "local_road" );
+            }
+        }
+    } else {
+        mandatory( jo, false, "connection", connection );
+    }
     optional( jo, false, "existing", existing );
     optional( jo, false, "from", from );
 }
@@ -1008,19 +1033,6 @@ void overmap_special::finalize()
     }
 
     for( auto &elem : connections ) {
-        const auto &oter = get_terrain_at( elem.p );
-        if( !elem.terrain && oter.terrain ) {
-            elem.terrain = oter.terrain->get_type_id();    // Defaulted.
-        }
-
-        // If the connection type hasn't been specified, we'll guess for them.
-        // The guess isn't always right (hence guessing) in the case where
-        // multiple connections types can be made on a single location type,
-        // e.g. both roads and forest trails can be placed on "forest" locations.
-        if( elem.connection.is_null() ) {
-            elem.connection = overmap_connections::guess_for( elem.terrain );
-        }
-
         // If the connection has a "from" hint specified, then figure out what the
         // resulting direction from the hinted location to the connection point is,
         // and use that as the intial direction to be passed off to the connection
@@ -1092,16 +1104,15 @@ void overmap_special::check() const
     }
 
     for( const auto &elem : connections ) {
-        const auto &oter = get_terrain_at( elem.p );
-        if( !elem.terrain ) {
-            debugmsg( "In overmap special \"%s\", connection [%d,%d,%d] doesn't have a terrain.",
-                      id.c_str(), elem.p.x, elem.p.y, elem.p.z );
-        } else if( !elem.existing && !elem.terrain->has_flag( line_drawing ) ) {
-            debugmsg( "In overmap special \"%s\", connection [%d,%d,%d] \"%s\" isn't drawn with lines.",
-                      id.c_str(), elem.p.x, elem.p.y, elem.p.z, elem.terrain.c_str() );
-        } else if( oter.terrain && !oter.terrain->type_is( elem.terrain ) ) {
-            debugmsg( "In overmap special \"%s\", connection [%d,%d,%d] overwrites \"%s\".",
-                      id.c_str(), elem.p.x, elem.p.y, elem.p.z, oter.terrain.c_str() );
+        const overmap_special_terrain &ter = get_terrain_at( elem.p );
+        if( !ter.terrain.is_null() ) {
+            debugmsg( "In overmap special \"%s\", connection at %s overwrites terrain.",
+                      id, elem.p.to_string() );
+        }
+
+        if( !elem.connection.is_valid() ) {
+            debugmsg( "In overmap special \"%s\", connection at %s has invalid id \"%s\".",
+                      id, elem.p.to_string(), elem.connection );
         }
 
         if( elem.from ) {
@@ -1117,8 +1128,8 @@ void overmap_special::check() const
                 case direction::WEST:
                     continue;
                 default:
-                    debugmsg( "In overmap special \"%s\", connection [%d,%d,%d] is not directly north, east, south or west of the defined \"from\" [%d,%d,%d].",
-                              id.c_str(), elem.p.x, elem.p.y, elem.p.z, elem.from->x, elem.from->y, elem.from->z );
+                    debugmsg( "In overmap special \"%s\", connection %s is not directly north, east, south or west of the defined \"from\" %s.",
+                              id, elem.p.to_string(), elem.from->to_string() );
                     break;
             }
         }
@@ -4227,7 +4238,7 @@ om_direction::type overmap::random_special_rotation( const overmap_special &spec
             }
             const oter_id &oter = ter( rp );
 
-            if( is_ot_match( con.terrain.str(), oter, ot_match_type::type ) ) {
+            if( belongs_to_connection( con.connection, oter ) ) {
                 ++score; // Found another one satisfied connection.
             } else if( !oter || con.existing || !con.connection->pick_subtype_for( oter ) ) {
                 valid = false;
@@ -5028,4 +5039,9 @@ int oter_get_rotations( const oter_id &oter )
 const std::string &oter_get_rotation_string( const oter_id &oter )
 {
     return om_direction::get_suffix( oter_get_rotation_dir( oter ) );
+}
+
+bool belongs_to_connection( const overmap_connection_id &id, const oter_id &oter )
+{
+    return is_ot_match( id->default_terrain.str(), oter, ot_match_type::type );
 }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -430,7 +430,6 @@ void overmap_special_terrain::deserialize( const JsonObject &jo )
 {
     mandatory( jo, false, "point", p );
     mandatory( jo, false, "overmap", terrain );
-    optional( jo, false, "flags", flags );
     optional( jo, false, "locations", locations );
 }
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -536,4 +536,9 @@ int oter_get_rotations( const oter_id &oter );
 * Returned reference is kept alive during the whole program execution.
 */
 const std::string &oter_get_rotation_string( const oter_id &oter );
+
+/**
+ * Determine whether provided tile belongs to overmap connection.
+ */
+bool belongs_to_connection( const overmap_connection_id &id, const oter_id &oter );
 #endif // CATA_SRC_OVERMAP_H

--- a/src/overmap_connection.cpp
+++ b/src/overmap_connection.cpp
@@ -100,7 +100,8 @@ bool overmap_connection::has( const oter_id &oter ) const
 
 void overmap_connection::load( const JsonObject &jo, const std::string & )
 {
-    mandatory( jo, false, "subtypes", subtypes );
+    mandatory( jo, was_loaded, "default_terrain", default_terrain );
+    mandatory( jo, was_loaded, "subtypes", subtypes );
 }
 
 void overmap_connection::check() const
@@ -127,12 +128,15 @@ void overmap_connection::finalize()
     cached_subtypes.resize( overmap_terrains::get_all().size() );
 }
 
-void overmap_connections::load( const JsonObject &jo, const std::string &src )
+namespace overmap_connections
+{
+
+void load( const JsonObject &jo, const std::string &src )
 {
     connections.load( jo, src );
 }
 
-void overmap_connections::finalize()
+void finalize()
 {
     connections.finalize();
     for( const auto &elem : connections.get_all() ) {
@@ -140,28 +144,30 @@ void overmap_connections::finalize()
     }
 }
 
-void overmap_connections::check_consistency()
+void check_consistency()
 {
     connections.check();
 }
 
-void overmap_connections::reset()
+void reset()
 {
     connections.reset();
 }
 
-overmap_connection_id overmap_connections::guess_for( const oter_id &oter_id )
+overmap_connection_id guess_for( const oter_id &oter )
 {
     const auto &all = connections.get_all();
     const auto iter = std::find_if( all.cbegin(),
-    all.cend(), [&oter_id]( const overmap_connection & elem ) {
-        return elem.pick_subtype_for( oter_id ) != nullptr;
+    all.cend(), [&oter]( const overmap_connection & elem ) {
+        return elem.pick_subtype_for( oter ) != nullptr;
     } );
 
     return iter != all.cend() ? iter->id : overmap_connection_id::NULL_ID();
 }
 
-overmap_connection_id overmap_connections::guess_for( const oter_type_id &oter_id )
+overmap_connection_id guess_for( const oter_type_id &oter )
 {
-    return guess_for( oter_id->get_first() );
+    return guess_for( oter->get_first() );
 }
+
+} // namespace overmap_connections

--- a/src/overmap_connection.h
+++ b/src/overmap_connection.h
@@ -58,6 +58,8 @@ class overmap_connection
         overmap_connection_id id;
         bool was_loaded = false;
 
+        oter_type_str_id default_terrain;
+
     private:
         struct cache {
             const subtype *value = nullptr;
@@ -79,8 +81,8 @@ void finalize();
 void check_consistency();
 void reset();
 
-overmap_connection_id guess_for( const oter_type_id &oter_id );
-overmap_connection_id guess_for( const oter_id &oter_id );
+overmap_connection_id guess_for( const oter_type_id &oter );
+overmap_connection_id guess_for( const oter_id &oter );
 
 } // namespace overmap_connections
 

--- a/src/overmap_special.h
+++ b/src/overmap_special.h
@@ -49,7 +49,6 @@ struct overmap_special_terrain {
     overmap_special_terrain() = default;
     tripoint p;
     oter_str_id terrain;
-    std::set<std::string> flags;
     std::set<overmap_location_id> locations;
 
     void deserialize( const JsonObject &jo );

--- a/src/overmap_special.h
+++ b/src/overmap_special.h
@@ -65,8 +65,6 @@ struct overmap_special_connection {
     tripoint p;
     cata::optional<tripoint> from;
     om_direction::type initial_dir = om_direction::type::invalid;
-    // TODO: Remove it.
-    oter_type_str_id terrain;
     overmap_connection_id connection;
     bool existing = false;
 

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -540,25 +540,6 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
                     }
                 }
             }
-        } else if( name == "roads_out" ) {
-            // Legacy data, superceded by that stored in the "connections_out" member. A load and save
-            // cycle will migrate this to "connections_out".
-            std::vector<tripoint_om_omt> &roads_out =
-                connections_out[string_id<overmap_connection>( "local_road" )];
-            jsin.start_array();
-            while( !jsin.end_array() ) {
-                jsin.start_object();
-                tripoint_om_omt new_road;
-                while( !jsin.end_object() ) {
-                    std::string road_member_name = jsin.get_member_name();
-                    if( road_member_name == "x" ) {
-                        jsin.read( new_road.x() );
-                    } else if( road_member_name == "y" ) {
-                        jsin.read( new_road.y() );
-                    }
-                }
-                roads_out.push_back( new_road );
-            }
         } else if( name == "radios" ) {
             jsin.start_array();
             while( !jsin.end_array() ) {


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Modernized oms connections JSON, deprecate autoguessing from "terrain""

#### Purpose of change
Railroad-related yak shaving.
Modernize overmap special connections JSON, deprecate "guess-connection-from-specified-terrain" hack.
No behavior changes intended.

#### Describe the solution
1. Remove some dead code (old "roads_out" migration, unused declarations, unused field "flags")
2. Replace terrain ids in connection with explicit connection ids (e.g. `"terrain": "road"` -> `"connection": "local_road"`)
3. Add a deprecation warning for `"terrain"` field, implement hardcoded migration to relevant connection for out-of-repo mods.
4. Prevent connections from starting at a point occupied by some other oms terrain, fix existing cases.
5. Simplify blacklist for No_Rail_Stations mod

#### Testing
Created new world, teleported around to check placed specials and their connections.
Spawned a few, checked their connections as well.