### PR TITLE
Remove messy flag within CRT expansion to get rid of load error. 

### DIFF
--- a/data/mods/CRT_EXPANSION/items/crt_gun.json
+++ b/data/mods/CRT_EXPANSION/items/crt_gun.json
@@ -350,7 +350,7 @@
     "clip_size": 8,
     "reload": 450,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "REACH", "em field saw", 5, [ "MELEE", "REACH_ATTACK" ] ] ],
-    "ammo_effects": [ "LIGHTNING", "MESSY" ],
+    "ammo_effects": [ "LIGHTNING" ],
     "flags": [ "NEVER_JAMS", "NON-FOULING" ]
   }
 ]


### PR DESCRIPTION

#### Summary Bugfixes "Fixes the error upon loading the game with CRT expansion mod. 



#### Purpose of change

In the mod CRT Expansion there and an effect called "messy" this was invalid so I got rid of it. This throws an error upon loading and this will fix it. 

#### Describe the solution

Just got rid of the [ "messy" ] effect for the gun. 

#### Describe alternatives you've considered

None

#### Testing

Tested in game. CRT loaded. Gun still works. Everything looks good. 

#### Additional context

N/A
