### PR TITLE
Longsword and estoc to fit in scabbard

### DIFF
--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -551,6 +551,7 @@
     "material": [ "rubber", "steel" ],
     "coverage": 3,
     "rigid": true,
+    "encumbrance": 0,
     "flags": [ "POWERARMOR_MOD", "COMPACT", "WATERPROOF", "STURDY", "WAIST" ]
   },
   {

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -542,15 +542,26 @@
   {
     "id": "power_armor_scabbard",
     "type": "ARMOR",
-    "copy-from": "scabbard",
     "name": { "str": "power armor scabbard" },
     "description": "A set of clamps and fittings to accommodate a variety of swords and similar weaponry.  Designed to interface with a military exoskeleton.  Activate to sheathe/draw a sword.",
     "weight": "1550 g",
+    "volume": "1750 ml",
     "price": 60000,
     "price_postapoc": 600,
+    "bashing": 4,
     "material": [ "rubber", "steel" ],
+    "symbol": "[",
+    "color": "brown",
+    "covers": [ "leg_either" ],
     "coverage": 3,
-    "rigid": true,
+    "material_thickness": 1,
+    "use_action": {
+      "type": "holster",
+      "holster_prompt": "Sheath sword",
+      "holster_msg": "You sheath your %s",
+      "max_volume": "2 L",
+      "flags": [ "SHEATH_SWORD" ]
+    },
     "flags": [ "POWERARMOR_MOD", "COMPACT", "WATERPROOF", "STURDY", "WAIST" ]
   },
   {

--- a/data/json/items/armor/power_armor.json
+++ b/data/json/items/armor/power_armor.json
@@ -542,26 +542,15 @@
   {
     "id": "power_armor_scabbard",
     "type": "ARMOR",
+    "copy-from": "scabbard",
     "name": { "str": "power armor scabbard" },
     "description": "A set of clamps and fittings to accommodate a variety of swords and similar weaponry.  Designed to interface with a military exoskeleton.  Activate to sheathe/draw a sword.",
     "weight": "1550 g",
-    "volume": "1750 ml",
     "price": 60000,
     "price_postapoc": 600,
-    "bashing": 4,
     "material": [ "rubber", "steel" ],
-    "symbol": "[",
-    "color": "brown",
-    "covers": [ "leg_either" ],
     "coverage": 3,
-    "material_thickness": 1,
-    "use_action": {
-      "type": "holster",
-      "holster_prompt": "Sheath sword",
-      "holster_msg": "You sheath your %s",
-      "max_volume": "2 L",
-      "flags": [ "SHEATH_SWORD" ]
-    },
+    "rigid": true,
     "flags": [ "POWERARMOR_MOD", "COMPACT", "WATERPROOF", "STURDY", "WAIST" ]
   },
   {

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -129,14 +129,13 @@
     "color": "brown",
     "covers": [ "leg_either" ],
     "coverage": 15,
-    "rigid": false,
-    "max_encumbrance": 4,
+    "encumbrance": 2,
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
       "holster_prompt": "Sheath sword",
       "holster_msg": "You sheath your %s",
-      "max_volume": "2750 ml",
+      "max_volume": "2 L",
       "flags": [ "SHEATH_SWORD" ]
     },
     "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY" ]

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -133,7 +133,7 @@
       "type": "holster",
       "holster_prompt": "Sheath sword",
       "holster_msg": "You sheath your %s",
-      "max_volume": "2 L",
+      "max_volume": "3 L",
       "flags": [ "SHEATH_SWORD" ]
     },
     "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY" ]

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -42,7 +42,8 @@
     "color": "brown",
     "covers": [ "torso" ],
     "coverage": 10,
-    "encumbrance": 3,
+    "rigid": false,
+    "max_encumbrance": 2,
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
@@ -99,7 +100,8 @@
     "color": "brown",
     "covers": [ "torso" ],
     "coverage": 10,
-    "encumbrance": 3,
+    "rigid": false,
+    "max_encumbrance": 2,
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
@@ -127,13 +129,14 @@
     "color": "brown",
     "covers": [ "leg_either" ],
     "coverage": 15,
-    "encumbrance": 2,
+    "rigid": false,
+    "max_encumbrance": 4,
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
       "holster_prompt": "Sheath sword",
       "holster_msg": "You sheath your %s",
-      "max_volume": "3 L",
+      "max_volume": "2750 ml",
       "flags": [ "SHEATH_SWORD" ]
     },
     "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY" ]

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -42,13 +42,14 @@
     "color": "brown",
     "covers": [ "torso" ],
     "coverage": 10,
-    "encumbrance": 3,
+    "rigid": false,
+    "max_encumbrance": 1,
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
       "holster_prompt": "Sheath sword",
       "holster_msg": "You sheath your %s",
-      "max_volume": "3 L",
+      "max_volume": "2750 ml",
       "draw_cost": 10,
       "flags": [ "SHEATH_SWORD" ]
     },
@@ -99,7 +100,8 @@
     "color": "brown",
     "covers": [ "torso" ],
     "coverage": 10,
-    "encumbrance": 3,
+    "rigid": false,
+    "max_encumbrance": 2,
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
@@ -127,13 +129,14 @@
     "color": "brown",
     "covers": [ "leg_either" ],
     "coverage": 15,
-    "encumbrance": 2,
+    "rigid": false,
+    "max_encumbrance": 4,
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
       "holster_prompt": "Sheath sword",
       "holster_msg": "You sheath your %s",
-      "max_volume": "3 L",
+      "max_volume": "2750 ml",
       "flags": [ "SHEATH_SWORD" ]
     },
     "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY" ]

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -130,6 +130,7 @@
     "covers": [ "leg_either" ],
     "coverage": 15,
     "rigid": false,
+    "encumbrance": 2,
     "max_encumbrance": 4,
     "material_thickness": 1,
     "use_action": {

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -129,13 +129,14 @@
     "color": "brown",
     "covers": [ "leg_either" ],
     "coverage": 15,
-    "encumbrance": 2,
+    "rigid": false,
+    "max_encumbrance": 4,
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
       "holster_prompt": "Sheath sword",
       "holster_msg": "You sheath your %s",
-      "max_volume": "2 L",
+      "max_volume": "2750 ml",
       "flags": [ "SHEATH_SWORD" ]
     },
     "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY" ]

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -42,14 +42,13 @@
     "color": "brown",
     "covers": [ "torso" ],
     "coverage": 10,
-    "rigid": false,
-    "max_encumbrance": 1,
+    "encumbrance": 3,
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
       "holster_prompt": "Sheath sword",
       "holster_msg": "You sheath your %s",
-      "max_volume": "2750 ml",
+      "max_volume": "3 L",
       "draw_cost": 10,
       "flags": [ "SHEATH_SWORD" ]
     },
@@ -100,8 +99,7 @@
     "color": "brown",
     "covers": [ "torso" ],
     "coverage": 10,
-    "rigid": false,
-    "max_encumbrance": 2,
+    "encumbrance": 3,
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
@@ -129,14 +127,13 @@
     "color": "brown",
     "covers": [ "leg_either" ],
     "coverage": 15,
-    "rigid": false,
-    "max_encumbrance": 4,
+    "encumbrance": 2,
     "material_thickness": 1,
     "use_action": {
       "type": "holster",
       "holster_prompt": "Sheath sword",
       "holster_msg": "You sheath your %s",
-      "max_volume": "2750 ml",
+      "max_volume": "3 L",
       "flags": [ "SHEATH_SWORD" ]
     },
     "flags": [ "WAIST", "OVERSIZE", "WATER_FRIENDLY" ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: Balance "Allow larger swords to fit in the scabbard"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

As talked about in discord previously i'm bringing this rather simple PR.
Longsword and estoc fall in the strange category where they have to be carried around using a baldric or a back scabbard, which is essentially wrong from both real life and balance perspective (longsword and estocs were carried in scabbard suspended on belt like one handed swords historically, they were just worn at different angle than shorter swords cause of their length).
I will leave back scabbard out of this as it's probably fine for it to remain as the only option to carry great swords.
Baldric is essentially a scabbard which hangs from your shoulder which is a problem gamewise since you basically trade leg encumbrance for torso encumbrance (torso waist layer) and having low torso encumbrance is vital for melee (0,1 dodge, -1% melee attack rolls and 1 melee movement point cost for each point of torso encumbrance). Another problem is stacking since baldric occupies the same layer as survivor harness/axe ring holster.
The most logic way to deal with this situation is not to either use these weapons at all (there are better weapons out there) or carry them in backpack (since you can fit anything in backpack) and not having to suffer the consequences of baldric, which has 3 encumbrance atm which translates to 0,3 dodge, -3% melee attack rolls and 3 melee MPC.
One can also drop the backpack prior to fight and not suffer the torso penalty at all, which can theoretically be done with baldric/back scabbard too but then that's 1 more tedious action to do before each fight.


#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Increase volume of scabbard so that longsword and estoc can fit in it (3000 ml). 
The logic here is that when using survivor backpack/rucksack, and carrying estoc in them, it will effectively raise torso encumbrance by 1 which translates to 0.1 dodge penalty, while a 2 leg encumbrance (one one leg) translates into 0.1 dodge penalty as well.
This will give scabbard an edge cause it doesn't suffer the 1% melee attack penalty and 1 melee MPC but the dodge penalty will stay through the fight unlike the torso encumbrance from backpack, which many people drop before fighting. 
This would be a straight buff to the scabbard so let me know if you think that this is too strong. The alternative is to create a new type of larger scabbard that would fit the larger sword, with higher encumbrance.
Baldrics encumbrance should likely be changed to 1 encumbrance to follow this logic.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

My original solution was to create a new item, something along the lines of "big scabbard" that would require more materials to craft, have large volume and bigger encumbrance than the original scabbard. 

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Changed the values, loaded the game and confirmed that both estoc and longsword can now fit in the scabbard and that scabbard has the proper encumbrance.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

![image](https://user-images.githubusercontent.com/72284934/182785451-8bd3ee02-ae08-424f-95fc-1c16ade8f79b.png)
https://en.wikipedia.org/wiki/Estoc
https://en.wikipedia.org/wiki/Longsword