### PR TITLE
[DDA Port] Fix black lines and misaligned rotated sprites on Windows

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2276,9 +2276,6 @@ bool cata_tiles::draw_sprite_at(
                 break;
             case 1:
                 // 90 degrees (and 270, with just two sprites)
-#if defined(_WIN32)
-                destination.y -= 1;
-#endif
                 if( !tile_iso ) {
                     // never rotate isometric tiles
                     ret = sprite_tex->render_copy_ex( renderer, &destination, -90, nullptr, SDL_FLIP_NONE );
@@ -2298,9 +2295,6 @@ bool cata_tiles::draw_sprite_at(
                 break;
             case 3:
                 // 270 degrees
-#if defined(_WIN32)
-                destination.x -= 1;
-#endif
                 if( !tile_iso ) {
                     // never rotate isometric tiles
                     ret = sprite_tex->render_copy_ex( renderer, &destination, 90, nullptr, SDL_FLIP_NONE );


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "[DDA Port] Fix black lines and misaligned rotated sprites on Windows"

#### Purpose of change
Fix black lines and misaligned rotated sprites on Windows.
Example cases:
![image](https://user-images.githubusercontent.com/60584843/183267739-ae832d90-07f9-4605-8cc1-6a29fd8c6541.png)
![image](https://user-images.githubusercontent.com/60584843/183267751-583119da-2cc4-45e7-ad13-e1c6baa61513.png)

#### Describe the solution
Cherry-pick https://github.com/CleverRaven/Cataclysm-DDA/pull/45524, which removes the offset.
From the discussion in original PR, that most likely was a workaround for some SDL bug which appears to have been fixed since (our mingw releases use SDL 2.0.14 at the moment and msvc - SDL 2.0.20).

#### Testing
Done on Windows 10.
Downloaded latest release, then compared with the fixed releases built by GA on my own fork:
https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/cbn-experimental-2022-08-06-2156
Before: tiles are misaligned with direct3d11/software/opengl renderers in both msvc and mingw x64 releases.
After: tiles are drawn properly with the aforementioned renderers.
![image](https://user-images.githubusercontent.com/60584843/183267823-4630fd23-27ad-4673-99a4-43f28f9152f1.png)
![image](https://user-images.githubusercontent.com/60584843/183267811-7bf58538-5cf4-4258-8b6a-fb002be02cc6.png)
