### PR TITLE
Add exe icon to msvc build

### DIFF
--- a/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-vcpkg-static.vcxproj
@@ -161,6 +161,9 @@
       <Project>{0009bb11-11ad-4c14-a5fc-d882a942c00b}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\src\resource.rc" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Added executable icon to msvc build"

#### Purpose of change
Fix #1717

#### Describe the solution
Mingw build includes a resource file that describes the ico to use for the executable.
Add this file to msvc build as well.

#### Testing
Compiled the game in Visual Studio and with Github Actions, launched the game on Windows, saw that exe has the icon.
https://github.com/olanti-p/Cataclysm-BN/releases/tag/cbn-experimental-2022-08-10-2041