### PR TITLE
Sort Character Creation skills in menus

### DIFF
--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -53,7 +53,7 @@ int modulo( int v, int m )
     // but this is supposed to be mathematical modulo: 0 <= v%m < m,
     const int r = v % m;
     // Adding m in that (and only that) case.
-    return r >= 0 ? r : r + m;
+    return r >= 0 ? r : r + ( m * ( 1 - r / m ) );
 }
 
 bool isBetween( int test, int down, int up )

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1778,17 +1778,22 @@ tab_direction set_skills( avatar &u, points_left &points )
     const Skill *currentSkill = skill_list[cur_pos].first;
     int selected = 0;
 
-    auto get_next = [&]( bool go_up ) {
-        if( go_up ) {
-            cur_pos--;
-            if( cur_pos < 0 ) {
-                cur_pos = num_skills - 1;
-            }
-        } else {
-            cur_pos++;
-            if( cur_pos >= num_skills ) {
-                cur_pos = 0;
-            }
+    auto get_next = [&]( ScrollDirection direction ) {
+        switch( direction ) {
+            case ScrollDirection::UP:
+                cur_pos--;
+                if( cur_pos < 0 ) {
+                    cur_pos = num_skills - 1;
+                }
+                break;
+            case ScrollDirection::DOWN:
+                cur_pos++;
+                if( cur_pos >= num_skills ) {
+                    cur_pos = 0;
+                }
+                break;
+            default:
+                break;
         }
         currentSkill = skill_list[cur_pos].first;
     };
@@ -1955,9 +1960,9 @@ tab_direction set_skills( avatar &u, points_left &points )
         ui_manager::redraw();
         const std::string action = ctxt.handle_input();
         if( action == "DOWN" ) {
-            get_next( false );
+            get_next( ScrollDirection::DOWN );
         } else if( action == "UP" ) {
-            get_next( true );
+            get_next( ScrollDirection::UP );
         } else if( action == "LEFT" ) {
             const int level = u.get_skill_level( currentSkill->ident() );
             if( level > 0 ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1747,11 +1747,74 @@ tab_direction set_skills( avatar &u, points_left &points )
         return localized_compare( a.name(), b.name() );
     } );
 
-    const int num_skills = sorted_skills.size();
-    int cur_offset = 0;
+    std::stable_sort( sorted_skills.begin(), sorted_skills.end(),
+    []( const Skill * a, const Skill * b ) {
+        return a->display_category() < b->display_category();
+    } );
+
+    std::vector<std::pair<skill_displayType_id, const Skill *>> skill_list;
+    for( const Skill *skl : sorted_skills ) {
+        if( skill_list.empty() ) {
+            skill_list.emplace_back( skl->display_category(), nullptr );
+        }
+
+        if( skl->display_category() == skill_list.back().first ) {
+            skill_list.emplace_back( skl->display_category(), skl );
+        } else {
+            skill_list.emplace_back( skl->display_category(), nullptr );
+            skill_list.emplace_back( skl->display_category(), skl );
+        }
+    }
+
+    const int num_skills = skill_list.size();
+    int cur_offset = 1;
     int cur_pos = 0;
-    const Skill *currentSkill = sorted_skills[cur_pos];
+    const Skill *currentSkill = nullptr;
     int selected = 0;
+
+    const int scroll_rate = num_skills > 20 ? 5 : 2;
+    auto get_next = [&]( bool go_up, bool fast_scroll ) {
+        bool invalid = true;
+        while( invalid ) {
+            if( fast_scroll ) {
+                if( go_up ) {
+                    if( cur_pos == 0 ) {
+                        cur_pos = num_skills - 1;
+                    } else if( cur_pos <= scroll_rate ) {
+                        cur_pos = 0;
+                    } else {
+                        cur_pos += -scroll_rate;
+                    }
+                } else {
+                    if( cur_pos == num_skills - 1 ) {
+                        cur_pos = 0;
+                    } else if( cur_pos + scroll_rate >= num_skills ) {
+                        cur_pos = num_skills - 1;
+                    } else {
+                        cur_pos += +scroll_rate;
+                    }
+                }
+            } else {
+                if( go_up ) {
+                    cur_pos--;
+                    if( cur_pos < 0 ) {
+                        cur_pos = num_skills - 1;
+                    }
+                } else {
+                    cur_pos++;
+                    if( cur_pos >= num_skills ) {
+                        cur_pos = 0;
+                    }
+                }
+            }
+            currentSkill = skill_list[cur_pos].second;
+            if( currentSkill ) {
+                invalid = false;
+            }
+        }
+    };
+
+    get_next( false, false );
 
     input_context ctxt( "NEW_CHAR_SKILLS" );
     ctxt.register_cardinal();
@@ -1870,10 +1933,13 @@ tab_direction set_skills( avatar &u, points_left &points )
         calcStartPos( cur_offset, cur_pos, iContentHeight, num_skills );
         for( int i = cur_offset; i < num_skills && i - cur_offset < iContentHeight; ++i ) {
             const int y = 5 + i - cur_offset;
-            const Skill *thisSkill = sorted_skills[i];
+            const skill_displayType_id &display_type = skill_list[i].first;
+            const Skill *thisSkill = skill_list[i].second;
             // Clear the line
             mvwprintz( w, point( 2, y ), c_light_gray, std::string( getmaxx( w ) - 3, ' ' ) );
-            if( u.get_skill_level( thisSkill->ident() ) == 0 ) {
+            if( !thisSkill ) {
+                mvwprintz( w, point( 2, y ), c_yellow, display_type->display_string() );
+            } else if( u.get_skill_level( thisSkill->ident() ) == 0 ) {
                 mvwprintz( w, point( 2, y ),
                            ( i == cur_pos ? h_light_gray : c_light_gray ), thisSkill->name() );
             } else {
@@ -1898,21 +1964,19 @@ tab_direction set_skills( avatar &u, points_left &points )
         wnoutrefresh( w_description );
     } );
 
+
+
     do {
         ui_manager::redraw();
         const std::string action = ctxt.handle_input();
         if( action == "DOWN" ) {
-            cur_pos++;
-            if( cur_pos >= num_skills ) {
-                cur_pos = 0;
-            }
-            currentSkill = sorted_skills[cur_pos];
+            get_next( false, false );
         } else if( action == "UP" ) {
-            cur_pos--;
-            if( cur_pos < 0 ) {
-                cur_pos = num_skills - 1;
-            }
-            currentSkill = sorted_skills[cur_pos];
+            get_next( true, false );
+        } else if( action == "PAGE_DOWN" ) {
+            get_next( false, true );
+        } else if( action == "PAGE_UP" ) {
+            get_next( true, true );
         } else if( action == "LEFT" ) {
             const int level = u.get_skill_level( currentSkill->ident() );
             if( level > 0 ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1940,16 +1940,10 @@ tab_direction set_skills( avatar &u, points_left &points )
         ui_manager::redraw();
         const std::string action = ctxt.handle_input();
         if( action == "DOWN" ) {
-            cur_pos++;
-            if( cur_pos >= num_skills ) {
-                cur_pos = 0;
-            }
+            cur_pos = modulo( cur_pos + 1, num_skills );
             currentSkill = skill_list[cur_pos].first;
         } else if( action == "UP" ) {
-            cur_pos--;
-            if( cur_pos < 0 ) {
-                cur_pos = num_skills - 1;
-            }
+            cur_pos = modulo( cur_pos - 1, num_skills );
             currentSkill = skill_list[cur_pos].first;
         } else if( action == "LEFT" ) {
             const int level = u.get_skill_level( currentSkill->ident() );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2530,7 +2530,7 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
         int line = 1;
         bool has_skills = false;
         profession::StartingSkillList list_skills = you.prof->skills();
-        skill_displayType_id currentcategory = skill_displayType_id::NULL_ID();
+        skill_displayType_id last_category = skill_displayType_id::NULL_ID();
         for( auto &elem : skillslist ) {
             int level = you.get_skill_level( elem->ident() );
 
@@ -2544,8 +2544,8 @@ tab_direction set_description( avatar &you, const bool allow_reroll,
             }
 
             if( level > 0 ) {
-                if( currentcategory != elem->display_category() ) {
-                    currentcategory = elem->display_category();
+                if( last_category != elem->display_category() ) {
+                    last_category = elem->display_category();
                     mvwprintz( w_skills, point( 0, line ), c_yellow, elem->display_category()->display_string() );
                     line++;
                 }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1778,26 +1778,6 @@ tab_direction set_skills( avatar &u, points_left &points )
     const Skill *currentSkill = skill_list[cur_pos].first;
     int selected = 0;
 
-    auto get_next = [&]( ScrollDirection direction ) {
-        switch( direction ) {
-            case ScrollDirection::UP:
-                cur_pos--;
-                if( cur_pos < 0 ) {
-                    cur_pos = num_skills - 1;
-                }
-                break;
-            case ScrollDirection::DOWN:
-                cur_pos++;
-                if( cur_pos >= num_skills ) {
-                    cur_pos = 0;
-                }
-                break;
-            default:
-                break;
-        }
-        currentSkill = skill_list[cur_pos].first;
-    };
-
     input_context ctxt( "NEW_CHAR_SKILLS" );
     ctxt.register_cardinal();
     ctxt.register_action( "SCROLL_DOWN" );
@@ -1960,9 +1940,17 @@ tab_direction set_skills( avatar &u, points_left &points )
         ui_manager::redraw();
         const std::string action = ctxt.handle_input();
         if( action == "DOWN" ) {
-            get_next( ScrollDirection::DOWN );
+            cur_pos++;
+            if( cur_pos >= num_skills ) {
+                cur_pos = 0;
+            }
+            currentSkill = skill_list[cur_pos].first;
         } else if( action == "UP" ) {
-            get_next( ScrollDirection::UP );
+            cur_pos--;
+            if( cur_pos < 0 ) {
+                cur_pos = num_skills - 1;
+            }
+            currentSkill = skill_list[cur_pos].first;
         } else if( action == "LEFT" ) {
             const int level = u.get_skill_level( currentSkill->ident() );
             if( level > 0 ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1927,8 +1927,9 @@ tab_direction set_skills( avatar &u, points_left &points )
                 mvwprintz( w, point( 4, y ),
                            ( i == cur_pos ? hilite( COL_SKILL_USED ) : COL_SKILL_USED ),
                            thisSkill->name() );
-                wprintz( w, ( i == cur_pos ? hilite( COL_SKILL_USED ) : COL_SKILL_USED ),
-                         " ( %d )", u.get_skill_level( thisSkill->ident() ) );
+                mvwprintz( w, point( 20, y ),
+                           ( i == cur_pos ? hilite( COL_SKILL_USED ) : COL_SKILL_USED ),
+                           " ( %d )", u.get_skill_level( thisSkill->ident() ) );
             }
             for( auto &prof_skill : u.prof->skills() ) {
                 if( prof_skill.first == thisSkill->ident() ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1892,9 +1892,9 @@ tab_direction set_skills( avatar &u, points_left &points )
         draw_scrollbar( w, selected, iContentHeight, iLines,
                         point( getmaxx( w ) - 1, 5 ), BORDER_COLOR, true );
 
-        calcStartPos( cur_offset, skill_list[cur_pos].second, iContentHeight, display_line );
+        calcStartPos( cur_offset, skill_list[cur_pos].second - 1, iContentHeight - 1, display_line - 1 );
         current_category = skill_displayType_id::NULL_ID();
-        for( int i = 0; i < num_skills && skill_list[i].second - cur_offset < iContentHeight; ++i ) {
+        for( int i = 0; i < num_skills && skill_list[i].second - cur_offset - 1 < iContentHeight; ++i ) {
             const int y = 5 + skill_list[i].second - cur_offset;
             // Necessary because cur_offset doesn't indicate the first object to read. A bit hacky.
             if( y < 5 ) {
@@ -1908,18 +1908,20 @@ tab_direction set_skills( avatar &u, points_left &points )
                 mvwprintz( w, point( 2, y - 1 ), c_yellow, display_type->display_string() );
                 current_category = display_type;
             }
-            // Clear the line. 2 for x-coord because category names will be scrolled over.
-            mvwprintz( w, point( 2, y ), c_light_gray, std::string( getmaxx( w ) - 3, ' ' ) );
-            if( u.get_skill_level( thisSkill->ident() ) == 0 ) {
-                mvwprintz( w, point( 4, y ),
-                           ( i == cur_pos ? h_light_gray : c_light_gray ), thisSkill->name() );
-            } else {
-                mvwprintz( w, point( 4, y ),
-                           ( i == cur_pos ? hilite( COL_SKILL_USED ) : COL_SKILL_USED ),
-                           thisSkill->name() );
-                mvwprintz( w, point( 20, y ),
-                           ( i == cur_pos ? hilite( COL_SKILL_USED ) : COL_SKILL_USED ),
-                           " ( %d )", u.get_skill_level( thisSkill->ident() ) );
+            if( y < iContentHeight + 5 ) {
+                // Clear the line. 2 for x-coord because category names will be scrolled over.
+                mvwprintz( w, point( 2, y ), c_light_gray, std::string( getmaxx( w ) - 3, ' ' ) );
+                if( u.get_skill_level( thisSkill->ident() ) == 0 ) {
+                    mvwprintz( w, point( 4, y ),
+                               ( i == cur_pos ? h_light_gray : c_light_gray ), thisSkill->name() );
+                } else {
+                    mvwprintz( w, point( 4, y ),
+                               ( i == cur_pos ? hilite( COL_SKILL_USED ) : COL_SKILL_USED ),
+                               thisSkill->name() );
+                    mvwprintz( w, point( 20, y ),
+                               ( i == cur_pos ? hilite( COL_SKILL_USED ) : COL_SKILL_USED ),
+                               " (%d)", u.get_skill_level( thisSkill->ident() ) );
+                }
             }
             for( auto &prof_skill : u.prof->skills() ) {
                 if( prof_skill.first == thisSkill->ident() ) {
@@ -1930,7 +1932,8 @@ tab_direction set_skills( avatar &u, points_left &points )
             }
         }
 
-        draw_scrollbar( w, skill_list[cur_pos].second, iContentHeight, display_line, point( 0, 5 ) );
+        draw_scrollbar( w, skill_list[cur_pos].second - 1, iContentHeight - 1, display_line - 1, point( 0,
+                        5 ) );
 
         wnoutrefresh( w );
         wnoutrefresh( w_description );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1505,14 +1505,25 @@ tab_direction set_profession( avatar &u, points_left &points,
             }
 
             // Profession skills
-            const auto prof_skills = sorted_profs[cur_id]->skills();
+            std::vector<std::pair<skill_id, int>> prof_skills = sorted_profs[cur_id]->skills();
+            std::stable_sort( prof_skills.begin(), prof_skills.end(),
+            []( const std::pair<skill_id, int> &a, const std::pair<skill_id, int> &b ) {
+                return localized_compare( std::make_pair( a.first->display_category(), a.first->name() ),
+                                          std::make_pair( b.first->display_category(), b.first->name() ) );
+            } );
             buffer += colorize( _( "Profession skills:" ), c_light_blue ) + "\n";
             if( prof_skills.empty() ) {
                 buffer += pgettext( "set_profession_skill", "None" ) + std::string( "\n" );
             } else {
+                skill_displayType_id cur_category = skill_displayType_id::NULL_ID();
                 for( const auto &sl : prof_skills ) {
+                    if( cur_category != sl.first->display_category() ) {
+                        cur_category = sl.first->display_category();
+                        buffer += colorize( string_format( sl.first->display_category()->display_string() ),
+                                            c_yellow ) + "\n";
+                    }
                     const auto format = pgettext( "set_profession_skill", "%1$s (%2$d)" );
-                    buffer += string_format( format, sl.first.obj().name(), sl.second ) + "\n";
+                    buffer += "  " + string_format( format, sl.first.obj().name(), sl.second ) + "\n";
                 }
             }
 

--- a/src/output.h
+++ b/src/output.h
@@ -496,6 +496,13 @@ enum PopupFlags {
     PF_FULLSCREEN  = 1 << 3,
 };
 
+enum class ScrollDirection : int {
+    UP,
+    DOWN,
+    FAST_UP,
+    FAST_DOWN
+};
+
 template<typename ...Args>
 inline int popup_getkey( const char *const mes, Args &&... args )
 {

--- a/src/output.h
+++ b/src/output.h
@@ -496,13 +496,6 @@ enum PopupFlags {
     PF_FULLSCREEN  = 1 << 3,
 };
 
-enum class ScrollDirection : int {
-    UP,
-    DOWN,
-    FAST_UP,
-    FAST_DOWN
-};
-
 template<typename ...Args>
 inline int popup_getkey( const char *const mes, Args &&... args )
 {

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -138,6 +138,19 @@ SkillDisplayType::SkillDisplayType( const skill_displayType_id &ident,
 {
 }
 
+/** @relates string_id */
+template<>
+const SkillDisplayType &skill_displayType_id::obj() const
+{
+    for( const SkillDisplayType &skill : SkillDisplayType::skillTypes ) {
+        if( skill.ident() == *this ) {
+            return skill;
+        }
+    }
+
+    return invalid_skill_type;
+}
+
 void SkillDisplayType::load( const JsonObject &jsobj )
 {
     // TEMPORARY until 0.G: Remove "ident" support


### PR DESCRIPTION
#### Summary

SUMMARY: Interface "Sort Character Creation skills in menus"

#### Purpose of change

Skills in character creation are sorted alphabetically currently, which isn't necessarily easy to look over. During the game, when opening the character menu skills are already sorted by category, so sorting it as such shouldn't be an issue.

#### Describe the solution

Ports over [53052](https://github.com/CleverRaven/Cataclysm-DDA/pull/53052).

Reworks the way the list is populated so that the categories themselves don't have to be added to the skill list, cutting down on excess code (stuff like checking if the item is actually valid or not) and making the solution much easier to add to other menus.

~~The profession menu is currently an issue, I can't get stable_sort to work on the vector of pairs.~~ Just me being an idiot and forgetting to remove `const`.

#### Describe alternatives you've considered

- Make the skills sort congruently by instead removing the sorting and categories from the character screen
~~But why?~~
- Rework the sorting so that within categories it's not alphabetical and instead follows the original sorting method in json.
Could be done, and could be in some ways be better, but adding skills via mods and similar will quickly mess up the order anyway.
- Make the DESCRIPTION menu display all skills instead of just the ones you have ranks in.
I think the current situation is more compact and still very functional.

#### Testing

- [x] Check that skills display correctly and are selected correctly.
- [x] Check that when incremented they increment the correct skill and this carries over to post character creation
- [x] Check that when professions are selected that grant skills the game does not CTD.
- [x] Check that the end DESCRIPTION menu displays correctly.
- [x] Check that the profession menu sorting displays correctly.
- [x] Ensure that all said menus sort skills the exact same way.
- [x] Ensure that scrolling isn't negatively affected.

#### Additional context

I tore out the fast scroll bit that was added via page_up page_down since we don't have a check for those buttons in the new_character menu and we also don't have enough skills to really warrant it. If we want to add it back it may be a good
idea to add it to trait selection and profession selection since we have _a lot_ of those.
![image_2022-08-17_020059397](https://user-images.githubusercontent.com/102964889/184947776-06d42ea4-b7ec-4cbc-b41b-45b28f2329fa.png) ![image_2022-08-16_222801506](https://user-images.githubusercontent.com/102964889/184905046-d9bcc024-2c4a-4b96-9daf-eabe66d561c6.png) 
