### PR TITLE
A new way to get into the Hazardous Waste Sarcophagus 

### DIFF
--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -957,5 +957,24 @@
     "price": 4550,
     "looks_like": "tall_tales",
     "fun": 3
+  },
+  {
+    "id": "sa_cryptology_key",
+    "type": "BOOK",
+    "name": { "str": "High Level Commercial and Military Cryptology", "str_pl": "High Level Commercial and Military Cryptology" },
+    "description": "An incredibly dense volume describing different advanced cryptographical methods, their strenghts, and weaknesses. This text would probably be easier to digest with an added decade in Computer Science Academia.",
+    "weight": 3000,
+    "volume": "2 L",
+    "price": "450 USD",
+    "bashing": 5,
+    "material": [ "paper" ],
+    "symbol": "?",
+    "color": "blue",
+    "skill": "computer",
+    "required_level": 7,
+    "max_level": 10,
+    "intelligence": 12,
+    "time": 40,
+    "fun": -5
   }
 ]

--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -962,7 +962,7 @@
     "id": "sa_cryptology_key",
     "type": "BOOK",
     "name": { "str_sp": "High Level Commercial and Military Cryptology" },
-    "description": "An  incredibly dense volume describing different advanced cryptographical methods, their strenghts, and weaknesses.  This text would probably be easier to digest with an added decade in Computer Science Academia.",
+    "description": "An incredibly dense volume describing different advanced cryptographical methods, their strenghts, and weaknesses.  This text would probably be easier to digest with an added decade in Computer Science Academia.",
     "weight": 3000,
     "volume": "2 L",
     "price": "450 USD",

--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -961,8 +961,8 @@
   {
     "id": "sa_cryptology_key",
     "type": "BOOK",
-    "name": { "str_sp": "High  Level  Commercial  and  Military  Cryptology" },
-    "description": "An  incredibly dense volume describing different advanced cryptographical methods, their strenghts, and weaknesses. This text would probably be easier to digest with an added decade in Computer Science Academia.",
+    "name": { "str_sp": "High Level Commercial and Military Cryptology" },
+    "description": "An  incredibly dense volume describing different advanced cryptographical methods, their strenghts, and weaknesses.  This text would probably be easier to digest with an added decade in Computer Science Academia.",
     "weight": 3000,
     "volume": "2 L",
     "price": "450 USD",

--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -961,8 +961,8 @@
   {
     "id": "sa_cryptology_key",
     "type": "BOOK",
-    "name": { "str_sp": "High Level Commercial and Military Cryptology" },
-    "description": "An  incredibly  dense  volume  describing  different  advanced  cryptographical  methods,  their strenghts,  and weaknesses.  This  text  would  probably  be  easier  to  digest  with  an  added  decade  in  Computer  Science  Academia.",
+    "name": { "str_sp": "High  Level  Commercial  and  Military  Cryptology" },
+    "description": "An  incredibly dense volume describing different advanced cryptographical methods, their strenghts, and weaknesses. This text would probably be easier to digest with an added decade in Computer Science Academia.",
     "weight": 3000,
     "volume": "2 L",
     "price": "450 USD",

--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -962,7 +962,7 @@
     "id": "sa_cryptology_key",
     "type": "BOOK",
     "name": { "str_sp": "High Level Commercial and Military Cryptology" },
-    "description": "An incredibly dense volume describing different advanced cryptographical methods, their strenghts, and weaknesses. This text would probably be easier to digest with an added decade in Computer Science Academia.",
+    "description": "An  incredibly  dense  volume  describing  different  advanced  cryptographical  methods,  their strenghts,  and weaknesses.  This  text  would  probably  be  easier  to  digest  with  an  added  decade  in  Computer  Science  Academia.",
     "weight": 3000,
     "volume": "2 L",
     "price": "450 USD",

--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -961,7 +961,7 @@
   {
     "id": "sa_cryptology_key",
     "type": "BOOK",
-    "name": { "str": "High Level Commercial and Military Cryptology", "str_pl": "High Level Commercial and Military Cryptology" },
+    "name": { "str_sp": "High Level Commercial and Military Cryptology" },
     "description": "An incredibly dense volume describing different advanced cryptographical methods, their strenghts, and weaknesses. This text would probably be easier to digest with an added decade in Computer Science Academia.",
     "weight": 3000,
     "volume": "2 L",

--- a/data/json/mapgen/hazardous_waste_sarcophagus.json
+++ b/data/json/mapgen/hazardous_waste_sarcophagus.json
@@ -143,11 +143,15 @@
         "r": { "item": "trash_cart", "chance": 50 },
         "d": { "item": "office", "chance": 50 },
         "c": { "item": "office_supplies", "chance": 60 },
-		"b": { "item": "lab_bookshelves", "chance": 60 },
+        "b": { "item": "lab_bookshelves", "chance": 60 },
         "l": { "item": "cleaning", "chance": 85, "repeat": 2 },
         "F": { "item": "office_paper", "chance": 50 }
       },
-      "place_item": [ { "item": "id_military", "x": 22, "y": 20 }, { "item": "sa_cryptology_key", "x": 22, "y": 20 }, { "item": "cleansuit", "x": 28, "y": 24 } ],
+      "place_item": [
+        { "item": "id_military", "x": 22, "y": 20 },
+        { "item": "sa_cryptology_key", "x": 22, "y": 20 },
+        { "item": "cleansuit", "x": 28, "y": 24 }
+      ],
       "set": [
         { "square": "radiation", "amount": [ 10, 30 ], "x": 0, "y": 0, "x2": 23, "y2": 23 },
         { "square": "radiation", "amount": [ 10, 30 ], "x": 0, "y": 24, "x2": 23, "y2": 47 },

--- a/data/json/mapgen/hazardous_waste_sarcophagus.json
+++ b/data/json/mapgen/hazardous_waste_sarcophagus.json
@@ -143,7 +143,7 @@
         "r": { "item": "trash_cart", "chance": 50 },
         "d": { "item": "office", "chance": 50 },
         "c": { "item": "office_supplies", "chance": 60 },
-        "b": { "item": "lab_bookshelves", "chance": 60 },
+        "b": { "item": "lab_bookshelves", "chance": 60, "repeat": 2 },
         "l": { "item": "cleaning", "chance": 85, "repeat": 2 },
         "F": { "item": "office_paper", "chance": 50 }
       },

--- a/data/json/mapgen/hazardous_waste_sarcophagus.json
+++ b/data/json/mapgen/hazardous_waste_sarcophagus.json
@@ -143,11 +143,11 @@
         "r": { "item": "trash_cart", "chance": 50 },
         "d": { "item": "office", "chance": 50 },
         "c": { "item": "office_supplies", "chance": 60 },
-        "b": { "item": "lab_bookshelves", "chance": 60, "repeat": 2 },
+		"b": { "item": "lab_bookshelves", "chance": 60 },
         "l": { "item": "cleaning", "chance": 85, "repeat": 2 },
         "F": { "item": "office_paper", "chance": 50 }
       },
-      "place_item": [ { "item": "id_military", "x": 22, "y": 20 }, { "item": "cleansuit", "x": 28, "y": 24 } ],
+      "place_item": [ { "item": "id_military", "x": 22, "y": 20 }, { "item": "sa_cryptology_key", "x": 22, "y": 20 }, { "item": "cleansuit", "x": 28, "y": 24 } ],
       "set": [
         { "square": "radiation", "amount": [ 10, 30 ], "x": 0, "y": 0, "x2": 23, "y2": 23 },
         { "square": "radiation", "amount": [ 10, 30 ], "x": 0, "y": 24, "x2": 23, "y2": 47 },

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -392,5 +392,22 @@
       [ [ "cable", 5 ] ],
       [ [ "pilot_light", 1 ] ]
     ]
+  },
+  {
+    "result": "sarcophagus_access_code",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "computer",
+    "difficulty": 10,
+    "time": "1 h 20 m",
+    "book_learn": [ [ "sa_cryptology_key", 10 ] ],
+    "tools": [
+      [ [ "software_hacking", -1 ] ],
+      [ [ "laptop", -1 ], [ "control_laptop", -1 ] ],
+      [ [ "sa_cryptology_key", -1 ] ],
+      [ [ "black_box", -1 ] ]
+    ],
+    "components": [ [ [ "paper", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
Adds a book that spawns with the military ID in the Hazardous Waste Sarcophagi.


SUMMARY: Content "Adds a new book that spawns with the military id card in the Hazardous Waste Sarcophagi overmap locations"


#### Purpose of change

1.) The main reason to change this is to give players the ability to go into the location and see what it may have downstairs. Im not spoiling anything, but its cool. 
2.) You can apparently access this location via a questline, however. I feel as though not everyone will find the quest giver (I don't even know who gives the quest) so I gave this as an extra option just in case players cant find it either. 
3.) Another good reason to have this as an option is to allow players to access what IS below and might be able to make use of it. Those of you who have been down to the basement know what loot is there. This may open up options, and make nanofab templets more...useable. 

#### Describe the solution

Added the new book as a dedicated spawn. In game youll ever only need one so this seems like a viable option. 
Also since it ONLY spawns in these locations this gives the people the *want* to loot them as well. 

#### Describe alternatives you've considered

None.

#### Testing

Tested in game, loaded up. Debug spawned the overmap special in and boom it spawned. Have fun guys! 

#### Additional context

![Screenshot (808)](https://user-images.githubusercontent.com/82045140/184683454-11c4e1c1-e2df-46ff-a7c5-89a392e2aa6f.png)

