### PR TITLE
Crouching beside vehicle holes

### DIFF
--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -164,7 +164,7 @@ bool map::build_transparency_cache( const int zlev )
     return true;
 }
 
-bool map::build_vision_transparency_cache( Character &player )
+bool map::build_vision_transparency_cache( const Character &player )
 {
     const tripoint &p = player.pos();
 
@@ -1309,7 +1309,7 @@ castLightAll<float, float, shrapnel_calc, shrapnel_check,
 void map::apply_vision_transparency_cache( const tripoint &center, int target_z,
         float ( &vision_restore_cache )[9], bool ( &blocked_restore_cache )[8] )
 {
-    auto &map_cache = get_cache( target_z );
+    level_cache &map_cache = get_cache( target_z );
     float ( &transparency_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.transparency_cache;
     diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.vehicle_obscured_cache;
 
@@ -1402,7 +1402,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
     bool blocked_restore_cache[8] = {false};
 
     if( origin.z == target_z ) {
-        apply_vision_transparency_cache( get_avatar().pos(), target_z, vision_restore_cache,
+        apply_vision_transparency_cache( get_player_character().pos(), target_z, vision_restore_cache,
                                          blocked_restore_cache );
     }
 
@@ -1445,7 +1445,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
     }
 
     if( origin.z == target_z ) {
-        restore_vision_transparency_cache( get_avatar().pos(), target_z, vision_restore_cache,
+        restore_vision_transparency_cache( get_player_character().pos(), target_z, vision_restore_cache,
                                            blocked_restore_cache );
     }
 

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1402,7 +1402,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
     bool blocked_restore_cache[8] = {false};
 
     if( origin.z == target_z ) {
-        apply_vision_transparency_cache( g->u.pos(), target_z, vision_restore_cache,
+        apply_vision_transparency_cache( get_avatar().pos(), target_z, vision_restore_cache,
                                          blocked_restore_cache );
     }
 
@@ -1445,7 +1445,7 @@ void map::build_seen_cache( const tripoint &origin, const int target_z )
     }
 
     if( origin.z == target_z ) {
-        restore_vision_transparency_cache( g->u.pos(), target_z, vision_restore_cache,
+        restore_vision_transparency_cache( get_avatar().pos(), target_z, vision_restore_cache,
                                            blocked_restore_cache );
     }
 

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -670,7 +670,8 @@ map::apparent_light_info map::apparent_light_helper( const level_cache &map_cach
     const bool obstructed = vis <= LIGHT_TRANSPARENCY_SOLID + 0.1;
 
     auto is_opaque = [&map_cache]( const point & p ) {
-        return map_cache.transparency_cache[p.x][p.y] <= LIGHT_TRANSPARENCY_SOLID && g->u.pos().xy() != p;
+        return map_cache.transparency_cache[p.x][p.y] <= LIGHT_TRANSPARENCY_SOLID &&
+               get_player_character().pos().xy() != p;
     };
 
     const bool p_opaque = is_opaque( p.xy() );

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -73,4 +73,10 @@ inline std::ostream &operator<<( std::ostream &os, const lit_level &ll )
     return os << static_cast<int>( ll );
 }
 
+enum vision_adjustment {
+    VISION_ADJUST_NONE,
+    VISION_ADJUST_SOLID,
+    VISION_ADJUST_HIDDEN
+};
+
 #endif // CATA_SRC_LIGHTMAP_H

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6247,7 +6247,8 @@ int map::coverage( const tripoint &p ) const
     if( const auto vp = veh_at( p ) ) {
         if( vp->obstacle_at_part() ) {
             return 60;
-        } else if( !vp->part_with_feature( VPFLAG_AISLE, true ) ) {
+        } else if( !vp->part_with_feature( VPFLAG_AISLE, true ) &&
+                   !vp->part_with_feature( "PROTRUSION", true ) ) {
             return 45;
         }
     }
@@ -8234,9 +8235,8 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     for( int z = minz; z <= maxz; z++ ) {
         do_vehicle_caching( z );
     }
-    for( int z = minz; z <= maxz; z++ ) {
-        seen_cache_dirty |= build_vision_transparency_cache( z );
-    }
+
+    seen_cache_dirty |= build_vision_transparency_cache( );
 
     if( seen_cache_dirty ) {
         skew_vision_cache.clear();
@@ -8736,7 +8736,6 @@ level_cache::level_cache()
     diagonal_blocks fill = {false, false};
     std::fill_n( &vehicle_obscured_cache[0][0], map_dimensions, fill );
     std::fill_n( &vehicle_obstructed_cache[0][0], map_dimensions, fill );
-    std::fill_n( &vision_transparency_cache[0][0], map_dimensions, 0.0f );
     std::fill_n( &seen_cache[0][0], map_dimensions, 0.0f );
     std::fill_n( &camera_cache[0][0], map_dimensions, 0.0f );
     std::fill_n( &visibility_cache[0][0], map_dimensions, lit_level::DARK );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8236,7 +8236,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         do_vehicle_caching( z );
     }
 
-    seen_cache_dirty |= build_vision_transparency_cache( );
+    seen_cache_dirty |= build_vision_transparency_cache( get_avatar() );
 
     if( seen_cache_dirty ) {
         skew_vision_cache.clear();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8236,7 +8236,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         do_vehicle_caching( z );
     }
 
-    seen_cache_dirty |= build_vision_transparency_cache( get_avatar() );
+    seen_cache_dirty |= build_vision_transparency_cache( get_player_character() );
 
     if( seen_cache_dirty ) {
         skew_vision_cache.clear();

--- a/src/map.h
+++ b/src/map.h
@@ -1799,7 +1799,7 @@ class map
         // Builds a transparency cache and returns true if the cache was invalidated.
         // Used to determine if seen cache should be rebuilt.
         bool build_transparency_cache( int zlev );
-        bool build_vision_transparency_cache( );
+        bool build_vision_transparency_cache( Character &player );
         // fills lm with sunlight. pzlev is current player's zlevel
         void build_sunlight_cache( int pzlev );
     public:
@@ -1815,6 +1815,12 @@ class map
         void generate_lightmap( int zlev );
         void build_seen_cache( const tripoint &origin, int target_z );
         void apply_character_light( Character &p );
+
+        //Adds/removes player specific transparencies
+        void apply_vision_transparency_cache( const tripoint &center, int target_z,
+                                              float ( &vision_restore_cache )[9], bool ( &blocked_restore_cache )[8] );
+        void restore_vision_transparency_cache( const tripoint &center, int target_z,
+                                                float ( &vision_restore_cache )[9], bool ( &blocked_restore_cache )[8] );
 
         int my_MAPSIZE;
         bool zlevels;

--- a/src/map.h
+++ b/src/map.h
@@ -338,11 +338,6 @@ struct level_cache {
     // same as above but for obstruction rather than light
     diagonal_blocks vehicle_obstructed_cache[MAPSIZE_X][MAPSIZE_Y];
 
-    // stores "adjusted transparency" of the tiles
-    // initial values derived from transparency_cache, uses same units
-    // examples of adjustment: changed transparency on player's tile and special case for crouching
-    float vision_transparency_cache[MAPSIZE_X][MAPSIZE_Y];
-
     // stores "visibility" of the tiles to the player
     // values range from 1 (fully visible to player) to 0 (not visible)
     float seen_cache[MAPSIZE_X][MAPSIZE_Y];
@@ -1804,7 +1799,7 @@ class map
         // Builds a transparency cache and returns true if the cache was invalidated.
         // Used to determine if seen cache should be rebuilt.
         bool build_transparency_cache( int zlev );
-        bool build_vision_transparency_cache( int zlev );
+        bool build_vision_transparency_cache( );
         // fills lm with sunlight. pzlev is current player's zlevel
         void build_sunlight_cache( int pzlev );
     public:
@@ -1823,6 +1818,10 @@ class map
 
         int my_MAPSIZE;
         bool zlevels;
+
+        // stores vision adjustment for the tiles immediately surrounding the player, the order is given by eight_adjacent_offsets in point.h
+        // examples of adjustment: crouching
+        vision_adjustment vision_transparency_cache[8] = { VISION_ADJUST_NONE };
 
         /**
          * Absolute coordinates of first submap (get_submap_at(0,0))

--- a/src/map.h
+++ b/src/map.h
@@ -1799,7 +1799,7 @@ class map
         // Builds a transparency cache and returns true if the cache was invalidated.
         // Used to determine if seen cache should be rebuilt.
         bool build_transparency_cache( int zlev );
-        bool build_vision_transparency_cache( Character &player );
+        bool build_vision_transparency_cache( const Character &player );
         // fills lm with sunlight. pzlev is current player's zlevel
         void build_sunlight_cache( int pzlev );
     public:

--- a/src/point.h
+++ b/src/point.h
@@ -359,6 +359,10 @@ static constexpr std::array<point, 4> four_adjacent_offsets{{
         point_north, point_east, point_south, point_west
     }};
 
+static constexpr std::array<point, 4> four_diagonal_offsets{{
+        point_north_east, point_south_east, point_south_west, point_north_west
+    }};
+
 static constexpr std::array<point, 8> eight_adjacent_offsets{{
         point_north, point_north_east, point_east, point_south_east,
         point_south, point_south_west, point_west, point_north_west


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Crouching next to a vehicle hole limits visibility appropriately"

#### Purpose of change

Fixes the bug where you could see through vehicle holes between transparent parts even when crouching should have rendered them opaque and changes coverage for vehicle parts so that protrusions don't provide cover and so don't affect crouching vision (same as aisles don't currently). It also incidentally fixes an almost unnoticeable issue that until you actually look at a z level, it will still be using uninitialized all solid transparency. 

#### Describe the solution

This hauls out the old crouching visibility system, which was a separate transparency cache per z level for the player. Every turn the level that you're looking at would be copied from the main cache and maybe have the 9 tiles around the player altered. It wasn't used for anything but crouching and making the player's tile transparent. 

This uses a single cache that describes vision adjustments for the 8 tiles around the player. As with the previous logic, tiles can be left alone or made solid but now they can also be hidden. Then, when we're doing the player's vision, these changes are applied to the normal transparency and blocked caches in place, taking care to store any changed values so the caches can be restored afterwards. 

In some ways it's backwards but tiles that are both hidden and made solid are just made solid. This is to avoid the case where crouching anywhere in a rotated car means you can't see the tiles on one diagonal. Technically they're between two opaque things and should be hidden but it looks weird. 

It also looks kinda weird when having a wing mirror lets you see a tile outside the car when you're crouch driving, hence the protrusion change. Crouching behind a wing mirror just seems wrong in general. I took a quick look through and while with some protrusions like the external tank or seed drill it's plausible you could hide behind them, most of them it's not and I wanted to keep the rule simple. 

#### Describe alternatives you've considered

We could go the other way and also produce a player only diagonal blocks cache, or leave the transparency cache in place and only handle diagonal blocks by changing and restoring. If there's something planned that would really use it like x-ray specs that's probably better but as is it's a ~140K per turn memcpy and ~2M of storage for just crouching. 