### PR TITLE
Point CONTRIBUTING.md to the right upstream repository

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -101,7 +101,7 @@ http://www.stack.nl/~dimitri/doxygen/manual/faq.html
 
         $ cd Cataclysm-BN
         # Changes the active directory in the prompt to the newly cloned "Cataclysm-BN" directory
-        $ git remote add -f upstream https://github.com/CleverRaven/Cataclysm-BN.git
+        $ git remote add -f upstream https://github.com/cataclysmbnteam/Cataclysm-BN.git
         # Assigns the original repository to a remote called "upstream"
 
 For further details about commit message guidelines please visit:


### PR DESCRIPTION
#### Summary

SUMMARY: Build "Change CONTRIBUTING.md to point at the current BN repository"

#### Purpose of change

The contributing document currently points to [a private or nonexistent repository](https://github.com/CleverRaven/Cataclysm-BN.git). This is a simple text change to point it at the current repository under cataclysmbnteam.

#### Testing

Simple documentation text change; no testing needed.