### PR TITLE
Add UPS conversion support to Bionic Scanner

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -278,6 +278,7 @@ static const itype_id itype_thermometer( "thermometer" );
 static const itype_id itype_towel( "towel" );
 static const itype_id itype_towel_soiled( "towel_soiled" );
 static const itype_id itype_towel_wet( "towel_wet" );
+static const itype_id itype_UPS( "UPS" );
 static const itype_id itype_UPS_off( "UPS_off" );
 static const itype_id itype_water( "water" );
 static const itype_id itype_water_clean( "water_clean" );
@@ -2276,6 +2277,8 @@ int iuse::noise_emitter_on( player *p, item *it, bool t, const tripoint &pos )
 // Ugly and uses variables that shouldn't be public
 int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
 {
+    const bool possess = p->has_item( *it );
+
     if( !t ) {
         it->deactivate( p, true );
         return 0;
@@ -2286,7 +2289,7 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
     }
     map &here = get_map();
 
-    if( !it->ammo_sufficient() ) {
+    if( !p->has_enough_charges( *it, false ) ) {
         it->deactivate( p, true );
         return 0;
     }
@@ -2307,7 +2310,14 @@ int iuse::note_bionics( player *p, item *it, bool t, const tripoint &pos )
                 }
             }
 
-            if( static_cast<int>( cbms.size() ) > it->ammo_consume( cbms.size(), pos ) ) {
+            int charges = static_cast<int>( cbms.size() );
+            charges -= it->ammo_consume( charges, pos );
+            if( possess && it->has_flag( "USE_UPS" ) ) {
+                if( p->use_charges_if_avail( itype_UPS, charges ) ) {
+                    charges = 0;
+                }
+            }
+            if( charges > 0 ) {
                 it->deactivate( p, true );
                 return 0;
             }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Make Bionic Scanners work with UPS Conversion Mods"

#### Purpose of change

If a bionic scanner has the UPS conversion mod installed, it will simply fail the moment you get close to a bionic carrying monster, as the `note_bionics` iuse has no support for the `USE_UPS` flag.

Fixes #1133 

#### Describe the solution

Adds a check to ensure that the bionic scanner is possessed by the character, and if there's not enough charge in the device (automatic since ups conversion mods remove the internal battery) it will draw from any UPS source you have instead.

#### Describe alternatives you've considered

- Make bionic scanners go by power_draw instead.
Rejected on basis of reward/resource consumption mismatch.

#### Testing

New game, spawned in bionic scanner. Installed ups conversion mod. Spawned bio-operator, killed bio-operator. Repeated while I checked several things.

- [x] Draws appropriately from UPS, Advanced UPS and UPS CBM.
- [x] Does not draw power from you while it is not on your person.

#### Additional context
