### PR TITLE
Fix double to int for debug message

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4183,7 +4183,7 @@ double vehicle::lift_thrust_of_rotorcraft( const bool fuelled, const bool safe )
 
     const double power_load {engine_power / rotor_area};
     const double lift_thrust = coeffiicient * engine_power * std::pow( power_load, exponentiation );
-    add_msg( m_debug, "lift thrust(N) of %s: %f, rotor area (m^2): %f, engine power (w): %f",
+    add_msg( m_debug, "lift thrust(N) of %s: %f, rotor area (m^2): %f, engine power (w): %i",
              name, lift_thrust, rotor_area, engine_power );
     return lift_thrust;
 }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfix "Make debug message for lift_thrust print properly"

#### Purpose of change

Debug message for lift_thrust couldn't print because it was trying to taking an int for a float conversion.

#### Describe the solution

Changes from float to int in the debug message.

#### Describe alternatives you've considered

#### Testing

Spawned atomic helicopter, turned on debug mode and started the vehicle, debug message displays properly.

#### Additional context

I know that lift is now displayed correctly, but the math is still a bit of a headache for me.