### PR TITLE
Removes Fitness band from relevant places

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -337,8 +337,7 @@
       { "item": "sf_watch", "prob": 5 },
       { "item": "pocketwatch", "prob": 30 },
       { "item": "diving_watch", "prob": 20 },
-      { "item": "game_watch", "prob": 20 },
-      { "item": "fitness_band", "prob": 10 }
+      { "item": "game_watch", "prob": 20 }
     ]
   },
   {
@@ -515,8 +514,7 @@
       { "item": "aspirin", "prob": 30 },
       { "item": "water_clean", "prob": 30 },
       { "item": "sports_drink", "prob": 30 },
-      { "item": "1st_aid", "prob": 20 },
-      { "item": "fitness_band", "prob": 5 }
+      { "item": "1st_aid", "prob": 20 }
     ]
   },
   {

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -1809,8 +1809,7 @@
       [ "briefs", 30 ],
       [ "yoghurt", 12 ],
       [ "vitamins", 10 ],
-      [ "aspirin", 10 ],
-      [ "fitness_band", 10 ]
+      [ "aspirin", 10 ]
     ]
   },
   {

--- a/data/json/itemgroups/Locations_MapExtras/mall_item_groups.json
+++ b/data/json/itemgroups/Locations_MapExtras/mall_item_groups.json
@@ -256,8 +256,7 @@
       [ "cell_phone", 1 ],
       [ "smart_phone", 120 ],
       [ "wristwatch", 60 ],
-      [ "mobile_memory_card_used", 10 ],
-      [ "fitness_band", 5 ]
+      [ "mobile_memory_card_used", 10 ]
     ]
   },
   {

--- a/data/json/itemgroups/Locations_MapExtras/mansion.json
+++ b/data/json/itemgroups/Locations_MapExtras/mansion.json
@@ -1009,8 +1009,7 @@
       [ "yoghurt", 12 ],
       [ "vitamins", 10 ],
       [ "aspirin", 15 ],
-      { "group": "corpse_mansion", "prob": 1 },
-      [ "fitness_band", 3 ]
+      { "group": "corpse_mansion", "prob": 1 }
     ]
   },
   {
@@ -1091,8 +1090,7 @@
       [ "vitamins", 10 ],
       [ "aspirin", 10 ],
       [ "karate_gi", 10 ],
-      [ "judo_gi", 5 ],
-      [ "fitness_band", 5 ]
+      [ "judo_gi", 5 ]
     ]
   },
   {

--- a/data/json/itemgroups/activities_hobbies.json
+++ b/data/json/itemgroups/activities_hobbies.json
@@ -106,8 +106,7 @@
       [ "survnote", 1 ],
       [ "halter_top", 30 ],
       [ "iceaxe", 30 ],
-      [ "tourist_table", 30 ],
-      [ "fitness_band", 5 ]
+      [ "tourist_table", 30 ]
     ]
   },
   {
@@ -156,8 +155,7 @@
       { "item": "slingshot", "prob": 10 },
       { "item": "wristrocket", "prob": 5 },
       { "item": "powered_earmuffs", "prob": 80 },
-      { "item": "bandolier_wrist", "prob": 100 },
-      { "item": "fitness_band", "prob": 5 }
+      { "item": "bandolier_wrist", "prob": 100 }
     ]
   },
   {


### PR DESCRIPTION
Gets rid of the fitness band from game since it does nothing.

#### Summary balance "Removes the fitness band in game"


#### Purpose of change

In game the fitness band currently doesn't do anything. Figured since its an item nobody can use it would be best to get rid of it. 

#### Describe the solution

Scrubbed the fitness band from various locations it was meant to spawn in. 

#### Describe alternatives you've considered

Either fixing the fitness band to work (I left it in the obsoleting file just in case) 

#### Testing

Tested in game, the item does not show up! 

#### Additional context

N/A