### PR TITLE
Character code reorganization 22-aug-2022

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -1484,8 +1484,6 @@ class Character : public Creature, public visitable<Character>
 
         std::string extended_description() const override;
 
-        // In newcharacter.cpp
-        void empty_skills();
         /** Returns a random name from NAMES_* */
         void pick_name( bool bUseDefault = false );
         /** Get the idents of all base traits. */
@@ -1495,6 +1493,8 @@ class Character : public Creature, public visitable<Character>
         const std::bitset<NUM_VISION_MODES> &get_vision_modes() const {
             return vision_mode_cache;
         }
+        /** Clear the skills map, setting all levels to 0 */
+        void clear_skills();
         /** Empties the trait and mutations lists */
         void clear_mutations();
         /**

--- a/src/character.h
+++ b/src/character.h
@@ -675,11 +675,6 @@ class Character : public Creature, public visitable<Character>
         std::map<bodypart_id, int> get_armor_fire( const std::map<bodypart_id, std::vector<const item *>>
                 &clothing_map ) const;
         // --------------- Mutation Stuff ---------------
-        // In newcharacter.cpp
-        /** Returns the id of a random starting trait that costs >= 0 points */
-        trait_id random_good_trait();
-        /** Returns the id of a random starting trait that costs < 0 points */
-        trait_id random_bad_trait();
 
         // In mutation.cpp
         /** Returns true if the player has the entered trait */
@@ -688,6 +683,8 @@ class Character : public Creature, public visitable<Character>
         bool has_base_trait( const trait_id &b ) const;
         /** Returns true if player has a trait with a flag */
         bool has_trait_flag( const std::string &b ) const;
+        /** Returns true if character has a trait which cancels the entered trait. */
+        bool has_opposite_trait( const trait_id &flag ) const;
         /** Returns the trait id with the given invlet, or an empty string if no trait has that invlet */
         trait_id trait_by_invlet( int ch ) const;
 
@@ -1497,12 +1494,6 @@ class Character : public Creature, public visitable<Character>
         void clear_skills();
         /** Empties the trait and mutations lists */
         void clear_mutations();
-        /**
-         * Adds mandatory scenario and profession traits unless you already have them
-         * And if you do already have them, refunds the points for the trait
-         */
-        void add_traits();
-        void add_traits( points_left &points );
         /** Returns true if the player has crossed a mutation threshold
          *  Player can only cross one mutation threshold.
          */
@@ -1710,8 +1701,6 @@ class Character : public Creature, public visitable<Character>
         void on_stat_change( const std::string &stat, int value ) override;
         /** Returns an unoccupied, safe adjacent point. If none exists, returns player position. */
         tripoint adjacent_tile() const;
-        /** Returns true if the player has a trait which cancels the entered trait */
-        bool has_opposite_trait( const trait_id &flag ) const;
         /** Removes "sleep" and "lying_down" */
         void wake_up();
         // how loud a character can shout. based on mutations and clothing

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1122,7 +1122,7 @@ static void do_purify( player &p )
     num_cured = std::min( 4, num_cured );
     for( int i = 0; i < num_cured && !valid.empty(); i++ ) {
         const trait_id id = random_entry_removed( valid );
-        if( p.purifiable( id ) ) {
+        if( id->purifiable ) {
             p.remove_mutation( id );
         } else {
             p.add_msg_if_player( m_warning, _( "You feel a slight itching inside, but it passes." ) );
@@ -1168,7 +1168,7 @@ int iuse::purify_iv( player *p, item *it, bool, const tripoint & )
     }
     for( int i = 0; i < num_cured && !valid.empty(); i++ ) {
         const trait_id id = random_entry_removed( valid );
-        if( p->purifiable( id ) ) {
+        if( id->purifiable ) {
             p->remove_mutation( id );
         } else {
             p->add_msg_if_player( m_warning, _( "You feel a distinct burning inside, but it passes." ) );
@@ -1197,7 +1197,7 @@ int iuse::purify_smart( player *p, item *it, bool, const tripoint & )
     for( auto &traits_iter : mutation_branch::get_all() ) {
         if( p->has_trait( traits_iter.id ) &&
             !p->has_base_trait( traits_iter.id ) &&
-            p->purifiable( traits_iter.id ) ) {
+            traits_iter.id->purifiable ) {
             //Looks for active mutation
             valid.push_back( traits_iter.id );
             valid_names.push_back( traits_iter.id->name() );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2816,7 +2816,7 @@ std::vector<trait_id> Character::get_base_traits() const
 std::vector<trait_id> Character::get_mutations( bool include_hidden ) const
 {
     std::vector<trait_id> result;
-    for( const std::pair<const trait_id, char_trait_data> &t : my_mutations ) {
+    for( const std::pair<const trait_id, trait_data> &t : my_mutations ) {
         if( include_hidden || t.first.obj().player_display ) {
             result.push_back( t.first );
         }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -247,7 +247,7 @@ void avatar::randomize( const bool random_scenario, points_left &points, bool pl
     int num_gtraits = 0;
     int num_btraits = 0;
     int tries = 0;
-    add_traits( points ); // adds mandatory profession/scenario traits.
+    newcharacter::add_traits( *this, points ); // adds mandatory profession/scenario traits.
     for( const trait_id &mut : get_mutations() ) {
         const mutation_branch &mut_info = mut.obj();
         if( mut_info.profession ) {
@@ -271,12 +271,12 @@ void avatar::randomize( const bool random_scenario, points_left &points, bool pl
         if( num_btraits < max_trait_points && one_in( 3 ) ) {
             tries = 0;
             do {
-                rn = random_bad_trait();
+                rn = newcharacter::random_bad_trait();
                 tries++;
             } while( ( has_trait( rn ) || num_btraits - rn->points > max_trait_points ) &&
                      tries < 5 );
 
-            if( tries < 5 && !has_conflicting_trait( rn ) ) {
+            if( tries < 5 && !newcharacter::has_conflicting_trait( *this, rn ) ) {
                 toggle_trait( rn );
                 points.trait_points -= rn->points;
                 num_btraits -= rn->points;
@@ -323,10 +323,11 @@ void avatar::randomize( const bool random_scenario, points_left &points, bool pl
             case 3:
             case 4:
                 if( allow_traits ) {
-                    rn = random_good_trait();
+                    rn = newcharacter::random_good_trait();
                     auto &mdata = rn.obj();
                     if( !has_trait( rn ) && points.trait_points_left() >= mdata.points &&
-                        num_gtraits + mdata.points <= max_trait_points && !has_conflicting_trait( rn ) ) {
+                        num_gtraits + mdata.points <= max_trait_points &&
+                        !newcharacter::has_conflicting_trait( *this, rn ) ) {
                         toggle_trait( rn );
                         points.trait_points -= mdata.points;
                         num_gtraits += mdata.points;
@@ -1080,7 +1081,7 @@ tab_direction set_traits( avatar &u, points_left &points )
     const auto recalc_display_cache = [&]() {
         for( int page = 0; page < used_pages; page++ ) {
             for( trait_entry &entry : vStartingTraits[page] ) {
-                entry.conflicts = u.has_conflicting_trait( entry.id );
+                entry.conflicts = newcharacter::has_conflicting_trait( u, entry.id );
                 entry.avatar_has = u.has_trait( entry.id );
             }
         }
@@ -1276,7 +1277,7 @@ tab_direction set_traits( avatar &u, points_left &points )
                     popup( _( "Your profession of %s prevents you from removing this trait." ),
                            u.prof->gender_appropriate_name( u.male ) );
                 }
-            } else if( u.has_conflicting_trait( cur_trait ) ) {
+            } else if( newcharacter::has_conflicting_trait( u, cur_trait ) ) {
                 popup( _( "You already picked a conflicting trait!" ) );
             } else if( g->scen->is_forbidden_trait( cur_trait ) ) {
                 popup( _( "The scenario you picked prevents you from taking this trait!" ) );
@@ -1686,7 +1687,7 @@ tab_direction set_profession( avatar &u, points_left &points,
             u.prof = sorted_profs[cur_id];
             // Add traits for the new profession (and perhaps scenario, if, for example,
             // both the scenario and old profession require the same trait)
-            u.add_traits( points );
+            newcharacter::add_traits( u, points );
             points.skill_points -= netPointCost;
         } else if( action == "CHANGE_GENDER" ) {
             u.male = !u.male;
@@ -2815,7 +2816,7 @@ std::vector<trait_id> Character::get_base_traits() const
 std::vector<trait_id> Character::get_mutations( bool include_hidden ) const
 {
     std::vector<trait_id> result;
-    for( const std::pair<const trait_id, trait_data> &t : my_mutations ) {
+    for( const std::pair<const trait_id, char_trait_data> &t : my_mutations ) {
         if( include_hidden || t.first.obj().player_display ) {
             result.push_back( t.first );
         }
@@ -2855,30 +2856,29 @@ void Character::clear_skills()
     }
 }
 
-void Character::add_traits()
+void newcharacter::add_traits( Character &ch )
 {
     points_left points = points_left();
-    add_traits( points );
+    add_traits( ch, points );
 }
 
-void Character::add_traits( points_left &points )
+void newcharacter::add_traits( Character &ch, points_left &points )
 {
-    // TODO: get rid of using g->u here, use `this` instead
-    for( const trait_id &tr : g->u.prof->get_locked_traits() ) {
-        if( !has_trait( tr ) ) {
-            toggle_trait( tr );
+    for( const trait_id &tr : ch.prof->get_locked_traits() ) {
+        if( !ch.has_trait( tr ) ) {
+            ch.toggle_trait( tr );
         } else {
             points.trait_points += tr->points;
         }
     }
     for( const trait_id &tr : g->scen->get_locked_traits() ) {
-        if( !has_trait( tr ) ) {
-            toggle_trait( tr );
+        if( !ch.has_trait( tr ) ) {
+            ch.toggle_trait( tr );
         }
     }
 }
 
-trait_id Character::random_good_trait()
+trait_id newcharacter::random_good_trait()
 {
     std::vector<trait_id> vTraitsGood;
 
@@ -2891,7 +2891,7 @@ trait_id Character::random_good_trait()
     return random_entry( vTraitsGood );
 }
 
-trait_id Character::random_bad_trait()
+trait_id newcharacter::random_bad_trait()
 {
     std::vector<trait_id> vTraitsBad;
 
@@ -3036,7 +3036,7 @@ void reset_scenario( avatar &u, const scenario *scen )
     u.clear_mutations();
     u.recalc_hp();
     u.clear_skills();
-    u.add_traits();
+    newcharacter::add_traits( u );
 }
 
 points_left::points_left()
@@ -3125,3 +3125,46 @@ std::string points_left::to_string()
         return _( "Freeform" );
     }
 }
+
+namespace newcharacter
+{
+
+bool has_conflicting_trait( const Character &ch, const trait_id &t )
+{
+    return ch.has_opposite_trait( t ) ||
+           has_lower_trait( ch, t ) ||
+           has_higher_trait( ch, t ) ||
+           has_same_type_trait( ch, t ) ;
+}
+
+bool has_lower_trait( const Character &ch, const trait_id &t )
+{
+    for( const trait_id &it : t->prereqs ) {
+        if( ch.has_trait( it ) || has_lower_trait( ch, it ) ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool has_higher_trait( const Character &ch, const trait_id &t )
+{
+    for( const trait_id &it : t->replacements ) {
+        if( ch.has_trait( it ) || has_higher_trait( ch, it ) ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool has_same_type_trait( const Character &ch, const trait_id &t )
+{
+    for( const trait_id &it : get_mutations_in_types( t->types ) ) {
+        if( ch.has_trait( it ) && t != it ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace newcharacter

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2848,7 +2848,7 @@ void Character::clear_mutations()
     cached_mutations.clear();
 }
 
-void Character::empty_skills()
+void Character::clear_skills()
 {
     for( auto &sk : *_skills ) {
         sk.second.level( 0 );
@@ -3035,7 +3035,7 @@ void reset_scenario( avatar &u, const scenario *scen )
     }
     u.clear_mutations();
     u.recalc_hp();
-    u.empty_skills();
+    u.clear_skills();
     u.add_traits();
 }
 

--- a/src/newcharacter.h
+++ b/src/newcharacter.h
@@ -4,6 +4,10 @@
 
 #include <string>
 
+#include "type_id.h"
+
+class Character;
+
 struct points_left {
     int stat_points = 0;
     int trait_points = 0;
@@ -28,5 +32,28 @@ struct points_left {
     bool has_spare();
     std::string to_string();
 };
+
+namespace newcharacter
+{
+/** Returns the id of a random starting trait that costs >= 0 points */
+trait_id random_good_trait();
+/** Returns the id of a random starting trait that costs < 0 points */
+trait_id random_bad_trait();
+/**
+ * Adds mandatory scenario and profession traits unless character already has them.
+ * And if they do, refunds the points.
+ */
+void add_traits( Character &ch );
+void add_traits( Character &ch, points_left &points );
+
+/** Returns true if character has a conflicting trait to the entered trait. */
+bool has_conflicting_trait( const Character &ch, const trait_id &t );
+/** Returns true if charcater has a trait which upgrades into the entered trait. */
+bool has_lower_trait( const Character &ch, const trait_id &t );
+/** Returns true if character has a trait which is an upgrade of the entered trait. */
+bool has_higher_trait( const Character &ch, const trait_id &t );
+/** Returns true if character has a trait that shares a type with the entered trait. */
+bool has_same_type_trait( const Character &ch, const trait_id &t );
+} // namespace newcharacter
 
 #endif // CATA_SRC_NEWCHARACTER_H

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -568,47 +568,6 @@ void player::mod_stat( const std::string &stat, float modifier )
     }
 }
 
-bool player::has_conflicting_trait( const trait_id &flag ) const
-{
-    return ( has_opposite_trait( flag ) || has_lower_trait( flag ) || has_higher_trait( flag ) ||
-             has_same_type_trait( flag ) );
-}
-
-bool player::has_lower_trait( const trait_id &flag ) const
-{
-    for( auto &i : flag->prereqs ) {
-        if( has_trait( i ) || has_lower_trait( i ) ) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool player::has_higher_trait( const trait_id &flag ) const
-{
-    for( auto &i : flag->replacements ) {
-        if( has_trait( i ) || has_higher_trait( i ) ) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool player::has_same_type_trait( const trait_id &flag ) const
-{
-    for( auto &i : get_mutations_in_types( flag->types ) ) {
-        if( has_trait( i ) && flag != i ) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool player::purifiable( const trait_id &flag ) const
-{
-    return flag->purifiable;
-}
-
 std::list<item *> player::get_artifact_items()
 {
     std::list<item *> art_items;

--- a/src/player.h
+++ b/src/player.h
@@ -140,21 +140,6 @@ class player : public Character
         /** Maintains body wetness and handles the rate at which the player dries */
         void update_body_wetness( const w_point &weather );
 
-        /** Returns true if the player has a conflicting trait to the entered trait
-         *  Uses has_opposite_trait(), has_lower_trait(), and has_higher_trait() to determine conflicts.
-         */
-        bool has_conflicting_trait( const trait_id &flag ) const;
-        /** Returns true if the player has a trait which upgrades into the entered trait */
-        bool has_lower_trait( const trait_id &flag ) const;
-        /** Returns true if the player has a trait which is an upgrade of the entered trait */
-        bool has_higher_trait( const trait_id &flag ) const;
-        /** Returns true if the player has a trait that shares a type with the entered trait */
-        bool has_same_type_trait( const trait_id &flag ) const;
-        /** Returns true if the entered trait may be purified away
-         *  Defaults to true
-         */
-        bool purifiable( const trait_id &flag ) const;
-
         /** Generates and handles the UI for player interaction with installed bionics */
         void power_bionics();
         void power_mutations();

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -382,7 +382,7 @@ TEST_CASE( "food freshness and lifetime", "[item][iteminfo][food]" )
     iteminfo_query q = q_vec( { iteminfo_parts::FOOD_ROT } );
 
     // Ensure test character has no skill estimating spoilage
-    g->u.empty_skills();
+    g->u.clear_skills();
     REQUIRE_FALSE( g->u.can_estimate_rot() );
 
     SECTION( "food is fresh" ) {
@@ -539,7 +539,7 @@ TEST_CASE( "show available recipes with item as an ingredient", "[item][iteminfo
 
     GIVEN( "character has a potassium iodide tablet and no skill" ) {
         item &iodine = g->u.i_add( item( "iodine" ) );
-        g->u.empty_skills();
+        g->u.clear_skills();
 
         THEN( "nothing is craftable from it" ) {
             test_info_equals(

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -84,7 +84,7 @@ void clear_character( player &dummy, bool debug_storage )
     // and sets hunger, thirst, fatigue and such to zero
     dummy.environmental_revert_effect();
 
-    dummy.empty_skills();
+    dummy.clear_skills();
     dummy.clear_morale();
     dummy.activity.set_to_null();
     dummy.reset_chargen_attributes();


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Reorganized some Character-related code"

#### Purpose of change
Continuing despaghettification.

#### Describe the solution
1. Rename `Character::empty_skills` -> `Character::clear_skills`, as `empty` is usually used for functions that check for emptiness.
2. Move more character creation code out of `player` and `Character` classes. Some of it has absolutely no business being non-const methods of `Character` class when all it does is operate on globals...
3. Move some of the methods tailored specifically for character creation menu into `newcharacter.h`/`.cpp` as well
4. Replace some `g->u` usages with `get_avatar()`
5. Get rid of `player::purifiable()` method since it only checks for trait flag under the hood

#### Testing
Game compiles. No behavior changes intended.