### PR TITLE
Add check for null field id in map::add_splatter

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5468,7 +5468,7 @@ void map::remove_field( const tripoint &p, const field_type_id &field_to_remove 
 
 void map::add_splatter( const field_type_id &type, const tripoint &where, int intensity )
 {
-    if( intensity <= 0 ) {
+    if( !type.id() || intensity <= 0 ) {
         return;
     }
     if( type.obj().is_splattering ) {


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fix null field id error when butchering some corpses"

#### Purpose of change
Fix #1753

#### Describe the solution
`map::add_splatter_trail` has a check for null id, but `map::add_splatter` does not. Add it there as well.

#### Describe alternatives you've considered
Tracking down every place in the code where `add_splatter` could be fed null id?

#### Testing
Tried dismembering broken cyborgs.
Before: debugmsg
After: no debugmsg