### PR TITLE
[DDA Port] Multiple fixes for gaspump placement

### DIFF
--- a/data/json/mapgen/lumbermill.json
+++ b/data/json/mapgen/lumbermill.json
@@ -111,8 +111,7 @@
       ],
       "palettes": [ "lumberyard" ],
       "terrain": { "o": "t_concrete" },
-      "place_terrain": [ { "ter": "t_gas_pump", "x": 4, "y": 39 } ],
-      "place_liquids": [ { "liquid": "gasoline", "x": 4, "y": 39, "repeat": [ 200, 1075 ] } ],
+      "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 50000, 268750 ] } },
       "place_vehicles": [
         { "vehicle": "flatbed_truck", "x": [ 43, 45 ], "y": 33, "chance": 30, "fuel": 25, "status": 1, "rotation": 90 },
         {

--- a/data/json/mapgen/military/mil_base/mil_base_z0.json
+++ b/data/json/mapgen/military/mil_base/mil_base_z0.json
@@ -1013,7 +1013,7 @@
         "|T+..S|[.............=..#h.|ss  ______________________________________________________,,,,b ,,,x",
         "--------ww-------|-+-|Y.#..wssssssss__________________________________________________,,,,b,,, x",
         "sssssssssss~|T+.S|...|O...$|ssssssss            sssssss            sXsssXXXXXXXXXs    ,,, b,,,,x",
-        "ssssssssssss|--.c|...|------------ss         sssssssssssss         sXs sGsssXsssGs     ,,,b,,, x",
+        "ssssssssssss|--.c|...|------------ss         sssssssssssss         sXspsGsssXsssGs     ,,,b,,, x",
         "          ss|T+..+...d..||>|uuuuu|{s        ssss_______ssss        sXsssXs*sXs*sXs     ,,,b ,, x",
         "          ss-----|...|uS||.|.....|{s      ssss___________ssss      sXsssXs*sXs*sXs     ,, b ,, x",
         "ssssssssssssw.hhh....|----d---D--|ss     sss_______________sss     sXsssGsssXsssGs     ,,,b ,,,x",
@@ -1107,8 +1107,7 @@
         "W": [ { "item": "mil_base_iv", "chance": 70 } ],
         "^": [ { "item": "mil_base_iv", "chance": 70 } ]
       },
-      "place_terrain": [ { "ter": "t_diesel_pump", "x": 70, "y": 24 } ],
-      "place_liquids": [ { "liquid": "diesel", "x": 70, "y": 24, "repeat": [ 800, 4000 ] } ],
+      "gaspumps": { "p": { "fuel": "diesel", "amount": [ 200000, 1000000 ] } },
       "place_loot": [
         { "group": "mil_base_hmg", "x": 65, "y": 46, "chance": 10, "magazine": 100 },
         { "group": "SUS_janitors_closet", "x": 22, "y": 26, "chance": 90, "repeat": [ 1, 2 ] },

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -630,8 +630,8 @@ jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string &tag )
     }
 }
 
-jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string &tag, const int &def_val,
-                          const int &def_valmax )
+jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string &tag, int def_val,
+                          int def_valmax )
     : val( def_val )
     , valmax( def_valmax )
 {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -630,8 +630,8 @@ jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string &tag )
     }
 }
 
-jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string &tag, const short def_val,
-                          const short def_valmax )
+jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string &tag, const int &def_val,
+                          const int &def_valmax )
     : val( def_val )
     , valmax( def_valmax )
 {

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -73,8 +73,7 @@ struct jmapgen_int {
      * Throws is the json is malformed (e.g. a string not an integer, but does not throw
      * if the member is just missing (the default values are used instead).
      */
-    jmapgen_int( const JsonObject &jo, const std::string &tag, const int &def_val,
-                 const int &def_valmax );
+    jmapgen_int( const JsonObject &jo, const std::string &tag, int def_val, int def_valmax );
 
     int get() const;
 };

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -57,11 +57,11 @@ class mapgen_function_builtin : public virtual mapgen_function
 /////////////////////////////////////////////////////////////////////////////////
 ///// json mapgen (and friends)
 /*
- * Actually a pair of shorts that can rng, for numbers that will never exceed 32768
+ * Actually a pair of integers that can rng, for numbers that will never exceed INT_MAX
  */
 struct jmapgen_int {
-    short val;
-    short valmax;
+    int val;
+    int valmax;
     jmapgen_int( int v ) : val( v ), valmax( v ) {}
     jmapgen_int( int v, int v2 ) : val( v ), valmax( v2 ) {}
     jmapgen_int( point p );
@@ -73,7 +73,8 @@ struct jmapgen_int {
      * Throws is the json is malformed (e.g. a string not an integer, but does not throw
      * if the member is just missing (the default values are used instead).
      */
-    jmapgen_int( const JsonObject &jo, const std::string &tag, short def_val, short def_valmax );
+    jmapgen_int( const JsonObject &jo, const std::string &tag, const int &def_val,
+                 const int &def_valmax );
 
     int get() const;
 };


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "[DDA Port] Fixed multiple issues with gaspump placement"

#### Purpose of change
Fix #1720 caused by integer overflow.
Fix gaspump placement in lumbermills and military bases.

#### Describe the solution
Port https://github.com/CleverRaven/Cataclysm-DDA/pull/46499 which enlarges jmapgen_int to int and prevents overflow.
Includes commit that fixes gaspump placement in lumbermills.
Port https://github.com/CleverRaven/Cataclysm-DDA/pull/46529 which does same but for milbases.

#### Testing
Spawned problematic locations, went there before and after the fix, saw all fixes work as expected.
