### PR TITLE
Unload pet food instead of eating it when activating container

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3241,6 +3241,14 @@ void player::use( int inventory_position )
     use( loc );
 }
 
+static bool is_pet_food( const item &itm )
+{
+    return itm.type->can_use( "DOGFOOD" ) ||
+           itm.type->can_use( "CATFOOD" ) ||
+           itm.type->can_use( "BIRDFOOD" ) ||
+           itm.type->can_use( "CATTLEFODDER" );
+}
+
 void player::use( item_location loc )
 {
     item &used = *loc.get_item();
@@ -3259,11 +3267,11 @@ void player::use( item_location loc )
         }
         invoke_item( &used, loc.position() );
 
-    } else if( used.type->can_use( "DOGFOOD" ) ||
-               used.type->can_use( "CATFOOD" ) ||
-               used.type->can_use( "BIRDFOOD" ) ||
-               used.type->can_use( "CATTLEFODDER" ) ) {
+    } else if( is_pet_food( used ) ) {
         invoke_item( &used, loc.position() );
+
+    } else if( !used.is_container_empty() && is_pet_food( used.get_contained() ) ) {
+        unload( loc );
 
     } else if( !used.is_craft() && ( used.is_medication() || ( !used.type->has_use() &&
                                      ( used.is_food() ||


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Unload pet food instead of eating it when activating container"

#### Purpose of change
Fixes #584
Activating unloaded pet food allows placing it, but when activating canned pet food, the character eats it.
That's almost always not the desired behavior.

#### Describe the solution
When activating canned pet food, unload it instead.

#### Describe alternatives you've considered
Making pet food inedible.

#### Testing
`a`ctivated can of dog food, it was unloaded.
`a`ctivated unloaded dog food, was prompted to feed a dog.
Explicitly `E`ating still works on both canned and uncanned.