### PR TITLE
Improve tileset invalidation between sessions

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -316,10 +316,18 @@ tile_type &tileset::create_tile_type( const std::string &id, tile_type &&new_til
     return inserted_tile;
 }
 
-void cata_tiles::load_tileset( const std::string &tileset_id, const bool precheck,
-                               const bool force )
+void cata_tiles::load_tileset(
+    const std::string &tileset_id,
+    const std::vector<mod_id> &mod_list,
+    const bool precheck,
+    const bool force
+)
 {
-    if( tileset_ptr && tileset_ptr->get_tileset_id() == tileset_id && !force ) {
+    if( !force && tileset_ptr &&
+        !get_option<bool>( "FORCE_TILESET_RELOAD" ) &&
+        tileset_ptr->get_tileset_id() == tileset_id &&
+        tileset_mod_list_stamp == mod_list
+      ) {
         return;
     }
     // TODO: move into clear or somewhere else.
@@ -332,6 +340,7 @@ void cata_tiles::load_tileset( const std::string &tileset_id, const bool prechec
     tileset_loader loader( *new_tileset_ptr, renderer );
     loader.load( tileset_id, precheck );
     tileset_ptr = std::move( new_tileset_ptr );
+    tileset_mod_list_stamp = mod_list;
 
     set_draw_scale( 16 );
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -540,11 +540,17 @@ class cata_tiles
          * Initialize the current tileset (load tile images, load mapping), using the current
          * tileset as it is set in the options.
          * @param tileset_id Ident of the tileset, as it appears in the options.
+         * @param mod_list List of active world mods, for correct caching behavior.
          * @param precheck If true, only loads the meta data of the tileset (tile dimensions).
          * @param force If true, forces loading the tileset even if it is already loaded.
          * @throw std::exception On any error.
          */
-        void load_tileset( const std::string &tileset_id, bool precheck = false, bool force = false );
+        void load_tileset(
+            const std::string &tileset_id,
+            const std::vector<mod_id> &mod_list,
+            bool precheck = false,
+            bool force = false
+        );
         /**
          * Reinitializes the current tileset, like @ref init, but using the original screen information.
          * @throw std::exception On any error.
@@ -592,7 +598,10 @@ class cata_tiles
         /** Variables */
         const SDL_Renderer_Ptr &renderer;
         const GeometryRenderer_Ptr &geometry;
+        /** Currently loaded tileset. */
         std::unique_ptr<tileset> tileset_ptr;
+        /** List of mods with which @ref tileset_ptr was loaded. */
+        std::vector<mod_id> tileset_mod_list_stamp;
 
         int tile_height = 0;
         int tile_width = 0;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -525,7 +525,12 @@ void game::reload_tileset()
 #if defined(TILES)
     try {
         tilecontext->reinit();
-        tilecontext->load_tileset( get_option<std::string>( "TILES" ), false, true );
+        std::vector<mod_id> dummy;
+        tilecontext->load_tileset(
+            get_option<std::string>( "TILES" ),
+            world_generator->active_world ? world_generator->active_world->active_mod_order : dummy,
+            false, true
+        );
         tilecontext->do_tile_loading_report();
     } catch( const std::exception &err ) {
         popup( _( "Loading the tileset failed: %s" ), err.what() );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2085,6 +2085,11 @@ void options_manager::add_options_debug()
          false
        );
 
+    add( "FORCE_TILESET_RELOAD", "debug", translate_marker( "Force tileset reload" ),
+         translate_marker( "If false, the game will keep tileset in memory after first load to speed up subsequent loadings of game data.  Enable this if you're working on a tileset for the game or a mod." ),
+         false
+       );
+
     add_empty_line();
 
     add_option_group( "debug", Group( "debug_log", to_translation( "Logging" ),
@@ -2622,7 +2627,14 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
         //try and keep SDL calls limited to source files that deal specifically with them
         try {
             tilecontext->reinit();
-            tilecontext->load_tileset( get_option<std::string>( "TILES" ), false, force_tile_change );
+            std::vector<mod_id> dummy;
+
+            tilecontext->load_tileset(
+                get_option<std::string>( "TILES" ),
+                ingame ? world_generator->active_world->active_mod_order : dummy,
+                false,
+                force_tile_change
+            );
             //game_ui::init_ui is called when zoom is changed
             g->reset_zoom();
             g->mark_main_ui_adaptor_resize();

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -71,6 +71,7 @@
 #include "uistate.h"
 #include "ui_manager.h"
 #include "wcwidth.h"
+#include "worldfactory.h"
 
 #if defined(__linux__)
 #   include <cstdlib> // getenv()/setenv()
@@ -3536,7 +3537,8 @@ void catacurses::init_interface()
     dbg( DL::Info ) << "Initializing SDL Tiles context";
     tilecontext = std::make_unique<cata_tiles>( renderer, geometry );
     try {
-        tilecontext->load_tileset( get_option<std::string>( "TILES" ), true );
+        std::vector<mod_id> dummy;
+        tilecontext->load_tileset( get_option<std::string>( "TILES" ), dummy, true );
     } catch( const std::exception &err ) {
         dbg( DL::Error ) << "failed to check for tileset: " << err.what();
         // use_tiles is the cached value of the USE_TILES option.
@@ -3575,7 +3577,10 @@ void load_tileset()
     if( !tilecontext || !use_tiles ) {
         return;
     }
-    tilecontext->load_tileset( get_option<std::string>( "TILES" ) );
+    tilecontext->load_tileset(
+        get_option<std::string>( "TILES" ),
+        world_generator->active_world->active_mod_order
+    );
     tilecontext->do_tile_loading_report();
 }
 


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fix mod graphics sometimes not loaded when loading multiple worlds in single session"

#### Purpose of change
Fix #1264

#### Describe the solution
Remember list of mods the tileset was loaded with, and invalidate it if the list changes.

Also added a debug switch that completely disables tileset caching, for modding purposes.

#### Testing
1. Set UDP as current tileset
2. Make a world without mods, save and quit to menu
3. Make a world with Magiclysm, spawn a plastic golem, see it has no sprite
4. Apply fix
5. Repeat steps 2 and 3, plastic golem now has a sprite