### PR TITLE
Misc bow loading/ammo selection fixes

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -258,6 +258,7 @@ bool aim_activity_actor::load_RAS_weapon()
         you.ammo_location.make_dirty();
         if( !you.ammo_location )
         {
+            you.ammo_location = item_location();
             return false;
         }
         if( !gun->can_reload_with( you.ammo_location->typeId() ) )

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -201,6 +201,7 @@ void aim_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "snap_to_target", snap_to_target );
     jsout.member( "shifting_view", shifting_view );
     jsout.member( "initial_view_offset", initial_view_offset );
+    jsout.member( "loaded_RAS_weapon", loaded_RAS_weapon );
 
     jsout.end_object();
 }
@@ -220,6 +221,7 @@ std::unique_ptr<activity_actor> aim_activity_actor::deserialize( JsonIn &jsin )
     data.read( "snap_to_target", actor.snap_to_target );
     data.read( "shifting_view", actor.shifting_view );
     data.read( "initial_view_offset", actor.initial_view_offset );
+    data.read( "loaded_RAS_weapon", actor.loaded_RAS_weapon );
 
     return actor.clone();
 }
@@ -292,6 +294,7 @@ bool aim_activity_actor::load_RAS_weapon()
     reload_time += ( sta_percent < 25 ) ? ( ( 25 - sta_percent ) * 2 ) : 0;
 
     you.moves -= reload_time;
+    loaded_RAS_weapon = true;
     return true;
 }
 
@@ -300,7 +303,7 @@ void aim_activity_actor::unload_RAS_weapon()
     // Unload reload-and-shoot weapons to avoid leaving bows pre-loaded with arrows
     avatar &you = get_avatar();
     item *weapon = get_weapon();
-    if( !weapon ) {
+    if( !weapon || !loaded_RAS_weapon ) {
         return;
     }
 
@@ -317,6 +320,8 @@ void aim_activity_actor::unload_RAS_weapon()
             you.moves = moves_before_unload;
         }
     }
+
+    loaded_RAS_weapon = false;
 }
 
 void autodrive_activity_actor::start( player_activity &act, Character &who )

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -33,6 +33,8 @@ class aim_activity_actor : public activity_actor
         tripoint initial_view_offset;
         /** Target UI requested to abort aiming */
         bool aborted = false;
+        /** RELOAD_AND_SHOOT weapon is kept loaded by the activity */
+        bool loaded_RAS_weapon = false;
         /**
          * Target UI requested to abort aiming and reload weapon
          * Implies aborted = true

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1124,6 +1124,8 @@ static item::reload_option favorite_ammo_or_select(
                 return *iter;
             }
         }
+    } else {
+        const_cast<item_location &>( u.ammo_location ) = item_location();
     }
     return u.select_ammo( it, prompt, empty );
 }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3756,9 +3756,13 @@ void ranged::prompt_select_default_ammo_for( avatar &u, const item &w )
     item::reload_option opt = u.select_ammo( w, false, true, true );
     if( opt ) {
         if( u.ammo_location && opt.ammo == u.ammo_location ) {
+            u.add_msg_if_player( _( "Cleared ammo preferences for %s." ), w.tname() );
             u.ammo_location = item_location();
-        } else {
+        } else if( u.has_item( *opt.ammo ) ) {
+            u.add_msg_if_player( _( "Selected %s as default ammo for %s." ), opt.ammo->tname(), w.tname() );
             u.ammo_location = opt.ammo;
+        } else {
+            u.add_msg_if_player( _( "You don't have that ammo on you." ) );
         }
     }
 }


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed miscellaneous bugs related to bow loading"

#### Purpose of change
Fix #1789
Should also fix #1560
Clear up some confusing UI moments.

#### Describe the solution
While investigating save file from #1789 I found out that `u.ammo_location` points to some item on map.
Turns out, nothing prevented player from selecting an item on map as default ammo for bow, and walking away from it and leaving it outside the bubble would break the `item_location` it points to.
As the solution, forbid selecting items outside player possession as default bow ammo, and future proof the code by resetting `u.ammo_location` whenever valididty check fails.
To improve UI feedback and clear up general confusion around "reloading" of bows, print messages whenever selecting an ammo as default for the bow.
Also fix "your bow isn't loaded" message that's printed whenever avatar can't fire the bow for some reason (strength too low, missing an arm, etc.)

#### Describe alternatives you've considered
Getting rid of `RELOAD_AND_SHOOT` items.

#### Testing
Tried "reloading" bow from ground and from inventory - the game allows selecting inventory ammo as default for the bow (and reports on doing so).
Walking next to an arrow and `f`iring still automatically picks up the arrow and loads it into the bow.
Firing with broken arm or with 0 strength no longer produces "You bow isn't loaded" message.