### PR TITLE
Pain Recovery Deobsoletion

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3203,6 +3203,35 @@
   },
   {
     "type": "mutation",
+    "id": "PAINREC1",
+    "name": { "str": "Pain Recovery" },
+    "points": 1,
+    "description": "You recover from pain slightly faster than normal.",
+    "changes_to": [ "PAINREC2" ],
+    "pain_recovery": 0.3
+  },
+  {
+    "type": "mutation",
+    "id": "PAINREC2",
+    "name": { "str": "Quick Pain Recovery" },
+    "points": 3,
+    "description": "You recover from pain faster than normal.",
+    "prereqs": [ "PAINREC1" ],
+    "changes_to": [ "PAINREC3" ],
+    "pain_recovery": 0.6
+  },
+  {
+    "type": "mutation",
+    "id": "PAINREC3",
+    "name": { "str": "Very Quick Pain Recovery" },
+    "points": 5,
+    "description": "You recover from pain much faster than normal.",
+    "prereqs": [ "PAINREC2" ],
+    "category": [ "MEDICAL" ],
+    "pain_recovery": 1.0
+  },
+  {
+    "type": "mutation",
     "id": "MUT_TOUGH2",
     "name": { "str": "Solidly Built" },
     "points": 3,

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3207,27 +3207,8 @@
     "name": { "str": "Pain Recovery" },
     "points": 1,
     "description": "You recover from pain slightly faster than normal.",
-    "changes_to": [ "PAINREC2" ],
-    "pain_recovery": 0.3
-  },
-  {
-    "type": "mutation",
-    "id": "PAINREC2",
-    "name": { "str": "Quick Pain Recovery" },
-    "points": 3,
-    "description": "You recover from pain faster than normal.",
-    "prereqs": [ "PAINREC1" ],
-    "changes_to": [ "PAINREC3" ],
-    "pain_recovery": 0.6
-  },
-  {
-    "type": "mutation",
-    "id": "PAINREC3",
-    "name": { "str": "Very Quick Pain Recovery" },
-    "points": 5,
-    "description": "You recover from pain much faster than normal.",
-    "prereqs": [ "PAINREC2" ],
-    "category": [ "MEDICAL" ],
+    "starting_trait": true,
+    "changes_to": [ "NOPAIN" ],
     "pain_recovery": 1.0
   },
   {
@@ -3269,7 +3250,7 @@
     "description": "You've developed a serious appetite for pain, and take pride in your scars.",
     "valid": false,
     "prereqs": [ "MASOCHIST", "PAINRESIST", "ADDICTIVE" ],
-    "prereqs2": [ "PAINREC2", "PAINREC3" ],
+    "prereqs2": [ "PAINREC1", "ADDICTIVE" ],
     "threshreq": [ "THRESH_MEDICAL" ],
     "leads_to": [ "MUT_TOUGH" ],
     "changes_to": [ "CENOBITE" ],
@@ -3287,7 +3268,6 @@
     "valid": false,
     "purifiable": false,
     "prereqs": [ "MASOCHIST_MED" ],
-    "prereqs2": [ "PAINREC3", "ADDICTIVE" ],
     "threshreq": [ "THRESH_MEDICAL" ],
     "category": [ "MEDICAL" ]
   },
@@ -3300,7 +3280,7 @@
     "valid": false,
     "purifiable": false,
     "prereqs": [ "MASOCHIST", "PAINRESIST" ],
-    "prereqs2": [ "PAINREC3" ],
+    "prereqs2": [ "PAINREC1" ],
     "cancels": [ "MORE_PAIN", "MORE_PAIN2", "MORE_PAIN3" ],
     "threshreq": [ "THRESH_MEDICAL" ],
     "category": [ "MEDICAL" ]

--- a/data/json/obsoletion/mutations.json
+++ b/data/json/obsoletion/mutations.json
@@ -19,33 +19,6 @@
   },
   {
     "type": "mutation",
-    "id": "PAINREC1",
-    "name": { "str": "Pain Recovery" },
-    "points": 0,
-    "description": "You recover from pain slightly faster than normal.  DUMMIED OUT because it wasn't actually functional…",
-    "valid": false,
-    "player_display": false
-  },
-  {
-    "type": "mutation",
-    "id": "PAINREC2",
-    "name": { "str": "Quick Pain Recovery" },
-    "points": 0,
-    "description": "You recover from pain faster than normal.  DUMMIED OUT because it wasn't actually functional…",
-    "valid": false,
-    "player_display": false
-  },
-  {
-    "type": "mutation",
-    "id": "PAINREC3",
-    "name": { "str": "Very Quick Pain Recovery" },
-    "points": 0,
-    "description": "You recover from pain much faster than normal.  DUMMIED OUT because it wasn't actually functional…",
-    "valid": false,
-    "player_display": false
-  },
-  {
-    "type": "mutation",
     "id": "TABLEMANNERS",
     "name": { "str": "Rigid Table Manners" },
     "points": 0,

--- a/data/json/obsoletion/mutations.json
+++ b/data/json/obsoletion/mutations.json
@@ -19,6 +19,24 @@
   },
   {
     "type": "mutation",
+    "id": "PAINREC2",
+    "name": { "str": "Quick Pain Recovery" },
+    "points": 0,
+    "description": "You recover from pain faster than normal.  DUMMIED OUT because it wasn't actually functional…",
+    "valid": false,
+    "player_display": false
+  },
+  {
+    "type": "mutation",
+    "id": "PAINREC3",
+    "name": { "str": "Very Quick Pain Recovery" },
+    "points": 0,
+    "description": "You recover from pain much faster than normal.  DUMMIED OUT because it wasn't actually functional…",
+    "valid": false,
+    "player_display": false
+  },
+  {
+    "type": "mutation",
     "id": "TABLEMANNERS",
     "name": { "str": "Rigid Table Manners" },
     "points": 0,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4562,7 +4562,8 @@ void Character::regen( int rate_multiplier )
 {
     int pain_ticks = rate_multiplier;
     while( get_pain() > 0 && pain_ticks-- > 0 ) {
-        mod_pain( -roll_remainder( 0.2f + get_pain() / 50.0f ) );
+        mod_pain( -roll_remainder( ( 0.2f + get_pain() / 50.0f ) * ( 1.0f +
+                                   mutation_value( "pain_recovery" ) ) ) );
     }
 
     float rest = rest_quality();
@@ -6723,6 +6724,7 @@ float calc_mutation_value_multiplicative( const std::vector<const mutation_branc
 
 static const std::map<std::string, std::function <float( std::vector<const mutation_branch *> )>>
 mutation_value_map = {
+    { "pain_recovery", calc_mutation_value<&mutation_branch::pain_recovery> },
     { "healing_awake", calc_mutation_value<&mutation_branch::healing_awake> },
     { "healing_resting", calc_mutation_value<&mutation_branch::healing_resting> },
     { "mending_modifier", calc_mutation_value<&mutation_branch::mending_modifier> },

--- a/src/character.h
+++ b/src/character.h
@@ -2154,7 +2154,6 @@ class Character : public Creature, public visitable<Character>
         void suffer_from_chemimbalance();
         void suffer_from_schizophrenia();
         void suffer_from_asthma( int current_stim );
-        void suffer_from_pain();
         void suffer_in_sunlight();
         void suffer_from_sunburn();
         void suffer_from_other_mutations();

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -110,6 +110,8 @@ struct mutation_branch {
         int bodytemp_min = 0;
         int bodytemp_max = 0;
         int bodytemp_sleep = 0;
+        // Pain Recovery per turn:
+        float pain_recovery = 0.0f;
         // Healing per turn
         float healing_awake = 0.0f;
         float healing_resting = 0.0f;

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -374,6 +374,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
         vitamin_absorb_multi.emplace( material_id( pair.get_string( 0 ) ), vit );
     }
 
+    optional( jo, was_loaded, "pain_recovery", pain_recovery, 0.0f );
     optional( jo, was_loaded, "healing_awake", healing_awake, 0.0f );
     optional( jo, was_loaded, "healing_resting", healing_resting, 0.0f );
     optional( jo, was_loaded, "mending_modifier", mending_modifier, 1.0f );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1460,10 +1460,6 @@ void Character::suffer_without_sleep( const int sleep_deprivation )
     }
 }
 
-void Character::suffer_from_pain()
-{
-}
-
 void Character::suffer()
 {
     const int current_stim = get_stim();
@@ -1520,7 +1516,6 @@ void Character::suffer()
     }
 
     suffer_without_sleep( sleep_deprivation );
-    suffer_from_pain();
     //Suffer from enchantments
     enchantment_cache->activate_passive( *this );
 


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Deobsoletes Pain Recovery mutations. Adds Pain Recovery mutation variable"

#### Purpose of change

Pain recovery was removed because at the time it didn't work. This was due to [#35300](https://github.com/CleverRaven/Cataclysm-DDA/pull/35300) attempting to move `suffer()` and forgetting to replace the effects under `suffer_from_pain()`

#### Describe the solution

`suffer_from_pain()` was removed in favour of applying the modifiers directly to pain recovery in `Character::regen`. A new variable was added to mutations. `pain_recovery` works much in the same way as `healing_awake` or `healing_asleep`. Being an additive modifier to the pain recovery multiplier.

After some discussion, pain recovery was made to give a 100% increase and made a chargen trait. The other versions will remain obsolete as Deadened is a 2 point mutation and is vastly superior to any form of pain recovery.

Updated the prereqs that utilized PAINREC2 and PAINREC3. Pain Junkie's alternate path is now Pain Recovery + Addictive, and Cenobite no longer has an alternate Pain Recovery Path as Pain Junkie will lead naturally into it. Pain Recovery itself can lead straight into Deadened if you're lucky.

#### Describe alternatives you've considered

-Port [#57798](https://github.com/CleverRaven/Cataclysm-DDA/pull/57798)
Considered but rejected on the basis that pain recovery is partially a scaling formula to current pain. A flat reduction will be disproportionately more effective at low pain than high pain.
-Rework `suffer_from_pain()`
Seen as unneeded. It's an extra call where we could just bake it into the recovery.

#### Testing

Spawned character, caused 1000 and 100 pain, tested pain recovery over the course of 1 hour.

Base Recovery:
1000 -> 782 : 218 recovery
100 -> 77 : 23 recovery

Pain Recovery:
1000 -> 608 : 392 recovery (~80% increase)
100 -> 57 : 43 recovery (~86% increase)

#### Additional context

Make sure that if you add a mutation that negatively affects pain recovery it's exclusive with the above, otherwise they will stack because of how pain recovery is tallied by `mutation_value()`

Otherwise, worth noting that the actual increase in pain recovery is somewhat lower (~20%) compared to the value in the `mutations.json` likely owing to how pain recovery is calculated.