### PR TITLE
Fix inverted condition causing spell study to fail

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4785,7 +4785,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
 
 void activity_handlers::study_spell_do_turn( player_activity *act, player *p )
 {
-    if( character_funcs::can_see_fine_details( *p ) ) {
+    if( !character_funcs::can_see_fine_details( *p ) ) {
         act->values[2] = -1;
         act->moves_left = 0;
         return;


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Fix regression after #1804 (reported on discord)
Fixes #1827 

#### Describe the solution
Fix inverted condition.

#### Describe alternatives you've considered
Double checked the rest, should be fine.

#### Testing
None, this change is trivial