### PR TITLE
Disallow selecting NPC for camp mission if they already have a mission

### DIFF
--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1901,13 +1901,16 @@ npc_ptr talk_function::companion_choose( const std::map<skill_id, int> &required
         if( !guy ) {
             continue;
         }
-        npc_companion_mission c_mission = guy->get_companion_mission();
-        // get non-assigned visible followers
-        if( g->u.posz() == guy->posz() && !guy->has_companion_mission() &&
-            !guy->is_travelling() &&
+        if( guy->has_companion_mission() ) {
+            // Already assigned on a task
+            continue;
+        }
+        // Try nearby visible followers
+        if( g->u.posz() == guy->posz() && !guy->is_travelling() &&
             ( rl_dist( g->u.pos(), guy->pos() ) <= SEEX * 2 ) && g->u.sees( guy->pos() ) ) {
             available.push_back( guy );
         } else if( bcp ) {
+            // Try NPCs assigned to this camp
             basecamp *player_camp = *bcp;
             std::vector<npc_ptr> camp_npcs = player_camp->get_npcs_assigned();
             if( std::any_of( camp_npcs.begin(), camp_npcs.end(),


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fix NPCs on a camp mission could be selected for another camp mission"

#### Purpose of change
Fix #780
Fix #1351
Fix #1491

#### Describe the solution
Disallow selecting NPCs that have missions assigned to them, regardless of whether they're a camp worker or not.

#### Testing
Made a camp, assigned a couple NPCs to it, selected one for camp expansion mission. He was no longer available for foraging mission.

#### Additional context
Basecamp/mission code is extremely convoluted, it wouldn't surprise me if this breaks something else.