### PR TITLE
[DDA Port] Add mutation value that lessens bionic power penalty on mana cap

### DIFF
--- a/data/mods/TEST_DATA/magic.json
+++ b/data/mods/TEST_DATA/magic.json
@@ -120,5 +120,16 @@
     "base_casting_time": 100,
     "base_energy_cost": 100,
     "energy_source": "MANA"
+  },
+  {
+    "id": "TEST_BIO_MANA_COMPAT",
+    "type": "mutation",
+    "name": { "str": "Debug mana compat" },
+    "points": 1,
+    "starting_trait": true,
+    "purifiable": true,
+    "valid": true,
+    "description": "Debug mutation.",
+    "bionic_mana_penalty": 0.5
   }
 ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6742,6 +6742,7 @@ mutation_value_map = {
     { "mana_modifier", calc_mutation_value_additive<&mutation_branch::mana_modifier> },
     { "mana_multiplier", calc_mutation_value_multiplicative<&mutation_branch::mana_multiplier> },
     { "mana_regen_multiplier", calc_mutation_value_multiplicative<&mutation_branch::mana_regen_multiplier> },
+    { "bionic_mana_penalty", calc_mutation_value_multiplicative<&mutation_branch::bionic_mana_penalty> },
     { "speed_modifier", calc_mutation_value_multiplicative<&mutation_branch::speed_modifier> },
     { "movecost_modifier", calc_mutation_value_multiplicative<&mutation_branch::movecost_modifier> },
     { "movecost_flatground_modifier", calc_mutation_value_multiplicative<&mutation_branch::movecost_flatground_modifier> },

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1436,7 +1436,10 @@ int known_magic::max_mana( const Character &guy ) const
     float mut_add = guy.mutation_value( "mana_modifier" );
     int natural_cap = std::max( 0.0f, ( ( mana_base + int_bonus ) * mut_mul ) + mut_add );
 
-    int bp_penalty = units::to_kilojoule( guy.get_power_level() );
+    int bp_penalty = std::round( std::max( 0.0f,
+                                           units::to_kilojoule( guy.get_power_level() ) *
+                                           guy.mutation_value( "bionic_mana_penalty" )
+                                         ) );
     int ench_bonus = guy.bonus_from_enchantments( natural_cap, enchant_vals::mod::MANA_CAP, true );
 
     return std::max( 0, natural_cap - bp_penalty + ench_bonus );

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -228,6 +228,8 @@ struct mutation_branch {
         float mana_modifier = 0.0f;
         float mana_multiplier = 1.0f;
         float mana_regen_multiplier = 1.0f;
+        // for every point of bionic power, reduces max mana pool by 1 * bionic_mana_penalty
+        float bionic_mana_penalty = 1.0f;
         // spells learned and their associated level when gaining the mutation
         std::map<spell_id, int> spells_learned;
         /** mutation enchantments */

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -426,6 +426,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "mana_modifier", mana_modifier, 0 );
     optional( jo, was_loaded, "mana_multiplier", mana_multiplier, 1.0f );
     optional( jo, was_loaded, "mana_regen_multiplier", mana_regen_multiplier, 1.0f );
+    optional( jo, was_loaded, "bionic_mana_penalty", bionic_mana_penalty, 1.0f );
 
     if( jo.has_object( "rand_cut_bonus" ) ) {
         JsonObject sm = jo.get_object( "rand_cut_bonus" );

--- a/tests/enchantment_test.cpp
+++ b/tests/enchantment_test.cpp
@@ -473,6 +473,7 @@ struct mana_test_case {
     int idx;
     int intellect;
     units::energy power_level;
+    bool has_mut;
     int norm_cap;
     int exp_cap;
     double norm_regen_amt_8h;
@@ -480,12 +481,17 @@ struct mana_test_case {
 };
 
 static const std::vector<mana_test_case> mana_test_data = {{
-        {0, 8, 0_kJ, 1000, 800, 1000.0, 560.0},
-        {1, 12, 0_kJ, 1400, 1080, 1400.0, 686.0},
-        {2, 8, 250_kJ, 750, 450, 750.0, 385.0},
-        {3, 12, 250_kJ, 1150, 830, 1150.0, 581.0},
-        {4, 8, 1250_kJ, 0, 0, 0.0, 0.0},
-        {5, 16, 1250_kJ, 550, 110, 550.0, 77.0},
+        {0, 8, 0_kJ, false, 1000, 800, 1000.0, 560.0},
+        {1, 12, 0_kJ, false, 1400, 1080, 1400.0, 686.0},
+        {2, 8, 250_kJ, false, 750, 450, 750.0, 385.0},
+        {3, 12, 250_kJ, false, 1150, 830, 1150.0, 581.0},
+        {4, 8, 1250_kJ, false, 0, 0, 0.0, 0.0},
+        {5, 16, 1250_kJ, false, 550, 110, 550.0, 77.0},
+        // Having the mutation halves the penalty
+        {2, 8, 500_kJ, true, 750, 450, 750.0, 385.0},
+        {3, 12, 500_kJ, true, 1150, 830, 1150.0, 581.0},
+        {4, 8, 2500_kJ, true, 0, 0, 0.0, 0.0},
+        {5, 16, 2500_kJ, true, 550, 110, 550.0, 77.0},
     }
 };
 
@@ -497,8 +503,8 @@ static void tests_mana_pool( Character &guy, const mana_test_case &t )
     guy.recalculate_enchantment_cache();
     advance_turn( guy );
 
-    guy.set_max_power_level( 2000_kJ );
-    REQUIRE( guy.get_max_power_level() == 2000_kJ );
+    guy.set_max_power_level( 20000_kJ );
+    REQUIRE( guy.get_max_power_level() == 20000_kJ );
 
     guy.set_power_level( t.power_level );
     REQUIRE( guy.get_power_level() == t.power_level );
@@ -544,6 +550,11 @@ static void tests_mana_pool_section( const mana_test_case &t )
     clear_map();
     Character &guy = get_player_character();
     clear_character( *guy.as_player(), true );
+
+    CAPTURE( t.has_mut );
+    if( t.has_mut ) {
+        guy.toggle_trait( trait_id( "TEST_BIO_MANA_COMPAT" ) );
+    }
 
     tests_mana_pool( guy, t );
 }


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "[DDA Port] Add mutation value that lessens bionic power penalty on mana cap"

#### Purpose of change
So @chaosvolt would stop pinging me on Discord
Follow-up to #844
Closes #471

#### Describe the solution
Loose port of required bits from https://github.com/CleverRaven/Cataclysm-DDA/pull/44357

#### Describe alternatives you've considered
Getting rid of it, it's badly communicated

#### Testing
Unit tests