### PR TITLE
Update food fun for test code

### DIFF
--- a/tests/food_fun_for_test.cpp
+++ b/tests/food_fun_for_test.cpp
@@ -302,7 +302,7 @@ TEST_CASE( "fun for bionic bio taste blocker", "[fun_for][food][bionic]" )
 
                 THEN( "the bad taste is nullified" ) {
                     dummy.eat( garlic );
-                    CHECK( !dummy.get_morale( MORALE_FOOD_BAD ) );
+                    CHECK( dummy.get_morale( MORALE_FOOD_BAD ) == 0 );
                 }
             }
         }


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Make the bionic taste modifier test explicitly look for 0."

#### Purpose of change

In #1769 @Coolthulhu made a comment about the tests. Fixing it.

#### Describe the solution

Makes the check explicitly look for 0 instead of implying it via false.

#### Describe alternatives you've considered

Ignore?

#### Testing

The tests didn't fail when I ran it...

#### Additional context
