### PR TITLE
Fix multiple issues with disassembly of count-by-charges items

### DIFF
--- a/data/json/obsoletion/items.json
+++ b/data/json/obsoletion/items.json
@@ -3190,7 +3190,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "22_casing_new", 1 ] ], [ [ "gunpowder_pistol", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "type": "AMMO",

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -252,7 +252,6 @@
     ],
     "using": [ [ "soldering_standard", 10 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "flags": [ "UNCRAFT_BY_QUANTITY" ],
     "components": [
       [ [ "oxy_powder", 50 ] ],
       [ [ "charcoal", 5 ], [ "coal_lump", 5 ] ],
@@ -271,7 +270,6 @@
     "reversible": true,
     "decomp_learn": 2,
     "autolearn": true,
-    "flags": [ "UNCRAFT_BY_QUANTITY" ],
     "components": [ [ [ "charcoal", 5 ] ], [ [ "paper", 2 ] ], [ [ "bag_plastic", 1 ] ] ]
   },
   {
@@ -285,7 +283,6 @@
     "reversible": true,
     "decomp_learn": 2,
     "autolearn": true,
-    "flags": [ "UNCRAFT_BY_QUANTITY" ],
     "components": [ [ [ "charcoal", 10 ] ], [ [ "paper", 2 ] ], [ [ "bag_plastic", 1 ] ] ]
   },
   {
@@ -299,7 +296,6 @@
     "time": "60 m",
     "reversible": true,
     "decomp_learn": 4,
-    "flags": [ "UNCRAFT_BY_QUANTITY" ],
     "book_learn": [
       [ "textbook_fireman", 4 ],
       [ "atomic_survival", 4 ],

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -1363,7 +1363,7 @@
     "time": "1 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "copper", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "camera",

--- a/data/json/uncraft/ammo/10mm.json
+++ b/data/json/uncraft/ammo/10mm.json
@@ -5,6 +5,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "10mm_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/120mm.json
+++ b/data/json/uncraft/ammo/120mm.json
@@ -13,6 +13,6 @@
       [ [ "impact_fuze", 1 ] ],
       [ [ "scrap", 25 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/22.json
+++ b/data/json/uncraft/ammo/22.json
@@ -7,7 +7,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "22_casing_new", 1 ] ], [ [ "gunpowder", 2 ] ], [ [ "copper", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "22_lr",
@@ -17,7 +17,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "22_casing_new", 1 ] ], [ [ "gunpowder", 2 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "22_ratshot",
@@ -27,6 +27,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "22_casing_new", 1 ] ], [ [ "gunpowder", 2 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/223.json
+++ b/data/json/uncraft/ammo/223.json
@@ -7,6 +7,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "223_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 4 ] ], [ [ "copper", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/270win.json
+++ b/data/json/uncraft/ammo/270win.json
@@ -13,6 +13,6 @@
       [ [ "gunpowder", 10 ] ],
       [ [ "copper", 3 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/30-06.json
+++ b/data/json/uncraft/ammo/30-06.json
@@ -13,7 +13,7 @@
       [ [ "gunpowder", 12 ] ],
       [ [ "copper", 4 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "3006_incendiary",
@@ -30,7 +30,7 @@
       [ [ "gunpowder", 12 ] ],
       [ [ "copper", 4 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "3006fmj",
@@ -46,6 +46,6 @@
       [ [ "gunpowder", 12 ] ],
       [ [ "copper", 4 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/300.json
+++ b/data/json/uncraft/ammo/300.json
@@ -13,6 +13,6 @@
       [ [ "gunpowder", 16 ] ],
       [ [ "copper", 4 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/300blk.json
+++ b/data/json/uncraft/ammo/300blk.json
@@ -13,7 +13,7 @@
       [ [ "gunpowder", 4 ] ],
       [ [ "copper", 2 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "300blk_ss",
@@ -29,6 +29,6 @@
       [ [ "gunpowder", 6 ] ],
       [ [ "copper", 2 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/308.json
+++ b/data/json/uncraft/ammo/308.json
@@ -7,6 +7,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 6 ] ], [ [ "308_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 8 ] ], [ [ "copper", 3 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/32.json
+++ b/data/json/uncraft/ammo/32.json
@@ -7,6 +7,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "32_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 2 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/357mag.json
+++ b/data/json/uncraft/ammo/357mag.json
@@ -11,7 +11,7 @@
       [ [ "gunpowder", 5 ] ],
       [ [ "copper", 1 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "357mag_jhp",
@@ -19,6 +19,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "357mag_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/357sig.json
+++ b/data/json/uncraft/ammo/357sig.json
@@ -11,7 +11,7 @@
       [ [ "gunpowder", 5 ] ],
       [ [ "copper", 1 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "357sig_jhp",
@@ -19,6 +19,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "357sig_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/38.json
+++ b/data/json/uncraft/ammo/38.json
@@ -5,7 +5,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "38_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 2 ] ], [ [ "copper", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "38_special",
@@ -13,6 +13,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "38_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 2 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/38super.json
+++ b/data/json/uncraft/ammo/38super.json
@@ -5,7 +5,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "38super_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 3 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "38super_fmj",
@@ -21,6 +21,6 @@
       [ [ "gunpowder", 3 ] ],
       [ [ "copper", 1 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/40.json
+++ b/data/json/uncraft/ammo/40.json
@@ -5,7 +5,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "40_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ], [ [ "copper", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "40sw",
@@ -13,6 +13,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "40_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/40x46mm.json
+++ b/data/json/uncraft/ammo/40x46mm.json
@@ -7,7 +7,7 @@
     "time": "3 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 35 ] ], [ [ "40x46mm_m212_casing", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "40x46mm_m433",
@@ -17,7 +17,7 @@
     "time": "3 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "combatnail", 70 ] ], [ [ "gunpowder", 35 ] ], [ [ "impact_fuze", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "40x46mm_m576",
@@ -27,7 +27,7 @@
     "time": "3 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lgpistol_primer", 1 ] ], [ [ "chem_compositionb", 32 ] ], [ [ "gunpowder", 35 ] ], [ [ "impact_fuze", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "40x46mm_m651",
@@ -37,6 +37,6 @@
     "time": "3 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 35 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/40x53mm.json
+++ b/data/json/uncraft/ammo/40x53mm.json
@@ -7,7 +7,7 @@
     "time": "3 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "40x53mm_m169_casing", 1 ] ], [ [ "combatnail", 100 ] ], [ [ "gunpowder", 35 ] ], [ [ "lgrifle_primer", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "40x53mm_m430a1",
@@ -23,6 +23,6 @@
       [ [ "impact_fuze", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/410shot.json
+++ b/data/json/uncraft/ammo/410shot.json
@@ -7,6 +7,6 @@
     "time": "1 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "410shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 5 ] ], [ [ "lead", 5 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/44.json
+++ b/data/json/uncraft/ammo/44.json
@@ -7,7 +7,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 4 ] ], [ [ "44_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 6 ] ], [ [ "copper", 2 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "44magnum",
@@ -17,6 +17,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 5 ] ], [ [ "44_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 6 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/45.json
+++ b/data/json/uncraft/ammo/45.json
@@ -5,7 +5,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "45_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ], [ [ "copper", 2 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "45_jhp",
@@ -13,7 +13,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "45_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "45_super",
@@ -21,6 +21,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "45_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/454.json
+++ b/data/json/uncraft/ammo/454.json
@@ -7,6 +7,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 4 ] ], [ [ "454_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 6 ] ], [ [ "copper", 2 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/4570.json
+++ b/data/json/uncraft/ammo/4570.json
@@ -11,7 +11,7 @@
       [ [ "lgrifle_primer", 1 ] ],
       [ [ "gunpowder", 15 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "4570_pen",
@@ -25,7 +25,7 @@
       [ [ "lgrifle_primer", 1 ] ],
       [ [ "gunpowder", 17 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "4570_low",
@@ -33,7 +33,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 8 ] ], [ [ "4570_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 12 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "id": "reloaded_4570_bp",

--- a/data/json/uncraft/ammo/45colt.json
+++ b/data/json/uncraft/ammo/45colt.json
@@ -5,6 +5,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 4 ] ], [ [ "45colt_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/460.json
+++ b/data/json/uncraft/ammo/460.json
@@ -13,7 +13,7 @@
       [ [ "gunpowder", 6 ] ],
       [ [ "copper", 2 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "460_rowland",
@@ -23,6 +23,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "460_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 6 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/46mm.json
+++ b/data/json/uncraft/ammo/46mm.json
@@ -7,6 +7,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "46mm_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 4 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/500.json
+++ b/data/json/uncraft/ammo/500.json
@@ -7,6 +7,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 5 ] ], [ [ "500_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 8 ] ], [ [ "copper", 2 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/50bmg.json
+++ b/data/json/uncraft/ammo/50bmg.json
@@ -14,7 +14,7 @@
       [ [ "gunpowder", 30 ] ],
       [ [ "copper", 6 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "50bmg",
@@ -30,7 +30,7 @@
       [ [ "gunpowder", 30 ] ],
       [ [ "copper", 6 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "50ss",
@@ -46,6 +46,6 @@
       [ [ "copper", 6 ] ],
       [ [ "scrap", 1 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/545.json
+++ b/data/json/uncraft/ammo/545.json
@@ -7,7 +7,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "545_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 5 ] ], [ [ "copper", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "545_ap",
@@ -17,6 +17,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "545_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 6 ] ], [ [ "copper", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/556.json
+++ b/data/json/uncraft/ammo/556.json
@@ -7,7 +7,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 3 ] ], [ [ "223_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 6 ] ], [ [ "copper", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "556_incendiary",
@@ -24,6 +24,6 @@
       [ [ "gunpowder", 6 ] ],
       [ [ "copper", 1 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/57mm.json
+++ b/data/json/uncraft/ammo/57mm.json
@@ -7,6 +7,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "57mm_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder", 4 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/5x50.json
+++ b/data/json/uncraft/ammo/5x50.json
@@ -14,7 +14,7 @@
       [ [ "gunpowder", 3 ] ],
       [ [ "combatnail", 1 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "5x50heavy",
@@ -31,6 +31,6 @@
       [ [ "gunpowder", 4 ] ],
       [ [ "scrap", 1 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/66mm.json
+++ b/data/json/uncraft/ammo/66mm.json
@@ -7,7 +7,7 @@
     "time": "10 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "incendiary", 295 ] ], [ [ "impact_fuze", 1 ] ], [ [ "scrap", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "66mm_HEAT",
@@ -17,6 +17,6 @@
     "time": "10 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "copper", 50 ] ], [ [ "chem_compositionb", 300 ] ], [ [ "impact_fuze", 1 ] ], [ [ "scrap", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/66mm.json
+++ b/data/json/uncraft/ammo/66mm.json
@@ -18,15 +18,5 @@
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "copper", 50 ] ], [ [ "chem_compositionb", 300 ] ], [ [ "impact_fuze", 1 ] ], [ [ "scrap", 1 ] ] ],
     "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
-  },
-  {
-    "result": "LAW",
-    "type": "uncraft",
-    "skill_used": "fabrication",
-    "difficulty": 6,
-    "time": "10 m",
-    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "copper", 50 ] ], [ [ "chem_compositionb", 300 ] ], [ [ "impact_fuze", 1 ] ], [ [ "scrap", 3 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
   }
 ]

--- a/data/json/uncraft/ammo/700nx.json
+++ b/data/json/uncraft/ammo/700nx.json
@@ -13,6 +13,6 @@
       [ [ "gunpowder", 30 ] ],
       [ [ "copper", 5 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/762x39.json
+++ b/data/json/uncraft/ammo/762x39.json
@@ -7,7 +7,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 4 ] ], [ [ "762_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 8 ] ], [ [ "copper", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "762_m87",
@@ -17,6 +17,6 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 4 ] ], [ [ "762_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 8 ] ], [ [ "copper", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/762x51.json
+++ b/data/json/uncraft/ammo/762x51.json
@@ -13,7 +13,7 @@
       [ [ "gunpowder", 10 ] ],
       [ [ "copper", 3 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "762_51_incendiary",
@@ -30,6 +30,6 @@
       [ [ "gunpowder", 10 ] ],
       [ [ "copper", 3 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/762x54.json
+++ b/data/json/uncraft/ammo/762x54.json
@@ -13,6 +13,6 @@
       [ [ "gunpowder", 10 ] ],
       [ [ "copper", 3 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/84x246mm.json
+++ b/data/json/uncraft/ammo/84x246mm.json
@@ -7,7 +7,7 @@
     "time": "10 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "chem_compositionb", 500 ] ], [ [ "impact_fuze", 1 ] ], [ [ "scrap", 3 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "84x246mm_hedp",
@@ -17,7 +17,7 @@
     "time": "10 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "chem_compositionb", 600 ] ], [ [ "impact_fuze", 1 ] ], [ [ "scrap", 3 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "84x246mm_smoke",
@@ -27,6 +27,6 @@
     "time": "10 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "impact_fuze", 1 ] ], [ [ "scrap", 2 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/9x18mm.json
+++ b/data/json/uncraft/ammo/9x18mm.json
@@ -7,7 +7,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "9x18mm_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 3 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "9x18mmP2",
@@ -17,7 +17,7 @@
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
     "components": [ [ [ "lead", 2 ] ], [ [ "9x18mm_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "9x18mmfmj",
@@ -33,6 +33,6 @@
       [ [ "gunpowder", 3 ] ],
       [ [ "copper", 1 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/atgm.json
+++ b/data/json/uncraft/ammo/atgm.json
@@ -14,6 +14,6 @@
       [ [ "scrap", 20 ] ],
       [ [ "e_scrap", 3 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/rpg.json
+++ b/data/json/uncraft/ammo/rpg.json
@@ -13,7 +13,7 @@
       [ [ "impact_fuze", 1 ] ],
       [ [ "scrap", 3 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "RPG-7_pg7vr",
@@ -29,7 +29,7 @@
       [ [ "impact_fuze", 1 ] ],
       [ [ "scrap", 3 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "RPG-7_tbg7v",
@@ -46,7 +46,7 @@
       [ [ "scrap", 3 ] ],
       [ [ "incendiary", 150 ] ]
     ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "RPG-7_og7v",
@@ -56,6 +56,6 @@
     "time": "10 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "chem_compositionb", 200 ] ], [ [ "gunpowder", 300 ] ], [ [ "impact_fuze", 1 ] ], [ [ "scrap", 3 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/ammo/shot.json
+++ b/data/json/uncraft/ammo/shot.json
@@ -7,7 +7,7 @@
     "time": "1 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 6 ] ], [ [ "lead", 10 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "shot_beanbag",
@@ -17,7 +17,7 @@
     "time": "1 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 3 ] ], [ [ "rubber_slug", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "shot_bird",
@@ -27,7 +27,7 @@
     "time": "1 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 3 ] ], [ [ "lead", 10 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "shot_dragon",
@@ -37,7 +37,7 @@
     "time": "1 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 3 ] ], [ [ "magnesium", 5 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "shot_flechette",
@@ -47,7 +47,7 @@
     "time": "1 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 6 ] ], [ [ "combatnail", 10 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "type": "uncraft",
@@ -58,7 +58,7 @@
     "//": "A little more carefully...",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 3 ] ], [ [ "chem_rdx", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "shot_slug",
@@ -68,6 +68,6 @@
     "time": "1 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "gunpowder", 6 ] ], [ [ "lead", 20 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/classes/ammo.json
+++ b/data/json/uncraft/classes/ammo.json
@@ -5,6 +5,6 @@
     "//": "Disassemble a single ammo cartridge",
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   }
 ]

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -45,7 +45,7 @@
     "time": "30 m",
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "steel_chunk", 38 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "mattress",
@@ -78,7 +78,7 @@
     "time": "2 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "thread", 1 ] ] ],
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ]
+    "charges": 1
   },
   {
     "result": "spatula",

--- a/data/json/uncraft/weapon/explosive.json
+++ b/data/json/uncraft/weapon/explosive.json
@@ -25,5 +25,14 @@
     "time": "50 s",
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "delay_fuze", 1 ] ], [ [ "canister_empty", 1 ] ], [ [ "chem_compositionb", 75 ] ] ]
+  },
+  {
+    "type": "uncraft",
+    "result": "LAW_Packed",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "time": "10 m",
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "copper", 50 ] ], [ [ "chem_compositionb", 300 ] ], [ [ "impact_fuze", 1 ] ], [ [ "scrap", 3 ] ] ]
   }
 ]

--- a/data/mods/EW_Pack/ew_bullet_pulling.json
+++ b/data/mods/EW_Pack/ew_bullet_pulling.json
@@ -5,7 +5,7 @@
     "skill_used": "gun",
     "difficulty": 5,
     "time": 500,
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ],
+    "charges": 1,
     "tools": [ [ [ "puller", -1 ] ] ],
     "components": [
       [ [ "lead", 5 ] ],
@@ -21,7 +21,7 @@
     "skill_used": "gun",
     "difficulty": 5,
     "time": 500,
-    "flags": [ "UNCRAFT_SINGLE_CHARGE" ],
+    "charges": 1,
     "tools": [ [ [ "puller", -1 ] ] ],
     "components": [
       [ [ "lead", 6 ] ],

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -1213,9 +1213,7 @@ These branches are also the valid entries for the categories of `dreams` in `dre
 - ```BLIND_EASY``` Easy to craft with little to no light.
 - ```BLIND_HARD``` Possible to craft with little to no light, but difficult.
 - ```SECRET``` Not automatically learned at character creation time based on high skill levels.
-- ```UNCRAFT_BY_QUANTITY``` Supresses the per-charge handling of uncraft recipes.
 - ```UNCRAFT_LIQUIDS_CONTAINED``` Spawn liquid items in its default container.
-- ```UNCRAFT_SINGLE_CHARGE``` Lists returned amounts for one charge of an item that is counted by charges.
 - ```FULL_MAGAZINE``` If this recipe requires magazines, it needs one that is full.  For deconstruction recipes, it will spawn a full magazine when deconstructed.
 
 

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -998,12 +998,22 @@ Mods can modify this via `add:traits` and `remove:traits`.
 
 ### Recipes
 
+Recipes represent both craft and uncraft (disassembly) recipes.
+
 ```C++
-"result": "javelin",         // ID of resulting item
+"type": "recipe",            // Recipe type. Possible values: 'recipe' (craft recipe) and 'uncraft' (uncraft recipe).
+"reversible": false,         // Generate an uncraft recipe that is a reverse of this craft recipe.
+"result": "javelin",         // ID of resulting item. By default, also used as the ID of the recipe.
+"id_suffix": "",             // Optional (default: empty string). Some suffix to make the ID of the recipe unique. The ID of the recipe is "<result><id_suffix>".
 "category": "CC_WEAPON",     // Category of crafting recipe. CC_NONCRAFT used for disassembly recipes
-"id_suffix": "",             // Optional (default: empty string). Some suffix to make the ident of the recipe unique. The ident of the recipe is "<id-of-result><id_suffix>".
-"override": false,           // Optional (default: false). If false and the ident of the recipe is already used by another recipe, loading of recipes fails. If true and a recipe with the ident is already defined, the existing recipe is replaced by the new recipe.
+"subcategory": "",           // Subcategory of crafting recipe. 
+"override": false,           // Optional (default: false). If false and the ID of the recipe is already used by another recipe, loading of recipes fails. If true and a recipe with the ID is already defined, the existing recipe is replaced by the new recipe.
+"obsolete": false,           // Optional (default: false). Marks this recipe as obsolete. Use this instead of outright deleting it to preserve save compatibility.
 "delete_flags": [ "CANNIBALISM" ], // Optional (default: empty list). Flags specified here will be removed from the resultant item upon crafting. This will override flag inheritance, but *will not* delete flags that are part of the item type itself.
+"contained": false,          // Optional (default: false). Spawn produced item in a container.
+"container": "can_medium",   // Optional. Override container to spawn item in (by default uses item's default container)
+"charges": 1,                // Optional (default: null). Override default charges for count-by-charges items (ammo, comestibles, etc.)
+"result_mult": 1,            // Optional (default: 1). Produce multiple items (or stacks for count-by-charges items) from single craft
 "skill_used": "fabrication", // Skill trained and used for success checks
 "skills_required": [["survival", 1], ["throw", 2]], // Skills required to unlock recipe
 "book_learn": [              // (optional) Array of books that this recipe can be learned from. Each entry contains the id of the book and the skill level at which it can be learned.
@@ -1011,9 +1021,8 @@ Mods can modify this via `add:traits` and `remove:traits`.
     [ "textbook_gaswarfare", 8, "" ] // If the name is empty, the recipe is hidden, it will not be shown in the description of the book.
 ],
 "difficulty": 3,             // Difficulty of success check
-"time": "5 m",               // Preferred time to perform recipe, can specify in minutes, hours etc.
-"time": 5000,                // Legacy time to perform recipe (where 1000 ~= 10 turns ~= 10 seconds game time).
-"reversible": false,         // Can be disassembled.
+"time": "5 m",               // Time to perform the recipe specified as time string (can use minutes, hours, etc.)
+"time": 5000,                // Legacy time format, in moves. Won't be supported in the future. Here, 1000 ~= 10 turns ~= 10 seconds of game time
 "autolearn": true,           // Automatically learned upon gaining required skills
 "autolearn" : [              // Automatically learned upon gaining listed skills
     [ "survival", 2 ],
@@ -1024,6 +1033,7 @@ Mods can modify this via `add:traits` and `remove:traits`.
     [ "survival", 1 ],
     [ "fabrication", 2 ]
 ],
+"never_learn": false,        // Optional (default: false). Prevents this recipe from being learned by the player. For debug or NPC purposes.
 "batch_time_factors": [25, 15], // Optional factors for batch crafting time reduction. First number specifies maximum crafting time reduction as percentage, and the second number the minimal batch size to reach that number. In this example given batch size of 20 the last 6 crafts will take only 3750 time units.
 "flags": [                   // A set of strings describing boolean features of the recipe
   "BLIND_EASY",
@@ -1031,6 +1041,9 @@ Mods can modify this via `add:traits` and `remove:traits`.
 ],
 "construction_blueprint": "camp", // an optional string containing an update_mapgen_id.  Used by faction camps to upgrade their buildings. If non-empty, the function must exist.
 "on_display": false,         // this is a hidden construction item, used by faction camps to calculate construction times but not available to the player
+"using": [                   // Optional, string or array. Additional external requirements to use.
+  "butter_resealable_containers"
+],
 "qualities": [               // Generic qualities of tools needed to craft
   {"id":"CUT","level":1,"amount":1}
 ],

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -555,7 +555,7 @@ bool can_butcher_at( const tripoint &p )
             if( factor != INT_MIN  || factorD != INT_MIN ) {
                 has_corpse = true;
             }
-        } else if( you.can_disassemble( items_it, crafting_inv ).success() ) {
+        } else if( crafting::can_disassemble( you, items_it, crafting_inv ).success() ) {
             has_item = true;
         }
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -580,6 +580,13 @@ bool disassemble_activity_actor::try_start_single( player_activity &act, Charact
     const item &itm = *target.loc;
     const recipe &dis = recipe_dictionary::get_uncraft( itm.typeId() );
 
+    // Have to check here again in case we ran out of tools
+    const ret_val<bool> can_do = crafting::can_disassemble( who, itm, who.crafting_inventory() );
+    if( !can_do.success() ) {
+        who.add_msg_if_player( m_info, "%s", can_do.c_str() );
+        return false;
+    }
+
     int moves_needed = dis.time * target.count;
 
     act.moves_total = moves_needed;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -13,6 +13,7 @@
 #include "avatar.h"
 #include "calendar.h"
 #include "character.h"
+#include "crafting.h"
 #include "debug.h"
 #include "enums.h"
 #include "event.h"
@@ -37,6 +38,7 @@
 #include "player_activity.h"
 #include "point.h"
 #include "ranged.h"
+#include "recipe_dictionary.h"
 #include "rng.h"
 #include "sounds.h"
 #include "timed_event.h"
@@ -560,6 +562,85 @@ std::unique_ptr<activity_actor> dig_channel_activity_actor::deserialize( JsonIn 
     data.read( "byproducts_location", actor.byproducts_location );
     data.read( "byproducts_count", actor.byproducts_count );
     data.read( "byproducts_item_group", actor.byproducts_item_group );
+
+    return actor.clone();
+}
+
+bool disassemble_activity_actor::try_start_single( player_activity &act, Character &who )
+{
+    if( targets.empty() ) {
+        return false;
+    }
+    const iuse_location &target = targets.front();
+    if( !target.loc ) {
+        debugmsg( "Lost target of ACT_DISASSEMBLE" );
+        targets.clear();
+        return false;
+    }
+    const item &itm = *target.loc;
+    const recipe &dis = recipe_dictionary::get_uncraft( itm.typeId() );
+
+    int moves_needed = dis.time * target.count;
+
+    act.moves_total = moves_needed;
+    act.moves_left = moves_needed;
+    return true;
+}
+
+void disassemble_activity_actor::start( player_activity &act, Character &who )
+{
+    if( !who.is_avatar() ) {
+        debugmsg( "ACT_DISASSEMBLE is not implemented for NPCs" );
+        act.set_to_null();
+    } else if( !try_start_single( act, who ) ) {
+        act.set_to_null();
+    }
+}
+
+void disassemble_activity_actor::finish( player_activity &act, Character &who )
+{
+    const iuse_location &target = targets.front();
+    if( !target.loc ) {
+        debugmsg( "Lost target of ACT_DISASSEMBLY" );
+    } else {
+        crafting::complete_disassemble( who, target, get_map().getlocal( pos.raw() ) );
+    }
+    targets.erase( targets.begin() );
+
+    if( try_start_single( act, who ) ) {
+        return;
+    }
+
+    // Make a copy to avoid use-after-free
+    bool recurse = this->recursive;
+
+    act.set_to_null();
+
+    if( recurse ) {
+        crafting::disassemble_all( *who.as_avatar(), recurse );
+    }
+}
+
+void disassemble_activity_actor::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+
+    jsout.member( "targets", targets );
+    jsout.member( "pos", pos );
+    jsout.member( "recursive", recursive );
+
+    jsout.end_object();
+}
+
+std::unique_ptr<activity_actor> disassemble_activity_actor::deserialize( JsonIn &jsin )
+{
+    disassemble_activity_actor actor;
+
+    JsonObject data = jsin.get_object();
+
+    data.read( "targets", actor.targets );
+    data.read( "pos", actor.pos );
+    data.read( "recursive", actor.recursive );
 
     return actor.clone();
 }

--- a/src/activity_actor.h
+++ b/src/activity_actor.h
@@ -8,11 +8,48 @@
 
 #include "activity_type.h"
 #include "clone_ptr.h"
+#include "optional.h"
 
 class Character;
 class JsonIn;
 class JsonOut;
 class player_activity;
+
+struct act_progress_message {
+    /**
+     * Whether activity actor implements the method.
+     * TODO: remove once migration to actors is complete.
+     */
+    bool implemented = true;
+
+    cata::optional<std::string> msg_extra_info;
+    cata::optional<std::string> msg_full;
+
+    /**
+     * The text will completely overwrite default message.
+     */
+    static act_progress_message make_full( std::string &&text ) {
+        act_progress_message ret;
+        ret.msg_full = std::move( text );
+        return ret;
+    }
+
+    /**
+     * The text will be appended to default message.
+     */
+    static act_progress_message make_extra_info( std::string &&text ) {
+        act_progress_message ret;
+        ret.msg_extra_info = std::move( text );
+        return ret;
+    }
+
+    /**
+     * There will be no message shown.
+     */
+    static act_progress_message make_empty() {
+        return act_progress_message{};
+    }
+};
 
 class activity_actor
 {
@@ -97,6 +134,14 @@ class activity_actor
          * added to the `activity_actor_deserializers` hashmap in activity_actor.cpp
          */
         virtual void serialize( JsonOut &jsout ) const = 0;
+
+        virtual act_progress_message get_progress_message(
+            const player_activity &, const Character & ) const {
+            // TODO: make it create default message once migration to actors is complete.
+            act_progress_message msg;
+            msg.implemented = false;
+            return msg;
+        }
 };
 
 namespace activity_actors

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -4,6 +4,7 @@
 
 #include "activity_actor.h"
 
+#include "coordinates.h"
 #include "item_handling_util.h"
 #include "item_location.h"
 #include "memory_fast.h"
@@ -224,6 +225,40 @@ class dig_channel_activity_actor : public activity_actor
 
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonIn &jsin );
+};
+
+class disassemble_activity_actor : public activity_actor
+{
+    private:
+        std::vector<iuse_location> targets;
+        tripoint_abs_ms pos;
+        bool recursive = false;
+
+    public:
+        disassemble_activity_actor() = default;
+        disassemble_activity_actor(
+            std::vector<iuse_location> &&targets,
+            tripoint_abs_ms pos,
+            bool recursive
+        ) : targets( std::move( targets ) ), pos( pos ), recursive( recursive ) {}
+        ~disassemble_activity_actor() = default;
+
+        activity_id get_type() const override {
+            return activity_id( "ACT_DISASSEMBLE" );
+        }
+
+        void start( player_activity &act, Character &who ) override;
+        void do_turn( player_activity &, Character & ) override {};
+        void finish( player_activity &act, Character &who ) override;
+
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<disassemble_activity_actor>( *this );
+        }
+
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonIn &jsin );
+
+        bool try_start_single( player_activity &act, Character &who );
 };
 
 class drop_activity_actor : public activity_actor

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -233,6 +233,7 @@ class disassemble_activity_actor : public activity_actor
         std::vector<iuse_location> targets;
         tripoint_abs_ms pos;
         bool recursive = false;
+        int initial_num_targets = 0;
 
     public:
         disassemble_activity_actor() = default;
@@ -258,7 +259,11 @@ class disassemble_activity_actor : public activity_actor
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonIn &jsin );
 
+        act_progress_message get_progress_message(
+            const player_activity &, const Character & ) const override;
+
         bool try_start_single( player_activity &act, Character &who );
+        int calc_num_targets() const;
 };
 
 class drop_activity_actor : public activity_actor

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -120,7 +120,6 @@ static const activity_id ACT_CONSUME_FOOD_MENU( "ACT_CONSUME_FOOD_MENU" );
 static const activity_id ACT_CONSUME_MEDS_MENU( "ACT_CONSUME_MEDS_MENU" );
 static const activity_id ACT_CRACKING( "ACT_CRACKING" );
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
-static const activity_id ACT_DISASSEMBLE( "ACT_DISASSEMBLE" );
 static const activity_id ACT_DISMEMBER( "ACT_DISMEMBER" );
 static const activity_id ACT_DISSECT( "ACT_DISSECT" );
 static const activity_id ACT_EAT_MENU( "ACT_EAT_MENU" );
@@ -390,7 +389,6 @@ activity_handlers::finish_functions = {
     { ACT_SOCIALIZE, socialize_finish },
     { ACT_TRY_SLEEP, try_sleep_finish },
     { ACT_OPERATION, operation_finish },
-    { ACT_DISASSEMBLE, disassemble_finish },
     { ACT_VIBE, vibe_finish },
     { ACT_ATM, atm_finish },
     { ACT_EAT_MENU, eat_menu_finish },
@@ -3990,11 +3988,6 @@ void activity_handlers::craft_do_turn( player_activity *act, player *p )
             p->cancel_activity();
         }
     }
-}
-
-void activity_handlers::disassemble_finish( player_activity *, player *p )
-{
-    p->complete_disassemble();
 }
 
 void activity_handlers::vibe_finish( player_activity *act, player *p )

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -242,7 +242,6 @@ void wait_stamina_finish( player_activity *act, player *p );
 void socialize_finish( player_activity *act, player *p );
 void try_sleep_finish( player_activity *act, player *p );
 void operation_finish( player_activity *act, player *p );
-void disassemble_finish( player_activity *act, player *p );
 void vibe_finish( player_activity *act, player *p );
 void hand_crank_finish( player_activity *act, player *p );
 void atm_finish( player_activity *act, player *p );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2007,6 +2007,7 @@ static disass_prompt_result prompt_disassemble_in_seq( avatar &you, const item &
         msg += "\n";
         msg += _( "Really disassemble?\n" );
         if( !query_yn( msg ) ) {
+            add_msg( _( "Never mind." ) );
             return res;
         }
     }
@@ -2035,6 +2036,7 @@ static disass_prompt_result prompt_disassemble_in_seq( avatar &you, const item &
             int result = num_batches;
             popup_input.title( title ).description( descr ).edit( result );
             if( popup_input.canceled() || result <= 0 ) {
+                add_msg( _( "Never mind." ) );
                 return res;
             }
             res.batches = std::min( result, num_batches );
@@ -2055,7 +2057,6 @@ static bool prompt_disassemble_single( avatar &you, item_location target, bool i
     disass_prompt_result res = prompt_disassemble_in_seq( you, *target, interactive, false );
 
     if( !res.success ) {
-        add_msg( _( "Never mind." ) );
         return false;
     }
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "activity_actor_definitions.h"
 #include "activity_handlers.h"
 #include "avatar.h"
 #include "bionics.h"
@@ -102,7 +103,6 @@ static const std::string flag_NO_RESIZE( "NO_RESIZE" );
 static const std::string flag_NO_UNLOAD( "NO_UNLOAD" );
 static const std::string flag_NUTRIENT_OVERRIDE( "NUTRIENT_OVERRIDE" );
 static const std::string flag_UNCRAFT_LIQUIDS_CONTAINED( "UNCRAFT_LIQUIDS_CONTAINED" );
-static const std::string flag_UNCRAFT_SINGLE_CHARGE( "UNCRAFT_SINGLE_CHARGE" );
 static const std::string flag_VARSIZE( "VARSIZE" );
 
 class basecamp;
@@ -1873,7 +1873,8 @@ void player::consume_tools( const std::vector<tool_comp> &tools, int batch,
                    cost_adjustment::none ), batch );
 }
 
-ret_val<bool> player::can_disassemble( const item &obj, const inventory &inv ) const
+ret_val<bool> crafting::can_disassemble( const Character &who, const item &obj,
+        const inventory &inv )
 {
     const auto &r = recipe_dictionary::get_uncraft( obj.typeId() );
 
@@ -1882,7 +1883,7 @@ ret_val<bool> player::can_disassemble( const item &obj, const inventory &inv ) c
     }
 
     // check sufficient light
-    if( lighting_crafting_speed_multiplier( *this, r ) == 0.0f ) {
+    if( lighting_crafting_speed_multiplier( who, r ) == 0.0f ) {
         return ret_val<bool>::make_failure( _( "You can't see to craft!" ) );
     }
 
@@ -1899,15 +1900,12 @@ ret_val<bool> player::can_disassemble( const item &obj, const inventory &inv ) c
                                             monster );
     }
 
-    if( !obj.is_ammo() ) { //we get ammo quantity to disassemble later on
-        if( obj.count_by_charges() && !r.has_flag( flag_UNCRAFT_SINGLE_CHARGE ) ) {
-            // Create a new item to get the default charges
-            int qty = r.create_result().charges;
-            if( obj.charges < qty ) {
-                auto msg = vgettext( "You need at least %d charge of %s.",
-                                     "You need at least %d charges of %s.", qty );
-                return ret_val<bool>::make_failure( msg, qty, obj.tname() );
-            }
+    if( obj.count_by_charges() ) {
+        int batch_size = r.disassembly_batch_size();
+        if( obj.charges < batch_size ) {
+            auto msg = vgettext( "You need at least %d charge of %s.",
+                                 "You need at least %d charges of %s.", batch_size );
+            return ret_val<bool>::make_failure( msg, batch_size, obj.tname() );
         }
     }
     const auto &dis = r.disassembly_requirements();
@@ -1946,46 +1944,45 @@ ret_val<bool> player::can_disassemble( const item &obj, const inventory &inv ) c
     return ret_val<bool>::make_success();
 }
 
-bool player::disassemble()
+struct disass_prompt_result {
+    bool success = false;
+    cata::optional<int> batches;
+    const recipe *r = nullptr;
+};
+
+static disass_prompt_result prompt_disassemble_in_seq( avatar &you, const item &obj,
+        bool interactive, bool autoselect_max )
 {
-    return disassemble( game_menus::inv::disassemble( *this ), false );
-}
+    disass_prompt_result res;
 
-bool player::disassemble( item_location target, bool interactive )
-{
-    if( !target ) {
-        add_msg( _( "Never mind." ) );
-        return false;
-    }
+    const ret_val<bool> can_do = crafting::can_disassemble( you, obj, you.crafting_inventory() );
 
-    const item &obj = *target;
-    const auto ret = can_disassemble( obj, crafting_inventory() );
-
-    if( !ret.success() ) {
+    if( !can_do.success() ) {
         if( interactive ) {
-            add_msg_if_player( m_info, "%s", ret.c_str() );
+            you.add_msg_if_player( m_info, "%s", can_do.c_str() );
         }
-        return false;
+        return res;
     }
 
-    const auto &r = recipe_dictionary::get_uncraft( obj.typeId() );
-    if( !obj.is_owned_by( g->u, true ) ) {
+    const recipe &r = recipe_dictionary::get_uncraft( obj.typeId() );
+    res.r = &r;
+    if( !obj.is_owned_by( you, true ) ) {
         if( !query_yn( _( "Disassembling the %s may anger the people who own it, continue?" ),
                        obj.tname() ) ) {
-            return false;
+            return res;
         } else {
             if( obj.get_owner() ) {
                 std::vector<npc *> witnesses;
                 for( npc &elem : g->all_npcs() ) {
-                    if( rl_dist( elem.pos(), g->u.pos() ) < MAX_VIEW_DISTANCE && elem.get_faction() &&
-                        obj.is_owned_by( elem ) && elem.sees( g->u.pos() ) ) {
+                    if( rl_dist( elem.pos(), you.pos() ) < MAX_VIEW_DISTANCE && elem.get_faction() &&
+                        obj.is_owned_by( elem ) && elem.sees( you.pos() ) ) {
                         elem.say( "<witnessed_thievery>", 7 );
                         npc *npc_to_add = &elem;
                         witnesses.push_back( npc_to_add );
                     }
                 }
                 if( !witnesses.empty() ) {
-                    if( g->u.add_faction_warning( obj.get_owner() ) ) {
+                    if( you.add_faction_warning( obj.get_owner() ) ) {
                         for( npc *elem : witnesses ) {
                             elem->make_angry();
                         }
@@ -1994,139 +1991,130 @@ bool player::disassemble( item_location target, bool interactive )
             }
         }
     }
-    // last chance to back out
+
+    int batch_size = r.disassembly_batch_size();
+
     if( interactive && get_option<bool>( "QUERY_DISASSEMBLE" ) ) {
-        std::string list;
-        const auto components = obj.get_uncraft_components();
-        for( const auto &component : components ) {
-            list += "- " + component.to_string() + "\n";
+        std::string msg;
+        msg += string_format( _( "Disassembling the %s may yield:\n" ),
+                              colorize( obj.tname(), obj.color_in_inventory() ) );
+        const std::vector<item_comp> components = obj.get_uncraft_components();
+        for( const item_comp &component : components ) {
+            msg += "- " + component.to_string() + "\n";
         }
-        if( !knows_recipe( &r ) && can_learn_by_disassembly( r ) ) {
-            if( !query_yn(
-                    _( "Disassembling the %s may yield:\n%s\nReally disassemble?\nYou feel you may be able to understand this object's construction.\n" ),
-                    colorize( obj.tname(), obj.color_in_inventory() ),
-                    list ) ) {
-                return false;
-            }
-        } else if( !query_yn( _( "Disassembling the %s may yield:\n%s\nReally disassemble?" ),
-                              colorize( obj.tname(), obj.color_in_inventory() ),
-                              list ) ) {
-            return false;
+        if( batch_size != 1 ) {
+            msg += string_format( _( "(per batch of %d)\n" ), batch_size );
         }
-    }
-    // If we're disassembling ammo, prompt the player to specify amount
-    // This could be extended more generally in the future
-    int num_dis = 0;
-    if( obj.is_ammo() && !r.has_flag( "UNCRAFT_BY_QUANTITY" ) ) {
-        string_input_popup popup_input;
-        const std::string title = string_format( _( "Disassemble how many %s [MAX: %d]: " ),
-                                  obj.type_name( 1 ), obj.charges );
-        popup_input.title( title ).edit( num_dis );
-        if( popup_input.canceled() || num_dis <= 0 ) {
-            add_msg( _( "Never mind." ) );
-            return false;
+        msg += "\n";
+        msg += _( "Really disassemble?\n" );
+        if( !query_yn( msg ) ) {
+            return res;
         }
     }
 
-    if( activity.id() != ACT_DISASSEMBLE ) {
-        if( num_dis != 0 ) {
-            assign_activity( ACT_DISASSEMBLE, r.time * num_dis );
+    if( obj.count_by_charges() ) {
+        int num_batches = obj.charges / batch_size;
+        if( num_batches == 0 ) {
+            // Not enough charges for even one disassembly
+            return res;
+        } else if( num_batches == 1 || autoselect_max ) {
+            // Skip prompt if can only do 1, or if we're doing all
+            res.batches = num_batches;
         } else {
-            assign_activity( ACT_DISASSEMBLE, r.time );
+            string_input_popup popup_input;
+            std::string title;
+            std::string descr;
+            if( batch_size != 1 ) {
+                descr = string_format( _( "Disassembly will be done in batches of %d." ), batch_size );
+                title = string_format(
+                            _( "Disassemble how many batches of %s [MAX: %d]: " ),
+                            obj.type_name( 1 ), num_batches );
+            } else {
+                title = string_format( _( "Disassemble how many %s [MAX: %d]: " ),
+                                       obj.type_name( 1 ), num_batches );
+            }
+            int result = num_batches;
+            popup_input.title( title ).description( descr ).edit( result );
+            if( popup_input.canceled() || result <= 0 ) {
+                return res;
+            }
+            res.batches = std::min( result, num_batches );
         }
-    } else if( activity.moves_left <= 0 ) {
-        activity.moves_left = r.time;
     }
 
-    // index is used as a bool that indicates if we want recursive uncraft.
-    activity.index = false;
-    activity.targets.emplace_back( std::move( target ) );
-    activity.str_values.push_back( r.result().str() );
-    // Unused position attribute used to store ammo to disassemble
-    activity.position = std::min( num_dis, obj.charges );
+    res.success = true;
+    return res;
+}
+
+static bool prompt_disassemble_single( avatar &you, item_location target, bool interactive )
+{
+    if( !target ) {
+        add_msg( _( "Never mind." ) );
+        return false;
+    }
+
+    disass_prompt_result res = prompt_disassemble_in_seq( you, *target, interactive, false );
+
+    if( !res.success ) {
+        add_msg( _( "Never mind." ) );
+        return false;
+    }
+
+    iuse_location loc;
+    loc.loc = target;
+    loc.count = res.batches ? *res.batches : 1;
+
+    tripoint_abs_ms pos_abs( get_map().getabs( you.pos() ) );
+
+    you.assign_activity( disassemble_activity_actor( {{ loc }}, pos_abs, false ) );
 
     return true;
 }
 
-void player::disassemble_all( bool one_pass )
+bool crafting::disassemble( avatar &you )
 {
-    // Reset all the activity values
-    assign_activity( ACT_DISASSEMBLE, 0 );
+    item_location target = game_menus::inv::disassemble( you );
+    return prompt_disassemble_single( you, target, false );
+}
 
-    bool found_any = false;
-    for( item &it : get_map().i_at( pos() ) ) {
-        if( disassemble( item_location( map_cursor( pos() ), &it ), false ) ) {
-            found_any = true;
+bool crafting::disassemble( avatar &you, item_location target )
+{
+    return prompt_disassemble_single( you, target, true );
+}
+
+bool crafting::disassemble_all( avatar &you, bool recursively )
+{
+    std::vector<iuse_location> targets;
+
+    tripoint pos = you.pos();
+
+    for( item &itm : get_map().i_at( pos ) ) {
+        disass_prompt_result res = prompt_disassemble_in_seq( you, itm, false, true );
+        if( res.success ) {
+            iuse_location loc;
+            loc.loc = item_location( map_cursor( pos ), &itm );
+            loc.count = res.batches ? *res.batches : 1;
+            targets.push_back( std::move( loc ) );
         }
     }
 
-    // index is used as a bool that indicates if we want recursive uncraft.
-    // Upon calling complete_disassemble, if we have no targets left,
-    // we will call this function again.
-    activity.index = !one_pass;
+    if( !targets.empty() ) {
+        tripoint_abs_ms pos_abs( get_map().getabs( you.pos() ) );
 
-    if( !found_any ) {
-        // Reset the activity - don't loop if there is nothing to do
-        activity = player_activity();
-    }
-}
-
-void player::complete_disassemble()
-{
-    // Cancel the activity if we have bad (possibly legacy) values
-    if( activity.targets.empty() || !activity.targets.back() ||
-        activity.targets.size() != activity.str_values.size() ) {
-        debugmsg( "bad disassembly activity values" );
-        activity.set_to_null();
-        return;
-    }
-
-    // Disassembly has 2 parallel vectors:
-    // item location, and recipe id
-    const recipe &rec = recipe_dictionary::get_uncraft( itype_id( activity.str_values.back() ) );
-
-    if( rec ) {
-        complete_disassemble( activity.targets.back(), rec );
+        you.assign_activity( disassemble_activity_actor( std::move( targets ), pos_abs, recursively ) );
+        return true;
     } else {
-        debugmsg( "bad disassembly recipe: %d", activity.str_values.back() );
-        activity.set_to_null();
-        return;
+        return false;
     }
-
-    activity.targets.pop_back();
-    activity.str_values.pop_back();
-
-    // If we have no more targets end the activity or start a second round
-    if( activity.targets.empty() ) {
-        // index is used as a bool that indicates if we want recursive uncraft.
-        if( activity.index ) {
-            disassemble_all( false );
-            return;
-        } else {
-            // No more targets
-            activity.set_to_null();
-            return;
-        }
-    }
-
-    // Set get and set duration of next uncraft
-    const recipe &next_recipe = recipe_dictionary::get_uncraft( itype_id(
-                                    activity.str_values.back() ) );
-
-    if( !next_recipe ) {
-        debugmsg( "bad disassembly recipe: %d", activity.str_values.back() );
-        activity.set_to_null();
-        return;
-    }
-
-    activity.moves_left = next_recipe.time;
 }
 
-void player::complete_disassemble( item_location &target, const recipe &dis )
+void crafting::complete_disassemble( Character &who, iuse_location target, const tripoint &/*pos*/ )
 {
+    item &org_item = *target.loc;
+    const recipe &dis = recipe_dictionary::get_uncraft( org_item.typeId() );
+
     // Get the proper recipe - the one for disassembly, not assembly
     const auto dis_requirements = dis.disassembly_requirements();
-    item &org_item = *target;
     const bool filthy = org_item.is_filthy();
 
     // Make a copy to keep its data (damage/components) even after it
@@ -2137,44 +2125,39 @@ void player::complete_disassemble( item_location &target, const recipe &dis )
 
     add_msg( _( "You disassemble the %s into its components." ), dis_item.tname() );
     // Remove any batteries, ammo and mods first
-    remove_ammo( dis_item, *this );
-    remove_radio_mod( dis_item, *this );
+    remove_ammo( dis_item, who );
+    remove_radio_mod( dis_item, *who.as_player() );
 
-    if( dis_item.count_by_charges() ) {
-        // remove the charges that one would get from crafting it
-        if( org_item.is_ammo() && !dis.has_flag( "UNCRAFT_BY_QUANTITY" ) ) {
-            //subtract selected number of rounds to disassemble
-            org_item.charges -= activity.position;
-        } else {
-            org_item.charges -= dis.create_result().charges;
-        }
+    if( org_item.count_by_charges() ) {
+        int batch_size = dis.disassembly_batch_size();
+        org_item.charges -= batch_size * target.count;
     }
     // remove the item, except when it's counted by charges and still has some
     if( !org_item.count_by_charges() || org_item.charges <= 0 ) {
-        target.remove_item();
+        target.loc.remove_item();
     }
 
     // Consume tool charges
     for( const auto &it : dis_requirements.get_tools() ) {
-        consume_tools( it );
+        who.as_player()->consume_tools( it );
     }
 
     // add the components to the map
     // Player skills should determine how many components are returned
 
-    int skill_dice = 2 + get_skill_level( dis.skill_used ) * 3;
-    skill_dice += get_skill_level( dis.skill_used );
+    int skill_dice = 2 + who.get_skill_level( dis.skill_used ) * 3;
+    skill_dice += who.get_skill_level( dis.skill_used );
 
     // Sides on dice is 16 plus your current intelligence
     ///\EFFECT_INT increases success rate for disassembling items
-    int skill_sides = 16 + int_cur;
+    int skill_sides = 16 + who.int_cur;
 
     int diff_dice = dis.difficulty;
     int diff_sides = 24; // 16 + 8 (default intelligence)
 
     // disassembly only nets a bit of practice
     if( dis.skill_used ) {
-        practice( dis.skill_used, ( dis.difficulty ) * 2, dis.difficulty );
+        who.as_player()->practice( dis.skill_used, ( dis.difficulty ) * 2, dis.difficulty );
     }
 
     // If the components aren't empty, we want items exactly identical to them
@@ -2186,16 +2169,8 @@ void player::complete_disassemble( item_location &target, const recipe &dis )
         const bool uncraft_liquids_contained = dis.has_flag( flag_UNCRAFT_LIQUIDS_CONTAINED );
         for( const auto &altercomps : dis_requirements.get_components() ) {
             const item_comp &comp = altercomps.front();
-            int compcount = comp.count;
+            int compcount = comp.count * target.count;
             item newit( comp.type, calendar::turn );
-            //If ammo, overwrite component count with selected quantity of ammo
-            if( dis_item.is_ammo() ) {
-                compcount *= activity.position;
-            } else if( dis_item.count_by_charges() && dis.has_flag( flag_UNCRAFT_SINGLE_CHARGE ) ) {
-                // Counted-by-charge items that can be disassembled individually
-                // have their component count multiplied by the number of charges.
-                compcount *= std::min( dis_item.charges, dis.create_result().charges );
-            }
             const bool is_liquid = newit.made_of( LIQUID );
             if( uncraft_liquids_contained && is_liquid && newit.charges != 0 ) {
                 // Spawn liquid item in its default container
@@ -2273,14 +2248,14 @@ void player::complete_disassemble( item_location &target, const recipe &dis )
         }
     }
 
-    put_into_vehicle_or_drop( *this, item_drop_reason::deliberate, drop_items );
+    put_into_vehicle_or_drop( who, item_drop_reason::deliberate, drop_items );
 
-    if( !dis.learn_by_disassembly.empty() && !knows_recipe( &dis ) ) {
-        if( can_learn_by_disassembly( dis ) ) {
+    if( !dis.learn_by_disassembly.empty() && !who.knows_recipe( &dis ) ) {
+        if( who.can_learn_by_disassembly( dis ) ) {
             // TODO: make this depend on intelligence
             if( one_in( 4 ) ) {
                 // TODO: change to forward an id or a reference
-                learn_recipe( &dis.ident().obj() );
+                who.learn_recipe( &dis.ident().obj() );
                 add_msg( m_good, _( "You learned a recipe for %s from disassembling it!" ),
                          dis_item.tname() );
             } else {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -77,7 +77,6 @@
 #include "vpart_position.h"
 
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
-static const activity_id ACT_DISASSEMBLE( "ACT_DISASSEMBLE" );
 
 static const efftype_id effect_contacts( "contacts" );
 

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -5,14 +5,19 @@
 #include <list>
 #include <set>
 #include <vector>
+
 #include "point.h"
+#include "ret_val.h"
 #include "type_id.h"
 
+class avatar;
 class Character;
 class inventory;
 class item;
+class item_location;
 class player;
 class recipe;
+struct iuse_location;
 struct tool_comp;
 
 enum class cost_adjustment : int;
@@ -97,6 +102,29 @@ comp_selection<tool_comp>
 select_tool_component( const std::vector<tool_comp> &tools, int batch, const inventory &map_inv,
                        const Character *player_with_inv,
                        bool can_cancel = false );
+
+/** Check if character can disassemble an item using the given crafting inventory. */
+ret_val<bool> can_disassemble( const Character &who, const item &obj, const inventory &inv );
+
+/**
+ * Prompt for an item to disassemble, then start activity.
+ */
+bool disassemble( avatar &you );
+
+/**
+ * Prompt to disassemble given item, then start activity.
+ */
+bool disassemble( avatar &you, item_location target );
+
+/**
+ * Start an activity to disassemble all items in avatar's square.
+ */
+bool disassemble_all( avatar &you, bool recursively );
+
+/**
+ * Complete disassembly of target item.
+ */
+void complete_disassemble( Character &who, iuse_location target, const tripoint &pos );
 
 } // namespace crafting
 

--- a/src/examine_item_menu.cpp
+++ b/src/examine_item_menu.cpp
@@ -6,6 +6,7 @@
 #include "auto_pickup.h"
 #include "avatar_action.h"
 #include "avatar.h"
+#include "crafting.h"
 #include "game_inventory.h"
 #include "input.h"
 #include "item.h"
@@ -182,7 +183,7 @@ bool run(
     } );
 
     add_entry( "DISASSEMBLE", rate_action_disassemble( you, itm ), [&]() {
-        you.disassemble( loc, false );
+        crafting::disassemble( you, loc );
         return true;
     } );
 
@@ -419,7 +420,7 @@ hint_rating rate_action_mend( const avatar &/*you*/, const item &it )
 
 hint_rating rate_action_disassemble( avatar &you, const item &it )
 {
-    if( you.can_disassemble( it, you.crafting_inventory() ).success() ) {
+    if( crafting::can_disassemble( you, it, you.crafting_inventory() ).success() ) {
         return hint_rating::good; // possible
     } else if( recipe_dictionary::get_uncraft( it.typeId() ) ) {
         return hint_rating::iffy; // potentially possible but we currently lack requirements

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -57,6 +57,7 @@
 #include "construction.h"
 #include "coordinate_conversions.h"
 #include "coordinates.h"
+#include "crafting.h"
 #include "creature_tracker.h"
 #include "cursesport.h"
 #include "damage.h"
@@ -8432,7 +8433,7 @@ void game::butcher()
             if( ( salvage_tool_index != INT_MIN ) && salvage_iuse->valid_to_cut_up( *it ) ) {
                 salvageables.push_back( it );
             }
-            if( u.can_disassemble( *it, crafting_inv ).success() ) {
+            if( crafting::can_disassemble( u, *it, crafting_inv ).success() ) {
                 disassembles.push_back( it );
             } else if( !first_item_without_tools ) {
                 first_item_without_tools = &*it;
@@ -8455,7 +8456,7 @@ void game::butcher()
         if( first_item_without_tools ) {
             add_msg( m_info, _( "You don't have the necessary tools to disassemble any items here." ) );
             // Just for the "You need x to disassemble y" messages
-            const auto ret = u.can_disassemble( *first_item_without_tools, crafting_inv );
+            const auto ret = crafting::can_disassemble( u, *first_item_without_tools, crafting_inv );
             if( !ret.success() ) {
                 add_msg( m_info, "%s", ret.c_str() );
             }
@@ -8585,10 +8586,10 @@ void game::butcher()
                     }
                     break;
                 case MULTIDISASSEMBLE_ONE:
-                    u.disassemble_all( true );
+                    crafting::disassemble_all( u, false );
                     break;
                 case MULTIDISASSEMBLE_ALL:
-                    u.disassemble_all( false );
+                    crafting::disassemble_all( u, true );
                     break;
                 default:
                     debugmsg( "Invalid butchery type: %d", indexer_index );
@@ -8603,7 +8604,7 @@ void game::butcher()
         case BUTCHER_DISASSEMBLE: {
             // Pick index of first item in the disassembly stack
             item *const target = &*disassembly_stacks[indexer_index].first;
-            u.disassemble( item_location( map_cursor( u.pos() ), target ), true );
+            crafting::disassemble( u, item_location( map_cursor( u.pos() ), target ) );
         }
         break;
         case BUTCHER_SALVAGE: {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -14,6 +14,7 @@
 #include "bionics.h"
 #include "calendar.h"
 #include "cata_utility.h"
+#include "crafting.h"
 #include "character.h"
 #include "character_functions.h"
 #include "character_martial_arts.h"
@@ -476,7 +477,7 @@ class disassemble_inventory_preset : public pickup_inventory_preset
         }
 
         std::string get_denial( const item_location &loc ) const override {
-            const auto ret = p.can_disassemble( *loc, inv );
+            const ret_val<bool> ret = crafting::can_disassemble( p, *loc, inv );
             if( !ret.success() ) {
                 return ret.str();
             }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -23,6 +23,7 @@
 #include "clzones.h"
 #include "color.h"
 #include "construction.h"
+#include "crafting.h"
 #include "cursesdef.h"
 #include "damage.h"
 #include "debug.h"
@@ -2144,7 +2145,7 @@ bool game::handle_action()
                 } else if( u.is_mounted() ) {
                     add_msg( m_info, _( "You can't disassemble items while you're riding." ) );
                 } else {
-                    u.disassemble();
+                    crafting::disassemble( u );
                 }
                 break;
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9597,6 +9597,10 @@ int iuse::craft( player *p, item *it, bool, const tripoint &pos )
 
 int iuse::disassemble( player *p, item *it, bool, const tripoint & )
 {
+    if( !p->is_avatar() ) {
+        debugmsg( "disassemble iuse is not implemented for NPCs." );
+        return 0;
+    }
     if( p->is_mounted() ) {
         p->add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
         return 0;
@@ -9605,7 +9609,7 @@ int iuse::disassemble( player *p, item *it, bool, const tripoint & )
         return 0;
     }
 
-    p->disassemble( item_location( *p, it ), false );
+    crafting::disassemble( *p->as_avatar(), item_location( *p, it ) );
 
     return 0;
 }

--- a/src/player.h
+++ b/src/player.h
@@ -559,18 +559,6 @@ class player : public Character
          * multiple steps of incremental skill gain simultaneously if needed.
          */
         void craft_skill_gain( const item &craft, const int &multiplier );
-        /**
-         * Check if the player can disassemble an item using the current crafting inventory
-         * @param obj Object to check for disassembly
-         * @param inv current crafting inventory
-         */
-        ret_val<bool> can_disassemble( const item &obj, const inventory &inv ) const;
-
-        bool disassemble();
-        bool disassemble( item_location target, bool interactive = true );
-        void disassemble_all( bool one_pass ); // Disassemble all items on the tile
-        void complete_disassemble();
-        void complete_disassemble( item_location &target, const recipe &dis );
 
         const requirement_data *select_requirements(
             const std::vector<const requirement_data *> &, int batch, const inventory &,

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -227,7 +227,6 @@ cata::optional<std::string> player_activity::get_progress_message( const avatar 
             type == activity_id( "ACT_HACKSAW" ) ||
             type == activity_id( "ACT_JACKHAMMER" ) ||
             type == activity_id( "ACT_PICKAXE" ) ||
-            type == activity_id( "ACT_DISASSEMBLE" ) ||
             type == activity_id( "ACT_VEHICLE" ) ||
             type == activity_id( "ACT_FILL_PIT" ) ||
             type == activity_id( "ACT_DIG" ) ||

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -179,6 +179,19 @@ cata::optional<std::string> player_activity::get_progress_message( const avatar 
         return cata::optional<std::string>();
     }
 
+    if( actor ) {
+        act_progress_message msg = actor->get_progress_message( *this, u );
+        if( msg.implemented ) {
+            if( msg.msg_full ) {
+                return *msg.msg_full;
+            } else if( msg.msg_extra_info ) {
+                return string_format( _( "%s: %s" ), get_verb().translated(), *msg.msg_extra_info );
+            } else {
+                return cata::nullopt;
+            }
+        }
+    }
+
     if( type == activity_id( "ACT_ADV_INVENTORY" ) ||
         type == activity_id( "ACT_AIM" ) ||
         type == activity_id( "ACT_ARMOR_LAYERS" ) ||

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -817,3 +817,16 @@ int recipe::makes_amount() const
     // return either charges * mult or 1
     return makes ? makes * result_mult : 1 ;
 }
+
+int recipe::disassembly_batch_size() const
+{
+    if( !result_->count_by_charges() ) {
+        return 1;
+    } else if( charges.has_value() ) {
+        return *charges;
+    } else if( has_flag( "UNCRAFT_SINGLE_CHARGE" ) ) {
+        return 1;
+    } else {
+        return result_->charges_default();
+    }
+}

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -379,6 +379,14 @@ std::string recipe::get_consistency_error() const
         return "specifies charges but result is not counted by charges";
     }
 
+    if( charges && result_mult != 1 ) {
+        return "specifies both charges and result_mult";
+    }
+
+    if( result_mult != 1 && reversible ) {
+        return "is reversible, so can't use result_mult";
+    }
+
     const auto is_invalid_bp = []( const std::pair<itype_id, int> &elem ) {
         return !elem.first.is_valid();
     };

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -352,6 +352,28 @@ void recipe::finalize()
             autolearn_requirements[ skill_used ] = difficulty;
         }
     }
+
+    {
+        auto it = flags.find( "UNCRAFT_SINGLE_CHARGE" );
+        if( it != flags.end() ) {
+            flags.erase( it );
+            charges = 1;
+            if( json_report_strict || !result_->count_by_charges() ) {
+                debugmsg( "recipe %s uses obsolete flag UNCRAFT_SINGLE_CHARGE, replace with \"charges\": 1",
+                          ident() );
+            }
+        }
+    }
+    {
+        auto it = flags.find( "UNCRAFT_BY_QUANTITY" );
+        if( it != flags.end() ) {
+            flags.erase( it );
+            if( json_report_strict ) {
+                debugmsg( "recipe %s uses obsolete flag UNCRAFT_BY_QUANTITY",
+                          ident() );
+            }
+        }
+    }
 }
 
 void recipe::add_requirements( const std::vector<std::pair<requirement_id, int>> &reqs )
@@ -824,8 +846,6 @@ int recipe::disassembly_batch_size() const
         return 1;
     } else if( charges.has_value() ) {
         return *charges;
-    } else if( has_flag( "UNCRAFT_SINGLE_CHARGE" ) ) {
-        return 1;
     } else {
         return result_->charges_default();
     }

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -176,8 +176,10 @@ class recipe
 
         bool hot_result() const;
 
-        // Returns the ammount or charges recipe will produce.
+        /** Returns the amount or charges recipe will produce. */
         int makes_amount() const;
+        /** Returns number of charges of the item needed for single disassembly. */
+        int disassembly_batch_size() const;
 
     private:
         void add_requirements( const std::vector<std::pair<requirement_id, int>> &reqs );


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed multiple issues with disassembly of count-by-charges items"

#### Purpose of change
Fix #71
Fix #621
Fix #1450
Fix the following bug:
1. Spawn and drop 1 processor board and 1 small LCD screen
2. Spawn 1 screwdriver and 1 soldering iron with 5 charges
3. Enter butcher menu -> Disassemble everything once
4. Expected: 5 charges is enough to disassemble only 1 item. Got: 5 charges are magically enough to disassemble both items, whereas each requires 5 on their own.

Fix the following bug:
1. Spawn and drop 1 soldering iron, then 1 processor board (order is important)
2. Spawn 1 screwdriver
3. Enter butcher menu -> Disassemble everything once
4. Expected: character disassembles the soldering iron, then fails to disassemble processor board due to missing requirements. Got: character disassembles the soldering iron, then disassembles the processor board with... their... bare hands?

#### Describe the solution
1. Rewrite disassembly activity from scratch.
    * Use an activity actor, which allows activity variables to have proper names
    * Track amount to disassemble on a per-item basis rather than per-activity
    * Check for requirements before starting each disassembly operation
5. Simplify handling of charges required for single disassembly
    * Get rid of `UNCRAFT_BY_QUANTITY` flag, it's just a hack that doesn't even work
    * Get rid of `UNCRAFT_SINGLE_CHARGE` flag, it duplicates functionality of `charges` field
    * Add `int disassembly_batch_size()` method to `recipe` which reports how much charges of item are needed for single disassembly operation. When trying to disassemble a count-by-charges item, use this value to determine how many "batches" of the item can be disassembled. The batch size value is derived from `result` and `charges` fields, which guarantees correctness of autogenerated uncraft recipes.
6. Update existing uncraft recipes to use new functionality
7. For `M72 LAW`, make only the packed version uncraftable. Handwave it as unpacked being armed and so too dangerous to uncraft.
8. As usual, move a bunch of methods out of `player`.
9. Update the docs

#### Describe alternatives you've considered
Not much alternatives here, it's just bugfixes.
The fix for `M72 LAW` is not perfect, but it's also the simplest solution.

#### Testing
Repeated steps from described issues, saw them resolved.