### PR TITLE
2 Fixes of shotgun shell recipes

### DIFF
--- a/data/json/recipes/ammo/shot.json
+++ b/data/json/recipes/ammo/shot.json
@@ -417,6 +417,7 @@
     "difficulty": 2,
     "skills_required": [ "gun", 1 ],
     "time": "2 m",
+    "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_bullets", 2 ], [ "manual_shotgun", 2 ] ],
     "charges": 1,
     "reversible": true,
@@ -537,7 +538,7 @@
     "using": [ [ "ammo_shot", 2 ] ],
     "tools": [ [ [ "press", -1 ], [ "press_dowel", -1 ] ] ],
     "components": [
-      [ [ "chem_black_powder", 6 ] ],
+      [ [ "chem_black_powder", 12 ] ],
       [
         [ "scrap", 1 ],
         [ "nail", 10 ],


### PR DESCRIPTION
Fixes 2 minor things:

black powder 00 shots was missing the batch time

black powder junk shots were using 50% of black powder actually needed.