### PR TITLE
Craft and uncraft recipe CBM (mod Aftershok)

### DIFF
--- a/data/mods/Aftershock/recipes/uncraft_bionic.json
+++ b/data/mods/Aftershock/recipes/uncraft_bionic.json
@@ -1,0 +1,115 @@
+[
+  {
+    "type": "uncraft",
+    "result": "bio_power_storage",
+    "skill_used": "electronics",
+    "difficulty": 6,
+    "time": "4 h",
+    "decomp_learn": 5,
+    "using": [ [ "soldering_standard", 20 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "BIONIC_ASSEMBLY", "level": 2 } ],
+    "components": [
+      [ [ "afs_energy_storage_3", 2 ] ],
+      [ [ "afs_material_1", 6 ] ],
+      [ [ "plut_cell", 1 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
+  },
+  {
+    "type": "uncraft",
+    "result": "bio_power_storage_mkII",
+    "skill_used": "electronics",
+    "difficulty": 10,
+    "time": "4 h",
+    "decomp_learn": 8,
+    "using": [ [ "soldering_standard", 20 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "BIONIC_ASSEMBLY", "level": 2 } ],
+    "components": [
+      [ [ "afs_energy_storage_4", 2 ] ],
+      [ [ "afs_material_1", 6 ] ],
+      [ [ "plut_cell", 2 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
+  },
+  {
+    "type": "uncraft",
+    "result": "bio_batteries",
+    "skill_used": "electronics",
+    "difficulty": 7,
+    "time": "4 h",
+    "decomp_learn": 7,
+    "using": [ [ "soldering_standard", 20 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "BIONIC_ASSEMBLY", "level": 2 } ],
+    "components": [
+      [ [ "afs_energy_storage_1", 2 ] ],
+      [ [ "afs_circuitry_2", 2 ] ],
+      [ [ "afs_material_2", 6 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
+  },
+  {
+    "type": "uncraft",
+    "result": "bio_ups",
+    "skill_used": "electronics",
+    "difficulty": 6,
+    "time": "4 h",
+    "using": [ [ "soldering_standard", 20 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "BIONIC_ASSEMBLY", "level": 2 } ],
+    "components": [
+      [ [ "afs_energy_storage_4", 1 ] ],
+      [ [ "afs_circuitry_2", 1 ] ],
+      [ [ "afs_material_2", 6 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
+  },
+  {
+    "type": "uncraft",
+    "result": "bio_evap",
+    "skill_used": "electronics",
+    "difficulty": 7,
+    "time": "4 h",
+    "decomp_learn": 7,
+    "using": [ [ "soldering_standard", 60 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "BIONIC_ASSEMBLY", "level": 2 } ],
+    "components": [
+      [ [ "afs_biomaterial_4", 1 ] ],
+      [ [ "afs_neural_io_1", 2 ] ],
+      [ [ "afs_circuitry_2", 1 ] ],
+      [ [ "afs_material_2", 6 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
+  },
+  {
+    "type": "uncraft",
+    "result": "bio_flashlight",
+    "skill_used": "electronics",
+    "difficulty": 6,
+    "time": "4 h",
+    "decomp_learn": 5,
+    "using": [ [ "soldering_standard", 20 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "BIONIC_ASSEMBLY", "level": 2 } ],
+    "components": [
+      [ [ "afs_neural_io_1", 1 ] ],
+      [ [ "afs_circuitry_1", 1 ] ],
+      [ [ "afs_material_1", 6 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
+  },
+  {
+    "type": "uncraft",
+    "result": "bio_water_extractor",
+    "skill_used": "electronics",
+    "difficulty": 7,
+    "time": "4 h",
+    "decomp_learn": 7,
+    "using": [ [ "soldering_standard", 60 ] ],
+    "qualities": [ { "id": "BIONIC_ASSEMBLY", "level": 2 } ],
+    "components": [
+      [ [ "afs_biomaterial_4", 1 ] ],
+      [ [ "afs_neural_io_1", 2 ] ],
+      [ [ "afs_circuitry_2", 1 ] ],
+      [ [ "afs_material_2", 6 ] ],
+      [ [ "burnt_out_bionic", 1 ] ]
+    ]
+  }
+]


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fixed desync of build recipes (aftershok mod) in uncraft recipes (base game) of some CBMs"

#### Purpose of change

The base game overwrites the uncraft recipes of the following CBMs that have a craft/uncraft recipe in the Aftershok mod:
"bio_energy_storage",
"bio_power_storage_mkII",
"biobatteries"
"bio_oops"
"bio_evap"
bio_flashlight
"bio_water_extractor"
does not match

#### Describe the solution

Separate uncraft recipes have been added to the Aftershok mod. copied from his craft recipes. only for problematic CBMs

#### Describe alternatives you've considered


#### Testing

The fix is tested in the game, all recipes work.

Note maybe the "decomp_learn" parameter is not required in uncraft recipes? (but, its presence does not interfere)

#### Additional context
