### PR TITLE
Fix Aftershock breaking vanilla UPS spawns

### DIFF
--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -219,15 +219,10 @@
     "type": "TOOL_ARMOR",
     "copy-from": "UPS_off",
     "name": { "str": "UPS", "str_pl": "UPS's" },
-    "description": "This is a unified power supply, or UPS.  It is a device developed jointly by military and scientific interests for use in combat and the field.  The UPS is designed to power armor and some guns, but drains batteries quickly.  It can be worn around to either leg for ease of access, and it's been waterproofed to protect the delicate electronics.  Has it's own custom battery, with higher capacity and rechargeable, but not removeable",
+    "description": "This is a unified power supply, or UPS.  It is a civilian evolution of a military project.  Designed to power advanced weapons and armor, the civilian version serves as a portable power bank and inverter for many household electronics.  It can be worn around to either leg for ease of access.",
     "coverage": 5,
-    "ammo": "battery",
-    "initial_charges": 1000,
-    "max_charges": 1500,
     "encumbrance": 2,
-    "covers": [ "leg_either" ],
-    "flags": [ "RECHARGE", "WAIST", "FRAGILE", "OVERSIZE", "WATERPROOF", "IS_UPS", "NO_RELOAD", "NO_UNLOAD" ],
-    "magazines": [  ]
+    "covers": [ "leg_either" ]
   },
   {
     "id": "adv_UPS_off",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix Aftershock UPS override creating UPSes loaded with a battery that can't be removed"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So one side benefit I made note of in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1760 is that I wasn't sure how Aftershock's weird overrides would interact with vanilla spawns, now that BN has spawns of the UPS item pre-loaded with a battery.

Turns out they do not fail gracefully, instead of an error on one spawning in you get stuck with a UPS that has a battery permanently stuck in it, that can't be removed and prevents the damn thing from recharging. Thanks to @EkarusRyndren for discovering this the hard way.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Removed changes to UPS in Aftershock that remove its magazine definition in favor of max charges.
2. Likewise removed any other unnecessary changes, and updated its description override to only add relevant info pertaining to the wearability edit.
3. For good measure, did a search-in-folder of data/mods to make damn sure no one else has had any weird ideas about messing with how the vanilla UPS works.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Hoping to convince Coolthulhu that vanilla wearable UPSes would be kinda neat and thus allowing Lone's PR to get revived and merged.
2. Deleting Aftershock's override to UPS full-stop just in case what's left of it breaks anything else in the future.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and lint errors.
2. Loaded up file change in a test build.
3. Entered a world with Aftershock added, confirmed it made UPS wearable but still allowed unloading the battery to recharge.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

This is technically my fault, as when I did https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1109 I did not think to check the mods to see if any of them did any self-copy-from edits to UPS.