### PR TITLE
Fix shebang in `update-pch.sh`

### DIFF
--- a/update-pch.sh
+++ b/update-pch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 suffix=`date|md5sum|awk '{print $1}'`
 tpchr=/tmp/_pchr_$suffix.hpp


### PR DESCRIPTION
#### Summary

SUMMARY: Build "Fix shebang in update-pch.sh"

#### Purpose of change
since [[ is bash specifix syntax, script fails unless running it explicitly with bash.

#### Describe the solution
Changed shebang to use bash as default interpreter.
