### PR TITLE
Disables mapgen and saving during the test suite.

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
@@ -9,6 +9,15 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "test",
+    "name": "test",
+    "sym": ".",
+    "color": "green",
+    "mapgen": [ { "method": "builtin", "name": "test" } ],
+    "flags": [ "NO_ROTATE" ]
+  },
+  {
+    "type": "overmap_terrain",
     "id": "crater",
     "name": "crater",
     "sym": "O",

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -139,6 +139,8 @@ static cata::colony<item> nulitems;          // Returned when &i_at() is asked f
 static field              nulfield;          // Returned when &field_at() is asked for an OOB value
 static level_cache        nullcache;         // Dummy cache for z-levels outside bounds
 
+bool disable_mapgen = false;
+
 map &get_map()
 {
     return g->m;

--- a/src/map.h
+++ b/src/map.h
@@ -92,6 +92,10 @@ template<typename T>
 struct weighted_int_list;
 struct rl_vec2d;
 
+
+/** Causes all generated maps to be empty grass and prevents saved maps from being loaded, used by the test suite */
+extern bool disable_mapgen;
+
 namespace cata
 {
 template <class T> class poly_serialized;

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -198,6 +198,10 @@ void mapbuffer::save_quad( const std::string &dirname, const std::string &filena
         return;
     }
 
+    if( disable_mapgen ) {
+        return;
+    }
+
     // Don't create the directory if it would be empty
     assure_dir_exist( dirname );
     write_to_file( filename, [&]( std::ostream & fout ) {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -338,7 +338,7 @@ class mapgen_factory
         }
         /// @see mapgen_basic_container::generate
         bool generate( mapgendata &dat, const std::string &key, const int hardcoded_weight = 0 ) const {
-            const auto iter = mapgens_.find( key );
+            const auto iter = mapgens_.find( disable_mapgen ? "test" : key );
             if( iter == mapgens_.end() ) {
                 return false;
             }

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -85,6 +85,7 @@ building_gen_pointer get_mapgen_cfunction( const std::string &ident )
 {
     static const std::map<std::string, building_gen_pointer> pointers = { {
             { "null",             &mapgen_null },
+            { "test",             &mapgen_test },
             { "crater",           &mapgen_crater },
             { "field",            &mapgen_field },
             { "forest",           &mapgen_forest },
@@ -185,6 +186,16 @@ void mapgen_null( mapgendata &dat )
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
             dat.m.ter_set( point( i, j ), t_null );
+            dat.m.set_radiation( point( i, j ), 0 );
+        }
+    }
+}
+
+void mapgen_test( mapgendata &dat )
+{
+    for( int i = 0; i < SEEX * 2; i++ ) {
+        for( int j = 0; j < SEEY * 2; j++ ) {
+            dat.m.ter_set( point( i, j ), t_grass );
             dat.m.set_radiation( point( i, j ), 0 );
         }
     }

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -35,6 +35,7 @@ ter_id clay_or_sand();
 
 // helper functions for mapgen.cpp, so that we can avoid having a massive switch statement (sorta)
 void mapgen_null( mapgendata &dat );
+void mapgen_test( mapgendata &dat );
 void mapgen_crater( mapgendata &dat );
 void mapgen_field( mapgendata &dat );
 void mapgen_forest( mapgendata &dat );

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -157,6 +157,7 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
     g->u.create( character_type::NOW );
 
     g->m = map( get_option<bool>( "ZLEVELS" ) );
+    disable_mapgen = true;
 
     overmap_special_batch empty_specials( point_abs_om{} );
     overmap_buffer.create_custom_overmap( point_abs_om{}, empty_specials );
@@ -243,6 +244,7 @@ struct CataListener : Catch::TestEventListenerBase {
         TestEventListenerBase::sectionStarting( sectionInfo );
         // Initialize the cata RNG with the Catch seed for reproducible tests
         rng_set_engine_seed( m_config->rngSeed() );
+        disable_mapgen = true;
     }
 
     bool assertionEnded( Catch::AssertionStats const &assertionStats ) override {


### PR DESCRIPTION

#### Summary

SUMMARY: Infrastructure "Disables map generation and saving during the test suite"

#### Purpose of change

This fixes two problems in the test suite, one that many tests would accidentally trigger mapgen and another that these maps would be saved and loaded between tests. However, the intent isn't really to fix the issues, it's to measure their impact. I have no idea how much this is actually going to fix. I know that mapgen can mess with but not break some vehicle tests and I know that disabling loading gets rid of an issue that only happens on the monster vision branch where ~50% of seeds will fail a bunch of the throwing balance tests but not when ran alone. Past that there could be no impact, but judging by how easy it is to trigger these behaviors, it could also be 99% of our problems. Either way, it helps narrow down the source of any remaining issues.

#### Describe the solution

This is an awful hack, it isn't intended to remain. The idea is to put this in place, see if issues remain, if they do keep going until they stop. Then look at where we are and design a good architecture around that. At the moment we don't really know what's causing the problems and so we don't really know what we want. Note we're not looking to fix everything before then. Our biggest issue is isolation, once those problems are solved and we can be reasonably confident that tests don't depend on their order we'll know what we need.

Isolation issues like the saving/loading muddy the waters and make everything more difficult to debug but also need to be addressed at a platform level. At the moment we leave a lot of isolation to the tests with things like clear_map and this has design problems. It expects tests to account for features that haven't been implemented yet. Not clearing the player because they're going underground is only ok until someone implements a psychic attack mutation where it's not. The only safe way is to clear everything and even then a new system might get missed and you may as well just do a blanket reset between tests as part of the platform at that point. 

It's something not all of our tests strictly need. Some are true unit tests that construct their own state to test but most are end to end tests that are setting up a full game and seeing what happens and they need a full blank slate. Without a way to pick easily tell between I was just going to add a map and player clear there and see what the performance was like but it segfaults doing body temp stuff... So that's something to look at and it's something I think we can go ahead and do nicely right off the bat. Even if all of the tests are calling clear_map etc perfectly and it isn't an actual source of problems I think it's still a potential source of future headaches. Also, I think the proper way to implement the saving hack is to add a clear_saved_maps there. 

There are also endemic unexpected rng issues like the mapgen. They're a bit more of a headache, they still want solving at a platform level but they can't be identified by just running the test alone. Hopefully there aren't many, there's a good chance there's just the one, but if we miss one before doing the design we'll have to come back to it. There's not too much can be done there, but a little bit of investigation of non-isolation problems helps a lot. It's only endemic if it's common so it's likely they'll turn up. 

Problems with individual tests are something we can look at later. I think it's reasonable that we don't actually have that many and that a lot of the failures are isolation related. If that's wrong we could give people a way to log bad seeds alongside a test to make it easier to investigate but it's all a bit moot until we can be more sure that it's the test that's failing that really is the problem. 

So yeah, isolation wise, I'm better we have a small number of big issues and we can put a few hacks in place and get isolation failures <1%. If we get to the stage where there's four or five hacks in place and still we have a good number of runs failing with problems that disappear when ran alone, we'll need to change course but I don't see that happening. For now we just have to see how much impact this has and how many more tests fail and how many are isolation problems. I'm gonna take a look at the segfault and generally getting a consistent starting state for all tests, if the problems do persist that's probably a good next step. I think it's a real possibility that they don't persist and this is all our big isolation problems. The throwing tests call clear_map, place the player at 30,30 and then don't move and they still somehow trigger it. It's not unreasonable to imagine that the vast majority of tests are impacted by this. 

#### Describe alternatives you've considered

Finding an exorcist because the test suite is haunted. 

#### Testing

It's pretty easy to see the changes can only possibly affect the suite, so at the very least it can't make things much worse. Oh note that tests can just toggle the bool off if they want to test mapgen normally and the saving hack breaks object permanence for tests but none of them mind and it is a temporary thing. 