### PR TITLE
[BUGFIXES] Fix candied honey to forest honey duplication bug

### DIFF
--- a/data/json/recipes/food/other.json
+++ b/data/json/recipes/food/other.json
@@ -1088,7 +1088,7 @@
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
     "difficulty": 1,
-    "charges": 14,
+    "charges": 7,
     "time": "20 m",
     "batch_time_factors": [ 50, 3 ],
     "autolearn": true,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

[BUGFIXES] Fix candied honey to forest honey duplication bug

#### Purpose of change

Fix #1813 

#### Describe the solution

In relation to the file "data/json/recipes/food/other.json", i changed the charges amount of "honey_bottled" from 14 to 7.

#### Describe alternatives you've considered

#### Testing

No tests have been carried out

#### Additional context
