### PR TITLE
Fixes a bug where no sight let you see items through walls

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1466,7 +1466,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 if( here.inbounds( p.pos ) ) {
                     if( !f.hide_unseen || ch.visibility_cache[p.pos.x][p.pos.y] != lit_level::BLANK ) {
                         const bool ( invis )[5] = {false, false, false, false, false};
-                        ( this->*( f.function ) )( {p.pos.xy(), z}, p.ll, p.height_3d, invis, center.z - z );
+                        ( this->*( f.function ) )( {p.pos.xy(), z}, p.ll, p.height_3d, z == p.pos.z ? p.invisible : invis,
+                                                   center.z - z );
                     }
                 } else {
                     ( this->*( f.function ) )( {p.pos.xy(), z}, p.ll, p.height_3d, p.invisible, center.z - z );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1463,11 +1463,10 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     break;
                 }
                 const auto &ch = here.access_cache( z );
-                if( here.inbounds( p.pos ) ) {
+                if( here.inbounds( p.pos ) && z != p.pos.z ) {
                     if( !f.hide_unseen || ch.visibility_cache[p.pos.x][p.pos.y] != lit_level::BLANK ) {
                         const bool ( invis )[5] = {false, false, false, false, false};
-                        ( this->*( f.function ) )( {p.pos.xy(), z}, p.ll, p.height_3d, z == p.pos.z ? p.invisible : invis,
-                                                   center.z - z );
+                        ( this->*( f.function ) )( {p.pos.xy(), z}, p.ll, p.height_3d, invis, center.z - z );
                     }
                 } else {
                     ( this->*( f.function ) )( {p.pos.xy(), z}, p.ll, p.height_3d, p.invisible, center.z - z );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "The no sight property works correctly again"

#### Purpose of change

Fixes #1858 

#### Describe the solution

Only overrides visibility for higher tiles in a stack rather than all tiles. 