### PR TITLE
Add power grid to farms (except Isherwood farms)

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -97,7 +97,7 @@
     "locations": [ "forest" ],
     "city_distance": [ 12, -1 ],
     "occurrences": [ 30, 100 ],
-    "flags": [ "CLASSIC", "FARM", "UNIQUE" ]
+    "flags": [ "CLASSIC", "FARM", "UNIQUE", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -383,7 +383,7 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 0, 3 ],
-    "flags": [ "CLASSIC", "FARM" ]
+    "flags": [ "CLASSIC", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -406,7 +406,7 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 0, 3 ],
-    "flags": [ "CLASSIC", "FARM" ]
+    "flags": [ "CLASSIC", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -430,7 +430,7 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 0, 3 ],
-    "flags": [ "CLASSIC", "FARM" ]
+    "flags": [ "CLASSIC", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -465,7 +465,7 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 0, 3 ],
-    "flags": [ "CLASSIC", "FARM" ]
+    "flags": [ "CLASSIC", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -488,7 +488,7 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 0, 3 ],
-    "flags": [ "CLASSIC", "FARM" ]
+    "flags": [ "CLASSIC", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -511,7 +511,7 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 0, 3 ],
-    "flags": [ "CLASSIC", "FARM" ]
+    "flags": [ "CLASSIC", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -543,7 +543,7 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 0, 3 ],
-    "flags": [ "CLASSIC", "FARM" ]
+    "flags": [ "CLASSIC", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -571,7 +571,7 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 0, 3 ],
-    "flags": [ "CLASSIC", "FARM" ]
+    "flags": [ "CLASSIC", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -602,7 +602,7 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 10, 100 ],
-    "flags": [ "UNIQUE", "FARM" ]
+    "flags": [ "UNIQUE", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -3549,7 +3549,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 5, 40 ],
     "occurrences": [ 0, 5 ],
-    "flags": [ "CLASSIC", "FARM" ]
+    "flags": [ "CLASSIC", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -3566,7 +3566,7 @@
     "locations": [ "field" ],
     "city_distance": [ 5, 60 ],
     "occurrences": [ 0, 3 ],
-    "flags": [ "CLASSIC", "FARM" ]
+    "flags": [ "CLASSIC", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -3882,7 +3882,7 @@
     "locations": [ "forest" ],
     "city_distance": [ 5, 40 ],
     "occurrences": [ 0, 5 ],
-    "flags": [ "CLASSIC", "FARM" ]
+    "flags": [ "CLASSIC", "FARM", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -6462,7 +6462,7 @@
     "city_distance": [ 5, -1 ],
     "occurrences": [ 95, 100 ],
     "//": "Inflated chance, effective rate ~ 30%",
-    "flags": [ "CLASSIC", "FARM", "UNIQUE", "ELECTRIC_GRID" ]
+    "flags": [ "CLASSIC", "FARM", "UNIQUE" ]
   },
   {
     "id": "airliner_crashed",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -6462,7 +6462,7 @@
     "city_distance": [ 5, -1 ],
     "occurrences": [ 95, 100 ],
     "//": "Inflated chance, effective rate ~ 30%",
-    "flags": [ "CLASSIC", "FARM", "UNIQUE" ]
+    "flags": [ "CLASSIC", "FARM", "UNIQUE", "ELECTRIC_GRID" ]
   },
   {
     "id": "airliner_crashed",


### PR DESCRIPTION
Add power grid to farms

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Content "Add power grid to farms (except Isherwood farms)"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
Continuation to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1244.

> Adding them to farms, despite the large amount of fields that would give powergen to. Since the ranch camp and industrial center have already been given the okay to have grids, and assuming it's deemed acceptable to do so with the refugee center, it may be fine to add it to farms too.

It seems players tends to try to use power grid on farms. It is logical, since farms - is good potential base location. But previously farms didn't have built in power grids. It time to change that.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Add ELECTRIC_GRID to all farms overmap special.
Obviously it will gridify soil as well due the way power grid works, but it should  doable compromise, since player convenience should be priority in this case.

Can't add power grid to Isherwood farms due bug: https://github.com/cataclysmbnteam/Cataclysm-BN/issues/1867
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Start game
2) Debug reveal map
3) Check if grids appeared on farms, using "Display overmap distribution grids".

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
We need give player manual way to connect multiple electric grids. Easy way to do it- add this option to voltmeter (for example)
>BroadFlatNails
> Not hard, but it would be hacky. I'd rather have something like "crude electric probe" crafted from wire+bulb and showing you connections and letting you pick one of 6 options: connect nwse/up/down. Even if it didn't have a long action and only ate up something like 10 copper wire.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
