### PR TITLE
[FIX] rebalance barbaran montante MA

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -68,7 +68,7 @@
     "type": "martial_art",
     "id": "style_barbaran",
     "name": { "str": "Barbaran Montante" },
-    "description": "The Barbaran Montante originated in 16th century Spain and focuses on overcoming thick armor with heavy weaponry and sweeping blows, transferring kinetic energy through armor and into vulnerable organs and bones. This style concentrates on the modern use of two handed swords but could be adapted to other types of two handed weaponry.",
+    "description": "The Barbaran Montante originated in 16th century Spain and focuses on overcoming thick armor with heavy weaponry and sweeping blows, transferring kinetic energy through armor and into vulnerable organs and bones.  This style concentrates on the modern use of two handed swords but could be adapted to other types of two handed weaponry.",
     "initiate": [
       "You heft your weapon, stretch your shoulders, and slide into the Represa.",
       "%s rolls their shoulders and prepares to duel."

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -83,9 +83,9 @@
         "description": "Sliding footwork enhances the crushing continuity of your attacks.\n\nArmor penetration increased by 100% of Strength.",
         "melee_allowed": true,
         "flat_bonuses": [
-          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 1.0 },
-          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 1.0 },
-          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 1.0 }
+          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 0.75 },
+          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 0.75 }
         ]
       }
     ],
@@ -134,7 +134,7 @@
         "flat_bonuses": [
           { "stat": "hit", "scaling-stat": "str", "scale": 0.15 },
           { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 1.25 },
-          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 1.75 },
+          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 2.25 },
           { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 1.25 }
         ],
         "buff_duration": 1

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -80,12 +80,12 @@
       {
         "id": "buff_barbaran_static",
         "name": "Barbaran Represa",
-        "description": "Sliding footwork enhances the crushing continuity of your attacks.\n\nArmor penetration increased by 75% of Strength.",
+        "description": "Sliding footwork enhances the crushing continuity of your attacks.\n\nArmor penetration increased by 100% of Strength.",
         "melee_allowed": true,
         "flat_bonuses": [
-          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
-          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 0.75 },
-          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 0.75 }
+          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 1.0 },
+          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 1.0 },
+          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 1.0 }
         ]
       }
     ],

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -68,7 +68,7 @@
     "type": "martial_art",
     "id": "style_barbaran",
     "name": { "str": "Barbaran Montante" },
-    "description": "The Barbaran Montante originated in 16th century Spain and focuses on overcoming thick armor with heavy weaponry and sweeping blows, transferring kinetic energy through armor and into vulnerable organs and bones.",
+    "description": "The Barbaran Montante originated in 16th century Spain and focuses on overcoming thick armor with heavy weaponry and sweeping blows, transferring kinetic energy through armor and into vulnerable organs and bones. This style concentrates on the modern use of two handed swords but could be adapted to other types of two handed weaponry.",
     "initiate": [
       "You heft your weapon, stretch your shoulders, and slide into the Represa.",
       "%s rolls their shoulders and prepares to duel."
@@ -128,14 +128,14 @@
       {
         "id": "buff_barbaran_onpause",
         "name": "Vulgar Preparation",
-        "description": "You prepare for the final crushing strike.\n\nAccuracy increased by 15% of Strength, Armor penetration increased by 225% of Strength.\nLasts 1 turn.",
+        "description": "You prepare for the final crushing strike.\n\nAccuracy increased by 15% of Strength, Armor penetration increased by 125% of Strength.\nLasts 1 turn.",
         "skill_requirements": [ { "name": "melee", "level": 4 } ],
         "melee_allowed": true,
         "flat_bonuses": [
           { "stat": "hit", "scaling-stat": "str", "scale": 0.15 },
-          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 2.25 },
-          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 2.25 },
-          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 2.25 }
+          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 1.25 },
+          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 1.25 },
+          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 1.25 }
         ],
         "buff_duration": 1
       }

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -134,7 +134,7 @@
         "flat_bonuses": [
           { "stat": "hit", "scaling-stat": "str", "scale": 0.15 },
           { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 1.25 },
-          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 1.25 },
+          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 1.75 },
           { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 1.25 }
         ],
         "buff_duration": 1
@@ -160,6 +160,7 @@
       "morningstar_fake",
       "sword_nail",
       "sword_crude",
+      "sword_metal",
       "sword_wood",
       "warhammer",
       "zweihander",

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -283,8 +283,8 @@
     "melee_allowed": true,
     "aoe": "impale",
     "mult_bonuses": [
-      { "stat": "damage", "type": "cut", "scale": 1.1 },
-      { "stat": "damage", "type": "stab", "scale": 1.1 },
+      { "stat": "damage", "type": "cut", "scale": 1.3 },
+      { "stat": "damage", "type": "stab", "scale": 1.3 },
       { "stat": "movecost", "scale": 1.2 }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
Balance "Rebalance barbaran montante MA"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
Barbaran montante was too powerful at low STR level, because you could reach 300% armor penetration, scaling with strength.
The description was also changed a bit to better reflect historical accuracy. (thanks krwak)
The impaling technique was also a bit useless (10% damage bonus, applied before armor reduction, which usually makes close to no difference).

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
After a very long discussion, we agreed on a different value: 200% total armor penetration (arpen).
The static bonus is changed from 75% arpen to 100%.
The onpause bonus is changed from 225% arpen to 125%.

Also, the impalade technique is changed from +10% damage to +30% damage.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
A gazillon, but at some point we need to choose.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested with 6 skills in everything, except dodge which I increased or lowered depending on if the MA benefits from it (some styles get buff from blocking so you'll prefer to avoid dodging with those ones). All tests were done against a kevlar hulk. If a MA had a counter attack (on dodge or parry), I added the damage to the next hit (it's essentialy a 0 move cost hit). If I got hurt or too low on stamina, I reseted it through the debug menu. 

The part in bold is the context (eg "BM, 12 STR, sledge" means "Barabaran Montante style, with a character that has 12 strength, with a sledgehammer").
The average damage is just below.

At 12 STR, this will be the best against heavy armored opponents, as it should.
At 18 STR, it's already beaten by Fior, but still pretty decent, be it with a mainly cutting weapon (zweihander) or a bashing weapon (sledgehammer).

This is a best case scenario. Against enemies that don't have armor, this style is one of the worst choice. It has no counter attack on block or dodge, no grab break etc. So this is an anti armor focused style, that is now nerfed at low STR.

![image](https://user-images.githubusercontent.com/71428793/191112974-efa0fe71-2977-4bca-af94-949d5a8a069d.png)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->