### PR TITLE
make repeating crossbow reload one bolt at a time

### DIFF
--- a/data/json/items/ranged/crossbows.json
+++ b/data/json/items/ranged/crossbows.json
@@ -483,7 +483,7 @@
     "description": "A custom-made crossbow with a clever mechanism that loads and fires bolts in a single motion, it has a wooden magazine that holds 10 bolts.  Bolts fired from this weapon have a good chance of remaining intact for re-use.",
     "price": 324000,
     "material": [ "steel", "wood" ],
-    "flags": [ "FIRE_TWOHAND", "PRIMITIVE_RANGED_WEAPON", "TRADER_AVOID", "CROSSBOW" ],
+    "flags": [ "FIRE_TWOHAND", "PRIMITIVE_RANGED_WEAPON", "TRADER_AVOID", "CROSSBOW", "RELOAD_ONE" ],
     "skill": "smg",
     "ammo": "bolt",
     "weight": "3628 g",


### PR DESCRIPTION
Repeating crossbows should reload only one bolt at a time, since the time for reloading won't benefit of an all at once method.

The old system had the problem that if your reloading has to be canceled, you will loose all reloading progress. This change will circumvent it and it will act like shotguns.