### PR TITLE
Glues added to soldering iron recipe

### DIFF
--- a/data/json/recipes/electronic/tools.json
+++ b/data/json/recipes/electronic/tools.json
@@ -112,7 +112,7 @@
       [ [ "e_scrap", 2 ], [ "glowplug", 1 ] ],
       [ [ "copper", 1 ], [ "nail", 1 ], [ "wire", 1 ] ],
       [ [ "scrap", 1 ] ],
-      [ [ "duct_tape", 10 ], [ "superglue", 1 ], [ "bone_glue", 1 ] ],
+      [ [ "adhesive", 1, "LIST" ] ],
       [ [ "cable", 5 ] ]
     ]
   },

--- a/data/json/recipes/electronic/tools.json
+++ b/data/json/recipes/electronic/tools.json
@@ -112,7 +112,7 @@
       [ [ "e_scrap", 2 ], [ "glowplug", 1 ] ],
       [ [ "copper", 1 ], [ "nail", 1 ], [ "wire", 1 ] ],
       [ [ "scrap", 1 ] ],
-      [ [ "duct_tape", 10 ] ],
+      [ [ "duct_tape", 10 ], [ "superglue", 1 ], [ "bone_glue", 1 ] ],
       [ [ "cable", 5 ] ]
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Balance] "[Added bone glue and superglue to the recipe]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

It is not possible to craft soldering iron without having duct tape. In order to get duct tape you either have to find it or learn the recipe from a book. You can't do any proper electronics work without having soldering iron and the problem of duct tape is a stopgap in this issue.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

I added the possibility of using bone glue or super glue in the recipe of soldering iron. I see no reason why only duct tape should be able to put the parts together.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Changed the recipe, loaded the game.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
