### PR TITLE
Fix gcc 11.2.0 build

### DIFF
--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -1384,8 +1384,8 @@ void load_effect_type( const JsonObject &jo )
     }
 
     // TODO: Implement handling of reduced morale, remove this
-    static const std::vector<const char *> mod_types = {{
-            "base_mods", "scaling_mods"
+    static const std::vector<std::string> mod_types = {{
+            {"base_mods"}, {"scaling_mods"}
         }
     };
     if( has_morale_effect ) {

--- a/src/optional.h
+++ b/src/optional.h
@@ -32,6 +32,9 @@ class optional
     private:
         using StoredType = typename std::remove_const<T>::type;
         union {
+            // `volatile` suppresses -Wmaybe-uninitialized false positive
+            // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635#c53
+            volatile char dont_use;
             char dummy;
             StoredType data;
         };

--- a/src/wisheffect.cpp
+++ b/src/wisheffect.cpp
@@ -37,7 +37,7 @@ struct entry_data {
     cata::optional<const effect *> eff;
 };
 
-template<class T, typename F = std::pair<std::string, void ( T::* )(
+template<class T, typename F = std::pair<const std::string, void ( T::* )(
              const input_context &,
              const input_event &,
              int,


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Fixes #1862
`maybe-uninitialized` quoted in the issue was a false positive.
There also were a couple `range-loop-construct`s.

#### Describe the solution
For former, port https://github.com/CleverRaven/Cataclysm-DDA/pull/51898
For latter, fix type mismatch

#### Describe alternatives you've considered
Giving up on C++

#### Testing
Compiled the game, ran the test suite.
The rest will be done by GA.