### PR TITLE
fix NPC blocking with broken limbs

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1595,7 +1595,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     item &shield = best_shield();
     block_bonus = blocking_ability( shield );
     bool conductive_shield = shield.conductive();
-    bool unarmed = weapon.has_flag( "UNARMED_WEAPON" );
+    bool unarmed = weapon.has_flag( "UNARMED_WEAPON" ) || weapon.is_null();
     bool force_unarmed = martial_arts_data->is_force_unarmed();
 
     int melee_skill = get_skill_level( skill_melee );
@@ -1657,6 +1657,12 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
             if( get_part_hp_cur( bodypart_id( "arm_r" ) ) > get_part_hp_cur( bodypart_id( "arm_l" ) ) ) {
                 bp_hit = bodypart_id( "arm_r" );
             }
+        }
+        
+        // if the limb in best condition usable to block is broken, this character can't block anymore
+        if (get_part_hp_cur(bp_hit) <= 0) {
+            blocks_left = 0;
+            return false;
         }
 
         thing_blocked_with = body_part_name( bp_hit->token );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1549,7 +1549,17 @@ item &Character::best_shield()
     item *best = best_value > 0 ? &weapon : &null_item_reference();
     for( item &shield : worn ) {
         if( shield.has_flag( "BLOCK_WHILE_WORN" ) && blocking_ability( shield ) >= best_value ) {
-            best = &shield;
+            if( ( shield.covers( bp_arm_l ) || shield.covers( bp_arm_r ) ) && get_working_arm_count() >= 1 ) {
+                best = &shield;
+            } else if( ( shield.covers( bp_leg_l ) || shield.covers( bp_leg_r ) ) &&
+                       get_working_leg_count() >= 1 ) {
+                best = &shield;
+            }
+            // in case a mod adds a weird worn blocking item, it's handled here
+            else if( !shield.covers( bp_arm_l ) && !shield.covers( bp_arm_r ) && !shield.covers( bp_leg_r ) &&
+                     !shield.covers( bp_leg_r ) ) {
+                best = &shield;
+            }
         }
     }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1558,12 +1558,8 @@ item &Character::best_shield()
                 }
             } else {
                 // leg guards
-                if( shield.covers( bp_leg_l ) || shield.covers( bp_leg_r ) ) {
-                    if( shield.covers( bp_leg_l ) && !is_limb_disabled( bodypart_id( "leg_l" ) ) ) {
-                        best = &shield;
-                    } else if( shield.covers( bp_leg_r ) && !is_limb_disabled( bodypart_id( "leg_r" ) ) ) {
-                        best = &shield;
-                    }
+                if( ( shield.covers( bp_leg_l ) || shield.covers( bp_leg_r ) ) && get_working_leg_count() >= 1 ) {
+                    best = &shield;
                 }
                 // in case a mod adds an unusual worn blocking item, like a magic bracelet/crown, it's handled here
                 else {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -363,7 +363,7 @@ static void melee_train( Character &p, int lo, int hi, const item &weap )
 
     // allocate XP proportional to damage stats
     // Pure unarmed needs a special case because it has 0 weapon damage
-    int cut  = weap.damage_melee( DT_CUT );
+    int cut = weap.damage_melee( DT_CUT );
     int stab = weap.damage_melee( DT_STAB );
     int bash = weap.damage_melee( DT_BASH ) + ( weap.is_null() ? 1 : 0 );
 
@@ -373,7 +373,7 @@ static void melee_train( Character &p, int lo, int hi, const item &weap )
     if( weap.is_unarmed_weapon() ) {
         u.practice( skill_unarmed, std::ceil( 1 * rng( lo, hi ) ), hi );
     } else {
-        u.practice( skill_cutting,  std::ceil( cut  / total * rng( lo, hi ) ), hi );
+        u.practice( skill_cutting, std::ceil( cut / total * rng( lo, hi ) ), hi );
         u.practice( skill_stabbing, std::ceil( stab / total * rng( lo, hi ) ), hi );
         u.practice( skill_bashing, std::ceil( bash / total * rng( lo, hi ) ), hi );
     }
@@ -1228,8 +1228,8 @@ bool Character::valid_aoe_technique( Creature &t, const ma_technique &technique,
     }
 
     // pre-computed matrix of adjacent squares
-    std::array<int, 9> offset_a = {{0, -1, -1, 1, 0, -1, 1, 1, 0 }};
-    std::array<int, 9> offset_b = {{-1, -1, 0, -1, 0, 1, 0, 1, 1 }};
+    std::array<int, 9> offset_a = { {0, -1, -1, 1, 0, -1, 1, 1, 0 } };
+    std::array<int, 9> offset_b = { {-1, -1, 0, -1, 0, 1, 0, 1, 1 } };
 
     // filter the values to be between -1 and 1 to avoid indexing the array out of bounds
     int dy = std::max( -1, std::min( 1, t.posy() - posy() ) );
@@ -1556,15 +1556,13 @@ item &Character::best_shield()
                 } else if( shield.covers( bp_arm_r ) && !is_limb_disabled( bodypart_id( "arm_r" ) ) ) {
                     best = &shield;
                 }
-            } else {
                 // leg guards
-                if( ( shield.covers( bp_leg_l ) || shield.covers( bp_leg_r ) ) && get_working_leg_count() >= 1 ) {
-                    best = &shield;
-                }
+            } else if( ( shield.covers( bp_leg_l ) || shield.covers( bp_leg_r ) ) &&
+                       get_working_leg_count() >= 1 ) {
+                best = &shield;
                 // in case a mod adds an unusual worn blocking item, like a magic bracelet/crown, it's handled here
-                else {
-                    best = &shield;
-                }
+            } else {
+                best = &shield;
             }
         }
     }
@@ -2032,7 +2030,7 @@ std::string melee_message( const ma_technique &tec, Character &p, const dealt_da
     // Those could be extracted to a json
 
     // Three last values are for low damage
-    static const std::array<std::string, 6> player_stab = {{
+    static const std::array<std::string, 6> player_stab = { {
             translate_marker( "You impale %s" ),
             translate_marker( "You gouge %s" ),
             translate_marker( "You run %s through" ),
@@ -2041,7 +2039,7 @@ std::string melee_message( const ma_technique &tec, Character &p, const dealt_da
             translate_marker( "You poke %s" )
         }
     };
-    static const std::array<std::string, 6> npc_stab = {{
+    static const std::array<std::string, 6> npc_stab = { {
             translate_marker( "<npcname> impales %s" ),
             translate_marker( "<npcname> gouges %s" ),
             translate_marker( "<npcname> runs %s through" ),
@@ -2051,7 +2049,7 @@ std::string melee_message( const ma_technique &tec, Character &p, const dealt_da
         }
     };
     // First 5 are for high damage, next 2 for medium, then for low and then for v. low
-    static const std::array<std::string, 9> player_cut = {{
+    static const std::array<std::string, 9> player_cut = { {
             translate_marker( "You gut %s" ),
             translate_marker( "You chop %s" ),
             translate_marker( "You slash %s" ),
@@ -2063,7 +2061,7 @@ std::string melee_message( const ma_technique &tec, Character &p, const dealt_da
             translate_marker( "You nick %s" )
         }
     };
-    static const std::array<std::string, 9> npc_cut = {{
+    static const std::array<std::string, 9> npc_cut = { {
             translate_marker( "<npcname> guts %s" ),
             translate_marker( "<npcname> chops %s" ),
             translate_marker( "<npcname> slashes %s" ),
@@ -2077,7 +2075,7 @@ std::string melee_message( const ma_technique &tec, Character &p, const dealt_da
     };
 
     // Three last values are for low damage
-    static const std::array<std::string, 6> player_bash = {{
+    static const std::array<std::string, 6> player_bash = { {
             translate_marker( "You clobber %s" ),
             translate_marker( "You smash %s" ),
             translate_marker( "You thrash %s" ),
@@ -2086,7 +2084,7 @@ std::string melee_message( const ma_technique &tec, Character &p, const dealt_da
             translate_marker( "You hit %s" )
         }
     };
-    static const std::array<std::string, 6> npc_bash = {{
+    static const std::array<std::string, 6> npc_bash = { {
             translate_marker( "<npcname> clobbers %s" ),
             translate_marker( "<npcname> smashes %s" ),
             translate_marker( "<npcname> thrashes %s" ),
@@ -2097,7 +2095,7 @@ std::string melee_message( const ma_technique &tec, Character &p, const dealt_da
     };
 
     const int bash_dam = ddi.type_damage( DT_BASH );
-    const int cut_dam  = ddi.type_damage( DT_CUT );
+    const int cut_dam = ddi.type_damage( DT_CUT );
     const int stab_dam = ddi.type_damage( DT_STAB );
 
     if( tec.id != tec_none ) {
@@ -2415,7 +2413,7 @@ void avatar::steal( npc &target )
     } else if( my_roll >= their_roll / 2 ) {
         add_msg( _( "You failed to steal %1$s from %2$s, but did not attract attention." ),
                  it->tname(), target.name );
-    } else  {
+    } else {
         add_msg( _( "You failed to steal %1$s from %2$s." ),
                  it->tname(), target.name );
         target.on_attacked( *this );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1658,9 +1658,9 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
                 bp_hit = bodypart_id( "arm_r" );
             }
         }
-        
+
         // if the limb in best condition usable to block is broken, this character can't block anymore
-        if (get_part_hp_cur(bp_hit) <= 0) {
+        if( get_part_hp_cur( bp_hit ) <= 0 ) {
             blocks_left = 0;
             return false;
         }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1639,7 +1639,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
 
         handle_melee_wear( shield, wear_modifier );
     } else {
-        //Choose which body part to block with, assume left side first
+        // Choose which body part to block with, assume left side first
         if( martial_arts_data->can_leg_block( *this ) && martial_arts_data->can_arm_block( *this ) ) {
             bp_hit = one_in( 2 ) ? bodypart_id( "leg_l" ) : bodypart_id( "arm_l" );
         } else if( martial_arts_data->can_leg_block( *this ) ) {
@@ -1659,7 +1659,8 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
             }
         }
 
-        // if the limb in best condition usable to block is broken, this character can't block anymore
+        // At this point, we know we won't try blocking with items, only with limbs.
+        // But there are no limbs left, so we can disable further attempts at blocking.
         if( get_part_hp_cur( bp_hit ) <= 0 ) {
             blocks_left = 0;
             return false;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1549,16 +1549,26 @@ item &Character::best_shield()
     item *best = best_value > 0 ? &weapon : &null_item_reference();
     for( item &shield : worn ) {
         if( shield.has_flag( "BLOCK_WHILE_WORN" ) && blocking_ability( shield ) >= best_value ) {
-            if( ( shield.covers( bp_arm_l ) || shield.covers( bp_arm_r ) ) && get_working_arm_count() >= 1 ) {
-                best = &shield;
-            } else if( ( shield.covers( bp_leg_l ) || shield.covers( bp_leg_r ) ) &&
-                       get_working_leg_count() >= 1 ) {
-                best = &shield;
-            }
-            // in case a mod adds a weird worn blocking item, it's handled here
-            else if( !shield.covers( bp_arm_l ) && !shield.covers( bp_arm_r ) && !shield.covers( bp_leg_r ) &&
-                     !shield.covers( bp_leg_r ) ) {
-                best = &shield;
+            // in case a mod adds a shield that protects only one arm, the corresponding arm needs to be working
+            if( shield.covers( bp_arm_l ) || shield.covers( bp_arm_r ) ) {
+                if( shield.covers( bp_arm_l ) && !is_limb_disabled( bodypart_id( "arm_l" ) ) ) {
+                    best = &shield;
+                } else if( shield.covers( bp_arm_r ) && !is_limb_disabled( bodypart_id( "arm_r" ) ) ) {
+                    best = &shield;
+                }
+            } else {
+                // leg guards
+                if( shield.covers( bp_leg_l ) || shield.covers( bp_leg_r ) ) {
+                    if( shield.covers( bp_leg_l ) && !is_limb_disabled( bodypart_id( "leg_l" ) ) ) {
+                        best = &shield;
+                    } else if( shield.covers( bp_leg_r ) && !is_limb_disabled( bodypart_id( "leg_r" ) ) ) {
+                        best = &shield;
+                    }
+                }
+                // in case a mod adds an unusual worn blocking item, like a magic bracelet/crown, it's handled here
+                else {
+                    best = &shield;
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
NPCs (and the player) could block with broken limbs if they were wearing an item with the "BLOCK_WHILE_WORN" flag.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Fixes #1790
In the end, this fixes:
- Blocks from BLOCK_WHILE_WORN items still working when all the related limbs are broken (eg both arms for arm guards)
- Blocks not working with MA other than forced unarmed when not using a weapon
- Blocks from forced unarmed still working when both arms are broken

Details:
Some mods can add shields or unusual "BLOCK_WHILE_WORN" worn item, so I tried to take them all into account.

If a worn item covers the arms, it's either an arm guard or shield.
In that case the covered arm must be working (arm guards cover both arms, so one working arm is enough)

Otherwise If a worn item covers the legs, one of them needs to be working

Finally, if an item doesn't cover arms or legs, it skips the health limbs check

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Testing
Spawn NPC, give him arm guards, hit him, he can block.
Break both his arms, he can't now.
Same for the player.
If an NPC is wielding a weapon with higher blocking, it will still be prioritized for blocking.