### PR TITLE
fix [E]xamine does not fallback to using lockpicks on locked doors when the player has no prying tool

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1470,10 +1470,10 @@ void iexamine::locked_object( player &p, const tripoint &examp )
 
     map &here = get_map();
     if( prying_items.empty() ) {
+        add_msg( m_info, _( "The %s is locked.  You could use something to pry it with…" ),
+                 here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
         if( here.has_furn( examp ) ? here.furn( examp ).obj().has_flag( "LOCKED" ) : here.ter(
                 examp ).obj().has_flag( "LOCKED" ) ) {
-            add_msg( m_info, _( "The %s is locked.  You could use something to pry it with…" ),
-                     here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
             iexamine::locked_object_pickable( p, examp );
         }
         return;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1460,11 +1460,6 @@ void iexamine::gunsafe_el( player &p, const tripoint &examp )
 
 safe_reference<item> find_best_prying_tool( player &p )
 {
-    /*auto prying_items = p.crafting_inventory().items_with( []( const item & it ) -> bool {
-        item temporary_item( it.type );
-        return temporary_item.has_quality( quality_id( "PRY" ), 1 );
-    } );*/
-
     std::vector<item *> prying_items = p.items_with( [&p]( const item & it ) {
         // Don't search for worn items such as hairpins
         if( p.get_item_position( &it ) >= -1 ) {
@@ -1489,7 +1484,6 @@ safe_reference<item> find_best_prying_tool( player &p )
 
 safe_reference<item> find_best_lock_picking_tool( player &p )
 {
-
     std::vector<item *> picklocks = p.items_with( [&p]( const item & it ) {
         // Don't search for worn items such as hairpins
         if( p.get_item_position( &it ) >= -1 ) {
@@ -1562,13 +1556,13 @@ void iexamine::locked_object( player &p, const tripoint &examp )
         if( lock_picking_tool ) {
             apply_lock_picking_tool( p, lock_picking_tool.get(), examp );
         } else {
-            add_msg( m_info, _( "The %s is locked.  If only you had something to pry or pick it with…" ),
+            add_msg( m_info, _( "The %s is locked.  If only you had something to pry it or pick its lock…" ),
                      here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
         }
         return;
     }
 
-    add_msg( m_info, _( "The %s is locked.  If only you had something to pry it with…" ),
+    add_msg( m_info, _( "The %s is locked.  If only you had something to pry it…" ),
              here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
 }
 
@@ -1585,7 +1579,7 @@ void iexamine::locked_object_pickable( player &p, const tripoint &examp )
         return;
     }
 
-    add_msg( m_info, _( "The %s is locked.  If only you had something to pick its lock with…" ),
+    add_msg( m_info, _( "The %s is locked.  If only you had something to pick its lock…" ),
              here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
 }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1458,7 +1458,7 @@ void iexamine::gunsafe_el( player &p, const tripoint &examp )
     }
 }
 
-safe_reference<item> find_best_prying_tool( player &p )
+static safe_reference<item> find_best_prying_tool( player &p )
 {
     std::vector<item *> prying_items = p.items_with( [&p]( const item & it ) {
         // Don't search for worn items such as hairpins
@@ -1482,7 +1482,7 @@ safe_reference<item> find_best_prying_tool( player &p )
     return ( *prying_items[0] ).get_safe_reference();
 }
 
-safe_reference<item> find_best_lock_picking_tool( player &p )
+static safe_reference<item> find_best_lock_picking_tool( player &p )
 {
     std::vector<item *> picklocks = p.items_with( [&p]( const item & it ) {
         // Don't search for worn items such as hairpins
@@ -1508,7 +1508,7 @@ safe_reference<item> find_best_lock_picking_tool( player &p )
     return ( *picklocks[0] ).get_safe_reference();
 }
 
-void apply_prying_tool( player &p, item *it, const tripoint &examp )
+static void apply_prying_tool( player &p, item *it, const tripoint &examp )
 {
     map &here = get_map();
     //~ %1$s: terrain/furniture name, %2$s: prying tool name
@@ -1520,7 +1520,7 @@ void apply_prying_tool( player &p, item *it, const tripoint &examp )
     iuse::crowbar( &p, it, false, examp );
 }
 
-void apply_lock_picking_tool( player &p, item *it, const tripoint &examp )
+static void apply_lock_picking_tool( player &p, item *it, const tripoint &examp )
 {
     map &here = get_map();
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1470,8 +1470,12 @@ void iexamine::locked_object( player &p, const tripoint &examp )
 
     map &here = get_map();
     if( prying_items.empty() ) {
-        add_msg( m_info, _( "The %s is locked.  If only you had something to pry it with…" ),
-                 here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
+        if( here.has_furn( examp ) ? here.furn( examp ).obj().has_flag( "LOCKED" ) : here.ter(
+                examp ).obj().has_flag( "LOCKED" ) ) {
+            add_msg( m_info, _( "The %s is locked.  You could use something to pry it with…" ),
+                     here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
+            iexamine::locked_object_pickable( p, examp );
+        }
         return;
     }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1557,8 +1557,7 @@ void iexamine::locked_object( player &p, const tripoint &examp )
     }
 
     // if the furniture/terrain is also lockpickable
-    if( here.has_furn( examp ) ? here.furn( examp ).obj().has_flag( "LOCKED" ) : here.ter(
-            examp ).obj().has_flag( "LOCKED" ) ) {
+    if( here.has_furn( examp ) && here.has_flag_ter_or_furn( "LOCKED", examp ) ) {
         safe_reference<item> lock_picking_tool = find_best_lock_picking_tool( p );
         if( lock_picking_tool ) {
             apply_lock_picking_tool( p, lock_picking_tool.get(), examp );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1557,7 +1557,7 @@ void iexamine::locked_object( player &p, const tripoint &examp )
     }
 
     // if the furniture/terrain is also lockpickable
-    if( here.has_furn( examp ) && here.has_flag_ter_or_furn( "LOCKED", examp ) ) {
+    if( here.has_flag_ter_or_furn( "LOCKED", examp ) ) {
         safe_reference<item> lock_picking_tool = find_best_lock_picking_tool( p );
         if( lock_picking_tool ) {
             apply_lock_picking_tool( p, lock_picking_tool.get(), examp );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1458,43 +1458,31 @@ void iexamine::gunsafe_el( player &p, const tripoint &examp )
     }
 }
 
-/**
- * Checks whether PC has a crowbar then calls iuse.crowbar.
- */
-void iexamine::locked_object( player &p, const tripoint &examp )
+safe_reference<item> find_best_prying_tool( player &p )
 {
     auto prying_items = p.crafting_inventory().items_with( []( const item & it ) -> bool {
         item temporary_item( it.type );
         return temporary_item.has_quality( quality_id( "PRY" ), 1 );
     } );
 
-    map &here = get_map();
-    if( prying_items.empty() ) {
-        add_msg( m_info, _( "The %s is locked.  If only you had something to pry it with…" ),
-                 here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
-        return;
-    }
 
     // Sort by their quality level.
     std::sort( prying_items.begin(), prying_items.end(), []( const item * a, const item * b ) -> bool {
         return a->get_quality( quality_id( "PRY" ) ) > b->get_quality( quality_id( "PRY" ) );
     } );
 
-    //~ %1$s: terrain/furniture name, %2$s: prying tool name
-    p.add_msg_if_player( _( "You attempt to pry open the %1$s using your %2$s…" ),
-                         here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ), prying_items[0]->tname() );
-
     // if crowbar() ever eats charges or otherwise alters the passed item, rewrite this to reflect
     // changes to the original item.
-    item temporary_item( prying_items[0]->type );
-    iuse::crowbar( &p, &temporary_item, false, examp );
+    if( prying_items.empty() ) {
+        return safe_reference<item>();
+    }
+    item best_prying_tool( prying_items[0]->type );
+    return best_prying_tool.get_safe_reference();
 }
 
-/**
-* Checks whether PC has picklocks then calls pick_lock_actor.
-*/
-void iexamine::locked_object_pickable( player &p, const tripoint &examp )
+safe_reference<item> find_best_lock_picking_tool( player &p )
 {
+
     std::vector<item *> picklocks = p.items_with( [&p]( const item & it ) {
         // Don't search for worn items such as hairpins
         if( p.get_item_position( &it ) >= -1 ) {
@@ -1502,13 +1490,6 @@ void iexamine::locked_object_pickable( player &p, const tripoint &examp )
         }
         return false;
     } );
-
-    map &here = get_map();
-    if( picklocks.empty() ) {
-        add_msg( m_info, _( "The %s is locked.  If only you had something to pick its lock with…" ),
-                 here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
-        return;
-    }
 
     // Sort by their picklock level.
     std::sort( picklocks.begin(), picklocks.end(), [&]( const item * a, const item * b ) {
@@ -1519,18 +1500,89 @@ void iexamine::locked_object_pickable( player &p, const tripoint &examp )
         return actor_a->pick_quality > actor_b->pick_quality;
     } );
 
-    for( item *it : picklocks ) {
-        const auto actor = dynamic_cast<const pick_lock_actor *>
-                           ( it->type->get_use( "picklock" )->get_actor_ptr() );
-        p.add_msg_if_player( _( "You attempt to pick lock of %1$s using your %2$s…" ),
-                             here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ), it->tname() );
-        const ret_val<bool> can_use = actor->can_use( p, *it, false, examp );
-        if( can_use.success() ) {
-            actor->use( p, *it, false, examp );
-            return;
+    if( picklocks.empty() ) {
+        return safe_reference<item>();
+    }
+
+    item best_picklock( picklocks[0]->type );
+    return best_picklock.get_safe_reference();
+}
+
+void apply_prying_tool( player &p, item *it, const tripoint &examp )
+{
+    map &here = get_map();
+    //~ %1$s: terrain/furniture name, %2$s: prying tool name
+    p.add_msg_if_player( _( "You attempt to pry open the %1$s using your %2$s…" ),
+                         here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ), it->tname() );
+
+    // if crowbar() ever eats charges or otherwise alters the passed item, rewrite this to reflect
+    // changes to the original item.
+    item temporary_item( it->type );
+    iuse::crowbar( &p, it, false, examp );
+}
+
+void apply_lock_picking_tool( player &p, item *it, const tripoint &examp )
+{
+    map &here = get_map();
+
+    const auto actor = dynamic_cast<const pick_lock_actor *>
+                       ( it->type->get_use( "picklock" )->get_actor_ptr() );
+    p.add_msg_if_player( _( "You attempt to pick lock of %1$s using your %2$s…" ),
+                         here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ), it->tname() );
+    const ret_val<bool> can_use = actor->can_use( p, *it, false, examp );
+    if( can_use.success() ) {
+        actor->use( p, *it, false, examp );
+        return;
+    } else {
+        p.add_msg_if_player( m_bad, can_use.str() );
+    }
+}
+
+/**
+ * Checks whether PC has a crowbar then calls iuse.crowbar.
+ */
+void iexamine::locked_object( player &p, const tripoint &examp )
+{
+    map &here = get_map();
+
+    safe_reference<item> prying_tool = find_best_prying_tool( p );
+    if( true ) {
+        apply_prying_tool( p, prying_tool.get(), examp );
+        return;
+    }
+
+    // if the furniture/terrain is also lockpickable
+    if( here.has_furn( examp ) ? here.furn( examp ).obj().has_flag( "LOCKED" ) : here.ter(
+            examp ).obj().has_flag( "LOCKED" ) ) {
+        safe_reference<item> lock_picking_tool = find_best_lock_picking_tool( p );
+        if( !!lock_picking_tool ) {
+            apply_lock_picking_tool( p, lock_picking_tool.get(), examp );
         } else {
-            p.add_msg_if_player( m_bad, can_use.str() );
+            add_msg( m_info, _( "The %s is locked.  If only you had something to pry or pick it with…" ),
+                     here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
         }
+        return;
+    }
+
+    add_msg( m_info, _( "The %s is locked.  If only you had something to pry it with…" ),
+             here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
+}
+
+/**
+* Checks whether PC has picklocks then calls pick_lock_actor.
+*/
+void iexamine::locked_object_pickable( player &p, const tripoint &examp )
+{
+    safe_reference<item> lock_picking_tool = find_best_lock_picking_tool( p );
+    if( lock_picking_tool ) {
+        apply_lock_picking_tool( p, lock_picking_tool.get(), examp );
+    }
+
+    map &here = get_map();
+    if( lock_picking_tool ) {
+        add_msg( m_info, _( "The %s is locked.  If only you had something to pick its lock with…" ),
+                 here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
+        return;
     }
 }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1473,10 +1473,10 @@ safe_reference<item> find_best_prying_tool( player &p )
 
     // if crowbar() ever eats charges or otherwise alters the passed item, rewrite this to reflect
     // changes to the original item.
-    if( prying_items.empty() ) {
+    if (prying_items.empty()) {
         return safe_reference<item>();
     }
-    item best_prying_tool( prying_items[0]->type );
+    item best_prying_tool(prying_items[0]->type);
     return best_prying_tool.get_safe_reference();
 }
 
@@ -1500,7 +1500,7 @@ safe_reference<item> find_best_lock_picking_tool( player &p )
         return actor_a->pick_quality > actor_b->pick_quality;
     } );
 
-    if( picklocks.empty() ) {
+    if (picklocks.empty()) {
         return safe_reference<item>();
     }
 
@@ -1546,7 +1546,7 @@ void iexamine::locked_object( player &p, const tripoint &examp )
     map &here = get_map();
 
     safe_reference<item> prying_tool = find_best_prying_tool( p );
-    if( true ) {
+    if( prying_tool ) {
         apply_prying_tool( p, prying_tool.get(), examp );
         return;
     }
@@ -1555,7 +1555,7 @@ void iexamine::locked_object( player &p, const tripoint &examp )
     if( here.has_furn( examp ) ? here.furn( examp ).obj().has_flag( "LOCKED" ) : here.ter(
             examp ).obj().has_flag( "LOCKED" ) ) {
         safe_reference<item> lock_picking_tool = find_best_lock_picking_tool( p );
-        if( !!lock_picking_tool ) {
+        if( lock_picking_tool ) {
             apply_lock_picking_tool( p, lock_picking_tool.get(), examp );
         } else {
             add_msg( m_info, _( "The %s is locked.  If only you had something to pry or pick it with…" ),
@@ -1576,14 +1576,12 @@ void iexamine::locked_object_pickable( player &p, const tripoint &examp )
     safe_reference<item> lock_picking_tool = find_best_lock_picking_tool( p );
     if( lock_picking_tool ) {
         apply_lock_picking_tool( p, lock_picking_tool.get(), examp );
+        return;
     }
 
     map &here = get_map();
-    if( lock_picking_tool ) {
         add_msg( m_info, _( "The %s is locked.  If only you had something to pick its lock with…" ),
                  here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
-        return;
-    }
 }
 
 void iexamine::bulletin_board( player &p, const tripoint &examp )

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1470,12 +1470,8 @@ void iexamine::locked_object( player &p, const tripoint &examp )
 
     map &here = get_map();
     if( prying_items.empty() ) {
-        add_msg( m_info, _( "The %s is locked.  You could use something to pry it with…" ),
+        add_msg( m_info, _( "The %s is locked.  If only you had something to pry it with…" ),
                  here.has_furn( examp ) ? here.furnname( examp ) : here.tername( examp ) );
-        if( here.has_furn( examp ) ? here.furn( examp ).obj().has_flag( "LOCKED" ) : here.ter(
-                examp ).obj().has_flag( "LOCKED" ) ) {
-            iexamine::locked_object_pickable( p, examp );
-        }
         return;
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfixes "[WIP] fix [E]xamine does not fallback to using lockpicks on locked doors when the player has no prying tool"
Fixes #282 

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
See title
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
For now the solution is to call the function used when examining a lockpickable only terrain (eg some doors).
Problem is, the part "The <thing> is locked." is repeated, so I don't find it very satisfying.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
- Changing the wording enough so that the repetition wouldn't be so obvious
- Finding a clean way to pass extra information to locked_object_pickable
- None were good enough

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Doors that are both pyrable and lockpickable work as intended.
Crates can't be lockpicked.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

Any idea?