### PR TITLE
Make glove liners autolearn at lvl 5

### DIFF
--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -199,6 +199,7 @@
     "skill_used": "tailor",
     "difficulty": 1,
     "time": "10 m",
+    "autolearn": [ [ "tailor", 5 ] ],
     "book_learn": [ [ "manual_tailor", 1 ], [ "mag_tailor", 0 ], [ "textbook_survival", 2 ], [ "pocket_survival", 2 ] ],
     "using": [ [ "sewing_standard", 2 ] ],
     "components": [ [ [ "rag", 2 ] ] ]


### PR DESCRIPTION
Glove liners were one of those early level items that can't be autolearned. Since they are very useful, and with enough experience, autolearned, this change will make it so. It will stay a level 1 craft, but will be autolearend at level 5. So finding the corresponding books would be a lot better.