### PR TITLE
Ski mask and balclava difficulty, craft time and book learning changes

### DIFF
--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -6,9 +6,9 @@
     "subcategory": "CSC_ARMOR_HEAD",
     "skill_used": "tailor",
     "difficulty": 2,
-    "skills_required": [ "survival", 1 ],
-    "time": "5 m",
-    "autolearn": true,
+    "time": "10 m",
+    "autolearn": [ [ "tailor", 4 ] ],
+    "book_learn": [ [ "textbook_tailor", 2 ], [ "manual_tailor", 2 ], [ "tailor_portfolio", 2 ] ],
     "using": [ [ "sewing_standard", 3 ] ],
     "components": [ [ [ "rag", 4 ] ] ]
   },

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -1048,9 +1048,10 @@
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_HEAD",
     "skill_used": "tailor",
-    "difficulty": 6,
-    "time": "2 h 30 m",
-    "autolearn": true,
+    "difficulty": 3,
+    "time": "30 m",
+    "autolearn": [ [ "tailor", 7 ] ],
+    "book_learn": [ [ "textbook_tailor", 3 ], [ "manual_tailor", 4 ], [ "tailor_portfolio", 3 ] ],
     "using": [ [ "sewing_standard", 80 ] ],
     "components": [ [ [ "felt_patch", 8 ] ] ]
   },


### PR DESCRIPTION
Ski masks were an odditiy, learnable at level 6 and with very few items craftable. This will make them craftable faster, but also autolearn it later, with an lower recipe level. On the plus side: it can be learned from books now.