### PR TITLE
Make duct tape autolearn at Fab 6

### DIFF
--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -315,6 +315,7 @@
     "subcategory": "CSC_OTHER_MATERIALS",
     "skill_used": "fabrication",
     "difficulty": 3,
+    "autolearn": [ [ "fabrication", 6 ] ],
     "time": "18 m",
     "book_learn": [ [ "textbook_fabrication", 3 ], [ "textbook_chemistry", 3 ], [ "adv_chemistry", 3 ], [ "textbook_mechanics", 5 ] ],
     "using": [ [ "filament", 50 ] ],


### PR DESCRIPTION
This will make duct tape autolearnable at level 6. It stays a level 3 craft with the same book learning options.