### PR TITLE
fixes for generic guns

### DIFF
--- a/data/mods/Generic_Guns/ammo/replacefix.json
+++ b/data/mods/Generic_Guns/ammo/replacefix.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "belt308",
+    "copy-from": "belt308",
+    "type": "MAGAZINE",
+    "name": { "str": "7.62x51mm ammo belt" },
+    "ammo_type": "ammo_rifle",
+    "default_ammo": "rifle_ball",
+    "linkage": "ammolink223"
+  }
+]

--- a/data/mods/Generic_Guns/firearms/pistol.json
+++ b/data/mods/Generic_Guns/firearms/pistol.json
@@ -62,5 +62,14 @@
     "ammo": "ammo_pistol",
     "description": "A crudely constructed fully automatic submachinegun, accepting standard submachine gun magazines.  The heavy bolt makes accurate fire difficult, and its questionable construction makes for poor reliability and longevity.  Similar designs of desperation from the Second World War served their nations well enough, so this should be good for zombies… right?  Accepts standard pistol ammunition.",
     "magazines": [ [ "ammo_pistol", [ "pistol_smg_mag", "pistol_smg_mag_hc" ] ] ]
+  },
+  {
+    "id": "submachine_turret_fake",
+    "copy-from": "pistol_smg",
+    "type": "GUN",
+    "name": "submachine gun",
+    "description": "You shouldn't see this! ",
+    "clip_size": 300,
+    "magazines": [  ]
   }
 ]

--- a/data/mods/Generic_Guns/robots/gg_bots_migration.json
+++ b/data/mods/Generic_Guns/robots/gg_bots_migration.json
@@ -29,5 +29,36 @@
         "no_ammo_sound": "a chk!"
       }
     ]
+  },
+  {
+    "id": "mon_turret_light",
+    "copy-from": "mon_turret_light",
+    "type": "MONSTER",
+    "name": { "str": "light turret" },
+    "description": "The General Atomics TX-1 Guardian, an popular automated turret equipped with a 9mm carbine.  Initially it was designed mainly for corporate property protection and police needs, however due to its popularity, it ended up being used even for military needs.  Its high-quality targeting system allows it to engage targets even at medium range.",
+    "default_faction": "military",
+    "starting_ammo": { "pistol_ball": 90 },
+    "special_attacks": [
+      {
+        "type": "gun",
+        "cooldown": 1,
+        "move_cost": 150,
+        "gun_type": "submachine_turret_fake",
+        "ammo_type": "pistol_ball",
+        "fake_skills": [ [ "gun", 5 ], [ "rifle", 5 ] ],
+        "fake_str": 16,
+        "fake_dex": 12,
+        "ranges": [ [ 0, 16, "AUTO" ], [ 17, 32, "DEFAULT" ] ],
+        "require_targeting_npc": true,
+        "require_targeting_monster": true,
+        "laser_lock": false,
+        "no_crits": true,
+        "targeting_cost": 200,
+        "targeting_timeout_extend": -10,
+        "targeting_sound": "\"Hostile detected.\"",
+        "targeting_volume": 20,
+        "no_ammo_sound": "a chk!"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
There was an error lingering, where light machine guns in cars would have sniper ammo instead of rifle ammo, this fixes the problem.