### PR TITLE
Fix bonuses displayed without +

### DIFF
--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -411,7 +411,7 @@ static void draw_stats_info( const catacurses::window &w_info,
         print_colored_text( w_info, point( 1, 4 ), col_temp, c_light_gray,
                             string_format( _( "Read times: <color_white>%d%%</color>" ), you.read_speed( false ) ) );
         print_colored_text( w_info, point( 1, 5 ), col_temp, c_light_gray,
-                            string_format( _( "Crafting bonus: <color_white>%d%%</color>" ), you.get_int() ) );
+                            string_format( _( "Crafting bonus: <color_white>+%d%%</color>" ), you.get_int() ) );
     } else if( line == 3 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -876,7 +876,7 @@ tab_direction set_stats( avatar &u, points_left &points )
                 // NOLINTNEXTLINE(cata-use-named-point-constants)
                 mvwprintz( w_description, point( 0, 1 ), COL_STAT_NEUTRAL, _( "Carry weight: %.1f %s" ),
                            convert_weight( u.weight_capacity() ), weight_units() );
-                mvwprintz( w_description, point( 0, 2 ), COL_STAT_BONUS, _( "Melee damage bonus: %.1f" ),
+                mvwprintz( w_description, point( 0, 2 ), COL_STAT_BONUS, _( "Melee damage bonus: +%.1f" ),
                            u.bonus_damage( false ) );
                 fold_and_print( w_description, point( 0, 4 ), getmaxx( w_description ) - 1, COL_STAT_NEUTRAL,
                                 _( "Strength also makes you more resistant to many diseases and poisons, and makes actions which require brute force more effective." ) );
@@ -917,7 +917,7 @@ tab_direction set_stats( avatar &u, points_left &points )
                 // NOLINTNEXTLINE(cata-use-named-point-constants)
                 mvwprintz( w_description, point( 0, 1 ), COL_STAT_PENALTY, _( "Skill rust: %d%%" ),
                            u.rust_rate() );
-                mvwprintz( w_description, point( 0, 2 ), COL_STAT_BONUS, _( "Crafting bonus: %2d%%" ),
+                mvwprintz( w_description, point( 0, 2 ), COL_STAT_BONUS, _( "Crafting bonus: +%d%%" ),
                            u.get_int() );
                 fold_and_print( w_description, point( 0, 4 ), getmaxx( w_description ) - 1, COL_STAT_NEUTRAL,
                                 _( "Intelligence is also used when crafting, installing bionics, and interacting with NPCs." ) );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -935,7 +935,7 @@ tab_direction set_stats( avatar &u, points_left &points )
                     mvwprintz( w_description, point_zero, COL_STAT_PENALTY, _( "Aiming penalty: -%d" ),
                                u.ranged_per_mod() );
                 }
-                mvwprintz( w_description, point( 0, 2 ), COL_STAT_BONUS, _( "Night vision bonus: -%.1f" ),
+                mvwprintz( w_description, point( 0, 2 ), COL_STAT_BONUS, _( "Night vision bonus: +%.1f" ),
                            vision::nv_range_from_per( u.per_max ) );
                 fold_and_print( w_description, point( 0, 4 ), getmaxx( w_description ) - 1, COL_STAT_NEUTRAL,
                                 _( "Perception is also used for detecting traps and other things of interest." ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfixes "Fix bonus displayed without +"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
Some bonuses displayed didn't have a "+" in front of them, while some did.
Also during character creation night vision bonus had a "-". 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Every bonus gets a +
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Removing the "+"
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Create new character, looking at every bonus. Then same thing in the "@" menu in game.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
Before
![NV1](https://user-images.githubusercontent.com/71428793/191990727-612df27d-b279-43c1-87af-153bb9638317.PNG)
After
![NV2](https://user-images.githubusercontent.com/71428793/191990740-54fc2224-8a7c-4919-936d-fc5f471d1daa.PNG)
PS: the changing for crafting bonus, from 2d to d is intentional, to remove the space between the + and the number when there's only one number (just in case)
