### PR TITLE
[DinoMod] faction updates

### DIFF
--- a/data/mods/DinoMod/monster_factions.json
+++ b/data/mods/DinoMod/monster_factions.json
@@ -9,7 +9,7 @@
   {
     "type": "MONSTER_FACTION",
     "name": "small_predator",
-    "base_faction": "cat",
+    "base_faction": "small_animal",
     "by_mood": [ "small_predator", "cat", "eoraptor" ],
     "hate": [ "small_animal", "very_small_predator" ]
   },

--- a/data/mods/DinoMod/monster_factions.json
+++ b/data/mods/DinoMod/monster_factions.json
@@ -2,14 +2,14 @@
   {
     "type": "MONSTER_FACTION",
     "name": "very_small_predator",
-    "base_faction": "small_animal",
+    "base_faction": "cat",
     "by_mood": [ "small_animal", "cat", "very_small_predator" ],
-    "hate": "vermin"
+    "hate": [ "vermin" ]
   },
   {
     "type": "MONSTER_FACTION",
     "name": "small_predator",
-    "base_faction": "small_animal",
+    "base_faction": "cat",
     "by_mood": [ "small_predator", "cat", "eoraptor" ],
     "hate": [ "small_animal", "very_small_predator" ]
   },
@@ -31,16 +31,31 @@
     "type": "MONSTER_FACTION",
     "name": "herbivore_young",
     "base_faction": "small_animal",
-    "neutral": "small_animal",
-    "friendly": "herbivore_dino"
+    "neutral": [ "small_animal", "herbivore" ],
+    "friendly": [ "herbivore_dino" ]
   },
   {
     "type": "MONSTER_FACTION",
     "name": "herbivore_dino",
     "base_faction": "herbivore",
-    "neutral": "herbivore",
-    "hate": "plant",
-    "friendly": "herbivore_young"
+    "neutral": [ "herbivore", "small_animal" ],
+    "friendly": [ "herbivore_young" ],
+    "hate": [ "plant" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "insectivore_young",
+    "base_faction": "small_animal",
+    "neutral": [ "small_animal" ],
+    "friendly": [ "insectivore_dino" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "insectivore_dino",
+    "base_faction": "very_small_predator",
+    "neutral": [ "herbivore" ],
+    "friendly": [ "insectivore_young" ],
+    "hate": [ "insect" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -56,7 +71,7 @@
     "base_faction": "fish",
     "neutral": [ "fishing_dino", "zombie_aquatic", "mixed_dino" ],
     "by_mood": [ "small_fisher", "very_small_mixed" ],
-    "hate": "fish"
+    "hate": [ "fish" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -71,7 +86,7 @@
     "name": "medium_mixed",
     "base_faction": "big_cat",
     "by_mood": [ "big_cat", "medium_mixed", "vermin", "aquatic_predator" ],
-    "hate": "fish"
+    "hate": [ "fish" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -93,26 +108,26 @@
     "base_faction": "aquatic_predator",
     "by_mood": [ "fishing_dino", "mixed_dino", "aquatic_predator" ],
     "neutral": [ "small_animal", "small_fisher" ],
-    "hate": "gator"
+    "hate": [ "gator" ]
   },
   {
     "type": "MONSTER_FACTION",
     "name": "compsognathus",
     "base_faction": "small_predator",
-    "friendly": "compsognathus_hatchling"
+    "friendly": [ "compsognathus_hatchling" ]
   },
   {
     "type": "MONSTER_FACTION",
     "name": "compsognathus_hatchling",
     "base_faction": "very_small_predator",
-    "friendly": "compsognathus"
+    "friendly": [ "compsognathus" ]
   },
   {
     "type": "MONSTER_FACTION",
     "name": "spinosaurus",
     "base_faction": "fishing_dino",
-    "by_mood": "spinosaurus",
-    "friendly": [ "spinosaurus_juvenile", "spinosaurus_hatchling" ]
+    "friendly": [ "spinosaurus_juvenile", "spinosaurus_hatchling" ],
+    "by_mood": [ "spinosaurus" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -128,42 +143,21 @@
   },
   {
     "type": "MONSTER_FACTION",
-    "name": "tyrannosaurus",
+    "name": "torvosaurus",
     "base_faction": "predator_dino",
-    "hate": [ "animal", "zombie", "human" ],
-    "by_mood": "tyrannosaurus",
-    "friendly": [ "tyrannosaurus_juvenile", "tyrannosaurus_hatchling" ]
+    "friendly": [ "torvosaurus_juvenile", "torvosaurus_hatchling" ]
   },
   {
     "type": "MONSTER_FACTION",
-    "name": "tyrannosaurus_juvenile",
+    "name": "torvosaurus_juvenile",
     "base_faction": "small_predator",
-    "friendly": [ "tyrannosaurus", "tyrannosaurus_hatchling" ]
+    "friendly": [ "torvosaurus", "torvosaurus_hatchling" ]
   },
   {
     "type": "MONSTER_FACTION",
-    "name": "tyrannosaurus_hatchling",
+    "name": "torvosaurus_hatchling",
     "base_faction": "very_small_predator",
-    "friendly": [ "tyrannosaurus", "tyrannosaurus_juvenile" ]
-  },
-  {
-    "type": "MONSTER_FACTION",
-    "name": "albertosaurus",
-    "base_faction": "predator_dino",
-    "by_mood": "albertosaurus",
-    "friendly": [ "albertosaurus_juvenile", "albertosaurus_hatchling" ]
-  },
-  {
-    "type": "MONSTER_FACTION",
-    "name": "albertosaurus_juvenile",
-    "base_faction": "small_predator",
-    "friendly": [ "albertosaurus", "albertosaurus_hatchling" ]
-  },
-  {
-    "type": "MONSTER_FACTION",
-    "name": "albertosaurus_hatchling",
-    "base_faction": "very_small_predator",
-    "friendly": [ "albertosaurus", "albertosaurus_juvenile" ]
+    "friendly": [ "torvosaurus", "torvosaurus_juvenile" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -187,8 +181,8 @@
     "type": "MONSTER_FACTION",
     "name": "acrocanthosaurus",
     "base_faction": "predator_dino",
-    "by_mood": "acrocanthosaurus",
-    "friendly": [ "acrocanthosaurus_juvenile", "acrocanthosaurus_hatchling" ]
+    "friendly": [ "acrocanthosaurus_juvenile", "acrocanthosaurus_hatchling" ],
+    "by_mood": [ "acrocanthosaurus" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -206,8 +200,8 @@
     "type": "MONSTER_FACTION",
     "name": "siats",
     "base_faction": "predator_dino",
-    "by_mood": "siats",
-    "friendly": [ "siats_juvenile", "siats_hatchling" ]
+    "friendly": [ "siats_juvenile", "siats_hatchling" ],
+    "by_mood": [ "siats" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -223,15 +217,163 @@
   },
   {
     "type": "MONSTER_FACTION",
+    "name": "dryptosaurus",
+    "base_faction": "predator_dino",
+    "friendly": [ "dryptosaurus_juvenile", "dryptosaurus_hatchling" ],
+    "by_mood": [ "dryptosaurus" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "dryptosaurus_juvenile",
+    "base_faction": "small_predator",
+    "friendly": [ "dryptosaurus", "dryptosaurus_hatchling" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "dryptosaurus_hatchling",
+    "base_faction": "very_small_predator",
+    "friendly": [ "dryptosaurus", "dryptosaurus_juvenile" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "appalachiosaurus",
+    "base_faction": "predator_dino",
+    "friendly": [ "appalachiosaurus_juvenile", "appalachiosaurus_hatchling" ],
+    "by_mood": [ "appalachiosaurus" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "appalachiosaurus_juvenile",
+    "base_faction": "small_predator",
+    "friendly": [ "appalachiosaurus", "appalachiosaurus_hatchling" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "appalachiosaurus_hatchling",
+    "base_faction": "very_small_predator",
+    "friendly": [ "appalachiosaurus", "appalachiosaurus_juvenile" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "gorgosaurus",
+    "base_faction": "predator_dino",
+    "friendly": [ "gorgosaurus_juvenile", "gorgosaurus_hatchling" ],
+    "by_mood": [ "gorgosaurus" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "gorgosaurus_juvenile",
+    "base_faction": "small_predator",
+    "friendly": [ "gorgosaurus", "gorgosaurus_hatchling" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "gorgosaurus_hatchling",
+    "base_faction": "very_small_predator",
+    "friendly": [ "gorgosaurus", "gorgosaurus_juvenile" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "albertosaurus",
+    "base_faction": "predator_dino",
+    "friendly": [ "albertosaurus_juvenile", "albertosaurus_hatchling" ],
+    "by_mood": [ "albertosaurus" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "albertosaurus_juvenile",
+    "base_faction": "small_predator",
+    "friendly": [ "albertosaurus", "albertosaurus_hatchling" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "albertosaurus_hatchling",
+    "base_faction": "very_small_predator",
+    "friendly": [ "albertosaurus", "albertosaurus_juvenile" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "nanuqsaurus",
+    "base_faction": "predator_dino",
+    "hate": [ "animal", "zombie", "human" ],
+    "friendly": [ "nanuqsaurus_juvenile", "nanuqsaurus_hatchling" ],
+    "by_mood": [ "nanuqsaurus" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "nanuqsaurus_juvenile",
+    "base_faction": "small_predator",
+    "friendly": [ "nanuqsaurus", "nanuqsaurus_hatchling" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "nanuqsaurus_hatchling",
+    "base_faction": "very_small_predator",
+    "friendly": [ "nanuqsaurus", "nanuqsaurus_juvenile" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "daspletosaurus",
+    "base_faction": "predator_dino",
+    "hate": [ "animal", "zombie", "human" ],
+    "friendly": [ "daspletosaurus_juvenile", "daspletosaurus_hatchling" ],
+    "by_mood": [ "daspletosaurus" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "daspletosaurus_juvenile",
+    "base_faction": "small_predator",
+    "friendly": [ "daspletosaurus", "daspletosaurus_hatchling" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "daspletosaurus_hatchling",
+    "base_faction": "very_small_predator",
+    "friendly": [ "daspletosaurus", "daspletosaurus_juvenile" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "tyrannosaurus",
+    "base_faction": "predator_dino",
+    "hate": [ "animal", "zombie", "human" ],
+    "friendly": [ "tyrannosaurus_juvenile", "tyrannosaurus_hatchling" ],
+    "by_mood": [ "tyrannosaurus" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "tyrannosaurus_juvenile",
+    "base_faction": "small_predator",
+    "friendly": [ "tyrannosaurus", "tyrannosaurus_hatchling" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "tyrannosaurus_hatchling",
+    "base_faction": "very_small_predator",
+    "friendly": [ "tyrannosaurus", "tyrannosaurus_juvenile" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "saurornitholestes",
+    "base_faction": "small_predator",
+    "friendly": [ "saurornitholestes_hatchling" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "saurornitholestes_hatchling",
+    "base_faction": "very_small_predator",
+    "friendly": [ "saurornitholestes" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
     "name": "velociraptor",
     "base_faction": "small_predator",
-    "friendly": "velociraptor_hatchling"
+    "friendly": [ "velociraptor_hatchling" ]
   },
   {
     "type": "MONSTER_FACTION",
     "name": "velociraptor_hatchling",
     "base_faction": "very_small_predator",
-    "friendly": "velociraptor"
+    "friendly": [ "velociraptor" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -272,6 +414,30 @@
   },
   {
     "type": "MONSTER_FACTION",
+    "name": "dromaeosaurus",
+    "base_faction": "small_predator",
+    "friendly": [ "dromaeosaurus_hatchling" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "dromaeosaurus_hatchling",
+    "base_faction": "very_small_predator",
+    "friendly": [ "dromaeosaurus" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "stenonychosaurus",
+    "base_faction": "small_predator",
+    "friendly": [ "stenonychosaurus_hatchling" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "stenonychosaurus_hatchling",
+    "base_faction": "very_small_predator",
+    "friendly": [ "stenonychosaurus" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
     "name": "dimorphodon",
     "base_faction": "small_fisher"
   },
@@ -279,13 +445,13 @@
     "type": "MONSTER_FACTION",
     "name": "pteranodon",
     "base_faction": "medium_fisher",
-    "friendly": "pteranodon_young"
+    "friendly": [ "pteranodon_young" ]
   },
   {
     "type": "MONSTER_FACTION",
     "name": "pteranodon_young",
     "base_faction": "small_fisher",
-    "friendly": "pteranodon"
+    "friendly": [ "pteranodon" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -307,6 +473,24 @@
   },
   {
     "type": "MONSTER_FACTION",
+    "name": "anzu",
+    "base_faction": "medium_mixed",
+    "friendly": [ "anzu_hatchling", "anzu_juvenile" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "anzu_juvenile",
+    "base_faction": "small_mixed",
+    "friendly": [ "anzu", "anzu_hatchling" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "anzu_hatchling",
+    "base_faction": "very_small_mixed",
+    "friendly": [ "anzu", "anzu_juvenile" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
     "name": "eoraptor",
     "//": "omnivore",
     "base_faction": "very_small_predator"
@@ -315,13 +499,13 @@
     "type": "MONSTER_FACTION",
     "name": "coelophysis",
     "base_faction": "small_predator",
-    "friendly": "coelophysis_hatchling"
+    "friendly": [ "coelophysis_hatchling" ]
   },
   {
     "type": "MONSTER_FACTION",
     "name": "coelophysis_hatchling",
     "base_faction": "very_small_predator",
-    "friendly": "coelophysis"
+    "friendly": [ "coelophysis" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -345,8 +529,8 @@
     "type": "MONSTER_FACTION",
     "name": "mosasaurus",
     "base_faction": "mixed_dino",
-    "by_mood": "mosasaurus",
-    "friendly": [ "mosasaurus_juvenile", "mosasaurus_hatchling" ]
+    "friendly": [ "mosasaurus_juvenile", "mosasaurus_hatchling" ],
+    "by_mood": [ "mosasaurus" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -364,8 +548,8 @@
     "type": "MONSTER_FACTION",
     "name": "ceratosaurus",
     "base_faction": "mixed_dino",
-    "by_mood": "fish",
-    "friendly": [ "ceratosaurus_juvenile", "ceratosaurus_hatchling" ]
+    "friendly": [ "ceratosaurus_juvenile", "ceratosaurus_hatchling" ],
+    "by_mood": [ "fish" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -396,5 +580,60 @@
     "name": "qianzhousaurus_hatchling",
     "base_faction": "very_small_predator",
     "friendly": [ "qianzhousaurus", "qianzhousaurus_juvenile" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "small_animal",
+    "copy-from": "small_animal",
+    "neutral": [ "predator_dino", "mixed_dino", "fishing_dino", "insectivore_young", "herbivore_young", "herbivore_dino" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "herbivore",
+    "copy-from": "herbivore",
+    "neutral": [ "herbivore_dino", "insectivore_dino", "herbivore_young" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "cat",
+    "copy-from": "cat",
+    "by_mood": [ "small_predator", "very_small_predator" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "wolf",
+    "copy-from": "wolf",
+    "by_mood": [ "medium_predator", "herbivore_dino" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "big_cat",
+    "copy-from": "big_cat",
+    "by_mood": [ "medium_mixed", "herbivore_dino" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "zombie_aquatic",
+    "copy-from": "zombie_aquatic",
+    "by_mood": [ "mixed_dino" ],
+    "neutral": [ "small_fisher" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "gator",
+    "copy-from": "gator",
+    "by_mood": [ "mixed_dino", "fishing_dino", "predator_dino", "herbivore_dino" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "fish",
+    "copy-from": "fish",
+    "by_mood": [ "mixed_dino", "aquatic_predator", "small_mixed", "small_fisher", "very_small_mixed" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "aquatic_predator",
+    "copy-from": "aquatic_predator",
+    "by_mood": [ "medium_fisher", "fishing_dino", "mixed_dino", "medium_mixed" ]
   }
 ]

--- a/data/mods/DinoMod/monster_factions.json
+++ b/data/mods/DinoMod/monster_factions.json
@@ -580,37 +580,5 @@
     "name": "qianzhousaurus_hatchling",
     "base_faction": "very_small_predator",
     "friendly": [ "qianzhousaurus", "qianzhousaurus_juvenile" ]
-  },
-  {
-    "type": "MONSTER_FACTION",
-    "name": "small_animal",
-    "base_faction": "animal",
-    "by_mood": "small_predator",
-    "neutral": [ "predator_dino", "mixed_dino", "fishing_dino", "insectivore_young", "herbivore_young", "herbivore_dino" ]
-  },
-  {
-    "type": "MONSTER_FACTION",
-    "name": "herbivore",
-    "base_faction": "animal",
-    "neutral": [ "small_animal", "herbivore_dino", "insectivore_dino", "herbivore_young" ]
-  },
-  {
-    "type": "MONSTER_FACTION",
-    "name": "cat",
-    "base_faction": "small_predator",
-    "by_mood": [ "small_predator", "very_small_predator" ]
-  },
-  {
-    "type": "MONSTER_FACTION",
-    "name": "zombie_aquatic",
-    "friendly": [ "blob", "cult", "zombie" ],
-    "neutral": [ "small_animal", "insect", "small_fisher" ],
-    "by_mood": [ "bee", "mixed_dino" ]
-  },
-  {
-    "type": "MONSTER_FACTION",
-    "name": "fish",
-    "base_faction": "animal",
-    "by_mood": [ "mixed_dino", "aquatic_predator", "small_mixed", "small_fisher", "very_small_mixed" ]
   }
 ]

--- a/data/mods/DinoMod/monster_factions.json
+++ b/data/mods/DinoMod/monster_factions.json
@@ -580,5 +580,37 @@
     "name": "qianzhousaurus_hatchling",
     "base_faction": "very_small_predator",
     "friendly": [ "qianzhousaurus", "qianzhousaurus_juvenile" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "small_animal",
+    "base_faction": "animal",
+    "by_mood": "small_predator",
+    "neutral": [ "predator_dino", "mixed_dino", "fishing_dino", "insectivore_young", "herbivore_young", "herbivore_dino" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "herbivore",
+    "base_faction": "animal",
+    "neutral": [ "small_animal", "herbivore_dino", "insectivore_dino", "herbivore_young" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "cat",
+    "base_faction": "small_predator",
+    "by_mood": [ "small_predator", "very_small_predator" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "zombie_aquatic",
+    "friendly": [ "blob", "cult", "zombie" ],
+    "neutral": [ "small_animal", "insect", "small_fisher" ],
+    "by_mood": [ "bee", "mixed_dino" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "fish",
+    "base_faction": "animal",
+    "by_mood": [ "mixed_dino", "aquatic_predator", "small_mixed", "small_fisher", "very_small_mixed" ]
   }
 ]

--- a/data/mods/DinoMod/monster_factions.json
+++ b/data/mods/DinoMod/monster_factions.json
@@ -584,56 +584,33 @@
   {
     "type": "MONSTER_FACTION",
     "name": "small_animal",
-    "copy-from": "small_animal",
+    "base_faction": "animal",
+    "by_mood": "small_predator",
     "neutral": [ "predator_dino", "mixed_dino", "fishing_dino", "insectivore_young", "herbivore_young", "herbivore_dino" ]
   },
   {
     "type": "MONSTER_FACTION",
     "name": "herbivore",
-    "copy-from": "herbivore",
-    "neutral": [ "herbivore_dino", "insectivore_dino", "herbivore_young" ]
+    "base_faction": "animal",
+    "neutral": [ "small_animal", "herbivore_dino", "insectivore_dino", "herbivore_young" ]
   },
   {
     "type": "MONSTER_FACTION",
     "name": "cat",
-    "copy-from": "cat",
+    "base_faction": "small_predator",
     "by_mood": [ "small_predator", "very_small_predator" ]
   },
   {
     "type": "MONSTER_FACTION",
-    "name": "wolf",
-    "copy-from": "wolf",
-    "by_mood": [ "medium_predator", "herbivore_dino" ]
-  },
-  {
-    "type": "MONSTER_FACTION",
-    "name": "big_cat",
-    "copy-from": "big_cat",
-    "by_mood": [ "medium_mixed", "herbivore_dino" ]
-  },
-  {
-    "type": "MONSTER_FACTION",
     "name": "zombie_aquatic",
-    "copy-from": "zombie_aquatic",
-    "by_mood": [ "mixed_dino" ],
-    "neutral": [ "small_fisher" ]
-  },
-  {
-    "type": "MONSTER_FACTION",
-    "name": "gator",
-    "copy-from": "gator",
-    "by_mood": [ "mixed_dino", "fishing_dino", "predator_dino", "herbivore_dino" ]
+    "friendly": [ "blob", "cult", "zombie" ],
+    "neutral": [ "small_animal", "insect", "small_fisher" ],
+    "by_mood": [ "bee", "mixed_dino" ]
   },
   {
     "type": "MONSTER_FACTION",
     "name": "fish",
-    "copy-from": "fish",
+    "base_faction": "animal",
     "by_mood": [ "mixed_dino", "aquatic_predator", "small_mixed", "small_fisher", "very_small_mixed" ]
-  },
-  {
-    "type": "MONSTER_FACTION",
-    "name": "aquatic_predator",
-    "copy-from": "aquatic_predator",
-    "by_mood": [ "medium_fisher", "fishing_dino", "mixed_dino", "medium_mixed" ]
   }
 ]


### PR DESCRIPTION
#### Summary

SUMMARY: Mods "[DinoMod] faction updates"

#### Purpose of change

Feature parity with DDA, bugfix geese murdering massive sauropods with no counter

#### Describe the solution

A ton of faction tweaks to prepare for new dinos and fix problems with monsters attacking with no counter by explicitly defining the interactions to be the same on both sides. Some tweaks to remove copy-from functionality (doesn't exist for factions in BN) and remove definitions for factions like gator that don't exist in BN.

#### Describe alternatives you've considered

N/A

#### Testing

Game loads no errors, debug spawned a goose and a brontosaurus next to each other and the goose didn't slowly murder the brontosaurus

#### Additional context

More table setting to start moving development to BN during DDA content freeze