### PR TITLE
New 3d shadowcasting algorithm

### DIFF
--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1596,14 +1596,14 @@ float fastexp( float x )
     return u.f / v.f;
 }
 
-float light_calc( const float &numerator, const float &transparency,
-                  const int &distance )
+static float light_calc( const float &numerator, const float &transparency,
+                         const int &distance )
 {
     // Light needs inverse square falloff in addition to attenuation.
     return numerator  / ( fastexp( transparency * distance ) * distance );
 }
 
-bool light_check( const float &transparency, const float &intensity )
+static bool light_check( const float &transparency, const float &intensity )
 {
     return transparency > LIGHT_TRANSPARENCY_SOLID && intensity > LIGHT_AMBIENT_LOW;
 }

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1127,6 +1127,7 @@ void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
             if( check_blocked( current ) ) {
                 end_block( distance, extra );
                 started_block = false;
+                started_row = false;
                 continue;
             }
 

--- a/src/shadowcasting.h
+++ b/src/shadowcasting.h
@@ -104,6 +104,15 @@ inline float accumulate_transparency( const float &cumulative_transparency,
     return ( ( distance - 1 ) * cumulative_transparency + current_transparency ) / distance;
 }
 
+inline bool noop_compare( const point &, void * )
+{
+    return true;
+}
+template <typename T>
+inline void noop_start_block( const point &, const T, const float, const float, const int,
+                              void * ) {}
+inline void noop_end_block( const int, void * ) {}
+
 template<typename T, typename Out, T( *calc )( const T &, const T &, const int & ),
          bool( *check )( const T &, const T & ),
          void( *update_output )( Out &, const T &, quadrant ),


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "New 3d shadowcasting algorithm"

#### Purpose of change

3d shadowcasting that builds upon the 2d algorithm. Hopefully it will be faster and mean less maintenance work. 

There are some behavioral changes. Tiles now have 25% "dead space" at the top, vision that only hits this space doesn't reveal the tile. This counteracts shadowcasting's permissiveness around 1 tile "corners" on the z axis. Standing on a 1 tile roof now has a similar effect to 2+ and in general it's easier to hide from the street by staying near the middle of a roof or to hide from a roof by hugging the wall. 

Floors are now handled differently. They are treated as opaque thin edges and affect casts appropriately. In terms of the old algorithm this meant some extra geometry to calculate where the floor ends and a bit of logic to make sure blocks with floor were split on every z level. The effect is the same in the new algorithm. 

Almost unrelated but there's a small change to 2d shadowcasting behavior. The rule that "The new span starts at the leading edge of the previous square if it is opaque, and at the trailing edge of the current square if it is transparent," assumes boolean transparency. There's a section in the middle that goes through both tiles and it wants to group it with the opaque side and doesn't account for the fact that we might not have an opaque side. Technically a third cast would be correct, but it's a tiny error. Instead the rule is now "more opaque" which is just a little nicer.

Not yet implemented, but I intend to default end_major to +inf to give you eyes in the top of your head to go along with the ones in the back. I think flying without being able to see directly above or below you is a problem. 

#### Describe the solution

First, changes to the 2d algorithm. The constant 60 used for the radius is now an argument called limit and there are 3 new template functions. "compare" is called on each tile and treated like transparency. If the results differ a recursive cast is made. start_block is called at the beginning of each new block (roughly one uninterrupted recursive cast) and end_block at the end. 

compare is used to check for floor. Note that floor means floor when going down and ceiling when going up. If the tile in that direction is opaque, it also counts as having floor. start_block and end_block are just used to keep track of the blocks that show up during the cast, though they will filter out blocks that are opaque or have floor.

The 3d algorithm begins by casting in 2d on a level with the player. Then we look at the list of blocks found. If there's a single element and it covers the full cast, then we go to the next z level and continue. If there's anything else, we do a recursive cast to handle each block a z level deeper then return. 

Each time we do a 2d cast, we use our start and end majors to determine the row and limit of the cast. Likewise when we do recursive casts, we use the row and limit of the block to calculate the new start and end majors. 

#### Describe alternatives you've considered

How long have you got? This is literally version 5 or something, though It's the first one to use this idea rather than being like the old algorithm just with floors and dead space. The reason I wasn't happy with the other versions is because they showed a form of error where vision that's <45 degrees from parallel with a wall creates jagged edges as you look over it. The cast hits the wall a y level deeper each time, giving a discretely different start_major, but it's a continuous wall and 4-6 z levels later this causes torn edges. This version does have the problem too, hitting a wall like that means a new block for each row, but I felt the new design was worth it anyway. 

#### Testing

There's a lot wrong with it still, it's just to show off the idea. It's missing transparency stuff entirely and I'm not convinced the geometry is at all right when looking over walls. Also, I'm pretty sure 25% is not the right number for dead space. Note more dead space means more error. 

#### Additional context

Obviously this conflicts with the lookup tables stuff. I want to get this working right before I merge them. I was worried that the geometry to calculate y_row and y_limit would be tough but it fell out quite nicely. It might end up being worth doing the same thing to the minors in the 2d algorithm for speed. 