### PR TITLE
fix "Explosion processing is delayed to end of turn for explode-on-impact ammo"

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -16,7 +16,7 @@
 #include "debug.h"
 #include "dispersion.h"
 #include "enums.h"
-#include "explosion.h"
+#include "explosion_queue.h"
 #include "game.h"
 #include "item.h"
 #include "line.h"
@@ -25,7 +25,6 @@
 #include "monster.h"
 #include "optional.h"
 #include "options.h"
-#include "point.h"
 #include "projectile.h"
 #include "rng.h"
 #include "sounds.h"
@@ -505,7 +504,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
                                      sfx::get_heard_volume( z.pos() ), sfx::get_heard_angle( z.pos() ) );
         }
     }
-
+    explosion_handler::get_explosion_queue().execute();
     return attack;
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfixes "add explosion effect triggers after each explosive ammo is shot" 

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
Fixes #1904
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Adding a "explosion_handler::get_explosion_queue().execute();" after a projectile is shot.
(Cf additional context of the issue for more details)
I repeated the steps in the issue, shotted 5 ammoes and got 5 nice explosions, precisely one after each shot,


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
None for now
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I repeated the steps in the issue.
I also tried some grenades but they worked fine. And I think it's not even related.
I tried to do the same by giving a weapon to a NPC, and I think it works, but he one shotted himself with it. Is it me or they don't seem to be able to shoot at more than 3 meters even with the right commands?
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
About this part
"This may require some measure to prevent two executes being called on the same queue in one call stack."
I suppose we're safe, _unless I'm missing something_, because the explosion queue uses a singleton (the explosion queue will always be the same object), so even if it's called several times at different places in one turn, the object will always be updated between each call.
