### PR TITLE
Some fixes to autodrive and map memory behavior

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -167,6 +167,11 @@ void avatar::clear_memorized_tile( const tripoint &pos )
     player_map_memory->clear_memorized_tile( pos );
 }
 
+bool avatar::has_memorized_tile_for_autodrive( const tripoint &p ) const
+{
+    return player_map_memory->has_memory_for_autodrive( p );
+}
+
 std::vector<mission *> avatar::get_active_missions() const
 {
     return active_missions;

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -96,6 +96,8 @@ class avatar : public player
         /** Returns last stored map tile in given location in curses mode */
         int get_memorized_symbol( const tripoint &p ) const;
         void clear_memorized_tile( const tripoint &pos );
+        /** Returns last stored map tile in given location in tiles mode */
+        bool has_memorized_tile_for_autodrive( const tripoint &p ) const;
 
         /** Provides the window and detailed morale data */
         void disp_morale();

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -78,6 +78,23 @@ const memorized_terrain_tile &map_memory::get_tile( const tripoint &pos ) const
     return sm.tile( p.loc );
 }
 
+bool map_memory::has_memory_for_autodrive( const tripoint &pos )
+{
+    // HACK: Map memory is not supposed to be used by ingame mechanics.
+    //       It's just a graphical overlay, it memorizes tileset tiles and text symbols.
+    //       Problem is, many cars' headlights won't cover every ground tile in front of them at night,
+    //       and these dark tiles would be considered as possible obstacles.
+    //       To work around it, we check for whether map memory has any data associated with the tile
+    //       and then assume it's up to date, which works in 99% cases.
+    //       Oh, and we can't use get_tile() and get_symbol() because both are supposed to be used for
+    //       map drawing and complain whenever we try to access stuff beyond game window
+    //       or without drawing at least one frame.
+    coord_pair p( pos );
+    shared_ptr_fast<mm_submap> sm = fetch_submap( p.sm );
+    return sm->tile( p.loc ) != mm_submap::default_tile ||
+           sm->symbol( p.loc ) != mm_submap::default_symbol;
+}
+
 void map_memory::memorize_tile( const tripoint &pos, const std::string &ter,
                                 const int subtile, const int rotation )
 {

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -45,7 +45,6 @@ struct reg_coord_pair {
 };
 
 mm_submap::mm_submap() = default;
-mm_submap::mm_submap( bool make_valid ) : valid( make_valid ) {}
 
 mm_region::mm_region() : submaps {{ nullptr }} {}
 
@@ -71,7 +70,7 @@ map_memory::map_memory()
     clear_cache();
 }
 
-const memorized_terrain_tile &map_memory::get_tile( const tripoint &pos ) const
+const memorized_terrain_tile &map_memory::get_tile( const tripoint &pos )
 {
     coord_pair p( pos );
     const mm_submap &sm = get_submap( p.sm );
@@ -86,9 +85,7 @@ bool map_memory::has_memory_for_autodrive( const tripoint &pos )
     //       and these dark tiles would be considered as possible obstacles.
     //       To work around it, we check for whether map memory has any data associated with the tile
     //       and then assume it's up to date, which works in 99% cases.
-    //       Oh, and we can't use get_tile() and get_symbol() because both are supposed to be used for
-    //       map drawing and complain whenever we try to access stuff beyond game window
-    //       or without drawing at least one frame.
+    //       Oh, and we don't want to use get_tile() and get_symbol() to avoid looking up the mm_submap twice.
     coord_pair p( pos );
     shared_ptr_fast<mm_submap> sm = fetch_submap( p.sm );
     return sm->tile( p.loc ) != mm_submap::default_tile ||
@@ -100,13 +97,10 @@ void map_memory::memorize_tile( const tripoint &pos, const std::string &ter,
 {
     coord_pair p( pos );
     mm_submap &sm = get_submap( p.sm );
-    if( !sm.is_valid() ) {
-        return;
-    }
     sm.set_tile( p.loc, memorized_terrain_tile{ ter, subtile, rotation } );
 }
 
-int map_memory::get_symbol( const tripoint &pos ) const
+int map_memory::get_symbol( const tripoint &pos )
 {
     coord_pair p( pos );
     const mm_submap &sm = get_submap( p.sm );
@@ -117,9 +111,6 @@ void map_memory::memorize_symbol( const tripoint &pos, const int symbol )
 {
     coord_pair p( pos );
     mm_submap &sm = get_submap( p.sm );
-    if( !sm.is_valid() ) {
-        return;
-    }
     sm.set_symbol( p.loc, symbol );
 }
 
@@ -127,9 +118,6 @@ void map_memory::clear_memorized_tile( const tripoint &pos )
 {
     coord_pair p( pos );
     mm_submap &sm = get_submap( p.sm );
-    if( !sm.is_valid() ) {
-        return;
-    }
     sm.set_symbol( p.loc, mm_submap::default_symbol );
     sm.set_tile( p.loc, mm_submap::default_tile );
 }
@@ -293,40 +281,20 @@ shared_ptr_fast<mm_submap> map_memory::load_submap( const tripoint &sm_pos )
     return ret;
 }
 
-static mm_submap null_mz_submap;
-static mm_submap invalid_mz_submap{ false };
-
-const mm_submap &map_memory::get_submap( const tripoint &sm_pos ) const
-{
-    if( cache_pos == tripoint_min ) {
-        debugmsg( "Called map_memory::get_submap() before initializing map memory region." );
-        return invalid_mz_submap;
-    }
-
-    int zoffset = get_map().has_zlevels() ? ( sm_pos.z + OVERMAP_DEPTH ) * cache_size.y * cache_size.x :
-                  0;
-    const point idx = ( sm_pos - cache_pos ).xy();
-    if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y ) {
-        return *cached[idx.y * cache_size.x + idx.x + zoffset];
-    } else {
-        return null_mz_submap;
-    }
-}
-
 mm_submap &map_memory::get_submap( const tripoint &sm_pos )
 {
-    if( cache_pos == tripoint_min ) {
-        return invalid_mz_submap;
+    // First, try fetching from cache.
+    // If it's not in cache (or cache is absent), go the long way.
+    if( cache_pos != tripoint_min ) {
+        int zoffset = get_map().has_zlevels()
+                      ? ( sm_pos.z + OVERMAP_DEPTH ) * cache_size.y * cache_size.x
+                      : 0;
+        const point idx = ( sm_pos - cache_pos ).xy();
+        if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y ) {
+            return *cached[idx.y * cache_size.x + idx.x + zoffset];
+        }
     }
-
-    int zoffset = get_map().has_zlevels() ? ( sm_pos.z + OVERMAP_DEPTH ) * cache_size.y * cache_size.x :
-                  0;
-    const point idx = ( sm_pos - cache_pos ).xy();
-    if( idx.x > 0 && idx.y > 0 && idx.x < cache_size.x && idx.y < cache_size.y ) {
-        return *cached[idx.y * cache_size.x + idx.x + zoffset];
-    } else {
-        return null_mz_submap;
-    }
+    return *fetch_submap( sm_pos );
 }
 
 void map_memory::load( const tripoint &pos )

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -160,6 +160,13 @@ class map_memory
         const memorized_terrain_tile &get_tile( const tripoint &pos ) const;
 
         /**
+         * For autodrive use only.
+         * Checks whether tile at given pos was memorized.
+         * @param pos tile position, in global ms coords.
+         */
+        bool has_memory_for_autodrive( const tripoint &pos );
+
+        /**
          * Memorizes given symbol, overwriting old value.
          * @param pos tile position, in global ms coords.
         */

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -34,16 +34,10 @@ struct mm_submap {
         static const int default_symbol;
 
         mm_submap();
-        explicit mm_submap( bool make_valid );
 
         /** Whether this mm_submap is empty. Empty submaps are skipped during saving. */
         bool is_empty() const {
             return tiles.empty() && symbols.empty();
-        }
-
-        // Whether this mm_submap is invalid, i.e. returned from an uninitialized region.
-        bool is_valid() const {
-            return valid;
         }
 
         inline const memorized_terrain_tile &tile( const point &p ) const {
@@ -139,7 +133,7 @@ class map_memory
         bool save( const tripoint &pos );
 
         /**
-         * Prepares map memory for rendering and/or memorization of given region.
+         * Prepares map memory for optimized rendering and/or memorization of given region.
          * @param p1 top-left corner of the region, in global ms coords
          * @param p2 bottom-right corner of the region, in global ms coords
          * Both coords are inclusive and should be on the same Z level.
@@ -157,7 +151,7 @@ class map_memory
          * Returns memorized tile.
          * @param pos tile position, in global ms coords.
          */
-        const memorized_terrain_tile &get_tile( const tripoint &pos ) const;
+        const memorized_terrain_tile &get_tile( const tripoint &pos );
 
         /**
          * For autodrive use only.
@@ -176,7 +170,7 @@ class map_memory
          * Returns memorized symbol.
          * @param pos tile position, in global ms coords.
          */
-        int get_symbol( const tripoint &pos ) const;
+        int get_symbol( const tripoint &pos );
 
         /**
          * Clears memorized tile and symbol.
@@ -191,7 +185,7 @@ class map_memory
         tripoint cache_pos;
         point cache_size;
 
-        /** Find, load or allocate a submap. @returns the submap. */
+        /** Find, load or allocate a submap. May be slow. @returns the submap. */
         shared_ptr_fast<mm_submap> fetch_submap( const tripoint &sm_pos );
         /** Find submap amongst the loaded submaps. @returns nullptr if failed. */
         shared_ptr_fast<mm_submap> find_submap( const tripoint &sm_pos );
@@ -200,11 +194,12 @@ class map_memory
         /** Allocate empty submap. @returns the submap. */
         shared_ptr_fast<mm_submap> allocate_submap( const tripoint &sm_pos );
 
-        /** Get submap from within the cache */
-        //@{
-        const mm_submap &get_submap( const tripoint &sm_pos ) const;
+        /**
+         * Find, load or allocate a submap.
+         * Uses cache made by @ref prepare_region to speed up the lookup.
+         * @returns the submap.
+         */
         mm_submap &get_submap( const tripoint &sm_pos );
-        //@}
 
         void clear_cache();
 };

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -24,7 +24,6 @@
 #include "hash_utils.h"
 #include "map.h"
 #include "map_iterator.h"
-#include "map_memory.h"
 #include "mapdata.h"
 #include "messages.h"
 #include "optional.h"
@@ -663,7 +662,7 @@ bool vehicle::autodrive_controller::check_drivable( tripoint pt ) const
         if( !driver.sees( pt ) ) {
             if( !driver.is_avatar() ) {
                 return false;
-            } else if( driver.as_avatar()->get_memorized_tile( pt_abs.raw() ) == mm_submap::default_tile ) {
+            } else if( !driver.as_avatar()->has_memorized_tile_for_autodrive( pt_abs.raw() ) ) {
                 // apparently open air doesn't get memorized, so pretend it is or else
                 // we can't fly helicopters due to the many unseen tiles behind the driver
                 if( !( data.air_ok && here.ter( pt ) == t_open_air ) ) {


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed a couple issues with autodrive and map memory"

#### Purpose of change
1. Fix some rare occurences of `Called map_memory::get_submap() before initializing map memory region.`
2. Make autodrive work at night when not using tiles

#### Describe the solution
1. Preparing memory map region is now not a hard requirement, but rather an optimization.
    Where before the mm_submaps were searched/loaded/allocated only on preparation step, and `get_tile()`/`get_symbol()` would only return data from prepared region, now these heavy operations can potentially happen on every `get_*` call. This makes it harder to reason about performance, but less prone to breakages.
2. Map memory was never designed as part of game state. It's a graphical overlay, it's state is used by map drawing routines and the occasional "unmemorize vehicle when it moves" hack. Using it for autodrive is hackish, but works. Solution was to encapsulate the hack, and check for either memorized tile or symbol, not just tile (original author probably assumed it was terrain tile id?).

#### Describe alternatives you've considered
1. It was a bad initial design choice on my part, should've gone with this solution back then.
2. Rewriting map memory from grounds up, to be updated on every turn or avatar action, and memorize actual map data?

#### Testing
1. I tried reproducing these before, but there's no precise repro steps whenever it gets reported. I'm fairly confident this will solve the issue, but can't verify beyond commenting out `prepare_map_memory_region` part in `cata_tiles.cpp`.
2. Autodrive a car in a straight line at day, do a u-turn, set time to night, try autodriving back.
    Without fix: works on tiles mode, fails on text mode. After fix: works on both versions.
