### PR TITLE
Add automated MA balance test system

### DIFF
--- a/tests/melee_balance_test.cpp
+++ b/tests/melee_balance_test.cpp
@@ -11,24 +11,17 @@
 #include "monattack.h"
 #include "monster.h"
 #include "npc.h"
+#include "game.h"
+#include "player_helpers.h"
 #include "player.h"
 #include "point.h"
 #include "string_formatter.h"
-#include "type_id.h"
+#include "map_helpers.h"
+#include "catch/catch.hpp"
+
+
 
 static constexpr tripoint dude_pos( HALF_MAPSIZE_X, HALF_MAPSIZE_Y, 0 );
-
-static std::vector<const itype *> find_weapons()
-{
-    std::vector<const itype *> result;
-    for( const itype *it : item_controller->all() ) {
-        if( it->melee[DT_BASH] + it->melee[DT_CUT] + it->melee[DT_STAB] >= 10 ) {
-            result.push_back( it );
-        }
-    }
-
-    return result;
-}
 
 static void print_stats( const player &p, const std::vector<const itype *> &weapons,
                          const monster &m )
@@ -68,13 +61,13 @@ TEST_CASE( "Average character using melee weapons against a hulk", "[.][melee][s
     }
 }
 
-TEST_CASE( "Strong character using melee weapons against a kevlar zombie", "[.][melee][slow]" )
+TEST_CASE("Strong character using melee weapons against a kevlar zombie", "[.][melee][slow]")
 {
-    monster zed( mtype_id( "mon_zombie_kevlar_1" ) );
+    monster zed(mtype_id("mon_zombie_kevlar_1"));
     auto weapons = find_weapons();
 
-    SECTION( "12/10/8/8, 3 in all skills" ) {
-        standard_npc dude( "TestCharacter", dude_pos, {}, 3, 12, 10, 8, 8 );
-        print_stats( dude, weapons, zed );
+    SECTION("12/10/8/8, 3 in all skills") {
+        standard_npc dude("TestCharacter", dude_pos, {}, 3, 12, 10, 8, 8);
+        print_stats(dude, weapons, zed);
     }
 }

--- a/tests/melee_balance_test.cpp
+++ b/tests/melee_balance_test.cpp
@@ -11,13 +11,10 @@
 #include "monattack.h"
 #include "monster.h"
 #include "npc.h"
-#include "game.h"
 #include "player_helpers.h"
 #include "player.h"
 #include "point.h"
 #include "string_formatter.h"
-#include "map_helpers.h"
-#include "catch/catch.hpp"
 
 
 
@@ -61,13 +58,13 @@ TEST_CASE( "Average character using melee weapons against a hulk", "[.][melee][s
     }
 }
 
-TEST_CASE("Strong character using melee weapons against a kevlar zombie", "[.][melee][slow]")
+TEST_CASE( "Strong character using melee weapons against a kevlar zombie", "[.][melee][slow]" )
 {
-    monster zed(mtype_id("mon_zombie_kevlar_1"));
+    monster zed( mtype_id( "mon_zombie_kevlar_1" ) );
     auto weapons = find_weapons();
 
-    SECTION("12/10/8/8, 3 in all skills") {
-        standard_npc dude("TestCharacter", dude_pos, {}, 3, 12, 10, 8, 8);
-        print_stats(dude, weapons, zed);
+    SECTION( "12/10/8/8, 3 in all skills" ) {
+        standard_npc dude( "TestCharacter", dude_pos, {}, 3, 12, 10, 8, 8 );
+        print_stats( dude, weapons, zed );
     }
 }

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -4,15 +4,29 @@
 #include <sstream>
 #include <string>
 
+#include "avatar.h"
+#include "bodypart.h"
+#include "character_martial_arts.h"
 #include "creature.h"
+#include "game.h"
 #include "game_constants.h"
 #include "item.h"
+#include "player_helpers.h"
+#include "map.h"
+#include "map_helpers.h"
 #include "monattack.h"
 #include "monster.h"
 #include "npc.h"
 #include "player.h"
+#include "player_helpers.h"
 #include "point.h"
+#include "rng.h"
+#include "skill.h"
 #include "type_id.h"
+#include "itype.h"
+
+static constexpr tripoint player_pos( 60, 60, 0 );
+static constexpr int iterations = 80;
 
 static float brute_probability( Creature &attacker, Creature &target, const size_t iters )
 {
@@ -69,7 +83,7 @@ static void check_near( float prob, const float expected, const float tolerance 
     }
 }
 
-static const int num_iters = 10000;
+static const int num_iters = 10;
 
 static constexpr tripoint dude_pos( HALF_MAPSIZE_X, HALF_MAPSIZE_Y, 0 );
 
@@ -235,5 +249,258 @@ TEST_CASE( "Hulk smashing a character", "[.], [melee], [monattack]" )
         const float prob = brute_special_probability( zed, dude, num_iters );
         INFO( "Has get_dodge() == " + std::to_string( dude.get_dodge() ) );
         check_near( prob, 0.2f, 0.05f );
+    }
+}
+
+
+// BALANCE MARTIAL ARTS
+
+TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kevlar hulk",
+           "[.][melee][slow]" )
+{
+    // CHANGE THIS VALUES AS YOU NEED
+    const std::vector<int> stats_level = { 12, 15, 18 }; // Will be tested by pair, eg 12-5, 15-7...
+    const std::vector<int> skills_level = { 5, 7, 9 };
+    // Cloths of character
+    const std::vector<std::string> &clothing = { "hoodie", "jeans", "long_underpants", "long_undertop", "survivor_suit" };
+    // attacks iterations between complete reset, for player/monster, don't get it too high or the player/monster will die. Default 3
+    const int attacks_numbers = 3;
+    // If testing a specific weapon, set one_weapon to true and replace the string below. Otherwise set it to false.
+    // If you want to test an unarmed MA, your best bet is to set an unarmed weapon here. They are not marked as compatible weapons in JSON, but still work
+    const bool one_weapon = false;
+    itype_id tested_weapon_id( "to_replace" );
+    // If you want the result damage for every weapons, of every MA
+    const bool verbose = false;
+    // Tests are for now very long, so set this to true to remove the less interesting weapons from MA who have a lot of them. Very, very WIP
+    const bool reduce_weapons = true;
+    // What monster(s) should be spawned?
+    const std::vector<mtype_id> monster_ids = {
+        mtype_id( "mon_zombie_kevlar_2" ),
+        mtype_id( "mon_zombie_hulk" )
+    };
+    // The martial arts to test
+    const std::vector<matype_id> tested_martial_arts = {
+        { matype_id( "style_medievalpole" ) },
+        { matype_id( "style_barbaran" ) },
+        { matype_id( "style_biojutsu" ) },
+        { matype_id( "style_ninjutsu" ) },
+        { matype_id( "style_niten" ) },
+        { matype_id( "style_swordsmanship" ) }
+    };
+
+
+    // Those will be used to store results and print them from best to worst
+    struct struct_ma {
+        matype_id ma_type_id;
+        double best_weapon_dmg;
+        std::string best_weapon;
+
+        bool operator<( const struct_ma &sm ) const {
+            return best_weapon_dmg > sm.best_weapon_dmg;
+        }
+
+    } STRUCT_MA;
+
+
+    // Get player
+    avatar &p = g->u;
+
+    // For each monster
+    for( size_t i = 0; i < monster_ids.size(); i++ ) {
+        // For stats/skills couple
+        for( size_t j = 0; j < stats_level.size(); j++ ) {
+            // Set up tested MA
+            std::vector<struct_ma> results_ma;
+            for( const matype_id ma : tested_martial_arts ) {
+                results_ma.push_back( { ma, 0.0,  "" } );
+            }
+
+
+            // Test performances with those weapons, with all martial arts
+            cata_print_stdout( "\n\nStarting tests for -> STATS: " + std::to_string(
+                                   stats_level[j] ) + " SKILLS: " + std::to_string( skills_level[j] ) + " M: " + monster_ids[i].str() +
+                               "\n" );
+
+            // For each MA to test
+            for( const matype_id ma : tested_martial_arts ) {
+                p.martial_arts_data->set_style( ma, true );
+
+                matec_id special_counter( "tec_none" );
+                double best_weapon_dmg = 0;
+                std::vector<const itype *> compatible_weapons;
+                std::string best_weapon = "";
+
+                // Find compatible weapons with this MA
+                for( const itype *it : find_weapons() ) {
+                    // If we test only one weapon, override and use this one
+                    if( one_weapon ) {
+                        if( it->get_id() == tested_weapon_id ) {
+                            compatible_weapons.push_back( it );
+                        }
+                    }
+                    // Otherwise get weapons allowed for this MA
+                    else {
+                        if( p.martial_arts_data->selected_has_weapon( it->get_id() ) ) {
+                            item player_wp( it );
+                            compatible_weapons.push_back( it );
+                        }
+                    }
+                }
+
+                // Reduce number of weapons to 4 by MA, to greatly speed up tests. Keep the ones with the best DPS
+                if( reduce_weapons ) {
+                    monster dummy_m( monster_ids[i] );
+                    std::sort( compatible_weapons.begin(), compatible_weapons.end(), [&]( const auto & l,
+                    const auto & r ) {
+
+                        item wp_l( l );
+                        double interesting_coefficient_l = wp_l.damage_melee( damage_type::DT_BASH ) * 2.0;
+                        interesting_coefficient_l += wp_l.damage_melee( damage_type::DT_CUT ) * 1.0;
+                        interesting_coefficient_l += wp_l.damage_melee( damage_type::DT_STAB ) * 1.5;
+                        //interesting_coefficient_l /= wp_l.attack_cost();
+                        item wp_r( r );
+                        double interesting_coefficient_r = wp_r.damage_melee( damage_type::DT_BASH ) * 2.0;
+                        interesting_coefficient_r += wp_r.damage_melee( damage_type::DT_CUT ) * 1.0;
+                        interesting_coefficient_r += wp_r.damage_melee( damage_type::DT_STAB ) * 1.5;
+                        //interesting_coefficient_r /= wp_r.attack_cost();
+                        return interesting_coefficient_l * wp_l.effective_dps( p,
+                                dummy_m ) > interesting_coefficient_r * wp_r.effective_dps( p, dummy_m );
+                    } );
+                    while( compatible_weapons.size() > 11 ) {
+                        compatible_weapons.pop_back();
+                    }
+                }
+
+                // Go through weapons
+                for( const itype *w : compatible_weapons ) {
+                    item player_wp( w ); // Player weapon
+                    int total_damage = 0;
+
+                    for( size_t k = 0; k < iterations; k++ ) {
+                        // Reset map
+                        clear_map();
+                        // Reset player
+                        clear_character( p );
+                        g->place_player( player_pos );
+                        p.martial_arts_data->set_style( ma, true );
+                        // Set stats
+                        p.str_cur = stats_level[j];
+                        p.str_max = stats_level[j];
+                        p.dex_cur = stats_level[j];
+                        p.dex_max = stats_level[j];
+                        p.per_cur = stats_level[j];
+                        p.per_max = stats_level[j];
+                        p.int_cur = stats_level[j];
+                        p.int_max = stats_level[j];
+                        // Set all skills to 5 and MA
+                        for( const Skill &e : Skill::skills ) {
+                            p.set_skill_level( e.ident(), skills_level[j] );
+                        }
+
+                        // A bit hacky, but some martial arts benefits a lot from their counter. So until we can trigger correcly, we get and trigger them manually
+                        // In a normal game, you would reach this by stacking armor
+                        for( const auto &mat_id : ma->techniques ) {
+                            const ma_technique &tec = mat_id.obj();
+                            if( tec.block_counter == true ) {
+                                special_counter = tec.id;
+                                p.set_skill_level( skill_id( "dodge" ), 0 );
+                                break;
+                            }
+                            if( tec.dodge_counter == true ) {
+                                special_counter = tec.id;
+                                break;
+                            }
+                        }
+
+
+                        // Wield weapon
+                        p.wield( player_wp );
+
+                        // equip armor
+                        for( const std::string &e : clothing ) {
+                            p.wear_item( item( e ) );
+                        }
+
+                        // Place new monster (clear_map delete all monsters)
+                        monster &z = spawn_test_monster( monster_ids[i].str(), p.pos() + point( 0, 1 ) );
+
+                        // Place terrain around player and monster, to avoid knockback issues
+                        // Nothing get through a resin wall
+                        ter_id resin_wall( "t_wall_resin" );
+                        // XXX top walls
+                        g->m.ter_set( p.pos() + point( -1, 2 ), resin_wall );
+                        g->m.ter_set( p.pos() + point( 0, 2 ), resin_wall );
+                        g->m.ter_set( p.pos() + point( 1, 2 ), resin_wall );
+                        // XmX monster level
+                        g->m.ter_set( p.pos() + point( -1, 1 ), resin_wall );
+                        g->m.ter_set( p.pos() + point( 1, 1 ), resin_wall );
+                        // XPX player level
+                        g->m.ter_set( p.pos() + point( -1, 0 ), resin_wall );
+                        g->m.ter_set( p.pos() + point( 1, 0 ), resin_wall );
+                        // XXX bottom walls
+                        g->m.ter_set( p.pos() + point( -1, -1 ), resin_wall );
+                        g->m.ter_set( p.pos() + point( 0, -1 ), resin_wall );
+                        g->m.ter_set( p.pos() + point( 1, -1 ), resin_wall );
+
+
+                        // Wait once for debuff (eg Barbaran montante)
+                        // TODO does it work?
+                        p.process_turn();
+
+                        // For each fight (a few hits for each iteration, no reset between them)
+                        for( size_t l = 0; l < attacks_numbers; l++ ) {
+
+                            p.melee_attack( z, true );
+                            // Important to trigger dodge counters/block counters, having enough moves means block/dodge counters left are reset
+                            g->u.mod_moves( 300 );
+                            p.process_turn();
+                            z.melee_attack( p );
+                            z.process_turn();
+
+                            // Since counter attacks seems to trigger a much lower rate than in game (meaning close to never), we trigger them manually
+
+                            if( ( k % 3 == 0 || one_in( 5 ) ) && special_counter->id.str() != "tec_none" ) {
+                                p.melee_attack( z, true, special_counter );
+                            }
+                        }
+
+
+                        total_damage += z.get_hp_max() - z.get_hp();
+                    }
+
+                    // Print average damage with this weapon and MA. Attack cost of weapon is taken into account
+                    double attack_cost_factor = static_cast<double>( player_wp.attack_cost() ) / 100;
+                    double average_damage = static_cast<double>( total_damage ) / ( iterations * attacks_numbers );
+                    double corrected_average_damage = average_damage / attack_cost_factor;
+
+                    // Store result in result_ma
+                    for( size_t e = 0; e < results_ma.size(); e++ ) {
+                        if( results_ma[e].ma_type_id == ma ) {
+                            if( corrected_average_damage > results_ma[e].best_weapon_dmg ) {
+                                results_ma[e].best_weapon_dmg = corrected_average_damage;
+                                results_ma[e].best_weapon = player_wp.display_name();
+                            }
+                            break;
+                        }
+                    }
+
+
+                    // Usually with one MA we want to see all weapons
+                    if( tested_martial_arts.size() == 1 || verbose ) {
+                        cata_printf( "%-30s : %-30s : %.1f\n", ma->name.translated( 1 ), player_wp.display_name(),
+                                     corrected_average_damage );
+                    }
+
+                }
+
+            }
+
+            std::sort( results_ma.begin(), results_ma.end() );
+            // Finally, print the MA results
+            for( const struct_ma rma : results_ma ) {
+                cata_printf( "%-30s : %-30s : %.1f\n", rma.ma_type_id->name.translated( 1 ), rma.best_weapon,
+                             rma.best_weapon_dmg );
+            }
+        }
     }
 }

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -330,7 +330,6 @@ TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kev
                 p.martial_arts_data->set_style( ma, true );
 
                 matec_id special_counter( "tec_none" );
-                double best_weapon_dmg = 0;
                 std::vector<const itype *> compatible_weapons;
                 std::string best_weapon = "";
 

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -308,7 +308,7 @@ TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kev
     // Get player
     avatar &p = g->u;
 
-    // For each monster
+    // For each monster(s)
     for( size_t i = 0; i < monster_ids.size(); i++ ) {
         // For stats/skills couple
         for( size_t j = 0; j < stats_level.size(); j++ ) {

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -309,7 +309,7 @@ TEST_CASE( "Balance Martial art system",
     avatar &p = g->u;
 
     // For each monster(s)
-    for each( mtype_id monster_id in monster_ids ) {
+    for( const mtype_id monster_id : monster_ids ) {
         // For stats/skills couple
         for( size_t j = 0; j < stats_level.size(); j++ ) {
             // Set up tested MA
@@ -474,11 +474,12 @@ TEST_CASE( "Balance Martial art system",
                     double corrected_average_damage = average_damage / attack_cost_factor;
 
                     // Store result in result_ma
-                    for each( struct_ma r in results_ma ) {
+                    for( struct_ma &r : results_ma ) {
                         if( r.ma_type_id == ma ) {
                             if( corrected_average_damage > r.best_weapon_dmg ) {
                                 r.best_weapon_dmg = corrected_average_damage;
                                 r.best_weapon = player_wp.display_name();
+                                // PB HERE
                             }
                             break;
                         }
@@ -504,5 +505,5 @@ TEST_CASE( "Balance Martial art system",
     }
 
 
-
+    CHECK( false );
 }

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -255,7 +255,7 @@ TEST_CASE( "Hulk smashing a character", "[.], [melee], [monattack]" )
 
 // BALANCE MARTIAL ARTS
 
-TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kevlar hulk",
+TEST_CASE( "Balance Martial art system",
            "[.][melee][slow]" )
 {
     // CHANGE THOSE VALUES AS YOU NEED
@@ -309,7 +309,7 @@ TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kev
     avatar &p = g->u;
 
     // For each monster(s)
-    for( size_t i = 0; i < monster_ids.size(); i++ ) {
+    for each( mtype_id monster_id in monster_ids ) {
         // For stats/skills couple
         for( size_t j = 0; j < stats_level.size(); j++ ) {
             // Set up tested MA
@@ -318,11 +318,10 @@ TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kev
                 results_ma.push_back( { ma, 0.0,  "" } );
             }
 
-
             // Test performances with those weapons, with all martial arts
             cata_print_stdout( "\nStarting tests for ->" );
             cata_print_stdout( "\n\nSTATS: " + std::to_string(
-                                   stats_level[j] ) + " SKILLS: " + std::to_string( skills_level[j] ) + " M: " + monster_ids[i].str() +
+                                   stats_level[j] ) + " SKILLS: " + std::to_string( skills_level[j] ) + " M: " + monster_id.str() +
                                "\n" );
 
             // For each MA to test
@@ -331,7 +330,7 @@ TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kev
 
                 matec_id special_counter( "tec_none" );
                 std::vector<const itype *> compatible_weapons;
-                std::string best_weapon = "";
+                std::string best_weapon;
 
                 // Find compatible weapons with this MA
                 for( const itype *it : find_weapons() ) {
@@ -353,7 +352,7 @@ TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kev
                 // Reduce number of weapons to "weapons_count_limit" by MA, to speed up tests. Keep the ones with the best DPS
                 // And favor damage type in this order -> Bash, Pierce, Cut
                 if( reduce_weapons ) {
-                    monster dummy_m( monster_ids[i] );
+                    monster dummy_m( monster_id );
                     std::sort( compatible_weapons.begin(), compatible_weapons.end(), [&]( const auto & l,
                     const auto & r ) {
 
@@ -404,12 +403,12 @@ TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kev
                         // In a normal game, you would reach this by stacking armor
                         for( const auto &mat_id : ma->techniques ) {
                             const ma_technique &tec = mat_id.obj();
-                            if( tec.block_counter == true ) {
+                            if( tec.block_counter ) {
                                 special_counter = tec.id;
                                 p.set_skill_level( skill_id( "dodge" ), 0 );
                                 break;
                             }
-                            if( tec.dodge_counter == true ) {
+                            if( tec.dodge_counter ) {
                                 special_counter = tec.id;
                                 break;
                             }
@@ -424,7 +423,7 @@ TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kev
                         }
 
                         // Place new monster - clear_map() delete all monsters -
-                        monster &z = spawn_test_monster( monster_ids[i].str(), p.pos() + point( 0, 1 ) );
+                        monster &z = spawn_test_monster( monster_id.str(), p.pos() + point( 0, 1 ) );
 
                         // Place terrain around player and monster, to avoid knockback issues
                         // Nothing get through a resin wall
@@ -434,15 +433,15 @@ TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kev
                         g->m.ter_set( p.pos() + point( 0, 2 ), resin_wall );
                         g->m.ter_set( p.pos() + point( 1, 2 ), resin_wall );
                         // XmX monster level
-                        g->m.ter_set( p.pos() + point( -1, 1 ), resin_wall );
-                        g->m.ter_set( p.pos() + point( 1, 1 ), resin_wall );
+                        g->m.ter_set( p.pos() + point_south_west, resin_wall );
+                        g->m.ter_set( p.pos() + point_south_east, resin_wall );
                         // XPX player level
-                        g->m.ter_set( p.pos() + point( -1, 0 ), resin_wall );
-                        g->m.ter_set( p.pos() + point( 1, 0 ), resin_wall );
+                        g->m.ter_set( p.pos() + point_west, resin_wall );
+                        g->m.ter_set( p.pos() + point_east, resin_wall );
                         // XXX bottom walls
-                        g->m.ter_set( p.pos() + point( -1, -1 ), resin_wall );
-                        g->m.ter_set( p.pos() + point( 0, -1 ), resin_wall );
-                        g->m.ter_set( p.pos() + point( 1, -1 ), resin_wall );
+                        g->m.ter_set( p.pos() + point_north_west, resin_wall );
+                        g->m.ter_set( p.pos() + point_north, resin_wall );
+                        g->m.ter_set( p.pos() + point_north_east, resin_wall );
 
 
                         // Wait once for debuff (eg Barbaran montante)
@@ -475,11 +474,11 @@ TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kev
                     double corrected_average_damage = average_damage / attack_cost_factor;
 
                     // Store result in result_ma
-                    for( size_t e = 0; e < results_ma.size(); e++ ) {
-                        if( results_ma[e].ma_type_id == ma ) {
-                            if( corrected_average_damage > results_ma[e].best_weapon_dmg ) {
-                                results_ma[e].best_weapon_dmg = corrected_average_damage;
-                                results_ma[e].best_weapon = player_wp.display_name();
+                    for each( struct_ma r in results_ma ) {
+                        if( r.ma_type_id == ma ) {
+                            if( corrected_average_damage > r.best_weapon_dmg ) {
+                                r.best_weapon_dmg = corrected_average_damage;
+                                r.best_weapon = player_wp.display_name();
                             }
                             break;
                         }
@@ -503,4 +502,7 @@ TEST_CASE( "Strong character, 5 in all skills, using melee weapons against a kev
             }
         }
     }
+
+
+
 }

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -20,6 +20,7 @@
 #include "map.h"
 #include "material.h"
 #include "npc.h"
+#include "item_factory.h"
 #include "pimpl.h"
 #include "player.h"
 #include "player_activity.h"
@@ -214,4 +215,16 @@ void arm_character( player &shooter, const std::string &gun_type,
         gun.put_in( item( itype_id( mod ) ) );
     }
     shooter.wield( gun );
+}
+
+std::vector<const itype*> find_weapons()
+{
+    std::vector<const itype*> result;
+    for (const itype* it : item_controller->all()) {
+        if (it->melee[DT_BASH] + it->melee[DT_CUT] + it->melee[DT_STAB] >= 10) {
+            result.push_back(it);
+        }
+    }
+
+    return result;
 }

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -217,12 +217,12 @@ void arm_character( player &shooter, const std::string &gun_type,
     shooter.wield( gun );
 }
 
-std::vector<const itype*> find_weapons()
+std::vector<const itype *> find_weapons()
 {
-    std::vector<const itype*> result;
-    for (const itype* it : item_controller->all()) {
-        if (it->melee[DT_BASH] + it->melee[DT_CUT] + it->melee[DT_STAB] >= 10) {
-            result.push_back(it);
+    std::vector<const itype *> result;
+    for( const itype *it : item_controller->all() ) {
+        if( it->melee[DT_BASH] + it->melee[DT_CUT] + it->melee[DT_STAB] >= 10 ) {
+            result.push_back( it );
         }
     }
 

--- a/tests/player_helpers.h
+++ b/tests/player_helpers.h
@@ -24,4 +24,6 @@ void arm_character( player &shooter, const std::string &gun_type,
                     const std::vector<std::string> &mods = {},
                     const std::string &ammo_type = "" );
 
+std::vector<const itype*> find_weapons();
+
 #endif // CATA_TESTS_PLAYER_HELPERS_H

--- a/tests/player_helpers.h
+++ b/tests/player_helpers.h
@@ -24,6 +24,6 @@ void arm_character( player &shooter, const std::string &gun_type,
                     const std::vector<std::string> &mods = {},
                     const std::string &ammo_type = "" );
 
-std::vector<const itype*> find_weapons();
+std::vector<const itype *> find_weapons();
 
 #endif // CATA_TESTS_PLAYER_HELPERS_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Balance "Add automated MA (Martial Art) balance test system"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
Original subject: https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1869
![image](https://user-images.githubusercontent.com/71428793/192494972-90baddd4-9ece-4044-85e0-4bf10f3fbbf5.png)

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Add a way to test the balance of MA.
This is basically one big test with options like:
- MA to test
- specific weapon (or weapons from the MA)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Using a way to trigger inputs in game through OS inputs (like with autoit for windows).
And extract the damage dealt through the save.
![image](https://user-images.githubusercontent.com/71428793/192500405-cd3af37e-b5fa-4e6d-975f-d6a5a56de191.png)
Some the basic idea would be:
- Create a world with 0 spawn, disable autosave and the like, spawn walls around player through debug menu, make him naked, equip him, set stats an skills, spawn a monster, hit a few times, kill all monsters through debug menu, heal player (and every X times reequip him), quicksave.
- Extract data from the save
- Repeat
##### Pro
- You can't be closer to the real game than that. No matter how complexe the combat system becomes, you just stimulate a player fighting and get the resulting damage. That's obviously the biggest pro and the real reason to do that.
- There's already a way to spawn monsters, heal players etc. with the debug menu. So it could be done
- CBN is especially adapted to that, everything can be done through keys (mouse input is less reliable), and it seems to get the input very reliably when I tested (each stimulated keys triggered the right action in the game)
- I know AutoIt well enough, everything said above can be done through it
- Easier to debug
- The system can be semi-automatic in a first time if something is hard to implement (eg if selecting a new MA isn't implemented, it could wait for a key input to start, then when you can, you select the MA and press the key input to continue script execution).

##### Cons
- This would work for windows only
- This would be slow, especially if the amount of "player_messages" stored can't be increased
- Extracting data like what weapons can be used with a MA will be done through JSON (might be a pro in some case)
- Even if AutoIt may be the easiest language I learnt, it's still a new syntaxe to learn if someone wants to continue the project in the future

Seeing how hard it is to create a reliable stimulation of a fight taking every systems into account, I'm seriously considering this option.
Otherwise, either there's a way to have a reliable combat system without recreating the game, or we're ok with a partially stimulated one.
(I'm considering doing it anyway to have a way to compare if the cpp version is taking everything into consideration)
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- I could extract those data with it, this gives the most damaging weapon with a stats/skills level given, against a specific monster:

| Starting tests for -> STATS: 12 SKILLS: 5 M: mon_zombie_kevlar_2 |                       |         |
|------------------------------------------------------------------|-----------------------|---------|
| Fior Di Battaglia                                                | : sledge hammer       | : 21.5  |
| Barbaran Montante                                                | : sledge hammer       | : 20.6  |
| Ninjutsu                                                         | : loaded stick        | : 15.1  |
| Medieval Swordsmanship                                           | : longsword replica   | : 14.7  |
| Niten Ichi-Ryu                                                   | : nodachi replica     | : 14.4  |
| Bionic Combatives                                                | : monomolecular blade | : 2.6   |
| Starting tests for -> STATS: 15 SKILLS: 7 M: mon_zombie_kevlar_2 |                       |         |
| Barbaran Montante                                                | : mace                | : 34.5  |
| Fior Di Battaglia                                                | : sledge hammer       | : 34.1  |
| Niten Ichi-Ryu                                                   | : bokken              | : 28.2  |
| Ninjutsu                                                         | : loaded stick        | : 26.6  |
| Medieval Swordsmanship                                           | : zweihaender replica | : 25.7  |
| Bionic Combatives                                                | : monomolecular blade | : 4.0   |
| Starting tests for -> STATS: 18 SKILLS: 9 M: mon_zombie_kevlar_2 |                       |         |
| Barbaran Montante                                                | : mace                | : 55.1  |
| Fior Di Battaglia                                                | : sledge hammer       | : 51.8  |
| Niten Ichi-Ryu                                                   | : bokken              | : 48.0  |
| Ninjutsu                                                         | : loaded stick        | : 42.6  |
| Medieval Swordsmanship                                           | : zweihaender replica | : 41.5  |
| Bionic Combatives                                                | : bionic claws        | : 15.5  |
| Starting tests for -> STATS: 12 SKILLS: 5 M: mon_zombie_hulk     |                       |         |
| Bionic Combatives                                                | : monomolecular blade | : 80.9  |
| Fior Di Battaglia                                                | : battle axe          | : 62.4  |
| Ninjutsu                                                         | : monomolecular blade | : 61.5  |
| Barbaran Montante                                                | : battle axe          | : 58.0  |
| Niten Ichi-Ryu                                                   | : hand-forged sword   | : 56.6  |
| Medieval Swordsmanship                                           | : broadsword          | : 49.2  |
| Starting tests for -> STATS: 15 SKILLS: 7 M: mon_zombie_hulk     |                       |         |
| Bionic Combatives                                                | : monomolecular blade | : 101.2 |
| Fior Di Battaglia                                                | : battle axe          | : 79.4  |
| Ninjutsu                                                         | : monomolecular blade | : 74.2  |
| Niten Ichi-Ryu                                                   | : hand-forged sword   | : 73.8  |
| Barbaran Montante                                                | : war hammer          | : 72.3  |
| Medieval Swordsmanship                                           | : broadsword          | : 63.7  |
| Starting tests for -> STATS: 18 SKILLS: 9 M: mon_zombie_hulk     |                       |         |
| Bionic Combatives                                                | : monomolecular blade | : 132.0 |
| Barbaran Montante                                                | : war hammer          | : 91.9  |
| Niten Ichi-Ryu                                                   | : hand-forged sword   | : 91.8  |
| Fior Di Battaglia                                                | : battle axe          | : 91.3  |
| Medieval Swordsmanship                                           | : estoc               | : 80.9  |
| Ninjutsu                                                         | : broadsword          | : 78.7  |
|                                                                  |                       |         |


#### Additional context
- Right now the system needs to trigger too many things manually
- Player/Monster won't hit each other automatically
- Counter attacks needs to be triggered manually
I think this is mainly because I couldn't find a way to advance the turns in the world, but I would like to do it with minimal modifications.
Can it be done?

#### TLDR for concerned people
- It's uncomplete and doesn't take some martial art functionnalities into account, but that's the goal
- Even with a fully done system, it's not meant to bring homogeneity to MA, MA are too complexe to be reduced at a "Damage per Second" comparison only. 
- Eg. A defensive style with low DPS is ok, a style with hgh DPS but no defense is ok, a style with high DPS and defense but needs a rare weapon, CBM + book is ok and the list goes on