### PR TITLE
Fix some frequent reallocations when drawing map with tiles

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -38,6 +38,7 @@
 #include "item_factory.h"
 #include "itype.h"
 #include "json.h"
+#include "make_static.h"
 #include "map.h"
 #include "map_memory.h"
 #include "mapbuffer.h"
@@ -2458,30 +2459,35 @@ bool cata_tiles::apply_vision_effects( const tripoint &pos,
     if( !would_apply_vision_effects( visibility ) ) {
         return false;
     }
-    std::string light_name;
+    const std::string *light_name = nullptr;
     switch( visibility ) {
-        case VIS_HIDDEN:
-            light_name = "lighting_hidden";
+        case VIS_HIDDEN: {
+            light_name = &STATIC( std::string( "lighting_hidden" ) );
             break;
-        case VIS_LIT:
-            light_name = "lighting_lowlight_light";
+        }
+        case VIS_LIT: {
+            light_name = &STATIC( std::string( "lighting_lowlight_light" ) );
             break;
-        case VIS_BOOMER:
-            light_name = "lighting_boomered_light";
+        }
+        case VIS_BOOMER: {
+            light_name = &STATIC( std::string( "lighting_boomered_light" ) );
             break;
-        case VIS_BOOMER_DARK:
-            light_name = "lighting_boomered_dark";
+        }
+        case VIS_BOOMER_DARK: {
+            light_name = &STATIC( std::string( "lighting_boomered_dark" ) );
             break;
-        case VIS_DARK:
-            light_name = "lighting_lowlight_dark";
+        }
+        case VIS_DARK: {
+            light_name = &STATIC( std::string( "lighting_lowlight_dark" ) );
             break;
+        }
         case VIS_CLEAR:
             // should never happen
             break;
     }
 
     // lighting is never rotated, though, could possibly add in random rotation?
-    draw_from_id_string( light_name, C_LIGHTING, empty_string, pos, 0, 0, lit_level::LIT, false, 0 );
+    draw_from_id_string( *light_name, C_LIGHTING, empty_string, pos, 0, 0, lit_level::LIT, false, 0 );
 
     return true;
 }

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -336,6 +336,8 @@ class idle_animation_manager
  */
 using color_block_overlay_container = std::pair<SDL_BlendMode, std::multimap<point, SDL_Color>>;
 
+struct tile_render_info;
+
 class cata_tiles
 {
     public:
@@ -677,6 +679,7 @@ class cata_tiles
         std::map<tripoint, bool> draw_below_override;
         // int represents spawn count
         std::map<tripoint, std::tuple<mtype_id, int, bool, Creature::Attitude>> monster_override;
+        pimpl<std::vector<tile_render_info>> draw_points_cache;
 
     private:
         /**


### PR DESCRIPTION
#### Summary
SUMMARY: Performance "Fixed some frequent reallocations when drawing map with tiles"

#### Purpose of change
Improve rendering performance on slow machines by avoiding repeated reallocations

#### Describe the solution
1. Persist `draw_points` vector. From testing, when zoomed out with Retrodays tileset it may grow in capacity to 16384 elements (458752 bytes on linux) and reallocate 11 times in the process over the course of single `cata_tiles::draw` call.
2. In `apply_vision_effects`, don't allocate a string each time when deciding on vision effect to apply. On default zoom with Retrodays, it may cause as many as 3000 allocations over the course of single `cata_tiles::draw` call, which even shows up in the Visual Studio profiler.

#### Describe alternatives you've considered
`map::apparent_light_at` takes up 34% for some reason, that's almost all of `map::update_visibility_cache` (35%).
`map::generate_lightmap` is also quite heavy, 10%, pretty sure we don't need to re-generate lightmap before redrawing same scene.

#### Testing
Somewhat hard to measure the impact precisely, it is quite small on a fast machine (96 -> 97 redraws per second on linux + opengl).

Comparing the old laptop and the new one, reallocations in `apply_vision_effects` (in unmodified code) went down in profiler from 5% to 1%, which suggests actual gains depend heavily on how old the machine is (CPU frequency, RAM frequency, CPU cache).
