### PR TITLE
Vortices can now fight back

### DIFF
--- a/data/json/monster_factions.json
+++ b/data/json/monster_factions.json
@@ -229,5 +229,15 @@
     "type": "MONSTER_FACTION",
     "name": "fox",
     "base_faction": "small_predator"
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "mutant",
+    "friendly": [ "vortex" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "vortex",
+    "friendly": [ "mutant" ]
   }
 ]

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -836,11 +836,18 @@
     "material": [ "powder" ],
     "symbol": "V",
     "color": "white",
-    "aggression": 100,
+    "aggression": 5,
     "morale": 100,
-    "melee_cut": 0,
+    "melee_skill": 6,
+    "melee_dice": 1,
+    "melee_dice_sides": 4,
+    "melee_damage": [ { "damage_type": "electric", "amount": 5 } ],
     "harvest": "exempt",
+    "vision_day": 5,
+    "vision_night": 5,
+    "anger_triggers": [ "STALK", "HURT", "FRIEND_ATTACKED" ],
+    "placate_triggers": [ "PLAYER_WEAK" ],
     "death_function": [ "MELT" ],
-    "flags": [ "HEARS", "GOODHEARING", "STUMBLES", "NOHEAD", "HARDTOSHOOT", "FLIES", "PLASTIC", "NO_BREATHE", "NOGIB" ]
+    "flags": [ "SEES", "HEARS", "GOODHEARING", "STUMBLES", "NOHEAD", "HARDTOSHOOT", "FLIES", "PLASTIC", "NO_BREATHE", "NOGIB" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Vortex monsters no longer harmless despite being aggressive, make vortices and mutants friendly"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This effectively ports over some changes to a vanilla monster from Arcana and Magic Items mod with some changes, to make one monster that is notably hostile but harmless (due to getting a special attack it used to use instead of normal attacks, long before my time it seems) actually do something.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Defined monster faction JSON for mutant and vortex faction, made mutually friendly as mine spirals are populate mainly by those two factions.
2. Set it so vortices actually have the ability to fight back. Gave them some basic melee damage (in line with some Arcana alterations to vanilla monsters I plan to rebalance and port over in the future), with a set amount of bonus electric damage.
3. Set it so that vortices aren't aggressive by default, but become hostile via stalking behavior or harming them, along with a placate trigger. This makes them start off behaving similar to the current status quo (hostile but harmless so they just meander), but pull out a nasty surprise when provoked, but can be calmed afterward as well.
4. Gave them ability to see, just short enough a range that they'll be likely to actually respond to the player's actions.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Figuring out some way to hack together an `area_push` spell that'll do something like what the ancient dummied-out vortex special attack used to do.
2. Giving them the SMASH attack and seeing if it can be flavored as a targeted gust of wind.
3. Giving them the stare attack once the nether attention require is merged.
4. Figuring out where else to spawn vortices. I have plans for more use of cult monsters and possibly wraiths, those being currently underused, but where else would be a good vanilla use for these things...

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Load-tested in compiled test build.
2. Went to a spiral mine, observed that vortices and local mutants weren't infighting.
5. Poked about with a vortex, got it to attack me, did indeed hurt.
6. Found that getting badly injured would sometimes stop the beatings.

So, a thing this lead me to discover: far as I can tell, whatever code is involved in processing `PLAYER_WEAK` as a placate trigger, it doesn't kick in noticeably unless all of your limbs are very badly damaged. If by sheer chance most of the damage goes disproportionately to your torso or head, despite `player::hp_percentage` weighting them higher, they likely won't even notice how close to dead you are until it's too late.

This is most easily tested with giant rattlesnakes, as other than that there are very few monsters have have `PLAYER_WEAK` as a placate trigger, and most of them are more likely to flee than turn hostile.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
