### PR TITLE
Wraith and shadow special attack updates

### DIFF
--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2253,6 +2253,9 @@ bool mattack::plant( monster *z )
 
 bool mattack::disappear( monster *z )
 {
+    // No death drops or corpse, just in case a vanishing monster is set to have that when killed normally
+    z->no_corpse_quiet = true;
+    z->no_extra_death_drops = true;
     z->set_hp( 0 );
     return true;
 }
@@ -4568,8 +4571,12 @@ bool mattack::darkman( monster *z )
         // TODO: handle friendly monsters
         return false;
     }
+    // Wont do stuff unless it can see you and is in range
     if( rl_dist( z->pos(), g->u.pos() ) > 40 ) {
         return false;
+    }
+    if( !z->sees( g->u ) ) {
+        return true;
     }
     if( monster *const shadow = g->place_critter_around( mon_shadow, z->pos(), 1 ) ) {
         z->moves -= 10;
@@ -4578,10 +4585,6 @@ bool mattack::darkman( monster *z )
             add_msg( m_warning, _( "A shadow splits from the %s!" ),
                      z->name() );
         }
-    }
-    // Wont do the combat stuff unless it can see you
-    if( !z->sees( g->u ) ) {
-        return true;
     }
     // What do we say?
     switch( rng( 1, 7 ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Wraiths don't spawn shadows when idle, DISAPPEAR special attack prevents death drops"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some adjustments to the behavior of shadow monsters and the wraith. The main objectives are twofold:
1. Adjust for the potential problems that may be caused by six-second turns if a wraith is given free rein to spam shadows out of combat, as one every five seconds is quite a lot more if you accidentally wait in range of one, compared to what was once one every 30 seconds.
2. Added compatibility with Arcana, via allowing shadow monsters to have a more reasonable drop rate, instead of having to worry about shadows that vanish on their own being a completely free source of essence and shadow gems.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Moved shadow spawning part of the wraith's special attack such that it only spawns 
2. Adjusted the disappear special attack to remove the user instead of setting HP to zero, to avoid triggering any death drops that may potentially be yielded otherwise.
3. Ran affected file through astyle.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making it so that shadows (but presumably not hallucinations) use a variant disappear attack that only triggers if they can see their target, then rigging wraiths to create shadows up to a certain limit based on how many are near them.
2. Increasing cooldown on the wraith's special attack 6x so they have consistent low-level spawning of shadows instead of rapid spawning only when they see you.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested.
2. Confirmed that wraiths only start producing shadows when they can see you, and don't produce them when left to their own devices.
3. Confirmed shadows vanish as expected either way.
4. Added Arcana in temporarily, with essence and shadow gem drop rate for shadows bumped up to values they had in the past.
5. Confirmed shadows don't drop either when they vanish on their own, but do when killed by other means.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Related: a suggestion that came up in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/546 was the idea of making it so shady zombies either transform in sunlight or suffer from `SUNDEATH`, and remove death drops if so, as a way to justify spawning shady zeds in other places too on day one. I'll have to look into that, but seeing how one removes death drops here shows me what I'd need to do if so.