### PR TITLE
Fix bash spells doing nothing to walls and windows

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1052,7 +1052,7 @@ void spell_effect::mutate( const spell &sp, Creature &caster, const tripoint &ta
 
 void spell_effect::bash( const spell &sp, Creature &caster, const tripoint &target )
 {
-    const std::set<tripoint> area = spell_effect_blast( sp, caster.pos(), target, sp.aoe(), false );
+    const std::set<tripoint> area = spell_effect_blast( sp, caster.pos(), target, sp.aoe(), true );
     for( const tripoint &potential_target : area ) {
         if( !sp.is_valid_target( caster, potential_target ) ) {
             continue;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Trivial bugfix for bash spell effect not working against impassible terrain"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes a long-running bug that @foulman reported in DDA ages ago: https://github.com/CleverRaven/Cataclysm-DDA/issues/38077 in which bash spells do absolutely nothing to solid terrain like doors, walls, or even windows.

Turns out, the code for it is immensely, hilariously easy to fix. As in, the sort of thing @KorGgenT could've fixed over 2 years ago with literally just the flip of a single boolean.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Literally just set the ignore_walls boolean in `area` defintion for `spell_effect::bash` to true.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Pestering someone else to do it.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Loaded in an existing release, debugged all spells plus 1000 INT, tested Artifact Pulse to confirm that windows only get yote when they're opened.
2. Compiled and load-tested.
3. Repeated step one in compiled build, terrain correctly suffers bashing even when impassible.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

This will allow me to remove the "ter_transform subspells as a workaound" hack I've been using to deal with this for Arcana's bash spell effects.

~~Ideally if we get someone to port this to DDA that'd be nice.~~ Tested and it looks like somehow their version of spell shape code properly bashes walls if it has `IGNORES_WALLS`, so it's actually fixed on their end but no one took notice of it.