### PR TITLE
While flying, warn when letting go of control or stop driving

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -614,7 +614,7 @@ void vehicle::use_controls( const tripoint &pos )
     Character &character = get_player_character();
     const auto confirm_stop_driving = [this] {
         return !is_flying_in_air() || query_yn(
-            _( "Really let go of controls while flying? This will result in a crash." ) );
+            _( "Really let go of controls while flying?  This will result in a crash." ) );
     };
 
     if( remote ) {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -612,9 +612,9 @@ void vehicle::use_controls( const tripoint &pos )
     bool remote = g->remoteveh() == this;
     bool has_electronic_controls = false;
     Character &character = get_player_character();
-    const auto confirm_stop_driving = [this]() {
-        return not is_flying_in_air() || query_yn(
-                   _( "Really let go of controls while flying? This will result in a crash." ) );
+    const auto confirm_stop_driving = [this] {
+        return !is_flying_in_air() || query_yn(
+            _( "Really let go of controls while flying? This will result in a crash." ) );
     };
 
     if( remote ) {
@@ -661,7 +661,7 @@ void vehicle::use_controls( const tripoint &pos )
         if( character.controlling_vehicle || ( remote && engine_on ) ) {
             options.emplace_back( _( "Stop driving" ), keybind( "TOGGLE_ENGINE" ) );
             actions.push_back( [&] {
-                if( not confirm_stop_driving() )
+                if( !confirm_stop_driving() )
                 {
                     return;
                 } else if( engine_on && has_engine_type_not( fuel_type_muscle, true ) )

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -655,7 +655,7 @@ void vehicle::use_controls( const tripoint &pos )
     }
 
     if( has_part( "ENGINE" ) ) {
-        if( g->u.controlling_vehicle || ( remote && engine_on ) ) {
+        if( character.controlling_vehicle || ( remote && engine_on ) ) {
             options.emplace_back( _( "Stop driving" ), keybind( "TOGGLE_ENGINE" ) );
             actions.push_back( [&] {
                 if( is_flying_in_air() )
@@ -695,7 +695,7 @@ void vehicle::use_controls( const tripoint &pos )
                 }
                 vehicle_noise = 0;
                 engine_on = false;
-                g->u.controlling_vehicle = false;
+                character.controlling_vehicle = false;
                 g->setremoteveh( nullptr );
                 sfx::do_vehicle_engine_sfx();
                 refresh();
@@ -801,7 +801,7 @@ void vehicle::use_controls( const tripoint &pos )
     if( menu.ret >= 0 ) {
         // allow player to turn off engine without triggering another warning
         if( menu.ret != 0 && menu.ret != 1 && menu.ret != 2 && menu.ret != 3 ) {
-            if( !handle_potential_theft( dynamic_cast<player &>( g->u ) ) ) {
+            if( !handle_potential_theft( dynamic_cast<player &>( character ) ) ) {
                 return;
             }
         }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "While flying, warn when letting go of control or stop driving"

#### Purpose of change

- Fixes #1924

#### Describe the solution
when trying to let go of control or stop driving while flying, warn `"Really let go of controls while flying? This will result in a crash."`

#### Describe alternatives you've considered

- make helicopters be able to fly without controls
- automatically land

either way won't take less than two `if`s.

#### Testing

it works on my machine!

#### Additional context

<details>
  <summary>Letting go of Control</summary>
  <img src="https://user-images.githubusercontent.com/54838975/194014266-2f78e90d-054c-4e5b-9802-21089565a62e.png" alt="_04">
  <img src="https://user-images.githubusercontent.com/54838975/194014281-0853f985-1955-473e-8ae5-aa1c157202d2.png" alt="_05"></p>
</details>

<details>
  <summary>Stopping Engine</summary>
  <img src="https://user-images.githubusercontent.com/54838975/194014348-020186b0-25bb-41d9-84f0-22dd443b1b93.png" alt="_06">
  <img src="https://user-images.githubusercontent.com/54838975/194014356-3cbc85e5-63ef-4014-a821-f2fe14e13439.png" alt="_07">
  <img src="https://user-images.githubusercontent.com/54838975/194014361-a69bcc8f-0866-4484-94a0-24528b9a95c3.png" alt="_08"></p>
</details>
