### PR TITLE
add clangd cache to `.gitignore` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ logg.txt
 .vscode/
 Debug*/
 Release*/
-.cache/clangd
+.cache/
 
 # Distribution script results
 /msvc-full-features/distribution

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ logg.txt
 .vscode/
 Debug*/
 Release*/
+.cache/clangd
 
 # Distribution script results
 /msvc-full-features/distribution


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Add clangd cache to .gitignore files"

#### Purpose of change
clangd stores cache into root directory

#### Describe the solution
- add `.cache/clangd` to gitignore

#### Additional context
![image](https://user-images.githubusercontent.com/54838975/193993272-a71d506c-6a62-44d7-89bd-908700f852bb.png)

[clangd](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd
) is fast, provides useful information, and has refactoring.