### PR TITLE
Prettier fuel selection menu

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4163,7 +4163,7 @@ bool vehicle::can_float() const
 
 double vehicle::total_rotor_area() const
 {
-    return std::accumulate( rotors.begin(), rotors.end(), double{0},
+    return std::accumulate( rotors.begin(), rotors.end(), double{0.0},
     [&]( double acc, int rotor ) {
         const double radius{ parts[ rotor ].info().rotor_diameter() / 2.0 };
         return acc + M_PI * std::pow( radius, 2 );
@@ -4174,15 +4174,15 @@ double vehicle::total_rotor_area() const
 // returns as newton
 double vehicle::lift_thrust_of_rotorcraft( const bool fuelled, const bool safe ) const
 {
-    constexpr double coeffiicient {0.8642};
-    constexpr double exponentiation {-0.3107};
+    constexpr double coefficient = 0.8642;
+    constexpr double exponentiation = -0.3107;
 
-    const double rotor_area {total_rotor_area()};
+    const double rotor_area = total_rotor_area();
     // take off 15 % due to the imaginary tail rotor power?
-    const int engine_power {total_power_w( fuelled, safe )};
+    const int engine_power = total_power_w( fuelled, safe );
 
-    const double power_load {engine_power / rotor_area};
-    const double lift_thrust = coeffiicient * engine_power * std::pow( power_load, exponentiation );
+    const double power_load = engine_power / rotor_area;
+    const double lift_thrust = coefficient * engine_power * std::pow( power_load, exponentiation );
     add_msg( m_debug, "lift thrust(N) of %s: %f, rotor area (m^2): %f, engine power (w): %i",
              name, lift_thrust, rotor_area, engine_power );
     return lift_thrust;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1102,7 +1102,7 @@ bool vehicle::is_alternator_on( const int a ) const
     }
 
     return std::any_of( engines.begin(), engines.end(), [this, &alt]( int idx ) {
-        auto &eng = parts [ idx ];
+        const auto &eng = parts [ idx ];
         //fuel_left checks that the engine can produce power to be absorbed
         return eng.is_available() && eng.enabled && fuel_left( eng.fuel_current() ) &&
                eng.mount == alt.mount && !eng.faults().count( fault_belt );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -462,6 +462,7 @@ int vehicle::select_engine()
         .with_txt_color( is_active ? c_light_green : c_light_gray );
     };
 
+    int i = 0;
     const auto entry_alt_fuels = [&]( size_t x ) {
         int e = engines[ x ];
         const std::string &part_name = parts[ e ].name();
@@ -473,7 +474,8 @@ int vehicle::select_engine()
         for( const itype_id &fuel_id : fuel_opts ) {
             const bool is_active = is_engine_active( e, fuel_id );
             const bool is_available = is_engine_available( x, fuel_id );
-            auto opt =  get_opt( is_available, is_active, item::nname( fuel_id ) );
+            auto opt = get_opt( is_available, is_active, item::nname( fuel_id ) );
+            opt.retval = i++;
             tmenu.entries.emplace_back( opt );
         }
     };

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -373,10 +373,10 @@ void vehicle::control_engines()
     int e_toggle = 0;
     bool dirty = false;
     //count active engines
-    int fuel_count = 0;
-    for( int e : engines ) {
-        fuel_count += part_info( e ).engine_fuel_opts().size();
-    }
+    const int fuel_count = std::accumulate( engines.begin(), engines.end(), int{0},
+    [&]( int acc, int e ) {
+        return acc + part_info( e ).engine_fuel_opts().size();
+    } );
 
     const auto adjust_engine = [this]( int e_toggle ) {
         int i = 0;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -677,9 +677,9 @@ void vehicle::use_controls( const tripoint &pos )
                 for( size_t e = 0; e < engines.size(); ++e )
                 {
                     if( is_engine_on( e ) ) {
-                        const vpart_info &engine_info = parts[ engines[ e ] ].info();
-                        const std::string &engine_id = engine_info.get_id().str();
-                        const int noise = engine_info.engine_noise_factor();
+                        const vpart_info &einfo = part_info( e );
+                        const std::string &engine_id = einfo.get_id().str();
+                        const int noise = einfo.engine_noise_factor();
 
                         if( sfx::has_variant_sound( "engine_stop", engine_id ) ) {
                             sfx::play_variant_sound( "engine_stop", engine_id, noise );
@@ -938,16 +938,20 @@ bool vehicle::start_engine( const int e )
     const vpart_info &einfo = part_info( engines[e] );
     vehicle_part &eng = parts[ engines[ e ] ];
 
-    bool out_of_fuel = false;
-    if( einfo.fuel_type != fuel_type_none && engine_fuel_left( e ) <= 0 ) {
-        for( const itype_id &fuel_id : einfo.engine_fuel_opts() ) {
+    const bool out_of_fuel = [&] {
+        if( einfo.fuel_type == fuel_type_none || engine_fuel_left( e ) > 0 )
+        {
+            return false;
+        }
+        for( const itype_id &fuel_id : einfo.engine_fuel_opts() )
+        {
             if( fuel_left( fuel_id ) > 0 ) {
                 eng.fuel_set( fuel_id );
-                break;
+                return false;
             }
         }
-        out_of_fuel = true;
-    }
+        return true;
+    }();
 
     if( out_of_fuel ) {
         if( einfo.fuel_type == fuel_type_muscle ) {
@@ -1051,9 +1055,9 @@ void vehicle::stop_engines()
     add_msg( _( "You turn the engine off." ) );
     for( size_t e = 0; e < engines.size(); ++e ) {
         if( is_engine_on( e ) ) {
-            const vpart_info &engine_info = parts[ engines[ e ] ].info();
-            const std::string &engine_id = engine_info.get_id().str();
-            const int noise = engine_info.engine_noise_factor();
+            const vpart_info &einfo = part_info( e );
+            const std::string &engine_id = einfo.get_id().str();
+            const int noise = einfo.engine_noise_factor();
 
             if( sfx::has_variant_sound( "engine_stop", engine_id ) ) {
                 sfx::play_variant_sound( "engine_stop", engine_id, noise );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -471,9 +471,7 @@ int vehicle::select_engine()
         const std::string &part_name = parts[ engine_id ].name();
 
         tmenu.entries.emplace_back( get_title( part_name ) );
-
-        const auto fuel_opts = part_info( engine_id ).engine_fuel_opts();
-        for( const itype_id &fuel_id : fuel_opts ) {
+        for( const auto &fuel_id : part_info( engine_id ).engine_fuel_opts() ) {
             auto opt = get_opt( x, fuel_id );
             opt.retval = i++;
             tmenu.entries.emplace_back( opt );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -375,7 +375,7 @@ void vehicle::control_engines()
     //count active engines
     const int fuel_count = std::accumulate( engines.begin(), engines.end(), int{0},
     [&]( int acc, int e ) {
-        return acc + part_info( e ).engine_fuel_opts().size();
+        return acc + static_cast<int>(part_info( e ).engine_fuel_opts().size());
     } );
 
     const auto adjust_engine = [this]( int e_toggle ) {
@@ -444,8 +444,7 @@ int vehicle::select_engine()
     const auto is_engine_available = [this]( size_t x, const itype_id & fuel_id ) -> bool {
         const int e = engines[x];
         return parts[ e ].is_available() &&
-        ( is_perpetual_type( x ) || fuel_id == fuel_type_muscle ||
-          fuel_left( fuel_id ) );
+        ( is_perpetual_type( x ) || fuel_id == fuel_type_muscle || ( fuel_left( fuel_id ) > 0 ) );
     };
 
     const auto add_entry = [&tmenu]( int idx, bool is_available, bool is_active,

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -677,21 +677,20 @@ void vehicle::use_controls( const tripoint &pos )
                 for( size_t e = 0; e < engines.size(); ++e )
                 {
                     if( is_engine_on( e ) ) {
-                        if( sfx::has_variant_sound( "engine_stop", parts[ engines[ e ] ].info().get_id().str() ) ) {
-                            sfx::play_variant_sound( "engine_stop", parts[ engines[ e ] ].info().get_id().str(),
-                                                     parts[ engines[ e ] ].info().engine_noise_factor() );
+                        const vpart_info &engine_info = parts[ engines[ e ] ].info();
+                        const std::string &engine_id = engine_info.get_id().str();
+                        const int noise = engine_info.engine_noise_factor();
+
+                        if( sfx::has_variant_sound( "engine_stop", engine_id ) ) {
+                            sfx::play_variant_sound( "engine_stop", engine_id, noise );
                         } else if( is_engine_type( e, fuel_type_muscle ) ) {
-                            sfx::play_variant_sound( "engine_stop", "muscle",
-                                                     parts[ engines[ e ] ].info().engine_noise_factor() );
+                            sfx::play_variant_sound( "engine_stop", "muscle", noise );
                         } else if( is_engine_type( e, fuel_type_wind ) ) {
-                            sfx::play_variant_sound( "engine_stop", "wind",
-                                                     parts[ engines[ e ] ].info().engine_noise_factor() );
+                            sfx::play_variant_sound( "engine_stop", "wind", noise );
                         } else if( is_engine_type( e, fuel_type_battery ) ) {
-                            sfx::play_variant_sound( "engine_stop", "electric",
-                                                     parts[ engines[ e ] ].info().engine_noise_factor() );
+                            sfx::play_variant_sound( "engine_stop", "electric", noise );
                         } else {
-                            sfx::play_variant_sound( "engine_stop", "combustion",
-                                                     parts[ engines[ e ] ].info().engine_noise_factor() );
+                            sfx::play_variant_sound( "engine_stop", "combustion", noise );
                         }
                     }
                 }
@@ -1052,15 +1051,16 @@ void vehicle::stop_engines()
     add_msg( _( "You turn the engine off." ) );
     for( size_t e = 0; e < engines.size(); ++e ) {
         if( is_engine_on( e ) ) {
-            if( sfx::has_variant_sound( "engine_stop", parts[ engines[ e ] ].info().get_id().str() ) ) {
-                sfx::play_variant_sound( "engine_stop", parts[ engines[ e ] ].info().get_id().str(),
-                                         parts[ engines[ e ] ].info().engine_noise_factor() );
+            const vpart_info &engine_info = parts[ engines[ e ] ].info();
+            const std::string &engine_id = engine_info.get_id().str();
+            const int noise = engine_info.engine_noise_factor();
+
+            if( sfx::has_variant_sound( "engine_stop", engine_id ) ) {
+                sfx::play_variant_sound( "engine_stop", engine_id, noise );
             } else if( is_engine_type( e, fuel_type_battery ) ) {
-                sfx::play_variant_sound( "engine_stop", "electric",
-                                         parts[ engines[ e ] ].info().engine_noise_factor() );
+                sfx::play_variant_sound( "engine_stop", "electric", noise );
             } else {
-                sfx::play_variant_sound( "engine_stop", "combustion",
-                                         parts[ engines[ e ] ].info().engine_noise_factor() );
+                sfx::play_variant_sound( "engine_stop", "combustion", noise );
             }
         }
     }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cmath>
 #include <cstdlib>
+#include <iterator>
 #include <list>
 #include <memory>
 #include <sstream>
@@ -447,15 +448,27 @@ int vehicle::select_engine()
           fuel_left( fuel_id ) );
     };
 
+    const auto add_entry = [&tmenu]( int idx, bool is_available, bool is_active,
+    const std::string & part_name, const std::string &  fuel_name ) {
+        tmenu.addentry( idx, is_available, -1, "[%s] %s %s",
+                        is_active ? "x" : " ", part_name, fuel_name );
+    };
+
+
     int i = 0;
     const auto entry_alt_fuels = [&]( size_t x ) {
         int e = engines[ x ];
-        for( const itype_id &fuel_id : part_info( e ).engine_fuel_opts() ) {
+        const std::string &part_name = parts[ e ].name();
+        const std::string spaces = std::string( parts[ e ].name( /*colorize*/ false ).size() + 3, ' ' );
+        const auto fuel_opts = part_info( e ).engine_fuel_opts();
+
+        bool is_first = true;
+        for( const itype_id &fuel_id : fuel_opts ) {
             const bool is_active = is_engine_active( e, fuel_id );
             const bool is_available = is_engine_available( x, fuel_id );
-            tmenu.addentry( i++, is_available, -1, "[%s] %s %s",
-                            is_active ? "x" : " ", parts[ e ].name(),
-                            item::nname( fuel_id ) );
+
+            add_entry( i++, is_available, is_active, is_first ? part_name : spaces, item::nname( fuel_id ) );
+            is_first = false;
         }
     };
 


### PR DESCRIPTION
#### Summary

SUMMARY: Interface "Prettier fuel selection menu"

#### Purpose of change
- engine entries have lots of duplicate names, so thought it'd be better to only print unique ones

#### Describe the solution
- also make them look pretty

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
now even prettier with same ui as aiming menu
![image](https://user-images.githubusercontent.com/54838975/194760943-3560d334-7714-4673-9f97-297d86aa61be.png)

<!-- ![_04](https://user-images.githubusercontent.com/54838975/194226393-33cef26c-09a0-4857-a6d3-b4e21d957edc.png) -->

