### PR TITLE
Fix latest release badge not showing latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Find a way to stop the Cataclysm ... or become one of its strongest monsters.
 [stable-releases]: https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/cbn-0.1
 [stable-releases-badge]: <https://img.shields.io/badge/Stable Release-0.1-success?style=for-the-badge>
 [all-releases]: https://github.com/cataclysmbnteam/Cataclysm-BN/releases
-[all-releases-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?color=important&include_prereleases&label=Latest%20Release&sort=semver&style=for-the-badge
+[all-releases-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?color=important&include_prereleases&label=Latest%20Release&sort=date&style=for-the-badge
 
 | [Source Code][source-zip-archive] | [Clone From Repo][clone] |
 | :-------------------------------: | :----------------------: |


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Fix latest release badge not showing latest release"

#### Purpose of change
fix shields.io url arguments mistake caused by #1939

#### Describe the solution
changed query parameter from `semver` -> `date`

#### Additional context
![image](https://user-images.githubusercontent.com/54838975/194231165-44697b8f-8114-4c0c-b87b-11cb4229b7d8.png)