### PR TITLE
Fix gate failing randomly

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -403,7 +403,7 @@
     "no_resume": true
   },
   {
-    "id": "ACT_OPEN_GATE",
+    "id": "ACT_TOGGLE_GATE",
     "type": "activity_type",
     "verb": "working the winch",
     "based_on": "speed"

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1080,19 +1080,19 @@ std::unique_ptr<activity_actor> migration_cancel_activity_actor::deserialize( Js
     return migration_cancel_activity_actor().clone();
 }
 
-void open_gate_activity_actor::start( player_activity &act, Character & )
+void toggle_gate_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves_total;
     act.moves_left = moves_total;
 }
 
-void open_gate_activity_actor::finish( player_activity &act, Character & )
+void toggle_gate_activity_actor::finish( player_activity &act, Character & )
 {
-    gates::open_gate( placement );
+    gates::toggle_gate( placement );
     act.set_to_null();
 }
 
-void open_gate_activity_actor::serialize( JsonOut &jsout ) const
+void toggle_gate_activity_actor::serialize( JsonOut &jsout ) const
 {
     jsout.start_object();
 
@@ -1102,9 +1102,9 @@ void open_gate_activity_actor::serialize( JsonOut &jsout ) const
     jsout.end_object();
 }
 
-std::unique_ptr<activity_actor> open_gate_activity_actor::deserialize( JsonIn &jsin )
+std::unique_ptr<activity_actor> toggle_gate_activity_actor::deserialize( JsonIn &jsin )
 {
-    open_gate_activity_actor actor( 0, tripoint_zero );
+    toggle_gate_activity_actor actor( 0, tripoint_zero );
 
     JsonObject data = jsin.get_object();
 
@@ -1265,7 +1265,7 @@ deserialize_functions = {
     { activity_id( "ACT_HACKING" ), &hacking_activity_actor::deserialize },
     { activity_id( "ACT_MIGRATION_CANCEL" ), &migration_cancel_activity_actor::deserialize },
     { activity_id( "ACT_MOVE_ITEMS" ), &move_items_activity_actor::deserialize },
-    { activity_id( "ACT_OPEN_GATE" ), &open_gate_activity_actor::deserialize },
+    { activity_id( "ACT_TOGGLE_GATE" ), &toggle_gate_activity_actor::deserialize },
     { activity_id( "ACT_PICKUP" ), &pickup_activity_actor::deserialize },
     { activity_id( "ACT_STASH" ), &stash_activity_actor::deserialize },
     { activity_id( "ACT_THROW" ), &throw_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -372,26 +372,27 @@ class move_items_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonIn &jsin );
 };
 
-class open_gate_activity_actor : public activity_actor
+class toggle_gate_activity_actor : public activity_actor
 {
     private:
         int moves_total;
         tripoint placement;
 
         /**
-         * @pre @p other is a open_gate_activity_actor
+         * @pre @p other is a toggle_gate_activity_actor
          */
         bool can_resume_with_internal( const activity_actor &other, const Character & ) const override {
-            const open_gate_activity_actor &og_actor = static_cast<const open_gate_activity_actor &>( other );
+            const toggle_gate_activity_actor &og_actor = static_cast<const toggle_gate_activity_actor &>
+                    ( other );
             return placement == og_actor.placement;
         }
 
     public:
-        open_gate_activity_actor( int gate_moves, const tripoint &gate_placement ) :
+        toggle_gate_activity_actor( int gate_moves, const tripoint &gate_placement ) :
             moves_total( gate_moves ), placement( gate_placement ) {}
 
         activity_id get_type() const override {
-            return activity_id( "ACT_OPEN_GATE" );
+            return activity_id( "ACT_TOGGLE_GATE" );
         }
 
         void start( player_activity &act, Character & ) override;
@@ -399,7 +400,7 @@ class open_gate_activity_actor : public activity_actor
         void finish( player_activity &act, Character & ) override;
 
         std::unique_ptr<activity_actor> clone() const override {
-            return std::make_unique<open_gate_activity_actor>( *this );
+            return std::make_unique<toggle_gate_activity_actor>( *this );
         }
 
         void serialize( JsonOut &jsout ) const override;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5219,6 +5219,9 @@ bool game::forced_door_closing( const tripoint &p, const ter_id &door_type, int 
                 it = items.erase( it );
                 continue;
             }
+            if (cannot_push) {
+                return false;
+            }
             m.add_item_or_charges( kbp, *it );
             it = items.erase( it );
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5226,9 +5226,9 @@ bool game::forced_door_closing( const tripoint &p, const ter_id &door_type, int 
     return true;
 }
 
-void game::open_gate( const tripoint &p )
+void game::toggle_gate( const tripoint &p )
 {
-    gates::open_gate( p, u );
+    gates::toggle_gate( p, u );
 }
 
 void game::moving_vehicle_dismount( const tripoint &dest_loc )

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5106,7 +5106,7 @@ bool game::forced_door_closing( const tripoint &p, const ter_id &door_type, int 
     const auto get_random_point = [&]() -> tripoint {
         if( auto pos = random_point( m.points_in_radius( p, 2 ), valid_location ) )
         {
-            return tripoint( -pos->xy() + p.xy() * 2, p.z );
+            return  p * 2 - ( *pos );
         } else
         {
             return p;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5115,10 +5115,10 @@ bool game::forced_door_closing( const tripoint &p, const ter_id &door_type, int 
         kb.y = -pos->y + y + y;
     }
     const tripoint kbp( kb, p.z );
-    if( kbp == p ) {
-        // can't pushback any creatures anywhere, that means the door can't close.
-        return false;
-    }
+
+    // can't pushback any creatures anywhere, that means the door can't close.
+    const bool cannot_push = kbp == p;
+
     const bool can_see = u.sees( tripoint( x, y, p.z ) );
     player *npc_or_player = critter_at<player>( tripoint( x, y, p.z ), false );
     if( npc_or_player != nullptr ) {
@@ -5135,6 +5135,9 @@ bool game::forced_door_closing( const tripoint &p, const ter_id &door_type, int 
         }
         // TODO: make the npc angry?
         npc_or_player->hitall( bash_dmg, 0, nullptr );
+        if( cannot_push ) {
+            return false;
+        }
         knockback( kbp, p, std::max( 1, bash_dmg / 10 ), -1, 1 );
         // TODO: perhaps damage/destroy the gate
         // if the npc was really big?
@@ -5161,6 +5164,9 @@ bool game::forced_door_closing( const tripoint &p, const ter_id &door_type, int 
         }
         if( !critter.is_dead() ) {
             // Still alive? Move the critter away so the door can close
+            if( cannot_push ) {
+                return false;
+            }
             knockback( kbp, p, std::max( 1, bash_dmg / 10 ), -1, 1 );
             if( critter_at( p ) ) {
                 return false;

--- a/src/game.h
+++ b/src/game.h
@@ -670,7 +670,7 @@ class game
 
         /**@}*/
 
-        void open_gate( const tripoint &p );
+        void toggle_gate( const tripoint &p );
 
         // Knockback functions: knock target at t along a line, either calculated
         // from source position s using force parameter or passed as an argument;

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -165,7 +165,7 @@ void gates::reset()
 //  !|   |!        !   |
 //
 
-void gates::open_gate( const tripoint &pos )
+void gates::toggle_gate( const tripoint &pos )
 {
     const gate_id gid = get_gate_id( pos );
 
@@ -233,7 +233,7 @@ void gates::open_gate( const tripoint &pos )
     }
 }
 
-void gates::open_gate( const tripoint &pos, player &p )
+void gates::toggle_gate( const tripoint &pos, player &p )
 {
     const gate_id gid = get_gate_id( pos );
 
@@ -245,7 +245,7 @@ void gates::open_gate( const tripoint &pos, player &p )
     const gate_data &gate = gates_data.obj( gid );
 
     p.add_msg_if_player( gate.pull_message );
-    p.assign_activity( player_activity( open_gate_activity_actor(
+    p.assign_activity( player_activity( toggle_gate_activity_actor(
                                             gate.moves,
                                             pos
                                         ) ) );

--- a/src/gates.h
+++ b/src/gates.h
@@ -17,10 +17,10 @@ void load( const JsonObject &jo, const std::string &src );
 void check();
 void reset();
 
-/** opens the gate via player's activity */
-void open_gate( const tripoint &pos, player &p );
-/** opens the gate immediately */
-void open_gate( const tripoint &pos );
+/** opens/closes the gate via player's activity */
+void toggle_gate( const tripoint &pos, player &p );
+/** opens/closes the gate immediately */
+void toggle_gate( const tripoint &pos );
 
 } // namespace gates
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -957,7 +957,7 @@ void iexamine::elevator( player &p, const tripoint &examp )
 }
 
 /**
- * Open gate.
+ * Open or close gate.
  */
 void iexamine::controls_gate( player &p, const tripoint &examp )
 {
@@ -965,7 +965,7 @@ void iexamine::controls_gate( player &p, const tripoint &examp )
         none( p, examp );
         return;
     }
-    g->open_gate( examp );
+    g->toggle_gate( examp );
 }
 
 static bool try_start_hacking( player &p, const tripoint &examp )


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix mechanical gates randomly failing to close"

#### Purpose of change

- `gates::open_gate` fails because `forced_door_closing` returns `false`
- `forced_door_closing` randomly fails because it checks room for pushback regardless of whether there's item/monster
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/6b7f879b6e6247d628d4ba2ae4680d8d86d770d8/src/game.cpp#L5117-L5121

#### Describe the solution

- 1724e0b7ccf051646cbc286e9bf2091dbefa0f17, 1724e0b7ccf051646cbc286e9bf2091dbefa0f17: lazy evaluate pushback check until `pushback()` and item moving is actually done
- 88c3ab07fb54c2db4dcda08b3a2c65285f5b1dfa: renamed `open_gate` and releated function name to `toggle_gate`
- 70708db39bb4d2a6150fba1641c49eeb5529ce5d, 29e5683b3d4120edab58786eeb2e0cafae1bdef8: removed duplicate points

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
