### PR TITLE
Fixes rendering monsters you can't see when using 2d vision

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3034,7 +3034,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
         }
         const Creature &critter = *pcritter;
 
-        if( fov_3d && !g->u.sees( critter ) ) {
+        if( !g->u.sees( critter ) ) {
             if( g->u.sees_with_infrared( critter ) || g->u.sees_with_specials( critter ) ) {
                 return draw_from_id_string( "infrared_creature", C_NONE, empty_string, p, 0, 0,
                                             lit_level::LIT, false, height_3d, z_drop );


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "No more rendering monsters you can't see"

#### Purpose of change

Only render seen creatures. 

#### Describe the solution

Remove the bit that says only check visibility when fov_3d is on. I don't know why I added that with the draw lower z levels but I did and it was a mistake. 

#### Describe alternatives you've considered

Getting my brain checked.

#### Additional context

Whoops.