### PR TITLE
Obsolete Graphical Overmap mod, rename to Larwick's Overmap

### DIFF
--- a/data/mods/Graphical_Overmap/modinfo.json
+++ b/data/mods/Graphical_Overmap/modinfo.json
@@ -2,11 +2,12 @@
   {
     "type": "MOD_INFO",
     "id": "Graphical_Overmap",
-    "name": "Graphical Overmap",
+    "name": "Larwick's Overmap",
     "authors": [ "Larwick" ],
     "maintainers": [ "Larwick" ],
     "description": "Gives the overmap a graphical overhaul.  Please refer to readme for installation.",
     "category": "graphical",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "dda" ],
+    "obsolete": true
   }
 ]

--- a/data/mods/Graphical_Overmap_FujiStruct/modinfo.json
+++ b/data/mods/Graphical_Overmap_FujiStruct/modinfo.json
@@ -2,10 +2,10 @@
   {
     "type": "MOD_INFO",
     "id": "Graphical_Overmap_Fujistruct",
-    "name": "Graphical Overmap Fujistruct",
+    "name": "Larwick's Overmap Fujistruct",
     "authors": [ "Kilvoctu" ],
     "maintainers": [ "Kilvoctu" ],
-    "description": "Fuji Structures mod support for Graphical Overmap.",
+    "description": "Fuji Structures mod support for Larwick's Overmap.",
     "category": "graphical",
     "dependencies": [ "dda", "Graphical_Overmap", "FujiStruct" ],
     "obsolete": true

--- a/data/mods/Graphical_Overmap_More_Locations/modinfo.json
+++ b/data/mods/Graphical_Overmap_More_Locations/modinfo.json
@@ -2,10 +2,10 @@
   {
     "type": "MOD_INFO",
     "id": "Graphical_Overmap_More_Locations",
-    "name": "Graphical Overmap More Locations",
+    "name": "Larwick's Overmap More Locations",
     "authors": [ "Kilvoctu" ],
     "maintainers": [ "Kilvoctu" ],
-    "description": "More Locations mod support for Graphical Overmap.",
+    "description": "More Locations mod support for Larwick's Overmap.",
     "category": "graphical",
     "dependencies": [ "dda", "Graphical_Overmap", "more_locations" ],
     "obsolete": true

--- a/data/mods/Graphical_Overmap_Urban_Development/modinfo.json
+++ b/data/mods/Graphical_Overmap_Urban_Development/modinfo.json
@@ -2,10 +2,10 @@
   {
     "type": "MOD_INFO",
     "id": "Graphical_Overmap_Urban_Development",
-    "name": "Graphical Overmap Urban Development",
+    "name": "Larwick's Overmap Urban Development",
     "authors": [ "Kilvoctu" ],
     "maintainers": [ "Kilvoctu" ],
-    "description": "Urban Development mod support for Graphical Overmap.",
+    "description": "Urban Development mod support for Larwick's Overmap.",
     "category": "graphical",
     "dependencies": [ "dda", "Graphical_Overmap", "Urban_Development" ],
     "obsolete": true


### PR DESCRIPTION
#### Summary
SUMMARY: Mods "Obsolete Graphical Overmap mod, rename to Larwick's Overmap"

#### Purpose of change
When people see nice screenshots of the graphical overmap with UDP, they frequently assume it's the "Graphical Overmap" mod they see in the new world menu. Furthermore, not all people see "please refer to readme" note that describes additional installation steps required in order for the mod to work.

#### Describe the solution
Get rid of the footgun by obsoleting the mod and giving it a somewhat obscure name. There were no actual changes done to its content or id, so existing saves will work as is.

#### Testing
Tried starting a new world, the mod is not there. Can still be activated after pressing `o` (`Toggle showing [o]bsolete mods`).