### PR TITLE
Fixes a bug where pathfinding could go through vehicle holes

### DIFF
--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -216,7 +216,8 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
         const auto line_path = line_to( f, t );
         const auto &pf_cache = get_pathfinding_cache_ref( f.z );
         // Check all points for any special case (including just hard terrain)
-        if( std::all_of( line_path.begin(), line_path.end(), [&pf_cache]( const tripoint & p ) {
+        if( !( pf_cache.special[f.x][f.y] & non_normal ) &&
+        std::all_of( line_path.begin(), line_path.end(), [&pf_cache]( const tripoint & p ) {
         return !( pf_cache.special[p.x][p.y] & non_normal );
         } ) ) {
             const std::set<tripoint> sorted_line( line_path.begin(), line_path.end() );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fixes a bug where pathfinding could go through vehicle holes"

#### Purpose of change

In some cases vehicles holes wouldn't be checked properly when building a path. 

#### Describe the solution

Moves checking holes to an earlier point in the check of the tile, so it's done regardless of the tile's properties. 

#### Testing

The easiest way to trigger this is to let an npc melee something through a hole. So long as the tile that's targeted doesn't have any movement affecting properties it'll be allowed. 