### PR TITLE
Prevents dodge gain exploit

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1394,7 +1394,6 @@ void monster::melee_attack( Creature &target )
 
 void monster::melee_attack( Creature &target, float accuracy )
 {
-    int hitspread = target.deal_melee_attack( this, melee::melee_hit_range( accuracy ) );
     mod_moves( -type->attack_cost );
     if( type->melee_dice == 0 ) {
         // We don't attack, so just return
@@ -1409,6 +1408,8 @@ void monster::melee_attack( Creature &target, float accuracy )
     if( !can_squeeze_to( target.pos() ) ) {
         return;
     }
+
+    int hitspread = target.deal_melee_attack( this, melee::melee_hit_range( accuracy ) );
 
     if( target.is_player() ||
         ( target.is_npc() && g->u.attitude_to( target ) == A_FRIENDLY ) ) {


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Prevents a dodge gain exploit using vehicle holes"

#### Purpose of change

Fixes #1929. Also prevents dodge gain in the cases where the monster has no attack dice or it's attacking itself but I don't think those matter. 

#### Describe the solution

Moves the dodge roll until after the conditions have been checked. 

#### Describe alternatives you've considered

We could look into the rest of the AI so it doesn't waste moves trying to do things like this in the first place, but that's a wider issue. 