### PR TITLE
Allows pushing vehicles over ramps

### DIFF
--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -147,7 +147,6 @@ bool game::grabbed_veh_move( const tripoint &dp )
         grabbed_vehicle->turn( mdir.dir() - grabbed_vehicle->face.dir() );
         grabbed_vehicle->face = grabbed_vehicle->turn_dir;
         grabbed_vehicle->precalc_mounts( 1, mdir.dir(), grabbed_vehicle->pivot_point() );
-        grabbed_vehicle->adjust_zlevel( 1, dp );
 
         // Grabbed part has to stay at distance 1 to the player
         // and in roughly the same direction.
@@ -155,6 +154,8 @@ bool game::grabbed_veh_move( const tripoint &dp )
                                       grabbed_vehicle->part( grabbed_part ).precalc[ 1 ];
         const tripoint expected_pos = u.pos() + dp + from;
         const tripoint actual_dir = expected_pos - new_part_pos;
+
+        grabbed_vehicle->adjust_zlevel( 1, dp );
 
         // Set player location to illegal value so it can't collide with vehicle.
         const tripoint player_prev = u.pos();


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Allows pushing vehicles over ramps"

#### Purpose of change

Fixes #1978. 

#### Describe the solution

The problem was that when you went over the ramp and your grab point moved in the z direction, some of the grab code would factor that in and end up having the collision calculated for the opposite direction, causing you to bump into the ground. The code that adjusts the z value has been moved until after the grab's calculations. 

#### Describe alternatives you've considered

You could also just set z to 0 after doing grab's calculations, it's all much the same. 

#### Additional context

You still have to do the awkward push it up and then go up yourself and grab it again, but I think that's the same as before.