### PR TITLE
Format configs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,13 +54,6 @@ Checks: >
   -readability-redundant-control-flow,
   -readability-identifier-length,
 
-  -modernize-use-nodiscard
-  -modernize-concat-nested-namespaces
-  -modernize-loop-convert
-  -modernize-unary-static-assert
-  -readability-redundant-declaration
-# C++17 changes that clang-tidy does not likes
-
 WarningsAsErrors: "*"
 HeaderFilterRegex: "(src|(test(?!.*catch.*catch.h))|tools).*"
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,6 +52,7 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-redundant-control-flow,
+  -readability-identifier-length,
 
 WarningsAsErrors: "*"
 HeaderFilterRegex: "(src|(test(?!.*catch.*catch.h))|tools).*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,62 +4,61 @@
 # this codebase and we do not intend to fix.  The disabled checks appearing
 # thereafter in a separate alphabetical list have yet to be triaged.  We may
 # fix their errors or recategorise them as checks we don't care about.
-Checks: "\
-bugprone-*,\
-cata-*,\
-cert-*,\
--cert-dcl21-cpp,\
--cert-env33-c,\
--cert-err58-cpp,\
-clang-diagnostic-*,\
-cppcoreguidelines-slicing,\
-llvm-namespace-comment,\
-misc-*,\
-modernize-*,\
--modernize-use-auto,\
--modernize-use-trailing-return-type,\
-performance-*,\
-readability-*,\
--bugprone-misplaced-widening-cast,\
--bugprone-narrowing-conversions,\
--bugprone-unused-return-value,\
--cert-err34-c,\
--cert-flp30-c,\
--cert-msc30-c,\
--cert-msc32-c,\
--cert-msc50-cpp,\
--cert-msc51-cpp,\
--misc-non-private-member-variables-in-classes,\
--modernize-avoid-c-arrays,\
--modernize-pass-by-value,\
--modernize-return-braced-init-list,\
--modernize-use-default-member-init,\
--modernize-use-emplace,\
--modernize-use-transparent-functors,\
--performance-for-range-copy,\
--performance-inefficient-vector-operation,\
--performance-noexcept-move-constructor,\
--performance-implicit-conversion-in-loop,\
--performance-inefficient-algorithm,\
--performance-inefficient-string-concatenation,\
--performance-type-promotion-in-math-fn,\
--performance-unnecessary-value-param,\
--readability-braces-around-statements,\
--readability-else-after-return,\
--readability-function-size,\
--readability-implicit-bool-conversion,\
--readability-isolate-declaration,\
--readability-magic-numbers,\
--readability-named-parameter,\
--readability-redundant-control-flow,\
-"
-WarningsAsErrors: '*'
-HeaderFilterRegex: '(src|(test(?!.*catch.*catch.h))|tools).*'
-FormatStyle:     none
+Checks: >
+  bugprone-*,
+  cata-*,
+  cert-*,
+  -cert-dcl21-cpp,
+  -cert-env33-c,
+  -cert-err58-cpp,
+  clang-diagnostic-*,
+  cppcoreguidelines-slicing,
+  llvm-namespace-comment,
+  misc-*,
+  modernize-*,
+  -modernize-use-auto,
+  -modernize-use-trailing-return-type,
+  performance-*,
+  readability-*,
+  -bugprone-misplaced-widening-cast,
+  -bugprone-narrowing-conversions,
+  -bugprone-unused-return-value,
+  -cert-err34-c,
+  -cert-flp30-c,
+  -cert-msc30-c,
+  -cert-msc32-c,
+  -cert-msc50-cpp,
+  -cert-msc51-cpp,
+  -misc-non-private-member-variables-in-classes,
+  -modernize-avoid-c-arrays,
+  -modernize-pass-by-value,
+  -modernize-return-braced-init-list,
+  -modernize-use-default-member-init,
+  -modernize-use-emplace,
+  -modernize-use-transparent-functors,
+  -performance-for-range-copy,
+  -performance-inefficient-vector-operation,
+  -performance-noexcept-move-constructor,
+  -performance-implicit-conversion-in-loop,
+  -performance-inefficient-algorithm,
+  -performance-inefficient-string-concatenation,
+  -performance-type-promotion-in-math-fn,
+  -performance-unnecessary-value-param,
+  -readability-braces-around-statements,
+  -readability-else-after-return,
+  -readability-function-size,
+  -readability-implicit-bool-conversion,
+  -readability-isolate-declaration,
+  -readability-magic-numbers,
+  -readability-named-parameter,
+  -readability-redundant-control-flow,
+
+WarningsAsErrors: "*"
+HeaderFilterRegex: "(src|(test(?!.*catch.*catch.h))|tools).*"
+FormatStyle: none
 CheckOptions:
   - key: readability-uppercase-literal-suffix.NewSuffixes
-    value: 'L;UL;LL;ULL'
+    value: "L;UL;LL;ULL"
   - key: cata-text-style.EscapeUnicode
     value: 0
-
 # vim:tw=0

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,6 +54,13 @@ Checks: >
   -readability-redundant-control-flow,
   -readability-identifier-length,
 
+  -modernize-use-nodiscard
+  -modernize-concat-nested-namespaces
+  -modernize-loop-convert
+  -modernize-unary-static-assert
+  -readability-redundant-declaration
+# C++17 changes that clang-tidy does not likes
+
 WarningsAsErrors: "*"
 HeaderFilterRegex: "(src|(test(?!.*catch.*catch.h))|tools).*"
 FormatStyle: none

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ indent_style = tab
 
 [*.{json,yml,yaml,md,markdown}]
 indent_size = 2
+
+[{.clang-tidy,.clang-format}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,8 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
-[*.json]
-end_of_line = lf
-insert_final_newline = true
-indent_style = space
+[Makefile]
+indent_style = tab
+
+[*.{json,yml,yaml,md,markdown}]
 indent_size = 2

--- a/doc/MODDING.md
+++ b/doc/MODDING.md
@@ -40,7 +40,7 @@ The `category` attribute denotes where the mod will appear in the mod selection 
 
 The `dependencies` attribute is used to tell Cataclysm that your mod is dependent on something present in another mod. If you have no dependencies outside of the core game, then just including `dda` in the list is good enough. If your mod depends on another one to work properly, adding that mod's `id` attribute to the array causes Cataclysm to force that mod to load before yours.
 
-For more details on `MOD_INFO` object, see [JSON_INFO.md](JSON_INFO.md/#mod_info).
+For more details on `MOD_INFO` object, see [JSON_INFO.md](JSON_INFO.md#mod_info).
 
 ## Actually adding things to your mod
 Now that you have a basic mod, you can get around to actually putting some stuff into it!
@@ -114,7 +114,7 @@ Professions are what the game calls the character classes you can choose from wh
 ````
 
 ### Adding an item
-Items are where you really want to read the [JSON_INFO.md](JSON_INFO.md) file, just because there's so much that you can do with them, and every category of item is a little bit different. 
+Items are where you really want to read the [JSON_INFO.md](JSON_INFO.md) file, just because there's so much that you can do with them, and every category of item is a little bit different.
 <!--I chose this one because it's about as basic an item as I could find. Everything else does something.-->
 ````json
 [


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Format .clang-tidy and append .editorconfig"

#### Purpose of change
- `.editorconfig` does not have config for markdown and yaml where indent 2 is used
- `.clang-tidy`'s file extension is `yaml` yet it's not formatted properly

#### Describe the solution
- add configs for `.editorconfig`
- format `.clang-tidy`
- disabled `readability-identifier-length` because almost every file uses variables with 1~2 length and it's clogging error messages