### PR TITLE
Melee skill actually impacts attack stamina usage

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -603,8 +603,10 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
     const int encumbrance_cost = roll_remainder( ( encumb( bp_arm_l ) + encumb( bp_arm_r ) ) *
                                  2.0f );
     const int deft_bonus = hit_spread < 0 && has_trait( trait_DEFT ) ? 50 : 0;
+    float skill_cost = ( 30 - melee ) / 30;
+    skill_cost = std::max( 0.667f, skill_cost );
     /** @EFFECT_MELEE reduces stamina cost of melee attacks */
-    const int mod_sta = ( weight_cost + encumbrance_cost - melee - deft_bonus + 50 ) * -1;
+    const int mod_sta = ( weight_cost + encumbrance_cost - deft_bonus + 50 ) * -1 * skill_cost;
     mod_stamina( std::min( -50, mod_sta ) );
     add_msg( m_debug, "Stamina burn: %d", std::min( -50, mod_sta ) );
     mod_moves( -move_cost );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -603,7 +603,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
     const int encumbrance_cost = roll_remainder( ( encumb( bp_arm_l ) + encumb( bp_arm_r ) ) *
                                  2.0f );
     const int deft_bonus = hit_spread < 0 && has_trait( trait_DEFT ) ? 50 : 0;
-    const float skill_cost = std::max( 0.667f, ( 30 - melee ) / 30 );
+    const float skill_cost = std::max( 0.667f, static_cast<float>( ( 30 - melee ) / 30 ) );
     /** @EFFECT_MELEE reduces stamina cost of melee attacks */
     const int mod_sta = ( weight_cost + encumbrance_cost - deft_bonus + 50 ) * -1 * skill_cost;
     mod_stamina( std::min( -50, mod_sta ) );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -603,8 +603,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
     const int encumbrance_cost = roll_remainder( ( encumb( bp_arm_l ) + encumb( bp_arm_r ) ) *
                                  2.0f );
     const int deft_bonus = hit_spread < 0 && has_trait( trait_DEFT ) ? 50 : 0;
-    float skill_cost = ( 30 - melee ) / 30;
-    skill_cost = std::max( 0.667f, skill_cost );
+    const float skill_cost = std::max( 0.667f, ( 30 - melee ) / 30 );
     /** @EFFECT_MELEE reduces stamina cost of melee attacks */
     const int mod_sta = ( weight_cost + encumbrance_cost - deft_bonus + 50 ) * -1 * skill_cost;
     mod_stamina( std::min( -50, mod_sta ) );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -603,7 +603,7 @@ void Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
     const int encumbrance_cost = roll_remainder( ( encumb( bp_arm_l ) + encumb( bp_arm_r ) ) *
                                  2.0f );
     const int deft_bonus = hit_spread < 0 && has_trait( trait_DEFT ) ? 50 : 0;
-    const float skill_cost = std::max( 0.667f, static_cast<float>( ( 30 - melee ) / 30 ) );
+    const float skill_cost = std::max( 0.667f, static_cast<float>( ( 30.0f - melee ) / 30.0f ) );
     /** @EFFECT_MELEE reduces stamina cost of melee attacks */
     const int mod_sta = ( weight_cost + encumbrance_cost - deft_bonus + 50 ) * -1 * skill_cost;
     mod_stamina( std::min( -50, mod_sta ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Change impact of melee skill on melee stamina cost to be proportionate, consistent with effect on movecost"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So one thing I noticed while poking through the code is that the stamina cost of melee attacks has a pretty bad flaw in it: it gives you a bonus for melee skill, but the bonus is so pathetically small that it basically does not matter.

It takes your melee skill out...directly. So a maximum of 10 stamina taken out of the stamina cost. In contrast, every 16 grams tacks on a point of stamina, so 1 kilogram of weapon has a base cost of 62.5 stamina. On top of that, every point of arm encumbrance (that is, per invividual arm) tacks on 2 more stamina cost.

In contrast, melee has a much more dramatic impact on movecost calculation:
```
const int skill_cost = static_cast<int>( ( base_move_cost * ( 15 - melee_skill ) / 15 ) );
```
While the entire function is a bit of a mess, the overall gist of it (if I'm reading it right) is weapon move cost is initially cut in half, and one of those halves is cut down to as low as a third by melee skill, before being slapped back onto the first half and combined with other modifiers, meaning that melee skill can reduce base movecost down to two-thirds its starting value or so.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

To implement a similar impact for stamina cost, I defined a following modifier in `Character::melee_attack` in melee.cpp. This directly turns melee skill into a multiplier float, and caps it at `0.667f` just in case the player shenanigans their way into having more than 10 melee skill.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making strength or dexterity factor into stamina cost of attacks.
2. Adding stamina cost mutation modifiers like how we have movecost modifiers for mutations.
3. Allowing movecost modifiers from martial arts to modify stamina cost too.
4. Defining stamina cost modifiers for martial arts to sprinkle in here and there, this is actually something I'd love to have for Via Gladium et Malleo and Post-Human Combatives.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Loaded into a previous release to test behavior of weapons without this PR's changes.
2. Debug mode on, slapped a debug monster with a zweihander as a standard zero-skills character.
3. Stamina cost reported as 252.
4. Raised all skills to 10.
5. Stamina cost now reported as 242, confirming my suspicion about melee skill having hilariously low impact on stamina to be correct.
6. Compiled and load tested.
7. Repeated steps 2 and 3, stamina cost still reported as 252.
8. Repeated steps 4 and 5, stamina cost now 168, as anticipated.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
