### PR TITLE
Fix duplicates in item view

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7011,7 +7011,7 @@ std::vector<map_item_stack> game::find_nearby_items( int iRadius )
         return ret;
     }
 
-    int range = fov_3d ? fov_3d_z_range * 2 : 1;
+    int range = fov_3d ? ( fov_3d_z_range * 2 ) + 1 : 1;
     int center_z = u.pos().z;
 
     for( int i = 1; i <= range; i++ ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7011,10 +7011,10 @@ std::vector<map_item_stack> game::find_nearby_items( int iRadius )
         return ret;
     }
 
-    int range = fov_3d ? fov_3d_z_range : 0;
+    int range = fov_3d ? fov_3d_z_range * 2 : 1;
     int center_z = u.pos().z;
 
-    for( int i = 0; i <= range * 2; i++ ) {
+    for( int i = 1; i <= range; i++ ) {
         int z = i % 2 ? center_z - i / 2 : center_z + i / 2;
         for( auto &points_p_it : closest_points_first( {u.pos().xy(), z}, iRadius ) ) {
             if( points_p_it.y >= u.posy() - iRadius && points_p_it.y <= u.posy() + iRadius &&


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Prevent duplicates in the item view when 3d vision is on"

#### Purpose of change

No more duplicates.

#### Describe the solution

Better math on the iteration over z levels, it was doing 0 twice.