### PR TITLE
Add grid flag to more specials, mods in particular

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -4825,7 +4825,7 @@
     "city_distance": [ 5, 60 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "WILDERNESS" ]
+    "flags": [ "CLASSIC", "WILDERNESS", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",

--- a/data/mods/Aftershock/maps/overmap_specials.json
+++ b/data/mods/Aftershock/maps/overmap_specials.json
@@ -31,7 +31,8 @@
     "locations": [ "wilderness", "swamp" ],
     "city_distance": [ -1, 6 ],
     "city_sizes": [ 2, 14 ],
-    "occurrences": [ 0, 4 ]
+    "occurrences": [ 0, 4 ],
+    "flags": [ "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -59,7 +60,7 @@
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 2, -1 ],
     "occurrences": [ 0, 1 ],
-    "flags": [ "CLASSIC" ]
+    "flags": [ "CLASSIC", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -74,7 +75,7 @@
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 12 ],
     "occurrences": [ 0, 0 ],
-    "flags": [ "UNIQUE" ]
+    "flags": [ "UNIQUE", "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",
@@ -86,6 +87,7 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "robot_dispatch_first_north" },
       { "point": [ 0, 0, 1 ], "overmap": "robot_dispatch_second_north" }
-    ]
+    ],
+    "flags": [ "ELECTRIC_GRID" ]
   }
 ]

--- a/data/mods/DinoMod/overmap/overmap_specials.json
+++ b/data/mods/DinoMod/overmap/overmap_specials.json
@@ -11,7 +11,7 @@
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 0, 20 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "WILDERNESS" ],
+    "flags": [ "CLASSIC", "WILDERNESS", "ELECTRIC_GRID" ],
     "rotate": false
   },
   {
@@ -61,7 +61,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 10, -1 ],
     "occurrences": [ 30, 100 ],
-    "flags": [ "LAB", "UNIQUE" ],
+    "flags": [ "LAB", "UNIQUE", "ELECTRIC_GRID" ],
     "rotate": false
   }
 ]

--- a/data/mods/Magiclysm/worldgen/overmap_specials.json
+++ b/data/mods/Magiclysm/worldgen/overmap_specials.json
@@ -9,7 +9,8 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 20 ],
-    "occurrences": [ 0, 5 ]
+    "occurrences": [ 0, 5 ],
+    "flags": [ "ELECTRIC_GRID" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Content "Added electric grid flag to saw mills, relevant mod locations"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This started as just something someone requested over on the BN discord, as it came up that with https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1866 being merged we can probably justify adding the `ELECTRIC_GRID` flag to at least a couple more locations we would've avoided earlier, and then roll them back in favor of partial grid coverage once we have support for junction boxes.

This quickly got derailed by me realizing we oughta check mods for any overmap specials obviously in need of the grid flag too, as presently it looks like only No Hope has gotten to make use of it so far.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Added `ELCTRIC_GRID` flag to lumber mills, per request. Normally I'd avoid doing this since it does have a decent chunk of fields that exist only to be filled with trees, but this is hopefully acceptable until we have junction boxes implemented, and farms recently got a grid expansion to set a precedent for erring on the side of "grid support now over waiting for the ability to only grid up part of a special".

Additionally, finally remembered to check in-repo mods and added the flag to:
* Municipal reactors (Aftershock)
* Variant mortuary (Aftershock)
* Whately LMOE shelter (Aftershock)
* Robot dispatch (Aftershock)
* Dino exhibit (Dinomod)
* Dino microlab (Dinomod)
* Magic cabin (Magiclysm)

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

* Adding it to Magiclysm's Lake Retreat, currently not changed since it has a BIG chunk of open lake, while I could justify electrifying it wasn't sure what performance impact might be.
* Adding it to Fuji's Structures, More Locations, National Guard Camp, and Salvaged Robots specials too, those are obsoleted mods though.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
