### PR TITLE
Fix consumption of mixed ammo in magazines

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7369,7 +7369,7 @@ int item::ammo_consume( int qty, const tripoint &pos )
             item &e = contents.front();
             if( need >= e.charges ) {
                 need -= e.charges;
-                remove_item( contents.back() );
+                remove_item( contents.front() );
             } else {
                 e.charges -= need;
                 need = 0;


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fix consumption of mixed ammo in magazines"

#### Purpose of change
When reloading a magazine with a mix of favorite and non-favorite ammo the 2 types stay as separate stacks inside the magazine.
But the gun code isn't "quite there" when it comes to handling mixed ammo, so the part where they're consumed mistakenly uses `back()` instead of `front()` to refer to the stack to remove, which ends up with wrong stack of ammo being erased.

Example repro steps:
1. Debug spawn `Glock 31`
2. Unload the glock
3. Drop 14 ammo
4. Mark the remaining as favorite
5. Pick up dropped ammo
6. Load glock with 1 piece of favorite ammo
7. Load glock with 14 pieces of non-favorite ammo
8. Shoot once
9. See 14 ammo being consumed

#### Describe the solution
Fix `back()` -> `front()`

#### Testing
Repeated repro steps, bug is fixed