### PR TITLE
Forbid firing bow when out of stamina, consume stamina after firing

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -22,6 +22,7 @@ class aim_activity_actor : public activity_actor
     private:
         cata::optional<item> fake_weapon;
         units::energy bp_cost_per_shot = 0_J;
+        int stamina_cost_per_shot = 0;
         std::vector<tripoint> fin_trajectory;
 
     public:


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Forbid firing bow when out of stamina, consume stamina after firing"

#### Purpose of change
Fix couple bugs:
1. Entering aiming menu with a bow and immediately closing it without doing anything consumes stamina
2. Starting to aim with a bow when low on stamina would trigger "catching breath" activity, which is frequently not desired when in the heat of a battle
3. It's possible to draw a bow when out of stamina, making it essentially free in that case
4. If "catching breath" activity is interrupted, the bow is never unloaded and keeps its arrow

#### Describe the solution
Move stamina consumption to fire action (after aiming), forbid aiming if not enough stamina to fire.
Removing stamina consumption from `do_turn()` makes it so stamina stays the same during activity and `ACT_WAIT_STAMINA` isn't triggered.

#### Describe alternatives you've considered
Refactoring activity code.

#### Testing
1. Repeatedly open and close firing menu when wielding a bow, see stamina does not drain.
2. Exhaust the character in melee, then try aiming. It now either lets you aim (with penalty to reload time), or outright forbids it.
3. Wear a few scarves, exhaust stamina, try repeatedly firing bow.
4. No catching breath activity means there's nothing to interrupt :)
