### PR TITLE
[DDA Port] Tweak msvc version generation script to reduce recompilations

### DIFF
--- a/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
@@ -99,7 +99,6 @@
         </Link>
         <PreBuildEvent>
             <Command>prebuild.cmd</Command>
-            <Message>Get version string</Message>
         </PreBuildEvent>
         <ProjectReference>
             <LinkLibraryDependencies>true</LinkLibraryDependencies>

--- a/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-test-vcpkg-static.vcxproj
@@ -97,7 +97,6 @@
     </Link>
     <PreBuildEvent>
       <Command>prebuild.cmd</Command>
-      <Message>Get version string</Message>
     </PreBuildEvent>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>

--- a/msvc-full-features/JsonFormatter-vcpkg-static.vcxproj
+++ b/msvc-full-features/JsonFormatter-vcpkg-static.vcxproj
@@ -109,7 +109,6 @@
     </Link>
     <PreBuildEvent>
       <Command>prebuild.cmd</Command>
-      <Message>Get version string</Message>
     </PreBuildEvent>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>

--- a/msvc-full-features/prebuild.cmd
+++ b/msvc-full-features/prebuild.cmd
@@ -2,14 +2,16 @@
 SETLOCAL
 
 cd ..\msvc-full-features
-echo Done
 set PATH=%PATH%;%VSAPPIDDIR%\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\cmd
-echo Generating "version.h"...
 if "%VERSION%"=="" (
 for /F "tokens=*" %%i in ('git describe --tags --always --dirty --match "[0-9]*.*"') do set VERSION=%%i
 )
 if "%VERSION%"=="" (
 set VERSION=Please install `git` to generate VERSION, or set the variable manually
 )
+findstr /c:%VERSION% ..\src\version.h > NUL 2> NUL
+if %ERRORLEVEL% NEQ 0 (
+echo Generating "version.h"...
 echo VERSION defined as "%VERSION%"
 >..\src\version.h echo #define VERSION "%VERSION%"
+)

--- a/msvc-full-features/prebuild.cmd
+++ b/msvc-full-features/prebuild.cmd
@@ -3,7 +3,7 @@ SETLOCAL
 
 cd ..\msvc-full-features
 echo Done
-
+set PATH=%PATH%;%VSAPPIDDIR%\CommonExtensions\Microsoft\TeamFoundation\Team Explorer\Git\cmd
 echo Generating "version.h"...
 if "%VERSION%"=="" (
 for /F "tokens=*" %%i in ('git describe --tags --always --dirty --match "[0-9]*.*"') do set VERSION=%%i


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Tweak msvc version generation script to reduce recompilations"

#### Purpose of change
Reduce recompilations caused by `prebuild.cmd` updating timestamp on `version.h` on each build.

#### Describe the solution
Port https://github.com/CleverRaven/Cataclysm-DDA/pull/60754 and a single commit from https://github.com/CleverRaven/Cataclysm-DDA/pull/56875

#### Testing
Editing tests' cpps and rebuilding no longer causes the lib to rebuild.
