### PR TITLE
Fix messages involving NPC suffering

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -532,8 +532,8 @@ bool Character::activate_bionic( int b, bool eff_only )
     bionic &bio = ( *my_bionics )[b];
     const bool mounted = is_mounted();
     if( bio.incapacitated_time > 0_turns ) {
-        add_msg( m_info, _( "Your %s is shorting out and can't be activated." ),
-                 bio.info().name );
+        add_msg_if_player( m_info, _( "Your %s is shorting out and can't be activated." ),
+                           bio.info().name );
         return false;
     }
 
@@ -1066,8 +1066,8 @@ bool Character::deactivate_bionic( int b, bool eff_only )
     bionic &bio = ( *my_bionics )[b];
 
     if( bio.incapacitated_time > 0_turns ) {
-        add_msg( m_info, _( "Your %s is shorting out and can't be deactivated." ),
-                 bio.info().name );
+        add_msg_if_player( m_info, _( "Your %s is shorting out and can't be deactivated." ),
+                           bio.info().name );
         return false;
     }
 
@@ -1089,8 +1089,8 @@ bool Character::deactivate_bionic( int b, bool eff_only )
             return false;
         }
         if( get_power_level() < bio.info().power_deactivate ) {
-            add_msg( m_info, _( "You don't have the power to deactivate your %s." ),
-                     bio.info().name );
+            add_msg_if_player( m_info, _( "You don't have the power to deactivate your %s." ),
+                               bio.info().name );
             return false;
         }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -317,8 +317,8 @@ void Character::suffer_while_awake( const int current_stim )
 
     if( ( has_trait( trait_NARCOLEPTIC ) || has_artifact_with( AEP_SCHIZO ) ) ) {
         if( one_turn_in( 8_hours ) ) {
-            add_msg( m_bad,
-                     _( "You're suddenly overcome with the urge to sleep and you pass out." ) );
+            add_msg_player_or_npc( m_bad, _( "You're suddenly overcome with the urge to sleep and you pass out." ),
+                                   _( "<npcname>'s suddenly passes out." ) );
             fall_asleep( 20_minutes );
         }
     }
@@ -525,7 +525,7 @@ void Character::suffer_from_schizophrenia()
         if( !followers.empty() ) {
             who_gets_angry = random_entry_ref( followers )->name;
         }
-        add_msg( m_bad, _( "%1$s gets angry!" ), who_gets_angry );
+        add_msg_if_player( m_bad, _( "%1$s gets angry!" ), who_gets_angry );
         return;
     }
 
@@ -536,14 +536,14 @@ void Character::suffer_from_schizophrenia()
                 mon_zombie, mon_zombie_fat, mon_zombie_fireman, mon_zombie_cop, mon_zombie_soldier
             }
         };
-        add_msg( _( "%s dies!" ), random_entry_ref( monsters )->nname() );
+        add_msg_if_player( _( "%s dies!" ), random_entry_ref( monsters )->nname() );
         return;
     }
 
     // Limb Breaks
     if( one_turn_in( 4_hours ) ) {
         const translation snip = SNIPPET.random_from_category( "broken_limb" ).value_or( translation() );
-        add_msg( m_bad, "%s", snip );
+        add_msg_if_player( m_bad, "%s", snip );
         return;
     }
 
@@ -555,14 +555,14 @@ void Character::suffer_from_schizophrenia()
                 translation() ).translated() );
         parse_tags( i_talk, *this, *this );
 
-        add_msg( _( "%1$s says: \"%2$s\"" ), i_name, i_talk );
+        add_msg_if_player( _( "%1$s says: \"%2$s\"" ), i_name, i_talk );
         return;
     }
 
     // Skill raise
     if( one_turn_in( 12_hours ) ) {
         skill_id raised_skill = Skill::random_skill();
-        add_msg( m_good, _( "You increase %1$s to level %2$d." ), raised_skill.obj().name(),
+        add_msg_if_player( m_good, _( "You increase %1$s to level %2$d." ), raised_skill.obj().name(),
                  get_skill_level( raised_skill ) + 1 );
         return;
     }
@@ -606,7 +606,7 @@ void Character::suffer_from_schizophrenia()
             does_talk = true;
         }
         if( does_talk ) {
-            add_msg( _( "%1$s says: \"%2$s\"" ), i_name_w, i_talk_w );
+            add_msg_if_player( _( "%1$s says: \"%2$s\"" ), i_name_w, i_talk_w );
             return;
         }
     }
@@ -1260,7 +1260,7 @@ void Character::suffer_from_bad_bionics()
             add_msg( m_bad, _( "A bionic emits a crackle of noise!" ) );
             sfx::play_variant_sound( "bionics", "elec_blast", 100 );
         } else {
-            add_msg( m_bad, _( "You feel your faulty bionic shuddering." ) );
+            add_msg_if_player( m_bad, _( "You feel your faulty bionic shuddering." ) );
             sfx::play_variant_sound( "bionics", "elec_blast_muffled", 100 );
         }
         sounds::sound( pos(), 60, sounds::sound_t::movement, _( "Crackle!" ) ); //sfx above
@@ -1278,8 +1278,8 @@ void Character::suffer_from_bad_bionics()
     }
     if( has_bionic( bio_spasm ) && one_turn_in( 5_hours ) && !has_effect( effect_downed ) &&
         !has_effect( effect_narcosis ) ) {
-        add_msg_if_player( m_bad,
-                           _( "Your malfunctioning bionic causes you to spasm and fall to the floor!" ) );
+        add_msg_player_or_npc( m_warning, _( "Your malfunctioning bionic causes you to spasm and fall to the floor!" ),
+                           _( "<npcname> spasms and falls to the floor!" ) );
         mod_pain( 1 );
         add_effect( effect_stunned, 1_turns );
         add_effect( effect_downed, 10_turns, num_bp, 0 );
@@ -1347,13 +1347,13 @@ void Character::suffer_from_stimulants( const int current_stim )
     }
     if( current_stim > 110 ) {
         if( !has_effect( effect_shakes ) && calendar::once_every( 10_minutes ) ) {
-            add_msg( _( "You shake uncontrollably." ) );
+            add_msg_if_player( _( "You shake uncontrollably." ) );
             add_effect( effect_shakes, 15_minutes + 1_turns );
         }
     }
     if( current_stim > 75 ) {
         if( calendar::once_every( 5_minutes ) && !has_effect( effect_nausea ) ) {
-            add_msg( _( "You feel nauseous…" ) );
+            add_msg_if_player( _( "You feel nauseous…" ) );
             add_effect( effect_nausea, 5_minutes );
         }
     }
@@ -1369,7 +1369,7 @@ void Character::suffer_from_stimulants( const int current_stim )
     }
     if( current_stim < -60 || get_painkiller() > 130 ) {
         if( calendar::once_every( 10_minutes ) ) {
-            add_msg( m_warning, _( "You feel tired…" ) );
+            add_msg_if_player( m_warning, _( "You feel tired…" ) );
             mod_fatigue( rng( 1, 2 ) );
         }
     }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -317,7 +317,8 @@ void Character::suffer_while_awake( const int current_stim )
 
     if( ( has_trait( trait_NARCOLEPTIC ) || has_artifact_with( AEP_SCHIZO ) ) ) {
         if( one_turn_in( 8_hours ) ) {
-            add_msg_player_or_npc( m_bad, _( "You're suddenly overcome with the urge to sleep and you pass out." ),
+            add_msg_player_or_npc( m_bad,
+                                   _( "You're suddenly overcome with the urge to sleep and you pass out." ),
                                    _( "<npcname>'s suddenly passes out." ) );
             fall_asleep( 20_minutes );
         }
@@ -563,7 +564,7 @@ void Character::suffer_from_schizophrenia()
     if( one_turn_in( 12_hours ) ) {
         skill_id raised_skill = Skill::random_skill();
         add_msg_if_player( m_good, _( "You increase %1$s to level %2$d." ), raised_skill.obj().name(),
-                 get_skill_level( raised_skill ) + 1 );
+                           get_skill_level( raised_skill ) + 1 );
         return;
     }
 
@@ -1278,8 +1279,9 @@ void Character::suffer_from_bad_bionics()
     }
     if( has_bionic( bio_spasm ) && one_turn_in( 5_hours ) && !has_effect( effect_downed ) &&
         !has_effect( effect_narcosis ) ) {
-        add_msg_player_or_npc( m_warning, _( "Your malfunctioning bionic causes you to spasm and fall to the floor!" ),
-                           _( "<npcname> spasms and falls to the floor!" ) );
+        add_msg_player_or_npc( m_warning,
+                               _( "Your malfunctioning bionic causes you to spasm and fall to the floor!" ),
+                               _( "<npcname> spasms and falls to the floor!" ) );
         mod_pain( 1 );
         add_effect( effect_stunned, 1_turns );
         add_effect( effect_downed, 10_turns, num_bp, 0 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix some suffer and bionic messages acting like the player is receiving effects applied to NPCs"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Was reminded recently that there's a good chunk of messages in the code that tell the player something is happening to them when it's actually happening to an NPC instead.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

* Fixed Narcolepsy message to use `add_msg_player_or_npc` so that the player will be alerted if an NPC passes out due to it, instead of printing the same message as if the player passes out.
* Fixed some nonsensical Psychosis messages to use `add_msg_if_player` so NPCs with Psychosis won't secretly gaslight the player.
* Fixed some faulty bionic effects triggering as `add_msg` incorrectly, plus in one case converted a use of `add_msg_if_player` with `add_msg_player_or_npc` since it has effects the player would see.
* Converted stim effects to use `add_msg_if_player` instead of `add_msg`.
* Also fixed bionic shorting out messages to not tell the player they're failing to use CBMs that NPCs have.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Screaming.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

* Checked affected files for astyle.
* Compiled and load tested.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
