### PR TITLE
Make grave inscription text prompt readable

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5518,6 +5518,7 @@ int iuse::handle_ground_graffiti( player &p, item *it, const std::string &prefix
     string_input_popup popup;
     std::string message = popup
                           .title( prefix + " " + _( "(To delete, clear the text and confirm)" ) )
+                          .width( 85 )
                           .text( g->m.has_graffiti_at( where ) ? g->m.graffiti_at( where ) : std::string() )
                           .identifier( "graffiti" )
                           .query_string();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Text prompt for inscribing during burial no longer only 3 characters wide"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Burying coffins had a major problem with the text prompt being effectively unreadable:
![image](https://user-images.githubusercontent.com/11582235/195246322-84162321-6c18-4406-a1aa-90d9c89eaa30.png)

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Defined a width entry for the popup created in `iuse::handle_ground_graffiti` so that it doesn't try to leave only 2 characters of prompt visible to the player.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

If I could figure out some way to have basically a newline after the text prompt's title and the text entry, so it'd look neater, that'd be even better. I couldn't find any sign of a way to do that with `string_input_popup` though.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->


1. Compiled and load tested.
2. Spawned in and rigged up a coffin ready to be buried
3 Confirmed the prompt gives more actual typing space:
![image](https://user-images.githubusercontent.com/11582235/195246393-e4926fe4-9cae-4665-bb33-2359718861f8.png)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
