### PR TITLE
fix: impossible hibernation

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5453,7 +5453,7 @@ needs_rates Character::calc_needs_rates() const
             // Hunger and thirst advance *much* more slowly whilst we hibernate.
             // This will slow calories consumption enough to go through the 7 days of hibernation
             if( one_in( 50 / rates.hunger ) ) {
-                g->u.mod_stored_kcal( 1 );
+                get_player_character().mod_stored_kcal( 1 );
             }
             rates.thirst *= ( 1.0f / 14.0f );
         }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5451,8 +5451,11 @@ needs_rates Character::calc_needs_rates() const
         rates.recovery = 2.0f * ( 1.0f + mutation_value( fatigue_regen_modifier ) );
         if( is_hibernating() ) {
             // Hunger and thirst advance *much* more slowly whilst we hibernate.
-            rates.hunger *= ( 1.0f / 7.0f );
-            rates.thirst *= ( 1.0f / 7.0f );
+            // This will slow calories consumption enough to go through the 7 days of hibernation
+            if( one_in( 50 / rates.hunger ) ) {
+                g->u.mod_stored_kcal( 1 );
+            }
+            rates.thirst *= ( 1.0f / 14.0f );
         }
         rates.recovery -= static_cast<float>( get_perceived_pain() ) / 60;
 
@@ -9808,7 +9811,7 @@ void Character::fall_asleep()
         }
     }
     if( has_active_mutation( trait_HIBERNATE ) ) {
-        if( get_stored_kcal() > max_stored_kcal() - bmr() / 4 &&
+        if( get_stored_kcal() > max_stored_kcal() * 0.9 &&
             get_thirst() < thirst_levels::thirsty ) {
             if( is_avatar() ) {
                 g->memorial().add( pgettext( "memorial_male", "Entered hibernation." ),

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -575,10 +575,10 @@ float Character::metabolic_rate_base() const
     static const std::string hunger_rate_string( "PLAYER_HUNGER_RATE" );
     static const std::string metabolism_modifier( "metabolism_modifier" );
 
-    float hunger_rate = get_option< float >( hunger_rate_string );
-    float mut_bonus = 1.0f + mutation_value( metabolism_modifier );
-    float with_mut = hunger_rate * mut_bonus;
-    float ench_bonus = bonus_from_enchantments( with_mut, enchant_vals::mod::METABOLISM );
+    const float hunger_rate = get_option< float >( hunger_rate_string );
+    const float mut_bonus = 1.0f + mutation_value( metabolism_modifier );
+    const float with_mut = hunger_rate * mut_bonus;
+    const float ench_bonus = bonus_from_enchantments( with_mut, enchant_vals::mod::METABOLISM );
 
     return std::max( 0.0f, with_mut + ench_bonus );
 }

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1066,7 +1066,7 @@ void Character::hardcoded_effects( effect &it )
             set_fatigue( 25 ); //Prevent us from waking up naturally while under anesthesia
         }
 
-        if( get_fatigue() <= 10 && !has_effect( effect_narcosis ) ) {
+        if( get_fatigue() <= 10 && !has_effect( effect_narcosis ) && !is_hibernating() ) {
             set_fatigue( 0 );
             if( get_sleep_deprivation() < sleep_deprivation_levels::harmless ) {
                 add_msg_if_player( m_good, _( "You feel well rested." ) );

--- a/tests/stomach_contents_test.cpp
+++ b/tests/stomach_contents_test.cpp
@@ -129,11 +129,15 @@ TEST_CASE( "starve_test_hunger3", "[starve][slow]" )
     unsigned int day = 0;
 
     do {
-        results.push_back( string_format( "\nday %d: %d", day, dummy.get_stored_kcal() ) );
+        const auto begin = dummy.get_stored_kcal();
+
         pass_time( dummy, 1_days );
         dummy.set_thirst( 0 );
         dummy.set_fatigue( 0 );
         set_all_vitamins( 0, dummy );
+
+        const auto end = dummy.get_stored_kcal();
+        results.push_back( string_format( "\nday %d: %d -> %d", day, begin, end ) );
         day++;
     } while( dummy.get_stored_kcal() > 0 );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfixes "Fix impossible hibernation"

Fixes #2010
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
1) Hibernation could only be triggered with an obscure system taking into account the possible calories you could burn in a day. Even if it could be triggered, the mechanic wasn't clear enough for the average player

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
- now you can hibernate when you're above 90% of maximum stored calories, it's just as simple as that
- it was also impossible to hibernate since your character would wake up after your fatigue level reached 0. I added an extra condition to ignore the fatigue level
- also, the rate of hunger was divided by 7 when hibernating, but it did close to nothing. I even tried to reduce it by 100000, this didn't change a thing. So I used a system to compensate the lost calories, taking into account the metabolic rate of the player
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
- fixing the bug that makes hunger rate modifications ignored (instead of my 3rd change in Describe the solution)
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Tested with light eater, fast metabolism, very fast metabolism, high thirst
- Being either too thirsty or hungry will wake you up
- With very fast metabolism, you can almost go through the 7 days of hibernations, from 17500 to ~8000 calories
