### PR TITLE
[DDA Port] Fix various issues with window redraw and event handling

### DIFF
--- a/doc/USER_INTERFACE.md
+++ b/doc/USER_INTERFACE.md
@@ -1,0 +1,12 @@
+# User Interface
+
+Cataclysm: Dark Days Ahead uses ncurses, or in the case of the tiles build, an
+ncurses port, for user interface. Window management is achieved by `ui_adaptor`,
+which requires a resizing callback and a redrawing callback for each UI to handle
+resizing and redrawing. Details on how to use `ui_adaptor` can be found within
+`ui_manager.h`.
+
+Some good examples of the usage of `ui_adaptor` can be found within the following
+files:
+- `query_popup` and `static_popup` in `popup.h/cpp`
+- `Messages::dialog` in `messages.cpp`

--- a/doc/USER_INTERFACE.md
+++ b/doc/USER_INTERFACE.md
@@ -1,6 +1,6 @@
 # User Interface
 
-Cataclysm: Dark Days Ahead uses ncurses, or in the case of the tiles build, an
+Cataclysm: Bright Nights uses ncurses, or in the case of the tiles build, an
 ncurses port, for user interface. Window management is achieved by `ui_adaptor`,
 which requires a resizing callback and a redrawing callback for each UI to handle
 resizing and redrawing. Details on how to use `ui_adaptor` can be found within

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -42,8 +42,8 @@ namespace
 class basic_animation
 {
     public:
-        basic_animation( const int scale ) :
-            delay{ 0, get_option<int>( "ANIMATION_DELAY" ) * scale * 1000000L } {
+        explicit basic_animation( const int scale ) :
+            delay( get_option<int>( "ANIMATION_DELAY" ) * scale * 1'000'000L ) {
         }
 
         void draw() const {
@@ -60,13 +60,21 @@ class basic_animation
         void progress() const {
             draw();
 
-            if( delay.tv_nsec > 0 ) {
-                nanosleep( &delay, nullptr );
+            // NOLINTNEXTLINE(cata-no-long): timespec uses long int
+            long int remain = delay;
+            while( remain > 0 ) {
+                // NOLINTNEXTLINE(cata-no-long): timespec uses long int
+                long int do_sleep = std::min( remain, 100'000'000L );
+                timespec to_sleep = timespec { 0, do_sleep };
+                nanosleep( &to_sleep, nullptr );
+                inp_mngr.pump_events();
+                remain -= do_sleep;
             }
         }
 
     private:
-        timespec delay;
+        // NOLINTNEXTLINE(cata-no-long): timespec uses long int
+        long int delay;
 };
 
 class explosion_animation : public basic_animation

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -43,7 +43,7 @@ class basic_animation
 {
     public:
         explicit basic_animation( const int scale ) :
-            delay( get_option<int>( "ANIMATION_DELAY" ) * scale * 1'000'000L ) {
+            delay( get_option<int>( "ANIMATION_DELAY" ) * scale * 1000000L ) {
         }
 
         void draw() const {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -241,9 +241,12 @@ class tileset_loader
         void load_ascii( const JsonObject &config );
         /** Load tileset, R,G,B, are the color components of the transparent color
          * Returns the number of tiles that have been loaded from this tileset image
+         * @param pump_events Handle window events and refresh the screen when necessary.
+         *        Please ensure that the tileset is not accessed when this method is
+         *        executing if you set it to true.
          * @throw std::exception If the image can not be loaded.
          */
-        void load_tileset( const std::string &path );
+        void load_tileset( const std::string &path, bool pump_events );
         /**
          * Load tiles from json data.This expects a "tiles" array in
          * <B>config</B>. That array should contain all the tile definition that
@@ -258,10 +261,13 @@ class tileset_loader
         void load_tilejson_from_file( const JsonObject &config );
         /**
          * Helper function called by load.
+         * @param pump_events Handle window events and refresh the screen when necessary.
+         *        Please ensure that the tileset is not accessed when this method is
+         *        executing if you set it to true.
          * @throw std::exception On any error.
          */
         void load_internal( const JsonObject &config, const std::string &tileset_root,
-                            const std::string &img_path );
+                            const std::string &img_path, bool pump_events );
     public:
         tileset_loader( tileset &ts, const SDL_Renderer_Ptr &r ) : ts( ts ), renderer( r ) {
         }
@@ -269,8 +275,11 @@ class tileset_loader
          * @throw std::exception On any error.
          * @param tileset_id Ident of the tileset, as it appears in the options.
          * @param precheck If tue, only loads the meta data of the tileset (tile dimensions).
+         * @param pump_events Handle window events and refresh the screen when necessary.
+         *        Please ensure that the tileset is not accessed when this method is
+         *        executing if you set it to true.
          */
-        void load( const std::string &tileset_id, bool precheck );
+        void load( const std::string &tileset_id, bool precheck, bool pump_events = false );
 };
 
 enum class text_alignment : int {
@@ -545,13 +554,17 @@ class cata_tiles
          * @param mod_list List of active world mods, for correct caching behavior.
          * @param precheck If true, only loads the meta data of the tileset (tile dimensions).
          * @param force If true, forces loading the tileset even if it is already loaded.
+         * @param pump_events Handle window events and refresh the screen when necessary.
+         *        Please ensure that the tileset is not accessed when this method is
+         *        executing if you set it to true.
          * @throw std::exception On any error.
          */
         void load_tileset(
             const std::string &tileset_id,
             const std::vector<mod_id> &mod_list,
             bool precheck = false,
-            bool force = false
+            bool force = false,
+            bool pump_events = false
         );
         /**
          * Reinitializes the current tileset, like @ref init, but using the original screen information.

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -226,6 +226,7 @@ void finalize()
     for( const construction &c_it : all_constructions.get_all() ) {
         construction &c = const_cast<construction &>( c_it );
         c.finalize();
+        inp_mngr.pump_events();
     }
 
     constructions_sorted.resize( all_constructions.get_all().size() );

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -208,9 +208,10 @@ static void debug_error_prompt(
         );
 #endif
 
-    // temporarily disable redrawing and resizing of previous uis since they
-    // could be in an unknown state.
-    ui_adaptor ui( ui_adaptor::disable_uis_below {} );
+    // Create a special debug message UI that does various things to ensure
+    // the graphics are correct when the debug message is displayed during a
+    // redraw callback.
+    ui_adaptor ui( ui_adaptor::debug_message_ui {} );
     const auto init_window = []( ui_adaptor & ui ) {
         ui.position_from_window( catacurses::stdscr );
     };
@@ -245,7 +246,7 @@ static void debug_error_prompt(
         catacurses::erase();
         fold_and_print( catacurses::stdscr, point_zero, getmaxx( catacurses::stdscr ), c_light_red,
                         "%s", message );
-        catacurses::refresh();
+        wnoutrefresh( catacurses::stdscr );
     } );
 
 #if defined(__ANDROID__)

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1295,6 +1295,7 @@ void benchmark( const int max_difference, bench_kind kind )
             break;
         }
         g->invalidate_main_ui_adaptor();
+        inp_mngr.pump_events();
         ui_manager::redraw_invalidated();
         if( kind == bench_kind::FPS ) {
             refresh_display();

--- a/src/game.h
+++ b/src/game.h
@@ -650,9 +650,13 @@ class game
         /**
          * Load the main map at given location, see @ref map::load, in global, absolute submap
          * coordinates.
+         * @param pump_events If true, handle window events during loading. If
+         * you set this to true, do ensure that the map is not accessed before
+         * this function returns (for example, UIs that draw the map should be
+         * disabled).
          */
-        void load_map( const tripoint &pos_sm );
-        void load_map( const tripoint_abs_sm &pos_sm );
+        void load_map( const tripoint &pos_sm, bool pump_events = false );
+        void load_map( const tripoint_abs_sm &pos_sm, bool pump_events = false );
         /**
          * The overmap which contains the center submap of the reality bubble.
          */

--- a/src/game_ui.cpp
+++ b/src/game_ui.cpp
@@ -2,7 +2,7 @@
 
 #if !defined(TILES)
 
-void reinitialize_framebuffer()
+void reinitialize_framebuffer( const bool /*force_invalidate*/ )
 {
     return;
 }

--- a/src/game_ui.h
+++ b/src/game_ui.h
@@ -13,6 +13,6 @@ void to_map_font_dim_height( int &h );
 void to_map_font_dimension( int &w, int &h );
 void from_map_font_dimension( int &w, int &h );
 void to_overmap_font_dimension( int &w, int &h );
-void reinitialize_framebuffer();
+void reinitialize_framebuffer( bool force_invalidate = false );
 
 #endif // CATA_SRC_GAME_UI_H

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -280,6 +280,7 @@ void defense_game::init_map()
                 popup.message( _( "Please wait as the map generates [%2d%%]" ), percent );
                 ui_manager::redraw();
                 refresh_display();
+                inp_mngr.pump_events();
                 old_percent = percent;
             }
             // Round down to the nearest even number

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -169,6 +169,7 @@ void DynamicDataLoader::load_deferred( deferred_json &data )
                 }
             }
             ++it;
+            inp_mngr.pump_events();
         }
         data.erase( data.begin(), it );
         if( data.size() == n ) {
@@ -184,6 +185,7 @@ void DynamicDataLoader::load_deferred( deferred_json &data )
                         debugmsg( "(json-error)\n%s", err.what() );
                     }
                 }
+                inp_mngr.pump_events();
             }
             data.clear();
             return; // made no progress on this cycle so abort
@@ -523,6 +525,7 @@ void DynamicDataLoader::load_all_from_json( JsonIn &jsin, const std::string &src
         // not an object or an array?
         jsin.error( "expected object or array" );
     }
+    inp_mngr.pump_events();
 }
 
 void DynamicDataLoader::unload_data()

--- a/src/input.h
+++ b/src/input.h
@@ -275,6 +275,10 @@ class input_manager
          * Defined in the respective platform wrapper, e.g. sdlcurse.cpp
          */
         input_event get_input_event();
+        /**
+         * Resize & refresh if necessary, process all pending window events, and ignore keypresses
+         */
+        void pump_events();
 
         /**
          * Wait until the user presses a key. Mouse and similar input is ignored,

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -30,6 +30,7 @@
 #include "game_constants.h"
 #include "generic_factory.h"
 #include "init.h"
+#include "input.h"
 #include "item.h"
 #include "item_contents.h"
 #include "item_group.h"
@@ -1515,6 +1516,7 @@ void Item_factory::check_definitions() const
     }
     for( const auto &elem : m_template_groups ) {
         elem.second->check_consistency( elem.first.str() );
+        inp_mngr.pump_events();
     }
 }
 

--- a/src/iuse_software_kitten.cpp
+++ b/src/iuse_software_kitten.cpp
@@ -494,11 +494,14 @@ void robot_finds_kitten::process_input()
                 }
             } else {
                 refresh_display();
-                end_animation_frame++;
                 timespec ts;
-                ts.tv_sec = 1;
-                ts.tv_nsec = 0;
-                nanosleep( &ts, nullptr );
+                ts.tv_sec = 0;
+                ts.tv_nsec = 100'000'000; // 100 ms
+                for( int i = 0; i < 10; ++i ) {
+                    nanosleep( &ts, nullptr );
+                    inp_mngr.pump_events();
+                }
+                end_animation_frame++;
             }
             break;
         case ui_state::exit:

--- a/src/iuse_software_kitten.cpp
+++ b/src/iuse_software_kitten.cpp
@@ -496,7 +496,7 @@ void robot_finds_kitten::process_input()
                 refresh_display();
                 timespec ts;
                 ts.tv_sec = 0;
-                ts.tv_nsec = 100'000'000; // 100 ms
+                ts.tv_nsec = 100000000; // 100 ms
                 for( int i = 0; i < 10; ++i ) {
                     nanosleep( &ts, nullptr );
                     inp_mngr.pump_events();

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -5,6 +5,7 @@
 
 #include "cached_options.h"
 #include "color.h"
+#include "input.h"
 #include "output.h"
 #include "sdl_wrappers.h"
 #include "translations.h"
@@ -79,8 +80,6 @@ void loading_ui::show()
     if( menu != nullptr ) {
         ui_manager::redraw();
         refresh_display();
-#if defined(TILES)
-        SDL_PumpEvents();
-#endif // TILES
+        inp_mngr.pump_events();
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "path_info.h"
 #include "rng.h"
 #include "type_id.h"
+#include "ui_manager.h"
 
 class ui_adaptor;
 
@@ -121,6 +122,8 @@ static void signal_handler( int signal )
         inp_mngr.reset_timeout();
         bool confirmed = query_yn( _( "Really Quit?  All unsaved changes will be lost." ) );
         inp_mngr.set_timeout( old_timeout );
+        ui_manager::redraw_invalidated();
+        catacurses::doupdate();
         if( !confirmed ) {
             return;
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -46,6 +46,7 @@
 #include "game.h"
 #include "harvest.h"
 #include "iexamine.h"
+#include "input.h"
 #include "int_id.h"
 #include "item.h"
 #include "item_contents.h"
@@ -751,6 +752,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
     // the vehicle was seen before or after the move.
     if( !player_character.activity && ( seen || sees_veh( player_character, veh, true ) ) ) {
         g->invalidate_main_ui_adaptor();
+        inp_mngr.pump_events();
         ui_manager::redraw_invalidated();
         refresh_display();
     }
@@ -6602,7 +6604,7 @@ void map::save()
     }
 }
 
-void map::load( const tripoint &w, const bool update_vehicle )
+void map::load( const tripoint &w, const bool update_vehicle, const bool pump_events )
 {
     for( auto &traps : traplocs ) {
         traps.clear();
@@ -6613,15 +6615,18 @@ void map::load( const tripoint &w, const bool update_vehicle )
     for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
         for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
             loadn( point( gridx, gridy ), update_vehicle );
+            if( pump_events ) {
+                inp_mngr.pump_events();
+            }
         }
     }
     reset_vehicle_cache( );
 }
 
-void map::load( const tripoint_abs_sm &w, const bool update_vehicle )
+void map::load( const tripoint_abs_sm &w, const bool update_vehicle, const bool pump_events )
 {
     // TODO: fix point types
-    load( w.raw(), update_vehicle );
+    load( w.raw(), update_vehicle, pump_events );
 }
 
 void map::shift_traps( const tripoint &shift )

--- a/src/map.h
+++ b/src/map.h
@@ -568,9 +568,13 @@ class map
          * @param w global coordinates of the submap at grid[0]. This
          * is in submap coordinates.
          * @param update_vehicles If true, add vehicles to the vehicle cache.
+         * @param pump_events If true, handle window events during loading. If
+         * you set this to true, do ensure that the map is not accessed before
+         * this function returns (for example, UIs that draw the map should be
+         * disabled).
          */
-        void load( const tripoint &w, bool update_vehicles );
-        void load( const tripoint_abs_sm &w, bool update_vehicles );
+        void load( const tripoint &w, bool update_vehicles, bool pump_events = false );
+        void load( const tripoint_abs_sm &w, bool update_vehicles, bool pump_events = false );
         /**
          * Shift the map along the vector s.
          * This is like loading the map with coordinates derived from the current

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -126,6 +126,7 @@ void mapbuffer::save( bool delete_after_save )
                            num_saved_submaps, num_total_submaps );
             ui_manager::redraw();
             refresh_display();
+            inp_mngr.pump_events();
             last_update = now;
         }
         // Whatever the coordinates of the current submap are,

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -29,6 +29,7 @@
 #include "game.h"
 #include "game_constants.h"
 #include "generic_factory.h"
+#include "input.h"
 #include "int_id.h"
 #include "item.h"
 #include "item_factory.h"
@@ -309,6 +310,7 @@ class mapgen_factory
         void setup() {
             for( std::pair<const std::string, mapgen_basic_container> &omw : mapgens_ ) {
                 omw.second.setup();
+                inp_mngr.pump_events();
             }
             // Dummy entry, overmap terrain null should never appear and is therefor never generated.
             mapgens_.erase( "null" );
@@ -365,11 +367,13 @@ void calculate_mapgen_weights()   // TODO: rename as it runs jsonfunction setup 
     for( auto &pr : nested_mapgen ) {
         for( weighted_object<int, std::shared_ptr<mapgen_function_json_nested>> &ptr : pr.second ) {
             ptr.obj->setup();
+            inp_mngr.pump_events();
         }
     }
     for( auto &pr : update_mapgen ) {
         for( auto &ptr : pr.second ) {
             ptr->setup();
+            inp_mngr.pump_events();
         }
     }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2661,6 +2661,7 @@ bool mattack::ranged_pull( monster *z )
         range--;
         if( target->is_player() && seen ) {
             g->invalidate_main_ui_adaptor();
+            inp_mngr.pump_events();
             ui_manager::redraw_invalidated();
             refresh_display();
         }

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -221,6 +221,7 @@ void catacurses::resizeterm()
     if( ::is_term_resized( new_x, new_y ) ) {
         game_ui::init_ui();
         ui_manager::screen_resized();
+        catacurses::doupdate();
     }
 }
 
@@ -246,6 +247,31 @@ void catacurses::init_interface()
     // TODO: error checking
     start_color();
     init_colors();
+}
+
+void input_manager::pump_events()
+{
+    if( test_mode ) {
+        return;
+    }
+
+    // Handle all events, but ignore any keypress
+    int key = ERR;
+    bool resize = false;
+    const int prev_timeout = input_timeout;
+    set_timeout( 0 );
+    do {
+        key = getch();
+        if( key == KEY_RESIZE ) {
+            resize = true;
+        }
+    } while( key != ERR );
+    set_timeout( prev_timeout );
+    if( resize ) {
+        catacurses::resizeterm();
+    }
+
+    previously_pressed_key = 0;
 }
 
 input_event input_manager::get_input_event()

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2629,6 +2629,8 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
                            bool force_tile_change )
 {
     if( used_tiles_changed ) {
+        // Disable UIs below to avoid accessing the tile context during loading.
+        ui_adaptor dummy( ui_adaptor::disable_uis_below {} );
         //try and keep SDL calls limited to source files that deal specifically with them
         try {
             tilecontext->reinit();
@@ -2637,8 +2639,9 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
             tilecontext->load_tileset(
                 get_option<std::string>( "TILES" ),
                 ingame ? world_generator->active_world->active_mod_order : dummy,
-                false,
-                force_tile_change
+                /*precheck=*/false,
+                /*force=*/force_tile_change,
+                /*pump_events=*/true
             );
             //game_ui::init_ui is called when zoom is changed
             g->reset_zoom();

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1002,11 +1002,9 @@ void player::hardcoded_effects( effect &it )
         }
     } else if( id == effect_sleep ) {
         set_moves( 0 );
-#if defined(TILES)
-        if( is_player() ) {
-            SDL_PumpEvents();
+        if( is_avatar() ) {
+            inp_mngr.pump_events();
         }
-#endif // TILES
 
         if( has_effect( effect_narcosis ) && get_fatigue() <= 25 ) {
             set_fatigue( 25 ); //Prevent us from waking up naturally while under anesthesia

--- a/src/popup.h
+++ b/src/popup.h
@@ -254,17 +254,19 @@ class query_popup
 /**
  * Create a popup on the UI stack that gets displayed but receives no input itself.
  * Call ui_manager::redraw() to redraw the popup along with other UIs on the stack,
- * and refresh_display() to force refresh the display if not receiving input after
- * redraw. The popup stays on the UI stack until its lifetime ends.
+ * and refresh_display() plus inp_mngr.pump_events() to force refresh the display
+ * and handle window events if not receiving input after redraw. The popup stays
+ * on the UI stack until its lifetime ends.
  *
  * Example:
  *
  * if( not_loaded ) {
  *     static_popup popup;
- *     popup.message( "Please wait…" );
  *     while( loading ) {
+ *         popup.message( _( "Please wait…  %d%% complete" ), percentage );
  *         ui_manager::redraw();
  *         refresh_display(); // force redraw since we're not receiving input here
+ *         inp_mngr.pump_events(); // handle window events such as resize
  *         load_part();
  *     }
  * }

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -10,6 +10,7 @@
 #include "cata_utility.h"
 #include "debug.h"
 #include "init.h"
+#include "input.h"
 #include "item.h"
 #include "item_factory.h"
 #include "itype.h"
@@ -354,6 +355,7 @@ void recipe_dictionary::finalize_internal( std::map<recipe_id, recipe> &obj )
 {
     for( auto &elem : obj ) {
         elem.second.finalize();
+        inp_mngr.pump_events();
     }
     // remove any blacklisted or invalid recipes...
     delete_if( []( const recipe & elem ) {

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -203,7 +203,10 @@ void game::unserialize( std::istream &fin )
         data.read( "om_x", com.x );
         data.read( "om_y", com.y );
 
-        load_map( tripoint( lev.x + com.x * OMAPX * 2, lev.y + com.y * OMAPY * 2, lev.z ) );
+        load_map(
+            tripoint( lev.x + com.x * OMAPX * 2, lev.y + com.y * OMAPY * 2, lev.z ),
+            /*pump_events=*/true
+        );
 
         safe_mode = static_cast<safe_mode_type>( tmprun );
         if( get_option<bool>( "SAFEMODE" ) && safe_mode == SAFE_MODE_OFF ) {
@@ -245,9 +248,11 @@ void game::unserialize( std::istream &fin )
         }
 
         data.read( "player", u );
+        inp_mngr.pump_events();
         data.read( "stats_tracker", *stats_tracker_ptr );
         data.read( "achievements_tracker", *achievements_tracker_ptr );
         data.read( "token_provider", token_provider_ptr );
+        inp_mngr.pump_events();
         Messages::deserialize( data );
 
     } catch( const JsonError &jsonerr ) {

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -182,7 +182,7 @@ void RenderClear( const SDL_Renderer_Ptr &renderer )
         dbg( DL::Error ) << "Tried to use a null renderer";
         return;
     }
-    printErrorIf( SDL_RenderClear( renderer.get() ) != 0, "SDL_RenderCopy failed" );
+    printErrorIf( SDL_RenderClear( renderer.get() ) != 0, "SDL_RenderClear failed" );
 }
 
 SDL_Surface_Ptr CreateRGBSurface( const Uint32 flags, const int width, const int height,

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -244,11 +244,14 @@ static void WinCreate()
     if( get_option<std::string>( "FULLSCREEN" ) == "fullscreen" ) {
         window_flags |= SDL_WINDOW_FULLSCREEN;
         fullscreen = true;
+        // It still minimizes, but the screen size is not set to 0 to cause
+        // division by zero
         SDL_SetHint( SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0" );
     } else if( get_option<std::string>( "FULLSCREEN" ) == "windowedbl" ) {
         window_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
         fullscreen = true;
-        SDL_SetHint( SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0" );
+        // So you can switch to desktop without the game window obscuring it.
+        SDL_SetHint( SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1" );
     } else if( get_option<std::string>( "FULLSCREEN" ) == "maximized" ) {
         window_flags |= SDL_WINDOW_MAXIMIZED;
     }
@@ -3538,7 +3541,13 @@ void catacurses::init_interface()
     tilecontext = std::make_unique<cata_tiles>( renderer, geometry );
     try {
         std::vector<mod_id> dummy;
-        tilecontext->load_tileset( get_option<std::string>( "TILES" ), dummy, true );
+        tilecontext->load_tileset(
+            get_option<std::string>( "TILES" ),
+            dummy,
+            /*precheck=*/true,
+            /*force=*/false,
+            /*pump_events=*/true
+        );
     } catch( const std::exception &err ) {
         dbg( DL::Error ) << "failed to check for tileset: " << err.what();
         // use_tiles is the cached value of the USE_TILES option.
@@ -3579,7 +3588,10 @@ void load_tileset()
     }
     tilecontext->load_tileset(
         get_option<std::string>( "TILES" ),
-        world_generator->active_world->active_mod_order
+        world_generator->active_world->active_mod_order,
+        /*precheck=*/false,
+        /*force=*/false,
+        /*pump_events=*/true
     );
     tilecontext->do_tile_loading_report();
 }
@@ -3609,6 +3621,19 @@ void input_manager::set_timeout( const int t )
 {
     input_timeout = t;
     inputdelay = t;
+}
+
+void input_manager::pump_events()
+{
+    if( test_mode ) {
+        return;
+    }
+
+    // Handle all events, but ignore any keypress
+    CheckMessages();
+
+    last_input = input_event();
+    previously_pressed_key = 0;
 }
 
 // This is how we're actually going to handle input events, SDL getch

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -542,11 +542,10 @@ void refresh_display()
     // Select default target (the window), copy rendered buffer
     // there, present it, select the buffer as target again.
     SetRenderTarget( renderer, nullptr );
+    ClearScreen();
 #if defined(__ANDROID__)
     SDL_Rect dstrect = get_android_render_rect( TERMINAL_WIDTH * fontwidth,
                        TERMINAL_HEIGHT * fontheight );
-    SetRenderDrawColor( renderer, 0, 0, 0, 255 );
-    RenderClear( renderer );
     RenderCopy( renderer, display_buffer, NULL, &dstrect );
 #else
     RenderCopy( renderer, display_buffer, nullptr, nullptr );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -592,7 +592,7 @@ static void invalidate_framebuffer( std::vector<curseline> &framebuffer )
     }
 }
 
-void reinitialize_framebuffer()
+void reinitialize_framebuffer( const bool force_invalidate )
 {
     static int prev_height = -1;
     static int prev_width = -1;
@@ -610,7 +610,7 @@ void reinitialize_framebuffer()
         for( int i = 0; i < new_height; i++ ) {
             terminal_framebuffer[i].chars.assign( new_width, cursecell( "" ) );
         }
-    } else if( need_invalidate_framebuffers ) {
+    } else if( force_invalidate || need_invalidate_framebuffers ) {
         need_invalidate_framebuffers = false;
         invalidate_framebuffer( oversized_framebuffer );
         invalidate_framebuffer( terminal_framebuffer );
@@ -1898,7 +1898,7 @@ bool handle_resize( int w, int h )
         TERMINAL_HEIGHT = WindowHeight / fontheight / scaling_factor;
         need_invalidate_framebuffers = true;
         catacurses::stdscr = catacurses::newwin( TERMINAL_HEIGHT, TERMINAL_WIDTH, point_zero );
-        SetupRenderTarget();
+        throwErrorIf( !SetupRenderTarget(), "SetupRenderTarget failed" );
         game_ui::init_ui();
         ui_manager::screen_resized();
         return true;
@@ -2990,7 +2990,8 @@ static void CheckMessages()
 
     last_input = input_event();
 
-    bool need_redraw = false;
+    cata::optional<point> resize_dims;
+    bool render_target_reset = false;
 
     while( SDL_PollEvent( &ev ) ) {
         switch( ev.type ) {
@@ -3026,7 +3027,6 @@ static void CheckMessages()
                     case SDL_WINDOWEVENT_FOCUS_GAINED:
                         break;
                     case SDL_WINDOWEVENT_EXPOSED:
-                        need_redraw = true;
                         needupdate = true;
                         break;
                     case SDL_WINDOWEVENT_RESTORED:
@@ -3038,18 +3038,15 @@ static void CheckMessages()
                         }
 #endif
                         break;
-                    case SDL_WINDOWEVENT_RESIZED: {
-                        restore_on_out_of_scope<input_event> prev_last_input( last_input );
-                        needupdate = handle_resize( ev.window.data1, ev.window.data2 );
+                    case SDL_WINDOWEVENT_RESIZED:
+                        resize_dims = point( ev.window.data1, ev.window.data2 );
                         break;
-                    }
                     default:
                         break;
                 }
                 break;
             case SDL_RENDER_TARGETS_RESET:
-                need_redraw = true;
-                needupdate = true;
+                render_target_reset = true;
                 break;
             case SDL_KEYDOWN: {
 #if defined(__ANDROID__)
@@ -3375,16 +3372,24 @@ static void CheckMessages()
             break;
         }
     }
-    if( need_redraw ) {
+    bool resized = false;
+    if( resize_dims.has_value() ) {
+        restore_on_out_of_scope<input_event> prev_last_input( last_input );
+        needupdate = resized = handle_resize( resize_dims.value().x, resize_dims.value().y );
+    }
+    // resizing already reinitializes the render target
+    if( !resized && render_target_reset ) {
+        throwErrorIf( !SetupRenderTarget(), "SetupRenderTarget failed" );
+        reinitialize_framebuffer( true );
+        needupdate = true;
         restore_on_out_of_scope<input_event> prev_last_input( last_input );
         // FIXME: SDL_RENDER_TARGETS_RESET only seems to be fired after the first redraw
         // when restoring the window after system sleep, rather than immediately
         // on focus gain. This seems to mess up the first redraw and
         // causes black screen that lasts ~0.5 seconds before the screen
         // contents are redrawn in the following code.
-        window_dimensions dim = get_window_dimensions( catacurses::stdscr );
-        ui_manager::invalidate( rectangle<point>( point_zero, dim.window_size_pixel ), false );
-        ui_manager::redraw();
+        ui_manager::invalidate( rectangle<point>( point_zero, point( WindowWidth, WindowHeight ) ), false );
+        ui_manager::redraw_invalidated();
     }
     if( needupdate ) {
         try_sdl_update();
@@ -3930,5 +3935,11 @@ HWND getWindowHandle()
     return info.info.win.window;
 }
 #endif
+
+const SDL_Renderer_Ptr &get_sdl_renderer()
+{
+    return renderer;
+}
+
 
 #endif // TILES

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -22,6 +22,9 @@ class window;
 extern std::unique_ptr<cata_tiles> tilecontext;
 extern std::array<SDL_Color, color_loader<SDL_Color>::COLOR_NAMES_COUNT> windowsPalette;
 
+// This function may refresh the screen, so it should not be used where tiles
+// may be displayed. Actually, this is supposed to be called from init.cpp,
+// and only from there.
 void load_tileset();
 void rescale_tileset( int size );
 bool save_screenshot( const std::string &file_path );

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -42,6 +42,8 @@ window_dimensions get_window_dimensions( const catacurses::window &win );
 // position and size. Unlike real catacurses::window, size can be zero.
 window_dimensions get_window_dimensions( const point &pos, const point &size );
 
+const SDL_Renderer_Ptr &get_sdl_renderer();
+
 #endif // TILES
 
 #endif // CATA_SRC_SDLTILES_H

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -5,29 +5,80 @@
 #include <memory>
 #include <vector>
 
+#include "cached_options.h"
 #include "cursesdef.h"
 #include "game_ui.h"
+#include "optional.h"
 #include "point.h"
 #include "sdltiles.h"
 
 using ui_stack_t = std::vector<std::reference_wrapper<ui_adaptor>>;
 
+static bool redraw_in_progress = false;
+static bool showing_debug_message = false;
+static bool restart_redrawing = false;
+#if defined( TILES )
+static cata::optional<SDL_Rect> prev_clip_rect;
+#endif
 static ui_stack_t ui_stack;
 
-ui_adaptor::ui_adaptor() : disabling_uis_below( false ), invalidated( false ),
-    deferred_resize( false )
-{
-    ui_stack.emplace_back( *this );
-}
-
-ui_adaptor::ui_adaptor( ui_adaptor::disable_uis_below ) : disabling_uis_below( true ),
+ui_adaptor::ui_adaptor() : disabling_uis_below( false ), is_debug_message_ui( false ),
     invalidated( false ), deferred_resize( false )
 {
     ui_stack.emplace_back( *this );
 }
 
+ui_adaptor::ui_adaptor( ui_adaptor::disable_uis_below ) : disabling_uis_below( true ),
+    is_debug_message_ui( false ), invalidated( false ), deferred_resize( false )
+{
+    ui_stack.emplace_back( *this );
+}
+
+ui_adaptor::ui_adaptor( ui_adaptor::debug_message_ui ) : disabling_uis_below( true ),
+    is_debug_message_ui( true ), invalidated( false ), deferred_resize( false )
+{
+    assert( !showing_debug_message );
+    showing_debug_message = true;
+    if( redraw_in_progress ) {
+        restart_redrawing = true;
+    }
+#if defined( TILES )
+    // Reset the clip rect because the debug message UI might be created in a
+    // redraw callback when a clip rect is active. When the UI is deconstructed,
+    // restore the previous clip rect to prevent the redraw callback from
+    // drawing outside the clip area, which will cause stuck graphics. This
+    // alone does not prevent the graphics from becoming borked in other ways,
+    // but `ui_manager` will redo the entire redrawing as soon as the redraw
+    // callback returns.
+    const SDL_Renderer_Ptr &renderer = get_sdl_renderer();
+    if( SDL_RenderIsClipEnabled( renderer.get() ) ) {
+        prev_clip_rect = SDL_Rect();
+        SDL_RenderGetClipRect( renderer.get(), &prev_clip_rect.value() );
+        SDL_RenderSetClipRect( renderer.get(), nullptr );
+    } else {
+        prev_clip_rect = cata::nullopt;
+    }
+#endif
+    // The debug message might be shown during a normal UI's redraw callback,
+    // so we need to invalidate the frame buffer so it does not interfere
+    // with the display of the debug message.
+    reinitialize_framebuffer( true );
+    ui_stack.emplace_back( *this );
+}
+
 ui_adaptor::~ui_adaptor()
 {
+    if( is_debug_message_ui ) {
+        assert( showing_debug_message );
+        showing_debug_message = false;
+#if defined( TILES )
+        // See ui_adaptor( debug_message_ui )
+        if( prev_clip_rect.has_value() ) {
+            const SDL_Renderer_Ptr &renderer = get_sdl_renderer();
+            SDL_RenderSetClipRect( renderer.get(), &prev_clip_rect.value() );
+        }
+#endif
+    }
     for( auto it = ui_stack.rbegin(); it < ui_stack.rend(); ++it ) {
         if( &it->get() == this ) {
             ui_stack.erase( std::prev( it.base() ) );
@@ -214,77 +265,94 @@ void ui_adaptor::redraw_invalidated()
         return;
     }
 
-    // Find the first enabled UI. From now on enabling and disabling UIs
-    // have no effect until the end of this call.
-    auto first = ui_stack.rbegin();
-    for( ; first != ui_stack.rend(); ++first ) {
-        if( first->get().disabling_uis_below ) {
-            break;
-        }
-    }
+    restore_on_out_of_scope<bool> prev_redraw_in_progress( redraw_in_progress );
+    restore_on_out_of_scope<bool> prev_restart_redrawing( restart_redrawing );
+    redraw_in_progress = true;
 
-    // Avoid a copy if possible to improve performance. `ui_stack_orig`
-    // always contains the original UI stack, and `first_enabled` always points
-    // to elements of `ui_stack_orig`.
-    std::unique_ptr<ui_stack_t> ui_stack_copy;
-    auto first_enabled = first == ui_stack.rend() ? ui_stack.begin() : std::prev( first.base() );
-    ui_stack_t *ui_stack_orig = &ui_stack;
+    do {
+        // Changed by the resize and redraw callbacks if they call `debugmsg`.
+        // When this becomes true, the `debugmsg` call would have already changed
+        // the resize and redraw flags according to the resized and redrawn states
+        // so far, so we restart redrawing using the changed flags to redraw
+        // the area invalidated by the debug message popup.
+        restart_redrawing = false;
 
-    // Apply deferred resizing.
-    bool needs_resize = false;
-    for( auto it = first_enabled; it != ui_stack_orig->end(); ++it ) {
-        ui_adaptor &ui = *it;
-        if( ui.deferred_resize && ui.screen_resized_cb ) {
-            needs_resize = true;
-            break;
+        // Find the first enabled UI. From now on enabling and disabling UIs
+        // have no effect until the end of this call.
+        auto first = ui_stack.rbegin();
+        for( ; first != ui_stack.rend(); ++first ) {
+            if( first->get().disabling_uis_below ) {
+                break;
+            }
         }
-    }
-    if( needs_resize ) {
-        if( !ui_stack_copy ) {
-            // Callbacks may modify the UI stack; make a copy of the original one.
-            ui_stack_copy = std::make_unique<ui_stack_t>( *ui_stack_orig );
-            first_enabled = ui_stack_copy->begin() + ( first_enabled - ui_stack_orig->begin() );
-            ui_stack_orig = &*ui_stack_copy;
-        }
-        for( auto it = first_enabled; it != ui_stack_orig->end(); ++it ) {
+
+        // Avoid a copy if possible to improve performance. `ui_stack_orig`
+        // always contains the original UI stack, and `first_enabled` always points
+        // to elements of `ui_stack_orig`.
+        std::unique_ptr<ui_stack_t> ui_stack_copy;
+        auto first_enabled = first == ui_stack.rend() ? ui_stack.begin() : std::prev( first.base() );
+        ui_stack_t *ui_stack_orig = &ui_stack;
+
+        // Apply deferred resizing.
+        bool needs_resize = false;
+        for( auto it = first_enabled; !needs_resize && it != ui_stack_orig->end(); ++it ) {
             ui_adaptor &ui = *it;
-            if( ui.deferred_resize ) {
-                if( ui.screen_resized_cb ) {
-                    ui.screen_resized_cb( ui );
-                }
-                ui.deferred_resize = false;
+            if( ui.deferred_resize && ui.screen_resized_cb ) {
+                needs_resize = true;
             }
         }
-        // Callbacks may have changed window sizes; reinitialize the frame buffer.
-        reinitialize_framebuffer();
-    }
+        if( needs_resize ) {
+            if( !ui_stack_copy ) {
+                // Callbacks may modify the UI stack; make a copy of the original one.
+                ui_stack_copy = std::make_unique<ui_stack_t>( *ui_stack_orig );
+                first_enabled = ui_stack_copy->begin() + ( first_enabled - ui_stack_orig->begin() );
+                ui_stack_orig = &*ui_stack_copy;
+            }
+            for( auto it = first_enabled; !restart_redrawing && it != ui_stack_orig->end(); ++it ) {
+                ui_adaptor &ui = *it;
+                if( ui.deferred_resize ) {
+                    if( ui.screen_resized_cb ) {
+                        ui.screen_resized_cb( ui );
+                    }
+                    if( !restart_redrawing ) {
+                        ui.deferred_resize = false;
+                    }
+                }
+            }
+            // Callbacks may have changed window sizes; reinitialize the frame buffer.
+            reinitialize_framebuffer();
+        }
 
-    // Redraw invalidated UIs.
-    bool needs_redraw = false;
-    for( auto it = first_enabled; it != ui_stack_orig->end(); ++it ) {
-        const ui_adaptor &ui = *it;
-        if( ui.invalidated && ui.redraw_cb ) {
-            needs_redraw = true;
-            break;
-        }
-    }
-    if( needs_redraw ) {
-        if( !ui_stack_copy ) {
-            // Callbacks may change the UI stack; make a copy of the original one.
-            ui_stack_copy = std::make_unique<ui_stack_t>( *ui_stack_orig );
-            first_enabled = ui_stack_copy->begin() + ( first_enabled - ui_stack_orig->begin() );
-            ui_stack_orig = &*ui_stack_copy;
-        }
-        for( auto it = first_enabled; it != ui_stack_orig->end(); ++it ) {
-            const ui_adaptor &ui = *it;
-            if( ui.invalidated ) {
-                if( ui.redraw_cb ) {
-                    ui.redraw_cb( ui );
+        // Redraw invalidated UIs.
+        bool needs_redraw = false;
+        if( !restart_redrawing ) {
+            for( auto it = first_enabled; !needs_redraw && it != ui_stack_orig->end(); ++it ) {
+                const ui_adaptor &ui = *it;
+                if( ui.invalidated && ui.redraw_cb ) {
+                    needs_redraw = true;
                 }
-                ui.invalidated = false;
             }
         }
-    }
+        if( !restart_redrawing && needs_redraw ) {
+            if( !ui_stack_copy ) {
+                // Callbacks may change the UI stack; make a copy of the original one.
+                ui_stack_copy = std::make_unique<ui_stack_t>( *ui_stack_orig );
+                first_enabled = ui_stack_copy->begin() + ( first_enabled - ui_stack_orig->begin() );
+                ui_stack_orig = &*ui_stack_copy;
+            }
+            for( auto it = first_enabled; !restart_redrawing && it != ui_stack_orig->end(); ++it ) {
+                const ui_adaptor &ui = *it;
+                if( ui.invalidated ) {
+                    if( ui.redraw_cb ) {
+                        ui.redraw_cb( ui );
+                    }
+                    if( !restart_redrawing ) {
+                        ui.invalidated = false;
+                    }
+                }
+            }
+        }
+    } while( restart_redrawing );
 }
 
 void ui_adaptor::screen_resized()

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -106,7 +106,7 @@ static bool overlap( const rectangle<point> &lhs, const rectangle<point> &rhs )
 // 2. Optimize the invalidated flag so completely occluded UIs will not be redrawn.
 //
 // The current implementation may still invalidate UIs that in fact do not need to
-// be redrawn, but all UIs that need to be redrawn are guaranteed be invalidated.
+// be redrawn, but all UIs that need to be redrawn are guaranteed to be invalidated.
 void ui_adaptor::invalidation_consistency_and_optimization()
 {
     // Only ensure consistency and optimize for UIs not disabled by another UI
@@ -210,36 +210,72 @@ void ui_adaptor::redraw()
 
 void ui_adaptor::redraw_invalidated()
 {
-    ui_stack_t ui_stack_copy = ui_stack;
-    // apply deferred resizing
-    auto first = ui_stack_copy.rbegin();
-    for( ; first != ui_stack_copy.rend(); ++first ) {
+    if( test_mode || ui_stack.empty() ) {
+        return;
+    }
+
+    // Find the first enabled UI. From now on enabling and disabling UIs
+    // have no effect until the end of this call.
+    auto first = ui_stack.rbegin();
+    for( ; first != ui_stack.rend(); ++first ) {
         if( first->get().disabling_uis_below ) {
             break;
         }
     }
-    for( auto it = first == ui_stack_copy.rend() ? ui_stack_copy.begin() : std::prev( first.base() );
-         it != ui_stack_copy.end(); ++it ) {
+
+    // Avoid a copy if possible to improve performance. `ui_stack_orig`
+    // always contains the original UI stack, and `first_enabled` always points
+    // to elements of `ui_stack_orig`.
+    std::unique_ptr<ui_stack_t> ui_stack_copy;
+    auto first_enabled = first == ui_stack.rend() ? ui_stack.begin() : std::prev( first.base() );
+    ui_stack_t *ui_stack_orig = &ui_stack;
+
+    // Apply deferred resizing.
+    bool needs_resize = false;
+    for( auto it = first_enabled; it != ui_stack_orig->end(); ++it ) {
         ui_adaptor &ui = *it;
-        if( ui.deferred_resize ) {
-            if( ui.screen_resized_cb ) {
-                ui.screen_resized_cb( ui );
-            }
-            ui.deferred_resize = false;
+        if( ui.deferred_resize && ui.screen_resized_cb ) {
+            needs_resize = true;
+            break;
         }
     }
-    reinitialize_framebuffer();
-
-    // redraw invalidated uis
-    if( !ui_stack_copy.empty() ) {
-        auto first = ui_stack_copy.crbegin();
-        for( ; first != ui_stack_copy.crend(); ++first ) {
-            if( first->get().disabling_uis_below ) {
-                break;
+    if( needs_resize ) {
+        if( !ui_stack_copy ) {
+            // Callbacks may modify the UI stack; make a copy of the original one.
+            ui_stack_copy = std::make_unique<ui_stack_t>( *ui_stack_orig );
+            first_enabled = ui_stack_copy->begin() + ( first_enabled - ui_stack_orig->begin() );
+            ui_stack_orig = &*ui_stack_copy;
+        }
+        for( auto it = first_enabled; it != ui_stack_orig->end(); ++it ) {
+            ui_adaptor &ui = *it;
+            if( ui.deferred_resize ) {
+                if( ui.screen_resized_cb ) {
+                    ui.screen_resized_cb( ui );
+                }
+                ui.deferred_resize = false;
             }
         }
-        for( auto it = first == ui_stack_copy.crend() ? ui_stack_copy.cbegin() : std::prev( first.base() );
-             it != ui_stack_copy.cend(); ++it ) {
+        // Callbacks may have changed window sizes; reinitialize the frame buffer.
+        reinitialize_framebuffer();
+    }
+
+    // Redraw invalidated UIs.
+    bool needs_redraw = false;
+    for( auto it = first_enabled; it != ui_stack_orig->end(); ++it ) {
+        const ui_adaptor &ui = *it;
+        if( ui.invalidated && ui.redraw_cb ) {
+            needs_redraw = true;
+            break;
+        }
+    }
+    if( needs_redraw ) {
+        if( !ui_stack_copy ) {
+            // Callbacks may change the UI stack; make a copy of the original one.
+            ui_stack_copy = std::make_unique<ui_stack_t>( *ui_stack_orig );
+            first_enabled = ui_stack_copy->begin() + ( first_enabled - ui_stack_orig->begin() );
+            ui_stack_orig = &*ui_stack_copy;
+        }
+        for( auto it = first_enabled; it != ui_stack_orig->end(); ++it ) {
             const ui_adaptor &ui = *it;
             if( ui.invalidated ) {
                 if( ui.redraw_cb ) {

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -99,7 +99,13 @@ namespace ui_manager
 {
 // rect is the pixel dimensions in tiles or console cell dimensions in curses
 void invalidate( const rectangle<point> &rect, bool reenable_uis_below );
-// invalidate the top window and redraw all invalidated windows
+/*
+ * Invalidate the top window and redraw all invalidated windows.
+ * Note that `ui_manager` may redraw multiple times when the game window is
+ * resized or the system requests a redraw during input calls, so any drawing
+ * code and other code that generates non-persistent UI info should be called
+ * inside the redraw callbacks of `ui_adaptor`, instead of being called directly.
+ */
 void redraw();
 // redraw all invalidated windows without invalidating the top window
 void redraw_invalidated();

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -70,6 +70,9 @@ class ui_adaptor
         struct disable_uis_below {
         };
 
+        struct debug_message_ui {
+        };
+
         /**
          * Construct a `ui_adaptor` which is automatically added to the UI stack,
          * and removed from the stack when it is deconstructed. (When declared as
@@ -79,9 +82,17 @@ class ui_adaptor
         /**
          * `ui_adaptor` constructed this way will block any UIs below from being
          * redrawn or resized until it is deconstructed.
-         * It is used for `debug_msg` and `throbber_popup`.
+         * It is used for `throbber_popup`.
          **/
         explicit ui_adaptor( disable_uis_below );
+        /**
+         * Special constructor used by debug.cpp when showing a debug message
+         * popup. If the UI is constructed when a redraw call is in progress,
+         * The redraw call will be restarted after this UI is deconstructed and
+         * the in progress callback returns, in order to prevent incorrect
+         * graphics caused by overwritten screen area and resizing.
+         **/
+        explicit ui_adaptor( debug_message_ui );
         ui_adaptor( const ui_adaptor &rhs ) = delete;
         ui_adaptor( ui_adaptor &&rhs ) = delete;
         ~ui_adaptor();
@@ -126,9 +137,6 @@ class ui_adaptor
          * - Call any function that does these things, except for `debugmsg`
          *
          * Otherwise, display glitches or even crashes might happen.
-         *
-         * Calling `debugmsg` inside the callbacks is (semi-)supported, but may
-         * cause display glitches after the debug message is closed.
          **/
         void on_redraw( const redraw_callback_t &fun );
         /* See `on_redraw`. */
@@ -171,6 +179,7 @@ class ui_adaptor
         screen_resize_callback_t screen_resized_cb;
 
         bool disabling_uis_below;
+        bool is_debug_message_ui;
 
         mutable bool invalidated;
         mutable bool deferred_resize;
@@ -199,10 +208,10 @@ namespace ui_manager
 void invalidate( const rectangle<point> &rect, bool reenable_uis_below );
 /**
  * Invalidate the top window and redraw all invalidated windows.
- * Note that `ui_manager` may redraw multiple times when the game window is
- * resized or the system requests a redraw during input calls, so any data
- * that may change after a resize or on each redraw should be calculated within
- * the respective callbacks.
+ * Note that `ui_manager` may redraw multiple times when a `ui_adaptor` callback
+ * calls `debugmsg`, the game window is resized, or the system requests a redraw,
+ * so any data that may change after a resize or on each redraw should be
+ * calculated within the respective callbacks.
  **/
 void redraw();
 /**

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -12,6 +12,55 @@ namespace catacurses
 class window;
 } // namespace catacurses
 
+/**
+ * Adaptor between UI code and the UI management system. Using this class allows
+ * UIs to be correctly resized and redrawn when the game window is resized or
+ * when exiting from other UIs.
+ *
+ * Usage example:
+ * ```
+ *     // Effective in the local scope
+ *     ui_adaptor ui;
+ *     // Ncurses window for drawing
+ *     catacurses::window win;
+ *     // Things to do when the game window changes size
+ *     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
+ *         // Create an ncurses window
+ *         win = catacurses::newwin( TERMX / 2, TERMY / 2, point( TERMX / 4, TERMY / 4 ) );
+ *         // The window passed to this call must contain all the space the redraw
+ *         // callback draws to, to ensure proper refreshing when resizing or exiting
+ *         // from other UIs.
+ *         ui.position_from_window( win );
+ *     } );
+ *     // Mark the resize callback to be called on the first redraw
+ *     ui.mark_resize();
+ *     // Things to do when redrawing the UI
+ *     ui.on_redraw( [&]( const ui_adaptor & ) {
+ *         // Clear UI area
+ *         werase( win );
+ *         // Print things
+ *         mvwprintw( win, point_zero, "Hello World!" );
+ *         // Write to frame buffer
+ *         wnoutrefresh( win );
+ *     } );
+ *
+ *     input_context ctxt( "<CATEGORY_NAME>" );
+ *     ctxt.register_action( "QUIT" );
+ *     while( true ) {
+ *         // Invalidate the top UI (that is, this UI) and redraw all
+ *         // invalidated UIs (including lower UIs that calls this UI).
+ *         // May call the resize callbacks.
+ *         ui_manager::redraw();
+ *         // Get user input. Note that this may call the resize and redraw
+ *         // callbacks multiple times due to screen resize, rendering target
+ *         // reset, etc.
+ *         const std::string action = ctxt.handle_input();
+ *         if( action == "QUIT" ) {
+ *             break;
+ *         }
+ *     }
+ * ```
+ **/
 class ui_adaptor
 {
     public:
@@ -21,11 +70,18 @@ class ui_adaptor
         struct disable_uis_below {
         };
 
+        /**
+         * Construct a `ui_adaptor` which is automatically added to the UI stack,
+         * and removed from the stack when it is deconstructed. (When declared as
+         * a local variable, it is removed from the stack when leaving the local scope.)
+         **/
         ui_adaptor();
-        // ui_adaptor constructed this way will block any uis below from being
-        // redrawn or resized until it is deconstructed.
-        // It is used for `debug_msg` and `throbber_popup`.
-        ui_adaptor( disable_uis_below );
+        /**
+         * `ui_adaptor` constructed this way will block any UIs below from being
+         * redrawn or resized until it is deconstructed.
+         * It is used for `debug_msg` and `throbber_popup`.
+         **/
+        explicit ui_adaptor( disable_uis_below );
         ui_adaptor( const ui_adaptor &rhs ) = delete;
         ui_adaptor( ui_adaptor &&rhs ) = delete;
         ~ui_adaptor();
@@ -33,39 +89,75 @@ class ui_adaptor
         ui_adaptor &operator=( const ui_adaptor &rhs ) = delete;
         ui_adaptor &operator=( ui_adaptor &&rhs ) = delete;
 
-        // If win is null, the function has the same effect as position( point_zero, point_zero )
+        /**
+         * Set the position and size of the UI to that of `win`. This information
+         * is used to calculate which UIs need redrawing during resizing and when
+         * exiting from other UIs, so do call this function in the resizing
+         * callback and ensure `win` contains all the space you will be drawing
+         * to. Transparency is not supported. If `win` is null, the function has
+         * the same effect as `position( point_zero, point_zero )`
+         **/
         void position_from_window( const catacurses::window &win );
-        // Set the position and size of the ui to that of an imaginary normal
-        // catacurses::window, except that size can be zero.
-        // Note that `topleft` and `size` are in console cells on both tiles
-        // and curses build.
+        /**
+         * Set the position and size of the UI to that of an imaginary
+         * `catacurses::window` in normal font, except that the size can be zero.
+         * Note that `topleft` and `size` are in console cells on both tiles
+         * and curses builds.
+         **/
         void position( const point &topleft, const point &size );
-        // Set redraw and resizing callbacks. These callbacks should NOT
-        // construct new `ui_adaptor` instances, deconstruct old
-        // `ui_adaptor` instances, call `redraw`, or call `screen_resized`.
-        //
-        // As a special case, calling `debugmsg` inside the callbacks is (semi-)
-        // supported, but may cause display glitches after the debug message is
-        // closed.
-        //
-        // The redraw callback should also not call `position_from_window`,
-        // otherwise it may cause UI glitch if the window position changes.
+        /**
+         * Set redraw and resize callbacks. The resize callback should
+         * call `position` or `position_from_window` to set the size of the UI,
+         * and (re-)calculate any UI data that is related to the screen size,
+         * including `catacurses::window` instances. In most cases, you should
+         * also call `mark_resize` along with `on_screen_resize` so the UI is
+         * initialized by the resizing callback when redrawn for the first time.
+         *
+         * The redraw callback should only redraw to the area specified by the
+         * `position` or `position_from_window` call. Content drawn outside this
+         * area may not render correctly when resizing or exiting from other UIs.
+         * Transparency is not currently supported.
+         *
+         * These callbacks should NOT:
+         * - Construct new `ui_adaptor` instances
+         * - Deconstruct old `ui_adaptor` instances
+         * - Call `redraw` or `screen_resized`
+         * - (Redraw callback) call `position_from_window`
+         * - Call any function that does these things, except for `debugmsg`
+         *
+         * Otherwise, display glitches or even crashes might happen.
+         *
+         * Calling `debugmsg` inside the callbacks is (semi-)supported, but may
+         * cause display glitches after the debug message is closed.
+         **/
         void on_redraw( const redraw_callback_t &fun );
+        /* See `on_redraw`. */
         void on_screen_resize( const screen_resize_callback_t &fun );
 
-        // Mark this ui_adaptor for resizing the next time `redraw()` is called.
-        // This is useful for deferring initialization of the UI when explicit
-        // initialization is not possible or wanted.
+        /**
+         * Mark this `ui_adaptor` for resizing the next time it is redrawn.
+         * This is normally called alongside `on_screen_resize` to initialize
+         * the UI on the first redraw. You should also use this function to
+         * explicitly request a reinitialization if any value the screen resize
+         * callback depends on (apart from the screen size) has changed.
+         **/
         void mark_resize() const;
 
-        // Invalidate this UI so it gets redrawn the next time screen is refreshed,
-        // unless an upper UI completely occludes this UI. May also cause upper UIs
-        // to redraw.
+        /**
+         * Invalidate this UI so it gets redrawn the next redraw unless an upper
+         * UI completely occludes this UI. May also cause upper UIs to redraw.
+         * Can be used to mark lower UIs for redrawing when their associated data
+         * has changed.
+         **/
         void invalidate_ui() const;
 
-        // Reset all callbacks and dimensions
+        /**
+         * Reset all callbacks and dimensions. Will cause invalidation of the
+         * previously specified screen area.
+         **/
         void reset();
 
+        /* See the `ui_manager` namespace */
         static void invalidate( const rectangle<point> &rect, bool reenable_uis_below );
         static void redraw();
         static void redraw_invalidated();
@@ -84,8 +176,10 @@ class ui_adaptor
         mutable bool deferred_resize;
 };
 
-// Helper class that fills the background and obscures all UIs below. It stays
-// on the UI stack until its lifetime ends.
+/**
+ * Helper class that fills the background and obscures all UIs below. It stays
+ * on the UI stack until its lifetime ends.
+ **/
 class background_pane
 {
     public:
@@ -97,18 +191,28 @@ class background_pane
 // export static funcs of ui_adaptor with a more coherent scope name
 namespace ui_manager
 {
-// rect is the pixel dimensions in tiles or console cell dimensions in curses
+/**
+ * Invalidate a portion of the screen when a UI is resized, closed, etc.
+ * Not supposed to be directly called by the user.
+ * rect is the pixel dimensions in tiles or console cell dimensions in curses
+ **/
 void invalidate( const rectangle<point> &rect, bool reenable_uis_below );
-/*
+/**
  * Invalidate the top window and redraw all invalidated windows.
  * Note that `ui_manager` may redraw multiple times when the game window is
- * resized or the system requests a redraw during input calls, so any drawing
- * code and other code that generates non-persistent UI info should be called
- * inside the redraw callbacks of `ui_adaptor`, instead of being called directly.
- */
+ * resized or the system requests a redraw during input calls, so any data
+ * that may change after a resize or on each redraw should be calculated within
+ * the respective callbacks.
+ **/
 void redraw();
-// redraw all invalidated windows without invalidating the top window
+/**
+ * Redraw all invalidated windows without invalidating the top window.
+ **/
 void redraw_invalidated();
+/**
+ * Handle resize of the game window.
+ * Not supposed to be directly called by the user.
+ **/
 void screen_resized();
 } // namespace ui_manager
 

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -663,6 +663,19 @@ static uint64_t GetPerfCount()
     return Count;
 }
 
+void input_manager::pump_events()
+{
+    if( test_mode ) {
+        return;
+    }
+
+    // Handle all events, but ignore any keypress
+    CheckMessages();
+
+    lastchar = ERR;
+    previously_pressed_key = 0;
+}
+
 input_event input_manager::get_input_event()
 {
     // standards note: getch is sometimes required to call refresh


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "[DDA Port] Fix various issues with window redraw and event handling"

#### Purpose of change
Fix window getting unresponsive on long operations.
Fix #2015

#### Describe the solution
Stuff being ported:
* Documentation improvements from:
  - https://github.com/CleverRaven/Cataclysm-DDA/pull/44633
  - https://github.com/CleverRaven/Cataclysm-DDA/pull/56281
* Handle system events during long operations:
  - https://github.com/CleverRaven/Cataclysm-DDA/pull/50360
* Fix artifacts in the undrawn part of the window:
  - https://github.com/CleverRaven/Cataclysm-DDA/pull/51053
  - https://github.com/CleverRaven/Cataclysm-DDA/pull/56215

#### Describe alternatives you've considered
That single clear call should've been enough, but I've decided to go an extra mile and port fixes for related issues.

#### Testing
Can no longer repro the bug with the repro steps described in linked issue.
