### PR TITLE
add GCC unreachability intrinstic on false branch of assert

### DIFF
--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <string>
 #include <utility>
+#include <limits>
 
 #include "optional.h"
 
@@ -37,7 +38,8 @@ class vpart_position
 {
     private:
         std::reference_wrapper<::vehicle> vehicle_;
-        size_t part_index_;
+        // silence GCC maybe-uninitialized warning by giving it a default value
+        size_t part_index_ = std::numeric_limits<size_t>::max();
 
     public:
         vpart_position( ::vehicle &v, const size_t part ) : vehicle_( v ), part_index_( part ) { }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "add GCC unreachability intrinstic on false branch of assert"

#### Purpose of change

```c++
/home/scarf/repo/cata/Cataclysm/src/vpart_position.h:52:20: error: ‘*(const vpart_position*)((char*)&<unnamed> + offsetof(vehicle_part_iterator<vehicle_part_range>,vehicle_part_iterator<vehicle_part_range>::vp_.cata::optional<vpart_reference>::<unnamed>)).vpart_position::part_index_’ may be used uninitialized [-Werror=maybe-uninitialized]
   52 |             return part_index_;
      |                    ^~~~~~~~~~~
```
- fix maybe-uninitialized compilation error
- fix from https://github.com/CleverRaven/Cataclysm-DDA/pull/58210

#### Describe the solution

- redefine `assert` to use `__builtin_unreachable()` on GCC
- only applied on vpart_range.h since BN does not have cata_assert.h

#### Describe alternatives you've considered

- cherry-pick `cata_assert.h`

#### Testing

Compiles on GCC