### PR TITLE
Makefile: make VERBOSE flag also work for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,8 @@
 #  make LINTJSON=0
 # Disable building and running tests.
 #  make RUNTESTS=0
-# Make compiling object file and linking show simple command (default 0)
-#  make VERBOSE=0
+# Make compiling object file and linking show full command.
+#  make VERBOSE=1
 
 # comment these to toggle them as one sees fit.
 # DEBUG is best turned on if you plan to debug in gdb -- please do!
@@ -882,7 +882,12 @@ $(PCH_P): $(PCH_H)
 	-$(CXX) $(CPPFLAGS) $(DEFINES) $(subst -Werror,,$(CXXFLAGS)) -c $(PCH_H) -o $(PCH_P)
 
 $(BUILD_PREFIX)$(TARGET_NAME).a: $(OBJS)
+ifeq ($(VERBOSE),1)
 	$(AR) rcs $(BUILD_PREFIX)$(TARGET_NAME).a $(filter-out $(ODIR)/main.o $(ODIR)/messages.o,$(OBJS))
+else
+	@echo "Creating $@..."
+	@$(AR) rcs $(BUILD_PREFIX)$(TARGET_NAME).a $(filter-out $(ODIR)/main.o $(ODIR)/messages.o,$(OBJS))
+endif
 
 .PHONY: version
 version:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -55,7 +55,12 @@ endif
 tests: $(TEST_TARGET)
 
 $(TEST_TARGET): $(OBJS) $(CATA_LIB)
+ifeq ($(VERBOSE),1)
 	+$(CXX) $(W32FLAGS) -o $@ $(DEFINES) $(OBJS) $(CATA_LIB) $(CXXFLAGS) $(LDFLAGS)
+else
+	@echo "Linking $@..."
+	@$(CXX) $(W32FLAGS) -o $@ $(DEFINES) $(OBJS) $(CATA_LIB) $(CXXFLAGS) $(LDFLAGS)
+endif
 
 $(PCH_P): $(PCH_H)
 	-$(CXX) $(CPPFLAGS) $(DEFINES) $(subst -Werror,,$(CXXFLAGS)) -Wno-non-virtual-dtor -Wno-unused-macros -I. -c $(PCH_H) -o $(PCH_P)
@@ -75,7 +80,12 @@ clean:
 $(shell mkdir -p $(ODIR))
 
 $(ODIR)/%.o: %.cpp $(PCH_P)
+ifeq ($(VERBOSE),1)
 	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) $(subst main-pch,tests-pch,$(PCHFLAGS)) -c $< -o $@
+else
+	@echo $(@F)
+	@$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) $(subst main-pch,tests-pch,$(PCHFLAGS)) -c $< -o $@
+endif
 
 .PHONY: clean check tests precompile_header
 


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Makefile: make VERBOSE flag also work for tests"

#### Purpose of change
Build consistency

#### Describe the solution
Add checks for VERBOSE when compiling/linking test executable, and when assembling the static lib for it.

#### Describe alternatives you've considered
Also adding these to PCH

#### Testing
Log is no longer starts getting spammed midway when compiling game+tests on linux.  
