### PR TITLE
Debug menu can look across z levels and reset ignored messages

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -482,6 +482,11 @@ static bool checkDebugLevelClass( DL lev, DC cl )
     }
 }
 
+void debug_reset_ignored_messages()
+{
+    ignored_messages.clear();
+}
+
 // Debug only                                                       {{{1
 // ---------------------------------------------------------------------
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -221,6 +221,11 @@ void setDebugLogClasses( const enum_bitset<DC> &mask, bool silent = false );
 bool debug_has_error_been_observed();
 
 /**
+ * Reset any ignored debug messages
+ */
+void debug_reset_ignored_messages();
+
+/**
  * Capturing debug messages during func execution,
  * used to test debugmsg calls in the unit tests
  * @return std::string debugmsg

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -177,7 +177,8 @@ enum debug_menu_index {
     DEBUG_TEST_MAP_EXTRA_DISTRIBUTION,
     DEBUG_VEHICLE_BATTERY_CHARGE,
     DEBUG_HOUR_TIMER,
-    DEBUG_NESTED_MAPGEN
+    DEBUG_NESTED_MAPGEN,
+    DEBUG_RESET_IGNORED_MESSAGES,
 };
 
 class mission_debug
@@ -233,6 +234,7 @@ static int info_uilist( bool display_all_entries = true )
             { uilist_entry( DEBUG_PRINT_NPC_MAGIC, true, 'M', _( "Print NPC magic info to console" ) ) },
             { uilist_entry( DEBUG_TEST_WEATHER, true, 'W', _( "Test weather" ) ) },
             { uilist_entry( DEBUG_TEST_MAP_EXTRA_DISTRIBUTION, true, 'e', _( "Test map extra list" ) ) },
+            { uilist_entry( DEBUG_RESET_IGNORED_MESSAGES, true, 'I', _( "Reset ignored debug messages" ) ) },
         };
         uilist_initializer.insert( uilist_initializer.begin(), debug_only_options.begin(),
                                    debug_only_options.end() );
@@ -370,7 +372,7 @@ static int debug_menu_uilist( bool display_all_entries = true )
 
 void teleport_short()
 {
-    const cata::optional<tripoint> where = g->look_around();
+    const cata::optional<tripoint> where = g->look_around( true );
     if( !where || *where == g->u.pos() ) {
         return;
     }
@@ -432,7 +434,7 @@ void spawn_nested_mapgen()
     nest_menu.query();
     const int nest_choice = nest_menu.ret;
     if( nest_choice >= 0 && nest_choice < static_cast<int>( nest_str.size() ) ) {
-        const cata::optional<tripoint> where = g->look_around();
+        const cata::optional<tripoint> where = g->look_around( true );
         if( !where ) {
             return;
         }
@@ -952,7 +954,7 @@ void character_edit_menu( Character &c )
             mission_debug::edit( p );
             break;
         case edit_character::tele: {
-            if( const cata::optional<tripoint> newpos = g->look_around() ) {
+            if( const cata::optional<tripoint> newpos = g->look_around( true ) ) {
                 p.setpos( *newpos );
                 if( p.is_player() ) {
                     if( p.is_mounted() ) {
@@ -1432,7 +1434,7 @@ void debug()
 
             tripoint initial_pos = g->u.pos();
             const look_around_result first = g->look_around( false, initial_pos, initial_pos,
-                                             false, true, false );
+                                             false, true, false, false, tripoint_zero, true );
 
             if( !first.position ) {
                 break;
@@ -1440,7 +1442,7 @@ void debug()
 
             popup.message( "%s", _( "Select second point." ) );
             const look_around_result second = g->look_around( false, initial_pos, *first.position,
-                                              true, true, false );
+                                              true, true, false, false, tripoint_zero, true );
 
             if( !second.position ) {
                 break;
@@ -1522,7 +1524,7 @@ void debug()
             break;
 
         case DEBUG_SPAWN_ARTIFACT:
-            if( const cata::optional<tripoint> center = g->look_around() ) {
+            if( const cata::optional<tripoint> center = g->look_around( true ) ) {
                 artifact_natural_property prop = static_cast<artifact_natural_property>( rng( ARTPROP_NULL + 1,
                                                  ARTPROP_MAX - 1 ) );
                 m.create_anomaly( *center, prop );
@@ -1605,7 +1607,7 @@ void debug()
         break;
 
         case DEBUG_GEN_SOUND: {
-            const cata::optional<tripoint> where = g->look_around();
+            const cata::optional<tripoint> where = g->look_around( true );
             if( !where ) {
                 return;
             }
@@ -2013,6 +2015,9 @@ void debug()
 
         case DEBUG_TEST_MAP_EXTRA_DISTRIBUTION:
             MapExtras::debug_spawn_test();
+            break;
+        case DEBUG_RESET_IGNORED_MESSAGES:
+            debug_reset_ignored_messages();
             break;
     }
     m.invalidate_map_cache( g->get_levz() );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6651,21 +6651,21 @@ void game::pre_print_all_tile_info( const tripoint &lp, const catacurses::window
     print_all_tile_info( lp, w_info, area_name, 1, first_line, last_line, cache );
 }
 
-cata::optional<tripoint> game::look_around()
+cata::optional<tripoint> game::look_around( bool force_3d )
 {
     tripoint center = u.pos() + u.view_offset;
     look_around_result result = look_around( /*show_window=*/true, center, center, false, false,
-                                false );
+                                false, false, tripoint_zero, force_3d );
     return result.position;
 }
 
 look_around_result game::look_around( bool show_window, tripoint &center,
                                       const tripoint &start_point, bool has_first_point, bool select_zone, bool peeking,
-                                      bool is_moving_zone, const tripoint &end_point )
+                                      bool is_moving_zone, const tripoint &end_point, bool force_3d )
 {
     bVMonsterLookFire = false;
     // TODO: Make this `true`
-    const bool allow_zlev_move = m.has_zlevels() && get_option<bool>( "FOV_3D" );
+    const bool allow_zlev_move = m.has_zlevels() && ( get_option<bool>( "FOV_3D" ) || force_3d );
 
     temp_exit_fullscreen();
 
@@ -6750,8 +6750,10 @@ look_around_result game::look_around( bool show_window, tripoint &center,
 #endif // TILES
 
     const int old_levz = get_levz();
-    const int min_levz = std::max( old_levz - fov_3d_z_range, -OVERMAP_DEPTH );
-    const int max_levz = std::min( old_levz + fov_3d_z_range, OVERMAP_HEIGHT );
+    const int min_levz = force_3d ? -OVERMAP_DEPTH : std::max( old_levz - fov_3d_z_range,
+                         -OVERMAP_DEPTH );
+    const int max_levz = force_3d ? OVERMAP_HEIGHT : std::min( old_levz + fov_3d_z_range,
+                         OVERMAP_HEIGHT );
 
     m.update_visibility_cache( old_levz );
     const visibility_variables &cache = m.get_visibility_variables_cache();

--- a/src/game.h
+++ b/src/game.h
@@ -574,7 +574,7 @@ class game
         void zones_manager();
 
         // Look at nearby terrain ';', or select zone points
-        cata::optional<tripoint> look_around();
+        cata::optional<tripoint> look_around( bool force_3d = false );
         /**
          * @brief
          *
@@ -590,7 +590,7 @@ class game
          */
         look_around_result look_around( bool show_window, tripoint &center,
                                         const tripoint &start_point, bool has_first_point, bool select_zone, bool peeking,
-                                        bool is_moving_zone = false, const tripoint &end_point = tripoint_zero );
+                                        bool is_moving_zone = false, const tripoint &end_point = tripoint_zero, bool force_3d = false );
 
         // Shared method to print "look around" info
         void pre_print_all_tile_info( const tripoint &lp, const catacurses::window &w_info,

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -431,7 +431,7 @@ void debug_menu::wishmonster( const cata::optional<tripoint> &p )
         wmenu.query();
         if( wmenu.ret >= 0 ) {
             const mtype_id &mon_type = mtypes[ wmenu.ret ]->id;
-            if( cata::optional<tripoint> spawn = p ? p : g->look_around() ) {
+            if( cata::optional<tripoint> spawn = p ? p : g->look_around( true ) ) {
                 int num_spawned = 0;
                 for( const tripoint &destination : closest_points_first( *spawn, cb.group ) ) {
                     monster *const mon = g->place_critter_at( mon_type, destination );


### PR DESCRIPTION
#### Summary

SUMMARY: Features "The debug menu can look across z levels and reset ignored messages"

#### Purpose of change

The various tile selection things in the debug menu no longer respect the 3d vision settings. They always let you select any z level. There's also an additional option under the info menu that clears the list of ignored debug messages. 

#### Describe the solution

look_around has gained a bool to force the full 3d range and there's a new menu option that clears the ignored list.

#### Describe alternatives you've considered

None really.

#### Testing

I checked looking around with fov_3d and z levels on and off and resetting works on the message you can generate in the debug menu. 
