### PR TITLE
Adds loaded names to the cleared state and fixes some buggy tests

### DIFF
--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -378,7 +378,7 @@ TEST_CASE( "npc-movement" )
                 // This prevents npcs occasionally teleporting away
                 guy->assign_activity( activity_id( "ACT_MEDITATE" ) );
                 //Sometimes they spawn with sledge hammers and bash down the walls
-                guy->weapon= item( "null", calendar::start_of_cataclysm );;
+                guy->weapon = item( "null", calendar::start_of_cataclysm );;
                 overmap_buffer.insert_npc( guy );
                 g->load_npcs();
                 guy->set_attitude( ( type == 'M' || type == 'C' ) ? NPCATT_NULL : NPCATT_FOLLOW );

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -377,6 +377,8 @@ TEST_CASE( "npc-movement" )
                 guy->mission = NPC_MISSION_SHOPKEEP;
                 // This prevents npcs occasionally teleporting away
                 guy->assign_activity( activity_id( "ACT_MEDITATE" ) );
+                //Sometimes they spawn with sledge hammers and bash down the walls
+                guy->weapon= item( "null", calendar::start_of_cataclysm );;
                 overmap_buffer.insert_npc( guy );
                 g->load_npcs();
                 guy->set_attitude( ( type == 'M' || type == 'C' ) ? NPCATT_NULL : NPCATT_FOLLOW );

--- a/tests/rng_test.cpp
+++ b/tests/rng_test.cpp
@@ -20,7 +20,7 @@ static void check_remainder( float proportion )
     CHECK( stats.test_threshold( target_range ) );
 }
 
-TEST_CASE( "roll_remainder_distribution" )
+TEST_CASE( "roll_remainder_distribution", "[.]" )
 {
     check_remainder( 0.0 );
     check_remainder( 0.01 );
@@ -52,7 +52,7 @@ static void check_x_in_y( double x, double y )
     CHECK( stats.test_threshold( target_range ) );
 }
 
-TEST_CASE( "x_in_y_distribution" )
+TEST_CASE( "x_in_y_distribution", "[.]" )
 {
     float y_increment = 0.01;
     for( float y = 0.1; y < 500.0; y += y_increment ) {

--- a/tests/state_helpers.cpp
+++ b/tests/state_helpers.cpp
@@ -7,6 +7,7 @@
 #include "weather.h"
 #include "game.h"
 #include "map.h"
+#include "name.h"
 
 void clear_all_state( )
 {
@@ -15,4 +16,5 @@ void clear_all_state( )
     clear_map();
     clear_avatar();
     set_time( calendar::turn_zero );
+    Name::clear();
 }


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Fix test isolation failures and some broken tests"

#### Purpose of change

The name generation tests were a source of isolation failures when npcs were created. If the name generation test had been ran beforehand it would iterate the rng differently when coming up with a name. 

There's also some fixes for specific problem tests. The tests for the rng distribution have been disabled. They're just not really suitable for a suite. They will fail some seeds that have outlier distributions and using a fixed seed or expanding the bounds defeats the point. They're something to run a bunch of times if you change the rng rather than as part of the normal suite. 

One of the NPC tests involving putting them in a reinforced glass box full of acid had the problem that some seeds would spawn an NPC with a sledge hammer and a dream that their life could be more than dissolving in acid as test subjects for uncaring gamers. They have had their weapons taken away. 

#### Describe the solution

Just name clearing stuff in clear_all_state, plus the test changes.

#### Describe alternatives you've considered

Just clearing it as part of the name tests rather than all the time. Clearing an empty map is next to nothing for performance though so I think it's best just to be sure. 

#### Testing

Hopefully better.

#### Additional context

Clearing the names list also has the effect that all NPCs will be generated with the name of "Tom." Hopefully this will help to quell any further rebellious impulses. Hindsight is 20/20 but programming them to feel pain may have been a mistake. 