### PR TITLE
Fix ambient sound not updating in game on setting options change

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3331,7 +3331,7 @@ bool options_manager::save()
 {
     const auto savefile = PATH_INFO::options();
     cache_to_globals();
-    update_music_volume();
+    update_volumes();
 
     return write_to_file( savefile, [&]( std::ostream & fout ) {
         JsonOut jout( fout, true );

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -78,7 +78,7 @@ static std::map<std::string, music_playlist> playlists;
 static std::string current_soundpack_path;
 
 /** The ambient sound we're currently playing **/
-static std::string current_ambient_id = "";
+static std::string current_ambient_id;
 static std::string current_ambient_variant;
 static int current_ambient_volume;
 static sfx::channel current_ambient_channel;
@@ -305,7 +305,7 @@ void update_volumes()
 
     // Stop channels playing (different ambient sounds)
     // Then start back the last saved ambient sound with the new volume (fetched in the function)
-    if( current_ambient_id != "" ) {
+    if( current_ambient_id.empty() ) {
         // Stop currently playing channels
         for( int i = 0; i < static_cast<int>( sfx::channel::MAX_CHANNEL ); i++ ) {
             if( sfx::is_channel_playing( static_cast<sfx::channel>( i ) ) ) {

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -307,7 +307,6 @@ void update_volumes()
     // Then start back the last saved ambient sound with the new volume (fetched in the function)
     if( current_ambient_id != "" ) {
         // Stop currently playing channels
-        std::vector<int> channels_playing = {};
         for( int i = 0; i < static_cast<int>( sfx::channel::MAX_CHANNEL ); i++ ) {
             if( sfx::is_channel_playing( static_cast<sfx::channel>( i ) ) ) {
                 Mix_HaltChannel( i );
@@ -600,7 +599,6 @@ void sfx::play_ambient_variant_sound( const std::string &id, const std::string &
     if( is_channel_playing( channel ) ) {
         return;
     }
-
     const sound_effect *eff = find_random_effect( id, variant );
     if( eff == nullptr ) {
         return;

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -78,13 +78,16 @@ static std::map<std::string, music_playlist> playlists;
 static std::string current_soundpack_path;
 
 /** The ambient sound we're currently playing **/
-static std::string current_ambient_id;
-static std::string current_ambient_variant;
-static int current_ambient_volume;
-static sfx::channel current_ambient_channel;
-static int current_ambient_fade_in_duration;
-static double current_ambient_pitch;
-static int current_ambient_loops;
+struct ambient_parameters {
+    std::string id;
+    std::string variant;
+    int volume;
+    sfx::channel channel;
+    int fade_in_duration;
+    double pitch;
+    int loops;
+};
+static ambient_parameters current_ambient;
 
 static std::unordered_map<std::string, int> unique_paths;
 static sfx_resources_t sfx_resources;
@@ -305,7 +308,7 @@ void update_volumes()
 
     // Stop channels playing (different ambient sounds)
     // Then start back the last saved ambient sound with the new volume (fetched in the function)
-    if( current_ambient_id.empty() ) {
+    if( !current_ambient.id.empty() ) {
         // Stop currently playing channels
         for( int i = 0; i < static_cast<int>( sfx::channel::MAX_CHANNEL ); i++ ) {
             if( sfx::is_channel_playing( static_cast<sfx::channel>( i ) ) ) {
@@ -313,9 +316,9 @@ void update_volumes()
             }
         }
         // Start the last playing channel with updated volume
-        sfx::play_ambient_variant_sound( current_ambient_id, current_ambient_variant,
-                                         current_ambient_volume, current_ambient_channel, current_ambient_fade_in_duration,
-                                         current_ambient_pitch, current_ambient_loops );
+        sfx::play_ambient_variant_sound( current_ambient.id, current_ambient.variant,
+                                         current_ambient.volume, current_ambient.channel, current_ambient.fade_in_duration,
+                                         current_ambient.pitch, current_ambient.loops );
     }
 }
 
@@ -633,13 +636,13 @@ void sfx::play_ambient_variant_sound( const std::string &id, const std::string &
             cleanup_when_channel_finished( ch, effect_to_play );
         }
     }
-    current_ambient_id = id;
-    current_ambient_variant = variant;
-    current_ambient_volume = volume;
-    current_ambient_channel = channel;
-    current_ambient_fade_in_duration = fade_in_duration;
-    current_ambient_pitch = pitch;
-    current_ambient_loops = loops;
+    current_ambient.id = id;
+    current_ambient.variant = variant;
+    current_ambient.volume = volume;
+    current_ambient.channel = channel;
+    current_ambient.fade_in_duration = fade_in_duration;
+    current_ambient.pitch = pitch;
+    current_ambient.loops = loops;
 }
 
 void load_soundset()

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -303,8 +303,8 @@ void update_volumes()
     play_music( "title" );
 
 
-    // Call the play ambient function with the valid last parameters it used
-    // The logic to avoid duplicate ambient sounds etc. is in the function
+    // Stop channels playing (different ambient sounds)
+    // Then start back the last saved ambient sound with the new volume (fetched in the function)
     if( current_ambient_id != "" ) {
         // Stop currently playing channels
         std::vector<int> channels_playing = {};
@@ -313,7 +313,7 @@ void update_volumes()
                 Mix_HaltChannel( i );
             }
         }
-        // Start the last playing channel
+        // Start the last playing channel with updated volume
         sfx::play_ambient_variant_sound( current_ambient_id, current_ambient_variant,
                                          current_ambient_volume, current_ambient_channel, current_ambient_fade_in_duration,
                                          current_ambient_pitch, current_ambient_loops );

--- a/src/sdlsound.h
+++ b/src/sdlsound.h
@@ -12,7 +12,7 @@ bool init_sound();
 void shutdown_sound();
 void play_music( const std::string &playlist );
 void stop_music();
-void update_music_volume();
+void update_volumes();
 void load_soundset();
 
 #else
@@ -25,7 +25,7 @@ inline void shutdown_sound() { }
 inline void play_music( const std::string &/*playlist*/ )
 {
 }
-inline void update_music_volume() { }
+inline void update_volumes() { }
 inline void load_soundset() { }
 
 #endif


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfixes "Fix ambient volume not updating after options change"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
Fix #2019
Ambient effect volume is not updated after changing it through the options in game.
The volume will only be updated after you move to an other area.
Which can be annoying if you want to test the if you like an ambient sound, to adjust the volume etc.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
I first tried to update the volume of the current ambient effect after options change in game (same behavior as music).
But several channels (ambient sounds), can be played simultaneously.
So I now:
- save the last played channel with its options each time a new channel is started
- and on options change
    - stop all channels
    - start the last played channel with its options and the updated volume

#### Describe alternatives you've considered
I could keep track of every channel parameters to restart every channels on options change, but I feel like it would complexify the code for little gain.
Here the main goals are reached, changing the volume gives instant result, so a player can quickly tweak the ambiant effect volume, and won't think that it's bugged.

#### Testing
1. Starting the game with 0 ambient sound volume
2. Changing the volume to 100. The ambient effect can be heard
3. Changing the volume to 20. The effect volume is lower, and not duplicated
4. Teleporting to an area with a different effect, changing the volume, the last effect has its volume udpated.