### PR TITLE
Fixes labs missing roofs

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -1715,24 +1715,20 @@ class map
 
     protected:
         void saven( const tripoint &grid );
-        bool loadn( const tripoint &grid, bool update_vehicles );
-        bool loadn( const point &grid, bool update_vehicles ) {
+        void loadn( const tripoint &grid, bool update_vehicles );
+        void loadn( const point &grid, bool update_vehicles ) {
             if( zlevels ) {
-                bool generated = false;
                 for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
-                    generated |= loadn( tripoint( grid, gridz ), update_vehicles );
+                    loadn( tripoint( grid, gridz ), update_vehicles );
                 }
 
-                if( generated ) {
-                    // Note: we want it in a separate loop! It is a post-load cleanup
-                    // Since we're adding roofs, we want it to go up (from lowest to highest)
-                    for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
-                        add_roofs( tripoint( grid, gridz ) );
-                    }
+                // Note: we want it in a separate loop! It is a post-load cleanup
+                // Since we're adding roofs, we want it to go up (from lowest to highest)
+                for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
+                    add_roofs( tripoint( grid, gridz ) );
                 }
-                return generated;
             } else {
-                return loadn( tripoint( grid, abs_sub.z ), update_vehicles );
+                loadn( tripoint( grid, abs_sub.z ), update_vehicles );
             }
         }
         /**


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fixes labs missing roofs"

#### Purpose of change

The recent changes I made to roof generation included an optimization that only newly generated tiles were roofed. This didn't play nice with special mapgen like labs. Depending on how they were loaded in it could miss that some of the tiles were new.

#### Describe the solution

It now roofs newly loaded tiles, regardless of if they're newly generated.

#### Describe alternatives you've considered

Fixing working out which tiles were newly generated but I don't want to make it too complex and this way it also fixes any old saves that have roofs missing. 

#### Testing

Labs now get a roof no matter which direction you come from, or if you teleport into them. 