### PR TITLE
Add the ability to mark items as favorite from the multidrop menu

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1498,12 +1498,26 @@ drop_locations game_menus::inv::multidrop( player &p )
     inv_s.set_title( _( "Multidrop" ) );
     inv_s.set_hint( _( "To drop x items, type a number before selecting." ) );
 
-    if( inv_s.empty() ) {
-        popup( std::string( _( "You have nothing to drop." ) ), PF_GET_KEY );
-        return drop_locations();
-    }
+    bool started_action = false;
+    do {
+        p.inv.restack( p );
+        inv_s.clear_items();
+        inv_s.add_character_items( p );
 
-    return inv_s.execute();
+        if( inv_s.empty() ) {
+            popup( std::string( _( "You have nothing to drop." ) ), PF_GET_KEY );
+            return drop_locations();
+        }
+
+        std::pair<int, drop_locations> result = inv_s.execute();
+        if( result.first == 0 ) {
+            return result.second;
+        }
+        // An item has been favorited, reopen the UI
+        else {
+            continue;
+        }
+    } while( true );
 }
 
 iuse_locations game_menus::inv::multiwash( Character &ch, int water, int cleanser, bool do_soft,

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1498,7 +1498,6 @@ drop_locations game_menus::inv::multidrop( player &p )
     inv_s.set_title( _( "Multidrop" ) );
     inv_s.set_hint( _( "To drop x items, type a number before selecting." ) );
 
-    bool started_action = false;
     do {
         p.inv.restack( p );
         inv_s.clear_items();

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1510,7 +1510,7 @@ drop_locations game_menus::inv::multidrop( player &p )
         }
 
         drop_locations result = inv_s.execute();
-        // An item has been favorited, reopen the UI
+        // an item has been favorited, reopen the UI
         if( inv_s.keep_open ) {
             continue;
         } else {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1498,7 +1498,7 @@ drop_locations game_menus::inv::multidrop( player &p )
     inv_s.set_title( _( "Multidrop" ) );
     inv_s.set_hint( _( "To drop x items, type a number before selecting." ) );
 
-    do {
+    while( true ) {
         p.inv.restack( p );
         inv_s.clear_items();
         inv_s.add_character_items( p );
@@ -1515,7 +1515,7 @@ drop_locations game_menus::inv::multidrop( player &p )
         } else {
             return result;
         }
-    } while( true );
+    }
 }
 
 iuse_locations game_menus::inv::multiwash( Character &ch, int water, int cleanser, bool do_soft,

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1509,13 +1509,12 @@ drop_locations game_menus::inv::multidrop( player &p )
             return drop_locations();
         }
 
-        std::pair<int, drop_locations> result = inv_s.execute();
-        if( result.first == 0 ) {
-            return result.second;
-        }
+        drop_locations result = inv_s.execute();
         // An item has been favorited, reopen the UI
-        else {
+        if( inv_s.keep_open ) {
             continue;
+        } else {
+            return result;
         }
     } while( true );
 }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1,3 +1,4 @@
+#pragma optimize("", off)
 #include "inventory_ui.h"
 
 #include "avatar.h"
@@ -2182,17 +2183,19 @@ drop_locations inventory_drop_selector::execute()
         return true;
     };
 
-    for( const std::pair<const item *const, int> &drop_pair : dropping ) {
+    for( std::pair<const item *const, int> &drop_pair : dropping ) {
         for( auto &col : get_all_columns() ) {
-            for( const auto &entry : col->get_entries( always_yes ) ) {
+            std::vector < inventory_entry *> entries = col->get_entries( always_yes );
+            for( const auto &entry : entries ) {
                 if( entry->any_item().get_item() == drop_pair.first ) {
                     selected_entries.push_back( std::pair<inventory_entry *, int>( entry, drop_pair.second ) );
-                    break;
                 }
             }
         }
     }
 
+    // clear the dropping variable, for the same reason as the refresh_active_column() one
+    dropping.clear();
     for( auto selected_entry : selected_entries ) {
         set_chosen_count( *selected_entry.first, selected_entry.second );
     }
@@ -2272,6 +2275,7 @@ drop_locations inventory_drop_selector::execute()
         } else if( input.action == "INVENTORY_FILTER" ) {
             set_filter();
         } else if( input.action == "TOGGLE_FAVORITE" ) {
+            // change the item favorited state
             get_active_column().on_input( input );
             this->keep_open = true;
             return drop_locations();

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2170,9 +2170,12 @@ void inventory_drop_selector::process_selected( int &count,
     count = 0;
 }
 
-drop_locations inventory_drop_selector::execute()
+std::pair<int, drop_locations> inventory_drop_selector::execute()
 {
     shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
+
+    dropping.clear();
+    refresh_active_column();
 
     int count = 0;
     while( true ) {
@@ -2244,11 +2247,12 @@ drop_locations inventory_drop_selector::execute()
             }
             break;
         } else if( input.action == "QUIT" ) {
-            return drop_locations();
+            return std::pair<int, drop_locations>( 0, drop_locations() );
         } else if( input.action == "INVENTORY_FILTER" ) {
             set_filter();
         } else if( input.action == "TOGGLE_FAVORITE" ) {
-            // TODO: implement favoriting in multi selection menus while maintaining selection
+            get_active_column().on_input( input );
+            return std::pair<int, drop_locations>( 1, drop_locations() );
         } else {
             on_input( input );
             count = 0;
@@ -2264,7 +2268,7 @@ drop_locations inventory_drop_selector::execute()
         dropped_pos_and_qty.emplace_back( loc, drop_pair.second );
     }
 
-    return dropped_pos_and_qty;
+    return std::pair<int, drop_locations>( 0, dropped_pos_and_qty );
 }
 
 void inventory_drop_selector::set_chosen_count( inventory_entry &entry, size_t count )

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1,4 +1,3 @@
-#pragma optimize("", off)
 #include "inventory_ui.h"
 
 #include "avatar.h"

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2182,10 +2182,9 @@ drop_locations inventory_drop_selector::execute()
         return true;
     };
 
-    for( std::pair<const item *const, int> &drop_pair : dropping ) {
+    for( const std::pair<const item *const, int> &drop_pair : dropping ) {
         for( auto &col : get_all_columns() ) {
-            std::vector < inventory_entry *> entries = col->get_entries( always_yes );
-            for( const auto &entry : entries ) {
+            for( const auto &entry : col->get_entries( always_yes ) ) {
                 if( entry->any_item().get_item() == drop_pair.first ) {
                     selected_entries.push_back( std::pair<inventory_entry *, int>( entry, drop_pair.second ) );
                 }
@@ -2193,7 +2192,7 @@ drop_locations inventory_drop_selector::execute()
         }
     }
 
-    // clear the dropping variable, for the same reason as the refresh_active_column() one
+    // empty the dropping variable, in case of 2 stacks of items being merged on unfavorite/favorite
     dropping.clear();
     for( auto selected_entry : selected_entries ) {
         set_chosen_count( *selected_entry.first, selected_entry.second );

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -712,7 +712,7 @@ class inventory_drop_selector : public inventory_multiselector
     public:
         inventory_drop_selector( player &p,
                                  const inventory_selector_preset &preset = default_preset );
-        std::pair<int, drop_locations> execute();
+        drop_locations execute();
 
     protected:
         stats get_raw_stats() const override;

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -1,3 +1,4 @@
+#pragma once
 #ifndef CATA_SRC_INVENTORY_UI_H
 #define CATA_SRC_INVENTORY_UI_H
 

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -18,6 +18,7 @@
 #include "color.h"
 #include "cursesdef.h"
 #include "input.h"
+#include "item.h"
 #include "item_handling_util.h"
 #include "item_location.h"
 #include "memory_fast.h"

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -1,4 +1,3 @@
-#pragma once
 #ifndef CATA_SRC_INVENTORY_UI_H
 #define CATA_SRC_INVENTORY_UI_H
 
@@ -18,7 +17,6 @@
 #include "color.h"
 #include "cursesdef.h"
 #include "input.h"
-#include "item.h"
 #include "item_handling_util.h"
 #include "item_location.h"
 #include "memory_fast.h"

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -712,7 +712,7 @@ class inventory_drop_selector : public inventory_multiselector
     public:
         inventory_drop_selector( player &p,
                                  const inventory_selector_preset &preset = default_preset );
-        drop_locations execute();
+        std::pair<int, drop_locations> execute();
 
     protected:
         stats get_raw_stats() const override;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Interface "Add favorite action in multidrop menu"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
Typical case:
- Back at your base you want to drop your loot, so you press "D" (or "d")
- But you notice a few items you want to keep, so you want to mark those items as favorite before using "," to drop all non favorite items
- And you can't, because it's not implemented, so you have to go back to the inventory menu, loosing your potential selection

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
- Add the ability to mark items as favorite from the multidrop menu
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Testing
- I tried every edge cases I could think off