### PR TITLE
Adds Display Mod Source as an option instead of tying to Debug Mode

### DIFF
--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -9,6 +9,7 @@ bool use_tiles_overmap = false;
 bool log_from_top;
 int message_ttl;
 int message_cooldown;
+bool display_mod_source;
 bool trigdist;
 bool fov_3d;
 bool static_z_effect = false;

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -48,6 +48,9 @@ extern bool log_from_top;
 extern int message_ttl;
 extern int message_cooldown;
 
+/** Display mod source for items, furniture, terrain and monsters.*/
+extern bool display_mod_source;
+
 /**
  * Circular distances.
  * If true, calculate distance in a realistic way [sqrt(dX^2 + dY^2)].

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -116,7 +116,7 @@ void game::extended_description( const tripoint &p )
                     desc = _( "You do not see any furniture here." );
                 } else {
                     const furn_id fid = m.furn( p );
-                    if( debug_mode ) {
+                    if( display_mod_source ) {
                         const std::string mod_src = enumerate_as_string( fid->src.begin(),
                         fid->src.end(), []( const std::pair<furn_str_id, mod_id> &source ) {
                             return string_format( "'%s'", source.second->name() );
@@ -132,7 +132,7 @@ void game::extended_description( const tripoint &p )
                     desc = _( "You can't see the terrain here." );
                 } else {
                     const ter_id tid = m.ter( p );
-                    if( debug_mode ) {
+                    if( display_mod_source ) {
                         const std::string mod_src = enumerate_as_string( tid->src.begin(),
                         tid->src.end(), []( const std::pair<ter_str_id, mod_id> &source ) {
                             return string_format( "'%s'", source.second->name() );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1469,7 +1469,7 @@ double item::average_dps( const player &guy ) const
 void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                        bool debug /* debug */ ) const
 {
-    if( debug_mode && parts->test( iteminfo_parts::BASE_MOD_SRC ) ) {
+    if( display_mod_source && parts->test( iteminfo_parts::BASE_MOD_SRC ) ) {
         info.emplace_back( "BASE", string_format( _( "<stat>Origin: %s</stat>" ),
                            enumerate_as_string( type->src.begin(),
         type->src.end(), []( const std::pair<itype_id, mod_id> &source ) {
@@ -3540,7 +3540,7 @@ void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *par
                                               &converted_volume_scale ), 2 );
                 info.emplace_back( "DESCRIPTION", contents_item->display_name() );
                 iteminfo::flags f = iteminfo::no_newline;
-                if( debug_mode ) {
+                if( display_mod_source ) {
                     info.emplace_back( "DESCRIPTION", string_format( _( "<stat>Origin: %s</stat>" ),
                                        enumerate_as_string( contents_item->type->src.begin(),
                     contents_item->type->src.end(), []( const std::pair<itype_id, mod_id> &content_source ) {
@@ -3555,7 +3555,7 @@ void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *par
                                    converted_volume );
             } else {
                 info.emplace_back( "DESCRIPTION", contents_item->display_name() );
-                if( debug_mode ) {
+                if( display_mod_source ) {
                     info.emplace_back( "DESCRIPTION", string_format( _( "<stat>Origin: %s</stat>" ),
                                        enumerate_as_string( contents_item->type->src.begin(),
                     contents_item->type->src.end(), []( const std::pair<itype_id, mod_id> &content_source ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -648,7 +648,7 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
         wprintz( w, c_light_gray, _( " Difficulty " ) + std::to_string( type->difficulty ) );
     }
 
-    if( debug_mode ) {
+    if( display_mod_source ) {
         const std::string mod_src = enumerate_as_string( type->src.begin(),
         type->src.end(), []( const std::pair<mtype_id, mod_id> &source ) {
             return string_format( "'%s'", source.second->name() );
@@ -708,7 +708,7 @@ std::string monster::extended_description() const
         }
     }
 
-    if( debug_mode ) {
+    if( display_mod_source ) {
         ss += _( "Origin: " );
         ss += enumerate_as_string( type->src.begin(),
         type->src.end(), []( const std::pair<mtype_id, mod_id> &source ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2092,6 +2092,13 @@ void options_manager::add_options_debug()
 
     add_empty_line();
 
+    add( "MOD_SOURCE", "debug", translate_marker( "Display Mod Source" ),
+         translate_marker( "Displays what content pack a piece of furniture, terrain, item or monster comes from or is affected by.  Disable if it's annoying." ),
+         true
+       );
+
+    add_empty_line();
+
     add_option_group( "debug", Group( "debug_log", to_translation( "Logging" ),
                                       to_translation( "Configure debug.log verbosity." ) ),
     [&]( const std::string & page_id ) {
@@ -2140,8 +2147,6 @@ void options_manager::add_options_debug()
          translate_marker( "Scales experience gained from practicing skills and reading books.  0.5 is half as fast as default, 2.0 is twice as fast, 0.0 disables skill training except for NPC training." ),
          0.0, 100.0, 1.0, 0.1
        );
-
-    add_empty_line();
 
     add( "SKILL_RUST", "debug", translate_marker( "Skill rust" ),
          translate_marker( "Set the level of skill rust.  Vanilla: Vanilla Cataclysm - Capped: Capped at skill levels 2 - Int: Intelligence dependent - IntCap: Intelligence dependent, capped - Off: None at all." ),
@@ -3312,6 +3317,7 @@ void options_manager::cache_to_globals()
 
     json_report_unused_fields = ::get_option<bool>( "REPORT_UNUSED_JSON_FIELDS" );
     json_report_strict = test_mode || json_report_unused_fields;
+    display_mod_source = ::get_option<bool>( "MOD_SOURCE" );
     trigdist = ::get_option<bool>( "CIRCLEDIST" );
     use_tiles = ::get_option<bool>( "USE_TILES" );
     use_tiles_overmap = ::get_option<bool>( "USE_TILES_OVERMAP" );


### PR DESCRIPTION
#### Summary

SUMMARY: Interface "Adds Display Mod Source to the debug tab in settings."

#### Purpose of change

Follows up on #1875 Coolthulhu asked that I make it into a setting, which makes sense since just today I forgot about it's existence while helping someone debug their game.

#### Describe the solution

Display Mod Source has been added to the debug tab of settings. It is on by default so people know it exists, but is toggleable if players think it is too intrusive.

#### Describe alternatives you've considered

... Ignore?

#### Testing

Started game with Aftershock, checked that items properly attributed and UPS displayed that it is from BN and altered by Aftershock. Turned off the setting and checked that it didn't display anymore.

#### Additional context

I removed the empty line between skill rust and skill gain debug options since they honestly feel like they should be in the same "block" so to speak. If this is not desired I will revert that change.