### PR TITLE
Shadow and cult creature updates from Arcana

### DIFF
--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -172,8 +172,8 @@
     "morale": 500,
     "melee_skill": 6,
     "melee_dice": 3,
-    "melee_dice_sides": 8,
-    "melee_cut": 3,
+    "melee_dice_sides": 3,
+    "melee_damage": [ { "damage_type": "cold", "amount": 9 } ],
     "dodge": 3,
     "armor_bash": 12,
     "armor_cut": 8,
@@ -184,7 +184,7 @@
     "special_attacks": [ [ "DARKMAN", 5 ], [ "scratch", 15 ] ],
     "death_function": [ "DARKMAN" ],
     "regenerates_in_dark": true,
-    "flags": [ "NOHEAD", "HARDTOSHOOT", "WEBWALK", "FLIES", "PLASTIC", "ELECTRIC", "ACIDPROOF", "SUNDEATH", "NO_BREATHE" ]
+    "flags": [ "NOHEAD", "HARDTOSHOOT", "WEBWALK", "FLIES", "PLASTIC", "COLDPROOF", "ACIDPROOF", "SUNDEATH", "NO_BREATHE" ]
   },
   {
     "id": "mon_dementia",
@@ -295,7 +295,20 @@
     "special_attacks": [ [ "FEAR_PARALYZE", 0 ], { "type": "bite", "cooldown": 5 } ],
     "death_drops": "default_zombie_clothes",
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BLEED", "HARDTOSHOOT", "ATTACKMON", "HUMAN", "POISON", "REVIVES", "FILTHY" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "WARM",
+      "BLEED",
+      "HARDTOSHOOT",
+      "ATTACKMON",
+      "FLIES",
+      "HUMAN",
+      "POISON",
+      "REVIVES",
+      "FILTHY"
+    ]
   },
   {
     "id": "mon_flying_polyp",
@@ -488,6 +501,7 @@
       "WARM",
       "BASHES",
       "ARTHROPOD_BLOOD",
+      "COLDPROOF",
       "NO_BREATHE",
       "HARDTOSHOOT"
     ]
@@ -533,6 +547,7 @@
       "BASHES",
       "ARTHROPOD_BLOOD",
       "NO_BREATHE",
+      "COLDPROOF",
       "HARDTOSHOOT"
     ]
   },
@@ -596,6 +611,7 @@
       "HARDTOSHOOT",
       "FLIES",
       "PLASTIC",
+      "COLDPROOF",
       "SUNDEATH",
       "NO_BREATHE",
       "HIT_AND_RUN",
@@ -650,8 +666,8 @@
     "morale": 100,
     "melee_skill": 6,
     "melee_dice": 1,
-    "melee_dice_sides": 2,
-    "melee_cut": 0,
+    "melee_dice_sides": 3,
+    "melee_damage": [ { "damage_type": "cold", "amount": 3 } ],
     "dodge": 4,
     "vision_day": 50,
     "harvest": "exempt",
@@ -670,7 +686,7 @@
       "FLIES",
       "PLASTIC",
       "SUNDEATH",
-      "ELECTRIC",
+      "COLDPROOF",
       "ACIDPROOF",
       "HIT_AND_RUN",
       "NO_BREATHE",
@@ -695,14 +711,14 @@
     "aggression": 100,
     "morale": 100,
     "melee_skill": 6,
-    "melee_dice": 1,
-    "melee_dice_sides": 4,
-    "melee_cut": 4,
+    "melee_dice": 2,
+    "melee_dice_sides": 3,
+    "melee_damage": [ { "damage_type": "cold", "amount": 6 } ],
     "dodge": 1,
     "harvest": "exempt",
     "special_attacks": [ [ "DISAPPEAR", 200 ] ],
     "death_function": [ "MELT" ],
-    "flags": [ "SEES", "SMELLS", "WARM", "SWIMS", "PLASTIC", "SUNDEATH", "NOGIB" ]
+    "flags": [ "SEES", "SMELLS", "WARM", "SWIMS", "PLASTIC", "COLDPROOF", "SUNDEATH", "NOGIB" ]
   },
   {
     "id": "mon_shoggoth",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Shadow and related nether monsters favor cold theming over electric, other overrides ported from Arcana"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This effectively ports over some of the last remaining changes to vanilla monsters from Arcana, except for stuff specific to the mod like the death drop overrides. This is mainly to further flesh out and make certain monster interactions a bit weirder without having to keep them in a mod override.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Ported over the concept of shadow monsters (for now just shadows, shadow snakes, and wraiths) dealing cold-type damage, with a corresponding adjustment of their base melee damage. also have those values standardized a bit more compared to how they are in Arcana. Part of the goal for the damage results (as seen below) was to make their approximate average damage progress more consistently, up to wraiths with have the same rough average damage as below (aside from losing the bonus `ELECTRIC` would give in exchange for cold damage being harder to mitigate).
2. Ported over the concept of shadows, shadow snakes, wraiths, hunting horrors, and hounds of tindalos having the `COLDPROOF` flag. Also comes with the removal of the `ELECTRIC` flag from monsters that had it.
3. Minor: porting over of `FLIES` applied to flesh angel.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Also adding `COLDPROOF` to zombie masters, zombie necromancers, and flying polyps, along with adding cold damage to hunting horrors, as was standard in Arcana before I decided it was okay to give that the axe during cleanup today (via commit: https://github.com/chaosvolt/cdda-arcana-mod/commit/e695dbf0a3e87585f826050c7ec4ff224be9e9e3).
2. Removing zapback from shadow monsters now that their base attacks no longer deal electric damage from the `ELECTRIC` flag.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors, and did the math on damage changes for shadow monsters.

Before:

Monster | Damage | Min | Max | Average
--- | --- | --- | --- | ---
Shadow | 1d2 bash | 1 | 2 | ~1
Shadow snake | 1d4 bash + 4 cut | 5 | 8 | ~5
Wraith | 3d8 bash + 3 cut | 6 | 27 | ~15

After:

Monster | Damage | Min | Max | Average
--- | --- | --- | --- | ---
Shadow | 1d3 bash + 3 cold | 4 | 6 | ~5
Shadow snake | 2d3 bash + 6 cold | 8 | 12 | ~10
Wraith | 3d3 bash + 9 cold | 12 | 18 | ~15

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

https://www.youtube.com/watch?v=Ho4xcXIgIr0