### PR TITLE
Add positional arguments to a few strings

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1316,10 +1316,15 @@ void benchmark( const int max_difference, bench_kind kind )
     std::string msg_txt;
     switch( kind ) {
         case bench_kind::FPS:
-            msg_txt = _( "Refreshed %d times in %.3f seconds.  (%.3f fps average)" );
+            //~ 'Refresh' here means draw + display, i.e. includes OS display delay.
+            //~ This is the actual "FPS" people often measure in games.
+            msg_txt = _( "Refreshed %1$d times in %2$.3f seconds.  (%3$.3f fps average)" );
             break;
         case bench_kind::DRAW:
-            msg_txt = _( "Drew %d times in %.3f seconds.  (%.3f per second average)" );
+            //~ 'Draw' here means time taken to draw the scene without displaying it.
+            //~ It's a separate thing from "FPS", and is mostly useful for profiling
+            //~ draw calls and measuring OS display delay caused by UI sync.
+            msg_txt = _( "Drew %1$d times in %2$.3f seconds.  (%3$.3f per second average)" );
             break;
     }
     add_msg( m_info, msg_txt, draw_counter,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4476,7 +4476,7 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
                 washing_machine_finished = true;
                 cur_veh.part( part ).enabled = false;
             } else if( calendar::once_every( 15_minutes ) ) {
-                add_msg( _( "It should take %d minutes to finish washing items in the %s." ),
+                add_msg( _( "It should take %1$d minutes to finish washing items in the %2$s." ),
                          to_minutes<int>( time_left ) + 1, cur_veh.name );
                 break;
             }


### PR DESCRIPTION
#### Summary
SUMMARY: I18N "Added positional arguments to a few strings"

#### Purpose of change
Fixing i18n updates warnings
```
Checking ko.po => 3 error(s) detected:
original  :Refreshed %d times in %.3f seconds.  (%.3f fps average)
translated:%.3f 초 동안 %d번 새로고침 (평균 %.3f fps)

original  :Drew %d times in %.3f seconds.  (%.3f per second average)
translated:%.3f초 동안 %d번 그림 (평균 초당 %.3f회)

original  :It should take %d minutes to finish washing items in the %s.
translated:%s의 내용물을 세탁하는데 %d분 걸립니다.

Checking pl_PL.po => 1 error(s) detected:
original  :It should take %d minutes to finish washing items in the %s.
translated:Wypranie rzeczy w %s powinno zająć %d minut.
```

#### Describe the solution
Add positional arguments.

#### Describe alternatives you've considered
Transifex erroneously shows positions for arguments that don't have them, and silently accepts malformed translations, which results in errors such as these.
I guess the most straightforward way to prevent such issues would be to add a warning in `lang/update_pot.sh` for strings that have multiple arguments without positions, and then fix all occurrences throughout the codebase.

#### Testing
`lang/update_pot.sh` succeeds locally.
