### PR TITLE
give two pet packs for Mr. Lapin's second mission

### DIFF
--- a/data/json/npcs/holdouts/Mr_Lapin.json
+++ b/data/json/npcs/holdouts/Mr_Lapin.json
@@ -152,6 +152,6 @@
       "success_lie": "Thanks for trying…  I guess.",
       "failure": "It's not a big deal, it isn't that urgent."
     },
-    "end": { "effect": [ { "u_buy_item": "petpack", "count": 1 } ] }
+    "end": { "effect": [ { "u_buy_item": "petpack", "count": 2 } ] }
   }
 ]


### PR DESCRIPTION

#### Summary

SUMMARY: Balance "give two pet packs for Mr. Lapin's second mission"

#### Purpose of change
- resolved #2068

#### Describe the solution

gives two pet packs for Mr. Lapin's second mission.
reasoning: as in #2068, since first mission gives you two cattle fodder to befriend two rabbits. less trip is good.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
