### PR TITLE
Add option to ignore dangerous terrain warnings

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8950,23 +8950,23 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
 
     if( !shifting_furniture && !pushing && is_dangerous_tile( dest_loc ) ) {
         std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
-        if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "ALWAYS" &&
-            !prompt_dangerous_tile( dest_loc ) ) {
+        const auto dangerous_terrain_opt = get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" );
+
+        if( dangerous_terrain_opt == "ALWAYS" && !prompt_dangerous_tile( dest_loc ) ) {
             return true;
-        } else if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "RUNNING" &&
+        } else if( dangerous_terrain_opt == "RUNNING" &&
                    ( !u.movement_mode_is( CMM_RUN ) || !prompt_dangerous_tile( dest_loc ) ) ) {
             add_msg( m_warning,
                      _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ),
                      enumerate_as_string( harmful_stuff ) );
             return true;
-        } else if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "CROUCHING" &&
+        } else if( dangerous_terrain_opt == "CROUCHING" &&
                    ( !u.movement_mode_is( CMM_CROUCH ) || !prompt_dangerous_tile( dest_loc ) ) ) {
             add_msg( m_warning,
                      _( "Stepping into that %1$s looks risky.  Crouch and move into it if you wish to enter anyway." ),
                      enumerate_as_string( harmful_stuff ) );
             return true;
-        } else if( get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" ) == "NEVER" &&
-                   !u.movement_mode_is( CMM_RUN ) ) {
+        } else if( dangerous_terrain_opt == "NEVER" && !u.movement_mode_is( CMM_RUN ) ) {
             add_msg( m_warning,
                      _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ),
                      enumerate_as_string( harmful_stuff ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8952,7 +8952,10 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
         std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
         const auto dangerous_terrain_opt = get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" );
 
-        if( dangerous_terrain_opt == "ALWAYS" && !prompt_dangerous_tile( dest_loc ) ) {
+        if( dangerous_terrain_opt == "IGNORE" ) {
+            add_msg( m_warning, _( "Stepping into that %1$s looked risky, but you entered anyway." ),
+            enumerate_as_string( harmful_stuff ) );
+        } else if( dangerous_terrain_opt == "ALWAYS" && !prompt_dangerous_tile( dest_loc ) ) {
             return true;
         } else if( dangerous_terrain_opt == "RUNNING" &&
                    ( !u.movement_mode_is( CMM_RUN ) || !prompt_dangerous_tile( dest_loc ) ) ) {
@@ -8971,7 +8974,6 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
                      _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ),
                      enumerate_as_string( harmful_stuff ) );
             return true;
-        } else if( dangerous_terrain_opt == "NEVERALT" ) {
         }
     }
     // Used to decide whether to print a 'moving is slow message

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8951,28 +8951,25 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
     if( !shifting_furniture && !pushing && is_dangerous_tile( dest_loc ) ) {
         std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
         const auto dangerous_terrain_opt = get_option<std::string>( "DANGEROUS_TERRAIN_WARNING_PROMPT" );
+        const auto harmful_text = enumerate_as_string( harmful_stuff );
+        const auto warn_msg = [&]( const char *const msg ) {
+            add_msg( m_warning, msg, harmful_text );
+        };
 
         if( dangerous_terrain_opt == "IGNORE" ) {
-            add_msg( m_warning, _( "Stepping into that %1$s looked risky, but you entered anyway." ),
-            enumerate_as_string( harmful_stuff ) );
+            warn_msg( _( "Stepping into that %1$s looks risky, but you enter anyway." ) );
         } else if( dangerous_terrain_opt == "ALWAYS" && !prompt_dangerous_tile( dest_loc ) ) {
             return true;
         } else if( dangerous_terrain_opt == "RUNNING" &&
                    ( !u.movement_mode_is( CMM_RUN ) || !prompt_dangerous_tile( dest_loc ) ) ) {
-            add_msg( m_warning,
-                     _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ),
-                     enumerate_as_string( harmful_stuff ) );
+            warn_msg( _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ) );
             return true;
         } else if( dangerous_terrain_opt == "CROUCHING" &&
                    ( !u.movement_mode_is( CMM_CROUCH ) || !prompt_dangerous_tile( dest_loc ) ) ) {
-            add_msg( m_warning,
-                     _( "Stepping into that %1$s looks risky.  Crouch and move into it if you wish to enter anyway." ),
-                     enumerate_as_string( harmful_stuff ) );
+            warn_msg( _( "Stepping into that %1$s looks risky.  Crouch and move into it if you wish to enter anyway." ) );
             return true;
         } else if( dangerous_terrain_opt == "NEVER" && !u.movement_mode_is( CMM_RUN ) ) {
-            add_msg( m_warning,
-                     _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ),
-                     enumerate_as_string( harmful_stuff ) );
+            warn_msg( _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ) );
             return true;
         }
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8971,6 +8971,8 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
                      _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ),
                      enumerate_as_string( harmful_stuff ) );
             return true;
+        } else if ( dangerous_terrain_opt == "NEVERALT" ) {
+            return true;
         }
     }
     // Used to decide whether to print a 'moving is slow message

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8971,7 +8971,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
                      _( "Stepping into that %1$s looks risky.  Run into it if you wish to enter anyway." ),
                      enumerate_as_string( harmful_stuff ) );
             return true;
-        } else if ( dangerous_terrain_opt == "NEVERALT" ) {
+        } else if( dangerous_terrain_opt == "NEVERALT" ) {
         }
     }
     // Used to decide whether to print a 'moving is slow message

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8972,7 +8972,6 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp )
                      enumerate_as_string( harmful_stuff ) );
             return true;
         } else if ( dangerous_terrain_opt == "NEVERALT" ) {
-            return true;
         }
     }
     // Used to decide whether to print a 'moving is slow message

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1292,13 +1292,13 @@ void options_manager::add_options_general()
 
     add( "DANGEROUS_TERRAIN_WARNING_PROMPT", "general",
          translate_marker( "Dangerous terrain warning prompt" ),
-         translate_marker( "Always: You will be prompted to move onto dangerous tiles.  Running: You will only be able to move onto dangerous tiles while running and will be prompted.  Crouching: You will only be able to move onto a dangerous tile while crouching and will be prompted.  Never:  You will not be able to move onto a dangerous tile unless running and will not be warned or prompted.  Never (Alt): No restriction whatsoever." ),
+         translate_marker( "Always: You will be prompted to move onto dangerous tiles.  Running: You will only be able to move onto dangerous tiles while running and will be prompted.  Crouching: You will only be able to move onto a dangerous tile while crouching and will be prompted.  Never:  You will not be able to move onto a dangerous tile unless running and will not be warned or prompted.  Ignore:  You will be able to move onto a dangerous tile without any warnings or prompts." ),
     {
         { "ALWAYS", to_translation( "Always" ) },
         { "RUNNING", translate_marker( "Running" ) },
         { "CROUCHING", translate_marker( "Crouching" ) },
         { "NEVER", translate_marker( "Never" ) },
-        { "NEVERALT", translate_marker( "Never (Alt)" ) }
+        { "IGNORE", translate_marker( "Ignore" ) }
     },
     "ALWAYS"
        );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1292,8 +1292,14 @@ void options_manager::add_options_general()
 
     add( "DANGEROUS_TERRAIN_WARNING_PROMPT", "general",
          translate_marker( "Dangerous terrain warning prompt" ),
-         translate_marker( "Always: You will be prompted to move onto dangerous tiles.  Running: You will only be able to move onto dangerous tiles while running and will be prompted.  Crouching: You will only be able to move onto a dangerous tile while crouching and will be prompted.  Never:  You will not be able to move onto a dangerous tile unless running and will not be warned or prompted." ),
-    { { "ALWAYS", to_translation( "Always" ) }, { "RUNNING", translate_marker( "Running" ) }, { "CROUCHING", translate_marker( "Crouching" ) }, { "NEVER", translate_marker( "Never" ) } },
+         translate_marker( "Always: You will be prompted to move onto dangerous tiles.  Running: You will only be able to move onto dangerous tiles while running and will be prompted.  Crouching: You will only be able to move onto a dangerous tile while crouching and will be prompted.  Never:  You will not be able to move onto a dangerous tile unless running and will not be warned or prompted.  Never (Alt): No restriction whatsoever." ),
+    {
+        { "ALWAYS", to_translation( "Always" ) },
+        { "RUNNING", translate_marker( "Running" ) },
+        { "CROUCHING", translate_marker( "Crouching" ) },
+        { "NEVER", translate_marker( "Never" ) },
+        { "NEVERALT", translate_marker( "Never (Alt)" ) }
+    },
     "ALWAYS"
        );
 


### PR DESCRIPTION
#### Summary

SUMMARY: Interface "Add option to ignore dangerous terrain warnings"

#### Purpose of change

- resolves #402

#### Describe the solution

- adds an option `Ignore`, which will disable all dangerous terrain check/prompts. live on the edge!
