### PR TITLE
Removes overmap generation from test startup

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -159,9 +159,6 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
     g->m = map( get_option<bool>( "ZLEVELS" ) );
     disable_mapgen = true;
 
-    overmap_special_batch empty_specials( point_abs_om{} );
-    overmap_buffer.create_custom_overmap( point_abs_om{}, empty_specials );
-
     g->m.load( tripoint( g->get_levx(), g->get_levy(), g->get_levz() ), false );
     get_distribution_grid_tracker().load( g->m );
 


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Removes overmap generation from testing startup"

#### Purpose of change

During test suite initialization create_custom_overmap is called. This isn't needed and can cause debug messages on some seeds. 

#### Describe the solution

Delete.