### PR TITLE
Bump vcpkg version to fix msvc builds

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -181,11 +181,11 @@ jobs:
           appendedCacheKey: ${{ hashFiles( 'msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/**' ) }}-${{ matrix.arch }}-1
           setupOnly: true
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          # We have to use at least this version of vcpkg to include fixes for yasm-tool's
-          # availability only as an x86 host tool. Keep it in sync with the builtin-baseline
+          # We have to use at least this version of vcpkg to include fixes for 
+          # various issues we've encountered over time. Keep it in sync with the builtin-baseline
           # field in vcpkg.json. Caching happens as a post-action which runs at the end of
           # the whole workflow, after vcpkg install happens during msbuild run.
-          vcpkgGitCommitId: '9d9a6f486cc7da7664117a75d01440db0088634a'
+          vcpkgGitCommitId: 'f4b262b259145adb2ab0116a390b08642489d32b'
       - name: Install dependencies (windows msvc) (3/3)
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -72,7 +72,7 @@ jobs:
         # Keep vcpkg version here in sync with the builtin-baseline
         # field in vcpkg.json. Caching happens as a post-action which runs at the end of
         # the whole workflow, after vcpkg install happens during msbuild run.
-        vcpkgGitCommitId: '9d9a6f486cc7da7664117a75d01440db0088634a'
+        vcpkgGitCommitId: 'f4b262b259145adb2ab0116a390b08642489d32b'
 
     - name: Integrate vcpkg
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,11 +176,11 @@ jobs:
           appendedCacheKey: ${{ hashFiles( 'msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/**' ) }}-${{ matrix.arch }}-1
           setupOnly: true
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          # We have to use at least this version of vcpkg to include fixes for yasm-tool's
-          # availability only as an x86 host tool. Keep it in sync with the builtin-baseline
+          # We have to use at least this version of vcpkg to include fixes for 
+          # various issues we've encountered over time. Keep it in sync with the builtin-baseline
           # field in vcpkg.json. Caching happens as a post-action which runs at the end of
           # the whole workflow, after vcpkg install happens during msbuild run.
-          vcpkgGitCommitId: '9d9a6f486cc7da7664117a75d01440db0088634a'
+          vcpkgGitCommitId: 'f4b262b259145adb2ab0116a390b08642489d32b'
       - name: Install dependencies (windows msvc) (3/3)
         if: runner.os == 'Windows'
         run: |

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -10,5 +10,5 @@
         },
         "sdl2-ttf"
     ],
-    "builtin-baseline": "9d9a6f486cc7da7664117a75d01440db0088634a"
+    "builtin-baseline": "f4b262b259145adb2ab0116a390b08642489d32b"
 }


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Bumped vcpkg version to fix msvc builds"

#### Purpose of change
Closes #2082

#### Describe the solution
Bump vcpkg version to latest-ish. It includes the change to zlib port file that makes it download the source code for version 1.2.12 from github mirror where it's still available.

It's a trivial change, yet should last us for another half a year or so if the trend continues.

#### Testing
Compiles locally, no game-breaking issues were noticed.
Opened the PR to test GitHub workflow, should work with no further changes.

#### Additional context
People with existing VS+vcpkg build setups will need to manually update their vcpkg.

Assuming the setup matches one described in the doc, this can be done in 2 steps:
1. Open vcpkg folder in cmd and run:
  ```
  git pull --ff origin master
  ```
2. Open the solution in Visual Studio and do a "Clean Solution" + "Build Solution"
