### PR TITLE
Add missing damage sources kills and suicide to kills list

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -475,7 +475,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
     apply_ammo_effects( tp, proj.get_ammo_effects() );
     const auto &expl = proj.get_custom_explosion();
     if( expl ) {
-        explosion_handler::explosion( tp, expl );
+        explosion_handler::explosion( tp, expl, origin );
     }
 
     // TODO: Move this outside now that we have hit point in return values?

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -472,7 +472,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
 
     drop_or_embed_projectile( attack );
 
-    apply_ammo_effects( tp, proj.get_ammo_effects() );
+    apply_ammo_effects( tp, proj.get_ammo_effects(), origin );
     const auto &expl = proj.get_custom_explosion();
     if( expl ) {
         explosion_handler::explosion( tp, expl, origin );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -906,8 +906,8 @@ bool Character::activate_bionic( int b, bool eff_only )
         sw.force = 4;
         sw.stun = 2;
         sw.dam_mult = 8;
-
-        explosion_handler::shockwave( pos(), sw, "explosion" );
+        // affects_player is always false, so assuming the player is always the source of this
+        explosion_handler::shockwave( pos(), sw, "explosion", &g->u );
         add_msg_if_player( m_neutral, _( "You unleash a powerful shockwave!" ) );
         mod_moves( -100 );
     } else if( bio.id == bio_meteorologist ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -907,7 +907,7 @@ bool Character::activate_bionic( int b, bool eff_only )
         sw.stun = 2;
         sw.dam_mult = 8;
         // affects_player is always false, so assuming the player is always the source of this
-        explosion_handler::shockwave( pos(), sw, "explosion", &g->u );
+        explosion_handler::shockwave( pos(), sw, "explosion", &get_player_character() );
         add_msg_if_player( m_neutral, _( "You unleash a powerful shockwave!" ) );
         mod_moves( -100 );
     } else if( bio.id == bio_meteorologist ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8444,6 +8444,14 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
         on_hurt( source );
     }
 
+    if( is_dead_state() ) {
+        // if the player killed himself, add it to the kill count list
+        if( !is_npc() && !killer && source == g->u.as_character() ) {
+            g->events().send<event_type::character_kills_character>( g->u.getID(), getID(), get_name() );
+        }
+        set_killer( source );
+    }
+
     if( !bypass_med ) {
         // remove healing effects if damaged
         int remove_med = roll_remainder( dam / 5.0f );
@@ -8706,10 +8714,6 @@ void Character::on_hurt( Creature *source, bool disturb /*= true*/ )
                 g->cancel_activity_or_ignore_query( distraction_type::attacked, _( "You were hurt!" ) );
             }
         }
-    }
-
-    if( is_dead_state() ) {
-        set_killer( source );
     }
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8447,7 +8447,8 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
     if( is_dead_state() ) {
         // if the player killed himself, add it to the kill count list
         if( !is_npc() && !killer && source == g->u.as_character() ) {
-            g->events().send<event_type::character_kills_character>( g->u.getID(), getID(), get_name() );
+            g->events().send<event_type::character_kills_character>( get_player_character().getID(), getID(),
+                    get_name() );
         }
         set_killer( source );
     }

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -935,7 +935,7 @@ void computer_session::action_srcf_seal()
     for( const tripoint &p : here.points_on_zlevel() ) {
         if( here.ter( p ) == t_elevator || here.ter( p ) == t_vat ) {
             here.make_rubble( p, f_rubble_rock, true );
-            explosion_handler::explosion( p, 40, 0.7, true );
+            explosion_handler::explosion( p, &g->u, 40, 0.7, true );
         }
         if( here.ter( p ) == t_wall_glass ) {
             here.make_rubble( p, f_rubble_rock, true );
@@ -945,7 +945,7 @@ void computer_session::action_srcf_seal()
         }
         if( here.ter( p ) == t_sewage_pump ) {
             here.make_rubble( p, f_rubble_rock, true );
-            explosion_handler::explosion( p, 50, 0.7, true );
+            explosion_handler::explosion( p, &g->u, 50, 0.7, true );
         }
     }
     comp.options.clear(); // Disable the terminal.
@@ -1042,7 +1042,7 @@ void computer_session::action_irradiator()
                     // critical failure - radiation spike sets off electronic detonators
                     if( it->typeId() == itype_mininuke || it->typeId() == itype_mininuke_act ||
                         it->typeId() == itype_c4 ) {
-                        explosion_handler::explosion( dest, 40 );
+                        explosion_handler::explosion( dest, &g->u, 40 );
                         reset_terminal();
                         print_error( _( "WARNING [409]: Primary sensors offline!" ) );
                         print_error( _( "  >> Initialize secondary sensors: Geiger profiling…" ) );
@@ -1367,7 +1367,7 @@ void computer_session::failure_pump_explode()
     for( const tripoint &p : here.points_on_zlevel() ) {
         if( here.ter( p ) == t_sewage_pump ) {
             here.make_rubble( p );
-            explosion_handler::explosion( p, 10 );
+            explosion_handler::explosion( p, nullptr, 10 );
         }
     }
 }
@@ -1408,9 +1408,11 @@ void computer_session::failure_amigara()
     g->timed_events.add( TIMED_EVENT_AMIGARA, calendar::turn + 30_seconds );
     g->u.add_effect( effect_amigara, 2_minutes );
     explosion_handler::explosion( tripoint( rng( 0, MAPSIZE_X ), rng( 0, MAPSIZE_Y ), g->get_levz() ),
+                                  nullptr,
                                   10,
                                   0.7, false, 10 );
     explosion_handler::explosion( tripoint( rng( 0, MAPSIZE_X ), rng( 0, MAPSIZE_Y ), g->get_levz() ),
+                                  nullptr,
                                   10,
                                   0.7, false, 10 );
     comp.remove_option( COMPACT_AMIGARA_START );

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -510,7 +510,7 @@ static std::map<const Creature *, int> do_blast_new( const tripoint &blast_cente
                     const int part_dam = rng( blast_force * blast_part.low_mul, blast_force * blast_part.high_mul );
                     const std::string hit_part_name = body_part_name_accusative( blast_part.bp->token );
                     const auto dmg_instance = damage_instance( DT_BASH, part_dam, 0, blast_part.armor_mul );
-                    const auto result = player_ptr->deal_damage( nullptr, blast_part.bp, dmg_instance );
+                    const auto result = player_ptr->deal_damage( source, blast_part.bp, dmg_instance );
                     const int res_dmg = result.total_damage();
 
                     if( res_dmg > 0 ) {
@@ -668,7 +668,7 @@ static std::map<const Creature *, int> shrapnel( const tripoint &src, const proj
                     // Halve damage to be closer to what monsters take
                     damage_instance half_impact = proj.impact;
                     half_impact.mult_damage( 0.5f );
-                    dealt_damage_instance dealt = critter->deal_damage( nullptr, bp, proj.impact );
+                    dealt_damage_instance dealt = critter->deal_damage( source, bp, proj.impact );
                     if( dealt.total_damage() > 0 ) {
                         damage_taken += dealt.total_damage();
                     }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -329,7 +329,7 @@ static std::map<const Creature *, int> do_blast( const tripoint &p, const float 
             const int part_dam = rng( force * blp.low_mul, force * blp.high_mul );
             const std::string hit_part_name = body_part_name_accusative( blp.bp->token );
             const auto dmg_instance = damage_instance( DT_BASH, part_dam, 0, blp.armor_mul );
-            const auto result = pl->deal_damage( nullptr, blp.bp, dmg_instance );
+            const auto result = pl->deal_damage( source, blp.bp, dmg_instance );
             const int res_dmg = result.total_damage();
 
             add_msg( m_debug, "%s for %d raw, %d actual", hit_part_name, part_dam, res_dmg );

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -1051,7 +1051,7 @@ void emp_blast( const tripoint &p )
 
 void resonance_cascade( const tripoint &p )
 {
-    get_explosion_queue().add( queued_explosion( p, ExplosionType::ResonanceCascade ) );
+    get_explosion_queue().add( queued_explosion( p, ExplosionType::ResonanceCascade, nullptr ) );
 }
 
 void explosion_funcs::resonance_cascade( const queued_explosion &qe )

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -40,11 +40,11 @@ namespace explosion_handler
  * If casing mass > 0, shrapnel is produced.
  */
 void explosion(
-    const tripoint &p, float power, float factor = 0.8f,
+    const tripoint &p, Creature *source, float power, float factor = 0.8f,
     bool fire = false, int legacy_casing_mass = 0, float legacy_frag_mass = 0.05
 );
 
-void explosion( const tripoint &p, const explosion_data &ex );
+void explosion( const tripoint &p, const explosion_data &ex, Creature *source );
 
 constexpr float power_to_dmg_mult = 2.0f / 15.0f;
 
@@ -57,7 +57,8 @@ void scrambler_blast( const tripoint &p );
 /** Triggers an EMP blast at p. */
 void emp_blast( const tripoint &p );
 /** Shockwave applies knockback with given parameters to all targets within radius of p. */
-void shockwave( const tripoint &p, const shockwave_data &sw, const std::string &exp_name );
+void shockwave( const tripoint &p, const shockwave_data &sw, const std::string &exp_name,
+                Creature *source );
 
 projectile shrapnel_from_legacy( int power, float blast_radius );
 float blast_radius_from_legacy( int power, float distance_factor );

--- a/src/explosion_queue.h
+++ b/src/explosion_queue.h
@@ -21,7 +21,7 @@ enum class ExplosionType {
 struct queued_explosion {
     queued_explosion() = default;
     queued_explosion( const tripoint &pos, ExplosionType type,
-                      Creature *source = nullptr ) : pos( pos ), type( type ), source( source ) {}
+                      Creature *source ) : pos( pos ), type( type ), source( source ) {}
 
     /** Origin */
     tripoint pos;

--- a/src/explosion_queue.h
+++ b/src/explosion_queue.h
@@ -20,7 +20,8 @@ enum class ExplosionType {
 
 struct queued_explosion {
     queued_explosion() = default;
-    queued_explosion( const tripoint &pos, ExplosionType type ) : pos( pos ), type( type ) {}
+    queued_explosion( const tripoint &pos, ExplosionType type,
+                      Creature *source = nullptr ) : pos( pos ), type( type ), source( source ) {}
 
     /** Origin */
     tripoint pos;
@@ -34,6 +35,8 @@ struct queued_explosion {
     std::string graphics_name;
     /** Whether it affects player */
     bool affects_player = false;
+    /** Who's responsible of the explosion */
+    Creature *source;
 };
 
 namespace explosion_funcs

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4452,15 +4452,15 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult,
                 break;
             }
             targ->setpos( traj[i] );
-            if( m.has_flag( "LIQUID", targ->pos() ) && !targ->can_drown() && !targ->is_dead() ) {
-                targ->die( nullptr );
+            if( m.has_flag( "LIQUID", targ->pos() ) && targ->can_drown() && !targ->is_dead() ) {
+                targ->die( source );
                 if( u.sees( *targ ) ) {
                     add_msg( _( "The %s drowns!" ), targ->name() );
                 }
             }
             if( !m.has_flag( "LIQUID", targ->pos() ) && targ->has_flag( MF_AQUATIC ) &&
                 !targ->is_dead() ) {
-                targ->die( nullptr );
+                targ->die( source );
                 if( u.sees( *targ ) ) {
                     add_msg( _( "The %s flops around and dies!" ), targ->name() );
                 }
@@ -4493,7 +4493,7 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult,
                     };
                     for( const bodypart_id &bp : bps ) {
                         if( one_in( 2 ) ) {
-                            targ->deal_damage( nullptr, bp, damage_instance( DT_BASH, force_remaining * dam_mult ) );
+                            targ->deal_damage( source, bp, damage_instance( DT_BASH, force_remaining * dam_mult ) );
                         }
                     }
                     targ->check_dead_state();
@@ -4569,7 +4569,6 @@ void game::knockback( std::vector<tripoint> &traj, int stun, int dam_mult,
                     };
                     for( const bodypart_id &bp : bps ) {
                         if( one_in( 2 ) ) {
-                            // how is killing yourself handled?
                             u.deal_damage( source, bp, damage_instance( DT_BASH, force_remaining * dam_mult ) );
                         }
                     }

--- a/src/game.h
+++ b/src/game.h
@@ -678,8 +678,9 @@ class game
         // force also determines damage along with dam_mult;
         // stun determines base number of turns target is stunned regardless of impact
         // stun == 0 means no stun, stun == -1 indicates only impact stun (wall or npc/monster)
-        void knockback( const tripoint &s, const tripoint &t, int force, int stun, int dam_mult );
-        void knockback( std::vector<tripoint> &traj, int stun, int dam_mult );
+        void knockback( const tripoint &s, const tripoint &t, int force, int stun, int dam_mult,
+                        Creature *source );
+        void knockback( std::vector<tripoint> &traj, int stun, int dam_mult, Creature *source );
 
         // Animation related functions
         void draw_bullet( const tripoint &t, int i, const std::vector<tripoint> &trajectory,

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2244,7 +2244,7 @@ bool game::handle_action()
             case ACTION_SUICIDE:
                 if( query_yn( _( "Commit suicide?" ) ) ) {
                     if( query_yn( _( "REALLY commit suicide?" ) ) ) {
-                        u.apply_damage( u.as_character(), body_part_head, 99999 );
+                        u.apply_damage( &u, body_part_head, 99999 );
                         u.moves = 0;
                         u.place_corpse();
                         uquit = QUIT_SUICIDE;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2244,6 +2244,7 @@ bool game::handle_action()
             case ACTION_SUICIDE:
                 if( query_yn( _( "Commit suicide?" ) ) ) {
                     if( query_yn( _( "REALLY commit suicide?" ) ) ) {
+                        u.apply_damage( u.as_character(), body_part_head, 99999 );
                         u.moves = 0;
                         u.place_corpse();
                         uquit = QUIT_SUICIDE;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8613,7 +8613,7 @@ bool item::will_explode_in_fire() const
 bool item::detonate( const tripoint &p, std::vector<item> &drops )
 {
     if( type->explosion ) {
-        explosion_handler::explosion( p, type->explosion, activated_by.get());
+        explosion_handler::explosion( p, type->explosion, activated_by.get() );
         return true;
     } else if( type->ammo && ( type->ammo->special_cookoff || type->ammo->cookoff ) ) {
         int charges_remaining = charges;
@@ -8624,7 +8624,7 @@ bool item::detonate( const tripoint &p, std::vector<item> &drops )
 
         if( ammo_type.special_cookoff ) {
             // If it has a special effect just trigger it.
-            apply_ammo_effects( p, ammo_type.ammo_effects, activated_by.get());
+            apply_ammo_effects( p, ammo_type.ammo_effects, activated_by.get() );
         }
         charges_remaining -= rounds_exploded;
         if( charges_remaining > 0 ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8613,7 +8613,8 @@ bool item::will_explode_in_fire() const
 bool item::detonate( const tripoint &p, std::vector<item> &drops )
 {
     if( type->explosion ) {
-        explosion_handler::explosion( p, type->explosion );
+        // TODO implement if the player is the source
+        explosion_handler::explosion( p, type->explosion, nullptr );
         return true;
     } else if( type->ammo && ( type->ammo->special_cookoff || type->ammo->cookoff ) ) {
         int charges_remaining = charges;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8625,7 +8625,7 @@ bool item::detonate( const tripoint &p, std::vector<item> &drops )
 
         if( ammo_type.special_cookoff ) {
             // If it has a special effect just trigger it.
-            apply_ammo_effects( p, ammo_type.ammo_effects );
+            apply_ammo_effects( p, ammo_type.ammo_effects, activated_by );
         }
         charges_remaining -= rounds_exploded;
         if( charges_remaining > 0 ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8613,8 +8613,7 @@ bool item::will_explode_in_fire() const
 bool item::detonate( const tripoint &p, std::vector<item> &drops )
 {
     if( type->explosion ) {
-        // TODO implement if the player is the source
-        explosion_handler::explosion( p, type->explosion, nullptr );
+        explosion_handler::explosion( p, type->explosion, activated_by.get());
         return true;
     } else if( type->ammo && ( type->ammo->special_cookoff || type->ammo->cookoff ) ) {
         int charges_remaining = charges;
@@ -8625,7 +8624,7 @@ bool item::detonate( const tripoint &p, std::vector<item> &drops )
 
         if( ammo_type.special_cookoff ) {
             // If it has a special effect just trigger it.
-            apply_ammo_effects( p, ammo_type.ammo_effects, activated_by );
+            apply_ammo_effects( p, ammo_type.ammo_effects, activated_by.get());
         }
         charges_remaining -= rounds_exploded;
         if( charges_remaining > 0 ) {

--- a/src/item.h
+++ b/src/item.h
@@ -2232,7 +2232,7 @@ class item : public visitable<item>
     public:
         char invlet = 0;      // Inventory letter
         bool active = false; // If true, it has active effects to be processed
-        Creature *activated_by = nullptr;
+        safe_reference<player> activated_by;
         bool is_favorite = false;
 
         void set_favorite( bool favorite );

--- a/src/item.h
+++ b/src/item.h
@@ -33,6 +33,7 @@ class Character;
 class JsonIn;
 class JsonObject;
 class JsonOut;
+class Creature;
 class faction;
 class gun_type_type;
 class gunmod_location;
@@ -2231,6 +2232,7 @@ class item : public visitable<item>
     public:
         char invlet = 0;      // Inventory letter
         bool active = false; // If true, it has active effects to be processed
+        Creature *activated_by = nullptr;
         bool is_favorite = false;
 
         void set_favorite( bool favorite );

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -98,6 +98,7 @@ void itype::tick( player &p, item &it, const tripoint &pos ) const
 {
     // Maybe should move charge decrementing here?
     for( auto &method : use_methods ) {
+        //player &pref = *it.activated_by.get();
         method.second.call( p, it, true, pos );
     }
 }
@@ -128,8 +129,8 @@ int itype::invoke( player &p, item &it, const tripoint &pos, const std::string &
     // used for grenades and such, to increase kill count
     // add this check because invoke is called a second time when the explosion detonate, with the avatar in p
     // even if the grenade has been thrown by a NPC
-    if( !it.activated_by ) {
-        it.activated_by = &p;
+    if( !it.activated_by.get() ) {
+        it.activated_by = p.get_safe_reference();
     }
 
     return use->call( p, it, false, pos );

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -125,6 +125,12 @@ int itype::invoke( player &p, item &it, const tripoint &pos, const std::string &
         p.add_msg_if_player( m_info, ret.str() );
         return 0;
     }
+    // used for grenades and such, to increase kill count
+    // add this check because invoke is called a second time when the explosion detonate, with the avatar in p
+    // even if the grenade has been thrown by a NPC
+    if( !it.activated_by ) {
+        it.activated_by = &p;
+    }
 
     return use->call( p, it, false, pos );
 }

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -127,9 +127,10 @@ int itype::invoke( player &p, item &it, const tripoint &pos, const std::string &
         return 0;
     }
     // used for grenades and such, to increase kill count
-    // add this check because invoke is called a second time when the explosion detonate, with the avatar in p
-    // even if the grenade has been thrown by a NPC
-    if( !it.activated_by.get() ) {
+    // invoke is called a first time with transform, when the explosive item is activated
+    // then a second time with draw explosion
+    // the player responsible of the explosion is the one that activated the object
+    if( iuse_name == "transform" ) {
         it.activated_by = p.get_safe_reference();
     }
 

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -98,7 +98,6 @@ void itype::tick( player &p, item &it, const tripoint &pos ) const
 {
     // Maybe should move charge decrementing here?
     for( auto &method : use_methods ) {
-        //player &pref = *it.activated_by.get();
         method.second.call( p, it, true, pos );
     }
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3765,7 +3765,7 @@ int iuse::grenade_inc_act( player *p, item *it, bool t, const tripoint &pos )
                 g->m.add_field( flame, fd_fire, rng( 0, 2 ) );
             }
         }
-        explosion_handler::explosion( pos, 8, 0.8, true );
+        explosion_handler::explosion( pos, p, 8, 0.8, true );
         for( const tripoint &dest : g->m.points_in_radius( pos, 2 ) ) {
             g->m.add_field( dest, fd_incendiary, 3 );
         }
@@ -5234,7 +5234,8 @@ int iuse::artifact( player *p, item *it, bool, const tripoint & )
 
             case AEA_FIREBALL: {
                 if( const cata::optional<tripoint> fireball = g->look_around() ) {
-                    explosion_handler::explosion( *fireball, 180, 0.5, true );
+                    // only the player can trigger artifact
+                    explosion_handler::explosion( *fireball, p, 180, 0.5, true );
                 }
             }
             break;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -564,14 +564,13 @@ int explosion_iuse::use( player &p, item &it, bool t, const tripoint &pos ) cons
         }
         return 0;
     }
-    trigger_explosion( pos, it.activated_by );
+    trigger_explosion( pos, it.activated_by.get() );
     return 1;
 }
 
 void explosion_iuse::trigger_explosion( const tripoint &pos, Creature *source ) const
 {
     if( explosion ) {
-        // TODO implement if the player is the source
         explosion_handler::explosion( pos, explosion, source );
     }
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -564,15 +564,15 @@ int explosion_iuse::use( player &p, item &it, bool t, const tripoint &pos ) cons
         }
         return 0;
     }
-
-    trigger_explosion( pos );
+    trigger_explosion( pos, it.activated_by );
     return 1;
 }
 
-void explosion_iuse::trigger_explosion( const tripoint &pos ) const
+void explosion_iuse::trigger_explosion( const tripoint &pos, Creature *source ) const
 {
     if( explosion ) {
-        explosion_handler::explosion( pos, explosion );
+        // TODO implement if the player is the source
+        explosion_handler::explosion( pos, explosion, source );
     }
 
     if( draw_explosion_radius >= 0 ) {

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -204,7 +204,7 @@ class explosion_iuse : public iuse_actor
         void info( const item &, std::vector<iteminfo> & ) const override;
 
         /** Produces all the explosions from this actor */
-        void trigger_explosion( const tripoint &p ) const;
+        void trigger_explosion( const tripoint &p, Creature *source ) const;
 };
 
 /**

--- a/src/magic.h
+++ b/src/magic.h
@@ -547,7 +547,7 @@ void timed_event( const spell &sp, Creature &caster, const tripoint & );
 void transform_blast( const spell &sp, Creature &caster, const tripoint &target );
 void noise( const spell &sp, Creature &, const tripoint &target );
 void vomit( const spell &sp, Creature &caster, const tripoint &target );
-void explosion( const spell &sp, Creature &, const tripoint &target );
+void explosion( const spell &sp, Creature &caster, const tripoint &target );
 void flashbang( const spell &sp, Creature &caster, const tripoint &target );
 void mod_moves( const spell &sp, Creature &caster, const tripoint &target );
 void map_area( const spell &sp, Creature &caster, const tripoint & );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -934,9 +934,9 @@ void spell_effect::vomit( const spell &sp, Creature &caster, const tripoint &tar
     }
 }
 
-void spell_effect::explosion( const spell &sp, Creature &, const tripoint &target )
+void spell_effect::explosion( const spell &sp, Creature &caster, const tripoint &target )
 {
-    explosion_handler::explosion( target, sp.damage(), sp.aoe() / 10.0, true );
+    explosion_handler::explosion( target, &caster, sp.damage(), sp.aoe() / 10.0, true );
 }
 
 void spell_effect::flashbang( const spell &sp, Creature &caster, const tripoint &target )

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3280,7 +3280,8 @@ bash_results map::bash_ter_success( const tripoint &p, const bash_params &params
     }
 
     if( bash.explosive > 0 ) {
-        explosion_handler::explosion( p, bash.explosive, 0.8, false );
+        // TODO Implement if the player triggered the explosive terrain
+        explosion_handler::explosion( p, nullptr, bash.explosive, 0.8, false );
     }
 
     return result;
@@ -3379,7 +3380,8 @@ bash_results map::bash_furn_success( const tripoint &p, const bash_params &param
     }
 
     if( bash.explosive > 0 ) {
-        explosion_handler::explosion( p, bash.explosive, 0.8, false );
+        // TODO implement if the player triggered the explosive furniture
+        explosion_handler::explosion( p, nullptr, bash.explosive, 0.8, false );
     }
 
     return result;

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -599,7 +599,7 @@ void mdeath::explode( monster &z )
             size = 15;
             break;
     }
-    explosion_handler::explosion( z.pos(), size );
+    explosion_handler::explosion( z.pos(), &z, size );
 }
 
 void mdeath::focused_beam( monster &z )
@@ -638,7 +638,7 @@ void mdeath::focused_beam( monster &z )
 
     z.inv.clear();
 
-    explosion_handler::explosion( z.pos(), 8 );
+    explosion_handler::explosion( z.pos(), &z, 8 );
 }
 
 void mdeath::broken( monster &z )

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2229,7 +2229,7 @@ void monster::process_turn()
                 const auto t = g->m.ter( zap );
                 if( t == ter_str_id( "t_gas_pump" ) || t == ter_str_id( "t_gas_pump_a" ) ) {
                     if( one_in( 4 ) ) {
-                        explosion_handler::explosion( pos(), 40, 0.8, true );
+                        explosion_handler::explosion( pos(), nullptr, 40, 0.8, true );
                         if( player_sees ) {
                             add_msg( m_warning, _( "The %s explodes in a fiery inferno!" ), g->m.tername( zap ) );
                         }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4293,5 +4293,5 @@ void player::reset_stats()
 
 safe_reference<player> player::get_safe_reference()
 {
-    return anchor.reference_to(this);
+    return anchor.reference_to( this );
 }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -4290,3 +4290,8 @@ void player::reset_stats()
     recalc_speed_bonus();
 
 }
+
+safe_reference<player> player::get_safe_reference()
+{
+    return anchor.reference_to(this);
+}

--- a/src/player.h
+++ b/src/player.h
@@ -28,6 +28,7 @@
 #include "pimpl.h"
 #include "point.h"
 #include "ret_val.h"
+#include "safe_reference.h"
 #include "string_id.h"
 #include "type_id.h"
 
@@ -413,6 +414,7 @@ class player : public Character
         void reset_stats() override;
 
     private:
+        safe_reference_anchor anchor;
         enum class power_mut_ui_cmd {
             Exit,
             Activate,
@@ -429,7 +431,7 @@ class player : public Character
         bool bio_soporific_powered_at_last_sleep_check = false;
 
     public:
-
+        safe_reference<player> get_safe_reference();
         //returns true if the warning is now beyond final and results in hostility.
         bool add_faction_warning( const faction_id &id );
         int current_warnings_fac( const faction_id &id );

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -123,7 +123,8 @@ void apply_ammo_effects( const tripoint &p, const std::set<ammo_effect_str_id> &
                 }
             }
         if( ae.aoe_explosion_data ) {
-            explosion_handler::explosion( p, ae.aoe_explosion_data );
+            // TODO implement if the player is the source
+            explosion_handler::explosion( p, ae.aoe_explosion_data, nullptr );
         }
         if( ae.do_flashbang ) {
             explosion_handler::flashbang( p, false, "explosion" );

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -107,7 +107,8 @@ void projectile::load( JsonObject &jo )
     jo.read( "proj_effects", proj_effects );
 }
 
-void apply_ammo_effects( const tripoint &p, const std::set<ammo_effect_str_id> &effects )
+void apply_ammo_effects( const tripoint &p, const std::set<ammo_effect_str_id> &effects,
+                         Creature *source )
 {
     map &here = get_map();
     for( const ammo_effect_str_id &ae_id : effects ) {
@@ -123,8 +124,7 @@ void apply_ammo_effects( const tripoint &p, const std::set<ammo_effect_str_id> &
                 }
             }
         if( ae.aoe_explosion_data ) {
-            // TODO implement if the player is the source
-            explosion_handler::explosion( p, ae.aoe_explosion_data, nullptr );
+            explosion_handler::explosion( p, ae.aoe_explosion_data, source );
         }
         if( ae.do_flashbang ) {
             explosion_handler::flashbang( p, false, "explosion" );
@@ -135,7 +135,7 @@ void apply_ammo_effects( const tripoint &p, const std::set<ammo_effect_str_id> &
     }
 }
 
-void apply_ammo_effects( const tripoint &p, const std::set<std::string> &effects )
+void apply_ammo_effects( const tripoint &p, const std::set<std::string> &effects, Creature *source )
 {
     std::set<ammo_effect_str_id> effect_ids;
     for( const std::string &s : effects ) {
@@ -144,7 +144,7 @@ void apply_ammo_effects( const tripoint &p, const std::set<std::string> &effects
             effect_ids.emplace( id );
         }
     }
-    apply_ammo_effects( p, effect_ids );
+    apply_ammo_effects( p, effect_ids, source );
 }
 
 static int aoe_of( const ammo_effect_str_id &ae_id )

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -75,9 +75,11 @@ struct dealt_projectile_attack {
     double missed_by; // Accuracy of dealt attack
 };
 
-void apply_ammo_effects( const tripoint &p, const std::set<ammo_effect_str_id> &effects );
+void apply_ammo_effects( const tripoint &p, const std::set<ammo_effect_str_id> &effects,
+                         Creature *source );
 // Legacy. TODO: Remove
-void apply_ammo_effects( const tripoint &p, const std::set<std::string> &effects );
+void apply_ammo_effects( const tripoint &p, const std::set<std::string> &effects,
+                         Creature *source );
 int max_aoe_size( const std::set<ammo_effect_str_id> &tags );
 int max_aoe_size( const std::set<std::string> &tags );
 

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -620,8 +620,7 @@ bool trapfunc::landmine( const tripoint &p, Creature *c, item *i )
         c->add_msg_player_or_npc( m_bad, _( "You trigger a land mine!" ),
                                   _( "<npcname> triggers a land mine!" ) );
     }
-
-    explosion_handler::explosion( p, get_basic_explosion_data(), i->activated_by );
+    explosion_handler::explosion( p, get_basic_explosion_data(), nullptr );
     g->m.remove_trap( p );
     return true;
 }

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -610,7 +610,7 @@ static explosion_data get_basic_explosion_data()
     return data;
 }
 
-bool trapfunc::landmine( const tripoint &p, Creature *c, item * )
+bool trapfunc::landmine( const tripoint &p, Creature *c, item *i )
 {
     // tiny animals are too light to trigger land mines
     if( c != nullptr && c->get_size() == MS_TINY ) {
@@ -620,7 +620,8 @@ bool trapfunc::landmine( const tripoint &p, Creature *c, item * )
         c->add_msg_player_or_npc( m_bad, _( "You trigger a land mine!" ),
                                   _( "<npcname> triggers a land mine!" ) );
     }
-    explosion_handler::explosion( p, get_basic_explosion_data() );
+
+    explosion_handler::explosion( p, get_basic_explosion_data(), i->activated_by );
     g->m.remove_trap( p );
     return true;
 }
@@ -631,7 +632,8 @@ bool trapfunc::boobytrap( const tripoint &p, Creature *c, item * )
         c->add_msg_player_or_npc( m_bad, _( "You trigger a booby trap!" ),
                                   _( "<npcname> triggers a booby trap!" ) );
     }
-    explosion_handler::explosion( p, get_basic_explosion_data() );
+    // TODO implement if the player is the source?
+    explosion_handler::explosion( p, get_basic_explosion_data(), nullptr );
     g->m.remove_trap( p );
     return true;
 }

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -610,7 +610,7 @@ static explosion_data get_basic_explosion_data()
     return data;
 }
 
-bool trapfunc::landmine( const tripoint &p, Creature *c, item *i )
+bool trapfunc::landmine( const tripoint &p, Creature *c, item * )
 {
     // tiny animals are too light to trigger land mines
     if( c != nullptr && c->get_size() == MS_TINY ) {

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -631,7 +631,6 @@ bool trapfunc::boobytrap( const tripoint &p, Creature *c, item * )
         c->add_msg_player_or_npc( m_bad, _( "You trigger a booby trap!" ),
                                   _( "<npcname> triggers a booby trap!" ) );
     }
-    // TODO implement if the player is the source?
     explosion_handler::explosion( p, get_basic_explosion_data(), nullptr );
     g->m.remove_trap( p );
     return true;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6616,7 +6616,7 @@ bool vehicle::explode_fuel( int p, damage_type type )
                                               ( parts[p].ammo_remaining() * data.fuel_size_factor ) ) );
         //debugmsg( "damage check dmg=%d pow=%d amount=%d", dmg, pow, parts[p].amount );
 
-        explosion_handler::explosion( global_part_pos3( p ), pow, 0.7, data.fiery_explosion );
+        explosion_handler::explosion( global_part_pos3( p ), nullptr, pow, 0.7, data.fiery_explosion );
         mod_hp( parts[p], 0 - parts[ p ].hp(), DT_HEAT );
         parts[p].ammo_unset();
     }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -882,7 +882,7 @@ void vehicle::handle_trap( const tripoint &p, int part )
                            veh_data.sound_type, veh_data.sound_variant );
         }
         if( veh_data.do_explosion ) {
-            explosion_handler::explosion( p, veh_data.damage, 0.5f, false, veh_data.shrapnel );
+            explosion_handler::explosion( p, nullptr, veh_data.damage, 0.5f, false, veh_data.shrapnel );
         } else {
             // Hit the wheel directly since it ran right over the trap.
             damage_direct( pwh, veh_data.damage );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:
SUMMARY: Features "Add missing damage sources kills and suicide to kills list"
SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
Explosion kills from player (grenades, launchers...) were not added to his kills list, probably due to the difficulty to know who's responsible for the explosion (it was a TODO somewhere).
Since explosions kills would be added to kills list, it seemed logical to add the player to his kills list if he killed himself.
Note that direct hit that killed a creature (from a grenade or launcher) already counted, but the explosion after the hit didn't.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
**Non technical:**
Kills from player with:
- explosive throwing items (eg grenades)
- launchers
- explosions from spells
- the shockwave generator bionic
- explosions from computers and such that can only be triggered by a player

are now added to his kill count list

If the player kill himself through damages triggered/caused by himself (including explosions), or through the "Q" key, he will be added to his kill count list.
Both old and new explosions are supported.

**Technical:**
<details>

  <summary>details</summary>

- "explosive throwable items" -> `item` get an `activated_by` field that stores who activated the object. This field is now sent to intermediate functions that call the `explosion()` functions
- "launchers" -> `projectile_attack()` already had an `origin` field that stores who is firing. This field is now sent to intermediate functions that call the `explosion()` functions
- `explosion()` functions, get a `source` parameter, for who is the source of the explosion
- The `explosion()` functions create a `queued_explosion` type, that will be executed later in the code. I stored the `source` here.
- When the `queued_explosion` is executed, they will call the old/new explosions functions (in `explosion_funcs::regular`), and apply the damages. Before this function used a nullptr as source, now they use the `source`
- When applying the damage, if something is killed by the damage and the source is the player, the kill is added to the kill list (same as before, but before the source of an explosion was always nullptr)

#### Describe alternatives you've considered
Developping this, I realised the many cases where a kill from a player is not added to his kill count, when it should.
So excluding what's fixed by this PR, there are still some cases, including but not limited to:
- flamethrowers
- emp damage that fries a robot
- closing the door on a creature and it kills it
- explosion from an explosive terrain (eg if a player shoot a gas pump)

</details>



#### Testing

- kill a zombie with a grenade, it is added to the kill list
- kill a zombie with the explosion of a launcher, same
- kill a zombie with the shockwave generator bionic, same
- same tests results when killing a NPC
- kill yourself with a grenade, you are added to the kill list
- kill yourself with a launcher, same

Have a friendly npc with a stack of grenades
- If he kills a zombie with a grenade, it's not added to the kill list
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->
