### PR TITLE
Add shrapnel animation

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -694,7 +694,6 @@ static std::map<const Creature *, int> shrapnel( const tripoint &src, const proj
     // BEGIN DRAWING EXPLOSION
     // Go see do_blast_new for detailled explanations
     const tripoint &blast_center = src;
-    const float raw_blast_force = fragment.impact.total_damage();
     const float raw_blast_radius = fragment.range;
 
     using dist_point_pair = std::pair<float, tripoint>;


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Add shrapnel animation"

#### Purpose of change
Fixes #2094 
Shrapnel had no animation, which lead to 2 problems:
1. It was hard to know wether one would be inside the shrapnel radius or not, when the radius is well defined in BN
2. Explosions that only used shrapnel had no animations (at all)

#### Describe the solution
After some exchanges on Discord:
- reuse the code that draws the new explosions, without the damage, part to draw the shrapnel animation
- draw only 1/2 rings to give it a faster visual and reduce the animation time (eg now grenades have 2 explosions animations)
- use the visual of smoke instead of explosion

#### Describe alternatives you've considered
This solution didn't get accepted (without extra changes), but I'll leave it here in case it inspires someone in the future:
<details>

  <summary>details</summary>

Every explosions that use shrapnel would use a regular explosion with 1/3 power of the shrapnel
This would:
- make every explosions feel like a real explosion, pushing mobs around etc.
- buff the epicenter of shrapnel explosions, they do quite low damage against monsters
- be more realistic (shrapnel needs an explosion)

</details>

#### Testing
- grenade

https://user-images.githubusercontent.com/71428793/197077154-015c2764-6366-477b-9b5b-6742477681ea.mp4

- launcher with shrapnel only ammo

https://user-images.githubusercontent.com/71428793/197077129-ab2c022e-3173-45bb-ba98-9d46388edc24.mp4

- grenade with the old explosions
Notice how the shrapnel radius is well demarcated in BN

https://user-images.githubusercontent.com/71428793/197078344-25d07bbc-0326-45be-9d18-8f40189466eb.mp4

- ascii, old explosions (several people asked how it looks)

https://user-images.githubusercontent.com/71428793/197125784-acb9b571-d744-4ded-8e81-dd17758fc19f.mp4




