### PR TITLE
[Magiclysm] add enchanted rings back to dragon's lair loot

### DIFF
--- a/data/mods/Magiclysm/worldgen/black_dragon_lair.json
+++ b/data/mods/Magiclysm/worldgen/black_dragon_lair.json
@@ -407,7 +407,7 @@
       "items": {
         ".": [ { "item": "lair_black_dragon", "chance": 15, "repeat": [ 0, 2 ] } ],
         " ": [
-          { "item": "lair_black_dragon", "chance": 10, "repeat": [ 0, 2 ] },
+          { "item": "lair_black_dragon_treasure", "chance": 10, "repeat": [ 0, 2 ] },
           { "item": "enchanted_small_items", "chance": 10, "repeat": [ 0, 2 ] },
           { "item": "enchanted_combat_items", "chance": 10, "repeat": [ 0, 2 ] },
           { "item": "enchanted_melee_weapons_plus2", "chance": 5 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfixes "add enchanted rings back to dragon's lair loot"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
Due to some unknown changes, the dragon's lair didn't use his "treasury" item group for the final room.
It used the item group for the random objects in the lair, before the "treasury" final room.
Since the enchanted rings are in the treasury item group, they never spawned in the lair.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Fix this problem by using the item group for the treasury.
This is also on par with the current DDA version, but I couldn't find the commit that resolved that, only the commit that introduced the bug.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Testing
- for testing, you might want to increase the probability that a ring appears, because it seems quite low.
- then reveal the map, go one tile below ground 0 and search for white "%" signes
![image](https://user-images.githubusercontent.com/71428793/197289339-e003117f-4f86-4e8c-a3fd-4f770fafdeae.png)
- teleport here and verify that at least one ring spawned
