### PR TITLE
Allow marking construction recipes as favorite, sort recipes by name in construction UI

### DIFF
--- a/data/json/construction_category.json
+++ b/data/json/construction_category.json
@@ -56,6 +56,12 @@
     "name": "Others"
   },
   {
+    "//": "Should be second to last in the list",
+    "type": "construction_category",
+    "id": "FAVORITE",
+    "name": "Favorite"
+  },
+  {
     "//": "Should be last in the list",
     "type": "construction_category",
     "id": "FILTER",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1320,6 +1320,13 @@
   },
   {
     "type": "keybinding",
+    "id": "TOGGLE_FAVORITE",
+    "category": "CONSTRUCTION",
+    "name": "Toggle construction as favorite",
+    "bindings": [ { "input_method": "keyboard", "key": "*" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "SCROLL_STAGE_UP",
     "category": "CONSTRUCTION",
     "name": "Scroll to previous stage",

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -278,6 +278,14 @@ static std::vector<const construction *> constructions_by_group( const construct
     return result;
 }
 
+static void sort_constructions_by_name( std::vector<construction_group_str_id> &list )
+{
+    std::sort( list.begin(), list.end(),
+    []( const construction_group_str_id & a, const construction_group_str_id & b ) {
+        return localized_compare( a->name(), b->name() );
+    } );
+}
+
 static void list_available_constructions( std::vector<construction_group_str_id> &available,
         std::map<construction_category_id, std::vector<construction_group_str_id>> &cat_available,
         bool hide_unconstructable )
@@ -309,6 +317,10 @@ static void list_available_constructions( std::vector<construction_group_str_id>
                 cat_available[c.category].push_back( c.group );
             }
         }
+    }
+    sort_constructions_by_name( available );
+    for( auto &it : cat_available ) {
+        sort_constructions_by_name( it.second );
     }
 }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4288,6 +4288,7 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "hidden_recipes", hidden_recipes );
     json.member( "favorite_recipes", favorite_recipes );
     json.member( "recent_recipes", recent_recipes );
+    json.member( "favorite_construct_recipes", favorite_construct_recipes );
     json.member( "bionic_ui_sort_mode", bionic_sort_mode );
     json.member( "overmap_debug_weather", overmap_debug_weather );
     json.member( "overmap_visible_weather", overmap_visible_weather );
@@ -4335,6 +4336,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "hidden_recipes", hidden_recipes );
     jo.read( "favorite_recipes", favorite_recipes );
     jo.read( "recent_recipes", recent_recipes );
+    jo.read( "favorite_construct_recipes", favorite_construct_recipes );
     jo.read( "bionic_ui_sort_mode", bionic_sort_mode );
     jo.read( "overmap_debug_weather", overmap_debug_weather );
     jo.read( "overmap_visible_weather", overmap_visible_weather );

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -138,6 +138,8 @@ class uistatedata
         std::set<recipe_id> favorite_recipes;
         std::vector<recipe_id> recent_recipes;
 
+        std::set<construction_group_str_id> favorite_construct_recipes;
+
         bionic_ui_sort_mode bionic_sort_mode = bionic_ui_sort_mode::POWER;
 
         /* to save input history and make accessible via 'up', you don't need to edit this file, just run:


### PR DESCRIPTION
#### Summary
SUMMARY: Interface "Allow marking construction recipes as favorite, sort recipes by name in construction UI"

#### Purpose of change
- Allow marking construction recipes as favorite
  QoL feature, useful for highlighting some of the common recipes like furniture disassembly or cleaning window from shards
- Sort recipes by name in construction UI
  To make skimming the list not painful with languages where "build" can be translated differently depending on context

#### Describe the solution
- Add separate construction category for favorites, add a keybind to toggle favorite, store favorite list in `uistate`
- Use `localized_compare` to sort by translated name according to user locale

#### Testing
Added and removed some recipes to/from favorites, saved & loaded to ensure they keep their favorite status.
Switched to Russian and ensured the construction order is alphabetic.
