### PR TITLE
[DDA Port] Follow HTTP 302 redirection in installing Transifex CLI for pull-translations.yml

### DIFF
--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: "Install Transifex CLI"
         run: |
-          curl -s https://github.com/transifex/cli/releases/download/v1.0.0/tx-linux-amd64.tar.gz | sudo tar zxvf - -C /usr/bin tx
+          curl -sL https://github.com/transifex/cli/releases/download/v1.0.0/tx-linux-amd64.tar.gz | sudo tar zxvf - -C /usr/bin tx
       - name: "Checkout"
         uses: actions/checkout@v2
       - name: "Get current date"


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
The workflow is failing because I forgot to include this change in #2007

#### Describe the solution
Port of DDA's https://github.com/CleverRaven/Cataclysm-DDA/pull/55342

#### Testing
None