### PR TITLE
Fix edge case in movement over diagonal rails

### DIFF
--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1750,6 +1750,20 @@ static bool scan_rails_from_veh_internal(
     return true;
 }
 
+// Get number of rotations of identity vector
+static inline int get_num_cw_rots_of_ray_delta( const point &v )
+{
+    if( v == point_north_east ) {
+        return 0;
+    } else if( v == point_south_east ) {
+        return 1;
+    } else if( v == point_south_west ) {
+        return 2;
+    } else {
+        return 3;
+    }
+}
+
 static bool scan_rails_at_shift(
     const map &m,
     const vehicle &veh,
@@ -1768,26 +1782,26 @@ static bool scan_rails_at_shift(
     if( ray_delta.x != 0 && ray_delta.y != 0 ) {
         // We can't cleanly map diagonally oriented vehicles to rail turns.
         // As such, treat the vehicle as if it can have either skew at the same time.
-        point rd_x = point( ray_delta.x, 0 );
-        point rd_y = point( 0, ray_delta.y );
+        int num_cw_rots = get_num_cw_rots_of_ray_delta( ray_delta );
+        point rd_l = point_north.rotate( num_cw_rots );
+        point rd_r = point_east.rotate( num_cw_rots );
+
+        point vyp_l = point_east.rotate( num_cw_rots );
+        point vyp_r = point_south.rotate( num_cw_rots );
+
+        tripoint scan_start = veh.global_pos3();
+        if( shift_sign > 0 ) {
+            scan_start += rd_r * velocity_sign;
+        } else if( shift_sign < 0 ) {
+            scan_start += rd_l * velocity_sign;
+        }
 
         point scan_vec = ray_delta * velocity_sign;
 
-        point veh_plus_y_vec_x = rd_x.rotate( 1 );
-        point veh_plus_y_vec_y = rd_y.rotate( 1 );
+        bool scan_res_l = scan_rails_from_veh_internal( m, veh, scan_start, vyp_l, scan_vec );
+        bool scan_res_r = scan_rails_from_veh_internal( m, veh, scan_start, vyp_r, scan_vec );
 
-        tripoint scan_start = veh.global_pos3();
-
-        if( shift_sign > 0 ) {
-            scan_start -= veh_plus_y_vec_x * velocity_sign;
-        } else if( shift_sign < 0 ) {
-            scan_start -= veh_plus_y_vec_y * velocity_sign;
-        }
-
-        bool scan_res_x = scan_rails_from_veh_internal( m, veh, scan_start, veh_plus_y_vec_x, scan_vec );
-        bool scan_res_y = scan_rails_from_veh_internal( m, veh, scan_start, veh_plus_y_vec_y, scan_vec );
-
-        if( scan_res_x || scan_res_y ) {
+        if( scan_res_l || scan_res_r ) {
             if( shift_amt ) {
                 *shift_amt = scan_start - veh.global_pos3();
             }

--- a/tests/vehicle_rails_test.cpp
+++ b/tests/vehicle_rails_test.cpp
@@ -629,7 +629,42 @@ static map_helpers::canvas rails_tee_diag()
     };
 }
 
-static map_helpers::canvas rails_straight_shifting()
+static map_helpers::canvas rails_straight_shifting_left()
+{
+    return { {
+            U".x..x..x...",
+            U".x..x..x...",
+            U".x..x..x...",
+            U".x..x..x...",
+            U".x..o..x...",
+            U".x..x..x...",
+            U".x..x..x...",
+            U".x..x..x...",
+            U".x..x..x...",
+            U".x..x..x...",
+            U".x..x..x...",
+            U"..x..x..x..",
+            U"..x..x..x..",
+            U"..x..x..x..",
+            U"..x..x..x..",
+            U"..x..x..x..",
+            U"..x..x..x..",
+            U"...x..x..x.",
+            U"...x..x..x.",
+            U"...x..x..x.",
+            U"...x..x..x.",
+            U"...x..x..x.",
+            U"...x..x..x.",
+            U"...x..*..x.",
+            U"...x..x..x.",
+            U"...x..x..x.",
+            U"...x..x..x.",
+            U"...x..x..x.",
+        }
+    };
+}
+
+static map_helpers::canvas rails_straight_shifting_right()
 {
     return { {
             U"...x..x..x.",
@@ -664,7 +699,7 @@ static map_helpers::canvas rails_straight_shifting()
     };
 }
 
-static map_helpers::canvas rails_diag_shifting()
+static map_helpers::canvas rails_diag_shifting_left()
 {
     return { {
             U"....................x..x..x..",
@@ -696,6 +731,40 @@ static map_helpers::canvas rails_diag_shifting()
             U"..x..........................",
             U".x...........................",
             U"x............................"
+        }
+    };
+}
+
+static map_helpers::canvas rails_diag_shifting_right()
+{
+    return { {
+            U"......................x..x..x..",
+            U".....................x..x..x...",
+            U"....................x..x..x....",
+            U"...................x..x..x.....",
+            U"..................x..o..x......",
+            U".................x..x..x.......",
+            U"................x..x..x........",
+            U"...............x..x..x.........",
+            U"..............x..x..x..........",
+            U".............x..x..x...........",
+            U"...........xx.xx.xx............",
+            U"..........x..x..x..............",
+            U".........x..x..x...............",
+            U".......xx.xx.xx................",
+            U"......x..x..x..................",
+            U".....x..x..x...................",
+            U"....x..x..x....................",
+            U"...x..x..x.....................",
+            U"..x..*..x......................",
+            U".x..x..x.......................",
+            U"x..x..x........................",
+            U"..x..x.........................",
+            U".x..x..........................",
+            U"x..x...........................",
+            U"..x............................",
+            U".x.............................",
+            U"x.............................."
         }
     };
 }
@@ -983,7 +1052,7 @@ TEST_CASE( "vehicle_rail_movement_fork", "[vehicle][railroad]" )
 TEST_CASE( "vehicle_rail_movement_shifting", "[vehicle][railroad]" )
 {
     clear_all_state();
-    SECTION( "rails_straight_shifting" ) {
+    SECTION( "rails_straight_shifting_left" ) {
         // Rail vehicle must shift by 1 tile left or right
         // if the rails shift left or right
         run_test_case( test_case{
@@ -993,7 +1062,7 @@ TEST_CASE( "vehicle_rail_movement_shifting", "[vehicle][railroad]" )
             -90_degrees,
             -90_degrees,
             -90_degrees,
-            rails_straight_shifting()
+            rails_straight_shifting_left()
         } );
 
         run_test_case( test_case{
@@ -1003,10 +1072,33 @@ TEST_CASE( "vehicle_rail_movement_shifting", "[vehicle][railroad]" )
             -90_degrees,
             -90_degrees,
             -90_degrees,
-            rails_straight_shifting()
+            rails_straight_shifting_left()
         } );
     }
-    SECTION( "rails_diag_shifting" ) {
+    SECTION( "rails_straight_shifting_right" ) {
+        // Rail vehicle must shift by 1 tile left or right
+        // if the rails shift left or right
+        run_test_case( test_case{
+            "motorcycle_rail",
+            tcscope::full,
+            -90_degrees,
+            -90_degrees,
+            -90_degrees,
+            -90_degrees,
+            rails_straight_shifting_right()
+        } );
+
+        run_test_case( test_case{
+            "motorized_draisine_trirail",
+            tcscope::full,
+            -90_degrees,
+            -90_degrees,
+            -90_degrees,
+            -90_degrees,
+            rails_straight_shifting_right()
+        } );
+    }
+    SECTION( "rails_diag_shifting_left" ) {
         // Same as above, but for diagonal case
         run_test_case( test_case{
             "motorcycle_rail",
@@ -1015,7 +1107,7 @@ TEST_CASE( "vehicle_rail_movement_shifting", "[vehicle][railroad]" )
             -45_degrees,
             -45_degrees,
             -45_degrees,
-            rails_diag_shifting()
+            rails_diag_shifting_left()
         } );
 
         run_test_case( test_case{
@@ -1025,7 +1117,29 @@ TEST_CASE( "vehicle_rail_movement_shifting", "[vehicle][railroad]" )
             -45_degrees,
             -45_degrees,
             -45_degrees,
-            rails_diag_shifting()
+            rails_diag_shifting_left()
+        } );
+    }
+    SECTION( "rails_diag_shifting_right" ) {
+        // Same as above, but for diagonal case
+        run_test_case( test_case{
+            "motorcycle_rail",
+            tcscope::full,
+            -45_degrees,
+            -45_degrees,
+            -45_degrees,
+            -45_degrees,
+            rails_diag_shifting_right()
+        } );
+
+        run_test_case( test_case{
+            "motorized_draisine_trirail",
+            tcscope::full,
+            -45_degrees,
+            -45_degrees,
+            -45_degrees,
+            -45_degrees,
+            rails_diag_shifting_right()
         } );
     }
 }


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fix edge case in movement over diagonal rails"

#### Purpose of change
Fix a bug with rail movement discovered during development.
"Shifting" movement (see #1634) on diagonal rails didn't work properly at some rotations when shifting right.

#### Describe the solution
Fix vector math, add tests. Also add tests for shifting left on straight rails to ensure correctness.

#### Testing
Automated tests, also tested on practice in an in-progress dev branch.