### PR TITLE
Removed unused variables

### DIFF
--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -960,12 +960,10 @@ cata::optional<std::vector<navigation_step>> vehicle::autodrive_controller::comp
                                    veh_pos.raw().xy(), to_orientation( driven_veh.face.dir() ) );
     known_nodes.emplace( start, make_start_node( start, driven_veh ) );
     open_set.push( scored_address{ start, 0 } );
-    int search_count = 0;
     std::vector<std::pair<node_address, navigation_node>> next_nodes;
     while( !open_set.empty() ) {
         const node_address cur_addr = open_set.top().addr;
         open_set.pop();
-        search_count++;
         const navigation_node &cur_node = known_nodes[cur_addr];
         if( cur_node.is_goal ) {
             node_address addr = cur_addr;

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -658,14 +658,11 @@ void worldfactory::draw_mod_list( const catacurses::window &w, int &start, size_
         const int wwidth = getmaxx( w ) - 1 - 3; // border (1) + ">> " (3)
 
         unsigned int iNum = 0;
-        int index = 0;
         bool bKeepIter = false;
-        int iCatBeforeCursor = 0;
 
         for( size_t i = 0; i <= iActive; i++ ) {
             if( !mSortCategory[i].empty() ) {
                 iActive++;
-                iCatBeforeCursor++;
             }
         }
 
@@ -678,7 +675,7 @@ void worldfactory::draw_mod_list( const catacurses::window &w, int &start, size_
         }
 
         int larger = ( iMaxRows > static_cast<int>( iModNum ) ) ? static_cast<int>( iModNum ) : iMaxRows;
-        for( auto iter = mods.begin(); iter != mods.end(); ++index ) {
+        for( auto iter = mods.begin(); iter != mods.end(); ) {
             if( iNum >= static_cast<size_t>( start ) && iNum < static_cast<size_t>( start + larger ) ) {
                 if( !mSortCategory[iNum].empty() ) {
                     bKeepIter = true;

--- a/tests/colony_test.cpp
+++ b/tests/colony_test.cpp
@@ -472,7 +472,6 @@ TEST_CASE( "colony insert and erase", "[colony]" )
                 ++count;
             }
         }
-        int count2 = 0;
         for( cata::colony<int>::iterator it = test_colony.begin(); it != test_colony.end(); ) {
             if( ( xor_rand() & 7 ) == 0 ) {
                 it = test_colony.erase( it );
@@ -480,7 +479,6 @@ TEST_CASE( "colony insert and erase", "[colony]" )
             } else {
                 ++it;
             }
-            ++count2;
         }
     }
 


### PR DESCRIPTION
#### Summary

SUMMARY: Build "Remove some unused variables"

#### Purpose of change

Newer versions of clang will throw warnings regarding some set but unused variables.

#### Describe the solution

Get rid of the unused variables.