### PR TITLE
Change id of core content pack from 'dda' to 'bn'

### DIFF
--- a/data/mods/Aftershock/modinfo.json
+++ b/data/mods/Aftershock/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Maleclypse", "Candlebury" ],
     "description": "Drifts the game away from realism and more towards sci-fi.  Long term goal of being a significantly different experience that remains compatible with other mods.",
     "category": "content",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "//": "We have our own headless zombies that were added first!",

--- a/data/mods/CRT_EXPANSION/modinfo.json
+++ b/data/mods/CRT_EXPANSION/modinfo.json
@@ -7,6 +7,6 @@
     "maintainers": [ "Soupster89" ],
     "description": "Adds a plethora of content: professions, guns/mods, WIP enemies, mutations, martial arts, melee weapons, and some QOL changes such as plants from cutting grass.",
     "category": "content",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/Craft_Gunpowder/modinfo.json
+++ b/data/mods/Craft_Gunpowder/modinfo.json
@@ -7,6 +7,6 @@
     "maintainers": [ "Noctifer-de-Mortem" ],
     "description": "Adds more craftable firearms, and gunpowder.",
     "category": "items",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/CrazyCataclysm/modinfo.json
+++ b/data/mods/CrazyCataclysm/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Kevin" ],
     "description": "Want a little crazy in your Cataclysm?  Try this one.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/Dark-Skies-Above/modinfo.json
+++ b/data/mods/Dark-Skies-Above/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "ephemeral_storyteller" ],
     "description": "A total conversion that shifts the Cataclysm towards an XCOM 2 style alien occupation. Use other mods at your own risk!",
     "category": "content",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/DeoxyMod/modinfo.json
+++ b/data/mods/DeoxyMod/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Deoxy", "Llamageddon" ],
     "description": "Makes solar panels and several other parts foldable, and adds foldable quarterboards.",
     "category": "vehicles",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/DinoMod/modinfo.json
+++ b/data/mods/DinoMod/modinfo.json
@@ -6,6 +6,6 @@
     "maintainers": [ "ephemeralstoryteller", "damien", "LyleSy" ],
     "description": "Adds dinosaurs. Some rideable, others less friendly. Life will find a way.",
     "category": "creatures",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/EW_Pack/modinfo.json
+++ b/data/mods/EW_Pack/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Icecoon", "community" ],
     "description": "For those gun nuts.  Don't have enough near-future firearms in your life?  Add this mod today!",
     "category": "items",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/FictonalWeapons/modinfo.json
+++ b/data/mods/FictonalWeapons/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "BorkBorkGoesTheCode" ],
     "description": "Adds a bunch of rare, fictional weapons.",
     "category": "items",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Fuji_Mil_Prof/modinfo.json
+++ b/data/mods/Fuji_Mil_Prof/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "Fuji" ],
     "description": "Numerous military themed professions",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/Fuji_Structures/modinfo.json
+++ b/data/mods/Fuji_Structures/modinfo.json
@@ -6,7 +6,7 @@
     "description": "Adds more buildings and more variations to existing buildings.  (Requires More Locations)",
     "category": "buildings",
     "authors": "Fuji",
-    "dependencies": [ "dda", "more_locations" ],
+    "dependencies": [ "bn", "more_locations" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Generic_Guns/modinfo.json
+++ b/data/mods/Generic_Guns/modinfo.json
@@ -7,6 +7,6 @@
     "maintainers": [ "Viss Valdyr" ],
     "description": "Replaces guns and ammo with generic types.  Warning: can cause issues with other gun mods.",
     "category": "items",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/Graphical_Overmap/modinfo.json
+++ b/data/mods/Graphical_Overmap/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Larwick" ],
     "description": "Gives the overmap a graphical overhaul.  Please refer to readme for installation.",
     "category": "graphical",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Graphical_Overmap_FujiStruct/modinfo.json
+++ b/data/mods/Graphical_Overmap_FujiStruct/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Kilvoctu" ],
     "description": "Fuji Structures mod support for Larwick's Overmap.",
     "category": "graphical",
-    "dependencies": [ "dda", "Graphical_Overmap", "FujiStruct" ],
+    "dependencies": [ "bn", "Graphical_Overmap", "FujiStruct" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Graphical_Overmap_More_Locations/modinfo.json
+++ b/data/mods/Graphical_Overmap_More_Locations/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Kilvoctu" ],
     "description": "More Locations mod support for Larwick's Overmap.",
     "category": "graphical",
-    "dependencies": [ "dda", "Graphical_Overmap", "more_locations" ],
+    "dependencies": [ "bn", "Graphical_Overmap", "more_locations" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Graphical_Overmap_Urban_Development/modinfo.json
+++ b/data/mods/Graphical_Overmap_Urban_Development/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Kilvoctu" ],
     "description": "Urban Development mod support for Larwick's Overmap.",
     "category": "graphical",
-    "dependencies": [ "dda", "Graphical_Overmap", "Urban_Development" ],
+    "dependencies": [ "bn", "Graphical_Overmap", "Urban_Development" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Growable_pots/modinfo.json
+++ b/data/mods/Growable_pots/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Honcharuk" ],
     "description": "Allows you to grow seeds in craftable garden pots that can be carried around as items.  Perfect for the nomadic botanist.",
     "category": "items",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/HeavyMining/modinfo.json
+++ b/data/mods/HeavyMining/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Ckpyt in the forest" ],
     "description": "Adds a few mining vehicles, requires Tanks and Other Vehicles as it is no longer dependent on blazemod.",
     "category": "vehicles",
-    "dependencies": [ "dda", "Tanks" ],
+    "dependencies": [ "bn", "Tanks" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Hydroponics/modinfo.json
+++ b/data/mods/Hydroponics/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Tiny Hippo" ],
     "description": "Adds hydroponic units, a furniture which can have crops planted in it for increased yields.  Spawn occasionally in labs or basements.  Or build your own.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/MMA/modinfo.json
+++ b/data/mods/MMA/modinfo.json
@@ -7,6 +7,6 @@
     "maintainers": [ "Hymore246" ],
     "description": "A collection of fictional, mythologically inspired or otherwise unrealistic martial arts.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/Magiclysm/modinfo.json
+++ b/data/mods/Magiclysm/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "KorGgenT" ],
     "description": "Cataclysm but with magic spells!",
     "category": "content",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "skill",

--- a/data/mods/ManualBionicInstall/modinfo.json
+++ b/data/mods/ManualBionicInstall/modinfo.json
@@ -7,6 +7,6 @@
     "maintainers": [ "Xhuis" ],
     "description": "Allows CBMs to be installed by hand.  Pairs well with Safe Autodoc.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/Medieval_Stuff/modinfo.json
+++ b/data/mods/Medieval_Stuff/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Chaosvolt" ],
     "description": "Assorted fun classes and shields for the wannabe knight, legionary, and more.",
     "category": "items",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Modular_Turrets/modinfo.json
+++ b/data/mods/Modular_Turrets/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Sunshine" ],
     "description": "Gives turrets swappable firearm modules, which can be reclaimed from broken robots.",
     "category": "creatures",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/More_Locations/modinfo.json
+++ b/data/mods/More_Locations/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Sunshine" ],
     "description": "Adds new Z-level buildings and dungeons.  Still unpolished.  Before generating a world, you can remove subfolders to nix unwanted locations.",
     "category": "buildings",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/More_Survival_Tools/modinfo.json
+++ b/data/mods/More_Survival_Tools/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "DangerNoodle" ],
     "description": "For those who prefer being innawoods.  Adds several tools, various recipes additions/tweaks, plus two new professions.",
     "category": "items",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Mundane_Zombies/modinfo.json
+++ b/data/mods/Mundane_Zombies/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Theundyingcode" ],
     "description": "Removes all special zombies from the game.",
     "category": "monster_exclude",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/Mutant_NPCs/modinfo.json
+++ b/data/mods/Mutant_NPCs/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Spencer Michaels" ],
     "description": "NPCs wandering the wasteland will occasionally have mutations --- your foes included.  Beware!",
     "category": "misc_additions",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/My_Sweet_Cataclysm/modinfo.json
+++ b/data/mods/My_Sweet_Cataclysm/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Fris0uman" ],
     "description": "In the wake of the Cataclysm sweets and snacks are coming to life.  You could be one of them and walk through the Cataclysm as a human shaped piece of sugar with your pet necco wafer, or you could just hunt them for some sweet treats.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/NW_Pack/modinfo.json
+++ b/data/mods/NW_Pack/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Zaweri" ],
     "description": "Adds recipes for replicas of mythological weapons.",
     "category": "items",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/National_Guard_Camp/modinfo.json
+++ b/data/mods/National_Guard_Camp/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "acidia" ],
     "description": "Help test the national guard camp before inclusion into the base game.  Provide feedback in the thread under 'The Lab'",
     "category": "buildings",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/No_Acid_Zombies/modinfo.json
+++ b/data/mods/No_Acid_Zombies/modinfo.json
@@ -5,7 +5,7 @@
     "name": "No Acid Zombies",
     "description": "Removes all acid-based zombies from the game.",
     "category": "monster_exclude",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "MONSTER_BLACKLIST",

--- a/data/mods/No_Anthills/modinfo.json
+++ b/data/mods/No_Anthills/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Inglonias" ],
     "description": "Removes ants and anthills from the game",
     "category": "monster_exclude",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/No_Beehives/modinfo.json
+++ b/data/mods/No_Beehives/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Inglonias" ],
     "description": "Removes bees and beehives from the game",
     "category": "monster_exclude",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/No_Big_Zombies/modinfo.json
+++ b/data/mods/No_Big_Zombies/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Inglonias" ],
     "description": "Removes shocker brutes, zombie hulks, and skeletal juggernauts from the game.",
     "category": "monster_exclude",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/No_Explosive_Zombies/modinfo.json
+++ b/data/mods/No_Explosive_Zombies/modinfo.json
@@ -5,7 +5,7 @@
     "name": "No Explosive Zombies",
     "description": "Removes all explosion-based zombies from the game.",
     "category": "monster_exclude",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "MONSTER_BLACKLIST",

--- a/data/mods/No_Filthy_Clothes/modinfo.json
+++ b/data/mods/No_Filthy_Clothes/modinfo.json
@@ -5,7 +5,7 @@
     "name": "No Filthy Clothing",
     "description": "Clothes dropped by zombies will be completely clean.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/No_Flaming_Weapons/modinfo.json
+++ b/data/mods/No_Flaming_Weapons/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "tungtn" ],
     "description": "Removes flaming melee weapons.",
     "category": "item_exclude",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/No_Fungi/modinfo.json
+++ b/data/mods/No_Fungi/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Chaosvolt" ],
     "description": "Removes fungal monsters and regions from the game.",
     "category": "monster_exclude",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "MONSTER_BLACKLIST",

--- a/data/mods/No_Hope/modinfo.json
+++ b/data/mods/No_Hope/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Night_Pryanik" ],
     "description": "- No more guaranteed loot spawns anywhere.\n- Loot spawn in buildings is drastically reduced, especially for food, tools, guns etc.\n- Most buildings are destroyed, vandalized, or looted.\n- Most cars are destroyed or at least damaged.  Intact cars are nearly impossible to find.\n- Fuel is much harder to find, almost all cars have no fuel in tanks.\n- Marauders, looters, and bandits everywhere.\n\nSee extended description in README.md.",
     "category": "content",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "version": "3.0"
   },
   {

--- a/data/mods/No_Lift_Requirements/modinfo.json
+++ b/data/mods/No_Lift_Requirements/modinfo.json
@@ -6,7 +6,7 @@
     "authors": "Wad67",
     "description": "Strength checks and lifting qualities are no longer required for installing or removing vehicle parts.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "WORLD_OPTION",

--- a/data/mods/No_Medieval_Items/modinfo.json
+++ b/data/mods/No_Medieval_Items/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Rivet-the-Zombie" ],
     "description": "Removes medieval weapons, armors, and specific books.",
     "category": "item_exclude",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/No_Mutagen/modinfo.json
+++ b/data/mods/No_Mutagen/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Kevin Granade" ],
     "description": "Removes mutagen items from the game.",
     "category": "item_exclude",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/No_NPC_Food/modinfo.json
+++ b/data/mods/No_NPC_Food/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Coolthulhu" ],
     "description": "Makes NPCs not require food, water or rest.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/No_Old_guns/modinfo.json
+++ b/data/mods/No_Old_guns/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Rivet-the-Zombie", "Cyrano7" ],
     "description": "Removes all black powder and pre-Cold War firearms.",
     "category": "item_exclude",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/No_Rail_Stations/modinfo.json
+++ b/data/mods/No_Rail_Stations/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "Inglonias" ],
     "description": "Removes above-ground rail stations from the game.",
     "category": "buildings",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/No_Religious_Books/modinfo.json
+++ b/data/mods/No_Religious_Books/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "dvolk" ],
     "description": "Removes religious text items from the game.",
     "category": "item_exclude",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/No_Reviving/modinfo.json
+++ b/data/mods/No_Reviving/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Prevent Zombie Revivication",
     "description": "Disables zombie revival.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "monster_adjustment",

--- a/data/mods/No_Rivtech_Guns/modinfo.json
+++ b/data/mods/No_Rivtech_Guns/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "tungtn/community" ],
     "description": "Removes fictional conventional firearms and ammunition.",
     "category": "item_exclude",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/No_Survivor_Armor/modinfo.json
+++ b/data/mods/No_Survivor_Armor/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "tungtn" ],
     "description": "Removes survivor armor.",
     "category": "item_exclude",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Old_Mutations/modinfo.json
+++ b/data/mods/Old_Mutations/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Coolthulhu" ],
     "description": "Makes mutations work like before, without balancing changes and mutagen accumulation.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/Only_Wildlife/modinfo.json
+++ b/data/mods/Only_Wildlife/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Kodi Arfer" ],
     "description": "Removes all monsters from the game, save for those in the WILDLIFE category.",
     "category": "monster_exclude",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "MONSTER_WHITELIST",

--- a/data/mods/RL_Classes/modinfo.json
+++ b/data/mods/RL_Classes/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Rivet-the-Zombie" ],
     "description": "Adds a set of professions which correspond to classic Roguelike character archetypes.",
     "category": "rebalance",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Salvaged_Robots/modinfo.json
+++ b/data/mods/Salvaged_Robots/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Anyone" ],
     "description": "Expands the types of robots and allows players to jury-rig broken robots into functioning companions.",
     "category": "creatures",
-    "dependencies": [ "dda", "modular_turrets" ],
+    "dependencies": [ "bn", "modular_turrets" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Sleep_Deprivation/modinfo.json
+++ b/data/mods/Sleep_Deprivation/modinfo.json
@@ -8,6 +8,6 @@
     "description": "Enables sleep deprivation mechanics independently of a player's fatigue.",
     "category": "rebalance",
     "obsolete": true,
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/StatsThroughSkills/modinfo.json
+++ b/data/mods/StatsThroughSkills/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Ryan \"DeNarr\" Saige", "Kevin Granade" ],
     "description": "Allows stats to raise via skill progression.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "skill_boost",

--- a/data/mods/TEST_DATA/modinfo.json
+++ b/data/mods/TEST_DATA/modinfo.json
@@ -7,6 +7,6 @@
     "category": "content",
     "//": "Not really obsolete! Marked as such to prevent it from showing in the main list",
     "obsolete": true,
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/Tanks/modinfo.json
+++ b/data/mods/Tanks/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "BorkBorkGoesTheCode" ],
     "description": "Adds a few armored fighting vehicles and other such things, requires Vehicle Additions Pack.",
     "category": "vehicles",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Tolerate_This/modinfo.json
+++ b/data/mods/Tolerate_This/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "TechyBen" ],
     "description": "Some simple gluten free and lactose free alternative recipe options.  NOT EXHAUSTIVE.",
     "category": "items",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/UDP_BN_FAKE_SNOW/modinfo.json
+++ b/data/mods/UDP_BN_FAKE_SNOW/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "SomeDeadGuy" ],
     "description": "Covers outdoor tiles with fake snow graphics.",
     "category": "graphical",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/Urban_Development/modinfo.json
+++ b/data/mods/Urban_Development/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Fuji" ],
     "description": "Holder for suburban and urban buildings.",
     "category": "buildings",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/Zombie_Nightvision/modinfo.json
+++ b/data/mods/Zombie_Nightvision/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Zombie Nightvision",
     "description": "Gives all zombies perfect nightvision.",
     "category": "rebalance",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/alt_map_key/modinfo.json
+++ b/data/mods/alt_map_key/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "Sunshine" ],
     "description": "Changes the overmap to be more readable.  Buildings are color coded by type and use initial letter of their names instead of ^v<>.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/blazemod/modinfo.json
+++ b/data/mods/blazemod/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Blaze-whatdoyoumeanitsalreadytaken" ],
     "description": "Please see the included PAQ.txt in the mod folder if you encounter any issues.",
     "category": "vehicles",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/bn/modinfo.json
+++ b/data/mods/bn/modinfo.json
@@ -1,0 +1,11 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "bn",
+    "name": "Bright Nights",
+    "description": "Core content for Cataclysm-BN",
+    "category": "core",
+    "core": true,
+    "path": "../../json"
+  }
+]

--- a/data/mods/cbm_slots/modinfo.json
+++ b/data/mods/cbm_slots/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "anothersimulacrum" ],
     "description": "Enables the bionic slots system, which limits the number of CBMs you can install in each bodypart.",
     "category": "rebalance",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "path": ""
   }
 ]

--- a/data/mods/classic_zombies/modinfo.json
+++ b/data/mods/classic_zombies/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "I-am-Erk" ],
     "description": "(Formerly Classic Zombies): Only spawn classic zombies (normal zombies and zombie animals) and natural wildlife.  Zombies do not revive and do not need pulping.  This disables certain buildings and map extras.  The long term plan is to make this a classic zombie movie simulator set in the present day.  If you have this mod enabled in experimental, some items may disappear.",
     "category": "monster_exclude",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "monster_adjustment",

--- a/data/mods/dda/modinfo.json
+++ b/data/mods/dda/modinfo.json
@@ -2,10 +2,13 @@
   {
     "type": "MOD_INFO",
     "id": "dda",
-    "name": "Bright Nights",
-    "description": "Core content for Cataclysm-BN",
-    "category": "core",
-    "core": true,
-    "path": "../../json"
+    "//1": "This is for mods that use old core content pack id 'dda'.",
+    "//2": "Don't use it, use 'bn' instead.",
+    "//3": "TODO: remove this wrapper once BN 0.2 rolls out and add 'dda'->'bn' migration to replacements.json",
+    "name": "Bright Nights (wrapper)",
+    "description": "Compatibility wrapper for mods and saves that use old core content id format.  If you're a player, ignore this.",
+    "dependencies": [ "bn" ],
+    "obsolete": true,
+    "category": "content"
   }
 ]

--- a/data/mods/default.json
+++ b/data/mods/default.json
@@ -1,5 +1,5 @@
 [
-  "dda",
+  "bn",
   "no_npc_food",
   "novitamins",
   "elevated_bridges"

--- a/data/mods/desert_region/modinfo.json
+++ b/data/mods/desert_region/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Dpwb", "DracoGriffin" ],
     "description": "A testbed/WIP mod to showcase regional_map_settings JSON changes.",
     "category": "content",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "version": "0.1",
     "obsolete": false
   }

--- a/data/mods/elevated_bridges/modinfo.json
+++ b/data/mods/elevated_bridges/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "olanti-p" ],
     "description": "Enables generation of elevated bridges and construction of ramps.  Requires z-levels to be ON to properly work.  Elevated bridges do not block river tiles and allow boats to pass underneath.",
     "category": "content",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "path": ""
   }
 ]

--- a/data/mods/fast_healing/modinfo.json
+++ b/data/mods/fast_healing/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [  ],
     "description": "Increases broken limb mending speed and the effectiveness of healing items.",
     "category": "misc_additions",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/makeshift/modinfo.json
+++ b/data/mods/makeshift/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Noctifer-de-Mortem" ],
     "description": "Adds more improvised item variants and rebalances existing ones.",
     "category": "items",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/mapspecials_demo/modinfo.json
+++ b/data/mods/mapspecials_demo/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Sunshine" ],
     "description": "Demo for JSONized mapgens (megastore, missile silo).",
     "category": "buildings",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/more_classes_scenarios/modinfo.json
+++ b/data/mods/more_classes_scenarios/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Noctifer-de-Mortem" ],
     "description": "Adds new classes and scenarios while rebalancing some existing ones.",
     "category": "rebalance",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/necromancy/modinfo.json
+++ b/data/mods/necromancy/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "dambuk1" ],
     "description": "Adds the ability to revive creatures as minions.",
     "category": "magical",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   }
 ]

--- a/data/mods/no_scifi/modinfo.json
+++ b/data/mods/no_scifi/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "mugling" ],
     "description": "Removes far-future Sci-Fi items such as powered armor and energy weapons.",
     "category": "item_exclude",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "obsolete": true
   },
   {

--- a/data/mods/novitamins/modinfo.json
+++ b/data/mods/novitamins/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "mugling" ],
     "description": "Disables vitamin requirements.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/rural_biome/modinfo.json
+++ b/data/mods/rural_biome/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "I-am-Erk" ],
     "description": "Play in the boonies: nothing but farms, forests, and villages.  Recommended city size set to 1 and spacing set to 8.",
     "category": "content",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "bn" ],
     "version": "0.1",
     "obsolete": false
   }

--- a/data/mods/sees_player_hitbutton/modinfo.json
+++ b/data/mods/sees_player_hitbutton/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "esotericist", "AnthonBerg" ],
     "description": "Adds indicator icon if a creature sees the player.  Designed for the HitButton isometric tileset.",
     "category": "graphical",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/sees_player_retro/modinfo.json
+++ b/data/mods/sees_player_retro/modinfo.json
@@ -6,6 +6,6 @@
     "authors": [ "esotericist" ],
     "description": "Adds indicator icon if a creature sees the player.  Designed for the retrodays tileset.",
     "category": "graphical",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]

--- a/data/mods/speedydex/modinfo.json
+++ b/data/mods/speedydex/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "KorGgenT" ],
     "description": "Higher dex increases your speed.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/stats_through_kills/modinfo.json
+++ b/data/mods/stats_through_kills/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "KorGgenT" ],
     "description": "You gain XP from kills that you can spend on increasing your stats.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3406,7 +3406,7 @@ Example:
     // Mod version string. This is for users' and maintainers' convenience, so you can use whatever is most convenient here (e.g. date).
     "version": "02 Dec 2021",
     // List of mod's dependencies. Dependencies are guaranteed to be loaded before the mod is loaded.
-    "dependencies": [ "dda", "zed_templates" ],
+    "dependencies": [ "bn", "zed_templates" ],
     // List of mods that are incompatible with this mod.
     "conflicts": [ "worse_zeds" ],
     // Special flag for core game data, can only be used by total overhaul mods. Only 1 core mod can be loaded at a time.

--- a/doc/MODDING.md
+++ b/doc/MODDING.md
@@ -21,7 +21,7 @@ A barebones `modinfo.json` file looks like this:
     "authors": [ "Your name here", "Your friend's name if you want" ],
     "description": "Your description here",
     "category": "content",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   }
 ]
 ````
@@ -231,7 +231,7 @@ The entire mod can fit into fifteen lines of JSON, and it's presented below. Jus
     "name": "Prevent Zombie Revivication",
     "description": "Disables zombie revival.",
     "category": "rebalance",
-    "dependencies": [ "dda" ]
+    "dependencies": [ "bn" ]
   },
   {
     "type": "monster_adjustment",

--- a/src/assign.h
+++ b/src/assign.h
@@ -38,6 +38,11 @@ class is_optional : public detail::is_optional_helper<typename std::decay<T>::ty
 {
 };
 
+/**
+ * Check whether strict checks are enabled for given mod.
+ */
+bool is_strict_enabled( const std::string &src );
+
 inline void report_strict_violation( const JsonObject &jo, const std::string &message,
                                      const std::string &name )
 {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -281,7 +281,7 @@ void bionic_data::reset()
 
 void bionic_data::load( const JsonObject &jsobj, const std::string src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     mandatory( jsobj, was_loaded, "name", name );
     mandatory( jsobj, was_loaded, "description", description );

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -18,6 +18,7 @@
 #include "itype.h"
 #include "loading_ui.h"
 #include "material.h"
+#include "mod_manager.h"
 #include "npc.h"
 #include "output.h"
 #include "recipe.h"
@@ -40,7 +41,7 @@ bool game::dump_stats( const std::string &what, dump_mode mode,
     try {
         loading_ui ui( false );
         load_core_data( ui );
-        load_packs( _( "Loading content packs" ), { mod_id( "dda" ) }, ui );
+        load_packs( _( "Loading content packs" ), { mod_management::get_default_core_content_pack() }, ui );
         DynamicDataLoader::get_instance().finalize_loaded_data( ui );
     } catch( const std::exception &err ) {
         std::cerr << "Error loading data from json: " << err.what() << std::endl;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2732,7 +2732,7 @@ void game::load_world_modfiles( loading_ui &ui )
     if( std::none_of( mods.begin(), mods.end(), []( const mod_id & e ) {
     return e->core;
 } ) ) {
-        mods.insert( mods.begin(), mod_id( "dda" ) );
+        mods.insert( mods.begin(), mod_management::get_default_core_content_pack() );
     }
 
     load_artifacts( get_world_base_save_path() + "/" + SAVE_ARTIFACTS );

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -268,7 +268,7 @@ class generic_factory
          * @throws JsonError If loading fails for any reason (thrown by `T::load`).
          */
         void load( const JsonObject &jo, const std::string &src ) {
-            bool strict = src == "dda";
+            const bool strict = is_strict_enabled( src );
 
             static const std::string abstract_member_name( "abstract" );
 

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -67,7 +67,7 @@ bool harvest_list::has_entry_type( std::string type ) const
 
 harvest_entry harvest_entry::load( const JsonObject &jo, const std::string &src )
 {
-    const bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     harvest_entry ret;
     assign( jo, "drop", ret.drop, strict );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1698,7 +1698,7 @@ void Item_factory::load_ammo( const JsonObject &jo, const std::string &src )
 {
     itype def;
     if( load_definition( jo, src, def ) ) {
-        assign( jo, "stack_size", def.stack_size, src == "dda", 1 );
+        assign( jo, "stack_size", def.stack_size, is_strict_enabled( src ), 1 );
         if( def.was_loaded ) {
             if( def.ammo ) {
                 def.ammo->was_loaded = true;
@@ -1745,7 +1745,7 @@ void Item_factory::load_wheel( const JsonObject &jo, const std::string &src )
 
 void Item_factory::load( islot_fuel &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     assign( jo, "energy", slot.energy, strict, 0.001f );
     if( jo.has_member( "pump_terrain" ) ) {
@@ -1773,7 +1773,7 @@ void Item_factory::load_fuel( const JsonObject &jo, const std::string &src )
 
 void Item_factory::load( islot_gun &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     if( jo.has_member( "burst" ) && jo.has_member( "modes" ) ) {
         jo.throw_error( "cannot specify both burst and modes", "burst" );
@@ -1850,7 +1850,7 @@ void Item_factory::load_pet_armor( const JsonObject &jo, const std::string &src 
 
 void Item_factory::load( islot_armor &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     assign( jo, "encumbrance", slot.encumber, strict, 0 );
     assign( jo, "max_encumbrance", slot.max_encumber, strict, slot.encumber );
@@ -1869,7 +1869,7 @@ void Item_factory::load( islot_armor &slot, const JsonObject &jo, const std::str
 
 void Item_factory::load( islot_pet_armor &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     assign( jo, "material_thickness", slot.thickness, strict, 0 );
     assign( jo, "max_pet_vol", slot.max_vol, strict, 0_ml );
@@ -1882,7 +1882,7 @@ void Item_factory::load( islot_pet_armor &slot, const JsonObject &jo, const std:
 
 void Item_factory::load( islot_tool &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     if( jo.has_array( "ammo" ) ) {
         for( const std::string id : jo.get_array( "ammo" ) ) {
@@ -1933,7 +1933,7 @@ void Item_factory::load( relic &slot, const JsonObject &jo, const std::string & 
 
 void Item_factory::load( islot_mod &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     if( jo.has_array( "ammo_modifier" ) ) {
         for( const std::string id : jo.get_array( "ammo_modifier" ) ) {
@@ -1985,7 +1985,7 @@ void Item_factory::load_tool_armor( const JsonObject &jo, const std::string &src
 
 void Item_factory::load( islot_book &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     assign( jo, "max_level", slot.level, strict, 0, MAX_SKILL );
     assign( jo, "required_level", slot.req, strict, 0, MAX_SKILL );
@@ -2013,7 +2013,7 @@ void Item_factory::load_book( const JsonObject &jo, const std::string &src )
 
 void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     JsonObject relative = jo.get_object( "relative" );
     JsonObject proportional = jo.get_object( "proportional" );
@@ -2143,7 +2143,7 @@ void Item_factory::load_comestible( const JsonObject &jo, const std::string &src
 {
     itype def;
     if( load_definition( jo, src, def ) ) {
-        assign( jo, "stack_size", def.stack_size, src == "dda", 1 );
+        assign( jo, "stack_size", def.stack_size, is_strict_enabled( src ), 1 );
         load_slot( def.comestible, jo, src );
         load_basic_info( jo, def, src );
     }
@@ -2179,7 +2179,7 @@ void Item_factory::load( islot_container &slot, const JsonObject &jo, const std:
 
 void Item_factory::load( islot_gunmod &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     assign( jo, "damage_modifier", slot.damage, strict, damage_instance( DT_NULL, -20, -20, -20,
             -20 ) );
@@ -2235,7 +2235,7 @@ void Item_factory::load_gunmod( const JsonObject &jo, const std::string &src )
 
 void Item_factory::load( islot_magazine &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
     if( jo.has_array( "ammo_type" ) ) {
         slot.type.clear();
         for( const std::string &id : jo.get_array( "ammo_type" ) ) {
@@ -2279,7 +2279,7 @@ void Item_factory::load_battery( const JsonObject &jo, const std::string &src )
 
 void Item_factory::load( islot_bionic &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     if( jo.has_member( "bionic_id" ) ) {
         assign( jo, "bionic_id", slot.id, strict );
@@ -2399,7 +2399,7 @@ void Item_factory::npc_implied_flags( itype &item_template )
 
 void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     assign( jo, "category", def.category_force, strict );
     assign( jo, "weight", def.weight, strict, 0_gram );
@@ -2606,7 +2606,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     load_slot_optional( def.book, jo, "book_data", src );
     load_slot_optional( def.gun, jo, "gun_data", src );
     load_slot_optional( def.bionic, jo, "bionic_data", src );
-    assign( jo, "ammo_data", def.ammo, src == "dda" );
+    assign( jo, "ammo_data", def.ammo, is_strict_enabled( src ) );
     load_slot_optional( def.seed, jo, "seed_data", src );
     load_slot_optional( def.artifact, jo, "artifact_data", src );
     load_slot_optional( def.brewable, jo, "brewable", src );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -43,7 +43,7 @@ generic_factory<furn_t> furniture_data( "furniture" );
 
 bool is_json_check_strict( const std::string &src )
 {
-    return json_report_strict || src == "dda";
+    return json_report_strict || is_strict_enabled( src );
 }
 
 } // namespace

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -47,6 +47,7 @@
 #include "mapgenformat.h"
 #include "memory_fast.h"
 #include "mission.h"
+#include "mod_manager.h"
 #include "mongroup.h"
 #include "npc.h"
 #include "omdata.h"
@@ -2403,7 +2404,9 @@ bool mapgen_function_json_base::setup_common( const JsonObject &jo )
     format.resize( static_cast<size_t>( mapgensize.x * mapgensize.y ) );
     // just like mapf::basic_bind("stuff",blargle("foo", etc) ), only json input and faster when applying
     if( jo.has_array( "rows" ) ) {
-        mapgen_palette palette = mapgen_palette::load_temp( jo, "dda" );
+        // TODO: forward correct 'src' parameter
+        mapgen_palette palette = mapgen_palette::load_temp( jo,
+                                 mod_management::get_default_core_content_pack().str() );
         auto &format_terrain = palette.format_terrain;
         auto &format_furniture = palette.format_furniture;
         auto &format_placings = palette.format_placings;

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -236,7 +236,7 @@ void assign_function( const JsonObject &jo, const std::string &id, Fun &target,
 
 void mission_type::load( const JsonObject &jo, const std::string &src )
 {
-    const bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     mandatory( jo, was_loaded, "name", name );
 

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -358,7 +358,17 @@ cata::optional<t_mod_list> load_mod_list( const std::string &path )
     }
 }
 
+mod_id get_default_core_content_pack()
+{
+    return mod_id( "bn" );
+}
+
 } // namespace mod_management
+
+bool is_strict_enabled( const std::string &src )
+{
+    return src == mod_management::get_default_core_content_pack().str();
+}
 
 void mod_manager::add_mods( std::vector<MOD_INFORMATION> &&list )
 {

--- a/src/mod_manager.h
+++ b/src/mod_manager.h
@@ -119,6 +119,12 @@ bool save_mod_list( const t_mod_list &list, const std::string &path );
  * @returns cata::nullopt on error.
  */
 cata::optional<t_mod_list> load_mod_list( const std::string &path );
+
+/**
+ * Get id of default core content pack.
+ */
+mod_id get_default_core_content_pack();
+
 } // namespace mod_management
 
 class mod_manager

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -682,7 +682,7 @@ class mon_attack_effect_reader : public generic_typed_reader<mon_attack_effect_r
 
 void mtype::load( const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     MonsterGenerator &gen = MonsterGenerator::generator();
 
@@ -1052,7 +1052,7 @@ mtype_special_attack MonsterGenerator::create_actor( const JsonObject &obj,
 
 void mattack_actor::load( const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     // Legacy support
     if( !jo.has_string( "id" ) ) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -374,7 +374,7 @@ std::string overmap_land_use_code::get_symbol() const
 
 void overmap_land_use_code::load( const JsonObject &jo, const std::string &src )
 {
-    const bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
     assign( jo, "land_use_code", land_use_code, strict );
     assign( jo, "name", name, strict );
     assign( jo, "detailed_definition", detailed_definition, strict );
@@ -642,7 +642,7 @@ std::string oter_type_t::get_symbol() const
 
 void oter_type_t::load( const JsonObject &jo, const std::string &src )
 {
-    const bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     optional( jo, was_loaded, "sym", symbol, unicode_codepoint_from_symbol_reader, NULL_UNICODE );
 
@@ -991,7 +991,7 @@ bool overmap_special::can_belong_to_city( const tripoint_om_omt &p, const city &
 
 void overmap_special::load( const JsonObject &jo, const std::string &src )
 {
-    const bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
     // city_building is just an alias of overmap_special
     // TODO: This comparison is a hack. Separate them properly.
     const bool is_special = jo.get_string( "type", "" ) == "overmap_special";

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -96,7 +96,7 @@ bool recipe::has_flag( const std::string &flag_name ) const
 
 void recipe::load( const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     abstract = jo.has_string( "abstract" );
 

--- a/src/rotatable_symbols.cpp
+++ b/src/rotatable_symbols.cpp
@@ -37,7 +37,7 @@ namespace rotatable_symbols
 void load( const JsonObject &jo, const std::string &src )
 {
     const std::string tuple_key = "tuple";
-    const bool strict = src == "dda";
+    const bool strict = is_strict_enabled( src );
 
     std::vector<std::string> tuple_temp;
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -42,6 +42,7 @@
 #include "language.h"
 #include "loading_ui.h"
 #include "map.h"
+#include "mod_manager.h"
 #include "options.h"
 #include "output.h"
 #include "overmap.h"
@@ -271,8 +272,9 @@ int main( int argc, const char *argv[] )
     std::vector<const char *> arg_vec( argv, argv + argc );
 
     std::vector<mod_id> mods = extract_mod_selection( arg_vec );
-    if( std::find( mods.begin(), mods.end(), mod_id( "dda" ) ) == mods.end() ) {
-        mods.insert( mods.begin(), mod_id( "dda" ) ); // @todo move unit test items to core
+    mod_id def_core_mod_id = mod_management::get_default_core_content_pack();
+    if( std::find( mods.begin(), mods.end(), def_core_mod_id ) == mods.end() ) {
+        mods.insert( mods.begin(), def_core_mod_id ); // @todo move unit test items to core
     }
 
     option_overrides_t option_overrides_for_test_suite = extract_option_overrides( arg_vec );


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Changed id of core content pack from 'dda' to 'bn'"

#### Purpose of change
At the moment, DDA and BN share the same core content pack id - `dda`. Because of that, any external DDA-compatible mod installed on BN will show up as compatible with BN in UI, but will throw arcane errors when attempting to load the world.

#### Describe the solution
Migrate to new content pack id:
* Create a new core content pack mod that's just a copy of existing `dda` mod, but with id `bn`
* Make `dda` into an empty obsolete mod that depends on `bn`
* Change all mainline mods to depend on new `bn`
* Adjust C++ code to use new id for core content pack 

This way:
* All mainline mods show up as depending on `Bright Nights`
* All external mods that haven't migrated will show up as depending on `Bright Nights (wrapper)`, but will keep functioning
* All existing saves will have the new `bn` mod automagically loaded because `dda` now depends on it
* Once the next stable rolls out and external mods have migrated to depend on `bn`, we can remove `dda` mod which will make all mods that depend on `dda` (DDA mods) incompatible with BN.

#### Describe alternatives you've considered
Hack it by adding `"is_compatible_with_bn": true` to `MODINFO` object.

#### Testing
* Created new world with no mods
* Created new world with mainline mods
* Created new world with mainline mods before migrating them to new id, `Bright Nights (wrapper)` gets automatically added to mod list
* Loaded an existing save that has only `dda` in its mod list, `Bright Nights` gets automatically loaded before `Bright Nights (wrapper)`, but save's mod list stays unchanged (expected behavior)
* Removed `dda` mod, added `dda`->`bn` migration to `data/mods/replacements.json` and tried to create new (or load existing) world. Result: mods that depend on `bn` work as expected, mods that depend on `dda` show missing dependency, saves that use `dda` have their mod list updated to use `bn`