### PR TITLE
Fix submap rotation rotating vehicles

### DIFF
--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -284,7 +284,7 @@ void submap::rotate( int turns )
         const auto new_pos = rotate_point( elem->pos );
 
         elem->pos = new_pos;
-        elem->set_facing( turns * 90_degrees );
+        elem->set_facing( elem->turn_dir + turns * 90_degrees );
     }
 
     std::map<point, computer> rot_comp;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix vehicles being incorrectly rotated when spawning"

#### Purpose of change

Fixes #2107. 

#### Describe the solution

This is something I broke when changing ramps. The rotation wasn't taking into account the vehicle's current facing. 

#### Testing

I generated a dairy farm house at a bunch of rotations. The truck outside was oriented correctly.
