### PR TITLE
Label PRs automatically

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+src:
+  - src/**/*
+
+tests:
+  - tests/**/*
+
+data:
+  - data/**/*
+
+mods:
+  - data/mods/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,3 +9,6 @@ data:
 
 mods:
   - data/mods/**/*
+
+translation:
+  - lang/**/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,17 @@
+name: Label Pull Requests
+
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Label new PRs automatically"

#### Purpose of change

It's often hard to see how much impact a PR would make. adding a corresponding label helps identifying each PRs and prioritizing them.

#### Describe the solution

![image](https://user-images.githubusercontent.com/54838975/198058061-c07b5f9c-592b-4563-bff2-2cc1501eb77a.png)

added [labeler](https://github.com/actions/labeler) that labels PRs matching these categories automatically: 
- src/
- tests/
- data/
- data/mods
- lang/

#### Additional context

made corresponding labels to be added:
![_01](https://user-images.githubusercontent.com/54838975/198052556-593f186a-8b9b-4e2b-a9ca-6d1dfb7d0e15.png)
![_02](https://user-images.githubusercontent.com/54838975/198052564-2483b9c2-ad9c-4650-9c77-fd0218503de4.png)
![_03](https://user-images.githubusercontent.com/54838975/198052568-acb972b8-ad3d-4ca0-bb89-0dd6e6a4064a.png)
![_04](https://user-images.githubusercontent.com/54838975/198052573-7dcbf25c-29a5-43b8-a6b5-5cfa593c43d7.png)

more labels could be added as well (such as `repo`, `lang`, `graphic`, etc) 