### PR TITLE
Fix false positive no return warnings in msvc

### DIFF
--- a/src/cata_unreachable.h
+++ b/src/cata_unreachable.h
@@ -1,0 +1,42 @@
+#pragma once
+#ifndef CATA_SRC_CATA_UNREACHABLE_H
+#define CATA_SRC_CATA_UNREACHABLE_H
+
+namespace cata
+{
+
+/**
+ * @brief Marks unreachable code.
+ *
+ * Utility function to mark unreachable code to help compiler with optimizations.
+ *
+ * Usage:
+ *     void ( bool always_true )
+ *     {
+ *       if ( always_true ) {
+ *         return;
+ *       } else {
+ *         // If always_true happens to be false, this will cause Undefined Behavior.
+ *         cata::unreachable();
+ *       }
+ *     }
+ *
+ * Source: https://stackoverflow.com/a/65258501
+ */
+#ifdef __GNUC__ // GCC 4.8+, Clang, Intel and other compilers compatible with GCC (-std=c++0x or above)
+[[noreturn]] inline __attribute__( ( always_inline ) ) void unreachable()
+{
+    __builtin_unreachable();
+}
+#elif defined(_MSC_VER) // MSVC
+[[noreturn]] __forceinline void unreachable()
+{
+    __assume( false );
+}
+#else // ???
+inline void unreachable() {}
+#endif
+
+} // namespace cata
+
+#endif // CATA_SRC_CATA_UNREACHABLE_H

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -10,6 +10,7 @@
 
 #include "avatar.h"
 #include "calendar.h"
+#include "cata_unreachable.h"
 #include "cata_utility.h"
 #include "character.h"
 #include "colony.h"
@@ -846,6 +847,7 @@ void cast_zlight_segment(
                          ( *blocked_caches[p.z + OVERMAP_DEPTH] )[p.x - 1][p.y + 1].ne );
                 break;
         }
+        cata::unreachable();
     };
 
     float radius = 60.0f - offset_distance;
@@ -1145,6 +1147,7 @@ void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                 return ( p.x > 1 && p.y < MAPSIZE_Y - 1 && blocked_array[p.x - 1][p.y + 1].ne );
                 break;
         }
+        cata::unreachable();
     };
 
     float newStart = 0.0f;


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Fix false positive no return warnings in msvc"

#### Purpose of change
Fix warnings in `lightmap.cpp`:
```
src\lightmap.cpp(1148): warning C4715: '<lambda_5114cbcce979430cdc53a0f312cda1c1>::operator()': not all control paths return a value
src\lightmap.cpp(849): warning C4715: '<lambda_97faf4a5c59a05aa0c0ff99c9f164228>::operator()': not all control paths return a value
```

#### Describe the solution
Add a platform-independent `unreachable()` hint found at Stackoverflow (https://stackoverflow.com/a/65258501)

#### Describe alternatives you've considered
c++23

#### Testing
Game compiles with no warnings in VS, does not crash and burn when loading a save.
