### PR TITLE
Fix deactivate friendly robots message spam when moving on same tile

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -236,10 +236,6 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
 
     dbg( DL::Debug ) << "game:plmove: From " << you.pos() << " to " << dest_loc;
 
-    if( g->disable_robot( dest_loc ) ) {
-        return false;
-    }
-
     // Check if our movement is actually an attack on a monster or npc
     // Are we displacing a monster?
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: [Category] "Fix deactivate robot message spam"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: Bugfixes "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
When you move on the same tile as a friendly robot, you automatically get a message to deactivate it.
![image](https://user-images.githubusercontent.com/71428793/198699786-bbd930de-bef2-4f58-8a51-749be543b60a.png)

This makes having several robots following you a real pain.
If you want to deactivate a robot, you can just use "Examine".
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Remove the prompt.
Now you just swap positions with it, like you do with pets. 
If you want to deactivate it, you can use "Examine".
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Testing
- spawn manhacks
- move in them, no more prompt!
- use "Examine", you can deactivate them that way
