### PR TITLE
Fix several prying/picking tools bugs

### DIFF
--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -66,6 +66,7 @@
     "move_cost_mod": -1,
     "coverage": 40,
     "required_str": 14,
+    "examine_action": "locked_object",
     "flags": [
       "TRANSPARENT",
       "CONTAINER",

--- a/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
+++ b/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
@@ -143,6 +143,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT" ],
+    "examine_action": "locked_object",
     "pry": {
       "success_message": "You lift the manhole cover.",
       "fail_message": "You pry, but cannot lift the manhole cover.",

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1464,8 +1464,7 @@ static safe_reference<item> find_best_prying_tool( player &p )
 {
     std::vector<item *> prying_items = p.items_with( []( const item & it ) {
         // we want to get worn items (eg crowbar in toolbelt), so no check on item position
-        item temporary_item( it.type );
-        return temporary_item.has_quality( quality_id( "PRY" ), 1 );
+        return it->has_quality( quality_id( "PRY" ), 1 );
     } );
 
     // Sort by their quality level.

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1464,7 +1464,7 @@ static safe_reference<item> find_best_prying_tool( player &p )
 {
     std::vector<item *> prying_items = p.items_with( []( const item & it ) {
         // we want to get worn items (eg crowbar in toolbelt), so no check on item position
-        return it->has_quality( quality_id( "PRY" ), 1 );
+        return it.has_quality( quality_id( "PRY" ), 1 );
     } );
 
     // Sort by their quality level.

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1462,7 +1462,7 @@ void iexamine::gunsafe_el( player &p, const tripoint &examp )
 
 static safe_reference<item> find_best_prying_tool( player &p )
 {
-    std::vector<item *> prying_items = p.items_with( [&p]( const item & it ) {
+    std::vector<item *> prying_items = p.items_with( []( const item & it ) {
         // we want to get worn items (eg crowbar in toolbelt), so no check on item position
         item temporary_item( it.type );
         return temporary_item.has_quality( quality_id( "PRY" ), 1 );
@@ -1483,7 +1483,7 @@ static safe_reference<item> find_best_prying_tool( player &p )
 
 static safe_reference<item> find_best_lock_picking_tool( player &p )
 {
-    std::vector<item *> picklocks = p.items_with( [&p]( const item & it ) {
+    std::vector<item *> picklocks = p.items_with( []( const item & it ) {
         // we want to get worn items (eg hairpin), so no check on item position
         return it.type->get_use( "picklock" ) != nullptr;
     } );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1463,12 +1463,9 @@ void iexamine::gunsafe_el( player &p, const tripoint &examp )
 static safe_reference<item> find_best_prying_tool( player &p )
 {
     std::vector<item *> prying_items = p.items_with( [&p]( const item & it ) {
-        // Don't search for worn items such as hairpins
-        if( p.get_item_position( &it ) >= -1 ) {
-            item temporary_item( it.type );
-            return temporary_item.has_quality( quality_id( "PRY" ), 1 );
-        }
-        return false;
+        // we want to get worn items (eg crowbar in toolbelt), so no check on item position
+        item temporary_item( it.type );
+        return temporary_item.has_quality( quality_id( "PRY" ), 1 );
     } );
 
     // Sort by their quality level.
@@ -1487,11 +1484,8 @@ static safe_reference<item> find_best_prying_tool( player &p )
 static safe_reference<item> find_best_lock_picking_tool( player &p )
 {
     std::vector<item *> picklocks = p.items_with( [&p]( const item & it ) {
-        // Don't search for worn items such as hairpins
-        if( p.get_item_position( &it ) >= -1 ) {
-            return it.type->get_use( "picklock" ) != nullptr;
-        }
-        return false;
+        // we want to get worn items (eg hairpin), so no check on item position
+        return it.type->get_use( "picklock" ) != nullptr;
     } );
 
     // Sort by their picklock level.

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1145,7 +1145,7 @@ void pick_lock_actor::load( const JsonObject &obj )
     pick_quality = obj.get_int( "pick_quality" );
 }
 
-int pick_lock_actor::use( player &p, item &it, bool, const tripoint & ) const
+int pick_lock_actor::use( player &p, item &it, bool, const tripoint &t ) const
 {
     if( p.is_npc() ) {
         return 0;
@@ -1167,7 +1167,7 @@ int pick_lock_actor::use( player &p, item &it, bool, const tripoint & ) const
         return is_allowed;
     };
 
-    const cata::optional<tripoint> pnt_ = choose_adjacent_highlight(
+    const cata::optional<tripoint> pnt_ = ( t != p.pos() ) ? t : choose_adjacent_highlight(
             _( "Use your lockpick where?" ), _( "There is nothing to lockpick nearby." ), f, false );
     if( !pnt_ ) {
         return 0;


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fix several prying/picking tools bugs"

#### Purpose of change
Fixes #2130 
- manholes and coffins were missing a json field
- when checking for the best items with lockpick/prying qualities, wearable items weren't taken into account

Fixes #1923 
- basically what is in the issue, the parameter was passed to the function but never used

#### Describe the solution
##### 2130
- add the missing json field so that they can be pried open with examine
- remove the check on wearable item
  - you can directly lockpick a lockpickable thing with a worn hairpin
  - you can also pry a pryable thing with crowbar in a toolbelt

##### 1923
- make the function ask for a direction only if the parameter passed isn't valid

#### Testing
- worn item: hairpin (action and examine key)
  - sealed coffin: no
  - crate: no
  - man hole: no
  - locked wood door: yes
  - gun safe: yes
- worn item: toolbelt with crowbar (examine only)
  - sealed coffin: yes
  - crate: yes
  - man hole: yes
  - locked wood door: yes
  - gun safe: no
- crowbar (action and examine key)
  - sealed coffin: yes
  - crate: yes
  - man hole: yes
  - locked wood door: yes
  - gun safe: no
 