### PR TITLE
Prevent out of bounds vehicle damage

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6626,15 +6626,17 @@ bool vehicle::explode_fuel( int p, damage_type type )
 
 int vehicle::damage_direct( int p, int dmg, damage_type type )
 {
+    map &here = get_map();
     // Make sure p is within range and hasn't been removed already
-    if( ( static_cast<size_t>( p ) >= parts.size() ) || parts[p].removed ) {
+    if( ( static_cast<size_t>( p ) >= parts.size() ) || parts[p].removed ||
+        !here.inbounds( global_part_pos3( p ) ) ) {
         return dmg;
     }
     // If auto-driving and damage happens, bail out
     if( is_autodriving ) {
         stop_autodriving();
     }
-    g->m.set_memory_seen_cache_dirty( global_part_pos3( p ) );
+    here.set_memory_seen_cache_dirty( global_part_pos3( p ) );
     if( parts[p].is_broken() ) {
         return break_off( p, dmg );
     }
@@ -6658,7 +6660,7 @@ int vehicle::damage_direct( int p, int dmg, damage_type type )
         leak_fuel( parts [ p ] );
 
         for( const auto &e : parts[p].items ) {
-            g->m.add_item_or_charges( global_part_pos3( p ), e );
+            here.add_item_or_charges( global_part_pos3( p ), e );
         }
         parts[p].items.clear();
 
@@ -6672,7 +6674,7 @@ int vehicle::damage_direct( int p, int dmg, damage_type type )
     if( parts[p].is_fuel_store() ) {
         explode_fuel( p, type );
     } else if( parts[ p ].is_broken() && part_flag( p, "UNMOUNT_ON_DAMAGE" ) ) {
-        g->m.spawn_item( global_part_pos3( p ), part_info( p ).item, 1, 0, calendar::turn );
+        here.spawn_item( global_part_pos3( p ), part_info( p ).item, 1, 0, calendar::turn );
         monster *mon = get_pet( p );
         if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
             mon->remove_effect( effect_harnessed );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -6,6 +6,7 @@
 #include "avatar.h"
 #include "damage.h"
 #include "enums.h"
+#include "game.h"
 #include "item.h"
 #include "map.h"
 #include "map_helpers.h"
@@ -14,6 +15,8 @@
 #include "state_helpers.h"
 #include "type_id.h"
 #include "vehicle.h"
+#include "vpart_position.h"
+#include "veh_type.h"
 
 TEST_CASE( "detaching_vehicle_unboards_passengers" )
 {
@@ -77,6 +80,40 @@ TEST_CASE( "add_item_to_broken_vehicle_part" )
     //Now part is really broken, adding an item should fail
     const item itm2 = item( "jeans" );
     REQUIRE( !veh_ptr->add_item( *cargo_part, itm2 ) );
+}
+
+TEST_CASE( "damage_vehicle_oob" )
+{
+    clear_all_state();
+    const tripoint test_origin( 60, 60, 0 );
+    g->place_player( test_origin );
+    const tripoint vehicle_origin( SEEX, 0, 0 );
+    vehicle *veh_ptr = get_map().add_vehicle( vproto_id( "bicycle" ), vehicle_origin, 0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+
+    //Put an item in the vehicle
+    const tripoint cargo_pos = vehicle_origin + tripoint_west;
+    auto cargo_parts = veh_ptr->get_parts_at( cargo_pos, "CARGO", part_status_flag::any );
+    REQUIRE( !cargo_parts.empty( ) );
+    vehicle_part *cargo_part = cargo_parts.front();
+    REQUIRE( cargo_part != nullptr );
+    const item itm = item( "jeans" );
+    REQUIRE( veh_ptr->add_item( *cargo_part, itm ) );
+
+    //Shift the vehicle half off the map
+    g->place_player( test_origin + tripoint_east * SEEX );
+
+    //Check the vehicle is still there.
+    optional_vpart_position part_pos = get_map().veh_at( {0, 0, 0} );
+    REQUIRE( part_pos );
+
+    auto parts = veh_ptr->parts_at_relative( veh_ptr->tripoint_to_mount( {-1, 0, 0} ), true );
+    REQUIRE( !parts.empty( ) );
+    for( int part : parts ) {
+        //We aren't actually smashing each chosen part in turn here
+        //it's picking a random one each time, hence why we smash them all
+        veh_ptr->damage( part, 10000 );
+    }
 }
 
 static void check_wreckage( int zlevel )


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Out of bounds vehicle parts can no longer take damage"

#### Purpose of change

Any time a vehicle is halfway across a submap boundary, it's possible one of the submaps could be unloaded leaving the vehicle half out of bounds. Damage that affected the whole vehicle could then destroy out of bounds parts. When this caused a new item to be created it would lead to a harmless debug message. When it caused a fuel tank to explode it would crash. 

#### Describe the solution

Out of bounds parts can't take damage any more.

#### Describe alternatives you've considered

Many, this is just a simple fix to prevent the crash. We should probably look at out of bounds vehicle behavior in general. There might be more problems.

There's a RemovePartHandler interface with default and mapgen implementations, but it's not used here. Interestingly it supports a permit_oob variable to its item creation method, though it's only used on the mapgen implementation and it causes it to clamp the location to the map bounds. 

#### Testing

There's a new test for the item creation case. It doesn't check for any specific behavior, just that it doesn't debugmsg. 