### PR TITLE
Remove overmap_debug_mongroup

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4291,7 +4291,6 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "bionic_ui_sort_mode", bionic_sort_mode );
     json.member( "overmap_debug_weather", overmap_debug_weather );
     json.member( "overmap_visible_weather", overmap_visible_weather );
-    json.member( "overmap_debug_mongroup", overmap_debug_mongroup );
 
     json.member( "input_history" );
     json.start_object();
@@ -4339,7 +4338,6 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "bionic_ui_sort_mode", bionic_sort_mode );
     jo.read( "overmap_debug_weather", overmap_debug_weather );
     jo.read( "overmap_visible_weather", overmap_visible_weather );
-    jo.read( "overmap_debug_mongroup", overmap_debug_mongroup );
 
     if( !jo.read( "vmenu_show_items", vmenu_show_items ) ) {
         // This is an old save: 1 means view items, 2 means view monsters,


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Remove overmap_debug_mongroup"

#### Purpose of change

While porting #2089 I accidentally included this into `savegame_json.cpp` under write but not read. It's a variable used in DDA but not in BN that I accidentally included while solving merge conflicts.

#### Describe the solution

Removes `overmap_debug_mongroup` from `savegame_json.cpp` entirely.

#### Describe alternatives you've considered

- Add in whatever it's supposed to reference.
I actually have no clue what it actually does and looking for it might take a while. I'd rather do that some other time, especially if it turns out that it's not something we even want.

#### Testing

Save load, then turn on "Report Unused JSON Fields", verified that the error no longer triggered.

#### Additional context

I really need to set "Report Unused JSON Fields" as true for all my test builds.
