### PR TITLE
Globals cleanup

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10145,14 +10145,14 @@ void game::vertical_move( int movez, bool force, bool peeking )
                 if( pts.empty() ) {
                     add_msg( m_info, _( "There is nothing above you that you can attach a web to." ) );
                 } else if( can_use_mutation_warn( trait_WEB_ROPE, u ) ) {
-                    if( g->m.move_cost( u.pos() ) != 2 && g->m.move_cost( u.pos() ) != 3 ) {
+                    if( m.move_cost( u.pos() ) != 2 && m.move_cost( u.pos() ) != 3 ) {
                         add_msg( m_info, _( "You can't spin a web rope there." ) );
-                    } else if( g->m.has_furn( u.pos() ) ) {
+                    } else if( m.has_furn( u.pos() ) ) {
                         add_msg( m_info, _( "There is already furniture at that location." ) );
                     } else {
                         if( query_yn( "Spin a rope and climb?" ) ) {
                             add_msg( m_good, _( "You spin a rope of web." ) );
-                            g->m.furn_set( u.pos(), furn_str_id( "f_rope_up_web" ) );
+                            m.furn_set( u.pos(), furn_str_id( "f_rope_up_web" ) );
                             u.mod_moves( to_turns<int>( 2_seconds ) );
                             u.mutation_spend_resources( trait_WEB_ROPE );
                             vertical_move( movez, force, peeking );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1133,10 +1133,10 @@ static std::string get_freshness_description( const item &food_item )
     if( time_left > shelf_life ) {
         time_left = shelf_life;
     }
-
+    avatar &you = get_avatar();
     if( food_item.is_fresh() ) {
         // Fresh food is assumed to be obviously so regardless of skill.
-        if( g->u.can_estimate_rot() ) {
+        if( you.can_estimate_rot() ) {
             return string_format( _( "* This food looks as <good>fresh</good> as it can be.  "
                                      "It still has <info>%s</info> until it spoils." ),
                                   to_string_approx( time_left ) );
@@ -1145,7 +1145,7 @@ static std::string get_freshness_description( const item &food_item )
         }
     } else if( food_item.is_going_bad() ) {
         // Old food likewise is assumed to be fairly obvious.
-        if( g->u.can_estimate_rot() ) {
+        if( you.can_estimate_rot() ) {
             return string_format( _( "* This food looks <bad>old</bad>.  "
                                      "It's just <info>%s</info> from becoming inedible." ),
                                   to_string_approx( time_left ) );
@@ -1155,7 +1155,7 @@ static std::string get_freshness_description( const item &food_item )
         }
     }
 
-    if( !g->u.can_estimate_rot() ) {
+    if( !you.can_estimate_rot() ) {
         // Unskilled characters only get a hint that more information exists...
         return _( "* This food looks <info>fine</info>.  If you were more skilled in "
                   "cooking or survival, you might be able to make a better estimation." );
@@ -1453,7 +1453,7 @@ std::map<std::string, double> item::dps( const bool for_display, const bool for_
 
 std::map<std::string, double> item::dps( const bool for_display, const bool for_calc ) const
 {
-    return dps( for_display, for_calc, g->u );
+    return dps( for_display, for_calc, get_avatar() );
 }
 
 double item::average_dps( const player &guy ) const
@@ -1647,7 +1647,7 @@ void item::med_info( const item *med_item, std::vector<iteminfo> &info, const it
 
     if( med_item->get_comestible_fun() != 0 && parts->test( iteminfo_parts::MED_JOY ) ) {
         info.push_back( iteminfo( "MED", _( "Enjoyability: " ),
-                                  g->u.fun_for( *med_item ).first ) );
+                                  get_avatar().fun_for( *med_item ).first ) );
     }
 
     if( med_com->stim != 0 && parts->test( iteminfo_parts::MED_STIMULATION ) ) {
@@ -1671,13 +1671,14 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
 {
     nutrients min_nutr;
     nutrients max_nutr;
+    avatar &you = get_avatar();
 
     std::string recipe_exemplar = get_var( "recipe_exemplar", "" );
     if( recipe_exemplar.empty() ) {
-        min_nutr = max_nutr = g->u.compute_effective_nutrients( *food_item );
+        min_nutr = max_nutr = you.compute_effective_nutrients( *food_item );
     } else {
         std::tie( min_nutr, max_nutr ) =
-            g->u.compute_nutrient_range( *food_item, recipe_id( recipe_exemplar ) );
+            you.compute_nutrient_range( *food_item, recipe_id( recipe_exemplar ) );
     }
 
     bool show_nutr = parts->test( iteminfo_parts::FOOD_NUTRITION ) ||
@@ -1708,7 +1709,7 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
         }
     }
 
-    const std::pair<int, int> fun_for_food_item = g->u.fun_for( *food_item );
+    const std::pair<int, int> fun_for_food_item = you.fun_for( *food_item );
     if( fun_for_food_item.first != 0 && parts->test( iteminfo_parts::FOOD_JOY ) ) {
         info.push_back( iteminfo( "FOOD", _( "Enjoyability: " ), fun_for_food_item.first ) );
     }
@@ -1718,19 +1719,19 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
                                   std::abs( static_cast<int>( food_item->charges ) * batch ) ) );
     }
     if( food_item->corpse != nullptr && parts->test( iteminfo_parts::FOOD_SMELL ) &&
-        ( debug || ( g != nullptr && ( g->u.has_trait( trait_CARNIVORE ) ||
-                                       g->u.has_artifact_with( AEP_SUPER_CLAIRVOYANCE ) ) ) ) ) {
+        ( debug || ( g != nullptr && ( you.has_trait( trait_CARNIVORE ) ||
+                                       you.has_artifact_with( AEP_SUPER_CLAIRVOYANCE ) ) ) ) ) {
         info.push_back( iteminfo( "FOOD", _( "Smells like: " ) + food_item->corpse->nname() ) );
     }
 
     auto format_vitamin = [&]( const std::pair<vitamin_id, int> &v, bool display_vitamins ) {
         const bool is_vitamin = v.first->type() == vitamin_type::VITAMIN;
         // only display vitamins that we actually require
-        if( g->u.vitamin_rate( v.first ) == 0_turns || v.second == 0 ||
+        if( you.vitamin_rate( v.first ) == 0_turns || v.second == 0 ||
             display_vitamins != is_vitamin || v.first->has_flag( flag_NO_DISPLAY ) ) {
             return std::string();
         }
-        const double multiplier = g->u.vitamin_rate( v.first ) / 1_days * 100;
+        const double multiplier = you.vitamin_rate( v.first ) / 1_days * 100;
         const int min_value = min_nutr.get_vitamin( v.first );
         const int max_value = v.second;
         const int min_rda = std::lround( min_value * multiplier );
@@ -1764,14 +1765,14 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
 
     insert_separation_line( info );
 
-    if( g->u.allergy_type( *food_item ) != morale_type( "morale_null" ) ) {
+    if( you.allergy_type( *food_item ) != morale_type( "morale_null" ) ) {
         info.emplace_back( "DESCRIPTION",
                            _( "* This food will cause an <bad>allergic reaction</bad>." ) );
     }
 
     if( food_item->has_flag( flag_CANNIBALISM ) &&
         parts->test( iteminfo_parts::FOOD_CANNIBALISM ) ) {
-        if( !g->u.has_trait_flag( trait_flag_CANNIBAL ) ) {
+        if( !you.has_trait_flag( trait_flag_CANNIBAL ) ) {
             info.emplace_back( "DESCRIPTION",
                                _( "* This food contains <bad>human flesh</bad>." ) );
         } else {
@@ -1786,7 +1787,7 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
     }
 
     ///\EFFECT_SURVIVAL >=3 allows detection of poisonous food
-    if( food_item->has_flag( flag_HIDDEN_POISON ) && g->u.get_skill_level( skill_survival ) >= 3 &&
+    if( food_item->has_flag( flag_HIDDEN_POISON ) && you.get_skill_level( skill_survival ) >= 3 &&
         parts->test( iteminfo_parts::FOOD_POISON ) ) {
         info.emplace_back( "DESCRIPTION",
                            _( "* On closer inspection, this appears to be "
@@ -1794,7 +1795,7 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
     }
 
     ///\EFFECT_SURVIVAL >=5 allows detection of hallucinogenic food
-    if( food_item->has_flag( flag_HIDDEN_HALLU ) && g->u.get_skill_level( skill_survival ) >= 5 &&
+    if( food_item->has_flag( flag_HIDDEN_HALLU ) && you.get_skill_level( skill_survival ) >= 5 &&
         parts->test( iteminfo_parts::FOOD_HALLUCINOGENIC ) ) {
         info.emplace_back( "DESCRIPTION",
                            _( "* On closer inspection, this appears to be "
@@ -1812,18 +1813,18 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
             info.emplace_back( "DESCRIPTION", get_freshness_description( *food_item ) );
         }
 
-        if( food_item->has_flag( flag_NO_PARASITES ) && g->u.get_skill_level( skill_cooking ) >= 3 ) {
+        if( food_item->has_flag( flag_NO_PARASITES ) && you.get_skill_level( skill_cooking ) >= 3 ) {
             info.emplace_back( "DESCRIPTION",
                                _( "* It seems that deep freezing <good>killed all "
                                   "parasites</good>." ) );
         }
         if( food_item->rotten() ) {
-            if( g->u.has_bionic( bio_digestion ) ) {
+            if( you.has_bionic( bio_digestion ) ) {
                 info.push_back( iteminfo( "DESCRIPTION",
                                           _( "This food has started to <neutral>rot</neutral>, "
                                              "but <info>your bionic digestion can tolerate "
                                              "it</info>." ) ) );
-            } else if( g->u.has_trait( trait_SAPROVORE ) ) {
+            } else if( you.has_trait( trait_SAPROVORE ) ) {
                 info.push_back( iteminfo( "DESCRIPTION",
                                           _( "This food has started to <neutral>rot</neutral>, "
                                              "but <info>you can tolerate it</info>." ) ) );
@@ -2041,8 +2042,8 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
         }
     }
     info.back().bNewLine = true;
-
-    int max_gun_range = loaded_mod->gun_range( &g->u );
+    avatar &you = get_avatar();
+    int max_gun_range = loaded_mod->gun_range( &you );
     if( max_gun_range > 0 && parts->test( iteminfo_parts::GUN_MAX_RANGE ) ) {
         info.emplace_back( "GUN", _( "Maximum range: " ), "<num>", iteminfo::no_flags,
                            max_gun_range );
@@ -2131,14 +2132,14 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
                                       loaded_mod->gun_dispersion( true, false ) ) );
             info.push_back( iteminfo( "GUN", "eff_dispersion", _( " (effective: <num>)" ),
                                       iteminfo::lower_is_better | iteminfo::no_name,
-                                      static_cast<int>( g->u.get_weapon_dispersion( *this ).max() ) ) );
+                                      static_cast<int>( you.get_weapon_dispersion( *this ).max() ) ) );
         }
     }
     info.back().bNewLine = true;
 
     // if effective sight dispersion differs from actual sight dispersion display both
     int act_disp = mod->sight_dispersion();
-    int eff_disp = g->u.effective_dispersion( act_disp );
+    int eff_disp = you.effective_dispersion( act_disp );
     int adj_disp = eff_disp - act_disp;
 
     if( parts->test( iteminfo_parts::GUN_DISPERSION_SIGHT ) ) {
@@ -2192,11 +2193,11 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
         } ) ) {
             info.emplace_back( "GUN", _( "Burst fire penalty: " ), "",
                                iteminfo::no_newline | iteminfo::lower_is_better,
-                               ranged::burst_penalty( g->u, *this, loaded_mod->gun_recoil() ) );
+                               ranged::burst_penalty( you, *this, loaded_mod->gun_recoil() ) );
             if( bipod ) {
                 info.emplace_back( "GUN", "bipod_burst", _( " (with bipod <num>)" ),
                                    iteminfo::lower_is_better | iteminfo::no_name,
-                                   ranged::burst_penalty( g->u, *this, loaded_mod->gun_recoil( true ) ) );
+                                   ranged::burst_penalty( you, *this, loaded_mod->gun_recoil( true ) ) );
             }
         }
         info.back().bNewLine = true;
@@ -2252,8 +2253,8 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     if( parts->test( iteminfo_parts::GUN_AIMING_STATS ) ) {
         insert_separation_line( info );
         info.emplace_back( "GUN", _( "<bold>Base aim speed</bold>: " ), "<num>", iteminfo::no_flags,
-                           g->u.aim_per_move( *mod, MAX_RECOIL ) );
-        for( const aim_type &type : g->u.get_aim_types( *mod ) ) {
+                           you.aim_per_move( *mod, MAX_RECOIL ) );
+        for( const aim_type &type : you.get_aim_types( *mod ) ) {
             // Nameless aim levels don't get an entry.
             if( type.name.empty() ) {
                 continue;
@@ -2262,11 +2263,11 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
             // distinct tag per aim type.
             const std::string tag = "GUN_" + type.name;
             info.emplace_back( tag, string_format( "<info>%s</info>", type.name ) );
-            int max_dispersion = g->u.get_weapon_dispersion( *loaded_mod ).max();
+            int max_dispersion = you.get_weapon_dispersion( *loaded_mod ).max();
             int range = range_with_even_chance_of_good_hit( max_dispersion + type.threshold );
             info.emplace_back( tag, _( "Even chance of good hit at range: " ),
                                _( "<num>" ), iteminfo::no_flags, range );
-            int aim_mv = g->u.gun_engagement_moves( *mod, type.threshold );
+            int aim_mv = you.gun_engagement_moves( *mod, type.threshold );
             info.emplace_back( tag, _( "Time to reach aim level: " ), _( "<num> moves " ),
                                iteminfo::lower_is_better, aim_mv );
         }
@@ -2495,8 +2496,9 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         return;
     }
 
-    int encumbrance = get_encumber( g->u );
-    const sizing sizing_level = get_sizing( g->u, encumbrance != 0 );
+    avatar &you = get_avatar();
+    int encumbrance = get_encumber( you );
+    const sizing sizing_level = get_sizing( you, encumbrance != 0 );
     const std::string space = "  ";
     body_part_set covered_parts = get_covered_body_parts();
     bool covers_anything = covered_parts.any();
@@ -2620,7 +2622,7 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                                   encumbrance ) );
         if( !type->rigid ) {
             const int encumbrance_when_full =
-                get_encumber_when_containing( g->u, get_total_capacity() );
+                get_encumber_when_containing( you, get_total_capacity() );
             info.push_back( iteminfo( "ARMOR", space + _( "Encumbrance when full: " ), "",
                                       iteminfo::no_newline | iteminfo::lower_is_better,
                                       encumbrance_when_full ) );
@@ -2702,8 +2704,9 @@ void item::armor_fit_info( std::vector<iteminfo> &info, const iteminfo_query *pa
         return;
     }
 
-    int encumbrance = get_encumber( g->u );
-    const sizing sizing_level = get_sizing( g->u, encumbrance != 0 );
+    avatar &you = get_avatar();
+    int encumbrance = get_encumber( you );
+    const sizing sizing_level = get_sizing( you, encumbrance != 0 );
 
     if( has_flag( flag_HELMET_COMPAT ) &&
         parts->test( iteminfo_parts::DESCRIPTION_FLAGS_HELMETCOMPAT ) ) {
@@ -2887,12 +2890,13 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
         info.push_back( iteminfo( "BOOK", _( "It can be <info>understood by "
                                              "beginners</info>." ) ) );
     }
-    if( !g->u.has_identified( typeId() ) && parts->test( iteminfo_parts::BOOK_UNREAD ) ) {
+    avatar &you = get_avatar();
+    if( !you.has_identified( typeId() ) && parts->test( iteminfo_parts::BOOK_UNREAD ) ) {
         info.push_back( iteminfo( "BOOK",
                                   _( "You have <info>never read</info> this book." ) ) );
     }
     if( book.skill ) {
-        const SkillLevel &skill = g->u.get_skill_level_object( book.skill );
+        const SkillLevel &skill = you.get_skill_level_object( book.skill );
         if( skill.can_train() && parts->test( iteminfo_parts::BOOK_SKILLRANGE_MAX ) ) {
             const std::string skill_name = book.skill->name();
             std::string fmt = string_format( _( "Can bring your <info>%s skill to</info> "
@@ -2941,7 +2945,7 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
     }
 
     if( book.chapters > 0 && parts->test( iteminfo_parts::BOOK_NUMUNREADCHAPTERS ) ) {
-        const int unread = get_remaining_chapters( g->u );
+        const int unread = get_remaining_chapters( you );
         std::string fmt = vgettext( "This book has <num> <info>unread chapter</info>.",
                                     "This book has <num> <info>unread chapters</info>.",
                                     unread );
@@ -2950,8 +2954,8 @@ void item::book_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
 
     std::vector<std::string> recipe_list;
     for( const islot_book::recipe_with_description_t &elem : book.recipes ) {
-        const bool knows_it = g->u.knows_recipe( elem.recipe );
-        const bool can_learn = g->u.get_skill_level( elem.recipe->skill_used )  >= elem.skill_level;
+        const bool knows_it = you.knows_recipe( elem.recipe );
+        const bool can_learn = you.get_skill_level( elem.recipe->skill_used )  >= elem.skill_level;
         // If the player knows it, they recognize it even if it's not clearly stated.
         if( elem.is_hidden() && !knows_it ) {
             continue;
@@ -3415,9 +3419,10 @@ void item::combat_info( std::vector<iteminfo> &info, const iteminfo_query *parts
         }
     }
 
+    avatar &you = get_avatar();
     // display which martial arts styles character can use with this weapon
     if( parts->test( iteminfo_parts::DESCRIPTION_APPLICABLEMARTIALARTS ) ) {
-        const std::string valid_styles = g->u.martial_arts_data->enumerate_known_styles( typeId() );
+        const std::string valid_styles = you.martial_arts_data->enumerate_known_styles( typeId() );
         if( !valid_styles.empty() ) {
             insert_separation_line( info );
             info.push_back( iteminfo( "DESCRIPTION",
@@ -3442,10 +3447,10 @@ void item::combat_info( std::vector<iteminfo> &info, const iteminfo_query *parts
 
     if( ( dmg_bash || dmg_cut || dmg_stab || type->m_to_hit > 0 ) || debug_mode ) {
         damage_instance non_crit;
-        g->u.roll_all_damage( false, non_crit, true, *this );
+        you.roll_all_damage( false, non_crit, true, *this );
         damage_instance crit;
-        g->u.roll_all_damage( true, crit, true, *this );
-        int attack_cost = g->u.attack_cost( *this );
+        you.roll_all_damage( true, crit, true, *this );
+        int attack_cost = you.attack_cost( *this );
         insert_separation_line( info );
         if( parts->test( iteminfo_parts::DESCRIPTION_MELEEDMG ) ) {
             info.push_back( iteminfo( "DESCRIPTION", _( "<bold>Average melee damage</bold>:" ) ) );
@@ -3454,9 +3459,9 @@ void item::combat_info( std::vector<iteminfo> &info, const iteminfo_query *parts
         if( parts->test( iteminfo_parts::DESCRIPTION_MELEEDMG_CRIT ) ) {
             info.push_back( iteminfo( "DESCRIPTION",
                                       string_format( _( "Critical hit chance <neutral>%d%% - %d%%</neutral>" ),
-                                              static_cast<int>( g->u.crit_chance( 0, 100, *this ) *
+                                              static_cast<int>( you.crit_chance( 0, 100, *this ) *
                                                       100 ),
-                                              static_cast<int>( g->u.crit_chance( 100, 0, *this ) *
+                                              static_cast<int>( you.crit_chance( 100, 0, *this ) *
                                                       100 ) ) ) );
         }
         // Bash damage
@@ -3600,7 +3605,8 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         }
     }
 
-    if( is_armor() && g->u.has_trait( trait_WOOLALLERGY ) &&
+    avatar &you = get_avatar();
+    if( is_armor() && you.has_trait( trait_WOOLALLERGY ) &&
         ( made_of( material_id( "wool" ) ) || has_own_flag( "wooled" ) ) ) {
         info.push_back( iteminfo( "DESCRIPTION",
                                   _( "* This clothing will give you an <bad>allergic "
@@ -3852,9 +3858,9 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
     // Recipes using this item as an ingredient
     if( parts->test( iteminfo_parts::DESCRIPTION_APPLICABLE_RECIPES ) ) {
         itype_id tid = contents.empty() ? typeId() : contents.front().typeId();
-        const inventory &crafting_inv = g->u.crafting_inventory();
+        const inventory &crafting_inv = you.crafting_inventory();
 
-        const recipe_subset available_recipe_subset = g->u.get_available_recipes( crafting_inv, nullptr,
+        const recipe_subset available_recipe_subset = you.get_available_recipes( crafting_inv, nullptr,
                 recipe_filter_by_component( tid ) );
         const std::set<const recipe *> &item_recipes = available_recipe_subset.of_component( tid );
 
@@ -4295,11 +4301,11 @@ void item::on_wear( Character &p )
     }
 
     // TODO: artifacts currently only work with the player character
-    if( &p == &g->u && type->artifact ) {
+    if( &p == &get_avatar() && type->artifact ) {
         g->add_artifact_messages( type->artifact->effects_worn );
     }
     // if game is loaded - don't want ownership assigned during char creation
-    if( g->u.getID().is_valid() ) {
+    if( get_avatar().getID().is_valid() ) {
         handle_pickup_ownership( p );
     }
     p.on_item_wear( *this );
@@ -4328,7 +4334,7 @@ void item::on_takeoff( Character &p )
 void item::on_wield( player &p, int mv )
 {
     // TODO: artifacts currently only work with the player character
-    if( &p == &g->u && type->artifact ) {
+    if( &p == &get_avatar() && type->artifact ) {
         g->add_artifact_messages( type->artifact->effects_wielded );
     }
 
@@ -4373,7 +4379,7 @@ void item::on_wield( player &p, int mv )
         msg = _( "You wield your %s." );
     }
     // if game is loaded - don't want ownership assigned during char creation
-    if( g->u.getID().is_valid() ) {
+    if( get_avatar().getID().is_valid() ) {
         handle_pickup_ownership( p );
     }
     p.add_msg_if_player( m_neutral, msg, tname() );
@@ -4395,11 +4401,12 @@ void item::handle_pickup_ownership( Character &c )
     if( owner.is_null() ) {
         set_owner( c );
     } else {
-        if( !is_owned_by( c ) && &c == &g->u ) {
+        Character &you = get_player_character();
+        if( !is_owned_by( c ) && &c == &you ) {
             std::vector<npc *> witnesses;
             for( npc &elem : g->all_npcs() ) {
-                if( rl_dist( elem.pos(), g->u.pos() ) < MAX_VIEW_DISTANCE && elem.get_faction() &&
-                    is_owned_by( elem ) && elem.sees( g->u.pos() ) ) {
+                if( rl_dist( elem.pos(), you.pos() ) < MAX_VIEW_DISTANCE && elem.get_faction() &&
+                    is_owned_by( elem ) && elem.sees( you.pos() ) ) {
                     elem.say( "<witnessed_thievery>", 7 );
                     npc *npc_to_add = &elem;
                     witnesses.push_back( npc_to_add );
@@ -4431,12 +4438,13 @@ void item::on_pickup( Character &p )
     if( p.is_fake() ) {
         return;
     }
+    avatar &you = get_avatar();
     // TODO: artifacts currently only work with the player character
-    if( &p == &g->u && type->artifact ) {
+    if( &p == &you && type->artifact ) {
         g->add_artifact_messages( type->artifact->effects_carried );
     }
     // if game is loaded - don't want ownership assigned during char creation
-    if( g->u.getID().is_valid() ) {
+    if( you.getID().is_valid() ) {
         handle_pickup_ownership( p );
     }
     if( is_bucket_nonempty() ) {
@@ -4581,16 +4589,17 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         maintext = label( quantity );
     }
 
+    avatar &you = get_avatar();
     std::string tagtext;
     if( is_food() ) {
-        if( has_flag( flag_HIDDEN_POISON ) && g->u.get_skill_level( skill_survival ) >= 3 ) {
+        if( has_flag( flag_HIDDEN_POISON ) && you.get_skill_level( skill_survival ) >= 3 ) {
             tagtext += _( " (poisonous)" );
-        } else if( has_flag( flag_HIDDEN_HALLU ) && g->u.get_skill_level( skill_survival ) >= 5 ) {
+        } else if( has_flag( flag_HIDDEN_HALLU ) && you.get_skill_level( skill_survival ) >= 5 ) {
             tagtext += _( " (hallucinogenic)" );
         }
     }
     if( is_book() ) {
-        if( !g->u.has_identified( typeId() ) ) {
+        if( !you.has_identified( typeId() ) ) {
             tagtext += _( " (unread)" );
         }
     }
@@ -4611,7 +4620,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         }
     }
 
-    const sizing sizing_level = get_sizing( g->u, get_encumber( g->u ) != 0 );
+    const sizing sizing_level = get_sizing( you, get_encumber( you ) != 0 );
 
     if( sizing_level == sizing::human_sized_small_char ) {
         tagtext += _( " (too big)" );
@@ -4661,7 +4670,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     if( has_flag( flag_WET ) ) {
         tagtext += _( " (wet)" );
     }
-    if( already_used_by_player( g->u ) ) {
+    if( already_used_by_player( you ) ) {
         tagtext += _( " (used)" );
     }
     if( active && ( has_flag( flag_WATER_EXTINGUISH ) || has_flag( flag_LITCIG ) ) ) {
@@ -4741,7 +4750,7 @@ std::string item::display_name( unsigned int quantity ) const
             sidetxt = string_format( " (%s)", _( "right" ) );
             break;
     }
-    avatar &player_character = get_avatar();
+    avatar &you = get_avatar();
     int amount = 0;
     int max_amount = 0;
     bool has_item = is_container() && contents.num_item_stacks() == 1;
@@ -4754,7 +4763,7 @@ std::string item::display_name( unsigned int quantity ) const
         max_amount = contents.front().charges_per_volume( get_container_capacity() );
     } else if( is_book() && get_chapters() > 0 ) {
         // a book which has remaining unread chapters
-        amount = get_remaining_chapters( g->u );
+        amount = get_remaining_chapters( you );
     } else if( ammo_capacity() > 0 ) {
         // anything that can be reloaded including tools, magazines, guns and auxiliary gunmods
         // but excluding bows etc., which have ammo, but can't be reloaded
@@ -4802,7 +4811,7 @@ std::string item::display_name( unsigned int quantity ) const
     if( is_map() && calendar::turn != calendar::turn_zero ) {
         // TODO: fix point types
         tripoint map_pos_omt =
-            get_var( "reveal_map_center_omt", player_character.global_omt_location().raw() );
+            get_var( "reveal_map_center_omt", you.global_omt_location().raw() );
         tripoint_abs_sm map_pos =
             project_to<coords::sm>( tripoint_abs_omt( map_pos_omt ) );
         const city *c = overmap_buffer.closest_city( map_pos ).city;
@@ -5838,7 +5847,7 @@ bool item::ready_to_revive( const tripoint &pos ) const
     if( !can_revive() ) {
         return false;
     }
-    if( g->m.veh_at( pos ) ) {
+    if( get_map().veh_at( pos ) ) {
         return false;
     }
     if( !calendar::once_every( 1_seconds ) ) {
@@ -5854,7 +5863,7 @@ bool item::ready_to_revive( const tripoint &pos ) const
         // If we're a special revival zombie, wait to get up until the player is nearby.
         const bool isReviveSpecial = has_flag( flag_REVIVE_SPECIAL );
         if( isReviveSpecial ) {
-            const int distance = rl_dist( pos, g->u.pos() );
+            const int distance = rl_dist( pos, get_player_character().pos() );
             if( distance > 3 ) {
                 return false;
             }
@@ -6939,7 +6948,7 @@ bool item::spill_contents( const tripoint &pos )
     }
 
     for( item *it : contents.all_items_top() ) {
-        g->m.add_item_or_charges( pos, *it );
+        get_map().add_item_or_charges( pos, *it );
     }
 
     contents.clear_items();
@@ -7254,7 +7263,7 @@ int item::ammo_remaining() const
     if( is_tool() || is_gun() ) {
         // includes auxiliary gunmods
         if( has_flag( flag_USES_BIONIC_POWER ) ) {
-            int power = units::to_kilojoule( g->u.get_power_level() );
+            int power = units::to_kilojoule( get_avatar().get_power_level() );
             return power;
         }
         return charges;
@@ -7356,7 +7365,7 @@ int item::ammo_consume( int qty, const tripoint &pos )
             if( mag->has_flag( flag_MAG_DESTROY ) ) {
                 remove_item( *mag );
             } else if( mag->has_flag( flag_MAG_EJECT ) ) {
-                g->m.add_item( pos, *mag );
+                get_map().add_item( pos, *mag );
                 remove_item( *mag );
             }
         }
@@ -7381,8 +7390,9 @@ int item::ammo_consume( int qty, const tripoint &pos )
     } else if( is_tool() || is_gun() ) {
         qty = std::min( qty, charges );
         if( has_flag( flag_USES_BIONIC_POWER ) ) {
-            charges = units::to_kilojoule( g->u.get_power_level() );
-            g->u.mod_power_level( units::from_kilojoule( -qty ) );
+            avatar &you = get_avatar();
+            charges = units::to_kilojoule( you.get_power_level() );
+            you.mod_power_level( units::from_kilojoule( -qty ) );
         }
         charges -= qty;
         if( charges == 0 ) {
@@ -8859,7 +8869,7 @@ bool item::process_rot( float /*insulation*/, const bool seals,
 
         const weather_generator &wgen = get_weather().get_cur_weather_gen();
         const unsigned int seed = g->get_seed();
-        int local_mod = g->new_game ? 0 : g->m.get_temperature( pos );
+        int local_mod = g->new_game ? 0 : get_map().get_temperature( pos );
 
         if( carried ) {
             local_mod += 5; // body heat increases inventory temperature
@@ -8932,7 +8942,7 @@ void item::process_artifact( player *carrier, const tripoint & /*pos*/ )
     // don't consider npcs. Also they are not processed when laying on the ground.
     // TODO: change game::process_artifact to work with npcs,
     // TODO: consider moving game::process_artifact here.
-    if( carrier == &g->u ) {
+    if( carrier == &get_avatar() ) {
         g->process_artifact( *this, *carrier );
     }
 }
@@ -8995,7 +9005,7 @@ bool item::process_corpse( player *carrier, const tripoint &pos )
     }
     if( rng( 0, volume() / units::legacy_volume_factor ) > burnt && g->revive_corpse( pos, *this ) ) {
         if( carrier == nullptr ) {
-            if( g->u.sees( pos ) ) {
+            if( get_avatar().sees( pos ) ) {
                 if( corpse->in_species( ROBOT ) ) {
                     add_msg( m_warning, _( "A nearby robot has repaired itself and stands up!" ) );
                 } else {
@@ -9020,13 +9030,15 @@ bool item::process_corpse( player *carrier, const tripoint &pos )
 
 bool item::process_fake_mill( player * /*carrier*/, const tripoint &pos )
 {
-    if( g->m.furn( pos ) != furn_str_id( "f_wind_mill_active" ) &&
-        g->m.furn( pos ) != furn_str_id( "f_water_mill_active" ) ) {
+    map &here = get_map();
+    if( here.furn( pos ) != furn_str_id( "f_wind_mill_active" ) &&
+        here.furn( pos ) != furn_str_id( "f_water_mill_active" ) ) {
         item_counter = 0;
         return true; //destroy fake mill
     }
     if( age() >= 6_hours || item_counter == 0 ) {
-        iexamine::mill_finalize( g->u, pos, birthday() ); //activate effects when timers goes to zero
+        iexamine::mill_finalize( get_avatar(), pos,
+                                 birthday() ); //activate effects when timers goes to zero
         return true; //destroy fake mill item
     }
 
@@ -9035,8 +9047,9 @@ bool item::process_fake_mill( player * /*carrier*/, const tripoint &pos )
 
 bool item::process_fake_smoke( player * /*carrier*/, const tripoint &pos )
 {
-    if( g->m.furn( pos ) != furn_str_id( "f_smoking_rack_active" ) &&
-        g->m.furn( pos ) != furn_str_id( "f_metal_smoking_rack_active" ) ) {
+    map &here = get_map();
+    if( here.furn( pos ) != furn_str_id( "f_smoking_rack_active" ) &&
+        here.furn( pos ) != furn_str_id( "f_metal_smoking_rack_active" ) ) {
         item_counter = 0;
         return true; //destroy fake smoke
     }
@@ -9059,6 +9072,7 @@ bool item::process_litcig( player *carrier, const tripoint &pos )
     if( !active ) {
         return false;
     }
+    map &here = get_map();
     // if carried by someone:
     if( carrier != nullptr ) {
         time_duration duration = 15_seconds;
@@ -9078,24 +9092,24 @@ bool item::process_litcig( player *carrier, const tripoint &pos )
         if( ( carrier->has_effect( effect_shakes ) && one_in( 10 ) ) ) {
             carrier->add_msg_if_player( m_bad, _( "Your shaking hand causes you to drop your %s." ),
                                         tname() );
-            g->m.add_item_or_charges( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), *this );
+            here.add_item_or_charges( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), *this );
             return true; // removes the item that has just been added to the map
         }
 
         if( carrier->has_effect( effect_sleep ) ) {
             carrier->add_msg_if_player( m_bad, _( "You fall asleep and drop your %s." ),
                                         tname() );
-            g->m.add_item_or_charges( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), *this );
+            here.add_item_or_charges( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), *this );
             return true; // removes the item that has just been added to the map
         }
     } else {
         // If not carried by someone, but laying on the ground:
         if( item_counter % 5 == 0 ) {
             // lit cigarette can start fires
-            if( g->m.flammable_items_at( pos ) ||
-                g->m.has_flag( flag_FLAMMABLE, pos ) ||
-                g->m.has_flag( flag_FLAMMABLE_ASH, pos ) ) {
-                g->m.add_field( pos, fd_fire, 1 );
+            if( here.flammable_items_at( pos ) ||
+                here.has_flag( flag_FLAMMABLE, pos ) ||
+                here.has_flag( flag_FLAMMABLE_ASH, pos ) ) {
+                here.add_field( pos, fd_fire, 1 );
             }
         }
     }
@@ -9113,7 +9127,7 @@ bool item::process_litcig( player *carrier, const tripoint &pos )
             convert( itype_joint_roach );
             if( carrier != nullptr ) {
                 carrier->add_effect( effect_weed_high, 1_minutes ); // one last puff
-                g->m.add_field( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), fd_weedsmoke, 2 );
+                here.add_field( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), fd_weedsmoke, 2 );
                 weed_msg( *carrier );
             }
         }
@@ -9146,11 +9160,12 @@ bool item::process_extinguish( player *carrier, const tripoint &pos )
         default:
             break;
     }
-    if( in_inv && !in_veh && g->m.has_flag( flag_DEEP_WATER, pos ) ) {
+    map &here = get_map();
+    if( in_inv && !in_veh && here.has_flag( flag_DEEP_WATER, pos ) ) {
         extinguish = true;
         submerged = true;
     }
-    if( ( !in_inv && g->m.has_flag( flag_LIQUID, pos ) && !g->m.veh_at( pos ) ) ||
+    if( ( !in_inv && here.has_flag( flag_LIQUID, pos ) && !here.veh_at( pos ) ) ||
         ( precipitation && !g->is_sheltered( pos ) ) ) {
         extinguish = true;
     }
@@ -9188,7 +9203,7 @@ bool item::process_extinguish( player *carrier, const tripoint &pos )
         if( type->tool->revert_to ) {
             convert( *type->tool->revert_to );
         } else {
-            type->invoke( carrier != nullptr ? *carrier : g->u, *this, pos, "transform" );
+            type->invoke( carrier != nullptr ? *carrier : get_avatar(), *this, pos, "transform" );
         }
 
     }
@@ -9203,7 +9218,8 @@ cata::optional<tripoint> item::get_cable_target( Character *p, const tripoint &p
     if( state != "pay_out_cable" && state != "cable_charger_link" ) {
         return cata::nullopt;
     }
-    const optional_vpart_position vp_pos = g->m.veh_at( pos );
+    map &here = get_map();
+    const optional_vpart_position vp_pos = here.veh_at( pos );
     if( vp_pos ) {
         const cata::optional<vpart_reference> seat = vp_pos.part_with_feature( "BOARDABLE", true );
         if( seat && p == seat->vehicle().get_passenger( seat->part_index() ) ) {
@@ -9213,7 +9229,7 @@ cata::optional<tripoint> item::get_cable_target( Character *p, const tripoint &p
 
     tripoint source( get_var( "source_x", 0 ), get_var( "source_y", 0 ), get_var( "source_z", 0 ) );
 
-    return g->m.getlocal( source );
+    return here.getlocal( source );
 }
 
 bool item::process_cable( player *carrier, const tripoint &pos )
@@ -9249,8 +9265,8 @@ bool item::process_cable( player *carrier, const tripoint &pos )
     if( !source ) {
         return false;
     }
-
-    if( !g->m.veh_at( *source ) || ( source->z != g->get_levz() && !g->m.has_zlevels() ) ) {
+    map &here = get_map();
+    if( !here.veh_at( *source ) || ( source->z != g->get_levz() && !here.has_zlevels() ) ) {
         if( carrier->has_item( *this ) ) {
             carrier->add_msg_if_player( m_bad, _( "You notice the cable has come loose!" ) );
         }
@@ -9322,6 +9338,7 @@ bool item::process_wet( player * /*carrier*/, const tripoint & /*pos*/ )
 
 bool item::process_tool( player *carrier, const tripoint &pos )
 {
+    avatar &you = get_avatar();
     // items with iuse set_transformed which are restricted turn off if not attached to their dependency.
     if( type->can_use( "set_transformed" ) ) {
         const set_transformed_iuse *actor = dynamic_cast<const set_transformed_iuse *>
@@ -9332,7 +9349,7 @@ bool item::process_tool( player *carrier, const tripoint &pos )
         }
         if( actor->restricted ) {
             if( !carrier ) {
-                actor->bypass( carrier != nullptr ? *carrier : g->u, *this, false, pos );
+                actor->bypass( carrier != nullptr ? *carrier : you, *this, false, pos );
                 return false;
             } else {
                 bool active = false;
@@ -9344,7 +9361,7 @@ bool item::process_tool( player *carrier, const tripoint &pos )
                     }
                 }
                 if( !active ) {
-                    actor->bypass( carrier != nullptr ? *carrier : g->u, *this, false, pos );
+                    actor->bypass( carrier != nullptr ? *carrier : you, *this, false, pos );
                     return false;
                 }
             }
@@ -9420,7 +9437,7 @@ bool item::process_tool( player *carrier, const tripoint &pos )
 
         // invoking the object can convert the item to another type
         const bool had_revert_to = type->tool->revert_to.has_value();
-        type->invoke( carrier != nullptr ? *carrier : g->u, *this, pos );
+        type->invoke( carrier != nullptr ? *carrier : you, *this, pos );
         if( had_revert_to ) {
             deactivate( carrier );
             return false;
@@ -9429,7 +9446,7 @@ bool item::process_tool( player *carrier, const tripoint &pos )
         }
     }
 
-    type->tick( carrier != nullptr ? *carrier : g->u, *this, pos );
+    type->tick( carrier != nullptr ? *carrier : you, *this, pos );
     return false;
 }
 
@@ -9492,8 +9509,9 @@ bool item::process_internal( player *carrier, const tripoint &pos, bool activate
         return process_blackpowder_fouling( carrier );
     }
 
+    avatar &you = get_avatar();
     if( activate ) {
-        return type->invoke( carrier != nullptr ? *carrier : g->u, *this, pos );
+        return type->invoke( carrier != nullptr ? *carrier : you, *this, pos );
     }
     // How this works: it checks what kind of processing has to be done
     // (e.g. for food, for drying towels, lit cigars), and if that matches,
@@ -9513,14 +9531,15 @@ bool item::process_internal( player *carrier, const tripoint &pos, bool activate
     }
 
     if( item_counter == 0 && type->countdown_action ) {
-        type->countdown_action.call( carrier ? *carrier : g->u, *this, false, pos );
+        type->countdown_action.call( carrier ? *carrier : you, *this, false, pos );
         if( type->countdown_destroy ) {
             return true;
         }
     }
 
+    map &here = get_map();
     for( const emit_id &e : type->emits ) {
-        g->m.emit_field( pos, e );
+        here.emit_field( pos, e );
     }
 
     if( has_flag( flag_FAKE_SMOKE ) && process_fake_smoke( carrier, pos ) ) {
@@ -9558,7 +9577,7 @@ bool item::process_internal( player *carrier, const tripoint &pos, bool activate
     if( ( is_food() || is_corpse() ) &&
         process_rot( insulation, seals, pos, carrier, flag ) ) {
         if( is_comestible() ) {
-            g->m.rotten_item_spawn( *this, pos );
+            here.rotten_item_spawn( *this, pos );
         }
         return true;
     }
@@ -9829,12 +9848,12 @@ skill_id item::contextualize_skill( const skill_id &id ) const
 bool item::is_filthy() const
 {
     return has_flag( flag_FILTHY ) && ( get_option<bool>( "FILTHY_MORALE" ) ||
-                                        g->u.has_trait( trait_SQUEAMISH ) );
+                                        get_avatar().has_trait( trait_SQUEAMISH ) );
 }
 
 bool item::on_drop( const tripoint &pos )
 {
-    return on_drop( pos, g->m );
+    return on_drop( pos, get_map() );
 }
 
 bool item::on_drop( const tripoint &pos, map &m )
@@ -9845,9 +9864,9 @@ bool item::on_drop( const tripoint &pos, map &m )
         !has_own_flag( "DIRTY" ) ) {
         set_flag( "DIRTY" );
     }
-
-    g->u.flag_encumbrance();
-    return type->drop_action && type->drop_action.call( g->u, *this, false, pos );
+    avatar &you = get_avatar();
+    you.flag_encumbrance();
+    return type->drop_action && type->drop_action.call( you, *this, false, pos );
 }
 
 time_duration item::age() const

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1155,12 +1155,14 @@ int pick_lock_actor::use( player &p, item &it, bool, const tripoint & ) const
         return 0;
     }
 
-    const std::function<bool( const tripoint & )> f = []( const tripoint & pnt ) {
+    map &here = get_map();
+
+    const std::function<bool( const tripoint & )> f = [&here]( const tripoint & pnt ) {
         if( pnt == g->u.pos() ) {
             return false;
         }
-        const ter_id ter = g->m.ter( pnt );
-        const furn_id furn = g->m.furn( pnt );
+        const ter_id ter = here.ter( pnt );
+        const furn_id furn = here.furn( pnt );
         lockpicking_open_result result = get_lockpicking_open_result( ter, furn );
         const bool is_allowed = result.new_ter_type || result.new_furn_type;
         return is_allowed;
@@ -1172,7 +1174,7 @@ int pick_lock_actor::use( player &p, item &it, bool, const tripoint & ) const
         return 0;
     }
     const tripoint &pnt = *pnt_;
-    const ter_id type = g->m.ter( pnt );
+    const ter_id type = here.ter( pnt );
     if( !f( pnt ) ) {
         if( pnt == p.pos() ) {
             p.add_msg_if_player( m_info, _( "You pick your nose and your sinuses swing open." ) );
@@ -2020,7 +2022,7 @@ int enzlave_actor::use( player &p, item &it, bool t, const tripoint & ) const
         p.add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
         return 0;
     }
-    map_stack items = g->m.i_at( point( p.posx(), p.posy() ) );
+    map_stack items = get_map().i_at( point( p.posx(), p.posy() ) );
     std::vector<const item *> corpses;
 
     for( item &corpse_candidate : items ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -137,7 +137,7 @@ std::string talk_trial::name() const
 /** Time (in turns) and cost (in cent) for training: */
 time_duration calc_skill_training_time( const npc &p, const skill_id &skill )
 {
-    return 1_minutes + 30_seconds * g->u.get_skill_level( skill ) -
+    return 1_minutes + 30_seconds * get_avatar().get_skill_level( skill ) -
            1_seconds * p.get_skill_level( skill );
 }
 
@@ -146,8 +146,8 @@ int calc_skill_training_cost( const npc &p, const skill_id &skill )
     if( p.is_player_ally() ) {
         return 0;
     }
-
-    return 1000 * ( 1 + g->u.get_skill_level( skill ) ) * ( 1 + g->u.get_skill_level( skill ) );
+    avatar &you = get_avatar();
+    return 1000 * ( 1 + you.get_skill_level( skill ) ) * ( 1 + you.get_skill_level( skill ) );
 }
 
 // TODO: all styles cost the same and take the same time to train,
@@ -281,7 +281,7 @@ static void npc_temp_orders_menu( const std::vector<npc *> &npc_list )
         nmenu.reset();
         nmenu.text = _( "Issue what temporary order?" );
         nmenu.desc_enabled = true;
-        parse_tags( output_string, g->u, *guy );
+        parse_tags( output_string, get_avatar(), *guy );
         nmenu.footer_text = output_string;
         nmenu.addentry( NPC_CHAT_DONE, true, 'd', _( "Done issuing orders" ) );
         nmenu.addentry( NPC_CHAT_FORBID_ENGAGE, true, 'f',
@@ -339,9 +339,9 @@ static void npc_temp_orders_menu( const std::vector<npc *> &npc_list )
 
 static void tell_veh_stop_following()
 {
-    for( wrapped_vehicle &veh : g->m.get_vehicles() ) {
+    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
         vehicle *v = veh.v;
-        if( v->has_engine_type( fuel_type_animal, false ) && v->is_owned_by( g->u ) ) {
+        if( v->has_engine_type( fuel_type_animal, false ) && v->is_owned_by( get_avatar() ) ) {
             v->is_following = false;
             v->engine_on = false;
         }
@@ -350,9 +350,9 @@ static void tell_veh_stop_following()
 
 static void assign_veh_to_follow()
 {
-    for( wrapped_vehicle &veh : g->m.get_vehicles() ) {
+    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
         vehicle *v = veh.v;
-        if( v->has_engine_type( fuel_type_animal, false ) && v->is_owned_by( g->u ) ) {
+        if( v->has_engine_type( fuel_type_animal, false ) && v->is_owned_by( get_avatar() ) ) {
             v->activate_animal_follow();
         }
     }
@@ -360,12 +360,12 @@ static void assign_veh_to_follow()
 
 static void tell_magic_veh_to_follow()
 {
-    for( wrapped_vehicle &veh : g->m.get_vehicles() ) {
+    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
         vehicle *v = veh.v;
         if( v->magic ) {
             for( const vpart_reference &vp : v->get_all_parts() ) {
                 const vpart_info &vpi = vp.info();
-                if( vpi.has_flag( "MAGIC_FOLLOW" ) && v->is_owned_by( g->u ) ) {
+                if( vpi.has_flag( "MAGIC_FOLLOW" ) && v->is_owned_by( get_avatar() ) ) {
                     v->activate_magical_follow();
                     break;
                 }
@@ -376,7 +376,7 @@ static void tell_magic_veh_to_follow()
 
 static void tell_magic_veh_stop_following()
 {
-    for( wrapped_vehicle &veh : g->m.get_vehicles() ) {
+    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
         vehicle *v = veh.v;
         if( v->magic ) {
             for( const vpart_reference &vp : v->get_all_parts() ) {
@@ -393,7 +393,7 @@ static void tell_magic_veh_stop_following()
 
 void game::chat()
 {
-    int volume = g->u.get_shout_volume();
+    int volume = u.get_shout_volume();
 
     const std::vector<npc *> available = get_npcs_if( [&]( const npc & guy ) {
         // TODO: Get rid of the z-level check when z-level vision gets "better"
@@ -412,18 +412,18 @@ void game::chat()
     } );
     const int guard_count = guards.size();
 
-    if( g->u.has_trait( trait_PROF_FOODP ) && !( g->u.is_wearing( itype_id( "foodperson_mask" ) ) ||
-            g->u.is_wearing( itype_id( "foodperson_mask_on" ) ) ) ) {
-        g->u.add_msg_if_player( m_warning, _( "You can't speak without your face!" ) );
+    if( u.has_trait( trait_PROF_FOODP ) && !( u.is_wearing( itype_id( "foodperson_mask" ) ) ||
+            u.is_wearing( itype_id( "foodperson_mask_on" ) ) ) ) {
+        u.add_msg_if_player( m_warning, _( "You can't speak without your face!" ) );
         return;
     }
     std::vector<vehicle *> animal_vehicles;
     std::vector<vehicle *> following_vehicles;
     std::vector<vehicle *> magic_vehicles;
     std::vector<vehicle *> magic_following_vehicles;
-    for( auto &veh : g->m.get_vehicles() ) {
+    for( auto &veh : m.get_vehicles() ) {
         auto &v = veh.v;
-        if( v->has_engine_type( fuel_type_animal, false ) && v->is_owned_by( g->u ) ) {
+        if( v->has_engine_type( fuel_type_animal, false ) && v->is_owned_by( u ) ) {
             animal_vehicles.push_back( v );
             if( v->is_following ) {
                 following_vehicles.push_back( v );
@@ -626,14 +626,15 @@ void game::chat()
 void npc::handle_sound( const sounds::sound_t spriority, const std::string &description,
                         int heard_volume, const tripoint &spos )
 {
-    const tripoint s_abs_pos = g->m.getabs( spos );
-    const tripoint my_abs_pos = g->m.getabs( pos() );
+    map &here = get_map();
+    const tripoint s_abs_pos = here.getabs( spos );
+    const tripoint my_abs_pos = here.getabs( pos() );
 
     add_msg( m_debug, "%s heard '%s', priority %d at volume %d from %d:%d, my pos %d:%d",
              disp_name(), description, static_cast<int>( spriority ), heard_volume,
              s_abs_pos.x, s_abs_pos.y, my_abs_pos.x, my_abs_pos.y );
 
-    bool player_ally = g->u.pos() == spos && is_player_ally();
+    bool player_ally = get_player_character().pos() == spos && is_player_ally();
     player *const sound_source = g->critter_at<player>( spos );
     bool npc_ally = sound_source && sound_source->is_npc() && is_ally( *sound_source );
 
@@ -659,7 +660,7 @@ void npc::handle_sound( const sounds::sound_t spriority, const std::string &desc
     }
     // discount if sound source is player, or seen by player,
     // and listener is friendly and sound source is combat or alert only.
-    if( spriority < sounds::sound_t::alarm && g->u.sees( spos ) ) {
+    if( spriority < sounds::sound_t::alarm && get_avatar().sees( spos ) ) {
         if( is_player_ally() ) {
             add_msg( m_debug, "NPC %s ignored low priority noise that player can see", name );
             return;
@@ -730,11 +731,12 @@ void npc_chatbin::check_missions()
 
 void npc::talk_to_u( bool radio_contact )
 {
-    if( g->u.is_dead_state() ) {
+    avatar &you = get_avatar();
+    if( you.is_dead_state() ) {
         set_attitude( NPCATT_NULL );
         return;
     }
-    const bool has_mind_control = g->u.has_trait( trait_DEBUG_MIND_CONTROL );
+    const bool has_mind_control = you.has_trait( trait_DEBUG_MIND_CONTROL );
     // This is necessary so that we don't bug the player over and over
     if( get_attitude() == NPCATT_TALK ) {
         set_attitude( NPCATT_NULL );
@@ -751,18 +753,18 @@ void npc::talk_to_u( bool radio_contact )
     }
     set_known_to_u( true );
     dialogue d;
-    d.alpha = &g->u;
+    d.alpha = &you;
     d.beta = this;
 
     chatbin.check_missions();
 
     // For each active mission we have, let the mission know we talked to this NPC.
-    for( auto &mission : g->u.get_active_missions() ) {
+    for( auto &mission : you.get_active_missions() ) {
         mission->on_talk_with_npc( this->getID() );
     }
 
     for( auto &mission : chatbin.missions_assigned ) {
-        if( mission->get_assigned_player_id() == g->u.getID() ) {
+        if( mission->get_assigned_player_id() == you.getID() ) {
             d.missions_assigned.push_back( mission );
         }
     }
@@ -777,7 +779,7 @@ void npc::talk_to_u( bool radio_contact )
     } else if( get_attitude() == NPCATT_RECOVER_GOODS ) {
         d.add_topic( "TALK_STOLE_ITEM" );
     }
-    g->u.dialogue_by_radio = d.by_radio;
+    you.dialogue_by_radio = d.by_radio;
     int most_difficult_mission = 0;
     for( auto &mission : chatbin.missions ) {
         const auto &type = mission->get_type();
@@ -790,7 +792,7 @@ void npc::talk_to_u( bool radio_contact )
     most_difficult_mission = 0;
     bool chosen_urgent = false;
     for( auto &mission : chatbin.missions_assigned ) {
-        if( mission->get_assigned_player_id() != g->u.getID() ) {
+        if( mission->get_assigned_player_id() != you.getID() ) {
             // Not assigned to the player that is currently talking to the npc
             continue;
         }
@@ -817,12 +819,12 @@ void npc::talk_to_u( bool radio_contact )
     }
 
     if( d.topic_stack.back().id == "TALK_NONE" ) {
-        d.topic_stack.back() = talk_topic( pick_talk_topic( g->u ) );
+        d.topic_stack.back() = talk_topic( pick_talk_topic( you ) );
     }
 
     moves -= 100;
 
-    if( g->u.is_deaf() ) {
+    if( you.is_deaf() ) {
         if( d.topic_stack.back().id == "TALK_MUG" ||
             d.topic_stack.back().id == "TALK_STRANGER_AGGRESSIVE" ) {
             make_angry();
@@ -832,8 +834,8 @@ void npc::talk_to_u( bool radio_contact )
         }
     }
 
-    if( g->u.has_trait( trait_PROF_FOODP ) && !( g->u.is_wearing( itype_id( "foodperson_mask" ) ) ||
-            g->u.is_wearing( itype_id( "foodperson_mask_on" ) ) ) ) {
+    if( you.has_trait( trait_PROF_FOODP ) && !( you.is_wearing( itype_id( "foodperson_mask" ) ) ||
+            you.is_wearing( itype_id( "foodperson_mask_on" ) ) ) ) {
         d.add_topic( "TALK_NOFACE" );
     }
 
@@ -848,7 +850,7 @@ void npc::talk_to_u( bool radio_contact )
     // Main dialogue loop
     do {
         if( chatbin.mission_selected != nullptr ) {
-            if( chatbin.mission_selected->get_assigned_player_id() != g->u.getID() ) {
+            if( chatbin.mission_selected->get_assigned_player_id() != you.getID() ) {
                 // Don't talk about a mission that is assigned to someone else.
                 chatbin.mission_selected = nullptr;
             }
@@ -876,17 +878,17 @@ void npc::talk_to_u( bool radio_contact )
         }
     } while( !d.done );
 
-    if( g->u.activity.id() == ACT_AIM && !g->u.has_weapon() ) {
-        g->u.cancel_activity();
+    if( you.activity.id() == ACT_AIM && !you.has_weapon() ) {
+        you.cancel_activity();
         // don't query certain activities that are started from dialogue
-    } else if( g->u.activity.id() == ACT_TRAIN ||
-               g->u.activity.id() == ACT_WAIT_NPC ||
-               g->u.activity.id() == ACT_SOCIALIZE ||
-               g->u.activity.index == getID().get_value() ) {
+    } else if( you.activity.id() == ACT_TRAIN ||
+               you.activity.id() == ACT_WAIT_NPC ||
+               you.activity.id() == ACT_SOCIALIZE ||
+               you.activity.index == getID().get_value() ) {
         return;
     }
 
-    if( !g->u.has_effect( effect_under_op ) ) {
+    if( !you.has_effect( effect_under_op ) ) {
         g->cancel_activity_or_ignore_query( distraction_type::talked_to,
                                             string_format( _( "%s talked to you." ), name ) );
     }
@@ -968,18 +970,19 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
         return ret;
     }
 
+    avatar &you = get_avatar();
     if( topic == "TALK_NONE" || topic == "TALK_DONE" ) {
         return _( "Bye." );
     } else if( topic == "TALK_TRAIN" ) {
-        if( !g->u.backlog.empty() && g->u.backlog.front().id() == ACT_TRAIN ) {
+        if( !you.backlog.empty() && you.backlog.front().id() == ACT_TRAIN ) {
             return _( "Shall we resume?" );
         }
-        std::vector<skill_id> trainable = p->skills_offered_to( g->u );
-        std::vector<matype_id> styles = p->styles_offered_to( g->u );
+        std::vector<skill_id> trainable = p->skills_offered_to( you );
+        std::vector<matype_id> styles = p->styles_offered_to( you );
         const std::vector<spell_id> spells = p->magic->spells();
         std::vector<spell_id> teachable_spells;
         for( const spell_id &sp : spells ) {
-            if( g->u.magic->can_learn_spell( g->u, sp ) ) {
+            if( you.magic->can_learn_spell( you, sp ) ) {
                 teachable_spells.emplace_back( sp );
             }
         }
@@ -1039,7 +1042,7 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic ) const
         ///\EFFECT_PER affects whether player can size up NPCs
 
         ///\EFFECT_INT slightly affects whether player can size up NPCs
-        int ability = g->u.per_cur * 3 + g->u.int_cur;
+        int ability = you.per_cur * 3 + you.int_cur;
         if( ability <= 10 ) {
             return _( "&You can't make anything out." );
         }
@@ -1247,7 +1250,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             return;
         }
     }
-
+    avatar &you = get_avatar();
     if( topic == "TALK_MISSION_LIST" ) {
         if( p->chatbin.missions.size() == 1 ) {
             add_response( _( "Tell me about it." ), "TALK_MISSION_OFFER",
@@ -1266,9 +1269,9 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             }
         }
     } else if( topic == "TALK_TRAIN" ) {
-        if( !g->u.backlog.empty() && g->u.backlog.front().id() == ACT_TRAIN &&
-            g->u.backlog.front().index == p->getID().get_value() ) {
-            player_activity &backlog = g->u.backlog.front();
+        if( !you.backlog.empty() && you.backlog.front().id() == ACT_TRAIN &&
+            you.backlog.front().index == p->getID().get_value() ) {
+            player_activity &backlog = you.backlog.front();
             const skill_id skillt( backlog.name );
             // TODO: This is potentially dangerous. A skill and a martial art
             // could have the same ident!
@@ -1290,15 +1293,15 @@ void dialogue::gen_responses( const talk_topic &the_topic )
                               "TALK_TRAIN_START", skillt );
             }
         }
-        std::vector<matype_id> styles = p->styles_offered_to( g->u );
-        std::vector<skill_id> trainable = p->skills_offered_to( g->u );
+        std::vector<matype_id> styles = p->styles_offered_to( you );
+        std::vector<skill_id> trainable = p->skills_offered_to( you );
         const std::vector<spell_id> spells = p->magic->spells();
         std::vector<spell_id> teachable_spells;
         for( const spell_id &sp : spells ) {
             const spell &temp_spell = p->magic->get_spell( sp );
-            if( g->u.magic->can_learn_spell( g->u, sp ) ) {
-                if( g->u.magic->knows_spell( sp ) ) {
-                    const spell &player_spell = g->u.magic->get_spell( sp );
+            if( you.magic->can_learn_spell( you, sp ) ) {
+                if( you.magic->knows_spell( sp ) ) {
+                    const spell &player_spell = you.magic->get_spell( sp );
                     if( player_spell.is_max_level() || player_spell.get_level() >= temp_spell.get_level() ) {
                         continue;
                     }
@@ -1312,7 +1315,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         }
         for( const spell_id &sp : teachable_spells ) {
             const spell &temp_spell = p->magic->get_spell( sp );
-            const bool knows = g->u.magic->knows_spell( sp );
+            const bool knows = you.magic->knows_spell( sp );
             const int cost = p->calc_spell_training_cost( knows, temp_spell.get_difficulty(),
                              temp_spell.get_level() );
             std::string text;
@@ -1335,7 +1338,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         }
         for( auto &trained : trainable ) {
             const int cost = calc_skill_training_cost( *p, trained );
-            SkillLevel skill_level_obj = g->u.get_skill_level_object( trained );
+            SkillLevel skill_level_obj = you.get_skill_level_object( trained );
             const int cur_level = skill_level_obj.level();
             const int cur_level_exercise = skill_level_obj.exercise();
             skill_level_obj.train( 100, true );
@@ -1355,7 +1358,7 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         add_response_done( _( "Let's keep moving." ) );
     }
 
-    if( g->u.has_trait( trait_DEBUG_MIND_CONTROL ) && !p->is_player_ally() ) {
+    if( you.has_trait( trait_DEBUG_MIND_CONTROL ) && !p->is_player_ally() ) {
         add_response( _( "OBEY ME!" ), "TALK_MIND_CONTROL" );
         add_response_done( _( "Bye." ) );
     }
@@ -2368,7 +2371,7 @@ void talk_effect_fun_t::set_add_mission( const std::string &mission_id )
     function = [mission_id]( const dialogue & d ) {
         npc &p = *d.beta;
         mission *miss = mission::reserve_new( mission_type_id( mission_id ), p.getID() );
-        miss->assign( g->u );
+        miss->assign( get_avatar() );
         p.chatbin.missions_assigned.push_back( miss );
     };
 }
@@ -3333,20 +3336,21 @@ std::string give_item_to( npc &p, bool allow_use )
     if( p.is_hallucination() ) {
         return _( "No thanks, I'm good." );
     }
-    item_location loc = game_menus::inv::titled_menu( g->u, _( "Offer what?" ),
+    avatar &you = get_avatar();
+    item_location loc = game_menus::inv::titled_menu( you, _( "Offer what?" ),
                         _( "You have no items to offer." ) );
     if( !loc ) {
         return _( "Changed your mind?" );
     }
     item &given = *loc;
 
-    if( ( &given == &g->u.weapon && given.has_flag( "NO_UNWIELD" ) ) || ( g->u.is_worn( given ) &&
+    if( ( &given == &you.weapon && given.has_flag( "NO_UNWIELD" ) ) || ( you.is_worn( given ) &&
             given.has_flag( "NO_TAKEOFF" ) ) ) {
         // Bionic weapon or shackles
         return _( "How?" );
     }
 
-    if( given.is_dangerous() && !g->u.has_trait( trait_DEBUG_MIND_CONTROL ) ) {
+    if( given.is_dangerous() && !you.has_trait( trait_DEBUG_MIND_CONTROL ) ) {
         return _( "Are you <swear> insane!?" );
     }
 
@@ -3365,9 +3369,9 @@ std::string give_item_to( npc &p, bool allow_use )
         const auto consume_res = try_consume( p, given, reason );
         if( consume_res != REFUSED ) {
             if( consume_res == CONSUMED_ALL ) {
-                g->u.i_rem( &given );
+                you.i_rem( &given );
             }
-            g->u.moves -= 100;
+            you.moves -= 100;
             if( given.is_container() ) {
                 given.on_contents_changed();
             }
@@ -3421,8 +3425,8 @@ std::string give_item_to( npc &p, bool allow_use )
     }
 
     if( taken ) {
-        g->u.i_rem( &given );
-        g->u.moves -= 100;
+        you.i_rem( &given );
+        you.moves -= 100;
         p.has_new_items = true;
     }
 

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -114,7 +114,7 @@ void apply_ammo_effects( const tripoint &p, const std::set<ammo_effect_str_id> &
     for( const ammo_effect_str_id &ae_id : effects ) {
         const ammo_effect &ae = *ae_id;
         if( ae.aoe_field_type )
-            for( auto &pt : g->m.points_in_radius( p, ae.aoe_radius, ae.aoe_radius_z ) ) {
+            for( auto &pt : here.points_in_radius( p, ae.aoe_radius, ae.aoe_radius_z ) ) {
                 if( x_in_y( ae.aoe_chance, 100 ) ) {
                     const bool check_sees = !ae.aoe_check_sees || here.sees( p, pt, ae.aoe_check_sees_radius );
                     const bool check_passable = !ae.aoe_check_passable || here.passable( pt );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -264,7 +264,7 @@ void Character::suffer_while_underwater()
             apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
         }
     }
-    if( has_trait( trait_FRESHWATEROSMOSIS ) && !g->m.has_flag_ter( "SALT_WATER", pos() ) &&
+    if( has_trait( trait_FRESHWATEROSMOSIS ) && !get_map().has_flag_ter( "SALT_WATER", pos() ) &&
         get_thirst() > thirst_levels::turgid ) {
         mod_thirst( -1 );
     }
@@ -658,10 +658,11 @@ void Character::suffer_from_asthma( const int current_stim )
         } else if( nearby_use ) {
             // create new variable to resolve a reference issue
             int amount = 1;
-            if( !g->m.use_charges( g->u.pos(), 2, itype_inhaler, amount ).empty() ) {
+            map &here = get_map();
+            if( !here.use_charges( g->u.pos(), 2, itype_inhaler, amount ).empty() ) {
                 add_msg_if_player( m_info, _( "You use your inhaler and go back to sleep." ) );
-            } else if( !g->m.use_charges( g->u.pos(), 2, itype_oxygen_tank, amount ).empty() ||
-                       !g->m.use_charges( g->u.pos(), 2, itype_smoxygen_tank, amount ).empty() ) {
+            } else if( !here.use_charges( g->u.pos(), 2, itype_oxygen_tank, amount ).empty() ||
+                       !here.use_charges( g->u.pos(), 2, itype_smoxygen_tank, amount ).empty() ) {
                 add_msg_if_player( m_info, _( "You take a deep breath from your oxygen tank "
                                               "and go back to sleep." ) );
             }
@@ -723,7 +724,7 @@ void Character::suffer_in_sunlight()
     const bool leafier = has_trait( trait_LEAVES2 ) || has_trait( trait_LEAVES3 );
     const bool leafiest = has_trait( trait_LEAVES3 );
     int sunlight_nutrition = 0;
-    if( leafy && g->m.is_outside( pos() ) && ( g->light_level( pos().z ) >= 40 ) ) {
+    if( leafy && get_map().is_outside( pos() ) && ( g->light_level( pos().z ) >= 40 ) ) {
         const float weather_factor = ( get_weather().weather_id->sun_intensity >=
                                        sun_intensity_type::normal ) ? 1.0 : 0.5;
         const int player_local_temp = get_weather().get_temperature( pos() );
@@ -943,9 +944,10 @@ void Character::suffer_from_sunburn()
 
 void Character::suffer_from_other_mutations()
 {
+    map &here = get_map();
     if( has_trait( trait_SHARKTEETH ) && one_turn_in( 24_hours ) ) {
         add_msg_if_player( m_neutral, _( "You shed a tooth!" ) );
-        g->m.spawn_item( pos(), "bone", 1 );
+        here.spawn_item( pos(), "bone", 1 );
     }
 
     if( has_active_mutation( trait_WINGS_INSECT ) ) {
@@ -957,7 +959,7 @@ void Character::suffer_from_other_mutations()
     bool wearing_shoes = is_wearing_shoes( side::LEFT ) || is_wearing_shoes( side::RIGHT );
     int root_vitamins = 0;
     int root_water = 0;
-    if( has_trait( trait_ROOTS3 ) && g->m.has_flag( flag_PLOWABLE, pos() ) && !wearing_shoes ) {
+    if( has_trait( trait_ROOTS3 ) && here.has_flag( flag_PLOWABLE, pos() ) && !wearing_shoes ) {
         root_vitamins += 1;
         if( get_thirst() <= thirst_levels::turgid ) {
             root_water += 51;
@@ -991,7 +993,7 @@ void Character::suffer_from_other_mutations()
     //Web Weavers...weave web
     if( has_active_mutation( trait_WEB_WEAVER ) && !in_vehicle ) {
         // this adds intensity to if its not already there.
-        g->m.add_field( pos(), fd_web, 1 );
+        here.add_field( pos(), fd_web, 1 );
 
     }
 
@@ -1016,7 +1018,7 @@ void Character::suffer_from_other_mutations()
 
     if( has_trait( trait_WEB_SPINNER ) && !in_vehicle && one_in( 3 ) ) {
         // this adds intensity to if its not already there.
-        g->m.add_field( pos(), fd_web, 1 );
+        here.add_field( pos(), fd_web, 1 );
     }
 
     bool should_mutate = has_trait( trait_UNSTABLE ) && !has_trait( trait_CHAOTIC_BAD ) &&
@@ -1051,9 +1053,10 @@ void Character::suffer_from_other_mutations()
 
 void Character::suffer_from_radiation()
 {
+    map &here = get_map();
     // checking for radioactive items in inventory
     const int item_radiation = leak_level( "RADIOACTIVE" );
-    const int map_radiation = g->m.get_radiation( pos() );
+    const int map_radiation = here.get_radiation( pos() );
     float rads = map_radiation / 100.0f + item_radiation / 10.0f;
 
     int rad_mut = 0;
@@ -1086,8 +1089,8 @@ void Character::suffer_from_radiation()
             // If you can't, irradiate the player instead
             tripoint rad_point = pos() + point( rng( -3, 3 ), rng( -3, 3 ) );
             // TODO: Radioactive vehicles?
-            if( g->m.get_radiation( rad_point ) < rad_mut ) {
-                g->m.adjust_radiation( rad_point, 1 );
+            if( here.get_radiation( rad_point ) < rad_mut ) {
+                here.adjust_radiation( rad_point, 1 );
             } else {
                 rads += rad_mut;
             }


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Clean up some uses of the old globals"

#### Purpose of change

Gets rid of a bunch of uses of g->m and g->u replacing them with the function alternatives. 

#### Describe the solution

Just elbow grease. With the idea that we want to bind the values to a local variable most of the time automating it isn't so easy. There's still plenty to go, even some the files touched here aren't totally finished. 

#### Describe alternatives you've considered

Doing the rest of them right now or waiting with the PR until they're done, but I think I want to spread it out a bit and this way means less conflicts and it's good that as much of our code as possible is a template for what new code should look like. 

#### Testing

They're all nothing changes. It's a pretty mechanical process and if it compiles it's hard to mess anything up. The only caveat to that is being careful when choosing get_player_character over get_avatar. 

#### Additional context

Before this (i.e. 17c7df71348fdb2d542ddd2b86ab8110e384574e) a count of the pattern '\bg->m\b' in src/ gives 898 results and g->u gives 1766. After this g->m gives 816 and g->u gives 1559. So that's about 82 uses of g->m and 207 of g->u removed. 