### PR TITLE
Loop element hotfix

### DIFF
--- a/pch/main-pch.hpp
+++ b/pch/main-pch.hpp
@@ -46,6 +46,7 @@
 #include <stack>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <system_error>
 #include <tuple>
 #include <type_traits>

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <fstream>
 #include <algorithm>
+#include <string_view>
 
 #include "avatar.h"
 #include "bionics.h"
@@ -747,9 +748,9 @@ void diary::export_to_md( bool last_export )
         for( std::string &str : left_diary_text ) {
             myfile << remove_color_tags( str ) + "\n";
         }
-        std::vector<std::string> folded_text = foldstring( page.m_text, 50 );
-        for( const auto &folded_text_char : folded_text ) {
-            myfile << folded_text_char + "\n";
+        std::vector<std::string> folded_texts = foldstring( page.m_text, 50 );
+        for( const std::string_view folded_text : folded_texts ) {
+            myfile << folded_text << "\n";
         }
         myfile << "\n\n\n";
     }

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -745,10 +745,10 @@ void diary::export_to_md( bool last_export )
         // add "## " before each "Entry" line to visually differentiate each page
         left_diary_text[0] = "## " + left_diary_text[0];
 
-        for( std::string &str : left_diary_text ) {
+        for( const std::string &str : left_diary_text ) {
             myfile << remove_color_tags( str ) + "\n";
         }
-        std::vector<std::string> folded_texts = foldstring( page.m_text, 50 );
+        const std::vector<std::string> folded_texts = foldstring( page.m_text, 50 );
         for( const std::string_view folded_text : folded_texts ) {
             myfile << folded_text << "\n";
         }

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -748,7 +748,7 @@ void diary::export_to_md( bool last_export )
             myfile << remove_color_tags( str ) + "\n";
         }
         std::vector<std::string> folded_text = foldstring( page.m_text, 50 );
-        for( const auto folded_text_char : folded_text ) {
+        for( const auto &folded_text_char : folded_text ) {
             myfile << folded_text_char + "\n";
         }
         myfile << "\n\n\n";


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Loop element hotfix"

#### Purpose of change

fix build error, failed to build because each element was being copied

```c++
1 | Error: /home/runner/work/Cataclysm-BN/Cataclysm-BN/src/diary.cpp:751:25: error: loop variable ‘folded_text_char’ creates a copy from type ‘const std::__cxx11::basic_string<char>’ [-Werror=range-loop-construct]
-- | --
2 | 751 \|         for( const auto folded_text_char : folded_text ) {
3 | \|                         ^~~~~~~~~~~~~~~~
4 | /home/runner/work/Cataclysm-BN/Cataclysm-BN/src/diary.cpp:751:25: note: use reference type to prevent copying
5 | 751 \|         for( const auto folded_text_char : folded_text ) {
6 | \|                         ^~~~~~~~~~~~~~~~
7 | \|                         &
```

#### Describe the solution
use [`std::string_view`](https://en.cppreference.com/w/cpp/string/basic_string_view) to [efficiently](https://quuxplusone.github.io/blog/2021/11/09/pass-string-view-by-value/) iterate through strings

#### Describe alternatives you've considered
prevent coping by adding &
