### PR TITLE
`maximum_charges()` now defaults to 0. Optical Cloak changed to TOOL_ARMOR category

### DIFF
--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -157,7 +157,7 @@
   },
   {
     "id": "optical_cloak",
-    "type": "ARMOR",
+    "type": "TOOL_ARMOR",
     "name": { "str": "FB51 optical cloak" },
     "description": "A plastic cloak embedded with cameras and LEDs that will render you fully invisible to normal vision when powered and worn.  You must be carrying a unified power supply, or UPS, to use it.  Activate to toggle visibility.",
     "weight": "1552 g",

--- a/src/itype.h
+++ b/src/itype.h
@@ -1104,7 +1104,7 @@ struct itype {
             if( tool ) {
                 return tool->max_charges;
             }
-            return 1;
+            return 0;
         }
         bool can_have_charges() const;
 


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "`maximum_charges()` now defaults to 0. Optical Cloak changed to TOOL_ARMOR category"

#### Purpose of change

Players reported an issue where ups conversion mods carried with an active UPS or other similar item would be charged, causing an error report on load since the item isn't supposed to carry charges.

Also noticed that while doing #1505 I'd neglected to make the base version of the optical cloak TOOL_ARMOR, which contributed to the same issue.

#### Describe the solution

The base optical cloak is now TOOL_ARMOR, which should prevent edge cases of it gaining charges through battery mods or other arcane methods from causing errors.

`maximum_charges()` was updated such that it defaults to 0 if the item is not a tool, this is consistent with `itype::can_have_charges()` which assumes that any non-tool, non-gunmod, non-count_by_charges() item has no charges. Far as I can tell this won't affect items with `count_by_charges()` since maximum_charges() isn't actually called by anything that doesn't have `USE_UPS` flag to it. If this ever changes a review will be needed.

#### Describe alternatives you've considered

- Add tool definitions to TOOL_MODs.
Not a bad idea, but this method is more conservative and won't add a number of fields to tool mods that aren't otherwise used. If more tool mods are added that require those fields or some change necessitates `maximum_charges()` being 1 instead of 0, then this is the next best option.

#### Testing

Advanced UPS carried on person, spawned UPS conversion mod and optical cloak, saved and loaded, no errors seen.

#### Additional context

Idle thought, but count_by_charges should really use a completely different field, using the same universal charge for electricity, portions and ammo is bound to bite us in the ass eventually.
