### PR TITLE
Add autolockpick on examine for fingerpick CBM

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -638,6 +638,7 @@
     "name": { "str": "Fingerpick" },
     "description": "One of your fingers has an electronic lockpick surgically embedded in it.  This automatic system will quickly unlock all but the most advanced key locks without any skill required on the part of the user.",
     "occupied_bodyparts": [ [ "hand_r", 2 ] ],
+    "fake_item": "fake_lockpick",
     "act_cost": "50 J"
   },
   {

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -155,6 +155,16 @@
     "use_action": { "type": "firestarter", "moves": 200 }
   },
   {
+    "id": "fake_lockpick",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "Fingerpick" },
+    "description": "An unbreakable, high-tech bionic lockpick.  If you see this, this is a bug.",
+    "volume": 0,
+    "qualities": [ [ "LOCKPICK", 250 ] ],
+    "use_action": { "type": "picklock", "pick_quality": 250 }
+  },
+  {
     "id": "migo_bio_gun",
     "type": "GUN",
     "copy-from": "fake_item",

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -205,6 +205,7 @@ static const itype_id itype_2x4( "2x4" );
 static const itype_id itype_animal( "animal" );
 static const itype_id itype_battery( "battery" );
 static const itype_id itype_burnt_out_bionic( "burnt_out_bionic" );
+static const itype_id itype_fake_lockpick( "fake_lockpick" );
 static const itype_id itype_grapnel( "grapnel" );
 static const itype_id itype_hd_tow_cable( "hd_tow_cable" );
 static const itype_id itype_log( "log" );
@@ -2554,7 +2555,7 @@ void activity_handlers::lockpicking_finish( player_activity *act, player *p )
     } else if( furn_type == f_gunsafe_ml && lock_roll > ( 3 * pick_roll ) ) {
         p->add_msg_if_player( m_bad, _( "Your clumsy attempt jams the lock!" ) );
         g->m.furn_set( act->placement, furn_str_id( "f_gunsafe_mj" ) );
-    } else if( lock_roll > ( 1.5 * pick_roll ) ) {
+    } else if( lock_roll > ( 1.5 * pick_roll ) && it->type->get_id() != itype_fake_lockpick ) {
         if( it->inc_damage() ) {
             p->add_msg_if_player( m_bad,
                                   _( "The lock stumps your efforts to pick it, and you destroy your tool." ) );
@@ -2574,7 +2575,8 @@ void activity_handlers::lockpicking_finish( player_activity *act, player *p )
                                  p->global_sm_location() );
         }
     }
-    if( destroy ) {
+    // if the item should be destroyed, or it's a dummy fake_lockpick destroy it
+    if( destroy || it->type->get_id() == itype_fake_lockpick ) {
         p->i_rem( it );
     }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -136,6 +136,7 @@ static const itype_id itype_charcoal( "charcoal" );
 static const itype_id itype_chem_carbide( "chem_carbide" );
 static const itype_id itype_corpse( "corpse" );
 static const itype_id itype_electrohack( "electrohack" );
+static const itype_id itype_fake_lockpick( "fake_lockpick" );
 static const itype_id itype_fake_milling_item( "fake_milling_item" );
 static const itype_id itype_fake_smoke_plume( "fake_smoke_plume" );
 static const itype_id itype_fertilizer( "fertilizer" );
@@ -208,6 +209,7 @@ static const mtype_id mon_spider_widow_giant_s( "mon_spider_widow_giant_s" );
 static const bionic_id bio_ears( "bio_ears" );
 static const bionic_id bio_fingerhack( "bio_fingerhack" );
 static const bionic_id bio_lighter( "bio_lighter" );
+static const bionic_id bio_lockpick( "bio_lockpick" );
 static const bionic_id bio_painkiller( "bio_painkiller" );
 static const bionic_id bio_power_storage( "bio_power_storage" );
 static const bionic_id bio_power_storage_mkII( "bio_power_storage_mkII" );
@@ -1484,6 +1486,17 @@ static safe_reference<item> find_best_prying_tool( player &p )
 
 static safe_reference<item> find_best_lock_picking_tool( player &p )
 {
+
+    // if player has fingerpick bionic, enough power, and doesn't already have a fake_lockpick (in case it could happen somehow), add it to its inventory
+    if( p.has_bionic( bio_lockpick ) && p.get_power_level() >= 50_kJ &&
+    !p.has_item_with( []( const item & it ) {
+    return it.type->get_id() == itype_fake_lockpick;
+    } ) ) {
+        item fake_lockpick( itype_fake_lockpick, calendar::turn );
+        p.i_add( fake_lockpick );
+        p.mod_power_level( -50_kJ );
+    }
+
     std::vector<item *> picklocks = p.items_with( []( const item & it ) {
         // we want to get worn items (eg hairpin), so no check on item position
         return it.type->get_use( "picklock" ) != nullptr;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1487,16 +1487,6 @@ static safe_reference<item> find_best_prying_tool( player &p )
 static safe_reference<item> find_best_lock_picking_tool( player &p )
 {
 
-    // if player has fingerpick bionic, enough power, and doesn't already have a fake_lockpick (in case it could happen somehow), add it to its inventory
-    if( p.has_bionic( bio_lockpick ) && p.get_power_level() >= 50_kJ &&
-    !p.has_item_with( []( const item & it ) {
-    return it.type->get_id() == itype_fake_lockpick;
-    } ) ) {
-        item fake_lockpick( itype_fake_lockpick, calendar::turn );
-        p.i_add( fake_lockpick );
-        p.mod_power_level( -50_kJ );
-    }
-
     std::vector<item *> picklocks = p.items_with( []( const item & it ) {
         // we want to get worn items (eg hairpin), so no check on item position
         return it.type->get_use( "picklock" ) != nullptr;
@@ -1562,6 +1552,13 @@ void iexamine::locked_object( player &p, const tripoint &examp )
 
     // if the furniture/terrain is also lockpickable
     if( here.has_flag_ter_or_furn( "LOCKED", examp ) ) {
+        // if player has fingerpick bionic, enough power add it to its inventory
+        if( p.has_bionic( bio_lockpick ) && p.get_power_level() >= 50_kJ ) {
+            item fake_lockpick( itype_fake_lockpick, calendar::turn );
+            p.i_add( fake_lockpick );
+            p.mod_power_level( -50_kJ );
+        }
+
         safe_reference<item> lock_picking_tool = find_best_lock_picking_tool( p );
         if( lock_picking_tool ) {
             apply_lock_picking_tool( p, lock_picking_tool.get(), examp );
@@ -1582,6 +1579,13 @@ void iexamine::locked_object( player &p, const tripoint &examp )
 void iexamine::locked_object_pickable( player &p, const tripoint &examp )
 {
     map &here = get_map();
+
+    // if player has fingerpick bionic, enough power add it to its inventory
+    if( p.has_bionic( bio_lockpick ) && p.get_power_level() >= 50_kJ ) {
+        item fake_lockpick( itype_fake_lockpick, calendar::turn );
+        p.i_add( fake_lockpick );
+        p.mod_power_level( -50_kJ );
+    }
 
     safe_reference<item> lock_picking_tool = find_best_lock_picking_tool( p );
     if( lock_picking_tool ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Content "Add autolockpick on examine for fingerpick CBM"

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
The fingerpick bionic can't be used automatically when examining locked things, like other lockpicks are.
You can only use it through the bionic interface.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Add a way to use it through "examine"
The way it works:
- if you're trying to lockpick something, have the fingerpick CBM installed, and have enough power for 1 use, it adds a fake "fingerpick" item in the inventory
- then, the furniture is unlocked with the item, and you lose some bionic power
- finally, the fake item is removed from the player inventory
- since the fingerpick is supposed to never fail when you use it through the bionic interface, I gave it a very high LOCKPICK quality to reproduce the behavior

#### Testing
- be naked, have the CBM installed, examine a lockpickable metal door/gunsafe, the fingerpick is used
- in theory, the item could stay on the player if the action is interrupted, but I think it's simply impossible because it has 0 turn duration
- I even tried with hulks, thinking that they could send the player action flying during the activity, but the activity is finished first, and then you are sent flying

![image](https://user-images.githubusercontent.com/71428793/200142927-72a7e57b-2437-4a8c-828d-e5e6813ebb2a.png)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
- this doesn't cover the usage through "a", otherwise it would need a more complexe system like the extendable function of the toolset, that create a "permanent" item in the player inventory
  - I prefer this approach, with benefits without drawbacks
- I think it would be great if we could add hidden items to the player permanently. Especially for bionics, where we could add/remove them with the CBM linked to them. This would greatly simplify those kind of changes. Here I followed jove's advice on how to implement this in the less hacky way possible
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
