### PR TITLE
Reduce blinking effects speed (300 -> 800ms), and add an option to change it in game

### DIFF
--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -37,6 +37,7 @@
 #include "monster.h"
 #include "mtype.h"
 #include "npc.h"
+#include "options.h"
 #include "omdata.h"
 #include "output.h"
 #include "overmapbuffer.h"
@@ -400,7 +401,7 @@ cata::optional<tripoint> editmap::edit()
 
         ui_manager::redraw();
 
-        action = ctxt.handle_input( BLINK_SPEED );
+        action = ctxt.handle_input( get_option<int>( "BLINK_SPEED" ) );
 
         if( action == "EDIT_TERRAIN" ) {
             edit_feature<ter_t>();
@@ -1150,7 +1151,7 @@ void editmap::edit_feature()
         info_title_curr = info_title<T_t>();
         do_ui_invalidation();
 
-        emenu.query( false, BLINK_SPEED );
+        emenu.query( false, get_option<int>( "BLINK_SPEED" ) );
         if( emenu.ret == UILIST_CANCEL ) {
             quit = true;
         } else if( ( emenu.ret >= 0 && static_cast<size_t>( emenu.ret ) < T_t::count() ) ||
@@ -1270,7 +1271,7 @@ void editmap::edit_fld()
         info_title_curr = pgettext( "Map editor: Editing field effects", "Field effects" );
         do_ui_invalidation();
 
-        fmenu.query( false, BLINK_SPEED );
+        fmenu.query( false, get_option<int>( "BLINK_SPEED" ) );
         if( ( fmenu.ret > 0 && static_cast<size_t>( fmenu.ret ) < field_type::count() ) ||
             ( fmenu.ret == UILIST_ADDITIONAL && ( fmenu.ret_act == "LEFT" || fmenu.ret_act == "RIGHT" ) ) ) {
 
@@ -1688,7 +1689,7 @@ int editmap::select_shape( shapetype shape, int mode )
         }
         do_ui_invalidation();
         ui_manager::redraw();
-        action = ctxt.handle_input( BLINK_SPEED );
+        action = ctxt.handle_input( get_option<int>( "BLINK_SPEED" ) );
         if( action == "RESIZE" ) {
             if( !moveall ) {
                 const int offset = 16;
@@ -1864,7 +1865,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
                                          oter_id( gmenu.selected ).id().str() );
         do_ui_invalidation();
 
-        gpmenu.query( false, BLINK_SPEED * 3 );
+        gpmenu.query( false, get_option<int>( "BLINK_SPEED" ) * 3 );
 
         if( gpmenu.ret == 0 ) {
             cleartmpmap( tmpmap );
@@ -2034,7 +2035,7 @@ void editmap::mapgen_retarget()
         do_ui_invalidation();
 
         ui_manager::redraw();
-        action = ctxt.handle_input( BLINK_SPEED );
+        action = ctxt.handle_input( get_option<int>( "BLINK_SPEED" ) );
         if( const cata::optional<tripoint> vec = ctxt.get_direction( action ) ) {
             point vec_ms = omt_to_ms_copy( vec->xy() );
             tripoint ptarget = target + vec_ms;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6660,7 +6660,7 @@ void game::zones_manager()
             const auto &zone = zones[active_index].get();
             zone_start = m.getlocal( zone.get_start_point() );
             zone_end = m.getlocal( zone.get_end_point() );
-            ctxt.set_timeout( BLINK_SPEED );
+            ctxt.set_timeout( get_option<int>( "BLINK_SPEED" ) );
         } else {
             blink = false;
             zone_start = zone_end = cata::nullopt;
@@ -6905,7 +6905,7 @@ look_around_result game::look_around( bool show_window, tripoint &center,
         invalidate_main_ui_adaptor();
         ui_manager::redraw();
         if( ( select_zone && has_first_point ) || is_moving_zone ) {
-            ctxt.set_timeout( BLINK_SPEED );
+            ctxt.set_timeout( get_option<int>( "BLINK_SPEED" ) );
         }
 
         //Wait for input

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -18,7 +18,6 @@ static constexpr int LOCATION_WIDTH = 48;
 static constexpr int STATUS_HEIGHT = 4;
 static constexpr int STATUS_WIDTH = 55;
 
-static constexpr int BLINK_SPEED = 300;
 static constexpr int EXPLOSION_MULTIPLIER = 7;
 
 // Really just a sanity check for functions not tested beyond this. in theory 4096 works (`InvletInvlet).

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1805,8 +1805,8 @@ void options_manager::add_options_graphics()
 
     get_option( "ANIMATION_DELAY" ).setPrerequisite( "ANIMATIONS" );
 
-    add( "BLINK_SPEED", "graphics", translate_marker( "Map blinking speed" ),
-         translate_marker( "The amount of time to pause between map extra informations blinking (notes, zombie hordes...) in ms." ),
+    add( "BLINK_SPEED", "graphics", translate_marker( "Blinking effects speed" ),
+         translate_marker( "The speed of every blinking effects in ms." ),
          100, 5000, 800
        );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1798,12 +1798,17 @@ void options_manager::add_options_graphics()
 
     get_option( "ANIMATION_SCT_USE_FONT" ).setPrerequisite( "ANIMATION_SCT" );
 
-    add( "ANIMATION_DELAY", "graphics", translate_marker( "Animation delay" ),
-         translate_marker( "The amount of time to pause between animation frames in ms." ),
-         0, 100, 10
-       );
+    add("ANIMATION_DELAY", "graphics", translate_marker("Animation delay"),
+        translate_marker("The amount of time to pause between animation frames in ms."),
+        0, 100, 10
+    );
 
     get_option( "ANIMATION_DELAY" ).setPrerequisite( "ANIMATIONS" );
+
+    add("BLINK_SPEED", "graphics", translate_marker("Map blinking speed"),
+        translate_marker("The amount of time to pause between map extra informations blinking (notes, zombie hordes...) in ms."),
+        100, 5000, 800
+    );
 
     add( "FORCE_REDRAW", "graphics", translate_marker( "Force redraw" ),
          translate_marker( "If true, forces the game to redraw at least once per turn." ),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1798,17 +1798,17 @@ void options_manager::add_options_graphics()
 
     get_option( "ANIMATION_SCT_USE_FONT" ).setPrerequisite( "ANIMATION_SCT" );
 
-    add("ANIMATION_DELAY", "graphics", translate_marker("Animation delay"),
-        translate_marker("The amount of time to pause between animation frames in ms."),
-        0, 100, 10
-    );
+    add( "ANIMATION_DELAY", "graphics", translate_marker( "Animation delay" ),
+         translate_marker( "The amount of time to pause between animation frames in ms." ),
+         0, 100, 10
+       );
 
     get_option( "ANIMATION_DELAY" ).setPrerequisite( "ANIMATIONS" );
 
-    add("BLINK_SPEED", "graphics", translate_marker("Map blinking speed"),
-        translate_marker("The amount of time to pause between map extra informations blinking (notes, zombie hordes...) in ms."),
-        100, 5000, 800
-    );
+    add( "BLINK_SPEED", "graphics", translate_marker( "Map blinking speed" ),
+         translate_marker( "The amount of time to pause between map extra informations blinking (notes, zombie hordes...) in ms." ),
+         100, 5000, 800
+       );
 
     add( "FORCE_REDRAW", "graphics", translate_marker( "Force redraw" ),
          translate_marker( "If true, forces the game to redraw at least once per turn." ),

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1670,7 +1670,7 @@ static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripo
         curs.y() = locations[i].y();
         om_ui.invalidate_ui();
         ui_manager::redraw();
-        action = ctxt.handle_input(get_option<int>("BLINK_SPEED"));
+        action = ctxt.handle_input( get_option<int>( "BLINK_SPEED" ) );
         if( uistate.overmap_blinking ) {
             uistate.overmap_show_overlays = !uistate.overmap_show_overlays;
         }
@@ -1795,7 +1795,7 @@ static void place_ter_or_special( const ui_adaptor &om_ui, tripoint_abs_omt &cur
             om_ui.invalidate_ui();
             ui_manager::redraw();
 
-            action = ctxt.handle_input(get_option<int>("BLINK_SPEED"));
+            action = ctxt.handle_input( get_option<int>( "BLINK_SPEED" ) );
 
             if( const cata::optional<tripoint> vec = ctxt.get_direction( action ) ) {
                 curs += vec->xy();
@@ -1981,7 +1981,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
         // If EDGE_SCROLL is disabled, it will have a value of -1.
         // blinking won't work if handle_input() is passed a negative integer.
         if( scroll_timeout < 0 ) {
-            scroll_timeout = get_option<int>("BLINK_SPEED");
+            scroll_timeout = get_option<int>( "BLINK_SPEED" );
         }
         action = ictxt.handle_input( scroll_timeout );
 #else
@@ -2103,7 +2103,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
         }
 
         std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now();
-        if( now > last_blink + std::chrono::milliseconds(get_option<int>("BLINK_SPEED")) ) {
+        if( now > last_blink + std::chrono::milliseconds( get_option<int>( "BLINK_SPEED" ) ) ) {
             if( uistate.overmap_blinking ) {
                 uistate.overmap_show_overlays = !uistate.overmap_show_overlays;
             }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1985,7 +1985,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
         }
         action = ictxt.handle_input( scroll_timeout );
 #else
-        action = ictxt.handle_input( BLINK_SPEED );
+        action = ictxt.handle_input( get_option<int>( "BLINK_SPEED" ) );
 #endif
         if( const cata::optional<tripoint> vec = ictxt.get_direction( action ) ) {
             int scroll_d = fast_scroll ? fast_scroll_offset : 1;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1670,7 +1670,7 @@ static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripo
         curs.y() = locations[i].y();
         om_ui.invalidate_ui();
         ui_manager::redraw();
-        action = ctxt.handle_input( BLINK_SPEED );
+        action = ctxt.handle_input(get_option<int>("BLINK_SPEED"));
         if( uistate.overmap_blinking ) {
             uistate.overmap_show_overlays = !uistate.overmap_show_overlays;
         }
@@ -1795,7 +1795,7 @@ static void place_ter_or_special( const ui_adaptor &om_ui, tripoint_abs_omt &cur
             om_ui.invalidate_ui();
             ui_manager::redraw();
 
-            action = ctxt.handle_input( BLINK_SPEED );
+            action = ctxt.handle_input(get_option<int>("BLINK_SPEED"));
 
             if( const cata::optional<tripoint> vec = ctxt.get_direction( action ) ) {
                 curs += vec->xy();
@@ -1981,7 +1981,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
         // If EDGE_SCROLL is disabled, it will have a value of -1.
         // blinking won't work if handle_input() is passed a negative integer.
         if( scroll_timeout < 0 ) {
-            scroll_timeout = BLINK_SPEED;
+            scroll_timeout = get_option<int>("BLINK_SPEED");
         }
         action = ictxt.handle_input( scroll_timeout );
 #else
@@ -2103,7 +2103,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
         }
 
         std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now();
-        if( now > last_blink + std::chrono::milliseconds( BLINK_SPEED ) ) {
+        if( now > last_blink + std::chrono::milliseconds(get_option<int>("BLINK_SPEED")) ) {
             if( uistate.overmap_blinking ) {
                 uistate.overmap_show_overlays = !uistate.overmap_show_overlays;
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: "Interface" Reduce blinking effects speed from 300 to 800ms, and add an option for change in game

#### Purpose of change
Blinking effects speed was 300ms, and could make people sensitive to high blink speed uneasy (most notably on the map).

#### Describe the solution
Change the blinking effects speed from 300 to 800ms.
Add an option to change it in game, since we all have our own idea of the ideal blinking effects speed.

#### Testing
Set the blink speed to the old 300ms
![image](https://user-images.githubusercontent.com/71428793/200203908-a8727afc-c4db-4da6-8770-17cb50862a5e.png)

https://user-images.githubusercontent.com/71428793/200147650-3d3bb6f3-6170-4208-bcec-c6df94bf3487.mp4

Change the blinking effects speed from 300 to 800ms

https://user-images.githubusercontent.com/71428793/200147583-c29c37d9-149e-4a66-ab84-e6779a53b231.mp4
