### PR TITLE
Fix rare crash when unfavoriting an item twice

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -699,8 +699,10 @@ void inventory_column::on_input( const inventory_input &input )
     } else if( input.action == "END" ) {
         select( entries.size() - 1, scroll_direction::BACKWARD );
     } else if( input.action == "TOGGLE_FAVORITE" ) {
-        const item_location &loc = get_selected().any_item();
-        set_stack_favorite( loc, !loc->is_favorite );
+        if( !get_selected().locations.empty() ) {
+            const item_location &loc = get_selected().any_item();
+            set_stack_favorite( loc, !loc->is_favorite );
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fix rare crash when unfavoriting an item twice"

#### Purpose of change
A crash could be triggered when doing a specific chain of action, eg:
- have some rocks on you
- have some unfavorited rocks on you
- place the cursor on the favorited rock
- press favorite key twice
This impacted the drop menu and the inventory menu

#### Describe the solution
Add a check to execute the favoriting action only if the cursor points to an item

#### Testing
Repeat the steps described in Purpose of change, no more crash
