### PR TITLE
Fix mountable autodoc/autodoc couch having a transparent background (undead tileset)

### DIFF
--- a/gfx/MSX++UnDeadPeopleEdition/tile_config.json
+++ b/gfx/MSX++UnDeadPeopleEdition/tile_config.json
@@ -22260,8 +22260,22 @@
         { "id": "f_anesthetic", "fg": 11582, "rotates": false },
         { "id": "f_autoclave", "fg": 11583, "rotates": false },
         { "id": "f_autoclave_full", "fg": 11584, "rotates": false },
-        { "id": [ "f_autodoc", "vp_autodoc" ], "fg": [ 11587, 11588, 11586, 11585 ], "rotates": true },
-        { "id": [ "f_autodoc_couch", "vp_autodoc_couch" ], "fg": [ 11591, 11592, 11590, 11589 ], "rotates": true },
+        { "id": "f_autodoc", "fg": [ 11587, 11588, 11586, 11585 ], "rotates": true },
+        {
+          "id": "vp_autodoc",
+          "fg": [ 11587, 11588, 11586, 11585 ],
+          "bg": 9122,
+          "rotates": true,
+          "multitile": true
+        },
+        { "id": "f_autodoc_couch", "fg": [ 11591, 11592, 11590, 11589 ], "rotates": true },
+        {
+          "id": "vp_autodoc_couch",
+          "fg": [ 11591, 11592, 11590, 11589 ],
+          "bg": 9122,
+          "rotates": true,
+          "multitile": true
+        },
         { "id": "f_centrifuge", "fg": 11593, "rotates": false },
         { "id": "f_CTscan", "fg": 11594, "rotates": false },
         { "id": "f_curtain", "fg": 11595, "rotates": false },


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fix mountable autodoc/autodoc couch having a transparent background (undead tileset)"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
kwark reported that the background was missing from the mountable autodoc/autodoc couch
![image](https://user-images.githubusercontent.com/71428793/201196417-3e903fa1-5827-49a7-ba08-a071ddcfb396.png)


#### Describe the solution
![image](https://user-images.githubusercontent.com/71428793/201197139-81bb4277-1f0a-4969-a1ed-1a278ff4229e.png)

#### Testing
Cf above, mountable versions have a black background, normal versions don't  