### PR TITLE
Allow repairing items with forges

### DIFF
--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -864,6 +864,7 @@
     "coverage": 10,
     "required_str": -1,
     "crafting_pseudo_item": "fake_gridforge",
+    "examine_action": "use_furn_fake_item",
     "flags": [ "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
     "deconstruct": {
       "items": [ { "item": "forge", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -240,6 +240,32 @@
     "name": { "str": "grid forge" },
     "sub": "forge",
     "max_charges": 2500,
+    "charges_per_use": 4,
+    "use_action": [
+      {
+        "type": "repair_item",
+        "item_action_type": "repair_metal",
+        "materials": [
+          "iron",
+          "steel",
+          "hardsteel",
+          "aluminum",
+          "copper",
+          "bronze",
+          "silver",
+          "gold",
+          "platinum",
+          "superalloy",
+          "lead",
+          "tin",
+          "zinc"
+        ],
+        "skill": "fabrication",
+        "tool_quality": 8,
+        "cost_scaling": 0.1,
+        "move_cost": 500
+      }
+    ],
     "flags": [ "USES_GRID_POWER" ]
   },
   {

--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -58,7 +58,7 @@
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "charcoal forge" },
-    "description": "This is a portable, charcoal fired, metalworking forge.  If combined with the right tools, you could use this for metalworking.",
+    "description": "This is a portable, charcoal fired, metalworking forge.  If combined with the right tools, you could use this for metalworking, or it could be used to repair metal items.",
     "weight": "8600 g",
     "volume": "8 L",
     "price": 20000,
@@ -71,6 +71,32 @@
     "ammo": "charcoal",
     "sub": "forge",
     "max_charges": 500,
+    "charges_per_use": 8,
+    "use_action": [
+      {
+        "type": "repair_item",
+        "item_action_type": "repair_metal",
+        "materials": [
+          "iron",
+          "steel",
+          "hardsteel",
+          "aluminum",
+          "copper",
+          "bronze",
+          "silver",
+          "gold",
+          "platinum",
+          "superalloy",
+          "lead",
+          "tin",
+          "zinc"
+        ],
+        "skill": "fabrication",
+        "tool_quality": 4,
+        "cost_scaling": 0.1,
+        "move_cost": 500
+      }
+    ],
     "flags": [ "ALLOWS_REMOTE_USE" ]
   },
   {
@@ -148,7 +174,7 @@
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "electric forge" },
-    "description": "This is a portable electric metalworking forge, powered by batteries.  Combined with the right tools, you could use this for metalworking.  With a little mechanical know-how, you could probably even convert it to run directly off a vehicle's power system.",
+    "description": "This is a portable electric metalworking forge, powered by batteries.  Combined with the right tools, you could use this for metalworking, or it could be used to repair metal items.  With a little mechanical know-how, you could probably even convert it to run directly off a vehicle's power system.",
     "weight": "10000 g",
     "volume": "6 L",
     "price": 40000,
@@ -159,6 +185,32 @@
     "symbol": ";",
     "color": "light_gray",
     "ammo": "battery",
+    "charges_per_use": 4,
+    "use_action": [
+      {
+        "type": "repair_item",
+        "item_action_type": "repair_metal",
+        "materials": [
+          "iron",
+          "steel",
+          "hardsteel",
+          "aluminum",
+          "copper",
+          "bronze",
+          "silver",
+          "gold",
+          "platinum",
+          "superalloy",
+          "lead",
+          "tin",
+          "zinc"
+        ],
+        "skill": "fabrication",
+        "tool_quality": 8,
+        "cost_scaling": 0.1,
+        "move_cost": 500
+      }
+    ],
     "flags": [ "ALLOWS_REMOTE_USE" ],
     "magazines": [
       [ "battery", [ "heavy_battery_cell", "heavy_plus_battery_cell", "heavy_atomic_battery_cell", "heavy_disposable_cell" ] ]

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -470,7 +470,7 @@ TEST_CASE( "repairable and with what tools", "[item][iteminfo][repair]" )
 
     test_info_contains(
         item( "test_halligan" ), q,
-        "<color_c_white>Repair</color> using grid welder, extended toolset, arc welder, or makeshift arc welder.\n" );
+        "<color_c_white>Repair</color> using charcoal forge, grid forge, grid welder, electric forge, extended toolset, arc welder, or makeshift arc welder.\n" );
 
     test_info_contains(
         item( "test_hazmat_suit" ), q,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Features "Add item repair use action to charcoal forges, electric forges, and grid forge fake item."

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Something I'd wanted for years but only realized I could implement while working on https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2187. This is basically why can forges in Cataclysm++ have a use action, because for the longest time you couldn't have forges do repair actions without it causing weird behavior with the furniture version.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added repair action to electric forges. Uses fabrication skill and targets all metal materials that welders and soldering irons target, uses tool quality and charges per use just below that of welders.
2. Added repair action to charcoal forges. Like with welders vs makeshift welders, charges consumed and time take is doubled while tool quality is halved.
3. Added the same repair action as electric forges to grid forges.
4. Added `use_furn_fake_item` examine to grid forges.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Allowing brick kilns to repair clay items, if the below problem can be resolved.
2. Adding this to the code for examining vehicle forge rigs maybe?

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Loaded up compiled test build.
3. Spawned in a grid forge, confirmed it let me try to repair stuff when examined.

One problem with this however: far as I'm aware, examine_action can't currently be an array, so charcoal forge furniture can't have both `use_furn_fake_item` and `reload_furniture`, meaning only its item form can be used for repairs.

Stuff like braziers can handle undeploying from `deployed_item` automatically, freeing up its examine action to count as a fireplace. Maybe I could look into the code to see if there's some way to handle `use_furn_fake_item` stuff automatically, or would converting `examine_action` into an array be a more desirable fix?

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Per testing in the linked PR above, being able to activate grid forges to repair items should correctly carry over to grid forge rigs.