### PR TITLE
Fix explosions delayed on special monster death effects

### DIFF
--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -18,7 +18,7 @@
 #include "colony.h"
 #include "creature.h"
 #include "enums.h"
-#include "explosion.h"
+#include "explosion_queue.h"
 #include "field_type.h"
 #include "fungal_effects.h"
 #include "game.h"
@@ -600,6 +600,7 @@ void mdeath::explode( monster &z )
             break;
     }
     explosion_handler::explosion( z.pos(), &z, size );
+    explosion_handler::get_explosion_queue().execute();
 }
 
 void mdeath::focused_beam( monster &z )
@@ -639,6 +640,7 @@ void mdeath::focused_beam( monster &z )
     z.inv.clear();
 
     explosion_handler::explosion( z.pos(), &z, 8 );
+    explosion_handler::get_explosion_queue().execute();
 }
 
 void mdeath::broken( monster &z )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Bugfixes "Fix explosions delayed on special monster death effects"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
Fixes #2189
The problem is linked to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2092 , on top of the fact that explosions from monster deaths are delayed by one turn, when they should happen instantly.

A quick explanation:
PR 2092 added the tracking of the source of an explosion (the caster of the spell, the thrower of a grenade, a monster that triggers a special attacks etc.).
This allowed kills from explosives to be added to the player's list.
Before that, explosions were supposed to have no origin/source.
Problem: explosions from monsters death are **assumed** to happen instantly, not 1 turn after.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Trigger the explosion just after a monster death, for monsters with on_death effects:
- "EXPLODE" (eg cleanerbot)
- "FOCUSEDBEAM" (eg milspec searchlight)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Testing
- Change radius of explosion to 40 to be sure that the player is caught in the explosion (necessary for the crash to happen)
- Kill a cleanerbot, no crash
- Kill a milspec searchlight, no crash
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
This PR does fix the delay problem, which also solves the crash problem, but a monster using some kind of delayed explosion attack could produce the same crash if it dies before the explosion.