### PR TITLE
Autodoc Deconstruction update

### DIFF
--- a/data/json/furniture_and_terrain/furniture-medical.json
+++ b/data/json/furniture_and_terrain/furniture-medical.json
@@ -13,7 +13,13 @@
     "flags": [ "TRANSPARENT", "AUTODOC", "CONTAINER" ],
     "examine_action": "autodoc",
     "surgery_skill_multiplier": 1.0,
-    "deconstruct": { "items": [ { "item": "autodoc", "count": 1 } ] },
+    "deconstruct": { "items": [
+        { "item": "autodoc", "count": 1 },
+        { "item": "power_supply", "count": 2 },
+        { "item": "heavy_battery_cell", "count": 2 },
+        { "item": "cable", "charges": 40 }
+        ]
+    },
     "bash": {
       "str_min": 8,
       "str_max": 150,

--- a/data/json/furniture_and_terrain/furniture-medical.json
+++ b/data/json/furniture_and_terrain/furniture-medical.json
@@ -13,12 +13,13 @@
     "flags": [ "TRANSPARENT", "AUTODOC", "CONTAINER" ],
     "examine_action": "autodoc",
     "surgery_skill_multiplier": 1.0,
-    "deconstruct": { "items": [
+    "deconstruct": {
+      "items": [
         { "item": "autodoc", "count": 1 },
         { "item": "power_supply", "count": 2 },
         { "item": "heavy_battery_cell", "count": 2 },
         { "item": "cable", "charges": 40 }
-        ]
+      ]
     },
     "bash": {
       "str_min": 8,


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Autodoc Deconstruction now gives same amount of materials as installation."

#### Purpose of change

Unlike lamps, batteries and similar appliances, the Autodoc installation consumes 2 power converters, 2 heavy batteries and 40 copper wires while deconstruction only refunds the Autodoc.

It makes moving the autodocs a real pain in the ass, and consumes power converters which are fairly rare and bulky.

#### Describe the solution

Autodoc deconstruction now regurgitates the same amount of materials you shoved into it.

#### Describe alternatives you've considered

- Create an autodoc specifically for home use that requires heavy batteries to indicate that autodocs in laboratories and similar areas are powered by their grid.
Note that autodocs don't actually consume power anyway, so this is realismic, not useful.

#### Testing

See that it is possible to construct and deconstruct autodocs without materials left over or extra materials needed.

#### Additional context
