### PR TITLE
Display name of loaded ammo instead of ammo type (#51439)

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -965,6 +965,11 @@ bool item::stacks_with( const item &rhs, bool check_components, bool skip_type_c
     if( contents.num_item_stacks() != rhs.contents.num_item_stacks() ) {
         return false;
     }
+
+    if( ammo_current() != rhs.ammo_current() ) {
+        return false;
+    }
+
     return contents.stacks_with( rhs.contents );
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4783,7 +4783,7 @@ std::string item::display_name( unsigned int quantity ) const
     std::string ammotext;
     if( ( ( is_gun() && ammo_required() ) || is_magazine() ) && get_option<bool>( "AMMO_IN_NAMES" ) ) {
         if( !ammo_current().is_null() ) {
-            ammotext = ammo_current()->ammo->type->name();
+            ammotext = ammo_current()->nname( 1 );
         } else {
             ammotext = ammotype( *ammo_types().begin() )->name();
         }


### PR DESCRIPTION
#### Summary

SUMMARY: Interface "Display name of loaded ammo instead of ammo type (#51439)"

#### Purpose of change

It's nice to know which one of my guns is loaded with FMJ or JHP so I can figure out which gun I should use on the armoured enemies

#### Describe the solution

Ports [#51439](https://github.com/CleverRaven/Cataclysm-DDA/pull/51439).

#### Describe alternatives you've considered

- Make it display the full name of the default ammo when it's not loaded.
Much less useful, I'd prefer it tell me the ammo group usable for the gun rather than the specific default ammo it assumes.

#### Testing

Spawned multiple Barrett rifles and M1911, loaded them with different ammunition and checked that they displayed correctly. Unloaded all of them and checked that they still displayed ammo group as expected.

#### Additional context

Came across it while looking over the Proportional and Relative support PR
