### PR TITLE
Makes Autodoc Couches assignable as seats in vehicles. Adjust autodoc couch capacity.

### DIFF
--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -867,7 +867,7 @@
     "damage_modifier": 80,
     "durability": 100,
     "description": "This is an autodoc couch.  You can use it to install or uninstall CBMs, splint broken limbs, treat wounds, check radiation level or conduct a blood analysis.  'e'xamine the tile with an autodoc, while on the autodoc couch, to use it.",
-    "size": 700,
+    "size": 252,
     "item": "vh_autodoc_couch",
     "comfort": 4,
     "floor_bedding_warmth": 500,

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -875,7 +875,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
     },
-    "flags": [ "CARGO", "AUTODOC_COUCH", "BED", "BOARDABLE", "BELTABLE" ],
+    "flags": [ "CARGO", "AUTODOC_COUCH", "BED", "BOARDABLE", "BELTABLE", "SEAT" ],
     "breaks_into": [
       { "item": "steel_lump", "count": [ 6, 10 ] },
       { "item": "steel_chunk", "count": [ 6, 10 ] },

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -869,6 +869,8 @@
     "description": "This is an autodoc couch.  You can use it to install or uninstall CBMs, splint broken limbs, treat wounds, check radiation level or conduct a blood analysis.  'e'xamine the tile with an autodoc, while on the autodoc couch, to use it.",
     "size": 700,
     "item": "vh_autodoc_couch",
+    "comfort": 4,
+    "floor_bedding_warmth": 500,
     "location": "center",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "vehicle_bolt", 1 ] ] },


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Makes Autodoc Couches assignable as seats in vehicles."

#### Purpose of change

ulila on the Discord suggested it and it made sense since companions zoom to unoccupied seats, making use of the autodoc in vehicles on companions very difficult.

@leoCottret suggested that comfort be added as it was not copied appropriately when he made the couch a vehicle part. I also copied over the bedding warmth. So now your NPCs can sleep under a bunch of sharp needles and scalpels fairly comfortably.

#### Describe the solution

Add `SEAT` flag to vehicle autodoc couches.

Copy over `comfort` and `floor_bedding_warmth` from the furniture version of the autodoc couch.

#### Describe alternatives you've considered

- Have examining the autodoc allow you to assign NPCs to the couch.
Would be useful on furniture, but in a vehicle it's just extra steps. And C++. ~I hate C++~
- Have `comfort` and `floor_bedding_warmth` reduced to coincide with it being a vehicle part instead of a piece of furniture, thus being more cramped.
No real reason to, it's not breaking the game or anything.

#### Testing

Spawned APC, mind controlled myself a companion and installed an autodoc couch into the vehicle, then checked that I could assign them to the couch.

#### Additional context

Need to see about assigning NPCs to furniture autodoc couches. Also check how the autodoc code handles multiple couches.