### PR TITLE
Camo tank top recipe

### DIFF
--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -25,6 +25,7 @@
     "name": { "str": "camo tank top" },
     "description": "A sleeveless cotton shirt with camouflage dye.  Very easy to move in.",
     "weight": "78 g",
+	"repairs_like": "tank_top",
     "volume": "250 ml",
     "price": 1500,
     "price_postapoc": 50,

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -25,7 +25,7 @@
     "name": { "str": "camo tank top" },
     "description": "A sleeveless cotton shirt with camouflage dye.  Very easy to move in.",
     "weight": "78 g",
-	"repairs_like": "tank_top",
+    "repairs_like": "tank_top",
     "volume": "250 ml",
     "price": 1500,
     "price_postapoc": 50,

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -1251,5 +1251,17 @@
     "book_learn": [ [ "textbook_armwest", 8 ] ],
     "using": [ [ "forging_standard", 14 ], [ "bronzesmithing_tools", 1 ] ],
     "components": [ [ [ "scrap_bronze", 28 ] ] ]
+  },
+  {
+    "result": "army_top",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 2,
+    "time": "38 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 4 ] ],
+    "components": [ [ [ "rag", 4 ] ] ]
   }
 ]

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -1251,17 +1251,5 @@
     "book_learn": [ [ "textbook_armwest", 8 ] ],
     "using": [ [ "forging_standard", 14 ], [ "bronzesmithing_tools", 1 ] ],
     "components": [ [ [ "scrap_bronze", 28 ] ] ]
-  },
-  {
-    "result": "army_top",
-    "type": "recipe",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_TORSO",
-    "skill_used": "tailor",
-    "difficulty": 2,
-    "time": "38 m",
-    "autolearn": true,
-    "using": [ [ "sewing_standard", 4 ] ],
-    "components": [ [ [ "rag", 4 ] ] ]
   }
 ]


### PR DESCRIPTION
#### Summary Balance/Content "Adds repairs like to camo tank top"


#### Purpose of change

I noticed while playing that the camo tank top cannot be repaired regardless of the players skill. This was because there was no repairs_like for the camo tank top. This changes it. 

#### Describe the solution

Added a recipe for the camo tank.

#### Describe alternatives you've considered

Leave it be with no ability to repair it? 
But also the main game has a normal tank top that you can repair? 

#### Testing

Tested in game, can repair it now! 

#### Additional context

N/A
