### PR TITLE
Fixes grappler zombies going through holes

### DIFF
--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2605,8 +2605,8 @@ bool mattack::ranged_pull( monster *z )
     for( auto &i : line ) {
         // Player can't be pulled though bars, furniture, cars or creatures
         // TODO: Add bashing? Currently a window is enough to prevent grabbing
-        if( ( !g->is_empty( i ) || here.obstructed_by_vehicle_rotation( prev_point, i ) ) &&
-            i != z->pos() && i != target->pos() ) {
+        if( ( !g->is_empty( i ) && i != z->pos() && i != target->pos() ) ||
+            here.obstructed_by_vehicle_rotation( prev_point, i ) ) {
             return false;
         }
         prev_point = i;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Grappler zombies can't grab through vehicle holes"

#### Purpose of change

Fixes #2198 

#### Describe the solution

Was missing the check on the final tile.