### PR TITLE
feat(UI): Add map position to each diary page

### DIFF
--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -26,6 +26,7 @@
 #include "skill.h"
 #include "string_formatter.h"
 #include "type_id.h"
+#include "overmap_ui.h"
 #include "units.h"
 
 diary_page::diary_page() = default;
@@ -708,9 +709,8 @@ void diary::new_page()
     page->kills = g->get_kill_tracker().kills;
     page->npc_kills = g->get_kill_tracker().npc_kills;
     avatar *u = &get_avatar();
-    const tripoint_abs_omt ppos = u->global_omt_location();
 
-    page->overmap_position_str = string_format( "(%d, %d, %d)", ppos.z(), ppos.x(), ppos.y() );
+    page->overmap_position_str = overmap_ui::fmt_omt_coords( u->global_omt_location() );
     page->mission_completed = mission::to_uid_vector( u->get_completed_missions() );
     page->mission_active = mission::to_uid_vector( u->get_active_missions() );
     page->mission_failed = mission::to_uid_vector( u->get_failed_missions() );

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -662,7 +662,7 @@ std::vector<std::string> diary::get_head_text()
         //~ %1$s is the player's position on the overmap when writing the page
         std::string overmap_position_text = ( !get_page_ptr()->overmap_position_str.empty() ) ?
                                             string_format(
-                                                _( "Map position: %1$s" ),
+                                                _( "Location: %1$s" ),
                                                 get_page_ptr()->overmap_position_str ) : "";
 
         head_text.insert( head_text.end(), year_and_season_text );

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -659,9 +659,9 @@ std::vector<std::string> diary::get_head_text()
         std::string year_and_season_text = complete_time_text.substr( 0,
                                            complete_time_text.find_last_of( ',' ) + 1 );
 
-        //~ %1$s is the player's position on the overmap when writing the page
         std::string overmap_position_text = ( !get_page_ptr()->overmap_position_str.empty() ) ?
                                             string_format(
+                                                //~ %1$s is the player's position on the overmap when writing the page
                                                 _( "Location: %1$s" ),
                                                 get_page_ptr()->overmap_position_str ) : "";
 

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -670,7 +670,10 @@ std::vector<std::string> diary::get_head_text()
         head_text.insert( head_text.end(), time_diff_text );
         head_text.insert( head_text.end(), overmap_position_text );
 
-        if( !time_diff_text.empty() || !overmap_position_text.empty() ) {
+        if( !time_diff_text.empty() ) {
+            head_text.insert( head_text.end(), { "" } );
+        }
+        if( !overmap_position_text.empty() ) {
             head_text.insert( head_text.end(), { "" } );
         }
 

--- a/src/diary.h
+++ b/src/diary.h
@@ -25,6 +25,8 @@ struct diary_page {
     std::string m_text;
     /*turn the page was created*/
     time_point turn;
+    /*player's position on overmap when writing the page*/
+    std::string overmap_position_str;
     /*mission ids for completed/active and failed missions*/
     std::vector<int> mission_completed;
     std::vector<int> mission_active;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -186,7 +186,7 @@ struct grids_draw_data {
         std::unordered_map<std::size_t, std::pair<std::vector<tripoint_abs_omt>, char>> list_inactive;
 };
 
-static std::string fmt_omt_coords( const tripoint_abs_omt &coord )
+auto fmt_omt_coords( const tripoint_abs_omt &coord ) -> std::string
 {
     if( get_option<std::string>( "OVERMAP_COORDINATE_FORMAT" ) == "subdivided" ) {
         point_abs_om abs_coord;

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -102,6 +102,8 @@ struct tiles_redraw_info {
 extern tiles_redraw_info redraw_info;
 #endif
 
+auto fmt_omt_coords( const tripoint_abs_omt &coord ) -> std::string;
+
 weather_type_id get_weather_at_point( const point_abs_omt &pos );
 std::tuple<char, nc_color, size_t> get_note_display_info( const std::string &note );
 } // namespace overmap_ui


### PR DESCRIPTION
#### Summary
SUMMARY: Interface "Add map position to each diary page"

#### Purpose of change
One information I felt was missing from the diary is the location where the player wrote a page.
It can be especially useful for players who travel a lot

#### Describe the solution
Add the information

#### Testing
- new character with existing diary pages. They just don't display the map position line
- new page, the position is added and it's the right one
- teleport, new page, the position is added and it's the right one
- save and reload, the pages still have the correct positions

#### Additional context
I'm displaying the player's map position as "Location: (z, x, y)".
I couldn't give more informations without it overflowing on phone.
![image](https://user-images.githubusercontent.com/71428793/203020970-5856b4c5-f79c-4cac-9946-1db1e4f1ba3e.png)

I think a player will quickly understand since it's the same as on the map and the first digit will always be close to 0
![image](https://user-images.githubusercontent.com/71428793/203021111-f220b3cc-c0e5-4ce9-8568-780138c8a8fe.png)

