### PR TITLE
Remove HIT_AND_RUN flag from Wraitheon Sentinels (Aftershock)

### DIFF
--- a/data/mods/Aftershock/mobs/robots.json
+++ b/data/mods/Aftershock/mobs/robots.json
@@ -226,8 +226,7 @@
       "NO_BREATHE",
       "PRIORITIZE_TARGETS",
       "GOODHEARING",
-      "PATH_AVOID_DANGER_2",
-      "HIT_AND_RUN"
+      "PATH_AVOID_DANGER_2"
     ]
   },
   {


### PR DESCRIPTION
For the bodyguard bots that come with the Wraitheon Executive, they do a terrible job because they hit and run every single mob, meaning they very often leave the Executive to die alone and surrounded. The robots are even shaped to look like knights, so it stands to reason they would defend their charge to the death. This is a simple change for the Wraitheon Executive profession, it makes the Sentinel robots brave again by removing the HIT_AND_RUN flag.