### PR TITLE
Convert Wraitheon Sentinel inactive robots to steel and plastic (Aftershock)

### DIFF
--- a/data/mods/Aftershock/items/inactiverobot.json
+++ b/data/mods/Aftershock/items/inactiverobot.json
@@ -184,7 +184,7 @@
     "price": 600000,
     "to_hit": -3,
     "bashing": 8,
-    "material": [ "alien_resin" ],
+    "material": [ "steel", "plastic" ],
     "symbol": ";",
     "color": "green",
     "use_action": {


### PR DESCRIPTION
Inactive Wraitheon Sentinels were made of alien resin which required a 'salvaged resin extruder' to repair. This has been fixed to match other robots.