### PR TITLE
Fix items rotting away inside fridges/freezers when returning to the reality bubble.

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8670,37 +8670,6 @@ bool item::has_rotten_away() const
     }
 }
 
-bool item::has_rotten_away( const tripoint &pnt )
-{
-    if( goes_bad() ) {
-        return process_rot( 1, false, pnt, nullptr );
-    } else if( type->container && type->container->preserves ) {
-        // Containers like tin cans preserves all items inside, they do not rot at all.
-        return false;
-    } else if( type->container && type->container->seals ) {
-        // Items inside rot but do not vanish as the container seals them in.
-        for( item *c : contents.all_items_top() ) {
-            if( c->goes_bad() ) {
-                c->process_rot( 1, true, pnt, nullptr );
-            }
-        }
-        return false;
-    } else {
-        std::vector<item *> removed_items;
-        // Check and remove rotten contents, but always keep the container.
-        for( item *it : contents.all_items_top() ) {
-            if( it->has_rotten_away( pnt ) ) {
-                removed_items.push_back( it );
-            }
-        }
-        for( item *it : removed_items ) {
-            remove_item( *it );
-        }
-
-        return false;
-    }
-}
-
 bool item_ptr_compare_by_charges( const item *left, const item *right )
 {
     if( left->contents.empty() ) {

--- a/src/item.h
+++ b/src/item.h
@@ -772,13 +772,6 @@ class item : public visitable<item>
          * @param mod How many charges should be removed.
          */
         void mod_charges( int mod );
-        /**
-         * Whether the item has to be removed as it has rotten away completely. May change the item as it calls process_rot()
-         * @param pnt The *absolute* position of the item in the world (see @ref map::getabs),
-         * used for rot calculation.
-         * @return true if the item has rotten away and should be removed, false otherwise.
-         */
-        bool has_rotten_away( const tripoint &pnt );
 
         /**
          * Accumulate rot of the item since last rot calculation.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7102,7 +7102,7 @@ template <typename Container>
 void map::remove_rotten_items( Container &items, const tripoint &pnt )
 {
     for( auto it = items.begin(); it != items.end(); ) {
-        if( it->has_rotten_away( pnt ) ) {
+        if( it->has_rotten_away() ) {
             if( it->is_comestible() ) {
                 rotten_item_spawn( *it, pnt );
             }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix items rotting away inside fridges/freezers when returning to the reality bubble."

#### Purpose of change

Items do not appropriately take fridges/freezers into account when you return to the map, processing them as though they'd been left out in the open.

Checking it I found that when actualizing the map instead of using `has_rotten_away()` to check that an item has rotted and replace it it uses `has_rotten_away( const tripoint &pnt)` which uses `process_rot` but doesn't pass the temperature flag with it. The temperature flag is not set properly in this scenario leading to food rotting at the same rate outside/inside fridges/freezers.

#### Describe the solution

Change the code so it doesn't use the pointer version and just checks that the item's relative rot has exceeded or not, allowing `process_items_in_submap` to `process_rot` instead, as it _does_ route through the temperature code for furniture.

#### Describe alternatives you've considered

- Make `bool item::has_rotten_away( const tripoint &pnt )` also consider the furniture flags and pass the appropriate temperature flags
Probably not necessary, the function itself is kind of weird, being recursive and not otherwise called by any other function. I'd like to know if it actually has a point to existing or if it's just been orphaned long ago and is just waiting for us to put it out of its misery.

#### Testing

Install Fridge and minifreezer, put cooked fish inside both and outside on the pavement. Teleport to another location, wait 1440 minutes. Return and check that rot timer has progressed appropriately instead of just failing on me.

#### Additional context

Another issue to take a look at at some point is #1726, but this seems more an issue with how fields work than anything, I'd probably want to solve it by making coolers/heaters radiate heat/cold instead of producing hot/cold air.
