### PR TITLE
[DDA Port] Pin mac_alias to 2.2.0 to fix dmgbuild

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -221,7 +221,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext ccache parallel
-          pip3 install dmgbuild==1.4.2 biplist
+          pip3 install mac_alias==2.2.0 dmgbuild==1.4.2 biplist
       - name: Compile translations (windows)
         if: runner.os == 'Windows'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,7 +216,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install sdl2 sdl2_image sdl2_ttf sdl2_mixer gettext ccache parallel
-          pip3 install dmgbuild==1.4.2 biplist
+          pip3 install mac_alias==2.2.0 dmgbuild==1.4.2 biplist
       - name: Compile translations (windows)
         if: runner.os == 'Windows'
         shell: bash


### PR DESCRIPTION
#### Summary
SUMMARY: Build "[DDA Port] Pin mac_alias to 2.2.0 to fix dmgbuild"

#### Purpose of change
Fix osx build

#### Describe the solution
Cherry-pick https://github.com/CleverRaven/Cataclysm-DDA/pull/62402

#### Testing
Tried on my fork, release compiled