### PR TITLE
[DDA Port] Build from custom MXE GCC 11

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -93,14 +93,14 @@ jobs:
             mxe: x86_64
             mxe_apt: x86-64
             artifact: windows-tiles-x64
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             ext: zip
             content: application/zip
           - name: Windows Tiles x32
             mxe: i686
             mxe_apt: i686
             artifact: windows-tiles-x32
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             ext: zip
             content: application/zip
           - name: Linux Tiles x64

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -200,17 +200,13 @@ jobs:
       - name: Install MXE
         if: matrix.mxe != 'none'
         run: |
-          sudo apt install software-properties-common lsb-release
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
-          sudo add-apt-repository "deb [arch=amd64] https://pkg.mxe.cc/repos/apt `lsb_release -sc` main"
-          sudo apt update
-          sudo apt install mxe-${{ matrix.mxe_apt }}-w64-mingw32.static-{sdl2,sdl2-ttf,sdl2-image,sdl2-mixer,gettext}
+          curl -L -o mxe-${{ matrix.mxe }}.tar.xz https://github.com/BrettDong/MXE-GCC/releases/download/mxe-gcc-11.2/mxe-${{ matrix.mxe }}.tar.xz
+          curl -L -o mxe-${{ matrix.mxe }}.tar.xz.sha256 https://github.com/BrettDong/MXE-GCC/releases/download/mxe-gcc-11.2/mxe-${{ matrix.mxe }}.tar.xz.sha256
+          shasum -a 256 -c ./mxe-${{ matrix.mxe }}.tar.xz.sha256
+          sudo tar xJf mxe-${{ matrix.mxe }}.tar.xz -C /opt
           curl -L -o libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz https://github.com/Qrox/libbacktrace/releases/download/2020-01-03/libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz
-          if ! shasum -a 256 -c ./build-scripts/libbacktrace-${{ matrix.mxe }}-w64-mingw32-sha256; then
-            echo "Checksum failed for libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz"
-            exit 1
-          fi
-          sudo tar -xzf libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz --exclude=LICENSE -C /usr/lib/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static
+          shasum -a 256 -c ./build-scripts/libbacktrace-${{ matrix.mxe }}-w64-mingw32-sha256
+          sudo tar -xzf libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz --exclude=LICENSE -C /opt/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static.gcc11
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none'
         run: |
@@ -235,7 +231,7 @@ jobs:
       - name: Build CBN (windows)
         if: matrix.mxe != 'none'
         env:
-          PLATFORM: /usr/lib/mxe/usr/bin/${{ matrix.mxe }}-w64-mingw32.static-
+          PLATFORM: /opt/mxe/usr/bin/${{ matrix.mxe }}-w64-mingw32.static-
         run: |
           make -j$((`nproc`+0)) CROSS="${PLATFORM}" TILES=1 SOUND=1 RELEASE=1 LANGUAGES=all PCH=0 bindist
           mv cataclysmbn-${{ inputs.version }}.zip cbn-${{ matrix.artifact }}-${{ inputs.version }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,17 +195,13 @@ jobs:
       - name: Install MXE
         if: matrix.mxe != 'none'
         run: |
-          sudo apt install software-properties-common lsb-release
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
-          sudo add-apt-repository "deb [arch=amd64] https://pkg.mxe.cc/repos/apt `lsb_release -sc` main"
-          sudo apt update
-          sudo apt install mxe-${{ matrix.mxe_apt }}-w64-mingw32.static-{sdl2,sdl2-ttf,sdl2-image,sdl2-mixer,gettext}
+          curl -L -o mxe-${{ matrix.mxe }}.tar.xz https://github.com/BrettDong/MXE-GCC/releases/download/mxe-gcc-11.2/mxe-${{ matrix.mxe }}.tar.xz
+          curl -L -o mxe-${{ matrix.mxe }}.tar.xz.sha256 https://github.com/BrettDong/MXE-GCC/releases/download/mxe-gcc-11.2/mxe-${{ matrix.mxe }}.tar.xz.sha256
+          shasum -a 256 -c ./mxe-${{ matrix.mxe }}.tar.xz.sha256
+          sudo tar xJf mxe-${{ matrix.mxe }}.tar.xz -C /opt
           curl -L -o libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz https://github.com/Qrox/libbacktrace/releases/download/2020-01-03/libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz
-          if ! shasum -a 256 -c ./build-scripts/libbacktrace-${{ matrix.mxe }}-w64-mingw32-sha256; then
-            echo "Checksum failed for libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz"
-            exit 1
-          fi
-          sudo tar -xzf libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz --exclude=LICENSE -C /usr/lib/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static
+          shasum -a 256 -c ./build-scripts/libbacktrace-${{ matrix.mxe }}-w64-mingw32-sha256
+          sudo tar -xzf libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz --exclude=LICENSE -C /opt/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static.gcc11
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none'
         run: |
@@ -230,7 +226,7 @@ jobs:
       - name: Build CBN (windows)
         if: matrix.mxe != 'none'
         env:
-          PLATFORM: /usr/lib/mxe/usr/bin/${{ matrix.mxe }}-w64-mingw32.static-
+          PLATFORM: /opt/mxe/usr/bin/${{ matrix.mxe }}-w64-mingw32.static.gcc11-
         run: |
           make -j$((`nproc`+0)) CROSS="${PLATFORM}" TILES=1 SOUND=1 RELEASE=1 LANGUAGES=all PCH=0 bindist
           mv cataclysmbn-unstable.zip cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,14 +88,14 @@ jobs:
             mxe: x86_64
             mxe_apt: x86-64
             artifact: windows-tiles-x64
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             ext: zip
             content: application/zip
           - name: Windows Tiles x32
             mxe: i686
             mxe_apt: i686
             artifact: windows-tiles-x32
-            os: ubuntu-22.04
+            os: ubuntu-20.04
             ext: zip
             content: application/zip
           - name: Linux Tiles x64

--- a/build-scripts/requirements.sh
+++ b/build-scripts/requirements.sh
@@ -48,21 +48,27 @@ fi
 
 # Influenced by https://github.com/zer0main/battleship/blob/master/build/windows/requirements.sh
 if [ -n "${MXE_TARGET}" ]; then
-    sudo add-apt-repository 'deb [arch=amd64] https://mirror.mxe.cc/repos/apt xenial main'
-    $travis_retry sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 84C7C89FC632241A6999ED0A580873F586B72ED9
-  # We need to treat apt-get update warnings as errors for which the exit code
-  # is not sufficient.  The following workaround inspired by
-  # https://unix.stackexchange.com/questions/175146/apt-get-update-exit-status/
-  exec {fd}>&2
-  $travis_retry bash -o pipefail -c \
-      "sudo apt-get update 2>&1 | tee /dev/fd/$fd | ( ! grep -q -e '^Err:' -e '^[WE]:' )"
-  exec {fd}>&-
+  sudo dpkg --add-architecture i386
+  sudo apt update
+  $travis_retry sudo apt-get --yes install wine wine32
 
-  MXE2_TARGET=$(echo "$MXE_TARGET" | sed 's/_/-/g')
-  export MXE_DIR=/usr/lib/mxe/usr/bin
-  $travis_retry sudo apt-get --yes install mxe-${MXE2_TARGET}-gcc mxe-${MXE2_TARGET}-gettext mxe-${MXE2_TARGET}-glib mxe-${MXE2_TARGET}-sdl2 mxe-${MXE2_TARGET}-sdl2-ttf mxe-${MXE2_TARGET}-sdl2-image mxe-${MXE2_TARGET}-sdl2-mixer
-  export PLATFORM="$MXE_TARGET"
-  export CROSS_COMPILATION='${MXE_DIR}/${PLATFORM}-'
+  set +e
+  retry=0
+  until [[ "$retry" -ge 5 ]]; do
+    curl -L -o mxe-i686.tar.xz https://github.com/BrettDong/MXE-GCC/releases/download/mxe-gcc-11.2/mxe-i686.tar.xz && curl -L -o mxe-i686.tar.xz.sha256 https://github.com/BrettDong/MXE-GCC/releases/download/mxe-gcc-11.2/mxe-i686.tar.xz.sha256 && shasum -a 256 -c ./mxe-i686.tar.xz.sha256 && break
+    retry=$((retry+1))
+    rm -f mxe-i686.tar.xz mxe-i686.tar.xz.sha256
+    sleep 10
+  done
+  if [[ "$retry" -ge 5 ]]; then
+    echo "Error downloading or checksum failed for MXE i686"
+    exit 1
+  fi
+  set -e
+  sudo tar xJf mxe-i686.tar.xz -C /opt
+
+  export MXE_DIR=/opt/mxe
+  export CROSS_COMPILATION="${MXE_DIR}/usr/bin/${MXE_TARGET}-"
   # Need to overwrite CXX to make the Makefile $CROSS logic work right.
   export CXX="$COMPILER"
   export CCACHE=1
@@ -73,14 +79,14 @@ if [ -n "${MXE_TARGET}" ]; then
       echo "Checksum failed for libbacktrace-x86_64-w64-mingw32.tar.gz"
       exit 1
     fi
-    sudo tar -xzf libbacktrace-x86_64-w64-mingw32.tar.gz --exclude=LICENSE -C ${MXE_DIR}/../${PLATFORM}
+    sudo tar -xzf libbacktrace-x86_64-w64-mingw32.tar.gz --exclude=LICENSE -C ${MXE_DIR}/usr/${MXE_TARGET}
   else
     curl -L -o libbacktrace-i686-w64-mingw32.tar.gz https://github.com/Qrox/libbacktrace/releases/download/2020-01-03/libbacktrace-i686-w64-mingw32.tar.gz
     if ! shasum -a 256 -c ./build-scripts/libbacktrace-i686-w64-mingw32-sha256; then
       echo "Checksum failed for libbacktrace-i686-w64-mingw32.tar.gz"
       exit 1
     fi
-    sudo tar -xzf libbacktrace-i686-w64-mingw32.tar.gz --exclude=LICENSE -C ${MXE_DIR}/../${PLATFORM}
+    sudo tar -xzf libbacktrace-i686-w64-mingw32.tar.gz --exclude=LICENSE -C ${MXE_DIR}/usr/${MXE_TARGET}
   fi
 fi
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -950,7 +950,13 @@ void debug_write_backtrace( std::ostream &out )
             out << "\n    (unable to get module base address),";
         }
         if( bt_state ) {
-            bt_syminfo( bt_state, reinterpret_cast<uintptr_t>( bt[i] ),
+#if defined(__MINGW64__)
+            constexpr uint64_t static_image_base = 0x140000000ULL;
+#elif defined(__MINGW32__)
+            constexpr uint64_t static_image_base = 0x400000ULL;
+#endif
+            uint64_t de_aslr_pc = reinterpret_cast<uintptr_t>( bt[i] ) - mod_base + static_image_base;
+            bt_syminfo( bt_state, de_aslr_pc,
                         // syminfo callback
                         [&out]( const uintptr_t pc, const char *const symname,
             const uintptr_t symval, const uintptr_t ) {
@@ -965,7 +971,7 @@ void debug_write_backtrace( std::ostream &out )
                     << ", msg = " << ( msg ? msg : "[no msg]" )
                     << "),";
             } );
-            bt_pcinfo( bt_state, reinterpret_cast<uintptr_t>( bt[i] ),
+            bt_pcinfo( bt_state, de_aslr_pc,
                        // backtrace callback
                        [&out]( const uintptr_t pc, const char *const filename,
             const int lineno, const char *const function ) -> int {


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Build from custom MXE GCC 11"

#### Purpose of change
Fix failing mxe builds.
1. GCC provided by mxe's apt repositories does not support c++17
2. There are no mxe repositories for `ubuntu-22.04`
3. `ubuntu-22.04` doesn't have `python` package, only `python3` and `python-is-python3`

#### Describe the solution
* Port https://github.com/CleverRaven/Cataclysm-DDA/pull/52023
* Port https://github.com/CleverRaven/Cataclysm-DDA/pull/53837
* Downgrade runner to `ubuntu-20.04`

#### Testing
Built a mxe release in a fork, downloaded it, tested backtrace generation on Windows

#### Additional context
