### PR TITLE
Added new helicopter parts group to helipad

### DIFF
--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -547,12 +547,17 @@
     "id": "civilian_helicopter_parts",
     "type": "item_group",
     "//": "Parts for civilian helicopter",
-    "items": [ [ "small_turbine_engine", 50 ], [ "small_helicopter_rotor", 50 ] ]
+    "items": [ [ "small_turbine_engine", 50 ], [ "small_helicopter_rotor", 50 ], [ "plating_steel", 50 ] ]
   },
   {
     "id": "military_helicopter_parts",
     "type": "item_group",
     "//": "GParts for military helicopter",
-    "items": [ [ "medium_turbine_engine", 30 ], [ "large_turbine_engine", 20 ], [ "heavy_duty_military_rotor", 50 ] ]
+    "items": [
+      [ "medium_turbine_engine", 30 ],
+      [ "large_turbine_engine", 20 ],
+      [ "heavy_duty_military_rotor", 50 ],
+      [ "plating_military", 50 ]
+    ]
   }
 ]

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -547,17 +547,12 @@
     "id": "civilian_helicopter_parts",
     "type": "item_group",
     "//": "Parts for civilian helicopter",
-    "items": [ [ "small_turbine_engine", 50 ], [ "small_helicopter_rotor", 50 ], [ "steel_plate", 50 ] ]
+    "items": [ [ "small_turbine_engine", 50 ], [ "small_helicopter_rotor", 50 ] ]
   },
   {
     "id": "military_helicopter_parts",
     "type": "item_group",
     "//": "GParts for military helicopter",
-    "items": [
-      [ "medium_turbine_engine", 30 ],
-      [ "large_turbine_engine", 20 ],
-      [ "heavy_duty_military_rotor", 50 ],
-      [ "mil_plate", 50 ]
-    ]
+    "items": [ [ "medium_turbine_engine", 30 ], [ "large_turbine_engine", 20 ], [ "heavy_duty_military_rotor", 50 ] ]
   }
 ]

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -547,7 +547,7 @@
     "id": "civilian_helicopter_parts",
     "type": "item_group",
     "//": "Parts for civilian helicopter",
-    "items": [ [ "small_turbine_engine", 50 ], [ "small_helicopter_rotor", 50 ], [ "plating_steel", 50 ] ]
+    "items": [ [ "small_turbine_engine", 50 ], [ "small_helicopter_rotor", 50 ], [ "steel_plate", 50 ] ]
   },
   {
     "id": "military_helicopter_parts",
@@ -557,7 +557,7 @@
       [ "medium_turbine_engine", 30 ],
       [ "large_turbine_engine", 20 ],
       [ "heavy_duty_military_rotor", 50 ],
-      [ "plating_military", 50 ]
+      [ "mil_plate", 50 ]
     ]
   }
 ]

--- a/data/json/mapgen/helipad.json
+++ b/data/json/mapgen/helipad.json
@@ -80,7 +80,9 @@
               { "group": "mil_food", "prob": 40, "count": [ 1, 5 ] },
               { "group": "infantry_medical_gear", "prob": 5, "count": [ 1, 2 ] },
               { "group": "supplies_metal", "prob": 150, "count": [ 2, 6 ] },
-              { "group": "supplies_mechanics", "prob": 50, "count": [ 0, 3 ] }
+              { "group": "supplies_mechanics", "prob": 50, "count": [ 1, 3 ] },
+              { "group": "civilian_helicopter_parts", "prob": 20, "count": [ 1, 3 ] },
+              { "group": "military_helicopter_parts", "prob": 20, "count": [ 1, 4 ] }
             ]
           },
           "chance": 50

--- a/data/json/mapgen/helipad.json
+++ b/data/json/mapgen/helipad.json
@@ -81,8 +81,8 @@
               { "group": "infantry_medical_gear", "prob": 5, "count": [ 1, 2 ] },
               { "group": "supplies_metal", "prob": 150, "count": [ 2, 6 ] },
               { "group": "supplies_mechanics", "prob": 50, "count": [ 1, 3 ] },
-              { "group": "civilian_helicopter_parts", "prob": 20, "count": [ 1, 3 ] },
-              { "group": "military_helicopter_parts", "prob": 20, "count": [ 1, 4 ] }
+              { "group": "civilian_helicopter_parts", "prob": 50 },
+              { "group": "military_helicopter_parts", "prob": 50 }
             ]
           },
           "chance": 50


### PR DESCRIPTION

#### Summary Content "Added helicopter parts group to helipads"


#### Purpose of change

@KheirFerrum had mentioned that helipads themselves don't have any helicopter parts. So I added the civilian and the military parts group to the crates that spawn. This allows for motors, rotors and now steel plating/military plating to the loot locations.

#### Describe the solution

Added the groups for civilian and military helicopter parts to the crates that spawn. I also added military plating and steel plating to these groups. 

#### Describe alternatives you've considered

not doing it

#### Testing

Tested in game. New parts show up in helipads now!

#### Additional context


![Screenshot (1395)](https://user-images.githubusercontent.com/82045140/204559604-385cd29c-96e8-4186-8dd1-9db4d5691c81.png)
![Screenshot (1396)](https://user-images.githubusercontent.com/82045140/204559607-e52d981a-1ff3-4d38-a635-094b07bc6217.png)

