### PR TITLE
Fix construction recipe

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4236,7 +4236,7 @@
     "required_skills": [  ],
     "time": "10 m",
     "qualities": [  ],
-    "components": [ [ [ "fridge", 1 ] ] ],
+    "components": [ [ [ "freezer", 1 ] ] ],
     "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
     "pre_special": "check_empty",
     "post_furniture": "f_freezer"


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix freezer construction recipe"

#### Purpose of change

I apparently didn't edit the construction recipe properly when I did #2172. Freezer recipe uses fridge.

#### Describe the solution

Edit `construction.json`

#### Describe alternatives you've considered

#### Testing

Construction uses freezer to make freezer.

#### Additional context
