### PR TITLE
Extract furniture switch prompt for translation

### DIFF
--- a/lang/extract_json_strings.py
+++ b/lang/extract_json_strings.py
@@ -123,6 +123,7 @@ ignorable = {
 #   "description" member
 #   "text" member
 #   "sound" member
+#   "prompt" member
 #   "messages" member containing an array of translatable strings
 automatically_convertible = {
     "achievement",
@@ -1091,6 +1092,9 @@ def extract(state, item):
         wrote = True
     if "text" in item:
         writestr(state, item["text"])
+        wrote = True
+    if "prompt" in item:
+        writestr(state, item["prompt"])
         wrote = True
     if "message" in item:
         writestr(state, item["message"], format_strings=True,


### PR DESCRIPTION
#### Summary
SUMMARY: I18N "Extract furniture switch prompt for translation"

#### Purpose of change
Allow translators translation "Switch on/off the floor lamp" and similar messages.

#### Describe the solution
Add new field to string extraction script.

#### Testing
On local clone, diffed freshly generated `cataclysm-bn.pot` before and after change, saw new strings appear.
