### PR TITLE
Debug option to show missing tiles

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3850,7 +3850,7 @@ void cata_tiles::get_tile_values( const int t, const int *tn, int &subtile, int 
     get_rotation_and_subtile( val, rotation, subtile );
 }
 
-void cata_tiles::do_tile_loading_report( std::function<void( std::string & )> out )
+void cata_tiles::do_tile_loading_report( std::function<void( std::string )> out )
 {
     out( "Loaded tileset: " + get_option<std::string>( "TILES" ) );
 
@@ -3897,7 +3897,7 @@ point cata_tiles::player_to_screen( const point &p ) const
 
 template<typename Iter, typename Func>
 void cata_tiles::lr_generic( Iter begin, Iter end, Func id_func, TILE_CATEGORY category,
-                             std::function<void( std::string & )> out, const std::string &prefix )
+                             std::function<void( std::string )> out, const std::string &prefix )
 {
     std::string missing_list;
     std::string missing_with_looks_like_list;
@@ -3918,7 +3918,7 @@ void cata_tiles::lr_generic( Iter begin, Iter end, Func id_func, TILE_CATEGORY c
 
 template <typename maptype>
 void cata_tiles::tile_loading_report( const maptype &tiletypemap, TILE_CATEGORY category,
-                                      std::function<void( std::string & )> out, const std::string &prefix )
+                                      std::function<void( std::string )> out, const std::string &prefix )
 {
     lr_generic( tiletypemap.begin(), tiletypemap.end(),
     []( const decltype( tiletypemap.begin() ) & v ) {
@@ -3929,7 +3929,7 @@ void cata_tiles::tile_loading_report( const maptype &tiletypemap, TILE_CATEGORY 
 
 template <typename base_type>
 void cata_tiles::tile_loading_report( const size_t count, TILE_CATEGORY category,
-                                      std::function<void( std::string & )> out, const std::string &prefix )
+                                      std::function<void( std::string )> out, const std::string &prefix )
 {
     lr_generic( static_cast<size_t>( 0 ), count,
     []( const size_t i ) {
@@ -3939,7 +3939,7 @@ void cata_tiles::tile_loading_report( const size_t count, TILE_CATEGORY category
 
 template <typename arraytype>
 void cata_tiles::tile_loading_report( const arraytype &array, int array_length,
-                                      TILE_CATEGORY category, std::function<void( std::string & )> out, const std::string &prefix )
+                                      TILE_CATEGORY category, std::function<void( std::string )> out, const std::string &prefix )
 {
     const auto begin = &( array[0] );
     lr_generic( begin, begin + array_length,

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3850,9 +3850,9 @@ void cata_tiles::get_tile_values( const int t, const int *tn, int &subtile, int 
     get_rotation_and_subtile( val, rotation, subtile );
 }
 
-void cata_tiles::do_tile_loading_report( std::function<std::ostream&()> out )
+void cata_tiles::do_tile_loading_report( std::function<void( std::string & )> out )
 {
-    out() << "Loaded tileset: " << get_option<std::string>( "TILES" );
+    out( "Loaded tileset: " + get_option<std::string>( "TILES" ) );
 
     if( !g->is_core_data_loaded() ) {
         // There's nothing to do anymore without the core data.
@@ -3897,7 +3897,7 @@ point cata_tiles::player_to_screen( const point &p ) const
 
 template<typename Iter, typename Func>
 void cata_tiles::lr_generic( Iter begin, Iter end, Func id_func, TILE_CATEGORY category,
-                             std::function<std::ostream&()> out, const std::string &prefix )
+                             std::function<void( std::string & )> out, const std::string &prefix )
 {
     std::string missing_list;
     std::string missing_with_looks_like_list;
@@ -3911,15 +3911,14 @@ void cata_tiles::lr_generic( Iter begin, Iter end, Func id_func, TILE_CATEGORY c
             missing_with_looks_like_list.append( id_string + " " );
         }
     }
-    out() << "Missing " << TILE_CATEGORY_IDS[category] << ": " << missing_list;
-    out() << "Missing " << TILE_CATEGORY_IDS[category] <<
-          " (but looks_like tile exists): " << missing_with_looks_like_list;
+    out( "Missing " + TILE_CATEGORY_IDS[category] + ": " + missing_list );
+    out( "Missing " + TILE_CATEGORY_IDS[category] + " (but looks_like tile exists): " +
+         missing_with_looks_like_list );
 }
 
 template <typename maptype>
 void cata_tiles::tile_loading_report( const maptype &tiletypemap, TILE_CATEGORY category,
-                                      std::function<std::ostream&()> out,
-                                      const std::string &prefix )
+                                      std::function<void( std::string & )> out, const std::string &prefix )
 {
     lr_generic( tiletypemap.begin(), tiletypemap.end(),
     []( const decltype( tiletypemap.begin() ) & v ) {
@@ -3930,8 +3929,7 @@ void cata_tiles::tile_loading_report( const maptype &tiletypemap, TILE_CATEGORY 
 
 template <typename base_type>
 void cata_tiles::tile_loading_report( const size_t count, TILE_CATEGORY category,
-                                      std::function<std::ostream&()> out,
-                                      const std::string &prefix )
+                                      std::function<void( std::string & )> out, const std::string &prefix )
 {
     lr_generic( static_cast<size_t>( 0 ), count,
     []( const size_t i ) {
@@ -3941,7 +3939,7 @@ void cata_tiles::tile_loading_report( const size_t count, TILE_CATEGORY category
 
 template <typename arraytype>
 void cata_tiles::tile_loading_report( const arraytype &array, int array_length,
-                                      TILE_CATEGORY category, std::function<std::ostream&()> out, const std::string &prefix )
+                                      TILE_CATEGORY category, std::function<void( std::string & )> out, const std::string &prefix )
 {
     const auto begin = &( array[0] );
     lr_generic( begin, begin + array_length,

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3850,31 +3850,31 @@ void cata_tiles::get_tile_values( const int t, const int *tn, int &subtile, int 
     get_rotation_and_subtile( val, rotation, subtile );
 }
 
-void cata_tiles::do_tile_loading_report()
+void cata_tiles::do_tile_loading_report( std::function<std::ostream&()> out )
 {
-    DebugLog( DL::Info, DC::Main ) << "Loaded tileset: " << get_option<std::string>( "TILES" );
+    out() << "Loaded tileset: " << get_option<std::string>( "TILES" );
 
     if( !g->is_core_data_loaded() ) {
         // There's nothing to do anymore without the core data.
         return;
     }
 
-    tile_loading_report<ter_t>( ter_t::count(), C_TERRAIN, "" );
-    tile_loading_report<furn_t>( furn_t::count(), C_FURNITURE, "" );
+    tile_loading_report<ter_t>( ter_t::count(), C_TERRAIN, out, "" );
+    tile_loading_report<furn_t>( furn_t::count(), C_FURNITURE, out, "" );
 
     std::map<itype_id, const itype *> items;
     for( const itype *e : item_controller->all() ) {
         items.emplace( e->get_id(), e );
     }
-    tile_loading_report( items, C_ITEM, "" );
+    tile_loading_report( items, C_ITEM, out, "" );
 
     auto mtypes = MonsterGenerator::generator().get_all_mtypes();
     lr_generic( mtypes.begin(), mtypes.end(), []( const std::vector<mtype>::iterator & m ) {
         return ( *m ).id.str();
-    }, C_MONSTER, "" );
-    tile_loading_report( vpart_info::all(), C_VEHICLE_PART, "vp_" );
-    tile_loading_report<trap>( trap::count(), C_TRAP, "" );
-    tile_loading_report<field_type>( field_type::count(), C_FIELD, "" );
+    }, C_MONSTER, out, "" );
+    tile_loading_report( vpart_info::all(), C_VEHICLE_PART, out, "vp_" );
+    tile_loading_report<trap>( trap::count(), C_TRAP, out, "" );
+    tile_loading_report<field_type>( field_type::count(), C_FIELD, out, "" );
 }
 
 point cata_tiles::player_to_screen( const point &p ) const
@@ -3897,7 +3897,7 @@ point cata_tiles::player_to_screen( const point &p ) const
 
 template<typename Iter, typename Func>
 void cata_tiles::lr_generic( Iter begin, Iter end, Func id_func, TILE_CATEGORY category,
-                             const std::string &prefix )
+                             std::function<std::ostream&()> out, const std::string &prefix )
 {
     std::string missing_list;
     std::string missing_with_looks_like_list;
@@ -3911,41 +3911,43 @@ void cata_tiles::lr_generic( Iter begin, Iter end, Func id_func, TILE_CATEGORY c
             missing_with_looks_like_list.append( id_string + " " );
         }
     }
-    DebugLog( DL::Info, DC::Main ) << "Missing " << TILE_CATEGORY_IDS[category] << ": " << missing_list;
-    DebugLog( DL::Info, DC::Main ) << "Missing " << TILE_CATEGORY_IDS[category] <<
-                                   " (but looks_like tile exists): " << missing_with_looks_like_list;
+    out() << "Missing " << TILE_CATEGORY_IDS[category] << ": " << missing_list;
+    out() << "Missing " << TILE_CATEGORY_IDS[category] <<
+          " (but looks_like tile exists): " << missing_with_looks_like_list;
 }
 
 template <typename maptype>
 void cata_tiles::tile_loading_report( const maptype &tiletypemap, TILE_CATEGORY category,
+                                      std::function<std::ostream&()> out,
                                       const std::string &prefix )
 {
     lr_generic( tiletypemap.begin(), tiletypemap.end(),
     []( const decltype( tiletypemap.begin() ) & v ) {
         // c_str works for std::string and for string_id!
         return v->first.c_str();
-    }, category, prefix );
+    }, category, out, prefix );
 }
 
 template <typename base_type>
 void cata_tiles::tile_loading_report( const size_t count, TILE_CATEGORY category,
+                                      std::function<std::ostream&()> out,
                                       const std::string &prefix )
 {
     lr_generic( static_cast<size_t>( 0 ), count,
     []( const size_t i ) {
         return int_id<base_type>( i ).id().str();
-    }, category, prefix );
+    }, category, out, prefix );
 }
 
 template <typename arraytype>
 void cata_tiles::tile_loading_report( const arraytype &array, int array_length,
-                                      TILE_CATEGORY category, const std::string &prefix )
+                                      TILE_CATEGORY category, std::function<std::ostream&()> out, const std::string &prefix )
 {
     const auto begin = &( array[0] );
     lr_generic( begin, begin + array_length,
     []( decltype( begin ) const v ) {
         return v->id;
-    }, category, prefix );
+    }, category, out, prefix );
 }
 
 std::vector<options_manager::id_and_option> cata_tiles::build_renderer_list()

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -644,7 +644,7 @@ class cata_tiles
         float get_tile_ratioy() const {
             return tile_ratioy;
         }
-        void do_tile_loading_report();
+        void do_tile_loading_report( std::function<std::ostream&()> out );
         point player_to_screen( const point & ) const;
         static std::vector<options_manager::id_and_option> build_renderer_list();
         static std::vector<options_manager::id_and_option> build_display_list();
@@ -654,19 +654,20 @@ class cata_tiles
     protected:
         template <typename maptype>
         void tile_loading_report( const maptype &tiletypemap, TILE_CATEGORY category,
-                                  const std::string &prefix = "" );
+                                  std::function<std::ostream&()> out, const std::string &prefix = "" );
         template <typename arraytype>
         void tile_loading_report( const arraytype &array, int array_length, TILE_CATEGORY category,
-                                  const std::string &prefix = "" );
+                                  std::function<std::ostream&()> out, const std::string &prefix = "" );
         template <typename basetype>
-        void tile_loading_report( size_t count, TILE_CATEGORY category, const std::string &prefix );
+        void tile_loading_report( size_t count, TILE_CATEGORY category, std::function<std::ostream&()> out,
+                                  const std::string &prefix );
         /**
          * Generic tile_loading_report, begin and end are iterators, id_func translates the iterator
          * to an id string (result of id_func must be convertible to string).
          */
         template<typename Iter, typename Func>
         void lr_generic( Iter begin, Iter end, Func id_func, TILE_CATEGORY category,
-                         const std::string &prefix );
+                         std::function<std::ostream&()> out, const std::string &prefix );
         /** Lighting */
         void init_light();
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -644,7 +644,7 @@ class cata_tiles
         float get_tile_ratioy() const {
             return tile_ratioy;
         }
-        void do_tile_loading_report( std::function<void( std::string & )> out );
+        void do_tile_loading_report( std::function<void( std::string )> out );
         point player_to_screen( const point & ) const;
         static std::vector<options_manager::id_and_option> build_renderer_list();
         static std::vector<options_manager::id_and_option> build_display_list();
@@ -654,13 +654,13 @@ class cata_tiles
     protected:
         template <typename maptype>
         void tile_loading_report( const maptype &tiletypemap, TILE_CATEGORY category,
-                                  std::function<void( std::string & )> out, const std::string &prefix = "" );
+                                  std::function<void( std::string )> out, const std::string &prefix = "" );
         template <typename arraytype>
         void tile_loading_report( const arraytype &array, int array_length, TILE_CATEGORY category,
-                                  std::function<void( std::string & )> out, const std::string &prefix = "" );
+                                  std::function<void( std::string )> out, const std::string &prefix = "" );
         template <typename basetype>
         void tile_loading_report( size_t count, TILE_CATEGORY category,
-                                  std::function<void( std::string & )> out,
+                                  std::function<void( std::string )> out,
                                   const std::string &prefix );
         /**
          * Generic tile_loading_report, begin and end are iterators, id_func translates the iterator
@@ -668,7 +668,7 @@ class cata_tiles
          */
         template<typename Iter, typename Func>
         void lr_generic( Iter begin, Iter end, Func id_func, TILE_CATEGORY category,
-                         std::function<void( std::string & )> out, const std::string &prefix );
+                         std::function<void( std::string )> out, const std::string &prefix );
         /** Lighting */
         void init_light();
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -644,7 +644,7 @@ class cata_tiles
         float get_tile_ratioy() const {
             return tile_ratioy;
         }
-        void do_tile_loading_report( std::function<std::ostream&()> out );
+        void do_tile_loading_report( std::function<void( std::string & )> out );
         point player_to_screen( const point & ) const;
         static std::vector<options_manager::id_and_option> build_renderer_list();
         static std::vector<options_manager::id_and_option> build_display_list();
@@ -654,12 +654,13 @@ class cata_tiles
     protected:
         template <typename maptype>
         void tile_loading_report( const maptype &tiletypemap, TILE_CATEGORY category,
-                                  std::function<std::ostream&()> out, const std::string &prefix = "" );
+                                  std::function<void( std::string & )> out, const std::string &prefix = "" );
         template <typename arraytype>
         void tile_loading_report( const arraytype &array, int array_length, TILE_CATEGORY category,
-                                  std::function<std::ostream&()> out, const std::string &prefix = "" );
+                                  std::function<void( std::string & )> out, const std::string &prefix = "" );
         template <typename basetype>
-        void tile_loading_report( size_t count, TILE_CATEGORY category, std::function<std::ostream&()> out,
+        void tile_loading_report( size_t count, TILE_CATEGORY category,
+                                  std::function<void( std::string & )> out,
                                   const std::string &prefix );
         /**
          * Generic tile_loading_report, begin and end are iterators, id_func translates the iterator
@@ -667,7 +668,7 @@ class cata_tiles
          */
         template<typename Iter, typename Func>
         void lr_generic( Iter begin, Iter end, Func id_func, TILE_CATEGORY category,
-                         std::function<std::ostream&()> out, const std::string &prefix );
+                         std::function<void( std::string & )> out, const std::string &prefix );
         /** Lighting */
         void init_light();
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2051,7 +2051,7 @@ void debug()
             break;
         case DEBUG_RELOAD_TILES:
             std::ostringstream ss;
-            g->reload_tileset( [&ss]( std::string & str ) {
+            g->reload_tileset( [&ss]( std::string str ) {
                 ss << str << std::endl;
             } );
             add_msg( ss.str() );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2051,8 +2051,8 @@ void debug()
             break;
         case DEBUG_RELOAD_TILES:
             std::ostringstream ss;
-            g->reload_tileset( [&ss]() -> std::ostream& {
-                return *detail::DebugLogGuard( ss );
+            g->reload_tileset( [&ss]( std::string & str ) {
+                ss << str << std::endl;
             } );
             add_msg( ss.str() );
             break;

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -181,6 +181,7 @@ enum debug_menu_index {
     DEBUG_HOUR_TIMER,
     DEBUG_NESTED_MAPGEN,
     DEBUG_RESET_IGNORED_MESSAGES,
+    DEBUG_RELOAD_TILES,
 };
 
 class mission_debug
@@ -238,6 +239,9 @@ static int info_uilist( bool display_all_entries = true )
             { uilist_entry( DEBUG_TEST_WEATHER, true, 'W', _( "Test weather" ) ) },
             { uilist_entry( DEBUG_TEST_MAP_EXTRA_DISTRIBUTION, true, 'e', _( "Test map extra list" ) ) },
             { uilist_entry( DEBUG_RESET_IGNORED_MESSAGES, true, 'I', _( "Reset ignored debug messages" ) ) },
+#if defined(TILES)
+            { uilist_entry( DEBUG_RELOAD_TILES, true, 'D', _( "Reload tileset and show missing tiles" ) ) },
+#endif
         };
         uilist_initializer.insert( uilist_initializer.begin(), debug_only_options.begin(),
                                    debug_only_options.end() );
@@ -2044,6 +2048,13 @@ void debug()
             break;
         case DEBUG_RESET_IGNORED_MESSAGES:
             debug_reset_ignored_messages();
+            break;
+        case DEBUG_RELOAD_TILES:
+            std::ostringstream ss;
+            g->reload_tileset( [&ss]() -> std::ostream& {
+                return *detail::DebugLogGuard( ss );
+            } );
+            add_msg( ss.str() );
             break;
     }
     m.invalidate_map_cache( g->get_levz() );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -526,7 +526,7 @@ void game::toggle_pixel_minimap()
 #endif // TILES
 }
 
-void game::reload_tileset( [[maybe_unused]] std::function<std::ostream&()> out )
+void game::reload_tileset( [[maybe_unused]] std::function<void( std::string & )> out )
 {
 #if defined(TILES)
     // Disable UIs below to avoid accessing the tile context during loading.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -526,7 +526,7 @@ void game::toggle_pixel_minimap()
 #endif // TILES
 }
 
-void game::reload_tileset( std::function<std::ostream&()> out )
+void game::reload_tileset( [[maybe_unused]] std::function<std::ostream&()> out )
 {
 #if defined(TILES)
     // Disable UIs below to avoid accessing the tile context during loading.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -526,7 +526,7 @@ void game::toggle_pixel_minimap()
 #endif // TILES
 }
 
-void game::reload_tileset( [[maybe_unused]] std::function<void( std::string & )> out )
+void game::reload_tileset( [[maybe_unused]] std::function<void( std::string )> out )
 {
 #if defined(TILES)
     // Disable UIs below to avoid accessing the tile context during loading.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -526,7 +526,7 @@ void game::toggle_pixel_minimap()
 #endif // TILES
 }
 
-void game::reload_tileset()
+void game::reload_tileset( std::function<std::ostream&()> out )
 {
 #if defined(TILES)
     // Disable UIs below to avoid accessing the tile context during loading.
@@ -541,7 +541,7 @@ void game::reload_tileset()
             /*force=*/true,
             /*pump_events=*/true
         );
-        tilecontext->do_tile_loading_report();
+        tilecontext->do_tile_loading_report( out );
     } catch( const std::exception &err ) {
         popup( _( "Loading the tileset failed: %s" ), err.what() );
     }

--- a/src/game.h
+++ b/src/game.h
@@ -617,7 +617,7 @@ class game
 
         void toggle_fullscreen();
         void toggle_pixel_minimap();
-        void reload_tileset( std::function<void( std::string & )> out );
+        void reload_tileset( std::function<void( std::string )> out );
         void temp_exit_fullscreen();
         void reenter_fullscreen();
         void zoom_in();

--- a/src/game.h
+++ b/src/game.h
@@ -617,7 +617,7 @@ class game
 
         void toggle_fullscreen();
         void toggle_pixel_minimap();
-        void reload_tileset( std::function<std::ostream&()> out );
+        void reload_tileset( std::function<void( std::string & )> out );
         void temp_exit_fullscreen();
         void reenter_fullscreen();
         void zoom_in();

--- a/src/game.h
+++ b/src/game.h
@@ -617,7 +617,7 @@ class game
 
         void toggle_fullscreen();
         void toggle_pixel_minimap();
-        void reload_tileset();
+        void reload_tileset( std::function<std::ostream&()> out );
         void temp_exit_fullscreen();
         void reenter_fullscreen();
         void zoom_in();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2363,8 +2363,8 @@ bool game::handle_action()
                 break;
 
             case ACTION_RELOAD_TILESET:
-                reload_tileset( []() -> std::ostream& {
-                    return DebugLog( DL::Info, DC::Main );
+                reload_tileset( []( std::string & str ) {
+                    DebugLog( DL::Info, DC::Main ) << str;
                 } );
                 break;
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2363,7 +2363,7 @@ bool game::handle_action()
                 break;
 
             case ACTION_RELOAD_TILESET:
-                reload_tileset( []( std::string & str ) {
+                reload_tileset( []( std::string str ) {
                     DebugLog( DL::Info, DC::Main ) << str;
                 } );
                 break;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2363,7 +2363,9 @@ bool game::handle_action()
                 break;
 
             case ACTION_RELOAD_TILESET:
-                reload_tileset();
+                reload_tileset( []() -> std::ostream& {
+                    return DebugLog( DL::Info, DC::Main );
+                } );
                 break;
 
             case ACTION_TOGGLE_AUTO_FEATURES:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2661,8 +2661,8 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
             //game_ui::init_ui is called when zoom is changed
             g->reset_zoom();
             g->mark_main_ui_adaptor_resize();
-            tilecontext->do_tile_loading_report( []() -> std::ostream& {
-                return DebugLog( DL::Info, DC::Main );
+            tilecontext->do_tile_loading_report( []( std::string & str ) {
+                DebugLog( DL::Info, DC::Main ) << str;
             } );
         } catch( const std::exception &err ) {
             popup( _( "Loading the tileset failed: %s" ), err.what() );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2661,7 +2661,7 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
             //game_ui::init_ui is called when zoom is changed
             g->reset_zoom();
             g->mark_main_ui_adaptor_resize();
-            tilecontext->do_tile_loading_report( []( std::string & str ) {
+            tilecontext->do_tile_loading_report( []( std::string str ) {
                 DebugLog( DL::Info, DC::Main ) << str;
             } );
         } catch( const std::exception &err ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2661,7 +2661,9 @@ static void refresh_tiles( bool used_tiles_changed, bool pixel_minimap_height_ch
             //game_ui::init_ui is called when zoom is changed
             g->reset_zoom();
             g->mark_main_ui_adaptor_resize();
-            tilecontext->do_tile_loading_report();
+            tilecontext->do_tile_loading_report( []() -> std::ostream& {
+                return DebugLog( DL::Info, DC::Main );
+            } );
         } catch( const std::exception &err ) {
             popup( _( "Loading the tileset failed: %s" ), err.what() );
             use_tiles = false;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3597,8 +3597,8 @@ void load_tileset()
         /*force=*/false,
         /*pump_events=*/true
     );
-    tilecontext->do_tile_loading_report( []() -> std::ostream& {
-        return DebugLog( DL::Info, DC::Main );
+    tilecontext->do_tile_loading_report( []( std::string str ) {
+        DebugLog( DL::Info, DC::Main ) << str;
     } );
 }
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3597,7 +3597,9 @@ void load_tileset()
         /*force=*/false,
         /*pump_events=*/true
     );
-    tilecontext->do_tile_loading_report();
+    tilecontext->do_tile_loading_report( []() -> std::ostream& {
+        return DebugLog( DL::Info, DC::Main );
+    } );
 }
 
 //Ends the terminal, destroy everything


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Show missing tiles from the debug menu"

#### Purpose of change

Make it easier for people to find this feature. 

#### Describe the solution

The reporting function takes a new argument of a function returning a stream and outputs to that stream. When triggered from the debug menu this is sent to a string and then added to the message log. 

#### Describe alternatives you've considered

Using a popup rather than the log, but they don't do scrolling. 