### PR TITLE
Modernize string_formatter for std::string_view

### DIFF
--- a/src/string_formatter.cpp
+++ b/src/string_formatter.cpp
@@ -105,8 +105,16 @@ cata::optional<int> cata::string_formatter::read_precision()
 
 void cata::string_formatter::throw_error( const std::string &msg ) const
 {
-    throw std::runtime_error( msg + " at: \"" + format.substr( 0,
-                              current_index_in_format ) + "|" + format.substr( current_index_in_format ) + "\"" );
+    // C++ standard wouldn't be C++ standard if they didn't implement a cool feature,
+    // but then fuck it up in the worst possible way.
+    // Behold: you can't concatenate std::string and std::string_view with operator+
+    std::string err = msg;
+    err += " at: \"";
+    err += format.substr( 0, current_index_in_format );
+    err += "|";
+    err += format.substr( current_index_in_format );
+    err += "\"";
+    throw std::runtime_error( err );
 }
 
 std::string cata::handle_string_format_error()
@@ -157,7 +165,7 @@ void string_formatter::do_formating( void *value )
     output.append( fmt::sprintf( current_format, value ) );
 }
 
-void string_formatter::do_formating( const char *value )
+void string_formatter::do_formating( std::string_view value )
 {
     output.append( fmt::sprintf( current_format, value ) );
 }

--- a/tests/string_formatter_test.cpp
+++ b/tests/string_formatter_test.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "string_formatter.h"
+#include "type_id.h"
 
 // Same as @ref string_format, but does not swallow errors and throws them instead.
 template<typename ...Args>
@@ -127,6 +128,12 @@ TEST_CASE( "string_formatter" )
     importet_test( 429, "100.4400000", "%3$-*1$.*2$f", 4, 7, 100.44 );
     importet_test( 430, "100.4400000", "%1$-*2$.*3$f", 100.44, 4, 7 );
     importet_test( 431, "100.4400000", "%2$-*3$.*1$f", 7, 100.44, 4 );
+
+    // test string-like arguments
+    importet_test( 432, "abcde", "%s", "abcde" );
+    importet_test( 433, "abcde", "%s", std::string_view( "abcde" ) );
+    importet_test( 434, "abcde", "%s", std::string( "abcde" ) );
+    importet_test( 435, "abcde", "%s", itype_id( "abcde" ) );
 
     // These calls should cause *compile* errors. Try it out.
 #if 0


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Modernize string_formatter for std::string_view"

#### Purpose of change
C++17 is here, it's time to recognize some C++17 features

#### Describe the solution
Make string_formatter accept std::string_view

#### Describe alternatives you've considered
Copying `std::string`s

#### Testing
Wrote some test cases for this
