### PR TITLE
Bump Android build to C++17

### DIFF
--- a/android/app/jni/Application.mk
+++ b/android/app/jni/Application.mk
@@ -2,7 +2,7 @@
 
 # See CPLUSPLUS-SUPPORT.html in the NDK documentation for more information
 APP_STL := c++_shared
-APP_CPPFLAGS += -std=c++14
+APP_CPPFLAGS += -std=c++17
 ifneq ($(OS),Windows_NT)
     APP_LDFLAGS += -fuse-ld=gold
 endif


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Bump Android build to C++17"

#### Purpose of change
Android builds got left out during #1953 

#### Describe the solution
Bump to C++17

#### Testing
Game compiles locally
