### PR TITLE
Release experimentals as pre-releases on GitHub

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -66,7 +66,7 @@ jobs:
           body: |
             ${{ steps.build_changelog.outputs.changelog }}
             These are the outputs for the manually triggered build of commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
-          draft: false
+          draft: true
           prerelease: false
   builds:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
             ${{ steps.build_changelog.outputs.changelog }}
             These are the outputs for the experimental build of commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
           draft: false
-          prerelease: false
+          prerelease: true
   builds:
     needs: release
     if: ${{ needs.release.outputs.release_already_exists == 'false' }}


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Release experimentals as pre-releases on GitHub"

#### Purpose of change
Fixes #2231

#### Describe the solution
Mark new experimental releases as pre-releases.
Also made manual release actions produce draft releases, so they could be reviewed before going public.
Existing releases would still remain as pre-releases, but they can be marked as pre- en masse with [a python script](https://gist.githubusercontent.com/olanti-p/6f30e959ee326832fec8222e9393dcba/raw/9de6efe28a21233c4c58a6ff9a09212c6ac826b0/mark_all_releases_as_pre).

#### Describe alternatives you've considered
Switching over to the newer version of the action (https://github.com/softprops/action-gh-release) and enabling a bunch of new features (changelog autogeneration, new discussion per release). 

#### Testing
Tried this on my fork, works as expected.