### PR TITLE
Fix android build, add android to CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,13 +22,6 @@ concurrency:
   group: android-build-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
-env:
-  # There's not enough disk space to build both release and debug versions of
-  # our dependencies, so we hack the triplet file to build only release versions
-  # Have to use github.workspace because runner namespace isn't available yet.
-  VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\.github\vcpkg_triplets
-  ZSTD_CLEVEL: 17
-
 jobs:
   build_catatclysm:
     name: Build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,59 @@
+name: Cataclysm Android build
+
+on:
+  pull_request:
+    branches:
+    - upload
+    paths-ignore:
+    - 'build-data/osx/**'
+    - 'doc/**'
+    - 'doxygen_doc/**'
+    - 'gfx/**'
+    - 'lang/**'
+    - 'lgtm/**'
+    - 'msvc-object_creator/**'
+    - 'object_creator/**'
+    - 'tools/**'
+    - '!tools/format/**'
+    - 'utilities/**'
+
+# We only care about the latest revision of a PR, so cancel previous instances.
+concurrency:
+  group: android-build-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  # There's not enough disk space to build both release and debug versions of
+  # our dependencies, so we hack the triplet file to build only release versions
+  # Have to use github.workspace because runner namespace isn't available yet.
+  VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\.github\vcpkg_triplets
+  ZSTD_CLEVEL: 17
+
+jobs:
+  build_catatclysm:
+    name: Build
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.draft == false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Set up JDK 8 (android)
+      uses: actions/setup-java@v2
+      with:
+        java-version: "8"
+        distribution: "adopt"
+    
+    - name: Setup build and dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install gettext
+
+    - name: Build
+      working-directory: ./android
+      run: |
+        chmod +x gradlew
+        ./gradlew -Pj=$((`nproc`+0)) -Pabi_arm_32=false assembleExperimentalRelease

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -242,10 +242,10 @@ detail::mutations_ui_result detail::show_mutations_ui_internal( Character &who )
     ctxt.register_action( "QUIT" );
 #if defined(__ANDROID__)
     for( const auto &p : passive ) {
-        ctxt.register_manual_key( my_mutations[p].key, p.obj().name() );
+        ctxt.register_manual_key( who.my_mutations[p].key, p.obj().name() );
     }
     for( const auto &a : active ) {
-        ctxt.register_manual_key( my_mutations[a].key, a.obj().name() );
+        ctxt.register_manual_key( who.my_mutations[a].key, a.obj().name() );
     }
 #endif
 


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Added android builds to CI"

#### Purpose of change
Fix #2243 and prevent future android build failures.

#### Describe the solution
Add a separate PR workflow that builds an android build.

#### Testing
Broken PR builds report error and a failed check: [run link](https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/3725085964/jobs/6317665520)
```
[arm64-v8a] Compile++      : main <= mutation_ui.cpp
/home/runner/work/Cataclysm-BN/Cataclysm-BN/android/app/jni/src/mutation_ui.cpp:245:35: error: use of undeclared identifier 'my_mutations'
        ctxt.register_manual_key( my_mutations[p].key, p.obj().name() );
                                  ^
/home/runner/work/Cataclysm-BN/Cataclysm-BN/android/app/jni/src/mutation_ui.cpp:248:35: error: use of undeclared identifier 'my_mutations'
        ctxt.register_manual_key( my_mutations[a].key, a.obj().name() );
                                  ^
2 errors generated.
```

Outdated builds on same PR get cancelled: [run link](https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/3725108519/jobs/6317703188)

Successful builds give green check mark: [run link](https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/3725115471/jobs/6317716391)