### PR TITLE
Enable strict JSON checks by default

### DIFF
--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -2,7 +2,6 @@
 
 bool test_mode = false;
 bool debug_mode = false;
-bool json_report_unused_fields = true;
 bool json_report_strict = true;
 bool use_tiles = false;
 bool use_tiles_overmap = false;

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -21,11 +21,6 @@ extern bool test_mode;
 extern bool debug_mode;
 
 /**
- * Report unused JSON fields in regular (non-test) mode.
- */
-extern bool json_report_unused_fields;
-
-/**
  * Report extra problems in JSONs.
  * Because either @ref test_mode or @ref json_report_unused_fields is set.
  */

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2095,9 +2095,9 @@ void options_manager::add_options_debug()
         this->add_empty_line( "debug" );
     };
 
-    add( "REPORT_UNUSED_JSON_FIELDS", "debug", translate_marker( "Report unused JSON fields" ),
-         translate_marker( "If false, unused JSON fields are silently ignored.  Enabling this will make it easier to spot mistakes or typos during modding." ),
-         false
+    add( "STRICT_JSON_CHECKS", "debug", translate_marker( "Strict JSON checks" ),
+         translate_marker( "If true, will show additional warnings for JSON data correctness." ),
+         true
        );
 
     add( "FORCE_TILESET_RELOAD", "debug", translate_marker( "Force tileset reload" ),
@@ -3335,8 +3335,7 @@ void options_manager::cache_to_globals()
     setDebugLogLevels( levels );
     setDebugLogClasses( classes );
 
-    json_report_unused_fields = ::get_option<bool>( "REPORT_UNUSED_JSON_FIELDS" );
-    json_report_strict = test_mode || json_report_unused_fields;
+    json_report_strict = test_mode || ::get_option<bool>( "STRICT_JSON_CHECKS" );
     display_mod_source = ::get_option<bool>( "MOD_SOURCE" );
     trigdist = ::get_option<bool>( "CIRCLEDIST" );
     use_tiles = ::get_option<bool>( "USE_TILES" );


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Enabled strict JSON checks by default"

#### Purpose of change
These checks are quite useful when it comes to making mods and changing game files, yet not all people know they are a thing, so make them much more noticeable.

#### Describe the solution
1. Rename "Report unused JSON fields" into "Strict JSON checks" as the feature has grown in scope
2. Enable it by default
3. Change ID of the option so it'll become enabled on existing installations
4. Simplify code a bit

#### Describe alternatives you've considered
Enabling them permanently