### PR TITLE
Add MSYS2 builds to CI

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -1,4 +1,4 @@
-name: Cataclysm Windows build
+name: Cataclysm Windows build (MSVC)
 
 on:
   push:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,0 +1,75 @@
+name: Cataclysm Windows build (MSYS2)
+
+on:
+  push:
+    branches:
+    - upload
+    paths-ignore:
+    - 'android/**'
+    - 'build-data/osx/**'
+    - 'doc/**'
+    - 'doxygen_doc/**'
+    - 'gfx/**'
+    - 'lang/**'
+    - 'tools/**'
+    - '!tools/format/**'
+    - 'utilities/**'
+  pull_request:
+    branches:
+    - upload
+    paths-ignore:
+    - 'android/**'
+    - 'build-data/osx/**'
+    - 'doc/**'
+    - 'doxygen_doc/**'
+    - 'gfx/**'
+    - 'lang/**'
+    - 'tools/**'
+    - '!tools/format/**'
+    - 'utilities/**'
+
+# We only care about the latest revision of a PR, so cancel previous instances.
+concurrency:
+  group: msys2-build-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build_catatclysm:
+    name: Build
+    runs-on: windows-2019
+    if: github.event.pull_request.draft == false
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Setup MSYS2
+      # Will by default install MINGW64
+      uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        install: |
+          git
+          make
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-libmad
+          mingw-w64-x86_64-libwebp
+          mingw-w64-x86_64-pkg-config
+          mingw-w64-x86_64-SDL2
+          mingw-w64-x86_64-SDL2_image
+          mingw-w64-x86_64-SDL2_mixer
+          mingw-w64-x86_64-SDL2_ttf
+
+    - name: Build
+      run: |
+        make -j$((`nproc`+0)) RELEASE=1 DYNAMIC_LINKING=1 TILES=1 SOUND=1 LANGUAGES=all LINTJSON=0 ASTYLE=0
+
+    - name: Run tests
+      run: |
+          ./tests/cata_test.exe --rng-seed time

--- a/tests/basecamp_test.cpp
+++ b/tests/basecamp_test.cpp
@@ -55,20 +55,21 @@ TEST_CASE( "distribute_food" )
     constexpr tripoint origin( 60, 60, 0 );
     constexpr tripoint thirty_steps_rd = tripoint( 30, 30, 0 );
     g->u.setpos( origin );
+    const tripoint origin_abs = get_map().getabs( origin );
     const tripoint_abs_omt omt_pos = g->u.global_omt_location();
     g->m.add_camp( omt_pos, "faction_camp_for_distribute" );
     basecamp *bcp = overmap_buffer.find_camp( omt_pos.xy() ).value();
-    bcp->set_bb_pos( origin + tripoint_east );
+    bcp->set_bb_pos( origin_abs + tripoint_east );
     zone_manager &zmgr = zone_manager::get_manager();
     const faction *yours = g->u.get_faction();
     zmgr.add( "Zone for dumping food", zone_type_id( "CAMP_FOOD" ),
               g->u.get_faction()->id, false, true,
-              origin - thirty_steps_rd,
-              origin + thirty_steps_rd );
+              origin_abs - thirty_steps_rd,
+              origin_abs + thirty_steps_rd );
     zmgr.add( "Storage zone", zone_type_id( "CAMP_STORAGE" ),
               g->u.get_faction()->id, false, true,
-              origin - thirty_steps_rd,
-              origin + thirty_steps_rd );
+              origin_abs - thirty_steps_rd,
+              origin_abs + thirty_steps_rd );
 
     calendar::turn = calendar::turn_zero + 365_days * 5;
 


### PR DESCRIPTION
#### Summary
SUMMARY: Build "Added MSYS2 builds to CI"

#### Purpose of change
MSYS2 builds are the 2nd build option on Windows after MSVC, it'd be nice to know when it breaks.

#### Describe the solution
Added MSYS2 builds to CI.

#### Describe alternatives you've considered
~~It took 1h 11m 17s to complete on my fork, so we may want to run these on `upload` only~~
Could've been some kind of throttling, the run on this PR completed in 25 minutes.

#### Testing
~~The [run](https://github.com/olanti-p/Cataclysm-BN/actions/runs/3726748032/jobs/6320393782) on my fork failed, I'll assume it's rng-related unless this one fails too.~~
It was an issue with the test, fixed it.