### PR TITLE
Fix broken `README` link on bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
         - `Main menu (ESC)` > `Debug Menu` > `Info` > `Submit a bug report on github`
         - it fills out necessary information automatically for you
 
-        please check [README](../../README.md#ive-found-a-bug-what-should-i-do) for more information.
+        please check [README](https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/README.md#ive-found-a-bug-what-should-i-do) for more information.
 
   - type: textarea
     id: describe-bug


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Fix broken `README` link on bug report"

#### Purpose of change

Relative link does not work when issue form is rendered in issues page.

#### Describe the solution
 
changed link to README to absolute URL.
