### PR TITLE
Get rid of linear texture scaling option

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2066,23 +2066,12 @@ void options_manager::add_options_graphics()
          false, COPT_CURSES_HIDE
        );
 
-    add( "SCALING_MODE", "graphics", translate_marker( "Scaling mode" ),
-         translate_marker( "Sets the scaling mode, 'none' ( default ) displays at the game's native resolution, 'nearest'  uses low-quality but fast scaling, and 'linear' provides high-quality scaling." ),
-         //~ Do not scale the game image to the window size.
-    {   { "none", translate_marker( "No scaling" ) },
-        //~ An algorithm for image scaling.
-        { "nearest", translate_marker( "Nearest neighbor" ) },
-        //~ An algorithm for image scaling.
-        { "linear", translate_marker( "Linear filtering" ) }
-    },
-    "none", COPT_CURSES_HIDE );
-
 #if !defined(__ANDROID__)
-    add( "SCALING_FACTOR", "graphics", translate_marker( "Scaling factor" ),
-    translate_marker( "Factor by which to scale the display.  Requires restart." ), {
+    add( "SCALING_FACTOR", "graphics", translate_marker( "Display scaling factor" ),
+    translate_marker( "Factor by which to scale the game display, 1x means no scaling.  Requires restart." ), {
         { "1", translate_marker( "1x" ) },
-        { "2", translate_marker( "2x" )},
-        { "4", translate_marker( "4x" )}
+        { "2", translate_marker( "2x" ) },
+        { "4", translate_marker( "4x" ) }
     },
     "1", COPT_CURSES_HIDE );
 #endif

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -236,9 +236,8 @@ static void WinCreate()
     WindowHeight = TERMINAL_HEIGHT * fontheight * scaling_factor;
     window_flags |= SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
 
-    if( get_option<std::string>( "SCALING_MODE" ) != "none" ) {
-        SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, get_option<std::string>( "SCALING_MODE" ).c_str() );
-    }
+    // We want our textures clean and sharp when zooming in.
+    SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, "nearest" );
 
 #if !defined(__ANDROID__)
     const auto screen_mode = get_option<std::string>( "FULLSCREEN" );


### PR DESCRIPTION
#### Summary
SUMMARY: Interface "Get rid of linear texture scaling option"

#### Purpose of change
Closes #2185
Closes #1888
Current issues with scaling options:
1. `Scaling mode` and `Scaling factor` options are worded similarly and placed in same block, which makes it look like they're responsible for single feature (scaling game display), but de-facto scaling mode is for _all_ texture scaling (tiles & display scaling) while scaling factor is for display scaling only.
2. `Scaling mode` option implies that `linear` scaling is of the higher quality, which may be true when it comes to 3D games and moving and/or natural textures, but BN is a 2D game with static pixel art, any scaling except nearest turns the pixel art into blurry mess whenever you zoom in.

#### Describe the solution
1. Add `Display` to `Scaling factor` option name to better reflect its purpose.
2. Get rid of the footgun by completely removing the "scaling mode" option. There's no "linear" scaling anymore.

#### Describe alternatives you've considered
1. Getting rid of `Scaling factor` too, usually OSes have per-screen DPI settings for this.
2. Not only linear scaling turns pixel art into shit when zooming in, there's also the issue of tile bleeding (oddly-colored half-visible lines at tile edges, see linked issue). Normally it could be fixed by offsetting texture coords by a fraction of a pixel (human eye won't notice that the tile is 31.98 pixels wide, not 32, but that's enough for the renderer to not sample from nearby tiles), but `SDL_RenderCopyEx` we use for drawing is too simple to support fractional texture coords. Alternative solution is either to rewrite renderer (ha!), or just pad every tile with a 1 pixel wide border of same color either on tileset load or by external tool on tileset creation, but both options are _way_ too much work to save linear scaling which is ill suited for our use case anyway. So, I got rid of it.
3. Adding a new option (exclusive to opengl) to make textures use "linear" filtering when zooming out and "nearest" when zooming in. This could be a middle ground of sorts. The new option could keep good parts from both old scaling mods, but here's some issues: 
    * I've no idea how to implement it for direct3d/metal/android, only win+linux and only for opengl. SDL does not support this "out of the box".
    * It'd need linking (and building against) opengl library (SDL uses it as backend, but does not expose it) on every build system we have

#### Testing
Works on Windows(msvc).
