### PR TITLE
Enable SDL Graphical Overmap by default

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1912,7 +1912,7 @@ void options_manager::add_options_graphics()
 
     add( "USE_TILES_OVERMAP", "graphics", translate_marker( "Use tiles to display overmap" ),
          translate_marker( "If true, replaces some TTF-rendered text with tiles for overmap display." ),
-         false, COPT_CURSES_HIDE
+         true, COPT_CURSES_HIDE
        );
 
     get_option( "USE_TILES_OVERMAP" ).setPrerequisite( "USE_TILES" );


### PR DESCRIPTION
#### Summary
SUMMARY: Interface "Enable SDL Graphical Overmap by default"

#### Purpose of change
Simple answer to all these "what mod?" and "how did you make it this way?" questions on Discord.

#### Describe the solution
Enable SDL Graphical Overmap by default.
People who dislike it can still turn it off in settings.

#### Testing
None should be needed.
