### PR TITLE
Ammo Rebalance, Part 8

### DIFF
--- a/data/json/items/ammo/223.json
+++ b/data/json/items/ammo/223.json
@@ -18,7 +18,7 @@
     "casing": "223_casing",
     "range": 36,
     "//": "Balanced as FMJ rather than JHP, as M855A1 is steel core and would fit better as AP.",
-    "damage": { "damage_type": "bullet", "amount": 42, "armor_penetration": 24 },
+    "damage": { "damage_type": "bullet", "amount": 42, "armor_penetration": 18 },
     "dispersion": 30,
     "recoil": 1500,
     "effects": [ "COOKOFF" ]
@@ -32,8 +32,8 @@
     "price": 290,
     "price_postapoc": 900,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
-    "//": "Balanced as AP, 7/8 damage, arpen matches damage.",
-    "relative": { "damage": { "damage_type": "bullet", "amount": -5, "armor_penetration": 13 }, "dispersion": -10 },
+    "//": "Balanced as AP, 7/8 damage, arpen 6/7 of that value.",
+    "relative": { "damage": { "damage_type": "bullet", "amount": -5, "armor_penetration": 14 }, "dispersion": -10 },
     "proportional": { "recoil": 1.1 },
     "extend": { "effects": [ "NEVER_MISFIRES" ] }
   },

--- a/data/json/items/ammo/270win.json
+++ b/data/json/items/ammo/270win.json
@@ -17,7 +17,7 @@
     "ammo_type": "270win",
     "casing": "270win_casing",
     "range": 65,
-    "damage": { "damage_type": "bullet", "amount": 60, "armor_penetration": 34 },
+    "damage": { "damage_type": "bullet", "amount": 60, "armor_penetration": 26 },
     "dispersion": 10,
     "recoil": 3800,
     "effects": [ "COOKOFF", "NEVER_MISFIRES" ]

--- a/data/json/items/ammo/300.json
+++ b/data/json/items/ammo/300.json
@@ -17,7 +17,7 @@
     "ammo_type": "300",
     "casing": "300_casing",
     "range": 65,
-    "damage": { "damage_type": "bullet", "amount": 70, "armor_penetration": 39 },
+    "damage": { "damage_type": "bullet", "amount": 70, "armor_penetration": 17 },
     "dispersion": 15,
     "recoil": 4000,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/3006.json
+++ b/data/json/items/ammo/3006.json
@@ -17,7 +17,7 @@
     "ammo_type": "3006",
     "casing": "3006_casing",
     "range": 61,
-    "damage": { "damage_type": "bullet", "amount": 62, "armor_penetration": 35 },
+    "damage": { "damage_type": "bullet", "amount": 62, "armor_penetration": 27 },
     "dispersion": 20,
     "recoil": 3800,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/300blk.json
+++ b/data/json/items/ammo/300blk.json
@@ -17,7 +17,7 @@
     "ammo_type": "300blk",
     "casing": "300blk_casing",
     "range": 45,
-    "damage": { "damage_type": "bullet", "amount": 43, "armor_penetration": 24 },
+    "damage": { "damage_type": "bullet", "amount": 43, "armor_penetration": 19 },
     "dispersion": 30,
     "recoil": 2000,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/308.json
+++ b/data/json/items/ammo/308.json
@@ -18,7 +18,7 @@
     "casing": "308_casing",
     "range": 65,
     "//": "Balanced as FMJ rather than JHP.",
-    "damage": { "damage_type": "bullet", "amount": 55, "armor_penetration": 31 },
+    "damage": { "damage_type": "bullet", "amount": 55, "armor_penetration": 24 },
     "dispersion": 15,
     "recoil": 3000,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/4570.json
+++ b/data/json/items/ammo/4570.json
@@ -17,8 +17,8 @@
     "ammo_type": "4570",
     "casing": "4570_casing",
     "range": 48,
-    "//": "Balanced as FMJ, half the expected armor penetration.",
-    "damage": { "damage_type": "bullet", "amount": 57, "armor_penetration": 16 },
+    "//": "Balanced as FMJ.",
+    "damage": { "damage_type": "bullet", "amount": 57, "armor_penetration": 25 },
     "dispersion": 20,
     "recoil": 4300,
     "effects": [ "COOKOFF" ]
@@ -33,8 +33,8 @@
     "price_postapoc": 600,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "count": 10,
-    "//": "Balanced as +P, 75% of the expected armor penetration.",
-    "relative": { "range": 2, "damage": { "damage_type": "bullet", "amount": 14, "armor_penetration": 8 }, "recoil": 300 }
+    "//": "Balanced as +P.",
+    "relative": { "range": 2, "damage": { "damage_type": "bullet", "amount": 14 }, "recoil": 300 }
   },
   {
     "id": "4570_low",
@@ -45,6 +45,6 @@
     "price": 250,
     "price_postapoc": 400,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
-    "relative": { "range": -8, "damage": { "damage_type": "bullet", "amount": -14, "armor_penetration": -16 }, "recoil": -900 }
+    "relative": { "range": -8, "damage": { "damage_type": "bullet", "amount": -14, "armor_penetration": -25 }, "recoil": -900 }
   }
 ]

--- a/data/json/items/ammo/50.json
+++ b/data/json/items/ammo/50.json
@@ -28,7 +28,7 @@
     "casing": "50_casing",
     "range": 110,
     "//": "Base damage of 131, balance reduction to roughly 75%.",
-    "damage": { "damage_type": "bullet", "amount": 100, "armor_penetration": 56 },
+    "damage": { "damage_type": "bullet", "amount": 100, "armor_penetration": 44 },
     "dispersion": 150,
     "recoil": 5000,
     "effects": [ "COOKOFF", "NEVER_MISFIRES" ]
@@ -51,7 +51,7 @@
     "description": "Variant of the .50 BMG round that uses a core of very dense, hardened tungsten steel.  Penetration is increased, but damage is reduced.",
     "count": 10,
     "//": "Balanced as AP, 7/8 damage, arpen matches damage.",
-    "relative": { "damage": { "damage_type": "bullet", "amount": -12, "armor_penetration": 32 } },
+    "relative": { "damage": { "damage_type": "bullet", "amount": -12, "armor_penetration": 31 } },
     "dispersion": 600
   },
   {

--- a/data/json/items/ammo/545x39.json
+++ b/data/json/items/ammo/545x39.json
@@ -18,7 +18,7 @@
     "ammo_type": "545x39",
     "casing": "545_casing",
     "range": 37,
-    "damage": { "damage_type": "bullet", "amount": 40, "armor_penetration": 23 },
+    "damage": { "damage_type": "bullet", "amount": 40, "armor_penetration": 18 },
     "dispersion": 30,
     "recoil": 1400,
     "effects": [ "COOKOFF" ]
@@ -34,7 +34,7 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "symbol": "=",
     "color": "yellow",
-    "//": "Balanced as AP, 7/8 damage, arpen matches damage.",
+    "//": "Balanced as AP, 7/8 damage, arpen 6/7 that value.",
     "relative": { "damage": { "damage_type": "bullet", "amount": -5, "armor_penetration": 12 } }
   }
 ]

--- a/data/json/items/ammo/700nx.json
+++ b/data/json/items/ammo/700nx.json
@@ -17,8 +17,8 @@
     "ammo_type": "700nx",
     "casing": "700nx_casing",
     "range": 42,
-    "//": "Base damage of 110, balance reduction to roughly 80%, armor penetration half expected value which is still quite a lot.",
-    "damage": { "damage_type": "bullet", "amount": 90, "armor_penetration": 25 },
+    "//": "Base damage of 110, balance reduction to roughly 80%.",
+    "damage": { "damage_type": "bullet", "amount": 90, "armor_penetration": 39 },
     "dispersion": 15,
     "recoil": 12100,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/ammo/762.json
+++ b/data/json/items/ammo/762.json
@@ -17,7 +17,7 @@
     "ammo_type": "762",
     "casing": "762_casing",
     "range": 30,
-    "damage": { "damage_type": "bullet", "amount": 45, "armor_penetration": 25 },
+    "damage": { "damage_type": "bullet", "amount": 45, "armor_penetration": 20 },
     "dispersion": 35,
     "recoil": 2036,
     "effects": [ "COOKOFF", "NEVER_MISFIRES" ]

--- a/data/json/items/ammo/762R.json
+++ b/data/json/items/ammo/762R.json
@@ -17,7 +17,7 @@
     "ammo_type": "762R",
     "casing": "762R_casing",
     "range": 75,
-    "damage": { "damage_type": "bullet", "amount": 54, "armor_penetration": 30 },
+    "damage": { "damage_type": "bullet", "amount": 54, "armor_penetration": 24 },
     "dispersion": 15,
     "recoil": 2650,
     "effects": [ "COOKOFF" ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Ammo Rebalance projectile part 8, applying new armor penetrationg standard to rifle ammo"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

As seen in part 7 (https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2121), while we've now got every ammo item updated, a less-broken scheme for calculating armor penetration was introduced in that PR for the ammo items that I updated in it. This PR starts backporting that new method to the other ammo items I'd already gone over, to make them less horrifically lethal against ballistic armor that's obstinately expected to make those hits survivable.

For the moment, I'm only focusing on applying this to the other rifle rounds, to make things a lil less cluttered but also due to a question posed in the alternatives section.

Said method is, per the documentation:
```
The relative combined damage plus armor penetration for each variant can likewise be summarized as follows:
1. Hollowpoints are considered to have 100% combined damage (example: 100 damage, 0 arpen)
2. Standard/FMJ variants are considered to have 115% combined damage, 80% damage and 35% arpen (example: 80 damage, 35 arpen)
3. AP variants are considered to have 130% combined damage, 70% damage and 60% arpen (example: 70 damage, 60 arpen)
```

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Updated .223 ammo according to the new balance plan, reducing basic .223 arpen to to 18, and 5.56mm arpen from 37 to 32.
2. Updated .270 winchester, reducing arpen from 34 to 26.
3. Updated .308 ammo, reducing standard arpen from 31 to 24, and 7.62 arpen from 48 to 41
4. Updated .300 blackout, reducing arpen from 24 to 19.
5. Updated .300 WM, reducing arpen from 39 to 17.
6. Updated .700 NX. Per Coolthulhu's advice, phased out the use of arbitrary half-arpen for "heavy" bullets, which combined with the new scaling changes arpen from 25 to 39.
7. Updated 5.45x39mm, reducing standard arpen from 23 to 18, and AP arpen from 35 to 30.
8. Updated 7.62x39mm, reducing arpen from 25 to 20.
9. Updated .45-70 government. Between no longer giving slow bullets an arbitrary arpen reduction and the new scaling, arpen changed from 16 to 25. +P ammo also no longer gets bonus AP since the norm for +P is HP's damage with FMJ's arpen.
10. .30-06 updated, standard arpen reduced from 35 to 27, and AP arpen reduced from 54 to 46
11. 7.62x54mmR updated, arpen reduced from 30 to 24.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Applying the less-aggressive apren scaling only to rifle-tier and other high-damage bullets, and leaving the apren scaling unchanged for pistol bullets. This is why I went straight to doing the rifle rounds first for this commit.

If so though, should the cutoff be pistol vs rifle/shotgun rounds, or instead base damage (like say, whether the ammo is eligible for damage rebalancing)?

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->


Checked affected files for syntax and lint errors. In addition, a relevant summary of how this affects the famously-problematic 5.56mm and 7.62mm rounds, plus a couple other comparisons, can be found below.

For .223 Remington (damage through power armor unchanged, as still zero):

Target | Ballistic Protection | Damage Before | Damage After
--- | --- | --- | ---
MBR vest (steel) | 44 | 22 | 16
MBR vest (hard) | 55 | 11 | 5
MBR vest (ceramic) | 63 | 3 | 0

For 5.56x45mm (damage through power armor unchanged, as still zero):

Target | Ballistic Protection | Damage Before | Damage After
--- | --- | --- | ---
MBR vest (steel) | 44 | 30 | 25
MBR vest (hard) | 55 | 19 | 14
MBR vest (ceramic) | 63 | 11 | 6

For .308 Winchester:

Target | Ballistic Protection | Damage Before | Damage After
--- | --- | --- | ---
MBR vest (steel) | 44 | 42 | 35
MBR vest (hard) | 55 | 31 | 24
MBR vest (ceramic) | 63 | 23 | 16
Light power armor | 77 | 9 | 2
Medium power armor | 94 | 0 | 0 (no change)
Heavy power armor | 121 | 0 | 0 (no change)

For 7.62x51mm:

Target | Ballistic Protection | Damage Before | Damage After
--- | --- | --- | ---
MBR vest (steel) | 44 | 48 | 41
MBR vest (hard) | 55 | 41 | 34
MBR vest (ceramic) | 63 | 33 | 26
Light power armor | 77 | 19 | 12
Medium power armor | 94 | 2 | 0
Heavy power armor | 121 | 0 | 0 (no change)

For .50 BMG:

Target | Ballistic Protection | Damage Before | Damage After
--- | --- | --- | ---
MBR vest (steel) | 44 | 100 | 100 (no change)
MBR vest (hard) | 55 | 100 | 89
MBR vest (ceramic) | 63 | 93 | 81
Light power armor | 77 | 79 | 67
Medium power armor | 94 | 56 | 44
Heavy power armor | 121 | 35 | 23

For .50 BMG AP:

Target | Ballistic Protection | Damage Before | Damage After
--- | --- | --- | ---
MBR vest (steel) | 44 | 88 | 88 (no change)
MBR vest (hard) | 55 | 88 | 88 (no change)
MBR vest (ceramic) | 63 | 88 | 88 (no change)
Light power armor | 77 | 88 | 86
Medium power armor | 94 | 82 | 81
Heavy power armor | 121 | 55 | 42

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
