### PR TITLE
Don't show warnings in log when scanning for files in non-existent dirs

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -289,6 +289,7 @@ bool name_contains( const dirent &entry, const std::string &match, const bool at
 // Return every file at root_path matching predicate.
 //
 // If root_path is empty, search the current working directory.
+// If root_path does not exist, returns empty list.
 // If recursive_search is true, search breadth-first into the directory hierarchy.
 //
 // Results are ordered depth-first with directories searched in lexically order. Furthermore,
@@ -310,6 +311,9 @@ std::vector<std::string> find_file_if_bfs( const std::string &root_path,
         directories.emplace_back( root_path + "/" );
     }
     std::vector<std::string> results;
+    if( !dir_exist( *directories.begin() ) ) {
+        return results;
+    }
 
     while( !directories.empty() ) {
         const auto path = std::move( directories.front() );


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Don't show warnings in log when scanning for files in non-existent dirs"

#### Purpose of change
There are warnings about missing directories in `debug.log` when game tries to load data from nonexistent user dirs:
```
15:11:02.060 WARNING : opendir [./user_dir/sound/] failed with "No such file or directory".
15:11:02.060 WARNING : opendir [./user_dir/gfx/] failed with "No such file or directory".
15:11:02.060 INFO : Number of render drivers on your system: 3
15:11:02.060 INFO : Render driver: 0/opengl
15:11:02.060 INFO : Render driver: 1/opengles2
15:11:02.060 INFO : Render driver: 2/software
15:11:02.073 WARNING : opendir [./user_dir/mods/] failed with "No such file or directory".
```

These are entirely benign, but the word "failed" seems to be an attention grabber whenever people try to figure out why their game has broken.

#### Describe the solution
If folder does not exist, just return an empty list.