### PR TITLE
Display fridge buff in `item::info`

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1338,11 +1338,10 @@ void advanced_inventory::action_examine( advanced_inv_listitem *sitem,
         recalc = true;
     } else {
         item &it = *sitem->items.front();
-        std::vector<iteminfo> vThisItem;
-        std::vector<iteminfo> vDummy;
-        it.info( true, vThisItem );
+        std::vector<iteminfo> dummy;
+        std::vector<iteminfo> item_info = it.info();
 
-        item_info_data data( it.tname(), it.type_name(), vThisItem, vDummy );
+        item_info_data data( it.tname(), it.type_name(), item_info, dummy );
         data.handle_scrolling = true;
 
         ret = draw_item_info( [&]() -> catacurses::window {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -176,8 +176,7 @@ const recipe *select_crafting_recipe( int &batch_size )
             item_info_scroll = 0;
             item_info_scroll_popup = 0;
         }
-        std::vector<iteminfo> info;
-        item_info_cache.dummy.info( true, info, count );
+        std::vector<iteminfo> info = item_info_cache.dummy.info( count );
         item_info_data data( item_info_cache.dummy.tname( count ),
                              item_info_cache.dummy.type_name( count ),
                              info, {}, scroll_pos );

--- a/src/enums.h
+++ b/src/enums.h
@@ -39,7 +39,7 @@ struct enum_traits<holiday> {
     static constexpr holiday last = holiday::num_holiday;
 };
 
-enum temperature_flag : int {
+enum class temperature_flag : int {
     TEMP_NORMAL = 0,
     TEMP_HEATER,
     TEMP_FRIDGE,

--- a/src/examine_item_menu.cpp
+++ b/src/examine_item_menu.cpp
@@ -8,6 +8,7 @@
 #include "avatar.h"
 #include "crafting.h"
 #include "game_inventory.h"
+#include "map.h"
 #include "input.h"
 #include "item.h"
 #include "item_functions.h"
@@ -15,6 +16,7 @@
 #include "messages.h"
 #include "output.h"
 #include "recipe_dictionary.h"
+#include "rot.h"
 #include "ui_manager.h"
 #include "ui.h"
 
@@ -55,7 +57,9 @@ bool run(
 
     int info_area_scroll_pos = 0;
     constexpr int info_area_scroll_step = 3;
-    std::vector<iteminfo> item_info_vals = itm.info();
+    temperature_flag temperature = rot::temperature_flag_for_location( get_map(), item_location( you,
+                                   &itm ) );
+    std::vector<iteminfo> item_info_vals = itm.info( temperature );
     std::vector<iteminfo> dummy_compare;
     item_info_data data( itm.tname(), itm.type_name(), item_info_vals, dummy_compare,
                          info_area_scroll_pos );

--- a/src/examine_item_menu.cpp
+++ b/src/examine_item_menu.cpp
@@ -55,9 +55,8 @@ bool run(
 
     int info_area_scroll_pos = 0;
     constexpr int info_area_scroll_step = 3;
-    std::vector<iteminfo> item_info_vals;
+    std::vector<iteminfo> item_info_vals = itm.info();
     std::vector<iteminfo> dummy_compare;
-    itm.info( true, item_info_vals );
     item_info_data data( itm.tname(), itm.type_name(), item_info_vals, dummy_compare,
                          info_area_scroll_pos );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -145,6 +145,7 @@
 #include "recipe.h"
 #include "recipe_dictionary.h"
 #include "ret_val.h"
+#include "rot.h"
 #include "rng.h"
 #include "safemode_ui.h"
 #include "scenario.h"
@@ -7423,7 +7424,10 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             werase( w_item_info );
 
             if( iItemNum > 0 && activeItem ) {
-                std::vector<iteminfo> this_item = activeItem->example->info();
+                item_location loc( map_cursor( u.pos() + activeItem->example_item_pos ),
+                                   const_cast<item *>( activeItem->example ) );
+                temperature_flag temperature = rot::temperature_flag_for_location( m, loc );
+                std::vector<iteminfo> this_item = activeItem->example->info( temperature );
                 std::vector<iteminfo> item_info_dummy;
 
                 item_info_data dummy( "", "", this_item, item_info_dummy, iScrollPos );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7491,10 +7491,13 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             addcategory = !sort_radius;
         } else if( action == "EXAMINE" && !filtered_items.empty() && activeItem ) {
             std::vector<iteminfo> dummy;
-            std::vector<iteminfo> this_item = activeItem->example->info();
+            const item *example_item = activeItem->example;
+            // TODO: const_item_location
+            item_location loc = item_location( u, const_cast<item *>( example_item ) );
+            temperature_flag temperature = rot::temperature_flag_for_location( m, loc );
+            std::vector<iteminfo> this_item = example_item->info( temperature );
 
-            item_info_data info_data( activeItem->example->tname(), activeItem->example->type_name(), this_item,
-                                      dummy );
+            item_info_data info_data( example_item->tname(), example_item->type_name(), this_item, dummy );
             info_data.handle_scrolling = true;
 
             draw_item_info( [&]() -> catacurses::window {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7423,11 +7423,10 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             werase( w_item_info );
 
             if( iItemNum > 0 && activeItem ) {
-                std::vector<iteminfo> vThisItem;
-                std::vector<iteminfo> vDummy;
-                activeItem->example->info( true, vThisItem );
+                std::vector<iteminfo> this_item = activeItem->example->info();
+                std::vector<iteminfo> item_info_dummy;
 
-                item_info_data dummy( "", "", vThisItem, vDummy, iScrollPos );
+                item_info_data dummy( "", "", this_item, item_info_dummy, iScrollPos );
                 dummy.without_getch = true;
                 dummy.without_border = true;
 
@@ -7487,12 +7486,11 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             uistate.list_item_filter_active = false;
             addcategory = !sort_radius;
         } else if( action == "EXAMINE" && !filtered_items.empty() && activeItem ) {
-            std::vector<iteminfo> vThisItem;
-            std::vector<iteminfo> vDummy;
-            activeItem->example->info( true, vThisItem );
+            std::vector<iteminfo> dummy;
+            std::vector<iteminfo> this_item = activeItem->example->info();
 
-            item_info_data info_data( activeItem->example->tname(), activeItem->example->type_name(), vThisItem,
-                                      vDummy );
+            item_info_data info_data( activeItem->example->tname(), activeItem->example->type_name(), this_item,
+                                      dummy );
             info_data.handle_scrolling = true;
 
             draw_item_info( [&]() -> catacurses::window {

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -79,22 +79,26 @@ static constexpr int PLUTONIUM_CHARGES = 500;
 namespace temperatures
 {
 // temperature at which something starts is considered HOT.
-constexpr int hot = 100; // ~ 38 Celsius
+constexpr units::temperature hot = 100_f; // ~ 38 Celsius
 
 // the "normal" temperature midpoint between cold and hot.
-constexpr int normal = 70; // ~ 21 Celsius
+constexpr units::temperature normal = 70_f; // ~ 21 Celsius
 
 // Temperature inside an active fridge in Fahrenheit.
-constexpr int fridge = 37; // ~ 2.7 Celsius
+constexpr units::temperature fridge = 37_f; // ~ 2.7 Celsius
 
 // Temperature at which things are considered "cold".
-constexpr int cold = 40; // ~4.4 C
+constexpr units::temperature cold = 40_f; // ~4.4 C
 
 // Temperature inside an active freezer in Fahrenheit.
-constexpr int freezer = 23; // -5 Celsius
+constexpr units::temperature freezer = 23_f; // -5 Celsius
 
 // Temperature in which water freezes in Fahrenheit.
-constexpr int freezing = 32; // 0 Celsius
+constexpr units::temperature freezing = 32_f; // 0 Celsius
+
+// Arbitrary constant for root cellar temperature
+// Should be equal to AVERAGE_ANNUAL_TEMPERATURE, but is declared before it...
+constexpr units::temperature root_cellar = 43_f;
 } // namespace temperatures
 
 // Weight per level of LIFT/JACK tool quality.

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1602,45 +1602,37 @@ void game_menus::inv::compare( const item &l, const item &r )
     ctxt.register_action( "PAGE_UP" );
     ctxt.register_action( "PAGE_DOWN" );
 
-    std::vector<iteminfo> vItemLastCh;
-    std::vector<iteminfo> vItemCh;
-    std::string sItemLastCh;
-    std::string sItemCh;
-    std::string sItemLastTn;
-    std::string sItemTn;
+    std::vector<iteminfo> lhs_info = l.info();
+    std::vector<iteminfo> rhs_info = r.info();
+    std::string lhs_tname = l.tname();
+    std::string rhs_tname = r.tname();
+    std::string lhs_type_name = l.type_name();
+    std::string rhs_type_name = r.type_name();
 
-    l.info( true, vItemLastCh );
-    sItemLastCh = l.tname();
-    sItemLastTn = l.type_name();
+    int lhs_scroll_pos = 0;
+    int rhs_scroll_pos = 0;
 
-    r.info( true, vItemCh );
-    sItemCh = r.tname();
-    sItemTn = r.type_name();
+    item_info_data lhs_item_info( lhs_tname, lhs_type_name, lhs_info, rhs_info, rhs_scroll_pos );
+    lhs_item_info.without_getch = true;
 
-    int iScrollPos = 0;
-    int iScrollPosLast = 0;
+    item_info_data rhs_item_info( rhs_tname, rhs_type_name, rhs_info, lhs_info, lhs_scroll_pos );
+    rhs_item_info.without_getch = true;
 
-    item_info_data last_item_info( sItemLastCh, sItemLastTn, vItemLastCh, vItemCh, iScrollPosLast );
-    last_item_info.without_getch = true;
-
-    item_info_data cur_item_info( sItemCh, sItemTn, vItemCh, vItemLastCh, iScrollPos );
-    cur_item_info.without_getch = true;
-
-    catacurses::window w_last_item_info;
-    catacurses::window w_cur_item_info;
+    catacurses::window w_lhs_item_info;
+    catacurses::window w_rhs_item_info;
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
         const int half_width = TERMX / 2;
         const int height = TERMY;
-        w_last_item_info = catacurses::newwin( height, half_width, point_zero );
-        w_cur_item_info = catacurses::newwin( height, half_width, point( half_width, 0 ) );
+        w_lhs_item_info = catacurses::newwin( height, half_width, point_zero );
+        w_rhs_item_info = catacurses::newwin( height, half_width, point( half_width, 0 ) );
         ui.position( point_zero, point( half_width * 2, height ) );
     } );
     ui.mark_resize();
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
-        draw_item_info( w_last_item_info, last_item_info );
-        draw_item_info( w_cur_item_info, cur_item_info );
+        draw_item_info( w_lhs_item_info, lhs_item_info );
+        draw_item_info( w_rhs_item_info, rhs_item_info );
     } );
 
     do {
@@ -1649,11 +1641,11 @@ void game_menus::inv::compare( const item &l, const item &r )
         action = ctxt.handle_input();
 
         if( action == "UP" || action == "PAGE_UP" ) {
-            iScrollPos--;
-            iScrollPosLast--;
+            lhs_scroll_pos--;
+            rhs_scroll_pos--;
         } else if( action == "DOWN" || action == "PAGE_DOWN" ) {
-            iScrollPos++;
-            iScrollPosLast++;
+            lhs_scroll_pos++;
+            rhs_scroll_pos++;
         }
 
     } while( action != "QUIT" );

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -19,6 +19,7 @@
 #include "input.h"
 #include "item.h"
 #include "item_group.h"
+#include "iteminfo_query.h"
 #include "map.h"
 #include "messages.h"
 #include "mongroup.h"
@@ -1247,7 +1248,7 @@ void draw_caravan_items( const catacurses::window &w, std::vector<itype_id> *ite
     // THEN print it--if item_selected is valid
     if( item_selected < static_cast<int>( items->size() ) ) {
         item tmp( ( *items )[item_selected], calendar::start_of_cataclysm );
-        fold_and_print( w, point( 1, 12 ), 38, c_white, tmp.info() );
+        fold_and_print( w, point( 1, 12 ), 38, c_white, tmp.info_string( iteminfo_query::notext ) );
     }
     // Next, clear the item list on the right
     for( int i = 1; i <= FULL_SCREEN_HEIGHT - 2; i++ ) {

--- a/src/gamemode_defense.cpp
+++ b/src/gamemode_defense.cpp
@@ -1248,7 +1248,7 @@ void draw_caravan_items( const catacurses::window &w, std::vector<itype_id> *ite
     // THEN print it--if item_selected is valid
     if( item_selected < static_cast<int>( items->size() ) ) {
         item tmp( ( *items )[item_selected], calendar::start_of_cataclysm );
-        fold_and_print( w, point( 1, 12 ), 38, c_white, tmp.info_string( iteminfo_query::notext ) );
+        fold_and_print( w, point( 1, 12 ), 38, c_white, tmp.info_string( iteminfo_query::no_text ) );
     }
     // Next, clear the item list on the right
     for( int i = 1; i <= FULL_SCREEN_HEIGHT - 2; i++ ) {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5486,7 +5486,7 @@ void iexamine::mill_finalize( player &, const tripoint &examp, const time_point 
 
     for( item &it : items ) {
         if( it.type->milling_data ) {
-            it.calc_rot_while_processing( milling_time );
+            it.mod_last_rot_check( milling_time );
             const islot_milling &mdata = *it.type->milling_data;
             item result( mdata.into_, start_time + milling_time, it.count() * mdata.conversion_rate_ );
             result.components.push_back( it );
@@ -5533,7 +5533,7 @@ static void smoker_finalize( player &, const tripoint &examp, const time_point &
             if( it.get_comestible()->smoking_result.is_empty() ) {
                 it.unset_flag( flag_PROCESSING );
             } else {
-                it.calc_rot_while_processing( 6_hours );
+                it.mod_last_rot_check( 6_hours );
 
                 item result( it.get_comestible()->smoking_result, start_time + 6_hours, it.charges );
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -786,7 +786,7 @@ void iexamine::vending( player &p, const tripoint &examp )
         werase( w_item_info );
         // | {line}|
         // 12      3
-        fold_and_print( w_item_info, point( 2, 1 ), w_info_w - 3, c_light_gray, cur_item->info( true ) );
+        fold_and_print( w_item_info, point( 2, 1 ), w_info_w - 3, c_light_gray, cur_item->info_string() );
         wborder( w_item_info, LINE_XOXO, LINE_XOXO, LINE_OXOX, LINE_OXOX,
                  LINE_OXXO, LINE_OOXX, LINE_XXOO, LINE_XOOX );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1800,34 +1800,36 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
                                              "shelf life of <info>%s</info>." ), rot_time ) );
 
 
-        std::string temperature_description;
-        // There should be a better way to do this...
-        switch( temperature ) {
-            case temperature_flag::TEMP_NORMAL:
-            case temperature_flag::TEMP_HEATER: {
-                temperature_description = _( "* Current storage conditions <bad>do not</bad> "
-                                             "protect this item from rot.  It will stay fresh at least <info>%s</info>." );
+        if( parts->test( iteminfo_parts::FOOD_ROT_STORAGE ) ) {
+            std::string temperature_description;
+            // There should be a better way to do this...
+            switch( temperature ) {
+                case temperature_flag::TEMP_NORMAL:
+                case temperature_flag::TEMP_HEATER: {
+                    temperature_description = _( "* Current storage conditions <bad>do not</bad> "
+                                                 "protect this item from rot.  It will stay fresh at least <info>%s</info>." );
+                }
+                break;
+                case temperature_flag::TEMP_FRIDGE:
+                case temperature_flag::TEMP_ROOT_CELLAR: {
+                    temperature_description = _( "* Current storage conditions <neutral>partially</neutral> "
+                                                 "protect this item from rot.  It will stay fresh at least <info>%s</info>." );
+                }
+                break;
+                case temperature_flag::TEMP_FREEZER: {
+                    temperature_description = _( "* Current storage conditions <good>fully</good> "
+                                                 "protect this item from rot.  It will stay fresh indefinitely." );
+                }
+                break;
             }
-            break;
-            case temperature_flag::TEMP_FRIDGE:
-            case temperature_flag::TEMP_ROOT_CELLAR: {
-                temperature_description = _( "* Current storage conditions <neutral>partially</neutral> "
-                                             "protect this item from rot.  It will stay fresh at least <info>%s</info>." );
-            }
-            break;
-            case temperature_flag::TEMP_FREEZER: {
-                temperature_description = _( "* Current storage conditions <good>fully</good> "
-                                             "protect this item from rot.  It will stay fresh indefinitely." );
-            }
-            break;
-        }
 
-        if( temperature != temperature_flag::TEMP_FREEZER ) {
-            time_duration remaining_fresh = minimum_freshness_duration( temperature );
-            std::string time_string = to_string_clipped( remaining_fresh );
-            info.emplace_back( "DESCRIPTION", string_format( temperature_description, time_string ) );
-        } else {
-            info.emplace_back( "DESCRIPTION", temperature_description );
+            if( temperature != temperature_flag::TEMP_FREEZER ) {
+                time_duration remaining_fresh = minimum_freshness_duration( temperature );
+                std::string time_string = to_string_clipped( remaining_fresh );
+                info.emplace_back( "DESCRIPTION", string_format( temperature_description, time_string ) );
+            } else {
+                info.emplace_back( "DESCRIPTION", temperature_description );
+            }
         }
 
         if( !food_item->rotten() ) {
@@ -3941,12 +3943,12 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query &parts_
 
 std::vector<iteminfo> item::info() const
 {
-    return info( iteminfo_query::all, 1 );
+    return info( iteminfo_query::no_conditions, 1, temperature_flag::TEMP_NORMAL );
 }
 
 std::vector<iteminfo> item::info( int batch ) const
 {
-    return info( iteminfo_query::all, batch );
+    return info( iteminfo_query::no_conditions, batch, temperature_flag::TEMP_NORMAL );
 }
 
 std::vector<iteminfo> item::info( temperature_flag temperature ) const
@@ -4041,7 +4043,7 @@ std::string item::info_string() const
 
 std::string item::info_string( const iteminfo_query &parts, int batch ) const
 {
-    std::vector<iteminfo> item_info = info( parts, batch );
+    std::vector<iteminfo> item_info = info( parts, batch, temperature_flag::TEMP_NORMAL );
     return format_item_info( item_info, {} );
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1106,22 +1106,6 @@ static float get_ranged_armor_mult( const common_ranged_data &ranged )
     return ranged.damage.damage_units.front().res_mult;
 }
 
-std::string item::info( bool showtext ) const
-{
-    std::vector<iteminfo> dummy;
-    return info( showtext, dummy );
-}
-
-std::string item::info( bool showtext, std::vector<iteminfo> &iteminfo ) const
-{
-    return info( showtext, iteminfo, 1 );
-}
-
-std::string item::info( bool showtext, std::vector<iteminfo> &iteminfo, int batch ) const
-{
-    return info( iteminfo, showtext ? &iteminfo_query::all : &iteminfo_query::notext, batch );
-}
-
 // Generates a long-form description of the freshness of the given rottable food item.
 // NB: Doesn't check for non-rottable!
 static std::string get_freshness_description( const item &food_item )
@@ -3920,15 +3904,23 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
     }
 }
 
-std::string item::info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch ) const
+std::vector<iteminfo> item::info() const
+{
+    return info( iteminfo_query::all, 1 );
+}
+
+std::vector<iteminfo> item::info( int batch ) const
+{
+    return info( iteminfo_query::all, batch );
+}
+
+std::vector<iteminfo> item::info( const iteminfo_query &parts_ref, int batch ) const
 {
     const bool debug = g != nullptr && debug_mode;
 
-    if( parts == nullptr ) {
-        parts = &iteminfo_query::all;
-    }
-
-    info.clear();
+    // TODO: Use reference properly
+    const iteminfo_query *parts = &parts_ref;
+    std::vector<iteminfo> info;
 
     if( !is_null() ) {
         basic_info( info, parts, batch, debug );
@@ -3998,7 +3990,18 @@ std::string item::info( std::vector<iteminfo> &info, const iteminfo_query *parts
         info.pop_back();
     }
 
-    return format_item_info( info, {} );
+    return info;
+}
+
+std::string item::info_string() const
+{
+    return info_string( iteminfo_query::all, 1 );
+}
+
+std::string item::info_string( const iteminfo_query &parts, int batch ) const
+{
+    std::vector<iteminfo> item_info = info( parts, batch );
+    return format_item_info( item_info, {} );
 }
 
 std::map<gunmod_location, int> item::get_mod_locations() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8924,9 +8924,6 @@ bool item::process_rot( const tripoint &pos )
     return process_rot( false, pos, nullptr, temperature_flag::TEMP_NORMAL, get_weather() );
 }
 
-bool item::process_rot( const bool seals, const tripoint &pos,
-                        player *carrier, const temperature_flag flag,
-                        const weather_manager &weather )
 static units::temperature clip_by_temperature_flag( units::temperature temperature,
         temperature_flag flag )
 {
@@ -8950,6 +8947,9 @@ static units::temperature clip_by_temperature_flag( units::temperature temperatu
     return temperature;
 }
 
+bool item::process_rot( const bool seals, const tripoint &pos,
+                        player *carrier, const temperature_flag flag,
+                        const weather_manager &weather )
 {
     const time_point now = calendar::turn;
 
@@ -8964,7 +8964,7 @@ static units::temperature clip_by_temperature_flag( units::temperature temperatu
     // note we're also gated by item::processing_speed
     time_duration smallest_interval = 10_minutes;
 
-    units::temperature temp = units::from_fahrenheit( get_weather().get_temperature( pos ) );
+    units::temperature temp = units::from_fahrenheit( weather.get_temperature( pos ) );
     temp = clip_by_temperature_flag( temp, flag );
 
     time_point time = last_rot_check;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5687,7 +5687,7 @@ time_duration item::minimum_freshness_duration( temperature_flag temperature ) c
     int rot_per_hour = get_hourly_rotpoints_at_temp( temperature_f );
 
     if( rot_per_hour <= 0 || !type->comestible ) {
-        return time_duration::from_days( 10000 );
+        return calendar::INDEFINITELY_LONG_DURATION;
     }
 
     time_duration remaining_rot = type->comestible->spoils - rot;

--- a/src/item.h
+++ b/src/item.h
@@ -374,12 +374,10 @@ class item : public visitable<item>
         *   the vector can be used to compare them to properties of another item.
         */
         /*@{*/
-        //std::vector<iteminfo> info() const;
-        //std::vector<iteminfo> info( int batch ) const;
+        std::vector<iteminfo> info() const;
+        std::vector<iteminfo> info( int batch ) const;
         std::vector<iteminfo> info( const iteminfo_query &parts, int batch,
                                     temperature_flag temperature ) const;
-        //std::vector<iteminfo> info( const iteminfo_query &parts, int batch = 1,
-        //                            temperature_flag temperature = temperature_flag::TEMP_NORMAL ) const;
         std::vector<iteminfo> info( temperature_flag temperature ) const;
         /*@}*/
         /**

--- a/src/item.h
+++ b/src/item.h
@@ -374,10 +374,13 @@ class item : public visitable<item>
         *   the vector can be used to compare them to properties of another item.
         */
         /*@{*/
-        std::vector<iteminfo> info() const;
-        std::vector<iteminfo> info( bool ) const = delete;
-        std::vector<iteminfo> info( int batch ) const;
-        std::vector<iteminfo> info( const iteminfo_query &parts, int batch = 1 ) const;
+        //std::vector<iteminfo> info() const;
+        //std::vector<iteminfo> info( int batch ) const;
+        std::vector<iteminfo> info( const iteminfo_query &parts, int batch,
+                                    temperature_flag temperature ) const;
+        //std::vector<iteminfo> info( const iteminfo_query &parts, int batch = 1,
+        //                            temperature_flag temperature = temperature_flag::TEMP_NORMAL ) const;
+        std::vector<iteminfo> info( temperature_flag temperature ) const;
         /*@}*/
         /**
          * As @ref info, but as a string rather than a vector of properties.
@@ -393,7 +396,7 @@ class item : public visitable<item>
         void med_info( const item *med_item, std::vector<iteminfo> &info, const iteminfo_query *parts,
                        int batch, bool debug ) const;
         void food_info( const item *food_item, std::vector<iteminfo> &info, const iteminfo_query *parts,
-                        int batch, bool debug ) const;
+                        int batch, bool debug, temperature_flag temperature ) const;
         void magazine_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                             bool debug ) const;
         void ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
@@ -432,7 +435,7 @@ class item : public visitable<item>
                           bool debug ) const;
         void contents_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                             bool debug ) const;
-        void final_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
+        void final_info( std::vector<iteminfo> &info, const iteminfo_query &parts, int batch,
                          bool debug ) const;
 
         /**
@@ -762,20 +765,27 @@ class item : public visitable<item>
                             const weather_manager &weather );
 
         /**
-         * Accumulate rot of the item since last rot calculation.
+         * Returns rot of the item since last rot calculation.
          * This function should not be called directly. since it does not have all the needed checks or temperature calculations.
          * If you need to calc rot of item call process_rot instead.
          * @param time Time point to which rot is calculated
          * @param temp Temperature at which the rot is calculated
          */
-        void calc_rot( time_point time, int temp );
+        time_duration calc_rot( time_point time, int temp ) const;
+
+        /**
+         * Time that this item is guaranteed to stay fresh.
+         * @param temperature Temperature flag used to cap the duration.
+         * @returns Remaining guaranteed freshness duration, assuming current storage conditions.
+         */
+        time_duration minimum_freshness_duration( temperature_flag temperature ) const;
 
         /**
          * This is part of a workaround so that items don't rot away to nothing if the smoking rack
          * is outside the reality bubble.
          * @param processing_duration
          */
-        void calc_rot_while_processing( time_duration processing_duration );
+        void mod_last_rot_check( time_duration processing_duration );
 
         /**
          * Update temperature for things like food

--- a/src/item.h
+++ b/src/item.h
@@ -362,54 +362,31 @@ class item : public visitable<item>
          * charges at all). Calls @ref tname with given quantity and with_prefix being true.
          */
         std::string display_name( unsigned int quantity = 1 ) const;
-        /**
-         * Return all the information about the item and its type.
-         *
-         * This includes the different
-         * properties of the @ref itype (if they are visible to the player). The returned string
-         * is already translated and can be *very* long.
-         * @param showtext If true, shows the item description, otherwise only the properties item type.
-         */
-        std::string info( bool showtext = false ) const;
 
         /**
-         * Return all the information about the item and its type, and dump to vector.
-         *
-         * This includes the different
-         * properties of the @ref itype (if they are visible to the player). The returned string
-         * is already translated and can be *very* long.
-         * @param showtext If true, shows the item description, otherwise only the properties item type.
-         * @param iteminfo The properties (encapsulated into @ref iteminfo) are added to this vector,
-         * the vector can be used to compare them to properties of another item.
-         */
-        std::string info( bool showtext, std::vector<iteminfo> &iteminfo ) const;
-
-        /**
-        * Return all the information about the item and its type, and dump to vector.
+        * Return all the information about the item and its type as a vector.
         *
         * This includes the different
-        * properties of the @ref itype (if they are visible to the player). The returned string
-        * is already translated and can be *very* long.
-        * @param showtext If true, shows the item description, otherwise only the properties item type.
-        * @param iteminfo The properties (encapsulated into @ref iteminfo) are added to this vector,
-        * the vector can be used to compare them to properties of another item.
-        * @param batch The batch crafting number to multiply data by
-        */
-        std::string info( bool showtext, std::vector<iteminfo> &iteminfo, int batch ) const;
-
-        /**
-        * Return all the information about the item and its type, and dump to vector.
-        *
-        * This includes the different
-        * properties of the @ref itype (if they are visible to the player). The returned string
-        * is already translated and can be *very* long.
+        * properties of the @ref itype (if they are visible to the player).
         * @param parts controls which parts of the iteminfo to return.
-        * @param info The properties (encapsulated into @ref iteminfo) are added to this vector,
-        * the vector can be used to compare them to properties of another item.
         * @param batch The batch crafting number to multiply data by
+        * @returns The properties (encapsulated into @ref iteminfo) are added to this vector,
+        *   the vector can be used to compare them to properties of another item.
         */
-        std::string info( std::vector<iteminfo> &info, const iteminfo_query *parts = nullptr,
-                          int batch = 1 ) const;
+        /*@{*/
+        std::vector<iteminfo> info() const;
+        std::vector<iteminfo> info( bool ) const = delete;
+        std::vector<iteminfo> info( int batch ) const;
+        std::vector<iteminfo> info( const iteminfo_query &parts, int batch = 1 ) const;
+        /*@}*/
+        /**
+         * As @ref info, but as a string rather than a vector of properties.
+         */
+        /*@{*/
+        std::string info_string() const;
+        std::string info_string( const iteminfo_query &parts, int batch = 1 ) const;
+        /*@}*/
+
         /* type specific helper functions for info() that should probably be in itype() */
         void basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                          bool debug ) const;

--- a/src/iteminfo_query.cpp
+++ b/src/iteminfo_query.cpp
@@ -3,34 +3,32 @@
 #include <string>
 #include <vector>
 
-iteminfo_query::iteminfo_query() = default;
-
-iteminfo_query::iteminfo_query( const std::string &bits ) : iteminfo_query_base( bits )
+iteminfo_query::iteminfo_query( const std::string &bits ) : parts( bits )
 {
 }
 
-iteminfo_query::iteminfo_query( const std::vector<iteminfo_parts> &setBits )
+iteminfo_query::iteminfo_query( const std::vector<iteminfo_parts> &set_bits )
 {
-    for( auto &bit : setBits ) {
-        set( static_cast<size_t>( bit ) );
+    for( auto &bit : set_bits ) {
+        parts.set( static_cast<size_t>( bit ) );
     }
 }
 
 iteminfo_query::iteminfo_query( const iteminfo_query_base &values )
-    : iteminfo_query_base( values )
+    : parts( values )
 {
 }
 
 bool iteminfo_query::test( const iteminfo_parts &value ) const
 {
-    return iteminfo_query_base::test( static_cast<size_t>( value ) );
+    return parts.test( static_cast<size_t>( value ) );
 }
 
 const iteminfo_query iteminfo_query::all = iteminfo_query(
             std::string( static_cast<size_t>( iteminfo_parts::NUM_VALUES ), '1' ) );
 
 const iteminfo_query iteminfo_query::notext = iteminfo_query(
-            iteminfo_query::all & ~iteminfo_query(
+            iteminfo_query::all.parts & ~( iteminfo_query(
 std::vector<iteminfo_parts> {
     iteminfo_parts::DESCRIPTION,
     iteminfo_parts::DESCRIPTION_TECHNIQUES,
@@ -74,7 +72,7 @@ std::vector<iteminfo_parts> {
     iteminfo_parts::DESCRIPTION_CONTENTS,
     iteminfo_parts::DESCRIPTION_APPLICABLE_RECIPES,
     iteminfo_parts::DESCRIPTION_MED_ADDICTING
-} ) );
+} ) ).parts );
 
 const iteminfo_query iteminfo_query::anyflags = iteminfo_query(
 std::vector<iteminfo_parts> {

--- a/src/iteminfo_query.cpp
+++ b/src/iteminfo_query.cpp
@@ -27,7 +27,7 @@ bool iteminfo_query::test( const iteminfo_parts &value ) const
 const iteminfo_query iteminfo_query::all = iteminfo_query(
             std::string( static_cast<size_t>( iteminfo_parts::NUM_VALUES ), '1' ) );
 
-const iteminfo_query iteminfo_query::notext = iteminfo_query(
+const iteminfo_query iteminfo_query::no_text = iteminfo_query(
             iteminfo_query::all.parts & ~( iteminfo_query(
 std::vector<iteminfo_parts> {
     iteminfo_parts::DESCRIPTION,
@@ -74,7 +74,7 @@ std::vector<iteminfo_parts> {
     iteminfo_parts::DESCRIPTION_MED_ADDICTING
 } ) ).parts );
 
-const iteminfo_query iteminfo_query::anyflags = iteminfo_query(
+const iteminfo_query iteminfo_query::any_flags = iteminfo_query(
 std::vector<iteminfo_parts> {
     iteminfo_parts::DESCRIPTION_FLAGS,
     iteminfo_parts::DESCRIPTION_FLAGS_HELMETCOMPAT,
@@ -85,3 +85,9 @@ std::vector<iteminfo_parts> {
     iteminfo_parts::DESCRIPTION_FLAGS_POWERARMOR_RADIATIONHINT,
     iteminfo_parts::DESCRIPTION_IRRADIATION
 } );
+
+const iteminfo_query iteminfo_query::no_conditions = iteminfo_query( iteminfo_query::all.parts &
+        ~( iteminfo_query(
+std::vector<iteminfo_parts> {
+    iteminfo_parts::FOOD_ROT_STORAGE
+} ) ).parts );

--- a/src/iteminfo_query.h
+++ b/src/iteminfo_query.h
@@ -221,41 +221,14 @@ enum class iteminfo_parts : size_t {
 
 using iteminfo_query_base = std::bitset < static_cast<size_t>( iteminfo_parts::NUM_VALUES ) >;
 
-class iteminfo_query : public iteminfo_query_base
+class iteminfo_query
 {
+    private:
+        iteminfo_query_base parts;
     public:
-        /* The implemented constructors are a bit arbitrary right now. Currently there are
-
-            ( const std::string &bits )
-
-                ("1001010111110000111....1101")
-
-                used to allow simple 'all'/'none' presets or potentially _very_ specific
-                combinations *but* you have to include _every_ bit here so, it'll mostly
-                just be all/none
-
-            ( const iteminfo_query_base &values )
-
-                ( A & (~ B | C) ^ D )
-
-                allows usage of the underlying std::bitset's many bit operators to combine
-                any sort of fields needed
-
-            ( const std::vector<iteminfo_parts> &setBits )
-
-                ( std::vector { iteminfo_parts::Foo, iteminfo_parts::Bar, ... } )
-
-                allows defining a subset with only specific bits turned on
-
-            These should be sufficient to allow _any_ preset to be defined.
-
-            Since those typically _always_ should all be 'static const' performance should
-            not be any issue.
-         */
-        iteminfo_query();
         iteminfo_query( const iteminfo_query_base &values );
         iteminfo_query( const std::string &bits );
-        iteminfo_query( const std::vector<iteminfo_parts> &setBits );
+        iteminfo_query( const std::vector<iteminfo_parts> &set_bits );
 
         bool test( const iteminfo_parts &value ) const;
 

--- a/src/iteminfo_query.h
+++ b/src/iteminfo_query.h
@@ -41,6 +41,7 @@ enum class iteminfo_parts : size_t {
     FOOD_POISON,
     FOOD_HALLUCINOGENIC,
     FOOD_ROT,
+    FOOD_ROT_STORAGE,
 
     MAGAZINE_CAPACITY,
     MAGAZINE_RELOAD,
@@ -233,8 +234,9 @@ class iteminfo_query
         bool test( const iteminfo_parts &value ) const;
 
         static const iteminfo_query all;
-        static const iteminfo_query notext;
-        static const iteminfo_query anyflags;
+        static const iteminfo_query no_text;
+        static const iteminfo_query any_flags;
+        static const iteminfo_query no_conditions;
 };
 
 #endif // CATA_SRC_ITEMINFO_QUERY_H

--- a/src/itype.h
+++ b/src/itype.h
@@ -163,7 +163,7 @@ struct islot_comestible {
         int radiation = 0;
 
         /** freezing point in degrees Fahrenheit, below this temperature item can freeze */
-        int freeze_point = temperatures::freezing;
+        int freeze_point = units::to_fahrenheit( temperatures::freezing );
 
         /**List of diseases carried by this comestible and their associated probability*/
         std::map<diseasetype_id, int> contamination;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -6751,14 +6751,13 @@ static std::string colorized_item_name( const item &item )
 
 static std::string colorized_item_description( const item &item )
 {
-    std::vector<iteminfo> dummy;
     iteminfo_query query = iteminfo_query(
     std::vector<iteminfo_parts> {
         iteminfo_parts::DESCRIPTION,
         iteminfo_parts::DESCRIPTION_NOTES,
         iteminfo_parts::DESCRIPTION_CONTENTS
     } );
-    return item.info( dummy, &query, 1 );
+    return item.info_string( query, 1 );
 }
 
 static item get_top_item_at_point( const tripoint &point,

--- a/src/map_item_stack.cpp
+++ b/src/map_item_stack.cpp
@@ -28,6 +28,7 @@ map_item_stack::map_item_stack( const item *const it, const tripoint &pos ) : ex
     totalcount( it->count() )
 {
     vIG.emplace_back( pos, totalcount );
+    example_item_pos = pos;
 }
 
 void map_item_stack::add_at_pos( const item *const it, const tripoint &pos )

--- a/src/map_item_stack.h
+++ b/src/map_item_stack.h
@@ -23,7 +23,9 @@ class map_item_stack
                 item_group( const tripoint &p, int arg_count );
         };
     public:
+        // This should be per-group!
         const item *example; //an example item for showing stats, etc.
+        tripoint example_item_pos;
         std::vector<item_group> vIG;
         int totalcount;
 

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -452,9 +452,9 @@ void trading_window::show_item_data( size_t offset,
 
             help += offset;
             if( help < target_list.size() ) {
-                std::vector<iteminfo> info;
                 const item &itm = *target_list[help].loc.get_item();
-                itm.info( true, info );
+                std::vector<iteminfo> info = itm.info();
+
                 item_info_data data( itm.tname(),
                                      itm.type_name(),
                                      info, {} );

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -851,13 +851,13 @@ void draw_item_filter_rules( const catacurses::window &win, int starty, int heig
     wnoutrefresh( win );
 }
 
-std::string format_item_info( const std::vector<iteminfo> &vItemDisplay,
-                              const std::vector<iteminfo> &vItemCompare )
+std::string format_item_info( const std::vector<iteminfo> &item_display,
+                              const std::vector<iteminfo> &item_compare )
 {
     std::string buffer;
     bool bIsNewLine = true;
 
-    for( const auto &i : vItemDisplay ) {
+    for( const auto &i : item_display ) {
         if( i.sType == "DESCRIPTION" ) {
             // Always start a new line for sType == "DESCRIPTION"
             if( !bIsNewLine ) {
@@ -888,7 +888,7 @@ std::string format_item_info( const std::vector<iteminfo> &vItemDisplay,
 
             if( i.sValue != "-999" ) {
                 nc_color thisColor = c_yellow;
-                for( auto &k : vItemCompare ) {
+                for( auto &k : item_compare ) {
                     if( k.sValue != "-999" ) {
                         if( i.sName == k.sName && i.sType == k.sType ) {
                             if( i.dValue > k.dValue - .1 &&
@@ -928,17 +928,17 @@ std::string format_item_info( const std::vector<iteminfo> &vItemDisplay,
 item_info_data::item_info_data() = default;
 item_info_data::~item_info_data() = default;
 
-item_info_data::item_info_data( const std::string &sItemName, const std::string &sTypeName,
-                                const std::vector<iteminfo> &vItemDisplay, const std::vector<iteminfo> &vItemCompare )
-    : sItemName( sItemName ), sTypeName( sTypeName ),
-      vItemDisplay( vItemDisplay ), vItemCompare( vItemCompare ),
+item_info_data::item_info_data( const std::string &item_name, const std::string &type_name,
+                                const std::vector<iteminfo> &item_display, const std::vector<iteminfo> &item_compare )
+    : item_name( item_name ), type_name( type_name ),
+      item_display( item_display ), item_compare( item_compare ),
       selected( 0 ), ptr_selected( &selected ) {}
 
-item_info_data::item_info_data( const std::string &sItemName, const std::string &sTypeName,
-                                const std::vector<iteminfo> &vItemDisplay, const std::vector<iteminfo> &vItemCompare,
+item_info_data::item_info_data( const std::string &item_name, const std::string &type_name,
+                                const std::vector<iteminfo> &item_display, const std::vector<iteminfo> &item_compare,
                                 int &ptr_selected )
-    : sItemName( sItemName ), sTypeName( sTypeName ),
-      vItemDisplay( vItemDisplay ), vItemCompare( vItemCompare ),
+    : item_name( item_name ), type_name( type_name ),
+      item_display( item_display ), item_compare( item_compare ),
       ptr_selected( &ptr_selected ) {}
 
 input_event draw_item_info( const catacurses::window &win, item_info_data &data )

--- a/src/output.h
+++ b/src/output.h
@@ -519,39 +519,39 @@ inline void full_screen_popup( const char *mes, Args &&... args )
 }
 
 /*@}*/
-std::string format_item_info( const std::vector<iteminfo> &vItemDisplay,
-                              const std::vector<iteminfo> &vItemCompare );
+std::string format_item_info( const std::vector<iteminfo> &item_display,
+                              const std::vector<iteminfo> &item_compare );
 
 // the extra data that item_info needs to draw
 struct item_info_data {
     private:
-        std::string sItemName;
-        std::string sTypeName;
-        std::vector<iteminfo> vItemDisplay;
-        std::vector<iteminfo> vItemCompare;
+        std::string item_name;
+        std::string type_name;
+        std::vector<iteminfo> item_display;
+        std::vector<iteminfo> item_compare;
         int selected = 0;
 
     public:
 
         item_info_data();
         ~item_info_data();
-        item_info_data( const std::string &sItemName, const std::string &sTypeName,
-                        const std::vector<iteminfo> &vItemDisplay, const std::vector<iteminfo> &vItemCompare );
-        item_info_data( const std::string &sItemName, const std::string &sTypeName,
-                        const std::vector<iteminfo> &vItemDisplay, const std::vector<iteminfo> &vItemCompare,
+        item_info_data( const std::string &item_name, const std::string &type_name,
+                        const std::vector<iteminfo> &item_display, const std::vector<iteminfo> &item_compare );
+        item_info_data( const std::string &item_name, const std::string &type_name,
+                        const std::vector<iteminfo> &item_display, const std::vector<iteminfo> &item_compare,
                         int &ptr_selected );
 
         const std::string &get_item_name() const {
-            return sItemName;
+            return item_name;
         }
         const std::string &get_type_name() const {
-            return sTypeName;
+            return type_name;
         }
         const std::vector<iteminfo> &get_item_display() const {
-            return vItemDisplay;
+            return item_display;
         }
         const std::vector<iteminfo> &get_item_compare() const {
-            return vItemCompare;
+            return item_compare;
         }
 
         int *ptr_selected = &selected;

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -791,10 +791,9 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
             const item &selected_item = *stacked_here[matches[selected]].front();
 
             if( selected >= 0 && selected <= static_cast<int>( stacked_here.size() ) - 1 ) {
-                std::vector<iteminfo> vThisItem;
-                selected_item.info( true, vThisItem );
+                std::vector<iteminfo> this_item = selected_item.info();
 
-                item_info_data dummy( {}, {}, vThisItem, {}, iScrollPos );
+                item_info_data dummy( {}, {}, this_item, {}, iScrollPos );
                 dummy.without_getch = true;
                 dummy.without_border = true;
 

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -48,6 +48,7 @@
 #include "point.h"
 #include "popup.h"
 #include "ret_val.h"
+#include "rot.h"
 #include "string_formatter.h"
 #include "string_input_popup.h"
 #include "translations.h"
@@ -791,7 +792,12 @@ void pickup::pick_up( const tripoint &p, int min, from_where get_items_from )
             const item &selected_item = *stacked_here[matches[selected]].front();
 
             if( selected >= 0 && selected <= static_cast<int>( stacked_here.size() ) - 1 ) {
-                std::vector<iteminfo> this_item = selected_item.info();
+                item_location loc = from_vehicle
+                                    ? item_location( vehicle_cursor( *veh, cargo_part ), &*stacked_here[matches[selected]].front() )
+                                    : item_location( map_cursor( p ), &*stacked_here[matches[selected]].front() );
+                temperature_flag temperature = rot::temperature_flag_for_location( get_map(), loc );
+
+                std::vector<iteminfo> this_item = selected_item.info( temperature );
 
                 item_info_data dummy( {}, {}, this_item, {}, iScrollPos );
                 dummy.without_getch = true;

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -194,7 +194,7 @@ std::vector<const recipe *> recipe_subset::search( const std::string &txt,
 
             case search_type::description_result: {
                 const item result = r->create_result();
-                return lcmatch( remove_color_tags( result.info_string( iteminfo_query::notext ) ), txt );
+                return lcmatch( remove_color_tags( result.info_string( iteminfo_query::no_text ) ), txt );
             }
 
             default:

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -13,6 +13,7 @@
 #include "input.h"
 #include "item.h"
 #include "item_factory.h"
+#include "iteminfo_query.h"
 #include "itype.h"
 #include "json.h"
 #include "output.h"
@@ -193,7 +194,7 @@ std::vector<const recipe *> recipe_subset::search( const std::string &txt,
 
             case search_type::description_result: {
                 const item result = r->create_result();
-                return lcmatch( remove_color_tags( result.info( true ) ), txt );
+                return lcmatch( remove_color_tags( result.info_string( iteminfo_query::notext ) ), txt );
             }
 
             default:

--- a/src/rot.cpp
+++ b/src/rot.cpp
@@ -1,0 +1,75 @@
+#include "rot.h"
+
+#include "item_location.h"
+#include "map.h"
+#include "vehicle.h"
+#include "units.h"
+#include "veh_type.h"
+#include "vpart_position.h"
+
+namespace rot
+{
+temperature_flag temperature_flag_for_location( const map &m, const item_location &loc )
+{
+    printf( "Pos: %d, %d, %d, Where: %d\n", loc.position().x, loc.position().y, loc.position().z,
+            static_cast<int>( loc.where() ) );
+    switch( loc.where() ) {
+        case item_location::type::invalid:
+            return temperature_flag::TEMP_NORMAL;
+        case item_location::type::character:
+            return temperature_flag::TEMP_NORMAL;
+        case item_location::type::map: {
+            tripoint pos = loc.position();
+            if( m.has_flag_furn( TFLAG_FREEZER, pos ) ) {
+                return temperature_flag::TEMP_FREEZER;
+            }
+            if( m.has_flag_furn( TFLAG_FRIDGE, pos ) ) {
+                return temperature_flag::TEMP_FRIDGE;
+            }
+            if( m.ter( pos ) == t_rootcellar ) {
+                return temperature_flag::TEMP_ROOT_CELLAR;
+            }
+
+            return temperature_flag::TEMP_NORMAL;
+        }
+        case item_location::type::vehicle: {
+            tripoint pos = loc.position();
+            optional_vpart_position veh = m.veh_at( pos );
+            if( !veh ) {
+                debugmsg( "Expected vehicle at %d, %d, %d, but couldn't find any", pos.x, pos.y, pos.z );
+                return temperature_flag::TEMP_NORMAL;
+            }
+            int cargo_index = veh->vehicle().part_with_feature( veh->part_index(), VPFLAG_CARGO, true );
+            if( cargo_index < 0 ) {
+                debugmsg( "Expected cargo part at %d, %d, %d, but couldn't find any", pos.x, pos.y, pos.z );
+                return temperature_flag::TEMP_NORMAL;
+            }
+            return temperature_flag_for_part( veh->vehicle(), cargo_index );
+        }
+        case item_location::type::container:
+            return temperature_flag_for_location( m, loc.parent_item() );
+        default:
+            debugmsg( "Invalid item location %d", static_cast<int>( loc.where() ) );
+            return temperature_flag::TEMP_NORMAL;
+
+    }
+}
+
+temperature_flag temperature_flag_for_part( const vehicle &veh, size_t part_index )
+{
+    const vehicle_part &part = veh.cpart( part_index );
+    if( !part.enabled ) {
+        return temperature_flag::TEMP_NORMAL;
+    }
+
+    if( part.has_flag( VPFLAG_FREEZER ) ) {
+        return temperature_flag::TEMP_FREEZER;
+    }
+
+    if( part.has_flag( VPFLAG_FRIDGE ) ) {
+        return temperature_flag::TEMP_FRIDGE;
+    }
+    return temperature_flag::TEMP_NORMAL;
+}
+
+}

--- a/src/rot.cpp
+++ b/src/rot.cpp
@@ -11,8 +11,6 @@ namespace rot
 {
 temperature_flag temperature_flag_for_location( const map &m, const item_location &loc )
 {
-    printf( "Pos: %d, %d, %d, Where: %d\n", loc.position().x, loc.position().y, loc.position().z,
-            static_cast<int>( loc.where() ) );
     switch( loc.where() ) {
         case item_location::type::invalid:
             return temperature_flag::TEMP_NORMAL;

--- a/src/rot.h
+++ b/src/rot.h
@@ -1,0 +1,18 @@
+#pragma once
+#ifndef CATA_SRC_ROT_H
+#define CATA_SRC_ROT_H
+
+enum class temperature_flag : int;
+
+class map;
+class item_location;
+
+namespace rot
+{
+
+// TODO: Move to item_location method?
+temperature_flag temperature_flag_for_location( const map &m, const item_location &loc );
+
+}
+
+#endif // CATA_SRC_ROT_H

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2014,4 +2014,9 @@ class vehicle
         std::vector<std::tuple<point, int, std::string>> get_debug_overlay_data() const;
 };
 
+namespace rot
+{
+temperature_flag temperature_flag_for_part( const vehicle &veh, size_t part );
+}
+
 #endif // CATA_SRC_VEHICLE_H

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -518,8 +518,10 @@ class wish_item_callback: public uilist_callback
                 mvwprintz( menu->window, point( startx + ( menu->pad_right - 1 - utf8_width( header ) ) / 2, 1 ),
                            c_cyan, header );
 
+                std::vector<iteminfo> info = tmp.info();
+                std::string info_string = format_item_info( info, {} );
                 fold_and_print( menu->window, point( startx, starty ), menu->pad_right - 1, c_light_gray,
-                                tmp.info( true ) );
+                                info_string );
             }
 
             if( spawn_everything ) {

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -411,7 +411,7 @@ TEST_CASE( "food freshness and lifetime", "[item][iteminfo][food]" )
             "* This food is <color_c_yellow>perishable</color>, and at room temperature has"
             " an estimated nominal shelf life of <color_c_cyan>3 seasons</color>.\n"
             "* Current storage conditions <color_c_red>do not</color> protect this item"
-            " from rot.  It will stay fresh at least <color_c_cyan>14 hours</color>.\n"
+            " from rot.  It will stay fresh at least <color_c_cyan>1 week</color>.\n"
             "* This food looks as <color_c_green>fresh</color> as it can be.\n" );
     }
 

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -19,8 +19,7 @@ static void test_info_equals( const item &i, const iteminfo_query &q,
                               const std::string &reference )
 {
     g->u.clear_mutations();
-    std::vector<iteminfo> info_v;
-    std::string info = i.info( info_v, &q, 1 );
+    std::string info = i.info_string( q, 1 );
     CHECK( info == reference );
 }
 
@@ -28,8 +27,7 @@ static void test_info_contains( const item &i, const iteminfo_query &q,
                                 const std::string &reference )
 {
     g->u.clear_mutations();
-    std::vector<iteminfo> info_v;
-    std::string info = i.info( info_v, &q, 1 );
+    std::string info = i.info_string( q, 1 );
     using Catch::Matchers::Contains;
     REQUIRE_THAT( info, Contains( reference ) );
 }

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -15,7 +15,7 @@
 #include "type_id.h"
 #include "value_ptr.h"
 
-std::string escape_newlines( const std::string &input )
+static std::string escape_newlines( const std::string &input )
 {
     std::string output;
     std::size_t pos = 0;

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -398,7 +398,7 @@ TEST_CASE( "nutrients in food", "[item][iteminfo][food]" )
 
 TEST_CASE( "food freshness and lifetime", "[item][iteminfo][food]" )
 {
-    iteminfo_query q = q_vec( { iteminfo_parts::FOOD_ROT } );
+    iteminfo_query q = q_vec( { iteminfo_parts::FOOD_ROT, iteminfo_parts::FOOD_ROT_STORAGE} );
 
     // Ensure test character has no skill estimating spoilage
     g->u.clear_skills();

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -48,7 +48,7 @@ TEST_CASE( "Rate of rotting" )
 
         set_map_temperature( weather, 65 ); // 18,3 C
         ensure_no_temperature_mods( tripoint_zero );
-        REQUIRE( get_weather().get_temperature( tripoint_zero ) == Approx( 65 ) );
+        REQUIRE( weather.get_temperature( tripoint_zero ) == Approx( 65 ) );
 
         normal_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_NORMAL, weather );
         sealed_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_NORMAL, weather );

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -7,6 +7,7 @@
 #include "item.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "game.h" // Just for get_convection_temperature(), TODO: Remove
 #include "point.h"
 #include "weather.h"
 
@@ -16,6 +17,13 @@ static void set_map_temperature( weather_manager &weather, int new_temperature )
 {
     weather.temperature = new_temperature;
     weather.clear_temp_cache();
+}
+
+static void ensure_no_temperature_mods( tripoint location )
+{
+    REQUIRE( get_heat_radiation( location, false ) == 0 );
+    REQUIRE( get_convection_temperature( location ) == 0 );
+    REQUIRE( get_map().get_temperature( location ) == 0 );
 }
 
 TEST_CASE( "Rate of rotting" )
@@ -39,6 +47,8 @@ TEST_CASE( "Rate of rotting" )
         sealed_item = sealed_item.in_its_container();
 
         set_map_temperature( weather, 65 ); // 18,3 C
+        ensure_no_temperature_mods( tripoint_zero );
+        REQUIRE( get_weather().get_temperature( tripoint_zero ) == Approx( 65 ) );
 
         normal_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_NORMAL, weather );
         sealed_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_NORMAL, weather );
@@ -65,6 +75,7 @@ TEST_CASE( "Rate of rotting" )
 
         // Move time 110 minutes
         calendar::turn += 110_minutes;
+        // TODO: Check >1 hour normal processing as well - can't be "simply done" because of weather globals
         sealed_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_NORMAL, weather );
         freeze_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_FREEZER, weather );
         // In freezer and in preserving container still should be no rot


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Interface "Display fridge/freezer buff to rot time in `item::info`"

#### Purpose of change

Close #1443

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution

* Refactored `item::info` to return the vector that it had as one of the arguments, rather than a string based on it - it seems to be used more than the string it returned before
* Created `item::info_string` that returns said string
* Added a new argument to `item::info` - a `temperature_flag` (as a simple enum right now, we may want a struct if we get more of those "context arguments", like "it is wielded by this NPC, so also print statblock modified by their stats")
* Remove sneaky +5 F temperature penalty for items carried on person
* Use `units::temperature` in few more places
* [x] Supply the new argument in all relevant places
* [x] Figure out how should the UI entry look like: proper "at current temp, will rot in 3.123 days", just "will last at least 2 days in current conditions"?
  * Currently: "It is/isn't protected from rot in current storage. It will last at least [time it will last at highest possible temperature this flag allows]"
* [x] Get #2206 working and merged, since it's a bit pointless to display the buff when there are bugs that wreck it

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

* Bringing back the old "cold" and "frozen" states - would require bringing back item temperature, which is a massive overkill for something as simple as showing rot times
* Hack "cold" and "frozen" states in some different way - might even be easier than this PR and even solve more cases, but could also have harder to find edge cases

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Spawn food
* Spawn fridge, battery, solar panels
* Put food in fridge
* Check the item's description with the fridge off
  * Should say that the item is not protected from rot
* Check the item's description with the fridge working
  * Should say that the item is protected from rot and should show guaranteed freshness time about 385% of shelf time

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
