### PR TITLE
Fix alternative sterilization using 1 mL of phenol

### DIFF
--- a/data/json/items/faults_bionic.json
+++ b/data/json/items/faults_bionic.json
@@ -26,7 +26,7 @@
           "components": [
             [
               [ "chem_formaldehyde", 1 ],
-              [ "chem_phenol", 1 ],
+              [ "chem_phenol", 250 ],
               [ "chem_hydrogen_peroxide_conc", 1 ],
               [ "chem_hydrogen_peroxide", 50 ],
               [ "chem_ethanol", 1000 ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bigfixes "Fix phenol being used 1 mL at a time instead of 250 mL by CBM sterilization option"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Simple problem Krwak spotted over on the BN discord, where it takes only a single milliliter of phenol to sterilize a CBM in the mending menu. Turns out in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1665 I failed to notice that phenol is one of the only chemicals in the JSON that has a volume of 1 mL instead of going the "volume of 250 mL per stack but 250 charges per stack" like you normally see, and thus assumed it was like water (no stack, 250 mL per unit).

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Changes the higher-level sterilization recipe in faults_bionic.json to use 250 mL of phenol as originally intended.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making more chems use this method instead of having a stack size of 250.
2. Screaming.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
