### PR TITLE
[Hotfix] Warn on unknown enchant_val instead of error

### DIFF
--- a/src/json.cpp
+++ b/src/json.cpp
@@ -238,6 +238,51 @@ void JsonObject::throw_error( std::string err ) const
     jsin->error( err );
 }
 
+void JsonObject::show_warning( std::string err ) const
+{
+    try {
+        throw_error( err );
+    } catch( const std::exception &e ) {
+        debugmsg( "%s", e.what() );
+    }
+}
+
+void JsonObject::show_warning( std::string err, const std::string &name ) const
+{
+    try {
+        throw_error( err, name );
+    } catch( const std::exception &e ) {
+        debugmsg( "%s", e.what() );
+    }
+}
+
+void JsonArray::show_warning( std::string err )
+{
+    try {
+        throw_error( err );
+    } catch( const std::exception &e ) {
+        debugmsg( "%s", e.what() );
+    }
+}
+
+void JsonArray::show_warning( std::string err, int idx )
+{
+    try {
+        throw_error( err, idx );
+    } catch( const std::exception &e ) {
+        debugmsg( "%s", e.what() );
+    }
+}
+
+void JsonValue::show_warning( std::string err ) const
+{
+    try {
+        throw_error( err );
+    } catch( const std::exception &e ) {
+        debugmsg( "%s", e.what() );
+    }
+}
+
 JsonIn *JsonObject::get_raw( const std::string &name ) const
 {
     int pos = verify_position( name );

--- a/src/json.h
+++ b/src/json.h
@@ -874,6 +874,8 @@ class JsonObject
         std::string str() const; // copy object json as string
         [[noreturn]] void throw_error( std::string err ) const;
         [[noreturn]] void throw_error( std::string err, const std::string &name ) const;
+        void show_warning( std::string err ) const;
+        void show_warning( std::string err, const std::string &name ) const;
         // seek to a value and return a pointer to the JsonIn (member must exist)
         JsonIn *get_raw( const std::string &name ) const;
         JsonValue get_member( const std::string &name ) const;
@@ -1053,6 +1055,8 @@ class JsonArray
         std::string str(); // copy array json as string
         [[noreturn]] void throw_error( std::string err );
         [[noreturn]] void throw_error( std::string err, int idx );
+        void show_warning( std::string err );
+        void show_warning( std::string err, int idx );
 
         // iterative access
         bool next_bool();
@@ -1179,6 +1183,7 @@ class JsonValue
         [[noreturn]] void throw_error( const std::string &err ) const {
             seek().error( err );
         }
+        void show_warning( std::string err ) const;
 
         std::string get_string() const {
             return seek().get_string();

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -246,13 +246,17 @@ void enchantment::load( const JsonObject &jo, const std::string & )
             std::string value_raw = value_obj.get_string( "value" );
             std::string value_new = migrate_ench_vals_enums( value_raw );
             if( json_report_strict && value_new != value_raw ) {
-                try {
-                    value_obj.throw_error( string_format( "%s has been renamed to %s", value_raw, value_new ) );
-                } catch( const std::exception &e ) {
-                    debugmsg( "%s", e.what() );
-                }
+                value_obj.show_warning(
+                    string_format( "%s has been renamed to %s", value_raw, value_new ), "value" );
             }
-            const enchant_vals::mod value = io::string_to_enum<enchant_vals::mod>( value_new );
+            enchant_vals::mod value;
+            try {
+                value = io::string_to_enum<enchant_vals::mod>( value_new );
+            } catch( const std::exception &e ) {
+                value_obj.show_warning(
+                    string_format( "Unknown enchant_val '%s', ignoring", value_new ), "value" );
+                continue;
+            }
 
             const int add = value_obj.get_int( "add", 0 );
             const double mult = value_obj.get_float( "multiply", 0.0 );


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Make it so old enchant values removed in #2264 show warning instead of preventing world loading.
I did not think any mods would be using the non-implemented values, but in hindsight I'm not sure why I thought that, of _course_ some mods would.

#### Describe the solution
Add try-catch block.



#### Testing
Tested locally, works as expected