### PR TITLE
Implement relic recharge

### DIFF
--- a/data/mods/TEST_DATA/relic_test.json
+++ b/data/mods/TEST_DATA/relic_test.json
@@ -1,0 +1,158 @@
+[
+  {
+    "id": "test_relic_act",
+    "type": "SPELL",
+    "name": "Activate Test Relic",
+    "description": "activates test relic",
+    "valid_targets": [ "self" ],
+    "effect": "mod_moves",
+    "message": "You activate your relic!",
+    "spell_class": "NONE",
+    "base_casting_time": 1
+  },
+  {
+    "type": "TOOL",
+    "id": "test_relic_tool",
+    "name": "TEST relic tool",
+    "description": "A relic for test purposes.",
+    "category": "spare_parts",
+    "weight": "1 kg",
+    "volume": "100 ml",
+    "material": [ "steel" ],
+    "symbol": "*",
+    "color": "yellow",
+    "charges_per_use": 5,
+    "max_charges": 20,
+    "use_action": { "type": "cast_spell", "spell_id": "test_relic_act", "no_fail": true, "level": 1 }
+  },
+  {
+    "type": "TOOL_ARMOR",
+    "id": "test_relic_tool_armor",
+    "category": "spare_parts",
+    "symbol": "[",
+    "color": "yellow",
+    "name": { "str": "TEST relic tool armor" },
+    "description": "A wearable relic for test purposes",
+    "material": [ "plastic" ],
+    "weight": "1 kg",
+    "volume": "100 ml",
+    "charges_per_use": 5,
+    "max_charges": 20,
+    "use_action": { "type": "cast_spell", "spell_id": "test_relic_act", "no_fail": true, "level": 1 },
+    "covers": [ "torso" ],
+    "warmth": 1,
+    "encumbrance": 1,
+    "coverage": 80,
+    "material_thickness": 1
+  },
+  {
+    "type": "TOOL",
+    "id": "test_relic_recharge_time_none",
+    "copy-from": "test_relic_tool",
+    "name": "TEST relic recharge time none",
+    "relic_data": { "recharge_scheme": [ { "type": "time", "req": "none", "interval": "5 s", "rate": 2, "message": "Tick!" } ] }
+  },
+  {
+    "type": "TOOL",
+    "id": "test_relic_recharge_pain_cts",
+    "copy-from": "test_relic_tool",
+    "name": "TEST relic recharge pain skin",
+    "relic_data": {
+      "recharge_scheme": [
+        {
+          "type": "pain",
+          "req": "close_to_skin",
+          "interval": "5 s",
+          "rate": 2,
+          "message": "Prick!",
+          "int_min": 5,
+          "int_max": 15
+        }
+      ]
+    }
+  },
+  {
+    "type": "TOOL",
+    "id": "test_relic_recharge_hp_equip",
+    "copy-from": "test_relic_tool",
+    "name": "TEST relic recharge hp equip",
+    "relic_data": {
+      "recharge_scheme": [ { "type": "hp", "req": "equipped", "interval": "5 s", "rate": 2, "message": "Prick!", "int_min": 1, "int_max": 3 } ]
+    }
+  },
+  {
+    "type": "TOOL",
+    "id": "test_relic_recharge_field_sky",
+    "copy-from": "test_relic_tool",
+    "name": "TEST relic recharge field sky",
+    "relic_data": {
+      "recharge_scheme": [
+        {
+          "type": "field",
+          "req": "sky",
+          "interval": "1 s",
+          "rate": 2,
+          "message": "Acid splatter evaporates!",
+          "int_min": 1,
+          "int_max": 2,
+          "field": "fd_acid"
+        }
+      ]
+    }
+  },
+  {
+    "type": "TOOL",
+    "id": "test_relic_recharge_trap_none",
+    "copy-from": "test_relic_tool",
+    "name": "TEST relic recharge trap none",
+    "relic_data": {
+      "recharge_scheme": [ { "type": "trap", "interval": "1 s", "rate": 2, "message": "Portal collapses!", "trap": "tr_portal" } ]
+    }
+  },
+  {
+    "type": "TOOL",
+    "id": "test_relic_recharge_solar_rad",
+    "copy-from": "test_relic_tool",
+    "name": "TEST relic recharge solar rad",
+    "relic_data": {
+      "recharge_scheme": [ { "type": "solar", "req": "rad", "interval": "5 s", "rate": 2, "message": "Sunlight dims around you for a second!" } ]
+    }
+  },
+  {
+    "type": "TOOL",
+    "id": "test_relic_recharge_time_wet",
+    "copy-from": "test_relic_tool",
+    "name": "TEST relic recharge time wet",
+    "relic_data": {
+      "recharge_scheme": [ { "type": "time", "req": "wet", "interval": "5 s", "rate": 2, "message": "You feel extremely wet." } ]
+    }
+  },
+  {
+    "type": "TOOL",
+    "id": "test_relic_recharge_time_sleep",
+    "copy-from": "test_relic_tool",
+    "name": "TEST relic recharge time sleep",
+    "relic_data": {
+      "recharge_scheme": [ { "type": "time", "req": "sleep", "interval": "30 minutes", "rate": 2, "message": "You dream of electric sheep." } ]
+    }
+  },
+  {
+    "type": "TOOL_ARMOR",
+    "id": "test_relic_armor_recharge_fatigue_cts",
+    "copy-from": "test_relic_tool_armor",
+    "name": "TEST relic armor recharge fatigue skin",
+    "relic_data": {
+      "recharge_scheme": [
+        {
+          "type": "fatigue",
+          "req": "close_to_skin",
+          "interval": "5 s",
+          "rate": 2,
+          "message": "You feel a wave of exhaustion!",
+          "int_min": 5,
+          "int_max": 20
+        }
+      ]
+    }
+  }
+]

--- a/data/mods/TEST_DATA/relic_test.json
+++ b/data/mods/TEST_DATA/relic_test.json
@@ -49,8 +49,8 @@
     "type": "TOOL",
     "id": "test_relic_recharge_time_none",
     "copy-from": "test_relic_tool",
-    "name": "TEST relic recharge time none",
-    "relic_data": { "recharge_scheme": [ { "type": "time", "req": "none", "interval": "5 s", "rate": 2, "message": "Tick!" } ] }
+    "name": "TEST relic recharge time none (silent)",
+    "relic_data": { "recharge_scheme": [ { "type": "time", "req": "none", "interval": "5 s", "rate": 2 } ] }
   },
   {
     "type": "TOOL",

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -76,9 +76,9 @@ Use the `Home` key to return to the top.
     + [Batteries](#batteries)
     + [Tools](#tools)
     + [Seed Data](#seed-data)
-    + [Artifact Data](#artifact-data)
     + [Brewing Data](#brewing-data)
-      - [`Charge_type`](#charge-type)
+    + [Relic Data](#relic-data)
+    + [Artifact Data](#artifact-data)
       - [`Effects_carried`](#effects-carried)
       - [`effects_worn`](#effects-worn)
       - [`effects_wielded`](#effects-wielded)
@@ -2138,6 +2138,15 @@ Currently only vats can only accept and produce liquid items.
     "result": "beer" // The id of the result of the fermentation.
 }
 ```
+
+### Relic Data
+
+Defines various (semi-)magical properties of items.
+See RELICS.md for
+
+### Artifact Data
+
+Artifacts are getting deprecated in favor of relic, avoid using them.
 
 #### `Effects_carried`
 

--- a/doc/RELICS.md
+++ b/doc/RELICS.md
@@ -1,0 +1,63 @@
+- [Relics](#relics)
+  - [Relic recharge](#relic-recharge)
+    - [Recharge type](#recharge-type)
+    - [Recharge requirements](#recharge-requirements)
+
+# Relics
+
+Relics are regular items with special relic data attached to them.
+
+Relic data is defined in JSON in `relic_data` field of corresponding item type definition,
+and whenever the item is spawned a copy of relic data is attached to the item instance.
+
+Relic data object can contain the following fields:
+```c++
+{
+"name": "Boots of Haste",       // Overrides default item name
+"moves": 100,                   // (optional) Activation move cost (default 100)
+"charges_per_activation": 1,    // (optional) Charges per activation (default 1)
+"active_effects": [ {}, ... ],  // (optional) Spells executed on activation (identical to `hit_you_effect`, see [MAGIC.md](MAGIC.md/#hit_you_effect))
+"passive_effects": [ {}, ... ], // (optional) List of passive effects (enchantments), see [MAGIC.md](MAGIC.md/#enchantments)
+"recharge_scheme": [ {}, ... ], // (optional) List of recharge methods, see below
+}
+```
+
+## Relic recharge
+
+Relics can recharge under certain conditions.
+Recharge method is defined as follows (all fields optional):
+```c++
+{
+"type": "time",                 // Defines what resource is consumed. Default: time
+"req": "none",                  // Defines under what conditions recharge works. Default: none (no special requirements)
+"field": "fd_blood",            // Field type to be consumed with 'field' recharge type
+"trap": "tr_portal",            // Trap type to be consumed with 'trap' recharge type
+"interval": "5 minutes",        // Interval at which the recharge check is done. Default: 1 second
+"int_min": 1,                   // Min intensity of related 'type' effect. Default: 0
+"int_min": 5,                   // Max intensity of related 'type' effect. Default: 0
+"rate": 2,                      // Amount of charges restored when recharge operation succeeds. Default: 0
+"message": "Your body decays!", // Optional message to print on success
+}
+```
+
+### Recharge type
+       ID       | Description
+----------------|--------------------------------
+`time`          | Needs no additional resources
+`solar`         | Consumes sunlight (character must be in sunlight)
+`pain`          | Causes pain to recharge. Intensity controlled by `int_min` and `int_max`
+`hp`            | Causes damage to all body parts. Intensity controlled by `int_min` and `int_max`
+`fatigue`       | Causes fatigue and drains stamina. Fatigue drain controlled by `int_min` and `int_max`, stamina drain rolled as `[ int_min*100, int_max*100 ]`
+`field`         | Consumes adjacent field. Allowed field intensity controlled by `int_min` and `int_max`
+`trap`          | Consumes adjacent trap.
+
+### Recharge requirements
+       ID       | Description
+----------------|--------------------------------
+`none`          | No additional requirements (always works)
+`equipped`      | Must be worn if armor, wielded if weapon.
+`close_to_skin` | Must be worn underneath all other clothing, or be wielded with bare hands
+`sleep`         | Character must be asleep
+`rad`           | Character or map tile must be irradiated
+`wet`           | Character must be wet, or it's raining
+`sky`           | Character must be above z=0

--- a/doc/RELICS.md
+++ b/doc/RELICS.md
@@ -41,23 +41,25 @@ Recharge method is defined as follows (all fields optional):
 ```
 
 ### Recharge type
-       ID       | Description
-----------------|--------------------------------
-`time`          | Needs no additional resources
-`solar`         | Consumes sunlight (character must be in sunlight)
-`pain`          | Causes pain to recharge. Intensity controlled by `int_min` and `int_max`
-`hp`            | Causes damage to all body parts. Intensity controlled by `int_min` and `int_max`
-`fatigue`       | Causes fatigue and drains stamina. Fatigue drain controlled by `int_min` and `int_max`, stamina drain rolled as `[ int_min*100, int_max*100 ]`
-`field`         | Consumes adjacent field. Allowed field intensity controlled by `int_min` and `int_max`
-`trap`          | Consumes adjacent trap.
+
+|       ID       | Description
+|----------------|--------------------------------
+|`time`          | Needs no additional resources
+|`solar`         | Consumes sunlight (character must be in sunlight)
+|`pain`          | Causes pain to recharge. Intensity controlled by `int_min` and `int_max`
+|`hp`            | Causes damage to all body parts. Intensity controlled by `int_min` and `int_max`
+|`fatigue`       | Causes fatigue and drains stamina. Fatigue drain controlled by `int_min` and `int_max`, stamina drain rolled as `[ int_min*100, int_max*100 ]`
+|`field`         | Consumes adjacent field. Allowed field intensity controlled by `int_min` and `int_max`
+|`trap`          | Consumes adjacent trap.
 
 ### Recharge requirements
-       ID       | Description
-----------------|--------------------------------
-`none`          | No additional requirements (always works)
-`equipped`      | Must be worn if armor, wielded if weapon.
-`close_to_skin` | Must be worn underneath all other clothing, or be wielded with bare hands
-`sleep`         | Character must be asleep
-`rad`           | Character or map tile must be irradiated
-`wet`           | Character must be wet, or it's raining
-`sky`           | Character must be above z=0
+
+|       ID       | Description
+|----------------|--------------------------------
+|`none`          | No additional requirements (always works)
+|`equipped`      | Must be worn if armor, wielded if weapon.
+|`close_to_skin` | Must be worn underneath all other clothing, or be wielded with bare hands
+|`sleep`         | Character must be asleep
+|`rad`           | Character or map tile must be irradiated
+|`wet`           | Character must be wet, or it's raining
+|`sky`           | Character must be above z=0

--- a/doc/TRANSLATING.md
+++ b/doc/TRANSLATING.md
@@ -332,6 +332,7 @@ issues reported by the `translation` class.
 | Template NPC names and name suffixes
 | NPC talk response text
 | Relic name overrides
+| Relic recharge messages
 | Speech text
 | Tutorial messages
 | Vitamin names

--- a/lang/extract_json_strings.py
+++ b/lang/extract_json_strings.py
@@ -1087,9 +1087,18 @@ def extract(state, item):
         seed_data = item["seed_data"]
         writestr(state, seed_data["plant_name"])
         wrote = True
-    if "relic_data" in item and "name" in item["relic_data"]:
-        writestr(state, item["relic_data"]["name"])
-        wrote = True
+    if "relic_data" in item:
+        relic_data = item["relic_data"]
+        if "name" in relic_data:
+            writestr(state, relic_data["name"])
+            wrote = True
+        if "recharge_scheme" in relic_data:
+            for rech in relic_data["recharge_scheme"]:
+                if "message" in rech:
+                    writestr(state, rech["message"],
+                      comment="Relic recharge message for {} '{}'".format(object_type, name)
+                    )
+                    wrote = True
     if "text" in item:
         writestr(state, item["text"])
         wrote = True

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -193,7 +193,7 @@ void Character::process_turn()
 
     visit_items( [this]( item * e ) {
         e->process_artifact( as_player(), pos() );
-        e->process_relic( as_player() );
+        e->process_relic( *this );
         return VisitResponse::NEXT;
     } );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6869,10 +6869,11 @@ bool item::is_relic() const
     return !!relic_data;
 }
 
-std::vector<enchantment> item::get_enchantments() const
+const std::vector<enchantment> &item::get_enchantments() const
 {
     if( !is_relic() ) {
-        return std::vector<enchantment> {};
+        static const std::vector<enchantment> fallback;
+        return fallback;
     }
     return relic_data->get_enchantments();
 }
@@ -6913,6 +6914,11 @@ double item::bonus_from_enchantments_wielded( double base, enchant_vals::mod val
         ret = trunc( ret );
     }
     return ret;
+}
+
+const std::vector<relic_recharge> &item::get_relic_recharge_scheme() const
+{
+    return relic_data->get_recharge_scheme();
 }
 
 bool item::can_contain( const item &it ) const
@@ -8994,7 +9000,7 @@ std::vector<trait_id> item::mutations_from_wearing( const Character &guy ) const
     return muts;
 }
 
-void item::process_relic( Character *carrier )
+void item::process_relic( Character &carrier )
 {
     if( !is_relic() ) {
         return;
@@ -9002,10 +9008,12 @@ void item::process_relic( Character *carrier )
     std::vector<enchantment> active_enchantments;
 
     for( const enchantment &ench : get_enchantments() ) {
-        if( ench.is_active( *carrier, *this ) ) {
+        if( ench.is_active( carrier, *this ) ) {
             active_enchantments.emplace_back( ench );
         }
     }
+
+    relic_funcs::process_recharge( *this, carrier );
 }
 
 bool item::process_corpse( player *carrier, const tripoint &pos )

--- a/src/item.h
+++ b/src/item.h
@@ -45,6 +45,7 @@ class nc_color;
 class player;
 class recipe;
 class relic;
+class relic_recharge;
 struct islot_comestible;
 struct itype;
 struct item_comp;
@@ -1126,7 +1127,7 @@ class item : public visitable<item>
          * @param pos The location of the artifact (should be the player location if carried).
          */
         void process_artifact( player *carrier, const tripoint &pos );
-        void process_relic( Character *carrier );
+        void process_relic( Character &carrier );
 
         bool destroyed_at_zero_charges() const;
         // Most of the is_whatever() functions call the same function in our itype
@@ -2094,7 +2095,7 @@ class item : public visitable<item>
         void set_cached_tool_selections( const std::vector<comp_selection<tool_comp>> &selections );
         const std::vector<comp_selection<tool_comp>> &get_cached_tool_selections() const;
 
-        std::vector<enchantment> get_enchantments() const;
+        const std::vector<enchantment> &get_enchantments() const;
 
         /**
          * Calculate bonus from enchantments that affect this item only.
@@ -2108,6 +2109,8 @@ class item : public visitable<item>
          */
         double bonus_from_enchantments_wielded( double base, enchant_vals::mod value,
                                                 bool round = false ) const;
+
+        const std::vector<relic_recharge> &get_relic_recharge_scheme() const;
 
     private:
         bool use_amount_internal( const itype_id &it, int &quantity, std::list<item> &used,

--- a/src/json.h
+++ b/src/json.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "enum_conversions.h"
+#include "json_source_location.h"
 #include "memory_fast.h"
 #include "string_id.h"
 
@@ -86,11 +87,6 @@ struct number_sci_notation {
     uint64_t number = 0;
     // AKA the order of magnitude
     int64_t exp = 0;
-};
-
-struct json_source_location {
-    shared_ptr_fast<std::string> path;
-    int offset = 0;
 };
 
 /* JsonIn

--- a/src/json_source_location.cpp
+++ b/src/json_source_location.cpp
@@ -1,0 +1,29 @@
+#include "json_source_location.h"
+
+#include "debug.h"
+#include "init.h"
+
+void throw_error_at_json_loc( const json_source_location &loc, const std::string &message )
+{
+    if( !loc.path ) {
+        throw JsonError( string_format( "Json error: (unknown pos): %s", message ) );
+    }
+    shared_ptr_fast<std::istream> stream = DynamicDataLoader::get_instance().get_cached_stream(
+            *loc.path );
+    if( !stream ) {
+        throw JsonError( string_format( "Json error: (%s:%d): %s", *loc.path, loc.offset, message ) );
+    }
+    // Pass a new location with offset 0 so JsonIn stream would begin from the beginning of the file
+    // and not from some old cached position.
+    JsonIn jsin( *stream, json_source_location{ loc.path, 0 } );
+    jsin.error( message, loc.offset );
+}
+
+void show_warning_at_json_loc( const json_source_location &loc, const std::string &message )
+{
+    try {
+        throw_error_at_json_loc( loc, message );
+    } catch( const JsonError &err ) {
+        debugmsg( "%s", err.what() );
+    }
+}

--- a/src/json_source_location.h
+++ b/src/json_source_location.h
@@ -1,0 +1,21 @@
+#pragma once
+#ifndef CATA_SRC_JSON_SOURCE_LOCATION_H
+#define CATA_SRC_JSON_SOURCE_LOCATION_H
+
+#include <string>
+
+#include "memory_fast.h"
+
+struct json_source_location {
+    shared_ptr_fast<std::string> path;
+    int offset = 0;
+};
+
+/** Throw error at given JSON location. */
+[[noreturn]]
+void throw_error_at_json_loc( const json_source_location &loc, const std::string &message );
+
+/** Show warning at given JSON location. */
+void show_warning_at_json_loc( const json_source_location &loc, const std::string &message );
+
+#endif // CATA_SRC_JSON_SOURCE_LOCATION_H

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -3,12 +3,142 @@
 #include <algorithm>
 #include <cmath>
 
+#include "cata_unreachable.h"
 #include "creature.h"
+#include "character.h"
+#include "field.h"
+#include "game.h"
 #include "json.h"
 #include "magic.h"
 #include "magic_enchantment.h"
+#include "map.h"
+#include "map_iterator.h"
+#include "messages.h"
+#include "rng.h"
 #include "translations.h"
+#include "trap.h"
 #include "type_id.h"
+#include "weather.h"
+
+static const efftype_id effect_sleep( "sleep" );
+
+namespace io
+{
+template<>
+std::string enum_to_string<relic_recharge_type>( relic_recharge_type data )
+{
+    switch( data ) {
+        // *INDENT-OFF*
+        case relic_recharge_type::time: return "time";
+        case relic_recharge_type::solar: return "solar";
+        case relic_recharge_type::pain: return "pain";
+        case relic_recharge_type::hp: return "hp";
+        case relic_recharge_type::fatigue: return "fatigue";
+        case relic_recharge_type::field: return "field";
+        case relic_recharge_type::trap: return "trap";
+        case relic_recharge_type::num:
+            break;
+        // *INDENT-ON*
+    }
+    debugmsg( "Invalid relic_recharge_type" );
+    abort();
+}
+
+template<>
+std::string enum_to_string<relic_recharge_req>( relic_recharge_req data )
+{
+    switch( data ) {
+        // *INDENT-OFF*
+        case relic_recharge_req::none: return "none";
+        case relic_recharge_req::equipped: return "equipped";
+        case relic_recharge_req::close_to_skin: return "close_to_skin";
+        case relic_recharge_req::sleep: return "sleep";
+        case relic_recharge_req::rad: return "rad";
+        case relic_recharge_req::wet: return "wet";
+        case relic_recharge_req::sky: return "sky";
+        case relic_recharge_req::num:
+            break;
+        // *INDENT-ON*
+    }
+    debugmsg( "Invalid relic_recharge_req" );
+    abort();
+}
+} // namespace io
+
+bool relic_recharge::operator==( const relic_recharge &rhs ) const
+{
+    return type == rhs.type &&
+           req == rhs.req &&
+           field_type == rhs.field_type &&
+           trap_type == rhs.trap_type &&
+           interval == rhs.interval &&
+           intensity_min == rhs.intensity_min &&
+           intensity_max == rhs.intensity_max &&
+           rate == rhs.rate &&
+           message == rhs.message;
+}
+
+void relic_recharge::load( const JsonObject &jo )
+{
+    try {
+        src_loc = jo.get_source_location();
+    } catch( const std::exception & ) {
+        // Savefiles don't specify source, so ignore error
+    }
+
+    jo.read( "type", type );
+    jo.read( "req", req );
+    jo.read( "field", field_type );
+    jo.read( "trap", trap_type );
+    jo.read( "interval", interval );
+    jo.read( "int_min", intensity_min );
+    jo.read( "int_max", intensity_max );
+    jo.read( "rate", rate );
+    jo.read( "message", message );
+}
+
+void relic_recharge::serialize( JsonOut &json ) const
+{
+    json.start_object();
+
+    json.member( "type", type );
+    json.member( "req", req );
+    json.member( "field", field_type );
+    json.member( "trap", trap_type );
+    json.member( "interval", interval );
+    json.member( "int_min", intensity_min );
+    json.member( "int_max", intensity_max );
+    json.member( "rate", rate );
+    json.member( "message", message );
+
+    json.end_object();
+}
+
+void relic_recharge::deserialize( JsonIn &jsin )
+{
+    JsonObject data = jsin.get_object();
+    load( data );
+}
+
+void relic_recharge::check() const
+{
+    if( type == relic_recharge_type::field && !field_type.is_valid() ) {
+        show_warning_at_json_loc( src_loc,
+                                  string_format( "Relic specifies invalid field type '%s' to recharge from.", field_type )
+                                );
+    }
+    if( type == relic_recharge_type::trap && !trap_type.is_valid() ) {
+        show_warning_at_json_loc( src_loc,
+                                  string_format( "Relic specifies invalid trap type '%s' to recharge from.", trap_type )
+                                );
+    }
+    if( to_seconds<int>( interval ) <= 0 ) {
+        show_warning_at_json_loc( src_loc, "Relic specifies invalid recharge interval." );
+    }
+    if( intensity_min < 0 || intensity_max < 0 ) {
+        show_warning_at_json_loc( src_loc, "Relic specifies invalid recharge intensity." );
+    }
+}
 
 void relic::add_active_effect( const fake_spell &sp )
 {
@@ -23,6 +153,11 @@ void relic::add_passive_effect( const enchantment &nench )
         }
     }
     passive_effects.emplace_back( nench );
+}
+
+void relic::add_recharge_scheme( const relic_recharge &r )
+{
+    recharge_scheme.emplace_back( r );
 }
 
 void relic::load( const JsonObject &jo )
@@ -42,6 +177,13 @@ void relic::load( const JsonObject &jo )
                 ench = ench.id.obj();
             }
             add_passive_effect( ench );
+        }
+    }
+    if( jo.has_array( "recharge_scheme" ) ) {
+        for( JsonObject jobj : jo.get_array( "recharge_scheme" ) ) {
+            relic_recharge recharge;
+            recharge.load( jobj );
+            add_recharge_scheme( recharge );
         }
     }
     jo.read( "name", item_name_override );
@@ -82,6 +224,15 @@ void relic::serialize( JsonOut &jsout ) const
         jsout.end_array();
     }
 
+    if( !recharge_scheme.empty() ) {
+        jsout.member( "recharge_scheme" );
+        jsout.start_array();
+        for( const relic_recharge &sp : recharge_scheme ) {
+            sp.serialize( jsout );
+        }
+        jsout.end_array();
+    }
+
     jsout.end_object();
 }
 
@@ -100,7 +251,8 @@ bool relic::operator==( const relic &rhs ) const
            moves == rhs.moves &&
            item_name_override == rhs.item_name_override &&
            active_effects == rhs.active_effects &&
-           passive_effects == rhs.passive_effects;
+           passive_effects == rhs.passive_effects &&
+           recharge_scheme == rhs.recharge_scheme;
 }
 
 std::string relic::name() const
@@ -108,14 +260,197 @@ std::string relic::name() const
     return item_name_override.translated();
 }
 
-std::vector<enchantment> relic::get_enchantments() const
-{
-    return passive_effects;
-}
-
 void relic::check() const
 {
     for( const enchantment &ench : passive_effects ) {
         ench.check();
     }
+    for( const relic_recharge &rech : recharge_scheme ) {
+        rech.check();
+    }
 }
+
+namespace relic_funcs
+{
+
+bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Character &carrier )
+{
+    switch( rech.req ) {
+        case relic_recharge_req::none: {
+            return true;
+        }
+        case relic_recharge_req::equipped: {
+            if( itm.is_armor() ) {
+                return carrier.is_wearing( itm );
+            } else {
+                return carrier.is_wielding( itm );
+            }
+        }
+        case relic_recharge_req::close_to_skin: {
+            if( itm.is_armor() ) {
+                if( !carrier.is_wearing( itm ) ) {
+                    return false;
+                }
+                for( const bodypart_id &bp : carrier.get_all_body_parts() ) {
+                    if( !itm.covers( bp ) ) {
+                        continue;
+                    }
+                    bool this_bp_good = true;
+                    for( const item &wi : carrier.worn ) {
+                        if( wi.get_coverage() == 0 ) {
+                            continue;
+                        }
+                        if( &wi == &itm ) {
+                            break;
+                        } else if( wi.covers( bp ) ) {
+                            this_bp_good = false;
+                            break;
+                        }
+                    }
+                    if( this_bp_good ) {
+                        return true;
+                    }
+                }
+                return false;
+            } else {
+                if( !carrier.is_wielding( itm ) ) {
+                    return false;
+                }
+                bool hand_l_ok = true;
+                bool hand_r_ok = true;
+                for( const item &wi : carrier.worn ) {
+                    if( wi.get_coverage() == 0 ) {
+                        continue;
+                    }
+                    if( wi.covers( body_part_hand_l ) ) {
+                        hand_l_ok = false;
+                    }
+                    if( wi.covers( body_part_hand_r ) ) {
+                        hand_r_ok = false;
+                    }
+                }
+                return hand_l_ok || hand_r_ok;
+            }
+        }
+        case relic_recharge_req::sleep: {
+            return carrier.has_effect( effect_sleep );
+        }
+        case relic_recharge_req::rad: {
+            return get_map().get_radiation( carrier.pos() ) > 0 || carrier.get_rad() > 0;
+        }
+        case relic_recharge_req::wet: {
+            bool has_wet = std::any_of( carrier.body_wetness.begin(), carrier.body_wetness.end(),
+            []( const int w ) {
+                return w != 0;
+            } );
+            if( has_wet ) {
+                return true;
+            } else {
+                const weather_type &wt = get_weather().weather_id.obj();
+                if( !wt.rains || wt.acidic || wt.precip == precip_class::none ) {
+                    return false;
+                }
+                return get_map().is_outside( carrier.pos() );
+            }
+        }
+        case relic_recharge_req::sky: {
+            return carrier.posz() > 0;
+        }
+        default: {
+            std::abort();
+        }
+    }
+    cata::unreachable();
+}
+
+bool process_recharge_entry( item &itm, const relic_recharge &rech, Character &carrier )
+{
+    if( !calendar::once_every( rech.interval ) ) {
+        return false;
+    }
+    if( !check_recharge_reqs( itm, rech, carrier ) ) {
+        return false;
+    }
+    map &here = get_map();
+    switch( rech.type ) {
+        case relic_recharge_type::time: {
+            break;
+        }
+        case relic_recharge_type::solar: {
+            if( !g->is_in_sunlight( carrier.pos() ) ) {
+                return false;
+            }
+            break;
+        }
+        case relic_recharge_type::pain: {
+            carrier.add_msg_if_player( m_bad, _( "You suddenly feel sharp pain for no reason." ) );
+            carrier.mod_pain_noresist( rng( rech.intensity_min, rech.intensity_max ) );
+            break;
+        }
+        case relic_recharge_type::hp: {
+            carrier.add_msg_if_player( m_bad, _( "You feel your body decaying." ) );
+            carrier.hurtall( rng( rech.intensity_min, rech.intensity_max ), nullptr );
+            break;
+        }
+        case relic_recharge_type::fatigue: {
+            carrier.add_msg_if_player( m_bad, _( "You feel fatigue seeping into your body." ) );
+            carrier.mod_fatigue( rng( rech.intensity_min, rech.intensity_max ) );
+            carrier.mod_stamina( -100 * rng( rech.intensity_min, rech.intensity_max ) );
+            break;
+        }
+        case relic_recharge_type::field: {
+            bool consumed = false;
+            for( const tripoint &dest : here.points_in_radius( carrier.pos(), 1 ) ) {
+                field_entry *field_at = here.field_at( dest ).find_field( rech.field_type );
+                if( !field_at ) {
+                    continue;
+                }
+                int int_here = field_at->get_field_intensity();
+                if( int_here >= rech.intensity_min && int_here <= rech.intensity_max ) {
+                    here.remove_field( dest, rech.field_type );
+                    consumed = true;
+                    break;
+                }
+            }
+            if( !consumed ) {
+                return false;
+            }
+            break;
+        }
+        case relic_recharge_type::trap: {
+            bool consumed = false;
+            for( const tripoint &dest : here.points_in_radius( carrier.pos(), 1 ) ) {
+                if( here.tr_at( dest ).id == rech.trap_type ) {
+                    here.remove_trap( dest );
+                    consumed = true;
+                }
+            }
+            if( !consumed ) {
+                return false;
+            }
+            break;
+        }
+        default: {
+            std::abort();
+        }
+    }
+    itm.charges = clamp( itm.charges + rech.rate, 0, itm.ammo_capacity() );
+    if( rech.message ) {
+        carrier.add_msg_if_player( _( *rech.message ) );
+    }
+    return true;
+}
+
+void process_recharge( item &itm, Character &carrier )
+{
+    if( !itm.is_tool() ) {
+        return;
+    }
+    if( itm.ammo_remaining() >= itm.ammo_capacity() ) {
+        return;
+    }
+    for( const relic_recharge &rech : itm.get_relic_recharge_scheme() ) {
+        process_recharge_entry( itm, rech, carrier );
+    }
+}
+} // namespace relic_funcs

--- a/src/relic.h
+++ b/src/relic.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "json_source_location.h"
 #include "magic.h"
 #include "magic_enchantment.h"
 #include "translations.h"
@@ -15,11 +16,95 @@ class JsonObject;
 class JsonOut;
 struct tripoint;
 
+enum class relic_recharge_type {
+    /** Recharges slowly with time */
+    time,
+    /** Recharges in sunlight */
+    solar,
+    /** Creates pain to recharge */
+    pain,
+    /** Drains HP to recharge */
+    hp,
+    /** Creates fatigue to recharge */
+    fatigue,
+    /** Consumes field to recharge */
+    field,
+    /** Consumes trap to recharge */
+    trap,
+
+    num
+};
+
+enum class relic_recharge_req {
+    /** No additional requirements */
+    none,
+    /** Must be worn/wielded */
+    equipped,
+    /**
+     * Must be worn on closest layer on at least 1 body part if armor, or
+     * must be wielding with nothing worn on left and/or right hand.
+     */
+    close_to_skin,
+    /** Will recharge only when character is asleep */
+    sleep,
+    /** Must be irradiated/in irradiated tile */
+    rad,
+    /** Must be wet or in rain */
+    wet,
+    /** Must be a Z-level above the surface */
+    sky,
+
+    num
+};
+
+template<>
+struct enum_traits<relic_recharge_type> {
+    static constexpr relic_recharge_type last = relic_recharge_type::num;
+};
+
+template<>
+struct enum_traits<relic_recharge_req> {
+    static constexpr relic_recharge_req last = relic_recharge_req::num;
+};
+
+class relic_recharge
+{
+        json_source_location src_loc;
+
+    public:
+        /** Relic recharge type */
+        relic_recharge_type type = relic_recharge_type::time;
+        /** Relic recharge requirements */
+        relic_recharge_req req = relic_recharge_req::none;
+        /** If relic consumes fields to recharge, this specifies field type */
+        field_type_str_id field_type;
+        /** If relic consumes traps to recharge, this specifies trap type */
+        trap_str_id trap_type;
+        /** For time-based recharge, specifies recharge interval */
+        time_duration interval = 1_seconds;
+        /** For intensity-based recharge types, specifies min intensity */
+        int intensity_min = 0;
+        /** For intensity-based recharge types, specifies max intensity */
+        int intensity_max = 0;
+        /** Specifies amount of charges gained per charge operation.  Can be 0 or even negative. */
+        int rate = 0;
+        /** Recharge activation message. */
+        cata::optional<std::string> message;
+
+        bool operator==( const relic_recharge &rhs ) const;
+
+        void load( const JsonObject &jo );
+        void serialize( JsonOut &json ) const;
+        void deserialize( JsonIn &jsin );
+        void check() const;
+};
+
 class relic
 {
     private:
         std::vector<fake_spell> active_effects;
         std::vector<enchantment> passive_effects;
+        std::vector<relic_recharge> recharge_scheme;
 
         // the item's name will be replaced with this if the string is not empty
         translation item_name_override;
@@ -41,10 +126,26 @@ class relic
 
         void add_passive_effect( const enchantment &ench );
         void add_active_effect( const fake_spell &sp );
+        void add_recharge_scheme( const relic_recharge &r );
 
-        std::vector<enchantment> get_enchantments() const;
+        inline const std::vector<enchantment> &get_enchantments() const {
+            return passive_effects;
+        }
+        inline const std::vector<relic_recharge> &get_recharge_scheme() const {
+            return recharge_scheme;
+        }
 
         void check() const;
 };
+
+namespace relic_funcs
+{
+
+bool check_recharge_reqs( const item &itm, const relic_recharge &rech, const Character &carrier );
+bool process_recharge_entry( item &itm, const relic_recharge &rech, Character &carrier );
+
+void process_recharge( item &itm, Character &carrier );
+
+} // namespace relic_funcs
 
 #endif // CATA_SRC_RELIC_H


### PR DESCRIPTION
#### Summary
SUMMARY: Features "Relics can recharge now"

#### Purpose of change
Working towards #1816 (implements step 3)

#### Describe the solution
~~Depends on #2283 and #2254~~ Rebased on latest `upload`, does not depend on them anymore.

This PR implements relic recharge that mirrors existing artifact recharge code, except it works for NPCs and also has a variety of knobs accessible from JSON.
Tweaked behavior of "close to skin" to be more transparent.

#### Describe alternatives you've considered
* Porting DDA relic recharge.
    I'm not sure how reliable it is. Also, no `ARTC_PORTAL`, which is a thing CV wants.

#### Testing
TODO:
- [x] playtest
- [x] implement analogue to `ACR_SKIN`
- [ ] ~~write tests?~~ Feeling lazy, added test relics but no tests
- [ ] ~~add more features?~~ Let's wait for actors framework on this
- [x] extract new strings to translation template
- [x] add docs