### PR TITLE
Turrets won't shoot vehicles on another z level when 3d vision is off

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -486,6 +486,9 @@ static vehicle *find_target_vehicle( monster &z, int range )
     map &here = get_map();
     vehicle *chosen = nullptr;
     for( wrapped_vehicle &v : here.get_vehicles() ) {
+        if( !fov_3d && v.pos.z != z.pos().z ) {
+            continue;
+        }
         int new_dist = rl_dist( z.pos(), v.pos );
         if( v.v->velocity != 0 && new_dist < range ) {
             chosen = v.v;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Turrets won't shoot vehicles on another z level when 3d vision is off"

#### Purpose of change

Fix the bug where turrets weren't respecting fov3d when firing at vehicles. 

#### Describe the solution

Just a simple fov3d and z level check. 
