### PR TITLE
Try to pick a safe direction to cut down a tree

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4185,7 +4185,7 @@ void activity_handlers::chop_tree_finish( player_activity *act, player *p )
     } else {
         // Try to safely fell tree
         std::vector<tripoint> valid_directions;
-        
+
         for( const tripoint &elem : here.points_in_radius( pos, 1 ) ) {
             bool cantuse = false;
             tripoint direc = elem - pos;
@@ -4198,8 +4198,8 @@ void activity_handlers::chop_tree_finish( player_activity *act, player *p )
                     break;
                 }
 
-                ter_t ter = here.ter(elem).obj();
-                furn_t furn = here.furn(elem).obj();
+                ter_t ter = here.ter( elem ).obj();
+                furn_t furn = here.furn( elem ).obj();
                 // Furniture / Terrain test
                 if( elem != pos && ( ter.bash.str_max != -1 || ( furn.id && furn.bash.str_max != -1 ) ) ) {
                     cantuse = true;


### PR DESCRIPTION
#### Summary
SUMMARY: Features "Make NPCs care more about how they cut down trees"

#### Purpose of change
NPCs only consider critters when cutting down trees. This can lead to vehicles being crushed or structures having their walls collapsed. This makes NPCs look really dumb.

#### Describe the solution
Check for Terrain, Furniture, and Vehicles in addition to Critters.
Additionally, if a direction is viable throw it into a collection to be randomly selected from so trees don't consistently fall in the same direction.

#### Testing
Spawned NPC with a start at LMOE shelter so I'm surrounded by trees. Set up a chop zone near the LMOE entrance and let the NPC get to work.