### PR TITLE
Fix actualize causing rot in working freezers

### DIFF
--- a/data/json/items/containers.json
+++ b/data/json/items/containers.json
@@ -600,8 +600,7 @@
     "symbol": "I",
     "color": "green",
     "seals": true,
-    "watertight": true,
-    "insulation": 10
+    "watertight": true
   },
   {
     "id": "clay_canister",

--- a/data/json/items/vehicle/utilities.json
+++ b/data/json/items/vehicle/utilities.json
@@ -187,8 +187,7 @@
     "copy-from": "washing_machine",
     "id": "minifridge",
     "name": { "str": "minifridge" },
-    "description": "A very small fridge for keeping food cool.  Provides some insulation from outside weather.",
-    "insulation": 2
+    "description": "A very small fridge for keeping food cool.  Provides some insulation from outside weather."
   },
   {
     "type": "GENERIC",
@@ -197,7 +196,6 @@
     "description": "Compact version of a chest freezer, designed as a mobile solution for freezing food.  Provides insulation from the elements.",
     "price": 70000,
     "price_postapoc": 4000,
-    "insulation": 4,
     "copy-from": "minifridge"
   },
   {
@@ -214,7 +212,6 @@
     "id": "fridgetank",
     "name": { "str": "refrigerated tank" },
     "description": "A 60L refrigerated tank for keeping liquids cool.  Provides some insulation from outside weather.",
-    "insulation": 2,
     "volume": "60 L",
     "weight": "48 kg"
   },

--- a/data/mods/TEST_DATA/furniture.json
+++ b/data/mods/TEST_DATA/furniture.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "furniture",
+    "id": "f_atomic_freezer",
+    "name": "atomic freezer",
+    "copy-from": "f_glass_fridge_base",
+    "symbol": "{",
+    "description": "A freezer that never runs out of juice!  Will preserve your bugs during tests.",
+    "color": "blue",
+    "extend": { "flags": [ "FREEZER" ] }
+  }
+]

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5345,7 +5345,7 @@ static void mill_activate( player &p, const tripoint &examp )
     for( auto &it : here.i_at( examp ) ) {
         if( it.type->milling_data ) {
             // Do one final rot check before milling, then apply the PROCESSING flag to prevent further checks.
-            it.process_rot( 1, false, examp, nullptr );
+            it.process_rot( examp );
             it.set_flag( flag_PROCESSING );
         }
     }
@@ -5446,7 +5446,7 @@ static void smoker_activate( player &p, const tripoint &examp )
     p.use_charges( itype_fire, 1 );
     for( auto &it : here.i_at( examp ) ) {
         if( it.has_flag( flag_SMOKABLE ) ) {
-            it.process_rot( 1, false, examp, nullptr );
+            it.process_rot( examp );
             it.set_flag( flag_PROCESSING );
         }
     }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2421,7 +2421,6 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     assign( jo, "emits", def.emits );
     assign( jo, "magazine_well", def.magazine_well );
     assign( jo, "explode_in_fire", def.explode_in_fire );
-    assign( jo, "insulation", def.insulation_factor );
     assign( jo, "solar_efficiency", def.solar_efficiency );
     assign( jo, "ascii_picture", def.picture_id );
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -1030,13 +1030,6 @@ struct itype {
         layer_level layer = layer_level::MAX_CLOTHING_LAYER;
 
         /**
-         * How much insulation this item provides, either as a container, or as
-         * a vehicle base part.  Larger means more insulation, less than 1 but
-         * greater than zero, transfers faster, cannot be less than zero.
-         */
-        float insulation_factor = 1;
-
-        /**
          * Efficiency of solar energy conversion for solarpacks.
          */
         float solar_efficiency = 0;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4464,9 +4464,9 @@ void map::update_lum( item_location &loc, bool add )
 }
 
 static bool process_map_items( item_stack &items, safe_reference<item> &item_ref,
-                               const tripoint &location, const float insulation, const temperature_flag flag )
+                               const tripoint &location, const temperature_flag flag )
 {
-    if( item_ref->process( nullptr, location, false, insulation, flag ) ) {
+    if( item_ref->process( nullptr, location, false, flag ) ) {
         // Item is to be destroyed so erase it from the map stack
         // unless it was already destroyed by processing.
         if( item_ref ) {
@@ -4605,6 +4605,21 @@ void map::process_items()
     }
 }
 
+static temperature_flag temperature_flag_at_point( const map &m, const tripoint &p )
+{
+    if( m.ter( p ) == t_rootcellar ) {
+        return temperature_flag::TEMP_ROOT_CELLAR;
+    }
+    if( m.has_flag_furn( TFLAG_FRIDGE, p ) ) {
+        return temperature_flag::TEMP_FRIDGE;
+    }
+    if( m.has_flag_furn( TFLAG_FREEZER, p ) ) {
+        return temperature_flag::TEMP_FREEZER;
+    }
+
+    return temperature_flag::TEMP_NORMAL;
+}
+
 void map::process_items_in_submap( submap &current_submap, const tripoint &gridp )
 {
     // Get a COPY of the active item list for this submap.
@@ -4619,19 +4634,9 @@ void map::process_items_in_submap( submap &current_submap, const tripoint &gridp
         }
 
         const tripoint map_location = tripoint( grid_offset + active_item_ref.location, gridp.z );
-        // root cellars are special
-        temperature_flag flag = temperature_flag::TEMP_NORMAL;
-        if( ter( map_location ) == t_rootcellar ) {
-            flag = temperature_flag::TEMP_ROOT_CELLAR;
-        }
-        if( has_flag_furn( TFLAG_FRIDGE, map_location ) ) {
-            flag = temperature_flag::TEMP_FRIDGE;
-        }
-        if( has_flag_furn( TFLAG_FREEZER, map_location ) ) {
-            flag = temperature_flag::TEMP_FREEZER;
-        }
+        temperature_flag flag = temperature_flag_at_point( *this, map_location );
         map_stack items = i_at( map_location );
-        process_map_items( items, active_item_ref.item_ref, map_location, 1, flag );
+        process_map_items( items, active_item_ref.item_ref, map_location, flag );
     }
 }
 
@@ -4688,25 +4693,20 @@ void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap )
         const vehicle_part &pt = it->part();
         const tripoint item_loc = it->pos();
         auto items = cur_veh.get_items( static_cast<int>( it->part_index() ) );
-        float it_insulation = 1.0;
         temperature_flag flag = temperature_flag::TEMP_NORMAL;
         if( target.is_food() || target.is_food_container() || target.is_corpse() ) {
             const vpart_info &pti = pt.info();
             if( engine_heater_is_on ) {
                 flag = temperature_flag::TEMP_HEATER;
             }
-            // some vehicle parts provide insulation, default is 1
-            it_insulation = pti.item->insulation_factor;
 
             if( pt.enabled && pti.has_flag( VPFLAG_FRIDGE ) ) {
-                it_insulation = 1; // ignore fridge insulation if on
                 flag = temperature_flag::TEMP_FRIDGE;
             } else if( pt.enabled && pti.has_flag( VPFLAG_FREEZER ) ) {
-                it_insulation = 1; // ignore freezer insulation if on
                 flag = temperature_flag::TEMP_FREEZER;
             }
         }
-        if( !process_map_items( items, active_item_ref.item_ref, item_loc, it_insulation, flag ) ) {
+        if( !process_map_items( items, active_item_ref.item_ref, item_loc, flag ) ) {
             // If the item was NOT destroyed, we can skip the remainder,
             // which handles fallout from the vehicle being damaged.
             continue;
@@ -7101,10 +7101,10 @@ void map::loadn( const tripoint &grid, const bool update_vehicles )
 }
 
 template <typename Container>
-void map::remove_rotten_items( Container &items, const tripoint &pnt )
+void map::remove_rotten_items( Container &items, const tripoint &pnt, temperature_flag temperature )
 {
     for( auto it = items.begin(); it != items.end(); ) {
-        if( it->has_rotten_away( pnt ) ) {
+        if( it->actualize_rot( pnt, temperature, get_weather() ) ) {
             if( it->is_comestible() ) {
                 rotten_item_spawn( *it, pnt );
             }
@@ -7440,7 +7440,8 @@ void map::actualize( const tripoint &grid )
             }
             // plants contain a seed item which must not be removed under any circumstances
             if( !furn.has_flag( "DONT_REMOVE_ROTTEN" ) ) {
-                remove_rotten_items( tmpsub->get_items( { x, y } ), pnt );
+                temperature_flag temperature = temperature_flag_at_point( *this, pnt );
+                remove_rotten_items( tmpsub->get_items( { x, y } ), pnt, temperature );
             }
 
             const auto trap_here = tmpsub->get_trap( p );

--- a/src/map.h
+++ b/src/map.h
@@ -1748,9 +1748,10 @@ class map
          * that have rotten away completely.
          * @param items items to remove
          * @param p The point on this map where the items are, used for rot calculation.
+         * @param temperature flag that overrides temperature processing at certain locations
          */
         template <typename Container>
-        void remove_rotten_items( Container &items, const tripoint &p );
+        void remove_rotten_items( Container &items, const tripoint &p, temperature_flag temperature );
         /**
          * Try to fill funnel based items here. Simulates rain from @p since till now.
          * @param p The location in this map where to fill funnels.

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -376,7 +376,7 @@ void vehicle_part::process_contents( const tripoint &pos, const bool e_heater )
         if( e_heater ) {
             flag = temperature_flag::TEMP_HEATER;
         }
-        base.process( nullptr, pos, false, 1, flag );
+        base.process( nullptr, pos, false, flag );
     }
 }
 

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -10,15 +10,18 @@
 #include "point.h"
 #include "weather.h"
 
-static void set_map_temperature( int new_temperature )
+static const furn_str_id f_atomic_freezer( "f_atomic_freezer" );
+
+static void set_map_temperature( weather_manager &weather, int new_temperature )
 {
-    get_weather().temperature = new_temperature;
-    get_weather().clear_temp_cache();
+    weather.temperature = new_temperature;
+    weather.clear_temp_cache();
 }
 
 TEST_CASE( "Rate of rotting" )
 {
     SECTION( "Passage of time" ) {
+        weather_manager weather;
         // Item rot is a time duration.
         // At 65 F (18,3 C) item rots at rate of 1h/1h
         // So the level of rot should be about same as the item age
@@ -31,17 +34,15 @@ TEST_CASE( "Rate of rotting" )
         }
 
         item normal_item( "meat_cooked" );
-
         item freeze_item( "offal_canned" );
-
         item sealed_item( "offal_canned" );
         sealed_item = sealed_item.in_its_container();
 
-        set_map_temperature( 65 ); // 18,3 C
+        set_map_temperature( weather, 65 ); // 18,3 C
 
-        normal_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
-        sealed_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
-        freeze_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
+        normal_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_NORMAL, weather );
+        sealed_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_NORMAL, weather );
+        freeze_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_NORMAL, weather );
 
         // Item should exist with no rot when it is brand new
         CHECK( normal_item.get_rot() == 0_turns );
@@ -51,9 +52,9 @@ TEST_CASE( "Rate of rotting" )
         INFO( "Initial turn: " << to_turn<int>( calendar::turn ) );
 
         calendar::turn += 20_minutes;
-        normal_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
-        sealed_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
-        freeze_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_FREEZER );
+        normal_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_NORMAL, weather );
+        sealed_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_NORMAL, weather );
+        freeze_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_FREEZER, weather );
 
         // After 20 minutes the normal item should have 20 minutes of rot
         CHECK( to_turns<int>( normal_item.get_rot() )
@@ -64,8 +65,8 @@ TEST_CASE( "Rate of rotting" )
 
         // Move time 110 minutes
         calendar::turn += 110_minutes;
-        sealed_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_NORMAL );
-        freeze_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_FREEZER );
+        sealed_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_NORMAL, weather );
+        freeze_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_FREEZER, weather );
         // In freezer and in preserving container still should be no rot
         CHECK( sealed_item.get_rot() == 0_turns );
         CHECK( freeze_item.get_rot() == 0_turns );
@@ -75,6 +76,7 @@ TEST_CASE( "Rate of rotting" )
 TEST_CASE( "Items rot away" )
 {
     SECTION( "Item in reality bubble rots away" ) {
+        weather_manager weather;
         // Item should rot away when it has 2x of its shelf life in rot.
 
         if( calendar::turn <= calendar::start_of_cataclysm ) {
@@ -84,18 +86,19 @@ TEST_CASE( "Items rot away" )
         item test_item( "meat_cooked" );
 
         // Process item once to set all of its values.
-        test_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_HEATER );
+        test_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_HEATER, weather );
 
         // Set rot to >2 days and process again. process_rot should return true.
         calendar::turn += 20_minutes;
         test_item.mod_rot( 2_days );
 
-        CHECK( test_item.process_rot( 1, false, tripoint_zero, nullptr,
-                                      temperature_flag::TEMP_HEATER ) );
+        CHECK( test_item.process_rot( false, tripoint_zero, nullptr,
+                                      temperature_flag::TEMP_HEATER, weather ) );
         INFO( "Rot: " << to_turns<int>( test_item.get_rot() ) );
     }
 
     SECTION( "Item on map rots away" ) {
+        weather_manager weather;
         const tripoint loc;
 
         if( calendar::turn <= calendar::start_of_cataclysm ) {
@@ -103,7 +106,7 @@ TEST_CASE( "Items rot away" )
         }
 
         item test_item( "meat_cooked" );
-        test_item.process( nullptr, tripoint_zero, false, 1, temperature_flag::TEMP_HEATER );
+        test_item.process( nullptr, tripoint_zero, false, temperature_flag::TEMP_HEATER, weather );
         map &m = get_map();
         m.add_item_or_charges( loc, test_item, false );
 
@@ -115,4 +118,68 @@ TEST_CASE( "Items rot away" )
 
         CHECK( m.i_at( loc ).empty() );
     }
+}
+
+TEST_CASE( "Items don't rot away on map load if in a freezer" )
+{
+    tinymap m;
+    weather_manager weather;
+    if( calendar::turn <= calendar::start_of_cataclysm ) {
+        calendar::turn = calendar::start_of_cataclysm + 1_minutes;
+    }
+
+    constexpr tripoint_abs_sm non_tested_location = tripoint_abs_sm( 0, 0, 0 );
+    constexpr tripoint_abs_sm test_location = tripoint_abs_sm( 100, 100, 0 );
+    m.load( test_location, false );
+
+    const tripoint freezer_pnt = {13, 13, 0};
+    const tripoint sealed_pnt = {14, 13, 0};
+    const tripoint normal_pnt = {15, 13, 0};
+    m.furn_set( freezer_pnt, f_atomic_freezer );
+    m.furn_set( sealed_pnt, furn_str_id::NULL_ID() );
+    m.furn_set( normal_pnt, furn_str_id::NULL_ID() );
+    m.ter_set( freezer_pnt, t_grass );
+    m.ter_set( sealed_pnt, t_grass );
+    m.ter_set( normal_pnt, t_grass );
+
+
+    item normal_item( "meat_cooked" );
+    item freeze_item( "offal_canned" );
+    item sealed_item( "offal_canned" );
+    sealed_item = sealed_item.in_its_container();
+
+    set_map_temperature( weather, 65 ); // 18,3 C
+
+    m.i_clear( freezer_pnt );
+    m.i_clear( sealed_pnt );
+    m.i_clear( normal_pnt );
+
+    m.add_item( freezer_pnt, freeze_item );
+    m.add_item( sealed_pnt, sealed_item );
+    m.add_item( normal_pnt, normal_item );
+
+    REQUIRE( normal_item.get_rot() == 0_turns );
+    REQUIRE( sealed_item.get_rot() == 0_turns );
+    REQUIRE( freeze_item.get_rot() == 0_turns );
+
+    auto freezer_stack = m.i_at( freezer_pnt );
+    REQUIRE( freezer_stack.size() == 1 );
+    auto sealed_stack = m.i_at( sealed_pnt );
+    REQUIRE( sealed_stack.size() == 1 );
+    auto normal_stack = m.i_at( normal_pnt );
+    REQUIRE( normal_stack.size() == 1 );
+
+    INFO( "Initial turn: " << to_turn<int>( calendar::turn ) );
+
+    // Change the date outside the location, to force @ref map::actualize to proc rot
+    m.load( non_tested_location, false );
+    calendar::turn += 365_days;
+    m.load( test_location, false );
+
+    auto freezer_stack_after = m.i_at( freezer_pnt );
+    REQUIRE( freezer_stack_after.size() == 1 );
+    auto sealed_stack_after = m.i_at( sealed_pnt );
+    REQUIRE( sealed_stack_after.size() == 1 );
+    auto normal_stack_after = m.i_at( normal_pnt );
+    REQUIRE( normal_stack_after.size() == 0 );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix actualize causing rot in working freezers"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

`map::actualize` doesn't pass the freezer/fridge/etc. flags to rot check functions. Now it should do it.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

* Pass the temperature flags in `map::actualize` rot functions to items "being actualized"
* Rename `item::has_rotten_away( tripoint )` to `item::actualize_rot`, to distinguish it from the actual `has_rotten_away`, which is only a check, not an update.
* Remove `insulation` along the way - it's unused anyway
* Pass weather generator to rot functions to minimize effects of global state weather on tests
* Add a test that loads a tinymap, spawns things to rot, unloads the area, advances time, then reloads (and thus actualizes) the area again
 * The test uses a debug "atomic freezer" furniture, to avoid possible bugs from grid components

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

* Bring back item temperature - "No."
* Add "is in a fridge/freezer" flags to items on update - would be simpler than this, but also uglier and more prone to weird behavior
* `process` items directly in `actualize` - would trigger some effects an extra time, meaning that `actualize`'d grenades would tick one extra tick etc.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

* Tests pass
* Spawn a(n active) freezer, a fridge, and enough batteries + panels to fuel those (we could use a debug power gen furniture here)
* Spawn 3 slices of pizza, then put each slice into a freezer, a fridge, and onto the ground
* Set time to spring
* Teleport away (enough for the pizza to get out of bubble)
* Advance time enough for the pizza on the ground to rot away
* Teleport back in
* Verify that pizza on the ground is no longer there (may need to repeat time advance because of weather RNG)
* Verify that the pizza in the fridge has some rot points on it, but isn't `(rotten)` yet
* Verify that the pizza in the freezer is near 100% fresh

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Fixes same things as #2206, just a bit differently and with more semi-related changes attached.