### PR TITLE
Fix Active Perpetual Power Gen and Charge Timer Handling

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1252,5 +1252,16 @@
     "act_cost": 50,
     "fake_item": "bio_blaster_gun",
     "flags": [ "BIONIC_GUN" ]
+  },
+  {
+    "id": "bio_perpetual_test",
+    "type": "bionic",
+    "name": { "str": "Perpetual Generator" },
+    "description": "Installed within you is a perpetual generator powered by nonsensoleum.  When activated it's power gen doubles.  If you are seeing this, you'd better be debugging.",
+    "fuel_options": [ "nonsensoleum" ],
+    "passive_fuel_efficiency": 1.0,
+    "fuel_efficiency": 2.0,
+    "time": 1,
+    "flags": [ "BIONIC_POWER_SOURCE", "BIONIC_TOGGLED" ]
   }
 ]

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -1266,5 +1266,13 @@
     "description": "Heavy-duty fusion blaster was integrated into your left arm!  You may use your energy banks to fire a damaging heat ray.",
     "price": 220000,
     "difficulty": 3
+  },
+  {
+    "id": "bio_perpetual_test",
+    "copy-from": "bionic_general",
+    "type": "BIONIC_ITEM",
+    "name": { "str": "Perpetual Generator CBM" },
+    "description": "Installed within you is a perpetual generator powered by nonsensoleum.  When activated it's power gen doubles.  If you are seeing this, you'd better be debugging.",
+    "price": 0
   }
 ]

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -83,6 +83,20 @@
   },
   {
     "type": "GENERIC",
+    "//": "pseudo item, used as fuel type for CBMs that are bug powered.",
+    "id": "nonsensoleum",
+    "symbol": "?",
+    "color": "white",
+    "name": { "str": "nonsensoleum" },
+    "description": "seeing this is a bug",
+    "stackable": true,
+    "price": 0,
+    "volume": "0 ml",
+    "flags": [ "PERPETUAL" ],
+    "fuel": { "energy": 1 }
+  },
+  {
+    "type": "GENERIC",
     "//": "pseudo item, only used for as a required tool, checked for in player::amount_of",
     "id": "apparatus",
     "symbol": "$",

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1255,6 +1255,8 @@ bool Character::burn_fuel( bionic &bio, bool start )
                                                      overmap_buffer.ter( global_omt_location() ), pos(), wm.winddirection,
                                                      g->is_sheltered( pos() ) );
                             mod_power_level( units::from_kilojoule( fuel_energy ) * windpower * effective_efficiency );
+                        } else {
+                            mod_power_level( units::from_kilojoule( fuel_energy ) * effective_efficiency );
                         }
                     } else if( is_cable_powered ) {
                         int to_consume = 1;
@@ -1561,8 +1563,8 @@ void Character::process_bionic( bionic &bio )
             if( bio.info().has_flag( STATIC( flag_str_id( "BIONIC_POWER_SOURCE" ) ) ) ) {
                 // Convert fuel to bionic power
                 burn_fuel( bio );
-                // Reset timer
-                bio.charge_timer = bio.info().charge_time;
+                // This is our first turn of charging, so subtract a turn from the recharge delay.
+                bio.charge_timer = std::max( 0, bio.info().charge_time - 1 );
             } else {
                 // Try to recharge our bionic if it is made for it
                 units::energy cost = 0_J;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix Active Perpetual Power Gen and Charge Timer Handling"

#### Purpose of change

Was reminded to look into power gen, originally to check if Joint Torsion Ratchet actually works and why the Atomic Battery CBM from Cata++ doesn't work when active.

#### Describe the solution

Adds a consideration in `bionics.cpp` for active perpetual power gen that isn't sunlight/wind. Fixed how charge timers are reset for power generators based on `attempt_recharge()` so that `"time": 1` means it gives power every turn, which is the intended approach as seen by how every other power drawing bionic uses that convention and 0 means it never recharges.

#### Describe alternatives you've considered

- Leave broken for kicks
- Alter the Joint Torsion Ratchet efficiency
Balance thing, best kept separate from bugfixes.

#### Testing

Installed the Cata++ mod, edited it to have `fuel_efficiency` and removed `passive_fuel_efficiency`, checked that it powered when on, didn't charge on the first turn and charged on every turn after that.

#### Additional context
