### PR TITLE
make light mounts bolt install and add forging recipe

### DIFF
--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -545,6 +545,20 @@
   },
   {
     "type": "recipe",
+    "result": "wheel_mount_light",
+    "id_suffix": "forging",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_VEHICLE",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "1 h",
+    "autolearn": true,
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "qualities": [ { "id": "CHISEL", "level": 3 } ],
+    "tools": [ [ [ "swage", -1 ] ] ]
+  },
+  {
+    "type": "recipe",
     "result": "turret_mount",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_VEHICLE",

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -14,7 +14,7 @@
     "description": "A piece of metal with holes suitable for a bike or motorbike wheel.",
     "item": "wheel_mount_light",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m", "using": [ [ "welding_standard", 3 ] ] },
+      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "vehicle_bolt", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m", "qualities": [ { "id": "SAW_M", "level": 1 } ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m", "using": [ [ "welding_standard", 5 ] ] }
     },


### PR DESCRIPTION
steerable mounts were blocked behind "paywall" (which is arc welding), so getting your own bike was nearly endgame material, especially, when playing with low item drops to get any sunglasses.

This should make it a bit easier building a bike.

Light mounts can be installed via bolting.
Light mounts can also be forged.