### PR TITLE
remove glare protection requirement for forged frames

### DIFF
--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -704,10 +704,7 @@
     "autolearn": true,
     "using": [ [ "steel_standard", 20 ] ],
     "qualities": [ { "id": "GLARE", "level": 2 } ],
-    "tools": [
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
-      [ [ "welder", 50 ], [ "welder_crude", 75 ], [ "toolset", 75 ], [ "forge", 50 ], [ "oxy_torch", 10 ] ]
-    ]
+    "tools": [ [ [ "welder", 50 ], [ "welder_crude", 75 ], [ "toolset", 75 ], [ "oxy_torch", 10 ] ] ]
   },
   {
     "type": "recipe",
@@ -721,10 +718,33 @@
     "autolearn": true,
     "qualities": [ { "id": "GLARE", "level": 2 } ],
     "using": [ [ "steel_standard", 100 ] ],
-    "tools": [
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
-      [ [ "welder", 50 ], [ "welder_crude", 75 ], [ "toolset", 75 ], [ "forge", 50 ], [ "oxy_torch", 10 ] ]
-    ]
+    "tools": [ [ [ "welder", 50 ], [ "welder_crude", 75 ], [ "toolset", 75 ], [ "oxy_torch", 10 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "frame",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_VEHICLE",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "id_suffix": "forge",
+    "time": "20 m",
+    "autolearn": true,
+    "using": [ [ "steel_standard", 20 ] ],
+    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 50 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "hdframe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_VEHICLE",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "id_suffix": "forge",
+    "time": "50 m",
+    "autolearn": true,
+    "using": [ [ "steel_standard", 100 ] ],
+    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 50 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
Steel frames had the oddity that there was the requirement for glare protection, even if no torch was needed (forged). This will split those 2 recipes into a dedicated forged and welded version.