### PR TITLE
obsolete fast noodle recipe, lower volume

### DIFF
--- a/data/json/items/comestibles/wheat.json
+++ b/data/json/items/comestibles/wheat.json
@@ -481,7 +481,7 @@
     "price": 200,
     "price_postapoc": 100,
     "material": "wheat",
-    "volume": "500 ml",
+    "volume": "250 ml",
     "vitamins": [ [ "calcium", 1 ], [ "iron", 18 ] ],
     "flags": [ "EDIBLE_FROZEN" ]
   },

--- a/data/json/obsoletion/recipes.json
+++ b/data/json/obsoletion/recipes.json
@@ -3157,5 +3157,10 @@
     "type": "recipe",
     "result": "40x53mm_flechette_m169",
     "obsolete": true
+  },
+  {
+    "type": "recipe",
+    "result": "noodles_fast",
+    "obsolete": true
   }
 ]

--- a/data/json/recipes/food/pasta.json
+++ b/data/json/recipes/food/pasta.json
@@ -118,19 +118,6 @@
     ]
   },
   {
-    "result": "noodles_fast",
-    "type": "recipe",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_PASTA",
-    "skill_used": "cooking",
-    "difficulty": 4,
-    "time": "30 m",
-    "batch_time_factors": [ 50, 3 ],
-    "autolearn": true,
-    "tools": [ [ [ "surface_heat", 25, "LIST" ] ], [ [ "pastaextruder", -1 ] ] ],
-    "components": [ [ [ "flour", 7 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ]
-  },
-  {
     "result": "spaghetti_raw",
     "type": "recipe",
     "category": "CC_FOOD",


### PR DESCRIPTION
Fast noodles were odd. 500 ml of volume (where from?) and have no special use, which can't be handles by macaroni or other noodles. The recipe got obsoleted and is now found in the wild only. 250 ml is the new volume.