### PR TITLE
Add Active Exception to `deploy_furn`

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1256,8 +1256,12 @@ void deploy_furn_actor::load( const JsonObject &obj )
     furn_type = furn_str_id( obj.get_string( "furn_type" ) );
 }
 
-int deploy_furn_actor::use( player &p, item &it, bool, const tripoint &pos ) const
+int deploy_furn_actor::use( player &p, item &it, bool t, const tripoint &pos ) const
 {
+    if( t ) {
+        return 0;
+    }
+
     if( p.is_mounted() ) {
         p.add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
         return 0;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfix "Add Active Exception to `deploy_furn`"

#### Purpose of change

Arcana's candle of warding couldn't be set to active when actually active as it would proc the `deploy_furn` iuse action on every turn. A closer look revealed that it was because unlike most other iuse_actors it didn't check the bool that denoted that an item was being processed because of active item processing.

#### Describe the solution

Adds the check that most other iuse_actors use to prevent undesired triggers of iuse_actor. This merely prevents it from continuously proc'ing when active, it doesn't prevent the player from activating an item and using the `deploy_furn` action.

#### Describe alternatives you've considered

-Rework entire system so that we know what iuse actors are active/passive.
Not particularly useful unless we actually have a way to json define iuse_actors, future project?

#### Testing

Installed Arcana mod, edited candle of warding to turn active when transforming to active form. Loaded game, checked that both versions could be deployed by player activation, checked that on version of candle of warding didn't trigger `deploy_furn` every turn.

#### Additional context

Underlying system with if hooks for each iuse is kind of clunky, but for now it will suffice, reworking it should be on the agenda at some point.

Also @chaosvolt just so it's in your notifications.