### PR TITLE
Fix autoforage failing with dandelions

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9187,7 +9187,7 @@ point game::place_player( const tripoint &dest_loc )
                 const bool forage_everything = forage_type == "both";
                 const bool forage_bushes = forage_everything || forage_type == "bushes";
                 const bool forage_trees = forage_everything || forage_type == "trees";
-                if( xter_t == &iexamine::none ) {
+                if( xter_t == &iexamine::none && xfurn_t == &iexamine::none ) {
                     return;
                 } else if( ( forage_bushes && xter_t == &iexamine::shrub_marloss ) ||
                            ( forage_bushes && xter_t == &iexamine::shrub_wildveggies ) ||


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix autoforage ignoring harvestable furniture if underlying terrain has no examine action"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

After much struggling to figure out why auto-harvesting dandelions wasn't working right (only triggering when on water or other examinable terrain, hence why cattails were working, per Lamandus' findings), Coolthulhu found the exact cause pretty quickly. Figured I'd try to implement the fix for it while I've got the time.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In game.cpp, `game::place_player`, changed the section checking for auto-foraging to only bail out if both the terrain AND furniture have no examine action detected, instead of only checking for whether terrain can be examined.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Removing the check entirely, if we feel the performance hit wouldn't matter.
2. Going back to procrastination and letting Coolthlhu fix it instead.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Spawned in a world, turning "auto-forage everything" on.
3. Walked past dandelions on plain grass, confirmed they get picked up.
4. Walked past some cattails to ensure they still harvest as intended too.
5. Walked past some underbrush and birch trees to confirm their lack of any furniture present doesn't break auto-harvesting terrain.
6. Astyled affected file.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Unrelated oddity noticed while testing this: flowers like dandelion and cattails can only be harvested if "everything" is on, as there's no "autoharvest flowers" setting and they aren't counted as bushes by the code's logic.