### PR TITLE
Standardize use of stock mount gunmod slot

### DIFF
--- a/data/json/items/classes/gun.json
+++ b/data/json/items/classes/gun.json
@@ -237,7 +237,7 @@
       [ "rail mount", 1 ],
       [ "sights mount", 1 ],
       [ "sling", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "underbarrel mount", 1 ]
     ]
   },
@@ -268,7 +268,7 @@
       [ "rail mount", 1 ],
       [ "sights mount", 1 ],
       [ "sling", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "underbarrel mount", 1 ]
     ]
   },

--- a/data/json/items/classes/gun.json
+++ b/data/json/items/classes/gun.json
@@ -61,7 +61,7 @@
       [ "muzzle", 1 ],
       [ "rail", 1 ],
       [ "sights", 1 ],
-      [ "stock", 1 ],
+      [ "stock mount", 1 ],
       [ "underbarrel", 1 ]
     ]
   },
@@ -106,7 +106,7 @@
       [ "grip", 1 ],
       [ "mechanism", 4 ],
       [ "sights", 1 ],
-      [ "stock", 1 ],
+      [ "stock mount", 1 ],
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ]
@@ -127,7 +127,7 @@
       [ "barrel", 1 ],
       [ "bore", 1 ],
       [ "grip", 1 ],
-      [ "stock", 1 ],
+      [ "stock mount", 1 ],
       [ "rail mount", 1 ],
       [ "sights mount", 1 ]
     ]

--- a/data/json/items/classes/gun.json
+++ b/data/json/items/classes/gun.json
@@ -61,7 +61,7 @@
       [ "muzzle", 1 ],
       [ "rail", 1 ],
       [ "sights", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ]
   },

--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -151,7 +151,7 @@
       [ "muzzle", 1 ],
       [ "rail", 1 ],
       [ "sights", 1 ],
-      [ "stock", 1 ],
+      [ "stock mount", 1 ],
       [ "underbarrel", 1 ]
     ],
     "magazine_well": "250 ml",

--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -151,7 +151,7 @@
       [ "muzzle", 1 ],
       [ "rail", 1 ],
       [ "sights", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
     "magazine_well": "250 ml",

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -432,7 +432,7 @@
       [ "sling", 1 ],
       [ "grip mount", 1 ],
       [ "rail mount", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "underbarrel mount", 1 ]
     ],
     "magazines": [ [ "223", [ "ruger20", "ruger5", "ruger10", "ruger30", "ruger90", "ruger100", "ruger_makeshiftmag" ] ] ]

--- a/data/json/items/gun/3006.json
+++ b/data/json/items/gun/3006.json
@@ -81,7 +81,7 @@
       [ "sling", 1 ],
       [ "grip mount", 1 ],
       [ "rail mount", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "underbarrel mount", 1 ]
     ],
     "magazines": [ [ "3006", [ "3006_clip" ] ] ],

--- a/data/json/items/gun/308.json
+++ b/data/json/items/gun/308.json
@@ -129,7 +129,7 @@
       [ "sling", 1 ],
       [ "grip mount", 1 ],
       [ "rail mount", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "underbarrel mount", 1 ]
     ],
     "magazines": [ [ "308", [ "m14mag", "m14smallmag", "m14_makeshiftmag" ] ] ]
@@ -306,7 +306,7 @@
       [ "brass catcher", 1 ],
       [ "muzzle", 1 ],
       [ "sling", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "mechanism", 4 ],
       [ "sights", 1 ],
       [ "grip mount", 1 ],

--- a/data/json/items/gun/38.json
+++ b/data/json/items/gun/38.json
@@ -122,7 +122,7 @@
       [ "mechanism", 4 ],
       [ "rail", 1 ],
       [ "sights", 1 ],
-      [ "stock", 1 ],
+      [ "stock mount", 1 ],
       [ "underbarrel", 1 ]
     ]
   },
@@ -154,7 +154,7 @@
       [ "mechanism", 4 ],
       [ "rail", 1 ],
       [ "sights", 1 ],
-      [ "stock", 1 ],
+      [ "stock mount", 1 ],
       [ "underbarrel", 1 ]
     ]
   }

--- a/data/json/items/gun/40x46mm.json
+++ b/data/json/items/gun/40x46mm.json
@@ -68,7 +68,7 @@
       [ "sling", 1 ],
       [ "grip mount", 1 ],
       [ "rail mount", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "underbarrel mount", 1 ]
     ]
   },
@@ -94,7 +94,7 @@
       [ "sling", 1 ],
       [ "grip mount", 1 ],
       [ "rail mount", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "underbarrel mount", 1 ]
     ]
   },

--- a/data/json/items/gun/4570.json
+++ b/data/json/items/gun/4570.json
@@ -24,7 +24,7 @@
       [ "sights", 1 ],
       [ "sling", 1 ],
       [ "rail mount", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "underbarrel mount", 1 ]
     ],
     "flags": [ "RELOAD_ONE" ]
@@ -84,7 +84,7 @@
       [ "sights", 1 ],
       [ "sling", 1 ],
       [ "rail mount", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "underbarrel mount", 1 ]
     ],
     "flags": [ "NEVER_JAMS", "RELOAD_EJECT" ]

--- a/data/json/items/gun/flintlock.json
+++ b/data/json/items/gun/flintlock.json
@@ -12,7 +12,7 @@
       [ "grip mount", 1 ],
       [ "rail mount", 1 ],
       [ "sights mount", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "underbarrel mount", 1 ]
     ],
     "volume": "2250 ml",
@@ -91,7 +91,7 @@
       [ "grip mount", 1 ],
       [ "rail mount", 1 ],
       [ "sights mount", 1 ],
-      [ "stock mount", 1 ]
+      [ "stock", 1 ]
     ],
     "flags": [ "NEVER_JAMS", "DURABLE_MELEE" ]
   },

--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -235,7 +235,7 @@
       [ "sling", 1 ],
       [ "barrel", 1 ],
       [ "grip mount", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "rail mount", 1 ],
       [ "loading port", 1 ],
       [ "brass catcher", 1 ],
@@ -446,7 +446,7 @@
     "valid_mod_locations": [
       [ "accessories", 2 ],
       [ "sling", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "mechanism", 4 ],
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],
@@ -478,7 +478,7 @@
       [ "sights mount", 1 ],
       [ "sling", 1 ],
       [ "mechanism", 2 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "grip mount", 1 ],
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
@@ -508,7 +508,7 @@
       [ "mechanism", 1 ],
       [ "sights mount", 1 ],
       [ "sling", 1 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "grip mount", 1 ],
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
@@ -683,7 +683,7 @@
     "copy-from": "shotgun_base",
     "type": "GUN",
     "name": { "str": "M1897 Trench Gun" },
-    "description": "The Winchester 1897 was one of the first commercially successful pump action shotguns.  In its 'trench' configuraton it has become a heavily romanticized American icon of World War 1.  With its barrel shroud, bayonet lug and 17 inch bayonet, this shotgun is undeniably fearsome in appearance.  There aren't any more trenches to clear, so the next zombie infested town will have to suffice.",
+    "description": "The Winchester 1897 was one of the first commercially successful pump action shotguns.  In its 'trench' configuration it has become a heavily romanticized American icon of World War 1.  With its barrel shroud, bayonet lug and 17 inch bayonet, this shotgun is undeniably fearsome in appearance.  There aren't any more trenches to clear, so the next zombie infested town will have to suffice.",
     "weight": "3629 g",
     "volume": "2564 ml",
     "looks_like": "remington_870_express",
@@ -697,7 +697,7 @@
     "modes": [ [ "DEFAULT", "single", 1 ], [ "AUTO", "2 rd.", 2 ] ],
     "valid_mod_locations": [
       [ "accessories", 2 ],
-      [ "stock mount", 1 ],
+      [ "stock", 1 ],
       [ "mechanism", 2 ],
       [ "barrel", 1 ],
       [ "muzzle", 1 ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Standardize use of stock mount slot vs stock slot for eventual implementation of sawing off stocks"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

As mentioned in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2314, I was planning to update some issues with stock mount slots, mainly:
1. It's inconsistent, most guns in the game that have a plain wooden stock can have their stock swapped out. Example: The M1 Garand and M1918 BAR can have their stocks modified from the get-go, but not the M1903? The M24 Sniper Weapon System can't have an adjustable stock (standard on the A2 version IRL) slapped on it by default? It seems to me like this would be better served using it primarily to represent guns that don't have a stock to begin with.
2. One of these days I plan to add some way to saw stocks off, and that would rather obviously go on the stock slot like sawing down barrels does. Now that https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2318 includes a check for whether the gun is a pistol and filters out non-wood guns, the need to have pistols all use the stock mount slot is toned down, but would still be reasonable for older pistols.

Fixing impossible mount installations quickly become its own entire thing so I had to shift this to a separate PR.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In json/items/classes/gun.json, updated `shotgun_base` and `shotgun_pump_3gun` to have stock slot instead of stock mount. Also changed stock to stock mount for `pistol_revolver` and `pistol_revolver_cap_ball`.
2. In json/items/gun/223.json, updated the Ruger Mini-14 to have a stock instead of stock mount, as it's a standard wood-furniture rifle inheriting from `rifle_semi`.
3. In json/items/gun/3006.json, updated the M1903 Springfield to have a stock instead of stock mount, being a standard wood-furniture rifle inheriting from `rifle_manual` (along with being one of the notable examples of inconsistency as mentioned above).
4. In json/items/gun/308.json, updated the M1A and M24 to have a stock instead of stock mount, being consistent with other wood-furniture rifles and one of the mentioned tacticool inconsistencies respectively.
5. In json/items/gun/38.json, updated the Ruger LCR .38 and S&W 619 to have stock mount instead of stock, as they're both standard revolvers.
6. In json/items/gun/40x46mm.json, gave the M79 launcher and Milkor MGL a stock instead of stock mount, the former being a typical fixed wooden stock and the latter technically comes with a folding or sliding stock standard anyway.
7. In json/items/gun/4570.json, updated the Marlin 1895 SBL and 1874 Sharps to have a stock instead of stock mount, being standard lever-action rifles with wooden furniture.
8. In json/items/gun/flintlock.json, updated the flintlock carbine and rifle to have a stock instead of stock mount, being basic wooden-furniture rifles.
9. In json/items/gun/shot.json, updated the Mossberg 930 SPX, Saiga-12, double barrel shotgun, single barrel shotgun, and M1897 Trench Gun to have a stock instead of stock mount, all of them being bog-standard shotties with a shoulder stock. The double-barrel in particular will be handy to stockify for proper Mad Max'ifcation when we eventually have the ability to saw off stocks.
10. Minor: Fixed a typo in description of trench gun spotted along the way.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Giving homemade guns stocks whenever their description mentions having a stock and the recipe includes wood, and removing any reference to an existing stock if the recipe doesn't include material for a stock. For example, the pipe guns tend to mention having a stock in their description and do include wood.
2. Alternatively, removing the mention of stocks, wood submaterial, and use of wood in pipe gun recipes since most real-world 3/4-inch pipe shotties are pure pipe slamfire affairs.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Side note: even with the volume reduction of 2/3 that (tested with a folding stock) and sawing down the barrel, a double-barreled shotgun still won't fit in even an XL holster. I recall @Lamandus may have had a plan to buff capacity of holsters though?

Then again, given how pathetic the amounts shaved off by most barrel lengths are, and the fact I'm not yet 100% sure how much volume stock removal will be balanced towards in the future, the minimum buffing needed to accommodate appropriately mad-max'd guns isn't quite set in stone yet anyway.