### PR TITLE
Fix Grid Welding Rig

### DIFF
--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -1001,10 +1001,11 @@
     "id": "f_welderrig",
     "copy-from": "f_gridwelder",
     "looks_like": "weldrig",
-    "name": "grid welder rig",
+    "name": "grid welding rig",
     "symbol": "#",
     "color": "red",
     "description": "A vehicle welding rig connected to a electrical grid.  Has a soldering iron attached.",
+    "extend": { "crafting_pseudo_item": [ "fake_gridsolderingiron" ] },
     "deconstruct": {
       "items": [ { "item": "weldrig", "count": 1 }, { "item": "cable", "charges": 5 }, { "item": "power_supply", "count": 1 } ]
     },


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix Grid Welding Rig"

#### Purpose of change

#2187 accidentally removed my update to grid welding rigs that allows them to double as soldering irons.

#### Describe the solution

Reverts the change and renames the furniture item while I'm at it since grid welder rig sounds weird.

#### Describe alternatives you've considered

Ignore?

#### Testing

Checked that once updated the game recognizes it as a grid soldering iron and allows it's use in crafting.

#### Additional context
