### PR TITLE
Port over sawing off stocks, plus adjustments

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -231,6 +231,11 @@
   },
   {
     "type": "item_action",
+    "id": "saw_stock",
+    "name": { "str": "Saw down stock" }
+  },
+  {
+    "type": "item_action",
     "id": "ACIDBOMB_ACT",
     "name": { "str": "Activate" }
   },

--- a/data/json/items/gunmod/stock.json
+++ b/data/json/items/gunmod/stock.json
@@ -125,7 +125,7 @@
     "location": "stock",
     "mod_targets": [ "smg", "rifle", "shotgun" ],
     "dispersion_modifier": 100,
-    "weight_multiplier": 0.8,
+    "weight_multiplier": 0.75,
     "handling_modifier": -15,
     "flags": [ "COLLAPSIBLE_STOCK", "IRREMOVABLE" ]
   }

--- a/data/json/items/gunmod/stock.json
+++ b/data/json/items/gunmod/stock.json
@@ -112,5 +112,21 @@
     "mod_targets": [ "rifle" ],
     "dispersion_modifier": -1,
     "handling_modifier": 5
+  },
+  {
+    "id": "stock_small",
+    "type": "GUNMOD",
+    "name": { "str": "shortened stock" },
+    "description": "Removing the stock results in markedly reduced accuracy and recoil handling, but also greatly improves the ease with which the weapon can be carried and wielded.",
+    "integral_volume": "0 ml",
+    "material": [ "wood" ],
+    "symbol": ":",
+    "color": "light_gray",
+    "location": "stock",
+    "mod_targets": [ "smg", "rifle", "shotgun" ],
+    "dispersion_modifier": 100,
+    "weight_multiplier": 0.8,
+    "handling_modifier": -15,
+    "flags": [ "COLLAPSIBLE_STOCK", "IRREMOVABLE" ]
   }
 ]

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -70,7 +70,7 @@
     "type": "tool_quality",
     "id": "SAW_W",
     "name": { "str": "wood sawing" },
-    "usages": [ [ 2, [ "LUMBER" ] ] ]
+    "usages": [ [ 2, [ "LUMBER", "saw_stock" ] ] ]
   },
   {
     "type": "tool_quality",

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1405,6 +1405,33 @@ class saw_barrel_inventory_preset: public weapon_inventory_preset
         const saw_barrel_actor &actor;
 };
 
+class saw_stock_inventory_preset : public weapon_inventory_preset
+{
+    public:
+        saw_stock_inventory_preset( const player &p, const item &tool, const saw_stock_actor &actor ) :
+            weapon_inventory_preset( p ), p( p ), tool( tool ), actor( actor ) {
+        }
+
+        bool is_shown( const item_location &loc ) const override {
+            return loc->is_gun();
+        }
+
+        std::string get_denial( const item_location &loc ) const override {
+            const auto ret = actor.can_use_on( p, tool, *loc );
+
+            if( !ret.success() ) {
+                return trim_punctuation_marks( ret.str() );
+            }
+
+            return std::string();
+        }
+
+    private:
+        const player &p;
+        const item &tool;
+        const saw_stock_actor &actor;
+};
+
 class salvage_inventory_preset: public inventory_selector_preset
 {
     public:
@@ -1470,6 +1497,25 @@ item_location game_menus::inv::saw_barrel( player &p, item &tool )
 
     return inv_internal( p, saw_barrel_inventory_preset( p, tool, *actor ),
                          _( "Saw barrel" ), 1,
+                         _( "You don't have any guns." ),
+                         string_format( _( "Choose a weapon to use your %s on" ),
+                                        tool.tname( 1, false )
+                                      )
+                       );
+}
+
+item_location game_menus::inv::saw_stock( player &p, item &tool )
+{
+    const auto actor = dynamic_cast<const saw_stock_actor *>
+                       ( tool.type->get_use( "saw_stock" )->get_actor_ptr() );
+
+    if( !actor ) {
+        debugmsg( "Tried to use a wrong item." );
+        return item_location();
+    }
+
+    return inv_internal( p, saw_stock_inventory_preset( p, tool, *actor ),
+                         _( "Saw stock" ), 1,
                          _( "You don't have any guns." ),
                          string_format( _( "Choose a weapon to use your %s on" ),
                                         tool.tname( 1, false )

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -96,6 +96,8 @@ item_location wield( avatar &you );
 item_location holster( player &p, item &holster );
 /** Choosing a gun to saw down it's barrel. */
 item_location saw_barrel( player &p, item &tool );
+/** Choosing a gun to saw down its barrel. */
+item_location saw_stock( player &p, item &tool );
 /** Choose item to wear. */
 item_location wear( player &p );
 /** Choose item to take off. */

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -140,6 +140,7 @@ static const itype_id itype_joint_roach( "joint_roach" );
 static const itype_id itype_plut_cell( "plut_cell" );
 static const itype_id itype_rad_badge( "rad_badge" );
 static const itype_id itype_tuned_mechanism( "tuned_mechanism" );
+static const itype_id itype_stock_small( "stock_small" );
 static const itype_id itype_UPS( "UPS" );
 static const itype_id itype_bio_armor( "bio_armor" );
 static const itype_id itype_waterproof_gunmod( "waterproof_gunmod" );
@@ -4743,6 +4744,9 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
     if( gunmod_find( itype_barrel_small ) ) {
         modtext += _( "sawn-off " );
     }
+    if( gunmod_find( itype_stock_small ) ) {
+        modtext += _( "pistol " );
+    }
     if( has_flag( flag_DIAMOND ) ) {
         modtext += std::string( pgettext( "Adjective, as in diamond katana", "diamond" ) ) + " ";
     }
@@ -5129,23 +5133,7 @@ units::volume item::volume( bool integral ) const
         // TODO: implement stock_length property for guns
         if( has_flag( flag_COLLAPSIBLE_STOCK ) ) {
             // consider only the base size of the gun (without mods)
-            int tmpvol = get_var( "volume",
-                                  ( type->volume - type->gun->barrel_length ) / units::legacy_volume_factor );
-            if( tmpvol <= 3 ) {
-                // intentional NOP
-            } else if( tmpvol <= 5 ) {
-                ret -= 250_ml;
-            } else if( tmpvol <= 6 ) {
-                ret -= 500_ml;
-            } else if( tmpvol <= 9 ) {
-                ret -= 750_ml;
-            } else if( tmpvol <= 12 ) {
-                ret -= 1000_ml;
-            } else if( tmpvol <= 15 ) {
-                ret -= 1250_ml;
-            } else {
-                ret -= 1500_ml;
-            }
+            ret -= ( type->volume / 3 );
         }
 
         if( gunmod_find( itype_barrel_small ) ) {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1074,6 +1074,7 @@ void Item_factory::init()
     add_actor( std::make_unique<place_trap_actor>() );
     add_actor( std::make_unique<emit_actor>() );
     add_actor( std::make_unique<saw_barrel_actor>() );
+    add_actor( std::make_unique<saw_stock_actor>() );
     add_actor( std::make_unique<install_bionic_actor>() );
     add_actor( std::make_unique<detach_gunmods_actor>() );
     add_actor( std::make_unique<mutagen_actor>() );

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1142,6 +1142,18 @@ class saw_barrel_actor : public iuse_actor
         ret_val<bool> can_use_on( const player &p, const item &it, const item &target ) const;
 };
 
+class saw_stock_actor : public iuse_actor
+{
+    public:
+        saw_stock_actor( const std::string &type = "saw_stock" ) : iuse_actor( type ) {}
+
+        void load( const JsonObject &jo ) override;
+        int use( player &p, item &it, bool t, const tripoint &pnt ) const override;
+        std::unique_ptr<iuse_actor> clone() const override;
+
+        ret_val<bool> can_use_on( const player &p, const item &it, const item &target ) const;
+};
+
 class install_bionic_actor : public iuse_actor
 {
     public:


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Features "Port over and adjust sawing off of firearm stocks"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This PR aims to implement sawing off stocks, and in the process also simplifies the behavior of stock-modified weapons. The goal here is to set it so, combined with https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2315 and https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2316, it will be possible to saw off the barrel and stock of a double-barreled shotgun and have it just about fit in an XL holster.

Makes use of some of changes in DDA's implementation of the idea, with some changes.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Defined a stock gunmod in json/items/gunmod/stock.json. Unlike the shortened barrel's effects, the actual gameplay effects of the shortened stock are handled purely through the gunmod for visibly, utilizing the same flag as other stock modifications along with the weight reduction. This accordingly makes removing the stock better overall for volume reduction than most barrel removals but less efficient at weight reduction (as would be expected since you're taking off wood rather than metal). Notable effects are 100 dispersion (1/3 more than shortened barrel), and -15 to recoil handling.
2. Ported over item action addition to wood sawing quality.
3. Simplified volume reduction effect of a short stock. Instead of a fiddly set of volume reductions in stages of gun volume, it now simply reduces volume to two-thirds the base volume. Changes in barrel length also no longer affect this, for simlicity of calculation (in particular so that it's easier to determine what combination of item volume and barrel length is needed for a fully-sawed-down gun to hit a given target volume).
4. Ported over stock-sawing use action and related functions.
5. Ported over changes adding to item tagtext with sawed-down stock. Had to convert it to be player-centric instead of character-centric before it'd compile. Check for stock accessories was removed since that slot doesn't exist in BN. Logic for checking is a bit more thorough, in addition to failing guns that have a modified stock it also excludes the stock mount (because the PR converting that stock to be used for stuff that doesn't come with a stock), also bails out if the gun is a pistol (just in case BN or a mod adds any C96-style pistols that logically shouldn't have a stock to begin with but start off compatible with the pistol stock)

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Keeping the weird stock volume reduction system and just buffing maximum capacity of XL holster from 1.25 liters to 1.5 liters.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested.
2. Briefly ported over the relevant JSON changes to double barrel shotgun from the sister PRs (namely giving it stock slot and changing barrel length).
3. Confirmed that sawing off the stock reduced volume of double barrel shotgun from 2946 mL to 1964 mL.
4. Confirmed that combining this with the current planned 750 mL reduction from the barrel PR it becomes 1214 mL, and thus barely fits in an XL holster.
5. Confirmed an M1 Garand can be sawn down just fine, but can't be sawn down twice nor if a folding stock is installed, and that the intended failure messages for those cases occur.
6. Confirmed that an AR-15 can't be sawn down because not made of wood, and Ruger LCP fails due to lack of stock before it fails due to being non-wooden.
7. Confirmed that M1911 fails due to lack of a stock despite having a stock slot in this branch.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Original PR: Sawed off stocks, by @bombasticSlacks: https://github.com/CleverRaven/Cataclysm-DDA/pull/58936