### PR TITLE
Allow uncrafting signal flares

### DIFF
--- a/data/json/uncraft/ammo/signal_flare.json
+++ b/data/json/uncraft/ammo/signal_flare.json
@@ -1,0 +1,12 @@
+[
+  {
+    "result": "signal_flare",
+    "type": "uncraft",
+    "skill_used": "gun",
+    "difficulty": 5,
+    "time": "1 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "shot_hull", 1 ] ], [ [ "shotgun_primer", 1 ] ], [ [ "incendiary", 25 ] ] ],
+    "charges": 1
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Allow disassembling signal flares for materials"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Thing thing I'd been wanting to do for a while was be able to uncraft signal flares. Because of the standard that shotshells use cutting quality instead of bullet pulling, this warrants assigning it an uncraft rather that making the recipe reversible like one would normally do.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added an uncraft result for signal flares, based off the uncraft for 00 shot and returning all the things the signal flare recipe requires as components. Realistically 12 guage flare rounds are often longer than normal shotshells, but that only really concerns crafting them in the first place since if there was excess material it could be cut down to length.
2. Also updated its tool requirements to be consistent with other shotshell recipes. This way the reversal code knows to set it to use cutting quality instead of pulling quality, as with the other shotshells.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Coding in a use action that shoots the flare into the air would be interesting, but not really necessary. Only other use we'd have for that would be if we could code it so that NPCs treat the location directly under a mid-air flare as a point of interest to investigate, but I assume that'd be fiddly and also of limited interest, not to mention hard to code.
2. Setting it to leave a luminescent field instead of dropping a lit hand flare, or else adding a variant lit flare item that has 1/3 the light intensity and duration of a hand flare (as signal flares use 1/3 as much incendiary as hand flares yield when uncrafted). Having it leave behind dead hand flares might be a bit abnormal after all.
3. Letting you load signal flares into shotguns for the hell of it. Technically you can do that with the long signal flares if you have a break-action shotgun or are able to wrangle with chambering it directly, otherwise I wouldn't expect it to feed from a tube magazine.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and lint errors.
2. Ported file over to test build.
3. Confirmed that signal flares can be uncrafted and that they use cutting quality to do so.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
