### PR TITLE
Winter boots now take 2 hours to craft

### DIFF
--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -223,7 +223,7 @@
     "subcategory": "CSC_ARMOR_FEET",
     "skill_used": "tailor",
     "difficulty": 6,
-    "time": "6 h",
+    "time": "2 h",
     "autolearn": true,
     "using": [ [ "sewing_standard", 80 ] ],
     "components": [ [ [ "felt_patch", 20 ] ], [ [ "bag_plastic", 8 ] ] ]


### PR DESCRIPTION
Crafting winter boots takes extremly long with 6 hours. It reduces it to 2 hours, to fit more to the "non survivor stuff" crafting times.