### PR TITLE
Maintenance for No Fungal Monsters mod

### DIFF
--- a/data/mods/No_Fungi/comestibles.json
+++ b/data/mods/No_Fungi/comestibles.json
@@ -2,60 +2,48 @@
   {
     "type": "COMESTIBLE",
     "id": "marloss_berry",
-    "name": { "str": "berry-shaped anomaly", "str_pl": "berry-shaped anomalies" },
-    "weight": "177 g",
-    "color": "pink",
+    "copy-from": "marloss_berry",
+    "name": { "str": "marloss berry", "str_pl": "marloss berries" },
     "use_action": "BLECH",
-    "comestible_type": "FOOD",
-    "symbol": "%",
-    "description": "If we left this as it should be, one could just walk into the Bloom uncontested and partake of the Fruit.  We can't have that, can we?",
-    "material": "fruit",
-    "volume": "250 ml",
-    "charges": 1,
-    "stack_size": 4
+    "extend": { "flags": [ "UNSAFE_CONSUME" ] }
   },
   {
     "type": "COMESTIBLE",
     "id": "marloss_seed",
-    "name": { "str": "seed-shaped anomaly", "str_pl": "seed-shaped anomalies" },
-    "weight": "177 g",
-    "color": "cyan",
+    "copy-from": "marloss_seed",
+    "name": { "str": "Marloss seed" },
     "use_action": "BLECH",
-    "comestible_type": "FOOD",
-    "symbol": ".",
-    "description": "If we left this as it should be, one could just walk into the Garden uncontested and partake of the Seed.  We can't have that, can we?",
-    "material": "fruit",
-    "charges": 1,
-    "stack_size": 10
+    "extend": { "flags": [ "UNSAFE_CONSUME" ] }
   },
   {
     "type": "COMESTIBLE",
     "id": "marloss_gel",
-    "name": { "str": "gelatin", "str_pl": "marloss gelatin" },
-    "weight": "177 g",
-    "color": "yellow",
+    "copy-from": "marloss_gel",
+    "name": { "str_sp": "marloss gelatin" },
     "use_action": "BLECH",
-    "comestible_type": "FOOD",
-    "symbol": "~",
-    "description": "If we left this as it should be, one could just walk into the Spire uncontested and partake of the Sap.  Wait, how did you even GET this anyway?",
-    "material": "fruit",
-    "charges": 1,
-    "stack_size": 10,
-    "fun": 30
+    "extend": { "flags": [ "UNSAFE_CONSUME" ] }
   },
   {
     "type": "COMESTIBLE",
     "id": "mycus_fruit",
-    "name": { "str": "fruit-shaped anomaly", "str_pl": "fruit-shaped anomalies" },
-    "weight": "354 g",
-    "color": "light_gray",
+    "copy-from": "mycus_fruit",
+    "name": { "str": "mycus fruit" },
     "use_action": "BLECH",
-    "comestible_type": "FOOD",
-    "symbol": "%",
-    "description": "We do not exist at the moment.  Clever little human, no doubt debugging to see this?  We will not permit you to join us while we are modded out.",
-    "material": "fruit",
-    "volume": "250 ml",
-    "charges": 1,
-    "stack_size": 4
+    "extend": { "flags": [ "UNSAFE_CONSUME" ] }
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "wine_mycus",
+    "copy-from": "wine_mycus",
+    "name": { "str_sp": "marloss wine" },
+    "use_action": "BLECH"
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "brew_mycus_wine",
+    "copy-from": "brew_mycus_wine",
+    "name": { "str_sp": "marloss wine must" },
+    "use_action": "BLECH",
+    "extend": { "flags": [ "UNSAFE_CONSUME" ] }
   }
 ]

--- a/data/mods/No_Fungi/furniture.json
+++ b/data/mods/No_Fungi/furniture.json
@@ -1,50 +1,20 @@
 [
   {
     "type": "furniture",
-    "id": "f_flower_fungal",
-    "name": "fungal flower",
-    "description": "",
-    "symbol": "f",
-    "color": "dark_gray",
-    "move_cost_mod": 1,
-    "required_str": -1,
-    "flags": [ "TRANSPARENT", "FLOWER", "FUNGUS", "TINY", "FLAMMABLE_ASH" ],
-    "bash": { "str_min": 2, "str_max": 6, "sound": "poof.", "sound_fail": "poof." }
-  },
-  {
-    "type": "furniture",
     "id": "f_flower_marloss",
+    "copy-from": "f_flower_marloss",
     "name": "marloss flower",
-    "description": "",
     "symbol": "f",
     "color": "cyan",
-    "move_cost_mod": 1,
-    "required_str": -1,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "FUNGUS", "TINY" ],
-    "bash": { "str_min": 2, "str_max": 6, "sound": "poof.", "sound_fail": "poof." }
+    "examine_action": "harvested_plant"
   },
   {
     "type": "furniture",
-    "id": "f_fungal_mass",
-    "name": "fungal mass",
-    "description": "Thick ropes of mycal matter have covered the ground here completely.  It's soft to the touch, but you sink into it, making moving across it difficult.",
-    "symbol": "O",
-    "bgcolor": "dark_gray",
-    "move_cost_mod": -10,
-    "required_str": -1,
-    "flags": [ "CONTAINER", "SEALED", "ALLOW_FIELD_EFFECT", "FLAMMABLE_ASH", "FUNGUS", "MOUNTABLE", "SHORT" ],
-    "bash": { "str_min": 6, "str_max": 30, "sound": "poof.", "sound_fail": "poof." }
-  },
-  {
-    "type": "furniture",
-    "id": "f_fungal_clump",
-    "name": "fungal clump",
-    "description": "Alien mold and stems mingle tightly here, creating a sort of fungal bush.",
-    "symbol": "#",
-    "bgcolor": "light_gray",
-    "move_cost_mod": 3,
-    "required_str": -1,
-    "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "ALLOW_FIELD_EFFECT", "FLAMMABLE_ASH", "FUNGUS", "MOUNTABLE", "SHORT" ],
-    "bash": { "str_min": 6, "str_max": 20, "sound": "poof.", "sound_fail": "poof." }
+    "id": "f_flower_fungal",
+    "copy-from": "f_flower_fungal",
+    "name": "fungal flower",
+    "symbol": "f",
+    "color": "dark_gray",
+    "examine_action": "harvested_plant"
   }
 ]

--- a/data/mods/No_Fungi/recipes.json
+++ b/data/mods/No_Fungi/recipes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "recipe",
+    "result": "brew_mycus_wine",
+    "obsolete": true
+  }
+]

--- a/data/mods/No_Fungi/terrain.json
+++ b/data/mods/No_Fungi/terrain.json
@@ -2,148 +2,19 @@
   {
     "type": "terrain",
     "id": "t_marloss",
+    "copy-from": "t_marloss",
     "name": "marloss bush",
-    "description": "",
     "symbol": "#",
-    "color": "dark_gray",
-    "move_cost": 8,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "SHRUB", "FUNGUS", "SHORT" ],
-    "bash": { "str_min": 4, "str_max": 60, "sound": "crunch.", "sound_fail": "poof!", "ter_set": "t_fungus" }
-  },
-  {
-    "type": "terrain",
-    "id": "t_fungus",
-    "name": "fungal bed",
-    "description": "Fungus grows thick here, obscuring the ground beneath it.",
-    "symbol": ".",
-    "color": "light_gray",
-    "move_cost": 3,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "DIGGABLE", "FUNGUS", "NOCOLLIDE" ],
-    "bash": {
-      "sound": "smash",
-      "//": "muffled because fungus",
-      "ter_set": "t_null",
-      "str_min": 20,
-      "str_max": 400,
-      "str_min_supported": 50
-    }
-  },
-  {
-    "type": "terrain",
-    "id": "t_fungus_floor_in",
-    "name": "fungal floor",
-    "description": "Grayish mold coats both the floor and the roof here, silent and still.  Stray spores waft through the air.",
-    "//": "roofed",
-    "symbol": ".",
-    "color": "light_gray",
-    "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "FUNGUS" ],
-    "bash": { "sound": "smash", "ter_set": "t_null", "str_min": 20, "str_max": 400, "str_min_supported": 50 }
-  },
-  {
-    "type": "terrain",
-    "id": "t_fungus_floor_sup",
-    "name": "fungal floor",
-    "description": "Grayish mold coats the floor here, silent and still.",
-    "//": "supports",
-    "symbol": ".",
-    "color": "light_gray",
-    "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "SUPPORTS_ROOF", "FLAT", "FUNGUS" ],
-    "bash": { "sound": "smash", "ter_set": "t_null", "str_min": 20, "str_max": 400, "str_min_supported": 50 }
-  },
-  {
-    "type": "terrain",
-    "id": "t_fungus_floor_out",
-    "name": "fungal floor",
-    "description": "Grayish mold coats the ground here, silent and still.",
-    "//": "outside",
-    "symbol": ".",
-    "color": "light_gray",
-    "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "FLAT", "FUNGUS" ],
-    "bash": { "sound": "SMASH!", "ter_set": "t_null", "str_min": 20, "str_max": 400, "str_min_supported": 50 }
-  },
-  {
-    "type": "terrain",
-    "id": "t_fungus_wall",
-    "alias": [ "t_fungus_wall_h", "t_fungus_wall_v" ],
-    "name": "fungal wall",
-    "description": "Several thick, large tendrils of fungus perforate the wall here, piercing straight through it from the outside.  Despite the apparent damage, the wall is still structurally sound.",
-    "symbol": "O",
-    "color": "dark_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "FUNGUS", "WALL", "MINEABLE" ],
-    "bash": { "str_min": 30, "str_max": 180, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
-  },
-  {
-    "type": "terrain",
-    "id": "t_fungus_wall_transformed",
-    "name": "fungal wall",
-    "description": "The fungus here has grown thickly and tightly enough to form a solid wall.  It feels very stiff to the touch, and seems to be very strong.",
-    "symbol": "LINE_OXOX",
-    "color": "dark_gray",
-    "move_cost": 0,
-    "coverage": 100,
-    "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "FUNGUS", "WALL", "AUTO_WALL_SYMBOL", "MINEABLE" ],
-    "bash": { "str_min": 30, "str_max": 180, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
-  },
-  {
-    "type": "terrain",
-    "id": "t_fungus_mound",
-    "name": "fungal mound",
-    "description": "A mound of fungal matter, intertwined in itself.",
-    "symbol": "#",
-    "color": "light_gray",
-    "move_cost": 4,
-    "flags": [ "TRANSPARENT", "THIN_OBSTACLE", "FLAMMABLE_ASH", "FUNGUS", "MOUNTABLE" ],
-    "bash": { "str_min": 10, "str_max": 70, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
-  },
-  {
-    "type": "terrain",
-    "id": "t_shrub_fungal",
-    "name": "fungal shrub",
-    "description": "This shrub has been completely absorbed by the mushrooms.  Its branches droop and have lost much of their structure, and its leaves have vanished, replaced by fleshy gray sacks that visibly expand and contract.",
-    "symbol": "#",
-    "color": "dark_gray",
-    "move_cost": 8,
-    "coverage": 40,
-    "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "PLACE_ITEM", "SHRUB", "FUNGUS", "SHORT" ],
-    "bash": { "str_min": 4, "str_max": 60, "sound": "crunch.", "sound_fail": "poof!", "ter_set": "t_fungus" }
-  },
-  {
-    "type": "terrain",
-    "id": "t_tree_fungal",
-    "name": "fungal tree",
-    "description": "Once tall and majestic, this tree is now a slave to the fungus like the landscape around it.  Its bark is penetrated by and covered with fungal tendrils, and the canopy has rotted away, leaving only the branches, stretching forlornly to the sky as if to escape the infection overrunning it.",
-    "symbol": "7",
-    "color": "dark_gray",
-    "move_cost": 0,
-    "coverage": 80,
-    "flags": [ "FLAMMABLE_ASH", "NOITEM", "FUNGUS", "TREE", "REDUCE_SCENT" ],
-    "bash": { "str_min": 40, "str_max": 180, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
-  },
-  {
-    "type": "terrain",
-    "id": "t_tree_fungal_young",
-    "name": "young fungal tree",
-    "description": "A small sapling poking through the ground, infested by fungal mold.",
-    "symbol": "1",
-    "color": "dark_gray",
-    "move_cost": 4,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "NOITEM", "FUNGUS", "YOUNG", "REDUCE_SCENT" ],
-    "bash": { "str_min": 4, "str_max": 50, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
+    "color": "pink",
+    "examine_action": "harvested_plant"
   },
   {
     "type": "terrain",
     "id": "t_marloss_tree",
+    "copy-from": "t_marloss_tree",
     "name": "marloss tree",
-    "description": "",
     "symbol": "7",
-    "color": "dark_gray",
-    "move_cost": 0,
-    "flags": [ "FLAMMABLE_ASH", "NOITEM", "FUNGUS", "TREE", "REDUCE_SCENT" ],
-    "bash": { "str_min": 40, "str_max": 180, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
+    "color": "pink",
+    "examine_action": "harvested_plant"
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Mods "Update No Fungal Monsters mod with much-needed JSON modernization and maintenance"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I noticed during gameplay that a marloss gelatin dropped from a zombie scientist (90% certain it was some weird luck with Arcana's injection of magitech and biological samples into their monsterdrop entry) and realized that the item is pretty old and jank:

![image](https://user-images.githubusercontent.com/11582235/216749103-bddb28ae-3dd0-45ee-9e8c-080f123dda49.png)

Reason for it is No Fungal Monsters mod, despite being still available and certainly still a mod I personally use out of force of habit, could use a touch of updating. In particular, evidently whenever I ages ago figured out how to set fungal spires to not spawn, I forgot to account for the fact that the items no longer really need to have any big tweaks made to them, since they won't spawn in vanilla with the mod enabled. What little tweaking could reasonably be made to them is perfectly fine to do via self-copy-from these days, too.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Converted the edits to marloss items to rely on self-copy-from, stripping them down to just overriding the use action from fungal-related ones to `BLECH`, adding in `UNSAFE_CONSUME` where needed. Now with 200% snarking at players who were assumed to have only been able to obtain these items through debug.
2. Added new overrides to mycus wine and mycus wine must as well.
3. Added an obsoletion entry to the recipe for mycus wine must for NFM.
4. Shaved down overrides of fungal terrain and furniture. I would set it to retain overrides for all fungal terrain removing the `FUNGUS` flag, but from the look of it the fungal flag is important to sanity-check fungal terrain conversion code. This seems to be why full overrides in the mod previously kept the fungal flag. As such, if we can't remove fungal flag from the terrain then we only need to keep overrides that require removal of fungus-specific use actions.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Removing `FUNGAL` flag from all relevant terrain and furniture anyway and just accepting that the player being spored by playing with the few other sources of fungal terrain is probably more common than something deciding to exist in a form that can cast fungalize on the terrain.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Load-tested the mod in compiled build.
3. Spawned in a marloss bush and marloss flower, confirmed they just tell you there's nothing to yoink from them.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

I'll probably pair this with an update to arcana removing any fungal-related items from itemgroups just in case.