### PR TITLE
Adjust "protected from rot" lines in item description

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -385,7 +385,8 @@ class item : public visitable<item>
          */
         /*@{*/
         std::string info_string() const;
-        std::string info_string( const iteminfo_query &parts, int batch = 1 ) const;
+        std::string info_string( const iteminfo_query &parts, int batch = 1,
+                                 temperature_flag temperature = temperature_flag::TEMP_NORMAL ) const;
         /*@}*/
 
         /* type specific helper functions for info() that should probably be in itype() */

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -432,11 +432,11 @@ TEST_CASE( "food freshness and lifetime", "[item][iteminfo][food]" )
         test_info_equals(
             nuts, q,
             "--\n"
-            "* This food is <color_c_yellow>perishable</color>, and at room temperature has"
-            " an estimated nominal shelf life of <color_c_cyan>3 seasons</color>.\n"
+            "* This food is <color_c_yellow>perishable</color>, and at room temperature"
+            " has an estimated nominal shelf life of <color_c_cyan>3 seasons</color>.\n"
             "* Current storage conditions <color_c_yellow>partially</color> protect this"
             " item from rot.  It will stay fresh at least <color_c_cyan>3 years</color>.\n"
-            "* This food looks <color_c_red>old</color>.  It's on the brink of becoming inedible.\n",
+            "* This food looks as <color_c_green>fresh</color> as it can be.\n",
             temperature_flag::TEMP_FRIDGE
         );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Interface "Adjust 'protected from rot' lines in item description"

#### Purpose of change

Making the new "item is protected from rot" descriptions less confusing.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution

* Don't show duration for unprotected items - it was remaining shelf life divided by ~6
* Fix "indefinite" duration for contained items - it tried to show rot duration for the container

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

1. Spawn a burger, confirm it has no duration line
2. Spawn a fridge, turn it on, give it power
3. Spawn a jug of milk and store it in the fridge
4. Confirm it has sane guaranteed freshness time in description

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
