### PR TITLE
Recharging relics now behave with ammo type

### DIFF
--- a/data/mods/TEST_DATA/relic_test.json
+++ b/data/mods/TEST_DATA/relic_test.json
@@ -141,6 +141,7 @@
     "id": "test_relic_armor_recharge_fatigue_cts",
     "copy-from": "test_relic_tool_armor",
     "name": "TEST relic armor recharge fatigue skin",
+    "ammo": [ "thread" ],
     "relic_data": {
       "recharge_scheme": [
         {

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -434,7 +434,13 @@ bool process_recharge_entry( item &itm, const relic_recharge &rech, Character &c
             std::abort();
         }
     }
-    itm.charges = clamp( itm.charges + rech.rate, 0, itm.ammo_capacity() );
+    // If relic has a valid ammo type, make sure the first charge loaded isn't a "none"
+    if( !itm.ammo_types().empty() && itm.charges == 0 ) {
+        itm.charges = clamp( itm.charges + rech.rate, 0, itm.ammo_capacity() );
+        itm.ammo_set( itm.ammo_default(), itm.charges );
+    } else {
+        itm.charges = clamp( itm.charges + rech.rate, 0, itm.ammo_capacity() );
+    }
     if( rech.message ) {
         carrier.add_msg_if_player( _( *rech.message ) );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Recharging relics assigned an ammotype no longer create none when unloaded"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A problem I'd noticed with the old artifact recharge mechanics, one also brought to recharging relics, was that a recharging artifact/relic does not play nice with having an ammo type assigned to it. If loaded with ammo beforehand it'd work fine, but if you let it recharge from empty, trying to unload the charges would print and error and give you a `none` instead.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In relic.cpp, changed `process_recharge_entry` to check for if the item has an ammotype assigned, and if it's currently empty. If so it proceeds as normal then promptly calls `ammo_set` to convert its charges into the default ammo type. Otherwise (i.e. no ammotype or already been loaded with ammo) it continues on with its original behavior.
2. Changed `test_relic_tool_armor` in test data mod to have an ammo type of `thread`, for testing purposes.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Procrastinating and/or relying on cast spell hackery to work around this.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested.
2. Started up a world and temporarily un-obsoleted test data mod to make use of it.
3. Spawned in and started giving myself debug recharging relics.
4. Confirmed that `TEST relic recharge time none (silent)` still gains 2 charges at a time every few seconds.
5. Confirmed that `TEST relic armor recharge fatigue skin` recharges at the same rate and exhausts you when worn under skin.
6. Unloaded the latter after having emptied it and allowed it to charge once, confirmed I got 2 units of thread and not `none`.
7. Spawned in 5 sinew, loaded it into the latter relic.
8. Let it recharge, unloaded and confirmed I now had 7 sinew.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Will also set aside an Arcana self-PR to update the restored ritual blade and the like soon-ish.