### PR TITLE
Updates to putting self out when on fire

### DIFF
--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -1009,13 +1009,13 @@ void do_pause( Character &who )
             // TODO: Tools and skills
             total_left += eff.get_duration();
             // Being on the ground will smother the fire much faster because you can roll
-            const time_duration dur_removed = on_ground ? eff.get_duration() / 2 + 2_turns : 1_turns;
+            const time_duration dur_removed = on_ground ? eff.get_duration() / 2 + 2_turns : 5_turns;
             eff.mod_duration( -dur_removed );
             total_removed += dur_removed;
         }
 
         // Don't drop on the ground when the ground is on fire
-        if( total_left > 1_minutes && !who.is_dangerous_fields( here.field_at( who.pos() ) ) ) {
+        if( total_left > 3_turns && !who.is_dangerous_fields( here.field_at( who.pos() ) ) ) {
             who.add_effect( effect_downed, 2_turns, num_bp, 0, true );
             who.add_msg_player_or_npc( m_warning,
                                        _( "You roll on the ground, trying to smother the fire!" ),


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Patting down fire has more impact, stop drop and roll triggers earlier"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A thing @KheirFerrum looked into on the BN discord recently, it was found that the "attempt to put yourself out if on fire" behavior was a bit flawed. Part of it was because DoT from being on fire itself appears to be add more duration from it dealing `DT_HEAT` hits depending on the clothing worn, which is fair since clothing is good fuel.

But where this became a problem was when it intersected with the code to try and put yourself out. The baseline reduction in duration does almost nothing, while the more effective "stop drop and roll" action was locked behind a threshold of more than a minute duration before your character would be willing to choose the (vastly more effective) option. Needless to say, your HP bar typically isn't going to last long enough for this to ever really be a factor.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Turned the 1 minute restriction for stop drop and roll down to only 3 turns.
2. Additionally, set the baseline impact of patting yourself down from 1 turn to 4 turns.

Combined, this should allow for situations where a single round of patting will negate being on fire if it's not that severe and thus letting you skip the turn loss from being knocked down, but any situation where the fire seems to escalate quickly prompts the more effective method to kick in.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Calculating exactly what the highest threshold for rolling can be such that the character will always patdown if it'd keep them out of action for less turns than rolling and standing back up would. Fine-tuning it too much beyond "we can be reasonably certain one patdown will always fix this" runs into problems because the fuel value of your armor factors into how much duration you get from fire DoT, so there'd be the risk that the patdown turn reduction might keep you burning forever if your armor's flammability is just right.
2. Just dropping the duration check entirely and accept that 2-turn time loss no matter what, just to idiotproof the function.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested.
2. Spawned in and debugged a small fire right on top of me, then immediately removed it.
3. Waited and observed my character happily favored rolling on the ground instead.
4. Spawned in a laser turret so I'd only get myself lit on fire on a single body part and wouldn't have the added field effects stacking up the duration.
5. Waited and confirmed that a patdown took care of it in only a single turn.

One weird thing I noticed, when you stop drop and roll, your character tends to both repeatedly drop and struggle to get up at the same time.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
