### PR TITLE
Updates to jabberwock map extra

### DIFF
--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -189,8 +189,8 @@
   {
     "id": "mx_jabberwock",
     "type": "map_extra",
-    "name": "Jabberwock",
-    "description": "Jabberwock is nearby.",
+    "name": "Eater of The Dead",
+    "description": "Something big and nasty is nearby.",
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_jabberwock" },
     "sym": "J",
     "color": "red",

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -505,6 +505,7 @@
           "mx_military": 5,
           "mx_science": 12,
           "mx_collegekids": 15,
+          "mx_jabberwock": 1,
           "mx_portal": 5,
           "mx_crater": 60,
           "mx_portal_in": 3,

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -134,7 +134,7 @@ static const mongroup_id GROUP_PETS( "GROUP_PETS" );
 static const mongroup_id GROUP_STRAY_DOGS( "GROUP_STRAY_DOGS" );
 
 static const mtype_id mon_dispatch( "mon_dispatch" );
-static const mtype_id mon_jabberwock( "mon_jabberwock" );
+static const mtype_id mon_fleshy_shambler( "mon_fleshy_shambler" );
 static const mtype_id mon_marloss_zealot_f( "mon_marloss_zealot_f" );
 static const mtype_id mon_marloss_zealot_m( "mon_marloss_zealot_m" );
 static const mtype_id mon_shia( "mon_shia" );
@@ -1821,17 +1821,9 @@ static bool mx_spider( map &m, const tripoint &abs_sub )
 
 static bool mx_jabberwock( map &m, const tripoint &loc )
 {
-    // A rare chance to spawn a jabberwock. This was extracted from the harcoded forest mapgen
-    // and moved into a map extra. It still has a one_in chance of spawning because otherwise
-    // the rarity skewed the values for all the other extras too much. I considered moving it
-    // into the monster group, but again the hardcoded rarity it had in the forest mapgen was
-    // not easily replicated there.
-    if( one_in( 50 ) ) {
-        m.add_spawn( mon_jabberwock, 1, { SEEX, SEEY, loc.z } );
-        return true;
-    }
-
-    return false;
+    // A rare chance to spawn a fleshy shambler, which can then evolve into a flesh golem/jabberwock.
+    m.add_spawn( mon_fleshy_shambler, 1, { SEEX, SEEY, loc.z } );
+    return true;
 }
 
 static bool mx_grove( map &m, const tripoint &abs_sub )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Jabberwock map extra cleaned up and given more usage, allows fleshy shamblers and flesh golems to actually exist"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This aims to make use of some unused pre-evolutions of the jabberwock monster, and in the process make it feasible to make use of the rare jabberwock map extra a bit more. Adding them to confined locations like building map extras seems like the sanest approach to introduce them with less risk of them wandering off and ganking players, Magiclysm-style.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Jabberwock map extra code set to place a fleshy shambler instead of a jabberwock. Since it can then evolve into flesh golems and then jabberwocks, this allows for the entire evolutionary chain to spawn in-game instead of only the original and final variant ever showing up. Additionally, due to its extremely low weight and starting off unevolved, the hardcoded "only 1 in 50 chance to spawn anyway" bit seems to hinge on the fact that forest map extras used to not be massively loaded down with groves, shubberies, and the like.
2. Jabberwock map extra added to the building map extra, at a weight of 1.
3. Weight of jabberwock map extra for research facilities increased from 1 to 3.
4. Edited the map note text for the jabberwock map extra since what variety of flesh golem might spawn now varies, and so a player that doesn't now what a jabberwock is will at least know it's a threat.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Increasing the weight of jabberwock map extras in thick forests, now that they can spawn as lesser flesh golems instead. See additional information for a summary of their effective spawn chance relative to the other map extras that call for them, and just how tiny that is even without the hardcode change.
2. Allowing fleshy shamblers and/or flesh golems to trigger the jabberwock death function, as while they aren't as lethal as fully-evolved jabberwocks, they're still a rare and reasonable challenge.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested.
2. Gave myself binoculars and Scout mutation.
3. Started in the woods and started to just teleport and fast travel around around a lot.
4. Confirmed that the change to the function didn't cause the jabberwock map extra to suddenly become ubiquitous.
5. Checked affected JSON files for syntax and lint errors.
6. Checked affected C++ file for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Effective odds of a given map extra being a meat lad spawn:
1. Thick forest: ~0.036%
2. Standard buildings: ~0.36%
3. Research facility interior: ~0.49% (previously ~0.17%)

Not counting the extra 1-in-50 reduction previously tacked on by hardcode.