### PR TITLE
Update badge text to stable `0.2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Find a way to stop the Cataclysm ... or become one of its strongest monsters.
 
 [![Stable][stable-releases-badge]][stable-releases] [![Recent][all-releases-badge]][all-releases]
 
-[stable-releases]: https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/cbn-0.1
-[stable-releases-badge]: <https://img.shields.io/badge/Stable Release-0.1-success?style=for-the-badge>
-[all-releases]: https://github.com/cataclysmbnteam/Cataclysm-BN/releases
-[all-releases-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?color=important&include_prereleases&label=Latest%20Release&sort=date&style=for-the-badge
+[stable-releases]: https://github.com/cataclysmbnteam/Cataclysm-BN/releases/tag/cbn-0.2
+[stable-releases-badge]: <https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?style=for-the-badge&color=success&label=stable>
+[all-releases]: https://github.com/cataclysmbnteam/Cataclysm-BN/releases/latest
+[all-releases-badge]: https://img.shields.io/github/v/release/cataclysmbnteam/Cataclysm-BN?style=for-the-badge&color=important&label=Latest%20Release&include_prereleases&sort=date
 
 | [Source Code][source-zip-archive] | [Clone From Repo][clone] |
 | :-------------------------------: | :----------------------: |

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -2,7 +2,7 @@
 
 When you `make` Cataclysm from source, an executable `tests/cata_test` is built
 from test cases found in the `tests/` directory. These tests are written in the
-[Catch2 framework](https://github.org/catchorg/Catch2).
+[Catch2 framework](https://github.com/catchorg/Catch2).
 
 Run `tests/cata_test --help` to see the available command-line options, and/or
 consult the [Catch2 tutorial](https://github.com/catchorg/Catch2/blob/master/docs/tutorial.md)


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Update badge text to stable 0.2"

#### Purpose of change

update badge in README to match with stable 0.2

#### Describe the solution

link badge to 0.2

#### Describe alternatives you've considered

it'd be great if there was a link to latest non pre-release release, but there wasn't.

#### Additional context

![image](https://user-images.githubusercontent.com/54838975/218304364-846f3e5e-0c86-4422-923e-ba6f77ee8555.png)

