### PR TITLE
Show maximum buoyancy on vehicle info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -875,6 +875,7 @@ ifeq ($(VERBOSE),1)
 else
 	@echo "Linking $@..."
 	@+$(LD) $(W32FLAGS) -o $(TARGET) $(OBJS) $(LDFLAGS)
+	@echo Done!
 endif
 
 ifeq ($(RELEASE), 1)

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2491,7 +2491,8 @@ void veh_interact::display_stats() const
             _( "Maximum Lift: <color_light_blue>%5.0f</color> %s" ),
             convert_weight( lift_as_mass ),
             weight_units() );
-    } else if( is_boat ) {
+    }
+    if( is_boat ) {
         // convert newton to kg.
         units::mass buoyancy_as_mass = units::from_newton(
                                            veh->max_buoyancy() );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2491,6 +2491,14 @@ void veh_interact::display_stats() const
             _( "Maximum Lift: <color_light_blue>%5.0f</color> %s" ),
             convert_weight( lift_as_mass ),
             weight_units() );
+    } else if( is_boat ) {
+        // convert newton to kg.
+        units::mass buoyancy_as_mass = units::from_newton(
+                                           veh->max_buoyancy() );
+        print_stat(
+            _( "Maximum Buoyancy: <color_light_blue>%5.0f</color> %s" ),
+            convert_weight( buoyancy_as_mass ),
+            weight_units() );
     }
     print_stat(
         _( "Cargo Volume: <color_light_blue>%s</color> / <color_light_blue>%s</color> %s" ),

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4224,6 +4224,8 @@ bool vehicle::is_in_water( bool deep_water ) const
     return deep_water ? is_floating : in_water;
 }
 
+static constexpr double water_density = 1000.0; // kg/m^3
+
 double vehicle::coeff_water_drag() const
 {
     if( !coeff_water_dirty ) {
@@ -4253,7 +4255,7 @@ double vehicle::coeff_water_drag() const
     double actual_area_m = width_m * structure_indices.size() / tile_width;
 
     // effective hull area is actual hull area * hull coverage
-    double hull_area_m   = actual_area_m * std::max( 0.1, hull_coverage );
+    hull_area = actual_area_m * std::max( 0.1, hull_coverage );
     // Treat the hullform as a simple cuboid to calculate displaced depth of
     // water.
     // Apply Archimedes' principle (mass of water displaced is mass of vehicle).
@@ -4261,8 +4263,7 @@ double vehicle::coeff_water_drag() const
     // water_mass = vehicle_mass
     // area * depth = vehicle_mass / water_density
     // depth = vehicle_mass / water_density / area
-    constexpr double water_density = 1000.0; // kg/m^3
-    draft_m = to_kilogram( total_mass() ) / water_density / hull_area_m;
+    draft_m = to_kilogram( total_mass() ) / water_density / hull_area;
     // increase the streamlining as more of the boat is covered in boat boards
     double c_water_drag = 1.25 - hull_coverage;
     // hull height starts at 0.3m and goes up as you add more boat boards

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4275,6 +4275,15 @@ double vehicle::coeff_water_drag() const
     return coefficient_water_resistance;
 }
 
+double vehicle::max_buoyancy() const
+{
+    if( coeff_water_dirty ) {
+        coeff_water_drag();
+    }
+    const double total_volume = hull_area * water_hull_height();
+    return total_volume * water_density * GRAVITY_OF_EARTH;
+}
+
 float vehicle::k_traction( float wheel_traction_area ) const
 {
     if( is_floating ) {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1337,6 +1337,19 @@ class vehicle
         double coeff_water_drag() const;
 
         /**
+         * maximum possible buoyancy in Newtons.
+         *
+         * buoyancy force = V * D * g
+         *
+         * V: total volume of the vehicle (because it's maximally submerged)
+         * D: density of submerged fluid (in our case, water)
+         * g: force of gravity
+         *
+         * @return The max buoyancy in Newtons.
+         */
+        double max_buoyancy() const;
+
+        /**
          * watertight hull height in meters measures distance from bottom of vehicle
          * to the point where the vehicle will start taking on water
          */

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1367,6 +1367,9 @@ class vehicle
          * total area of every rotors in m^2
          */
         double total_rotor_area() const;
+        /**
+         * lift of rotorcraft in newton
+         */
         double lift_thrust_of_rotorcraft( bool fuelled, bool safe = false ) const;
         bool has_sufficient_rotorlift() const;
         int get_z_change() const;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1788,6 +1788,7 @@ class vehicle
         mutable double coefficient_water_resistance = 1;
         mutable double draft_m = 1;
         mutable double hull_height = 0.3;
+        mutable double hull_area = 0; // total area of hull in m^2
 
         // Cached points occupied by the vehicle
         std::set<tripoint> occupied_points;


### PR DESCRIPTION
#### Summary

SUMMARY: Interface "Show maximum buoyancy"

#### Purpose of change

- resolves #2276 

#### Describe the solution

calculate maximum buoyancy using archimedes's law, that is `volume * density of water * earth gravity`.
display method is identical to #1631 .

#### Describe alternatives you've considered

- change `water_hull_height` as mutable?
- instead show 'mass left until sinking'? (max buoyancy - total mass)

#### Testing

**boat**

<details>
<summary>screenshots</summary>

![Cataclysm: Bright Nights - cda4bc75df-dirty_04](https://user-images.githubusercontent.com/54838975/218311158-d53648c4-0025-4c41-a6a2-95ae1826861f.png)
![Cataclysm: Bright Nights - cda4bc75df-dirty_05](https://user-images.githubusercontent.com/54838975/218311161-077cd23a-06c1-4ee1-a28d-3dde81ac4d8f.png)
![Cataclysm: Bright Nights - cda4bc75df-dirty_06](https://user-images.githubusercontent.com/54838975/218311164-ef39a6f6-b531-4f11-85fc-43ffa417e04f.png)

</details>

created a canoe, calculated maximum buoyancy was 2880kg.
the canoe sank at approx. 2890kg.

**seaplane**


<details>
<summary>screenshots</summary>

![Cataclysm: Bright Nights - a286e23cea-dirty_01](https://user-images.githubusercontent.com/54838975/220787208-9cab1c41-df0a-429f-a09a-d4bf9539e309.png)
![Cataclysm: Bright Nights - a286e23cea-dirty_02](https://user-images.githubusercontent.com/54838975/220787214-d1242f6a-68c0-4590-8032-68add3406450.png)
![Cataclysm: Bright Nights - a286e23cea-dirty_03](https://user-images.githubusercontent.com/54838975/220787216-94c59241-9131-4d2d-8534-0780ce183703.png)

</details>

created a seaplane, it both shows maximum lift and buoyancy accordingly.
