### PR TITLE
Make Music Equipment uncraftable. And small tweaks

### DIFF
--- a/data/json/items/generic/music.json
+++ b/data/json/items/generic/music.json
@@ -49,32 +49,33 @@
     "type": "GENERIC",
     "id": "mic_stand_tall",
     "name": { "str": "microphone stand" },
-    "description": "A lightweight telescoping boom stand made of aluminum and painted black.  About 6' tall when full extended, or 3' when closed fully.  Has threads for a mic clip on one end.",
+    "description": "A telescoping boom stand made of steel and painted black.  About 6' tall when full extended, or 3' when closed fully.  Has threads for a mic clip on one end.",
     "symbol": "Γ",
     "color": "dark_gray",
-    "volume": "2200 ml",
-    "material": [ "aluminum" ],
+    "volume": "1200 ml",
+    "material": [ "steel" ],
     "weight": "1542 g"
   },
   {
     "type": "GENERIC",
     "id": "guitar_stand",
     "name": { "str": "guitar stand" },
-    "description": "A small, oddly shaped piece of aluminum hardware with three legs.  When placed on the ground, this can support one guitar in an upright position.",
-    "material": [ "aluminum" ],
+    "description": "A small, oddly shaped piece of steel hardware with three legs.  When placed on the ground, this can support one guitar in an upright position.",
+    "material": [ "steel" ],
     "symbol": "y",
     "color": "dark_gray",
     "volume": "800 ml",
-    "weight": "500 g"
+    "weight": "1100 g"
   },
   {
     "type": "GENERIC",
     "id": "mixer_music",
     "name": { "str": "mixer" },
     "description": "A device with faders, switches, and knobs that mixes input signal and sends it to two output XLR cables.  (left and right)",
+    "material": [ "plastic" ],
     "symbol": "□",
     "color": "light_gray",
-    "volume": "8 L",
-    "weight": "40 kg"
+    "volume": "3 L",
+    "weight": "2 kg"
   }
 ]

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -103,5 +103,77 @@
     "time": "10 s",
     "components": [ [ [ "bag_canvas", 1 ] ], [ [ "material_soil", 3 ] ] ],
     "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "type": "uncraft",
+    "result": "cable_xlr",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "5 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "cable", 60 ] ] ]
+  },
+  {
+    "type": "uncraft",
+    "result": "cable_instrument",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "8 m",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "cable", 70 ] ] ]
+  },
+  {
+    "type": "uncraft",
+    "result": "headphones_circumaural",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "8 m",
+    "using": [ [ "soldering_standard", 10 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [ [ [ "solder_wire", 5 ] ], [ [ "plastic_chunk", 1 ] ] ]
+  },
+  {
+    "type": "uncraft",
+    "result": "microphone_xlr_generic",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "8 m",
+    "using": [ [ "soldering_standard", 5 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [ [ [ "solder_wire", 3 ] ], [ [ "transponder", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
+  },
+  {
+    "type": "uncraft",
+    "result": "mic_stand_tall",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "12 m",
+    "qualities": [ { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "steel_lump", 1 ] ] ]
+  },
+  {
+    "type": "uncraft",
+    "result": "guitar_stand",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "12 m",
+    "qualities": [ { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "steel_chunk", 3 ] ] ]
+  },
+  {
+    "type": "uncraft",
+    "result": "mixer_music",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "30 m",
+    "using": [ [ "soldering_standard", 15 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "solder_wire", 15 ] ],
+      [ [ "circuit", 1 ] ],
+      [ [ "processor", 1 ] ],
+      [ [ "receiver", 1 ] ],
+      [ [ "plastic_chunk", 5 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
Music equipment always was a sore thumb in my eyes. It was fluff without any reason to be there. Was someone flexing on their music knowledge, adding XLR and whatnot cables into the game without any gain or use? Maybe. But now they are now at least somewhat relevant. That stuff can now be uncrafted for parts you may need.