### PR TITLE
Correct J22 magazine volumes

### DIFF
--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -191,6 +191,7 @@
     "material": [ "budget_steel" ],
     "color": "dark_gray",
     "ammo": "22",
+    "magazine_well": "55 ml",
     "dispersion": 600,
     "durability": 5,
     "min_cycle_recoil": 39,

--- a/data/json/items/magazine/22.json
+++ b/data/json/items/magazine/22.json
@@ -132,7 +132,7 @@
     "name": { "str": "Jennings J-22 magazine" },
     "description": "A cheap 6-round steel box magazine for the Jennings J-22.",
     "weight": "55 g",
-    "volume": "27 ml",
+    "volume": "60ml",
     "price": 2800,
     "price_postapoc": 100,
     "material": "steel",


### PR DESCRIPTION
The J22 used wacky values for their magazines. It seems it wasn't updated to the "magazine well" standards. This will correct the issue.