### PR TITLE
Make plastic containers craftable from scratch (Jug+jerrycan) + tweaks

### DIFF
--- a/data/json/items/containers.json
+++ b/data/json/items/containers.json
@@ -934,7 +934,7 @@
     "category": "container",
     "name": { "str": "gallon jug" },
     "description": "A standard plastic jug used for milk and household cleaning chemicals.",
-    "weight": "190 g",
+    "weight": "19 g",
     "volume": "3750 ml",
     "price": 0,
     "price_postapoc": 10,

--- a/data/json/recipes/other/containers.json
+++ b/data/json/recipes/other/containers.json
@@ -74,7 +74,7 @@
     "autolearn": true,
     "using": [ [ "cordage", 1 ] ],
     "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 30, "LIST" ] ] ],
-    "components": [ [ [ "plastic_chunk", 15 ] ] ]
+    "components": [ [ [ "plastic_chunk", 35 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/containers.json
+++ b/data/json/recipes/other/containers.json
@@ -74,7 +74,7 @@
     "autolearn": true,
     "using": [ [ "cordage", 1 ] ],
     "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 30, "LIST" ] ] ],
-    "components": [ [ [ "plastic_chunk", 35 ] ] ]
+    "components": [ [ [ "plastic_chunk", 40 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/containers.json
+++ b/data/json/recipes/other/containers.json
@@ -44,8 +44,21 @@
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_CONTAINERS",
     "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "40 m",
+    "autolearn": true,
+    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 30, "LIST" ] ] ],
+    "components": [ [ [ "plastic_chunk", 15 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "jug_plastic",
+    "id_suffix": "ducted",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_CONTAINERS",
+    "skill_used": "fabrication",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "20 m",
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "duct_tape", 10 ] ], [ [ "bottle_plastic", 8 ], [ "bottle_plastic_small", 16 ] ] ]
@@ -56,8 +69,22 @@
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_CONTAINERS",
     "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "50 m",
+    "autolearn": true,
+    "using": [ [ "cordage", 1 ] ],
+    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 30, "LIST" ] ] ],
+    "components": [ [ [ "plastic_chunk", 15 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "jerrycan",
+    "id_suffix": "ducted",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_CONTAINERS",
+    "skill_used": "fabrication",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "15 m",
     "autolearn": true,
     "using": [ [ "cordage", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
@@ -123,9 +150,9 @@
     "subcategory": "CSC_OTHER_CONTAINERS",
     "skill_used": "fabrication",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "20 m",
     "autolearn": true,
-    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 5, "LIST" ] ] ],
+    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 4, "LIST" ] ] ],
     "components": [ [ [ "plastic_chunk", 2 ] ] ]
   },
   {
@@ -135,9 +162,9 @@
     "subcategory": "CSC_OTHER_CONTAINERS",
     "skill_used": "fabrication",
     "difficulty": 3,
-    "time": "20 m",
+    "time": "15 m",
     "autolearn": true,
-    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 3, "LIST" ] ] ],
+    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 2, "LIST" ] ] ],
     "components": [ [ [ "plastic_chunk", 1 ] ] ]
   },
   {
@@ -147,9 +174,9 @@
     "subcategory": "CSC_OTHER_CONTAINERS",
     "skill_used": "fabrication",
     "difficulty": 3,
-    "time": "1 h",
+    "time": "30 m",
     "autolearn": true,
-    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 10, "LIST" ] ] ],
+    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 16, "LIST" ] ] ],
     "components": [ [ [ "plastic_chunk", 8 ] ] ]
   },
   {


### PR DESCRIPTION
gallon jugs and plastic jerrycans couldn't be crafted with mold from scratch. This will change it. It makes them craftable with plastic chunks and crafting times got tweaked. Also made the gallon jug lighter to be comparable to the 2 litre bottle.