### PR TITLE
Implement grid recharging stations, battery charger tweak

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4284,6 +4284,20 @@
   },
   {
     "type": "construction",
+    "id": "constr_recharge_station",
+    "group": "place_recharge_station",
+    "category": "WORKSHOP",
+    "required_skills": [ [ "electronics", 1 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "SCREW", "level": 1 } ] ],
+    "using": [ [ "soldering_standard", 20 ] ],
+    "components": [ [ [ "cable", 5 ] ], [ [ "recharge_station", 1 ] ], [ [ "power_supply", 1 ] ], [ [ "solder_wire", 5 ] ] ],
+    "pre_note": "Will only work if constructed in a building with an electric grid.",
+    "pre_special": "check_empty",
+    "post_furniture": "f_recharge_station"
+  },
+  {
+    "type": "construction",
     "id": "constr_gridwelder",
     "group": "place_arc_welder",
     "category": "WORKSHOP",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1061,6 +1061,11 @@
   },
   {
     "type": "construction_group",
+    "id": "place_recharge_station",
+    "name": "Place Recharging Station"
+  },
+  {
+    "type": "construction_group",
     "id": "place_electric_forge",
     "name": "Place Electric Forge"
   },

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -945,6 +945,24 @@
   },
   {
     "type": "furniture",
+    "id": "f_recharge_station",
+    "copy-from": "f_charger",
+    "looks_like": "recharge_station",
+    "name": "grid recharging station",
+    "description": "A vehicle recharging station connected to building's electric grid, providing higher output than consumer battery chargers.",
+    "symbol": ":",
+    "color": "blue_white",
+    "active": [ "charger", { "power": 600 } ],
+    "deconstruct": {
+      "items": [
+        { "item": "cable", "charges": [ 2, 5 ] },
+        { "item": "recharge_station", "count": 1 },
+        { "item": "power_supply", "count": 1 }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_cable_connector",
     "looks_like": "f_TV_antenna",
     "name": "jumper cable connector",

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -920,7 +920,7 @@
     "move_cost_mod": -1,
     "coverage": 90,
     "required_str": -1,
-    "active": [ "charger", { "power": 100 } ],
+    "active": [ "charger", { "power": 15 } ],
     "deconstruct": {
       "items": [
         { "item": "cable", "charges": [ 2, 5 ] },

--- a/data/json/items/vehicle/utilities.json
+++ b/data/json/items/vehicle/utilities.json
@@ -85,7 +85,7 @@
     "type": "GENERIC",
     "id": "recharge_station",
     "name": { "str": "recharging station" },
-    "description": "A universal recharging station designed to operate on vehicle power.  While on it will steadily charge all rechargeable batteries (battery cells, lead-acid batteries, etc) placed directly within its storage space.  The system can only be installed onto existing storage compartments, and is controlled from a dashboard or electronics control unit.",
+    "description": "A universal recharging station designed to operate on vehicle power.  While on it will steadily charge all rechargeable batteries (battery cells, lead-acid batteries, etc) placed directly within its storage space, at a greater rate than most consumer chargers.  The system can only be installed onto existing storage compartments, and is controlled from a dashboard or electronics control unit.",
     "weight": "10000 g",
     "to_hit": 1,
     "color": "light_blue",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2227,7 +2227,7 @@
     "broken_color": "blue",
     "damage_modifier": 10,
     "durability": 20,
-    "description": "A device for recharging batteries.  When turned on, it charges any rechargeable batteries (battery cells, lead-acid batteries, etc) placed directly in the attached storage space.",
+    "description": "A device for recharging batteries, capable of higher output than most consumer models.  When turned on, it charges any rechargeable batteries (battery cells, lead-acid batteries, etc) placed directly in the attached storage space.",
     "bonus": 600,
     "item": "recharge_station",
     "location": "on_cargo",
@@ -2251,7 +2251,7 @@
     "name": { "str": "battery charger" },
     "durability": 5,
     "description": "A small, low-power consumer device for recharging batteries.  It slowly charges any rechargeable batteries (battery cells, lead-acid batteries, etc) placed directly in the attached storage space.",
-    "bonus": 15,
+    "bonus": 100,
     "item": "battery_charger",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "vehicle_screw", 1 ] ] },

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2251,7 +2251,7 @@
     "name": { "str": "battery charger" },
     "durability": 5,
     "description": "A small, low-power consumer device for recharging batteries.  It slowly charges any rechargeable batteries (battery cells, lead-acid batteries, etc) placed directly in the attached storage space.",
-    "bonus": 100,
+    "bonus": 15,
     "item": "battery_charger",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "vehicle_screw", 1 ] ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Content "Add construction for grid-placed recharging stations, consistency update for vehiclepart battery chargers"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

As requested by Chorus System on the BN discord, having grid-placeable recharging stations would be something neat to add. However in the process, it was discovered that the `bonus` value of charger vehicle parts is used in the exact same manner as the `power` value of grid rechargers.

Power values of vehiclepart and grid chargers were found to behave identically, so per feedback basic chargers were tweaked to be consistent across versions.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added furniture definition, construction recipe, and construction namegroup for grid recharging stations. Uses a `power` value of 600, matching the `bonus` value of vehiclepart recharging stations.
2. Per Coolthulhu's recommendation, grid chargers nrfed from 100 power to 15, to be identical to the vehiclepart version.
3. Also updated description of recharging stations, both item form and vehicle part, to clarify that recharging stations are the faster option. I myself wasn't really aware of the difference until I checked the JSON, so it may be helpful for new players to hint at which is the stronger option.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Bundling a conversion of `x_in_y` RNG weirdness into some kinda actual function that tracks accumulated joules and translates it into a charge of battery whenever it exceeds 1000, and further making Chorus System sad at the growing number of obstacles delaying grid recharging stations.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
