### PR TITLE
make quick draw holsters hold pistols up to 500 ml (glocks)

### DIFF
--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -100,7 +100,7 @@
     "description": "A comfortable quick draw holster for small guns.  Activate to holster/draw a gun.",
     "price_postapoc": 500,
     "encumbrance": 1,
-    "use_action": { "type": "holster", "max_volume": "400 ml", "min_volume": "100 ml", "draw_cost": 80, "skills": [ "pistol" ] }
+    "use_action": { "type": "holster", "max_volume": "500 ml", "min_volume": "100 ml", "draw_cost": 80, "skills": [ "pistol" ] }
   },
   {
     "id": "bholster",


### PR DESCRIPTION
fast draw holsters only hold weapons up to 400 ml, like deep concealment and ankle holsters. But there are quick draw holsters on the market for glocks as well. Raising the possible volume to 500 ml should make sense.

https://www.kurt24.eu/airsoft/taktische-ausruestung/holster/4523/fast-draw-holster-glock-17-22-31-gen-1-4