### PR TITLE
lower "bulkiness" of maple syrup recipe

### DIFF
--- a/data/json/recipes/food/drinks.json
+++ b/data/json/recipes/food/drinks.json
@@ -591,13 +591,13 @@
     "subcategory": "CSC_FOOD_DRINKS",
     "skill_used": "cooking",
     "difficulty": 4,
-    "time": "1 h 20 m",
-    "charges": 16,
+    "time": "10 m",
+    "charges": 2,
     "autolearn": true,
     "batch_time_factors": [ 60, 3 ],
     "qualities": [ { "id": "BOIL", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 12, "LIST" ] ], [ [ "rag", -1 ] ] ],
-    "components": [ [ [ "maple_sap", 40 ] ] ]
+    "tools": [ [ [ "surface_heat", 2, "LIST" ] ], [ [ "rag", -1 ] ] ],
+    "components": [ [ [ "maple_sap", 5 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
Maple syrup recipe was quite bulky. you needed 40*x amounts of maple sap to create 16*x syrup units.

This will change to 5*x sap and it will produce 2*x syrup units