### PR TITLE
Make water from the cellar water heater "non-clean"

### DIFF
--- a/data/json/mapgen/basement/basement_bionic.json
+++ b/data/json/mapgen/basement/basement_bionic.json
@@ -50,7 +50,7 @@
         "F": "f_home_furnace",
         "W": "f_water_heater"
       },
-      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "W": { "liquid": "water", "amount": [ 0, 100 ] } },
       "place_loot": [
         { "group": "alcohol", "x": [ 14, 15 ], "y": 12, "chance": 96, "repeat": [ 1, 2 ] },
         { "group": "fridgesnacks", "x": [ 14, 15 ], "y": 12, "chance": 80, "repeat": [ 1, 2 ] },
@@ -125,7 +125,7 @@
         "F": "f_home_furnace",
         "W": "f_water_heater"
       },
-      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "W": { "liquid": "water", "amount": [ 0, 100 ] } },
       "place_loot": [
         { "group": "alcohol", "x": [ 14, 15 ], "y": 12, "chance": 96, "repeat": [ 1, 2 ] },
         { "group": "fridgesnacks", "x": [ 14, 15 ], "y": 12, "chance": 80, "repeat": [ 1, 2 ] },

--- a/data/json/mapgen/basement/basement_chem.json
+++ b/data/json/mapgen/basement/basement_chem.json
@@ -53,7 +53,7 @@
         "T": "t_linoleum_gray",
         "F": "t_linoleum_gray"
       },
-      "liquids": { "E": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "E": { "liquid": "water", "amount": [ 0, 100 ] } },
       "furniture": {
         "T": "f_workbench",
         "c": "f_counter",
@@ -149,7 +149,7 @@
         "T": "t_linoleum_white",
         "8": "t_console_broken"
       },
-      "liquids": { "E": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "E": { "liquid": "water", "amount": [ 0, 100 ] } },
       "furniture": {
         "T": "f_workbench",
         "G": "f_glass_cabinet",

--- a/data/json/mapgen/basement/basement_game.json
+++ b/data/json/mapgen/basement/basement_game.json
@@ -35,7 +35,7 @@
         "                        "
       ],
       "furniture": { "F": "f_home_furnace", "W": "f_water_heater", "S": "f_utility_shelf", "L": "f_floor_lamp", "G": "f_glass_cabinet" },
-      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "W": { "liquid": "water", "amount": [ 0, 100 ] } },
       "palettes": [ "basement_game" ],
       "place_loot": [
         { "group": "alcohol", "x": [ 16, 20 ], "y": 5, "chance": 96 },
@@ -87,7 +87,7 @@
         "                        "
       ],
       "furniture": { "F": "f_home_furnace", "W": "f_water_heater", "L": "f_floor_lamp" },
-      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "W": { "liquid": "water", "amount": [ 0, 100 ] } },
       "palettes": [ "basement_game" ],
       "place_loot": [
         { "group": "alcohol", "x": [ 16, 20 ], "y": 5, "chance": 96 },
@@ -139,7 +139,7 @@
         "                        "
       ],
       "furniture": { "F": "f_home_furnace", "W": "f_water_heater", "S": "f_utility_shelf" },
-      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "W": { "liquid": "water", "amount": [ 0, 100 ] } },
       "palettes": [ "basement_game" ],
       "place_loot": [
         { "group": "alcohol", "x": [ 16, 20 ], "y": 5, "chance": 96 },
@@ -189,7 +189,7 @@
         "                        "
       ],
       "furniture": { "F": "f_home_furnace", "W": "f_water_heater" },
-      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "W": { "liquid": "water", "amount": [ 0, 100 ] } },
       "palettes": [ "basement_game" ],
       "place_loot": [
         { "group": "alcohol", "x": [ 16, 20 ], "y": 5, "chance": 96 },
@@ -239,7 +239,7 @@
         "                        "
       ],
       "furniture": { "H": "f_home_furnace", "W": "f_water_heater" },
-      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "W": { "liquid": "water", "amount": [ 0, 100 ] } },
       "palettes": [ "basement_game" ],
       "place_loot": [
         { "item": "dnd_handbook", "x": 18, "y": 8, "chance": 100 },

--- a/data/json/mapgen/basement/basement_messed.json
+++ b/data/json/mapgen/basement/basement_messed.json
@@ -47,7 +47,7 @@
         "<": "t_stairs_up",
         "|": "t_wall"
       },
-      "liquids": { "E": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "E": { "liquid": "water", "amount": [ 0, 100 ] } },
       "furniture": {
         "c": "f_counter",
         "r": "f_rack",

--- a/data/json/mapgen/basement/basement_weed.json
+++ b/data/json/mapgen/basement/basement_weed.json
@@ -62,7 +62,7 @@
         "Q": "t_linoleum_white",
         "T": "t_linoleum_white"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "item": { "item": "seed_weed" }, "furniture": "f_planter_mature" } },
       "furniture": {
         "T": "f_workbench",

--- a/data/json/mapgen/gunsmith.json
+++ b/data/json/mapgen/gunsmith.json
@@ -150,7 +150,7 @@
         "+": "t_door_locked"
       },
       "furniture": { "W": "f_water_heater" },
-      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "W": { "liquid": "water", "amount": [ 0, 100 ] } },
       "items": { "C": { "item": "ammo_common", "chance": 30 }, "r": { "item": "tools_blacksmith", "chance": 30 } }
     }
   },

--- a/data/json/mapgen/hotel_tower.json
+++ b/data/json/mapgen/hotel_tower.json
@@ -530,7 +530,7 @@
         "H": "t_generator_broken"
       },
       "furniture": { "Y": "f_standing_tank", "6": "f_water_heater", "7": "f_roof_turbine_vent" },
-      "liquids": { "6": { "liquid": "water_clean", "amount": [ 0, 100 ] }, "Y": { "liquid": "water_clean", "amount": [ 100, 1000 ] } },
+      "liquids": { "6": { "liquid": "water", "amount": [ 0, 100 ] }, "Y": { "liquid": "water_clean", "amount": [ 100, 1000 ] } },
       "place_monsters": [
         { "monster": "GROUP_ROOF_ZOMBIE", "x": [ 7, 23 ], "y": [ 0, 22 ], "repeat": 2 },
         { "monster": "GROUP_ROOF_ZOMBIE", "x": [ 24, 47 ], "y": [ 23, 3 ], "repeat": 2 },

--- a/data/json/mapgen/isherwood_farms/cabin_isherwood.json
+++ b/data/json/mapgen/isherwood_farms/cabin_isherwood.json
@@ -156,7 +156,7 @@
         "2": "f_smoking_rack"
       },
       "toilets": { "&": {  } },
-      "liquids": { "l": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "l": { "liquid": "water", "amount": [ 0, 100 ] } },
       "place_loot": [
         { "item": "cattlefodder", "x": [ 17, 18 ], "y": [ 2, 4 ], "chance": 100 },
         { "item": "horse_tack", "x": 15, "y": 2, "chance": 100 },

--- a/data/json/mapgen/lake_buildings/cabin_lake.json
+++ b/data/json/mapgen/lake_buildings/cabin_lake.json
@@ -71,7 +71,7 @@
         "k": "f_water_purifier"
       },
       "toilets": { "&": {  } },
-      "liquids": { "l": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "l": { "liquid": "water", "amount": [ 0, 100 ] } },
       "items": {
         "b": { "item": "homebooks", "chance": 20, "repeat": [ 2, 4 ] },
         "@": { "item": "bed", "chance": 30, "repeat": [ 2, 4 ] },

--- a/data/json/mapgen/lake_buildings/lighthouse.json
+++ b/data/json/mapgen/lake_buildings/lighthouse.json
@@ -69,7 +69,7 @@
         "W": "f_woodstove",
         "v": "f_workbench"
       },
-      "liquids": { "l": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "l": { "liquid": "water", "amount": [ 0, 100 ] } },
       "items": {
         "7": { "item": "fishing_items", "chance": 20, "repeat": [ 2, 4 ] },
         "b": { "item": "homebooks", "chance": 20, "repeat": [ 2, 4 ] },

--- a/data/json/mapgen/movie_theater.json
+++ b/data/json/mapgen/movie_theater.json
@@ -240,7 +240,7 @@
         "|----------------------------------------------------------------------3"
       ],
       "palettes": [ "roof_palette" ],
-      "liquids": { "6": { "liquid": "water_clean", "amount": [ 0, 100 ] }, "Y": { "liquid": "water_clean", "amount": [ 100, 1000 ] } },
+      "liquids": { "6": { "liquid": "water", "amount": [ 0, 100 ] }, "Y": { "liquid": "water_clean", "amount": [ 100, 1000 ] } },
       "terrain": {
         ">": "t_ladder_down",
         "_": "t_thconc_floor",

--- a/data/json/mapgen/nested/basement_nested.json
+++ b/data/json/mapgen/nested/basement_nested.json
@@ -107,7 +107,7 @@
     "id": "basement_utility_nest_palette",
     "terrain": { " ": "t_null", ".": "t_thconc_floor", "g": "t_thconc_floor", "f": "t_thconc_floor" },
     "furniture": { "g": "f_water_heater", "f": "f_home_furnace", "a": [ "f_air_conditioner", "f_null", "f_counter" ] },
-    "liquids": { "g": { "liquid": "water_clean", "amount": [ 0, 100 ] } }
+    "liquids": { "g": { "liquid": "water", "amount": [ 0, 100 ] } }
   },
   {
     "type": "mapgen",
@@ -526,7 +526,7 @@
         "Q": "t_linoleum_gray",
         "T": "t_linoleum_gray"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "item": { "item": "seed_weed" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "T": "f_workbench",
@@ -585,7 +585,7 @@
         "Q": "t_linoleum_gray",
         "T": "t_linoleum_gray"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "item": { "item": "seed_weed" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "T": "f_workbench",
@@ -644,7 +644,7 @@
         "Q": "t_linoleum_gray",
         "T": "t_linoleum_gray"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "item": { "item": "seed_weed" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "T": "f_workbench",
@@ -703,7 +703,7 @@
         "Q": "t_linoleum_gray",
         "T": "t_linoleum_gray"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "item": { "item": "seed_weed" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "T": "f_workbench",

--- a/data/json/mapgen/nested/nested_chunks_roof.json
+++ b/data/json/mapgen/nested/nested_chunks_roof.json
@@ -147,7 +147,7 @@
       ],
       "terrain": { "_": "t_concrete", "x": "t_sewage_pipe" },
       "furniture": { "o": "f_water_heater", "a": "f_air_conditioner" },
-      "liquids": { "o": { "liquid": "water_clean", "amount": [ 0, 100 ] } }
+      "liquids": { "o": { "liquid": "water", "amount": [ 0, 100 ] } }
     }
   },
   {
@@ -165,7 +165,7 @@
       ],
       "terrain": { "_": "t_null", "c": "t_chaingate_l", "U": "t_chainfence" },
       "furniture": { "o": "f_water_heater", "a": "f_water_purifier", "A": "f_standing_tank" },
-      "liquids": { "o": { "liquid": "water_clean", "amount": [ 0, 100 ] } }
+      "liquids": { "o": { "liquid": "water", "amount": [ 0, 100 ] } }
     }
   },
   {
@@ -185,7 +185,7 @@
       ],
       "terrain": { "_": "t_null", "x": "t_sewage_pipe" },
       "furniture": { "o": "f_water_heater", "a": "f_water_purifier", "A": "f_standing_tank" },
-      "liquids": { "o": { "liquid": "water_clean", "amount": [ 0, 100 ] } }
+      "liquids": { "o": { "liquid": "water", "amount": [ 0, 100 ] } }
     }
   },
   {

--- a/data/json/mapgen/prison_1.json
+++ b/data/json/mapgen/prison_1.json
@@ -183,7 +183,7 @@
         "L": [ { "item": "hand_tools", "chance": 40 } ],
         "P": [ { "item": "tools_plumbing", "chance": 100, "repeat": [ 1, 3 ] } ]
       },
-      "liquids": { "4": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "4": { "liquid": "water", "amount": [ 0, 100 ] } },
       "place_monsters": [
         { "monster": "GROUP_ZOMBIE_PRISON", "x": [ 15, 23 ], "y": [ 20, 23 ], "density": 0.3 },
         { "monster": "GROUP_ZOMBIE_PRISON", "x": [ 14, 15 ], "y": [ 50, 55 ], "density": 0.3 },

--- a/data/json/mapgen/ws_biker_dump.json
+++ b/data/json/mapgen/ws_biker_dump.json
@@ -206,7 +206,7 @@
         "P": "f_shower"
       },
       "toilets": { "&": {  } },
-      "liquids": { "K": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "K": { "liquid": "water", "amount": [ 0, 100 ] } },
       "place_loot": [
         { "item": "television", "x": 68, "y": 7, "chance": 100 },
         { "item": "stepladder", "x": 68, "y": 17, "chance": 100 },

--- a/data/json/mapgen_palettes/basement.json
+++ b/data/json/mapgen_palettes/basement.json
@@ -172,7 +172,7 @@
       "z": "f_cardboard_box"
     },
     "toilets": { "t": {  } },
-    "liquids": { "g": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+    "liquids": { "g": { "liquid": "water", "amount": [ 0, 100 ] } },
     "items": {
       "t": { "item": "SUS_toilet", "chance": 10, "repeat": [ 1, 3 ] },
       "v": [

--- a/data/json/mapgen_palettes/city_block_palette.json
+++ b/data/json/mapgen_palettes/city_block_palette.json
@@ -72,7 +72,7 @@
       "$": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ]
     },
     "toilets": { "t": {  } },
-    "liquids": { "g": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+    "liquids": { "g": { "liquid": "water", "amount": [ 0, 100 ] } },
     "items": {
       "O": [ { "item": "SUS_wardrobe_mens", "chance": 50 }, { "item": "SUS_wardrobe_womens", "chance": 50, "repeat": [ 1, 2 ] } ],
       "Q": [

--- a/data/json/mapgen_palettes/house_general_palette.json
+++ b/data/json/mapgen_palettes/house_general_palette.json
@@ -96,7 +96,7 @@
       "<": "t_wood_stairs_up",
       ">": "t_wood_stairs_down"
     },
-    "liquids": { "g": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+    "liquids": { "g": { "liquid": "water", "amount": [ 0, 100 ] } },
     "items": {
       "a": { "item": "stash_wood", "chance": 30, "repeat": [ 2, 5 ] },
       "d": [

--- a/data/json/mapgen_palettes/house_w_palette.json
+++ b/data/json/mapgen_palettes/house_w_palette.json
@@ -73,7 +73,7 @@
       "?": "t_console_broken"
     },
     "toilets": { "t": {  } },
-    "liquids": { "g": { "liquid": "water_clean", "amount": [ 0, 100 ] } }
+    "liquids": { "g": { "liquid": "water", "amount": [ 0, 100 ] } }
   },
   {
     "type": "palette",
@@ -149,7 +149,7 @@
       "$": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ]
     },
     "toilets": { "t": {  } },
-    "liquids": { "g": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+    "liquids": { "g": { "liquid": "water", "amount": [ 0, 100 ] } },
     "items": {
       "O": [ { "item": "SUS_wardrobe_mens", "chance": 50 }, { "item": "SUS_wardrobe_womens", "chance": 50, "repeat": [ 1, 2 ] } ],
       "Q": [

--- a/data/json/mapgen_palettes/military/mil_base_palette.json
+++ b/data/json/mapgen_palettes/military/mil_base_palette.json
@@ -109,7 +109,7 @@
       "!": "f_dryer"
     },
     "liquids": {
-      "6": { "liquid": "water_clean", "amount": [ 0, 100 ] },
+      "6": { "liquid": "water", "amount": [ 0, 100 ] },
       "7": { "liquid": "water_sewage", "amount": [ 0, 200 ] },
       "H": { "liquid": "diesel", "amount": [ 0, 30000 ] }
     },

--- a/data/mods/Aftershock/maps/mapgen/basement_bionic.json
+++ b/data/mods/Aftershock/maps/mapgen/basement_bionic.json
@@ -50,7 +50,7 @@
         "F": "f_home_furnace",
         "W": "f_water_heater"
       },
-      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "W": { "liquid": "water", "amount": [ 0, 100 ] } },
       "place_loot": [
         { "group": "alcohol", "x": [ 14, 15 ], "y": 12, "chance": 96, "repeat": [ 1, 2 ] },
         { "group": "fridgesnacks", "x": [ 14, 15 ], "y": 12, "chance": 80, "repeat": [ 1, 2 ] },

--- a/data/mods/Aftershock/maps/mapgen/millyficent_lab.json
+++ b/data/mods/Aftershock/maps/mapgen/millyficent_lab.json
@@ -155,7 +155,7 @@
         "W": "t_water_dispenser",
         "*": "t_thconc_floor_olight"
       },
-      "liquids": { "E": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "E": { "liquid": "water", "amount": [ 0, 100 ] } },
       "furniture": {
         "T": "f_workbench",
         "G": "f_glass_cabinet",

--- a/data/mods/Aftershock/maps/nested/basement.json
+++ b/data/mods/Aftershock/maps/nested/basement.json
@@ -213,7 +213,7 @@
         "Q": "t_linoleum_gray",
         "T": "t_linoleum_gray"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "items": { "item": "exoticplants", "chance": 100 }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "T": "f_workbench",
@@ -272,7 +272,7 @@
         "Q": "t_linoleum_gray",
         "T": "t_linoleum_gray"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "items": { "item": "exoticplants", "chance": 100 }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "T": "f_workbench",
@@ -331,7 +331,7 @@
         "Q": "t_linoleum_gray",
         "T": "t_linoleum_gray"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "items": { "item": "exoticplants", "chance": 100 }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "T": "f_workbench",
@@ -390,7 +390,7 @@
         "Q": "t_linoleum_gray",
         "T": "t_linoleum_gray"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "items": { "item": "exoticplants", "chance": 100 }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "T": "f_workbench",

--- a/data/mods/No_Hope/Mapgen/basement_nested.json
+++ b/data/mods/No_Hope/Mapgen/basement_nested.json
@@ -107,7 +107,7 @@
     "id": "basement_utility_nest_palette",
     "terrain": { " ": "t_null", ".": "t_thconc_floor", "g": "t_thconc_floor", "f": "t_thconc_floor" },
     "furniture": { "g": "f_water_heater", "f": "f_home_furnace", "a": [ "f_air_conditioner", "f_null", "f_counter" ] },
-    "liquids": { "g": { "liquid": "water_clean", "amount": [ 0, 100 ] } }
+    "liquids": { "g": { "liquid": "water", "amount": [ 0, 100 ] } }
   },
   {
     "type": "mapgen",
@@ -526,7 +526,7 @@
         "Q": "t_linoleum_gray",
         "T": "t_linoleum_gray"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "item": { "item": "seed_weed" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "T": "f_workbench",
@@ -585,7 +585,7 @@
         "Q": "t_linoleum_gray",
         "T": "t_linoleum_gray"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "item": { "item": "seed_weed" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "T": "f_workbench",
@@ -644,7 +644,7 @@
         "Q": "t_linoleum_gray",
         "T": "t_linoleum_gray"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "item": { "item": "seed_weed" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "T": "f_workbench",
@@ -703,7 +703,7 @@
         "Q": "t_linoleum_gray",
         "T": "t_linoleum_gray"
       },
-      "liquids": { "H": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "H": { "liquid": "water", "amount": [ 0, 100 ] } },
       "sealed_item": { "Q": { "item": { "item": "seed_weed" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "T": "f_workbench",

--- a/data/mods/No_Hope/Mapgen/cabin_isherwood.json
+++ b/data/mods/No_Hope/Mapgen/cabin_isherwood.json
@@ -156,7 +156,7 @@
         "2": "f_smoking_rack"
       },
       "toilets": { "&": {  } },
-      "liquids": { "l": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "l": { "liquid": "water", "amount": [ 0, 100 ] } },
       "place_loot": [
         { "item": "cattlefodder", "x": [ 17, 18 ], "y": [ 2, 4 ], "chance": 50 },
         { "item": "horse_tack", "x": 15, "y": 2, "chance": 50 },

--- a/data/mods/No_Hope/Mapgen/cabin_lake.json
+++ b/data/mods/No_Hope/Mapgen/cabin_lake.json
@@ -71,7 +71,7 @@
         "k": "f_water_purifier"
       },
       "toilets": { "&": {  } },
-      "liquids": { "l": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "l": { "liquid": "water", "amount": [ 0, 100 ] } },
       "items": {
         "b": { "item": "homebooks", "chance": 20, "repeat": [ 2, 4 ] },
         "@": { "item": "bed", "chance": 30, "repeat": [ 2, 4 ] },

--- a/data/mods/No_Hope/Mapgen/gunsmith.json
+++ b/data/mods/No_Hope/Mapgen/gunsmith.json
@@ -150,7 +150,7 @@
         "+": "t_door_locked"
       },
       "furniture": { "W": "f_water_heater" },
-      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "W": { "liquid": "water", "amount": [ 0, 100 ] } },
       "items": { "C": { "item": "ammo_common", "chance": 30 }, "r": { "item": "tools_blacksmith", "chance": 30 } }
     }
   },

--- a/data/mods/No_Hope/Mapgen/hotel_tower.json
+++ b/data/mods/No_Hope/Mapgen/hotel_tower.json
@@ -530,7 +530,7 @@
         "H": "t_generator_broken"
       },
       "furniture": { "Y": "f_standing_tank", "6": "f_water_heater", "7": "f_roof_turbine_vent" },
-      "liquids": { "6": { "liquid": "water_clean", "amount": [ 0, 100 ] }, "Y": { "liquid": "water_clean", "amount": [ 100, 1000 ] } },
+      "liquids": { "6": { "liquid": "water", "amount": [ 0, 100 ] }, "Y": { "liquid": "water_clean", "amount": [ 100, 1000 ] } },
       "place_monsters": [
         { "monster": "GROUP_ROOF_ZOMBIE", "x": [ 7, 23 ], "y": [ 0, 22 ], "repeat": 2 },
         { "monster": "GROUP_ROOF_ZOMBIE", "x": [ 24, 47 ], "y": [ 23, 3 ], "repeat": 2 },

--- a/data/mods/No_Hope/Mapgen/lighthouse.json
+++ b/data/mods/No_Hope/Mapgen/lighthouse.json
@@ -69,7 +69,7 @@
         "W": "f_woodstove",
         "v": "f_workbench"
       },
-      "liquids": { "l": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "l": { "liquid": "water", "amount": [ 0, 100 ] } },
       "items": {
         "7": { "item": "fishing_items", "chance": 20, "repeat": [ 2, 4 ] },
         "b": { "item": "homebooks", "chance": 20, "repeat": [ 2, 4 ] },

--- a/data/mods/No_Hope/Mapgen/ws_biker_dump.json
+++ b/data/mods/No_Hope/Mapgen/ws_biker_dump.json
@@ -206,7 +206,7 @@
         "P": "f_shower"
       },
       "toilets": { "&": {  } },
-      "liquids": { "K": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+      "liquids": { "K": { "liquid": "water", "amount": [ 0, 100 ] } },
       "place_loot": [
         { "item": "television", "x": 68, "y": 7, "chance": 50 },
         { "item": "stepladder", "x": 68, "y": 17, "chance": 50 },

--- a/data/mods/No_Hope/palettes.json
+++ b/data/mods/No_Hope/palettes.json
@@ -108,7 +108,7 @@
       "<": "t_wood_stairs_up",
       ">": "t_wood_stairs_down"
     },
-    "liquids": { "g": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+    "liquids": { "g": { "liquid": "water", "amount": [ 0, 100 ] } },
     "items": {
       "a": { "item": "fireplace_fill", "chance": 30, "repeat": [ 2, 5 ] },
       "d": [
@@ -304,7 +304,7 @@
       "$": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ]
     },
     "toilets": { "t": {  } },
-    "liquids": { "g": { "liquid": "water_clean", "amount": [ 0, 100 ] } },
+    "liquids": { "g": { "liquid": "water", "amount": [ 0, 100 ] } },
     "items": {
       "O": [ { "item": "SUS_wardrobe_mens", "chance": 20 }, { "item": "SUS_wardrobe_womens", "chance": 20, "repeat": [ 1, 2 ] } ],
       "Q": [


### PR DESCRIPTION
This will make water from the heater in most basements not clean. As in, it is just water. Reasoning behind it, is, that it is stagnant enough to produce bacteria and it should be treated the same as toilet tank water.