### PR TITLE
Power lathe addition

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4602,5 +4602,18 @@
     "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
     "pre_special": "check_empty",
     "post_furniture": "f_floor_lamp_off"
+  },
+  {
+    "type": "construction",
+    "id": "constr_heavylathe",
+    "group": "install_heavy_lathe",
+    "category": "WORKSHOP",
+    "required_skills": [  ],
+    "time": "10 m",
+    "qualities": [  ],
+    "components": [ [ [ "heavy_lathe", 1 ] ] ],
+    "pre_note": "Will only work if constructed in/on a building that has an electric grid with a mounted battery.",
+    "pre_special": "check_empty",
+    "post_furniture": "f_heavy_lathe"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1353,5 +1353,10 @@
     "type": "construction_group",
     "id": "wax_floor",
     "name": "Wax Floor"
+  },
+  {
+    "type": "construction_group",
+    "id": "install_heavy_lathe",
+    "name": "Install Power Lathe"
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -704,6 +704,7 @@
     "move_cost_mod": -1,
     "coverage": 40,
     "required_str": 16,
+	"crafting_pseudo_item": "fake_heavylathe",
     "flags": [ "BLOCKSDOOR" ],
     "bash": {
       "str_min": 40,
@@ -716,16 +717,7 @@
         { "item": "steel_lump", "count": [ 1, 2 ] }
       ]
     },
-    "deconstruct": {
-      "items": [
-        { "item": "cable", "charges": [ 4, 8 ] },
-        { "item": "steel_chunk", "count": [ 4, 6 ] },
-        { "item": "steel_lump", "count": [ 2, 4 ] },
-        { "item": "scrap", "count": [ 12, 16 ] },
-        { "item": "pipe", "count": [ 0, 4 ] },
-        { "item": "motor_small", "count": 1 }
-      ]
-    }
+    "deconstruct": { "items": [ { "item": "heavy_lathe", "count": 1 } ] }
   },
   {
     "type": "furniture",

--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -103,6 +103,7 @@
       [ "bio_syringe", 8 ],
       [ "software_electronics_reference", 10 ],
       [ "software_useless", 10 ],
+	  [ "software_CAD", 5 ],
       [ "canteen", 15 ],
       [ "2lcanteen", 10 ],
       [ "camelbak", 5 ],

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -340,5 +340,13 @@
     "sub": "autoclave",
     "max_charges": 1000,
     "flags": [ "USES_GRID_POWER" ]
+  },
+  {
+    "id": "fake_heavylathe",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "heavy lathe" },
+    "max_charges": 2500,
+    "flags": [ "USES_GRID_POWER" ]
   }
 ]

--- a/data/json/items/furniture.json
+++ b/data/json/items/furniture.json
@@ -69,5 +69,19 @@
     "material": "steel",
     "symbol": "#",
     "color": "dark_gray"
-  }
+  },
+  {
+    "id": "heavy_lathe",
+    "type": "TOOL",
+    "looks_like": "f_heavy_lathe",
+    "name": "power lathe",
+    "description": "An industrial-grade lathe, for turning chunks of metal and other hard things into round chunks of metal and other hard things.",
+    "weight": "80 kg",
+    "volume": "210000 ml",
+    "price": 1000,
+    "price_postapoc": 150,
+    "material": "steel",
+    "symbol": "{",
+    "color": "light_cyan"
+  },
 ]

--- a/data/json/items/furniture.json
+++ b/data/json/items/furniture.json
@@ -83,5 +83,5 @@
     "material": "steel",
     "symbol": "{",
     "color": "light_cyan"
-  },
+  }
 ]

--- a/data/json/items/software.json
+++ b/data/json/items/software.json
@@ -254,5 +254,14 @@
     "description": "Huge archives of numerous IC circuit datasheets from several major manufacturers.  Probably valuable to the right person, as it would be hard to salvage and reuse these components without them.",
     "price": 40000,
     "price_postapoc": 0
+  },
+  {
+    "id": "software_CAD",
+    "copy-from": "software",
+    "type": "GENERIC",
+    "name": { "str_sp": "autoCAD" },
+    "description": "A piece of computer design software for CNC machines.",
+    "price": 600,
+    "price_postapoc": 2000
   }
 ]

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -4177,5 +4177,20 @@
     "difficulty": 2,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "components": [ [ [ "2x4", 12 ] ], [ [ "rag", 33 ] ], [ [ "nail", 15 ] ], [ [ "cable", 10 ] ] ]
+  },
+  {
+    "result": "heavy_lathe",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "time": "1 h",
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
+    "components": [
+      [ [ "steel_chunk", 6 ] ],
+      [ [ "cable", 8 ] ],
+      [ [ "steel_lump", 4 ] ],
+      [ [ "scrap", 16 ] ],
+      [ [ "motor_small", 1 ] ],
+      [ [ "pipe", 4 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary

SUMMARY: [Content] "The Power lathe is set up to have a game function as grid furniture instead of just scrapping for parts. "

#### Purpose of change

A number of existing furniture items have no purpose in the game but are very useful in real life. This addresses the heavy lathe, which in the future could be used to make pipes and gun barrels.

#### Describe the solution

The heavy lathe is given an item that is granted on deconstruct, this operates how a refrigerator deconstruct does. There is a re-construct option that just takes the item, and the lathe can be further disassembled using an uncraft to give its original parts. There is also a new software item for computer design, that should likely be required for advanced machining recipes later on. The lathe also has a new pseudo-item that will be used for crafting recipes

#### Describe alternatives you've considered

Hand tools and time consuming recipes could be used instead of factory machines, but as is the case with crafting pipes at an anvil a machine could do it faster, and complex machining such as modern firearm crafting would all but require a proper factory.

#### Testing

I tested my JSON changes by loading into the game and trying out the construct/deconstruct and making sure the items worked as expected.

#### Additional context

We need recipes to utilize it but I don't have a background in machining and was hoping this foundation would get others encouraged. The other existing machines such as the CNC, planer, etc. will come in future PR's.
