### PR TITLE
Make the foldable sheet seat use nails instead of "bolts" to install

### DIFF
--- a/data/json/vehicleparts/seats.json
+++ b/data/json/vehicleparts/seats.json
@@ -133,9 +133,9 @@
     "folded_volume": "2500 ml",
     "location": "anywhere",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "200 s", "using": [ [ "vehicle_bolt", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "200 s", "using": [ [ "vehicle_bolt", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 s", "using": [ [ "welding_standard", 5 ] ] }
+      "install": { "skills": [ [ "mechanics", 0 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
+      "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
+      "repair": { "skills": [ [ "tailor", 1 ] ], "time": "150 s", "using": [ [ "sewing_standard", 50 ], [ "fabric_standard", 1 ] ] }
     },
     "flags": [ "SEAT", "BOARDABLE", "FOLDABLE" ],
     "breaks_into": [ { "item": "rag", "count": [ 1, 6 ] } ]


### PR DESCRIPTION
This makes it that installing a cloth sheet seat doesn't require a wrench (?) but rather a hammer and some nails to put it in place ontop of the frame.

![grafik](https://user-images.githubusercontent.com/33199510/221997962-3a66acec-d8e2-41ba-96e9-a2fb313523ef.png)
