### PR TITLE
Reducing uncraft times.

### DIFF
--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -836,7 +836,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 3,
-    "time": "3 h",
+    "time": "2 h",
     "using": [ [ "welding_standard", 6 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
     "components": [
@@ -1012,7 +1012,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 8,
-    "time": "10 h",
+    "time": "4 h",
     "using": [ [ "soldering_standard", 30 ], [ "welding_standard", 20 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [
@@ -1033,7 +1033,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 8,
-    "time": "10 h",
+    "time": "4 h",
     "using": [ [ "soldering_standard", 30 ], [ "welding_standard", 20 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [
@@ -1054,7 +1054,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 8,
-    "time": "10 h",
+    "time": "4 h",
     "using": [ [ "soldering_standard", 30 ], [ "welding_standard", 20 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [
@@ -1248,7 +1248,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 5,
-    "time": "5 h",
+    "time": "3 h",
     "using": [ [ "soldering_standard", 20 ] ],
     "components": [ [ [ "processor", 4 ] ], [ [ "power_supply", 1 ] ], [ [ "e_scrap", 6 ] ], [ [ "solder_wire", 1 ] ] ]
   },
@@ -1257,7 +1257,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 5,
-    "time": "5 h",
+    "time": "3 h",
     "using": [ [ "soldering_standard", 20 ] ],
     "components": [ [ [ "processor", 4 ] ], [ [ "power_supply", 1 ] ], [ [ "e_scrap", 6 ] ], [ [ "solder_wire", 1 ] ] ]
   },
@@ -1266,7 +1266,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 5,
-    "time": "5 h",
+    "time": "3 h",
     "using": [ [ "soldering_standard", 20 ] ],
     "components": [ [ [ "processor", 4 ] ], [ [ "power_supply", 1 ] ], [ [ "e_scrap", 6 ] ], [ [ "solder_wire", 1 ] ] ]
   },
@@ -1275,7 +1275,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 5,
-    "time": "5 h",
+    "time": "3 h",
     "using": [ [ "soldering_standard", 20 ] ],
     "components": [ [ [ "processor", 4 ] ], [ [ "RAM", 10 ] ], [ [ "power_supply", 1 ] ], [ [ "e_scrap", 6 ] ], [ [ "solder_wire", 1 ] ] ]
   },
@@ -1284,7 +1284,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 5,
-    "time": "5 h",
+    "time": "3 h",
     "using": [ [ "soldering_standard", 20 ] ],
     "components": [
       [ [ "processor", 4 ] ],
@@ -1300,7 +1300,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 5,
-    "time": "5 h",
+    "time": "3 h",
     "using": [ [ "soldering_standard", 20 ] ],
     "components": [
       [ [ "processor", 4 ] ],
@@ -1315,7 +1315,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 5,
-    "time": "5 h",
+    "time": "3 h",
     "using": [ [ "soldering_standard", 20 ] ],
     "components": [
       [ [ "processor", 10 ] ],
@@ -1331,7 +1331,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 5,
-    "time": "5 h",
+    "time": "3 h",
     "using": [ [ "soldering_standard", 20 ] ],
     "components": [
       [ [ "processor", 5 ] ],
@@ -1347,7 +1347,7 @@
     "type": "uncraft",
     "skill_used": "electronics",
     "difficulty": 5,
-    "time": "5 h",
+    "time": "3 h",
     "using": [ [ "soldering_standard", 20 ] ],
     "components": [
       [ [ "processor", 15 ] ],
@@ -1363,7 +1363,7 @@
     "type": "uncraft",
     "skill_used": "mechanics",
     "difficulty": 5,
-    "time": "5 h",
+    "time": "3 h",
     "using": [ [ "soldering_standard", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [
@@ -2291,7 +2291,7 @@
   {
     "result": "mininuke",
     "type": "uncraft",
-    "time": "6 h",
+    "time": "3 h",
     "skill_used": "electronics",
     "difficulty": 8,
     "skills_required": [ [ "fabrication", 4 ], [ "mechanics", 6 ] ],


### PR DESCRIPTION
Some recipes took a very high amount of time to uncraft, giving a relatively low amount of stuff back. This will reduce the times like this: 
3 hours -> 2 hours
5 and 6 hours -> 3 hours
7+ hours -> 4 hours.