### PR TITLE
make standard crossbow autolearn at 5 fab+2 mech

### DIFF
--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -297,6 +297,7 @@
     "time": "15 m",
     "reversible": true,
     "decomp_learn": 2,
+    "autolearn": [ [ "mechanics", 2 ], [ "fabrication", 5 ] ],
     "book_learn": [
       [ "recipe_bows", 2 ],
       [ "manual_archery", 4 ],


### PR DESCRIPTION
No crossbow version was autolearn. This will change it, that the standard version is now autolearn at 5 fab and 2 mech. I can alternatively use "skill_requiered" for 2 mechanics.