### PR TITLE
Updates to auto-eat filtration behavior

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3142,8 +3142,6 @@ bool find_auto_consume( player &p, const bool food )
     if( p.has_effect( effect_nausea ) ) {
         return true;
     }
-    static const std::string flag_MELTS( "MELTS" );
-    static const std::string flag_EDIBLE_FROZEN( "EDIBLE_FROZEN" );
     const tripoint pos = p.pos();
     map &here = get_map();
     zone_manager &mgr = zone_manager::get_manager();
@@ -3194,10 +3192,6 @@ bool find_auto_consume( player &p, const bool food )
             if( !p.can_consume( *it ) ) {
                 continue;
             }
-            if( food && p.compute_effective_nutrients( comest ).kcal < 50 ) {
-                // not filling enough
-                continue;
-            }
             if( !p.will_eat( comest, false ).success() ) {
                 // wont like it, cannibal meat etc
                 continue;
@@ -3212,10 +3206,6 @@ bool find_auto_consume( player &p, const bool food )
             }
             if( comest.has_flag( flag_UNSAFE_CONSUME ) ) {
                 // Unsafe to drink or eat
-                continue;
-            }
-            if( !food && it->is_watertight_container() && it->contents_made_of( SOLID ) ) {
-                // its frozen
                 continue;
             }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Auto-eat can target valid low-calorie foods, remove behaviors related to old freezing code"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Per Viss' request, a bit of cleanup on auto-eat behavior in preparation for later on maybe trying to make its behavior a bit saner in a later PR, if either of us gets around to it.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

In `find_auto_consume` of activity_item_handling.cpp:
1. Removed references to unused `MELTS` and `EDIBLE_FROZEN` flags, as freshly-frozen hot meat is no longer a thing in BN.
2. Per Viss' request, removed the check that removes otherwise-valid items with less than 50 calories from the list. This allows stuff like cooked dandelion greens to be selected. Additionally, the character will automatically eat enough stuff to become sated when auto-eat triggers anyway, and we don't have massive time inflation based on comestible volume like in DDA.
3. Removed exclusion check that filters out frozen drinks, which as noted no longer happens.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Removing the "but sad :<" exclusion filter so stuff like cooked brains gets used too.
2. Changing either the "but sad :<" exclusion filter or the fun value of cooked brains to fix that via another way.
3. Adding a "make sure there's no chance of parasites in this" check to idiotproof unsafe consumables, in case any item exists that can infect the player with parasites but lacks the `UNSAFE_CONSUME` flag.
4. Making the `UNSAFE_CONSUME` exclusion check an OR statement that also checks parasite chance for a bit extra idiotproofing.
5. Rigging some way to exclude foods with mutant toxins from auto-eat just for fun. Holding off on that for after we figure out a way to fuck with the order of what gets eaten first and baking that into the new sorting method is also an option though.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Spawned in an auto-eat zone and placed cooked dandelion greens in it.
3. Character will snack on those while reading.
4. Checked affected file for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

So, we eventually figured out that the real magic here, how auto-eat determines what item it eats first out of what's not been filtered out as invalid, is basically determined by which item was placed in that location first.

Viss has been wanting to implement something that makes it instead favor whatever will rot first, like how the `E`at menu is already ordered. My rough guess is the relevant bit to mess with is this part: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/src/activity_item_handling.cpp#L3159
```
    const std::unordered_set<tripoint> &dest_set = mgr.get_near( consume_type_zone, here.getabs( pos ),
            ACTIVITY_SEARCH_DISTANCE );
```