### PR TITLE
Add a few more fitting options for vehicle turrets

### DIFF
--- a/data/json/vehicleparts/turret.json
+++ b/data/json/vehicleparts/turret.json
@@ -22,6 +22,34 @@
     "requirements": { "install": { "skills": [ [ "mechanics", 5 ], [ "launcher", 1 ] ] }, "removal": { "skills": [ [ "mechanics", 3 ] ] } }
   },
   {
+    "id": "mounted_huge_crossbow",
+    "copy-from": "turret",
+    "type": "vehicle_part",
+    "name": { "str": "mounted huge crossbow" },
+    "item": "huge_crossbow",
+    "looks_like": "mounted_bigun",
+    "color": "green",
+    "broken_color": "green",
+    "breaks_into": [
+      { "item": "scrap", "count": [ 6, 12 ] },
+      { "item": "splinter", "count": [ 8, 16 ] },
+      { "item": "string_36", "count": [ 3, 6 ] }
+    ],
+    "requirements": { "install": { "skills": [ [ "mechanics", 3 ], [ "rifle", 1 ] ] }, "removal": { "skills": [ [ "mechanics", 1 ] ] } }
+  },
+  {
+    "id": "mounted_rep_crossbow",
+    "copy-from": "turret",
+    "type": "vehicle_part",
+    "name": { "str": "mounted repeating crossbow" },
+    "item": "rep_crossbow",
+    "looks_like": "mounted_bigun",
+    "color": "green",
+    "broken_color": "green",
+    "breaks_into": [ { "item": "splinter", "count": [ 4, 8 ] }, { "item": "string_6", "count": [ 1, 2 ] } ],
+    "requirements": { "install": { "skills": [ [ "mechanics", 3 ], [ "smg", 1 ] ] }, "removal": { "skills": [ [ "mechanics", 1 ] ] } }
+  },
+  {
     "id": "mounted_emp_gun",
     "copy-from": "turret",
     "type": "vehicle_part",
@@ -60,6 +88,20 @@
     "broken_color": "dark_gray",
     "breaks_into": [ { "item": "scrap", "count": 3 }, { "item": "steel_chunk", "count": 1 }, { "item": "steel_lump", "count": 1 } ],
     "requirements": { "install": { "skills": [ [ "mechanics", 5 ], [ "launcher", 1 ] ] }, "removal": { "skills": [ [ "mechanics", 3 ] ] } },
+    "extend": { "flags": [ "USE_TANKS" ] }
+  },
+  {
+    "id": "mounted_rm451_flamethrower",
+    "copy-from": "turret",
+    "type": "vehicle_part",
+    "name": { "str": "mounted RM451 flamethrower" },
+    "item": "rm451_flamethrower",
+    "looks_like": "flamethrower",
+    "default_ammo": "napalm",
+    "color": "dark_gray",
+    "broken_color": "dark_gray",
+    "breaks_into": [ { "item": "scrap", "count": 3 }, { "item": "steel_chunk", "count": 1 }, { "item": "steel_lump", "count": 1 } ],
+    "requirements": { "install": { "skills": [ [ "mechanics", 6 ], [ "launcher", 2 ] ] }, "removal": { "skills": [ [ "mechanics", 4 ] ] } },
     "extend": { "flags": [ "USE_TANKS" ] }
   },
   {
@@ -127,6 +169,30 @@
     "requirements": { "install": { "skills": [ [ "mechanics", 3 ], [ "shotgun", 1 ] ] }, "removal": { "skills": [ [ "mechanics", 1 ] ] } }
   },
   {
+    "id": "mounted_helsing",
+    "copy-from": "turret",
+    "type": "vehicle_part",
+    "name": { "str": "mounted pneumatic bolt driver" },
+    "item": "helsing",
+    "looks_like": "mounted_m1918",
+    "color": "dark_gray",
+    "broken_color": "dark_gray",
+    "breaks_into": [ { "item": "scrap", "count": [ 5, 10 ] }, { "item": "splinter", "count": [ 2, 4 ] } ],
+    "requirements": { "install": { "skills": [ [ "mechanics", 3 ], [ "rifle", 1 ] ] }, "removal": { "skills": [ [ "mechanics", 1 ] ] } }
+  },
+  {
+    "id": "mounted_tihar",
+    "copy-from": "turret",
+    "type": "vehicle_part",
+    "name": { "str": "mounted pneumatic assault rifle" },
+    "item": "tihar",
+    "looks_like": "mounted_m1918",
+    "color": "dark_gray",
+    "broken_color": "dark_gray",
+    "breaks_into": [ { "item": "scrap", "count": [ 5, 10 ] }, { "item": "splinter", "count": [ 2, 4 ] } ],
+    "requirements": { "install": { "skills": [ [ "mechanics", 3 ], [ "rifle", 1 ] ] }, "removal": { "skills": [ [ "mechanics", 1 ] ] } }
+  },
+  {
     "id": "mounted_browning",
     "copy-from": "turret",
     "type": "vehicle_part",
@@ -135,6 +201,18 @@
     "color": "green",
     "broken_color": "green",
     "breaks_into": [ { "item": "scrap", "count": 80 }, { "item": "steel_chunk", "count": 48 }, { "item": "steel_lump", "count": 18 } ],
+    "requirements": { "install": { "skills": [ [ "mechanics", 4 ], [ "rifle", 2 ] ] }, "removal": { "skills": [ [ "mechanics", 2 ] ] } }
+  },
+  {
+    "id": "mounted_m2browning_sawn",
+    "copy-from": "turret",
+    "type": "vehicle_part",
+    "name": { "str": "mounted .50 caliber rifle" },
+    "item": "m2browning_sawn",
+    "looks_like": "mounted_browning",
+    "color": "green",
+    "broken_color": "green",
+    "breaks_into": [ { "item": "scrap", "count": 40 }, { "item": "steel_chunk", "count": 24 }, { "item": "steel_lump", "count": 9 } ],
     "requirements": { "install": { "skills": [ [ "mechanics", 4 ], [ "rifle", 2 ] ] }, "removal": { "skills": [ [ "mechanics", 2 ] ] } }
   },
   {
@@ -205,6 +283,30 @@
     "requirements": { "install": { "skills": [ [ "mechanics", 5 ], [ "launcher", 3 ] ] }, "removal": { "skills": [ [ "mechanics", 3 ] ] } }
   },
   {
+    "id": "mounted_m202_flash",
+    "copy-from": "turret",
+    "type": "vehicle_part",
+    "name": { "str": "mounted M202A1 FLASH" },
+    "item": "m202_flash",
+    "looks_like": "tow_launcher",
+    "color": "dark_gray",
+    "broken_color": "dark_gray",
+    "breaks_into": [ { "item": "scrap", "count": 16 }, { "item": "steel_chunk", "count": 2 }, { "item": "steel_lump", "count": 2 } ],
+    "requirements": { "install": { "skills": [ [ "mechanics", 4 ], [ "launcher", 2 ] ] }, "removal": { "skills": [ [ "mechanics", 2 ] ] } }
+  },
+  {
+    "id": "mounted_surv_rocket_launcher",
+    "copy-from": "turret",
+    "type": "vehicle_part",
+    "name": { "str": "mounted crude rocket launcher" },
+    "item": "surv_rocket_launcher",
+    "looks_like": "tow_launcher",
+    "color": "light_gray",
+    "broken_color": "light_gray",
+    "breaks_into": [ { "item": "scrap", "count": [ 10, 20 ] } ],
+    "requirements": { "install": { "skills": [ [ "mechanics", 3 ], [ "launcher", 1 ] ] }, "removal": { "skills": [ [ "mechanics", 1 ] ] } }
+  },
+  {
     "id": "mounted_rm298",
     "copy-from": "turret",
     "type": "vehicle_part",
@@ -252,5 +354,17 @@
     "breaks_into": [ { "item": "scrap", "count": 40 }, { "item": "steel_chunk", "count": 30 }, { "item": "steel_lump", "count": 13 } ],
     "requirements": { "install": { "skills": [ [ "mechanics", 4 ] ] }, "removal": { "skills": [ [ "mechanics", 2 ] ] } },
     "extend": { "flags": [ "USE_TANKS" ] }
+  },
+  {
+    "id": "mounted_paintballgun",
+    "copy-from": "turret",
+    "type": "vehicle_part",
+    "name": { "str": "mounted Paintball gun" },
+    "item": "paintballgun",
+    "looks_like": "mounted_m1918",
+    "color": "light_gray",
+    "broken_color": "light_gray",
+    "breaks_into": [ { "item": "scrap", "count": 8 }, { "item": "steel_chunk", "count": 3 }, { "item": "steel_lump", "count": 1 } ],
+    "requirements": { "install": { "skills": [ [ "mechanics", 3 ], [ "rifle", 1 ] ] }, "removal": { "skills": [ [ "mechanics", 1 ] ] } }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Content "Add a few extra options for vehicle mounted guns"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Minor item on my idea list I started work on earlier today, while out and about on my laptop and thus wasn't able to do C++ stuff, adding a bit more variety to the options for what weapons you can mount on vehicle, in particular including more missile, survivor-made, and ballista-like options.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added a turret vehiclepart for huge crossbows. This particularly fits the role of a ballista-style vehiclepart, something that blazemod had in most versions of it, with the big-ass crossbow being the most fitting vanilla counterpart.
2. Added a turret vehiclepart for repeated crossbows, also seemed fitting for a light ballista role.
3. Added the RM451 flamethrower as an option to mount on vehicles, fitting with regular flamethrowers being an option.
4. Added the stripped-down M2 Browning as a turret vehiclepart, since the standard M2 is an option.
5. Added paintball guns as an option, aside from making them marginally more useful this is mostly a flavor option like the water cannon (though I have an idea on an improvement for water cannons).
6. Added the M202A1 FLASH as a turret vehiclepart option, seemed the most potentially fitting to install on a deathmobile in the vein of the TOW.
7. Added the crude rocket launcher as a survivor-made option to fill the same niche as the FLASH and TOW.
8. Added the pneumatic assault rifle as another potential survivor-made vehicle turret option. This also fits with one of the refugee center NPCs wanting to someday install a similar setup as defenses for the center, plus with the below option it makes the full triad of oddball survivor guns mountable.
9. Added the pneumatic bolt driver as a turret option as well, for completeness together with the existing option to mount the gatling shotgun and the above pneumatic assault rifle option.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

We could go the whole hog and allow most rifles to be mountable, or at least all full-auto and full-on sniper rifles.

Alternatively we could look into porting over the DDA PR that generates valid turrets automatically: https://github.com/CleverRaven/Cataclysm-DDA/pull/59563 Not having them accessible via JSON and not being able to customize their properties (durability, skill requirements, foldability, etc) is a downside however.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
