### PR TITLE
Remove filthy tag of used antiseptic cotton balls and rags.

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1769,7 +1769,7 @@
       "disinfectant_power": 2,
       "bite": 0.5,
       "move_cost": 200,
-      "used_up_item": { "id": "rag", "quantity": 1, "flags": [ "FILTHY" ] }
+      "used_up_item": { "id": "rag", "quantity": 1 }
     }
   },
   {
@@ -1793,7 +1793,7 @@
       "disinfectant_power": 3,
       "bite": 0.66,
       "move_cost": 300,
-      "used_up_item": { "id": "cotton_ball", "quantity": 1, "charges": 1, "flags": [ "FILTHY" ] }
+      "used_up_item": { "id": "cotton_ball", "quantity": 1, "charges": 1 }
     }
   },
   {


### PR DESCRIPTION
Using antiseptic soaked cotton balls/rags lead to filthy end objects. It was just unnecessary button presses to get them clean again, since soap or normal water rarelly are an issue. This will turn the balls and rags to their "normal" form, making them reusable again.