### PR TITLE
Remove bionic mana penalty

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1436,10 +1436,9 @@ int known_magic::max_mana( const Character &guy ) const
     float mut_add = guy.mutation_value( "mana_modifier" );
     int natural_cap = std::max( 0.0f, ( ( mana_base + int_bonus ) * mut_mul ) + mut_add );
 
-    int bp_penalty = units::to_kilojoule( guy.get_power_level() );
     int ench_bonus = guy.bonus_from_enchantments( natural_cap, enchant_vals::mod::MANA_CAP, true );
 
-    return std::max( 0, natural_cap - bp_penalty + ench_bonus );
+    return std::max( 0, natural_cap + ench_bonus );
 }
 
 double known_magic::mana_regen_rate( const Character &guy ) const

--- a/tests/enchantment_test.cpp
+++ b/tests/enchantment_test.cpp
@@ -474,7 +474,6 @@ TEST_CASE( "Enchantments modify metabolic rate", "[magic][enchantment][metabolis
 struct mana_test_case {
     int idx;
     int intellect;
-    units::energy power_level;
     int norm_cap;
     int exp_cap;
     double norm_regen_amt_8h;
@@ -482,12 +481,8 @@ struct mana_test_case {
 };
 
 static const std::vector<mana_test_case> mana_test_data = {{
-        {0, 8, 0_kJ, 1000, 800, 1000.0, 560.0},
-        {1, 12, 0_kJ, 1400, 1080, 1400.0, 686.0},
-        {2, 8, 250_kJ, 750, 450, 750.0, 385.0},
-        {3, 12, 250_kJ, 1150, 830, 1150.0, 581.0},
-        {4, 8, 1250_kJ, 0, 0, 0.0, 0.0},
-        {5, 16, 1250_kJ, 550, 110, 550.0, 77.0},
+        {0, 8, 1000, 800, 1000.0, 560.0},
+        {1, 12, 1400, 1080, 1400.0, 686.0},
     }
 };
 
@@ -497,12 +492,6 @@ static void tests_mana_pool( Character &guy, const mana_test_case &t )
     double exp_regen_rate = t.exp_regen_amt_8h / to_turns<double>( time_duration::from_hours( 8 ) );
 
     advance_turn( guy );
-
-    guy.set_max_power_level( 2000_kJ );
-    REQUIRE( guy.get_max_power_level() == 2000_kJ );
-
-    guy.set_power_level( t.power_level );
-    REQUIRE( guy.get_power_level() == t.power_level );
 
     guy.int_max = t.intellect;
     guy.int_cur = guy.int_max;
@@ -548,7 +537,7 @@ static void tests_mana_pool_section( const mana_test_case &t )
     tests_mana_pool( guy, t );
 }
 
-TEST_CASE( "Mana pool", "[magic][enchantment][mana][bionic]" )
+TEST_CASE( "Mana pool", "[magic][enchantment][mana]" )
 {
     clear_all_state();
     for( const mana_test_case &it : mana_test_data ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Bionic power no longer affects maximum mana"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Per discussion on the BN discord, implementing an in-repo example of mana-casting that isn't affected by the bionic energy penalty was running into delays (as the main example of it in action was planned to be Arcana mod, when it's ported over to become an in-repo mod), and most opinions have weighed in favor of it being fine to just axe the feature outright.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In magic.cpp, updated `known_magic::max_mana` to remove the `bp_penalty` feature entirely.
2. Updated enchantment_test.cpp, removing test cases and data only relevant to testing if the now-removed penalty is working correctly.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Rigging a quick-and-dirty in-repo solution to allow https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1823 to be merged without any more delays.
2. Moving forward with porting over Arcana anyway and just figuring out what the merge order should be to get it all to come together without causing any problems.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Spawned in a character and debugged in all spells.
3. Observed max mana was default of 1000.
4. Debugged in some filled power storage.
5. Waited a bit and confirmed man mana didn't change.
6. Checked affected file for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
