### PR TITLE
Fix description of "minimize on focus loss" option

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2009,8 +2009,8 @@ void options_manager::add_options_graphics()
        );
 
     add( "MINIMIZE_ON_FOCUS_LOSS", "graphics",
-         translate_marker( "Minimize on focus loss.  Requires restart." ),
-         translate_marker( "Minimize fullscreen window when it loses focus." ), false );
+         translate_marker( "Minimize on focus loss" ),
+         translate_marker( "Minimize fullscreen window when it loses focus.  Requires restart." ), false );
 #endif
 
 #if !defined(__ANDROID__)


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Follow-up to #2139.
Move 'Requires restart' from option name to option description to be consistent with other options.