### PR TITLE
Fix loading of laser_lock

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -458,13 +458,13 @@ void gun_actor::load_internal( const JsonObject &obj, const std::string & )
 
     obj.read( "targeting_volume", targeting_volume );
 
-    obj.get_bool( "laser_lock", laser_lock );
+    obj.read( "laser_lock", laser_lock );
 
     obj.read( "target_moving_vehicles", target_moving_vehicles );
 
     obj.read( "require_sunlight", require_sunlight );
 
-    no_crits = obj.get_bool( "no_crits", no_crits );
+    obj.read( "no_crits", no_crits );
 }
 
 std::unique_ptr<mattack_actor> gun_actor::clone() const


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed laser lock from enemies"

#### Purpose of change
Fixes #2014

#### Describe the solution
Fix deserialization code.

#### Describe alternatives you've considered
Removing this functionality. It's only used by couple robots from Aftershock and a few other robots from obsolete mods.

#### Testing
Spawned a railgun robot from Aftershock, got a warning message about laser targeting a few turns before getting shot.