### PR TITLE
Fix black map screen on curses build

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3328,8 +3328,13 @@ void options_manager::cache_to_globals()
     json_report_strict = test_mode || ::get_option<bool>( "STRICT_JSON_CHECKS" );
     display_mod_source = ::get_option<bool>( "MOD_SOURCE" );
     trigdist = ::get_option<bool>( "CIRCLEDIST" );
+#if defined(TILES)
     use_tiles = ::get_option<bool>( "USE_TILES" );
     use_tiles_overmap = ::get_option<bool>( "USE_TILES_OVERMAP" );
+#else
+    use_tiles = false;
+    use_tiles_overmap = false;
+#endif
     log_from_top = ::get_option<std::string>( "LOG_FLOW" ) == "new_top";
     message_ttl = ::get_option<int>( "MESSAGE_TTL" );
     message_cooldown = ::get_option<int>( "MESSAGE_COOLDOWN" );


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fix black map screen on curses build"

#### Purpose of change
Fix #2333

#### Describe the solution
Don't attempt to draw map with tiles on curses build.

#### Testing
![image](https://user-images.githubusercontent.com/60584843/224728350-1953da98-c584-4296-8749-d60d2e55fb72.png)
