### PR TITLE
Add more variation to some zombie evolutions

### DIFF
--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -1,14 +1,47 @@
 [
   {
     "type": "monstergroup",
+    "name": "GROUP_BOOMER_UPGRADE",
+    "default": "mon_boomer_huge",
+    "monsters": [ { "monster": "mon_gas_zombie", "freq": 50, "cost_multiplier": 10 } ]
+  },
+  {
+    "type": "monstergroup",
     "name": "GROUP_SOLDIER_UPGRADE",
     "default": "mon_zombie_kevlar_1",
     "//": "Masters pick from here when upgrading.",
     "monsters": [
-      { "monster": "mon_zombie_soldier_blackops_1", "freq": 20, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_soldier_acid_1", "freq": 10, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_soldier_acid_2", "freq": 15, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_kevlar_1", "freq": 25, "cost_multiplier": 2 }
+      { "monster": "mon_zombie_soldier_blackops_1", "freq": 100, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_soldier_acid_1", "freq": 100, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_soldier_acid_2", "freq": 150, "cost_multiplier": 2 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE_BURNER_UPGRADE",
+    "default": "mon_zombie_kevlar_1",
+    "monsters": [
+      { "monster": "mon_zombie_soldier_blackops_1", "freq": 100, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_soldier_acid_1", "freq": 100, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_soldier_acid_2", "freq": 150, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_smoker", "freq": 100, "cost_multiplier": 5 },
+      { "monster": "mon_gas_zombie", "freq": 50, "cost_multiplier": 10 },
+      { "monster": "mon_zombie_fiend", "freq": 50, "cost_multiplier": 10 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE_DOG_UPGRADE",
+    "default": "mon_dog_skeleton",
+    "monsters": [ { "monster": "mon_dog_zombie_rot", "freq": 100, "cost_multiplier": 2 } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE_SWAT_UPGRADE",
+    "default": "mon_zombie_kevlar_1",
+    "monsters": [
+      { "monster": "mon_zombie_tough", "freq": 250, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_hunter", "freq": 100, "cost_multiplier": 2 }
     ]
   }
 ]

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -304,10 +304,7 @@
     "type": "monstergroup",
     "name": "GROUP_ZOMBIE_GRAB",
     "default": "mon_zombie_grappler",
-    "monsters": [
-      { "monster": "mon_zombie_grappler", "freq": 40, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_biter", "freq": 40, "cost_multiplier": 2 }
-    ]
+    "monsters": [ { "monster": "mon_zombie_biter", "freq": 300, "cost_multiplier": 2 } ]
   },
   {
     "type": "monstergroup",

--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -57,7 +57,7 @@
     "harvest": "zombie",
     "special_attacks": [ { "type": "bite", "cooldown": 5 } ],
     "death_function": [ "NORMAL" ],
-    "upgrades": { "half_life": 28, "into": "mon_dog_skeleton" },
+    "upgrades": { "half_life": 28, "into_group": "GROUP_ZOMBIE_DOG_UPGRADE" },
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "FILTHY" ]
   },
   {

--- a/data/json/monsters/zed-classic.json
+++ b/data/json/monsters/zed-classic.json
@@ -32,6 +32,7 @@
     },
     "death_function": [ "NORMAL" ],
     "burn_into": "mon_zombie_scorched",
+    "upgrades": { "half_life": 28, "into_group": "GROUP_ZOMBIE_UPGRADE" },
     "flags": [
       "HEARS",
       "SMELLS",
@@ -127,6 +128,7 @@
     "death_function": [ "NORMAL" ],
     "fungalize_into": "mon_zombie_fungus",
     "burn_into": "mon_zombie_scorched",
+    "upgrades": { "half_life": 28, "into_group": "GROUP_ZOMBIE_UPGRADE" },
     "flags": [
       "SEES",
       "HEARS",
@@ -445,7 +447,7 @@
     "special_attacks": [ [ "GRAB", 7 ], [ "scratch", 15 ] ],
     "death_drops": "mon_zombie_swat_death_drops",
     "death_function": [ "NORMAL" ],
-    "upgrades": { "half_life": 28, "into": "mon_zombie_kevlar_1" },
+    "upgrades": { "half_life": 28, "into_group": "GROUP_ZOMBIE_SWAT_UPGRADE" },
     "burn_into": "mon_zombie_scorched",
     "flags": [
       "SEES",

--- a/data/json/monsters/zed_explosive.json
+++ b/data/json/monsters/zed_explosive.json
@@ -27,7 +27,7 @@
     "death_drops": "default_zombie_items",
     "death_function": [ "BOOMER" ],
     "fungalize_into": "mon_boomer_fungus",
-    "upgrades": { "half_life": 14, "into": "mon_boomer_huge" },
+    "upgrades": { "half_life": 14, "into_group": "GROUP_BOOMER_UPGRADE" },
     "flags": [
       "SEES",
       "HEARS",

--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -323,6 +323,7 @@
     "special_attacks": [ { "type": "bite", "cooldown": 5 }, [ "GRAB", 7 ], [ "scratch", 20 ] ],
     "death_drops": "mon_zombie_military_pilot_death_drops",
     "death_function": [ "NORMAL" ],
+    "upgrades": { "half_life": 28, "into_group": "GROUP_SOLDIER_UPGRADE" },
     "burn_into": "mon_zombie_scorched",
     "flags": [
       "SEES",
@@ -372,6 +373,7 @@
     "starting_ammo": { "pressurized_tank": 1000 },
     "death_drops": { "subtype": "collection", "groups": [ [ "mon_zombie_soldier_death_drops", 100 ], [ "mon_zombie_flamer", 100 ] ] },
     "death_function": [ "FIREBALL" ],
+    "upgrades": { "half_life": 28, "into_group": "GROUP_ZOMBIE_BURNER_UPGRADE" },
     "burn_into": "mon_zombie_scorched",
     "flags": [
       "SEES",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Increase variety of spawns for zombie evolution"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A small improvement that came to mind, and one I might someday follow up on by either porting over some monsters from DDA, or devising other fitting evolutions to add in.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Defined `GROUP_BOOMER_UPGRADE` for boomers to evolve into, defaulting to huge boomers and a small chance of becoming a gasoline zombie. One of my random ideas for the future is an acidic variation that'll likely be quite a bit more common an evolution than gasoline zombies (since acid can't burn your house down).
2. Increased the odds of grabber zombies evolving into slavering biters instead of grapplers, for increased variation since `GROUP_ZOMBIE_GRAB` has grapplers as the default outcome.
3. Increased the weights for non-kevlar evolutions in `GROUP_SOLDIER_UPGRADE` increased variation, removed the extra call to kevlar zombies as they're the default result.
4. Allowed zombie pilots evolve into kevlar variations, same as labsec and soldier zombies.
5. Defined `GROUP_ZOMBIE_BURNER_UPGRADE` for zombie burners. This copies `GROUP_SOLDIER_UPGRADE` for the most part except it adds potential spawns of smoker zombies, gasoline zombies, and provides for a rare natural spawn of fiends.
6. Defined branching evolution for zombie dogs, giving them a small chance of evolving into rot-weilers instead of skeletal dogs. Also sets up the potential to add more variations in the future, possibly porting over any interesting ideas DDA might have added.
7. Set it so that scarred zombies and zombie cops can evolve into regular zombie upgrades, but at a slower rate. Could add a dedicated group for scarred zombies that favors some new monsters in the future maybe.
8. Defined `GROUP_ZOMBIE_SWAT_UPGRADE` for SWAT zombies, giving them variation so they don't exclusively evolve into kevlar zombies. This basically splits it between kevlar zombies, regular brute zombies, and feral hunters for a slight bit of variety, with the alternatives representing mutations that busted out of their armor instead of fusing with it.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Focusing on porting over monsters from DDA first.
2. Adding whatever new ideas come to mind now instead of later.
3. Adding evolution monstergroups to hazmat and fightfighter zeds. I was going to (rare non-necropolis spawn of charred nightmares for hazmats, another chance to pre-spawn burnt zeds for firefighters) but decided to hold off on that in favor of waiting and doing that when I have some extra ideas for their evolutions to add.
4. Changing it so that zombie fiends evolve into fireproof and smoky variations on the brute's evolutions instead of just regrowing back into a regular zed.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Faffed about with checking some of the spawns by spawning a giant group of a target zed in, teleporting away, waiting 2 years, then teleporting back. Zombie soldiers notably produced a much less homogeneous gaggle of evolutions after this change.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Example before:
![1](https://user-images.githubusercontent.com/11582235/224783449-49ee8b77-0d39-4897-b1aa-a5174813de49.png)

Example after:
![2](https://user-images.githubusercontent.com/11582235/224783478-60c12ae5-5280-4fca-ad78-68838b578605.png)

Some of the ideas I had for another time:
1. Noxious shambler: A zombie practically hollowed out by fuming corrosive materials, combing acidic attacks with toxic gas emissions, possibly a focus on venomous attacks or in some way corrosive bites. Potential evolution of decayed zombie as an alternative to dissoluted devourers, along with being a possible sidegrade in the acidic zombie line, maybe a possible outcome of evolving hazmat zombies.
2. Acid bloat: Basically an acid variation of boomers. Potential sidegrade in the acidic zombie evolutionary line, and in the boomer evolutionary line.
3. Luminous zombie: Lit up critter that's basically the BN equivalent of a glowing one from Fallout. Emits light, attacks should in some way irradiate victims, possibly emits nuke gas (unless it can damage zombies too), possibly has a blinding flash AoE attack either as a special attack or added to its death function.
4. Ossified fiend: A skeletal zombie gone wrong, bristling with bony spikes growing in twisted brambles growing though its flesh. To be added as a sidegrade for skeletal zombies, to be less tanky than the skeletal brute line but much more stabby, possibly including a thorns-style monster counterattack (which could be ported to thorny shamblers too) if hit in melee.
5. Charnal abomination: Basically a juggernaut-tier evolution of the ossified fiend, bigger and tougher but still more offensive-over-defense than skeletal juggernauts. Gains a ranged spike attack firing splinters of bone.
6. Slithering zombie: The upper half of a zombie now crawling around on its own, leaving a smear of fetid and mutated gore along the ground. Leaves a slime trail behind it that might bog players down, can inflict the slime speed debuff amoebic molds have as a counterattack, possibly uses acidbarf attack or maybe just a nastier bite. A potential evolution of crawling zombies, to make the most pathetic monster in the game into something with a functioning evolutionary tree.
7. Zombie mantrap: Another potential crawling zombie evolution, a mess of spindly limbs haphazardly groping about. Most of the same focus on grabbing and pulling in from a distance as grappler zombies but with less mobility, possibly in exchange for being able to trip up victims and knock them to the ground as well.
8. Scuttling horror: Another possible crawling zombie evolution, basically the crawlers from Killing Floor. A humanoid zombie doing its best spider impression, gaining back a good bit of speed and adding wall-climbing.