### PR TITLE
Add debug option to show object IDs in game

### DIFF
--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -9,6 +9,7 @@ bool log_from_top;
 int message_ttl;
 int message_cooldown;
 bool display_mod_source;
+bool display_object_ids;
 bool trigdist;
 bool fov_3d;
 bool static_z_effect = false;

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -45,6 +45,8 @@ extern int message_cooldown;
 
 /** Display mod source for items, furniture, terrain and monsters.*/
 extern bool display_mod_source;
+/** Display internal IDs for items, furniture, terrain and monsters.*/
+extern bool display_object_ids;
 
 /**
  * Circular distances.

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -121,10 +121,12 @@ void game::extended_description( const tripoint &p )
                         fid->src.end(), []( const std::pair<furn_str_id, mod_id> &source ) {
                             return string_format( "'%s'", source.second->name() );
                         }, enumeration_conjunction::arrow );
-                        desc = string_format( _( "Origin: %s\n%s" ), mod_src, fid->extended_description() );
-                    } else {
-                        desc = fid.obj().extended_description();
+                        desc = string_format( _( "Origin: %s\n" ), mod_src );
                     }
+                    if( display_object_ids ) {
+                        desc += colorize( string_format( "[%s]\n", fid.id() ), c_light_blue );
+                    }
+                    desc += fid.obj().extended_description();
                 }
                 break;
             case description_target::terrain:
@@ -137,10 +139,12 @@ void game::extended_description( const tripoint &p )
                         tid->src.end(), []( const std::pair<ter_str_id, mod_id> &source ) {
                             return string_format( "'%s'", source.second->name() );
                         }, enumeration_conjunction::arrow );
-                        desc = string_format( _( "Origin: %s\n%s" ), mod_src, tid->extended_description() );
-                    } else {
-                        desc = tid.obj().extended_description();
+                        desc = string_format( _( "Origin: %s\n" ), mod_src );
                     }
+                    if( display_object_ids ) {
+                        desc += colorize( string_format( "[%s]\n", tid.id() ), c_light_blue );
+                    }
+                    desc += tid.obj().extended_description();
                 }
                 break;
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5805,14 +5805,19 @@ void game::print_terrain_info( const tripoint &lp, const catacurses::window &w_l
         map &here = get_map();
         std::string ret;
         if( debug_mode ) {
-            ret = string_format( "%s %s", lp.to_string(), here.ter( lp )->id );
-            if( here.has_furn( lp ) ) {
-                ret += "; " + here.furn( lp )->id.str();
-            }
+            ret += lp.to_string();
+            ret += "\n";
+        }
+        if( debug_mode || display_object_ids ) {
+            ret += string_format( "%s [%s]", here.tername( lp ), here.ter( lp )->id );
         } else {
-            ret = here.tername( lp );
-            if( here.has_furn( lp ) ) {
-                ret += "; " + here.furnname( lp );
+            ret += here.tername( lp );
+        }
+        if( here.has_furn( lp ) ) {
+            if( debug_mode || display_object_ids ) {
+                ret += string_format( "; %s [%s]", here.furnname( lp ), here.furn( lp )->id );
+            } else {
+                ret += string_format( "; %s", here.furnname( lp ) );
             }
         }
         return ret;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5808,16 +5808,14 @@ void game::print_terrain_info( const tripoint &lp, const catacurses::window &w_l
             ret += lp.to_string();
             ret += "\n";
         }
+        ret += here.tername( lp );
         if( debug_mode || display_object_ids ) {
-            ret += string_format( "%s [%s]", here.tername( lp ), here.ter( lp )->id );
-        } else {
-            ret += here.tername( lp );
+            ret += colorize( string_format( " [%s]", here.ter( lp )->id ), c_light_blue );
         }
         if( here.has_furn( lp ) ) {
+            ret += string_format( "; %s", here.furnname( lp ) );
             if( debug_mode || display_object_ids ) {
-                ret += string_format( "; %s [%s]", here.furnname( lp ), here.furn( lp )->id );
-            } else {
-                ret += string_format( "; %s", here.furnname( lp ) );
+                ret += colorize( string_format( " [%s]", here.furn( lp )->id ), c_light_blue );
             }
         }
         return ret;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1466,6 +1466,10 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         }, enumeration_conjunction::arrow ) ) );
         insert_separation_line( info );
     }
+    if( display_object_ids && parts->test( iteminfo_parts::BASE_ID ) ) {
+        info.emplace_back( "BASE", colorize( string_format( "[%s]", type->get_id() ), c_light_blue ) );
+        insert_separation_line( info );
+    }
 
     const std::string space = "  ";
     if( parts->test( iteminfo_parts::BASE_MATERIAL ) ) {
@@ -3580,6 +3584,11 @@ void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *par
                         return string_format( "'%s'", content_source.second->name() );
                     }, enumeration_conjunction::arrow ) ) );
                 }
+                if( display_object_ids ) {
+                    info.emplace_back( "DESCRIPTION", colorize(
+                                           string_format( "[%s]", contents_item->type->get_id() ),
+                                           c_light_blue ) );
+                }
                 if( converted_volume_scale != 0 ) {
                     f |= iteminfo::is_decimal;
                 }
@@ -3594,6 +3603,11 @@ void item::contents_info( std::vector<iteminfo> &info, const iteminfo_query *par
                     contents_item->type->src.end(), []( const std::pair<itype_id, mod_id> &content_source ) {
                         return string_format( "'%s'", content_source.second->name() );
                     }, enumeration_conjunction::arrow ) ) );
+                }
+                if( display_object_ids ) {
+                    info.emplace_back( "DESCRIPTION", colorize(
+                                           string_format( "[%s]", contents_item->type->get_id() ),
+                                           c_light_blue ) );
                 }
                 info.emplace_back( "DESCRIPTION", description.translated() );
             }

--- a/src/iteminfo_query.h
+++ b/src/iteminfo_query.h
@@ -10,6 +10,7 @@
 enum class iteminfo_parts : size_t {
     BASE_CATEGORY = 0,
     BASE_MOD_SRC,
+    BASE_ID,
     BASE_PRICE,
     BASE_BARTER,
     BASE_VOLUME,

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -656,6 +656,9 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
         vStart += fold_and_print( w, point( column, vStart + 1 ), getmaxx( w ) - 2, c_cyan,
                                   string_format( _( "Origin: %s" ), mod_src ) );
     }
+    if( display_object_ids ) {
+        mvwprintz( w, point( column, ++vStart ), c_light_blue, string_format( "[%s]", type->id.str() ) );
+    }
 
     if( sees( g->u ) ) {
         mvwprintz( w, point( column, ++vStart ), c_yellow, _( "Aware of your presence!" ) );
@@ -714,6 +717,12 @@ std::string monster::extended_description() const
         type->src.end(), []( const std::pair<mtype_id, mod_id> &source ) {
             return string_format( "'%s'", source.second->name() );
         }, enumeration_conjunction::arrow );
+    }
+    if( display_object_ids ) {
+        if( display_mod_source ) {
+            ss += "\n";
+        }
+        ss += colorize( string_format( "[%s]", type->id.str() ), c_light_blue );
     }
 
     ss += "\n--\n";

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2260,6 +2260,10 @@ int npc::print_info( const catacurses::window &w, int line, int vLines, int colu
     mvwprintz( w, point( column, line++ ), c_white, _( "NPC: " ) );
     wprintz( w, basic_symbol_color(), name );
 
+    if( display_object_ids ) {
+        mvwprintz( w, point( column, line++ ), c_light_blue, string_format( "[%s]", myclass ) );
+    }
+
     if( sees( g->u ) ) {
         mvwprintz( w, point( column, line++ ), c_yellow, _( "Aware of your presence!" ) );
     }
@@ -3016,8 +3020,13 @@ std::string npc::extended_description() const
         ss += _( "Is neutral." );
     }
 
+    if( display_object_ids ) {
+        ss += "\n--\n";
+        ss += colorize( string_format( "[%s]", myclass ), c_light_blue );
+    }
+
     if( hit_by_player ) {
-        ss += "--\n";
+        ss += "\n--\n";
         ss += _( "Is still innocent and killing them will be considered murder." );
         // TODO: "But you don't care because you're an edgy psycho"
     }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2101,6 +2101,11 @@ void options_manager::add_options_debug()
          true
        );
 
+    add( "SHOW_IDS", "debug", translate_marker( "Display Object IDs" ),
+         translate_marker( "Displays internal IDs of game objects and creatures.  Warning: IDs may contain spoilers." ),
+         false
+       );
+
     add_empty_line();
 
     add_option_group( "debug", Group( "debug_log", to_translation( "Logging" ),
@@ -3327,6 +3332,7 @@ void options_manager::cache_to_globals()
 
     json_report_strict = test_mode || ::get_option<bool>( "STRICT_JSON_CHECKS" );
     display_mod_source = ::get_option<bool>( "MOD_SOURCE" );
+    display_object_ids = ::get_option<bool>( "SHOW_IDS" );
     trigdist = ::get_option<bool>( "CIRCLEDIST" );
 #if defined(TILES)
     use_tiles = ::get_option<bool>( "USE_TILES" );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2582,8 +2582,17 @@ void veh_interact::display_stats() const
 
     i = std::max( i, 2 * stats_h );
 
+    int fuel_gauge_start_y = y[i];
+    if( display_object_ids ) {
+        // Print vehicle type id over above gauges
+        mvwprintz( w_stats, point( x[i], fuel_gauge_start_y ), c_light_blue,
+                   string_format( "[%s]", veh->type )
+                 );
+        fuel_gauge_start_y++;
+    }
+
     // Print fuel percentage & type name only if it fits in the window, 10 is width of "E...F 100%"
-    veh->print_fuel_indicators( w_stats, point( x[i], y[i] ), fuel_index, true,
+    veh->print_fuel_indicators( w_stats, point( x[i], fuel_gauge_start_y ), fuel_index, true,
                                 ( x[ i ] + 10 < getmaxx( w_stats ) ),
                                 ( x[ i ] + 10 < getmaxx( w_stats ) ) );
 


### PR DESCRIPTION
#### Summary
SUMMARY: Interface "Add debug option to show object IDs in game"

#### Purpose of change
Closes #2225

#### Describe the solution
Items
![image](https://user-images.githubusercontent.com/60584843/224800236-035b77a5-fb4c-4fc9-8f99-3c67dcf910fe.png)

Item contents
![image](https://user-images.githubusercontent.com/60584843/224800326-12fed35a-497c-4042-88d0-4aeef58848f5.png)

Furniture and terrain
![image](https://user-images.githubusercontent.com/60584843/224836217-d058e50d-dada-4046-b643-638b183aa62e.png)

Furniture (extended view)
![image](https://user-images.githubusercontent.com/60584843/224800684-c0793118-c42c-4d65-bada-d3d06f125a76.png)

Terrain (extended view)
![image](https://user-images.githubusercontent.com/60584843/224800709-790c4834-ae74-4e30-b9c4-da5767c93f40.png)

Monsters
![image](https://user-images.githubusercontent.com/60584843/224800401-1c986168-e9ce-445c-9ecd-2fe0f3fd86e4.png)

Monsters (extended view)
![image](https://user-images.githubusercontent.com/60584843/224800461-9bd5b37b-b1c5-4576-8466-c70259a9f898.png)

NPCs
![image](https://user-images.githubusercontent.com/60584843/224800531-a362016c-bd94-49ab-9f2f-876d93209170.png)

NPCs (extended view)
![image](https://user-images.githubusercontent.com/60584843/224800581-a3aa58ce-2d8d-456f-afe4-8cf99e0a7083.png)

Vehicles
![image](https://user-images.githubusercontent.com/60584843/224800803-c46f12d9-962d-4a60-921e-b97ed4e38867.png)

#### Describe alternatives you've considered
Light blue color for ids inspired by id display in Minecraft UI.
~~For terrain and furniture, we have id display in mouse look & plain examine that can be activated by enabling debug mode, should it be rolled into this option?~~ Done.

#### Testing
See screenshots. With option off, works as before.