### PR TITLE
Don't build stairs going lower z = -10

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3426,7 +3426,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
 
     ter_set( p, labt_core );
     int numstairs = 0;
-    if( s > 0 ) { // Build stairs going down
+    if( s > 0 && p.z() != -OVERMAP_DEPTH ) { // Build stairs going down
         while( !one_in( 6 ) ) {
             tripoint_om_omt stair;
             int tries = 0;


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed downstairs generating in labs at z = -10"

#### Purpose of change
Fix #496

#### Describe the solution
Don't generate stairs if we're at the bottom layer.

#### Describe alternatives you've considered
Reworking lab mapgen.

#### Testing
Somewhat hard to test given how our mapgen is semi-random.
I teleported around overmaps and checked that labs that reached the bottom don't have downstairs, so it seems to be working.
This should also fix the occasional CI final lab error.