### PR TITLE
Removal of lab kennel gate rubble tile

### DIFF
--- a/data/json/mapgen/lab/lab_rooms.json
+++ b/data/json/mapgen/lab/lab_rooms.json
@@ -837,14 +837,14 @@
       "rows": [
         ",,=.=,,",
         ",,=.=,,",
-        "=^=.=^=",
+        "=H=.=H=",
         ".......",
-        "=^=....",
+        "=H=....",
         ",,=..hl",
         ",,=.ccx"
       ],
       "palettes": [ "lab_palette", "lab_loot_home_office" ],
-      "terrain": { "=": "t_chainfence_h", "^": [ "t_chaingate_c", "t_chaingate_c", "t_chaingate_c", "t_chaingate_o" ] },
+      "terrain": { "=": "t_chainfence_h", "H": [ "t_chaingate_c", "t_chaingate_c", "t_chaingate_c", "t_chaingate_o" ] },
       "mapping": { "l": { "items": [ { "item": "vet_softdrug", "chance": 80, "repeat": 2 } ] } },
       "place_monster": [
         { "monster": "mon_zombie_dog", "x": [ 0, 1 ], "y": [ 0, 1 ], "chance": 50, "pack_size": [ 1, 2 ], "one_or_none": true },


### PR DESCRIPTION
Removed the rubble tiles that spawned on lab kennel gates, by changing the gate symbol from caret ^ to H.



#### Summary



SUMMARY: Content. Removed the rubble tiles that spawned on lab kennel gates, by changing the gate symbol from caret ^ to H.






#### Purpose of change

Always seemed like a very old oversight. The caret symbol is used for rubble in many places IIRC. For some reason it was also defined for the kennel gates in this case.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered



#### Testing

Played with this changed over many releases, always doing it manually for myself for each version. Got tired of doing it, so here we are. A smallest changed that has been, to put it mildly, overtested. CAUTION: wait for me to edit the No Hope mod too, because I forgot it has to be edited too, and idk how to cancel this.

#### Additional context


