### PR TITLE
Fix issue with the durability of monster drops

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2945,8 +2945,6 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj )
     bool use_modifier = false;
     use_modifier |= load_min_max( modifier.damage, obj, "damage" );
     use_modifier |= load_min_max( modifier.dirt, obj, "dirt" );
-    modifier.damage.first *= itype::damage_scale;
-    modifier.damage.second *= itype::damage_scale;
     use_modifier |= load_min_max( modifier.charges, obj, "charges" );
     use_modifier |= load_min_max( modifier.count, obj, "count" );
     use_modifier |= load_sub_ref( modifier.ammo, obj, "ammo", ig );

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -242,7 +242,10 @@ void Item_modifier::modify( item &new_item ) const
         return;
     }
 
-    new_item.set_damage( rng( damage.first, damage.second ) );
+    int final_damage = rng( damage.first, damage.second );
+    // Round final_damage to the closest thousandth
+    final_damage = std::lround( static_cast<float>( final_damage ) / 1000 ) * 1000;
+    new_item.set_damage( final_damage );
     // no need for dirt if it's a bow
     if( new_item.is_gun() && !new_item.has_flag( flag_PRIMITIVE_RANGED_WEAPON ) &&
         !new_item.has_flag( flag_NON_FOULING ) ) {

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -242,10 +242,7 @@ void Item_modifier::modify( item &new_item ) const
         return;
     }
 
-    int final_damage = rng( damage.first, damage.second );
-    // Round final_damage to the closest thousandth
-    final_damage = std::lround( static_cast<float>( final_damage ) / 1000 ) * 1000;
-    new_item.set_damage( final_damage );
+    new_item.set_damage( rng( damage.first, damage.second ) * itype::damage_scale );
     // no need for dirt if it's a bow
     if( new_item.is_gun() && !new_item.has_flag( flag_PRIMITIVE_RANGED_WEAPON ) &&
         !new_item.has_flag( flag_NON_FOULING ) ) {

--- a/tests/item_group_test.cpp
+++ b/tests/item_group_test.cpp
@@ -31,8 +31,8 @@ TEST_CASE( "spawn with default charges and with ammo", "[item_group]" )
 TEST_CASE( "Item_modifier damages item", "[item_group]" )
 {
     Item_modifier damaged;
-    damaged.damage.first = 1000;
-    damaged.damage.second = 1000;
+    damaged.damage.first = 1;
+    damaged.damage.second = 1;
     SECTION( "except when it's an ammunition" ) {
         item rock( "rock" );
         REQUIRE( rock.damage() == 0 );

--- a/tests/item_group_test.cpp
+++ b/tests/item_group_test.cpp
@@ -31,8 +31,8 @@ TEST_CASE( "spawn with default charges and with ammo", "[item_group]" )
 TEST_CASE( "Item_modifier damages item", "[item_group]" )
 {
     Item_modifier damaged;
-    damaged.damage.first = 1;
-    damaged.damage.second = 1;
+    damaged.damage.first = 1000;
+    damaged.damage.second = 1000;
     SECTION( "except when it's an ammunition" ) {
         item rock( "rock" );
         REQUIRE( rock.damage() == 0 );
@@ -43,9 +43,9 @@ TEST_CASE( "Item_modifier damages item", "[item_group]" )
     SECTION( "when it can be damaged" ) {
         item glock( "glock_19" );
         REQUIRE( glock.damage() == 0 );
-        REQUIRE( glock.max_damage() > 0 );
+        REQUIRE( glock.max_damage() > 1000 );
         damaged.modify( glock );
-        CHECK( glock.damage() == 1 );
+        CHECK( glock.damage() == 1000 );
     }
 }
 


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix issue with the durability of monster drops"

#### Purpose of change

Fixes #2400 

#### Describe the solution

The damage range was previously multiplied by 1000, which meant for a damage range of [0, 1] in JSON, a number between 0 and 1000 would be rolled for item damage. With the damage range no longer multiplied by 1000, the RNG rolls either 0 or 1 at a 50% chance for each, which then can be multiplied by 1000 to get the final damage value.

#### Testing

Spawned a bunch of zombie cops, killed them, made sure roughly 50% of dropped weapons were damaged.

#### Additional context

Might affect things other than monster drops, and could be considered a balance change since it does change the distribution of item damage a bit. I had to change a test that didn't make sense.