### PR TITLE
Crafting the hackPRO

### DIFF
--- a/data/json/recipes/electronic/other.json
+++ b/data/json/recipes/electronic/other.json
@@ -787,6 +787,22 @@
   },
   {
     "type": "recipe",
+    "result": "software_hacking",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_OTHER",
+    "skill_used": "computer",
+    "skills_required": [ [ "computer", 8 ] ],
+    "difficulty": 8,
+    "time": "12 h",
+    "autolearn": true,
+    "contained": true,
+    "using": [ [ "coding_standard", 500 ] ],
+    "components": [
+      [ [ "usb_drive", 1 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
     "result": "bionic_scanner",
     "category": "CC_ELECTRONIC",
     "subcategory": "CSC_ELECTRONIC_OTHER",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -77,6 +77,12 @@
     "components": [ [ [ "solder_wire", 1 ] ] ]
   },
   {
+    "id": "coding_standard",
+    "type": "requirement",
+    "//": "For writing software",
+    "tools": [ [ [ "laptop", 1 ] ] ]
+  },
+  {
     "id": "anesthetic",
     "type": "requirement",
     "//": "Rate of anesthetic used for a surgery in 1E-2 mL/kg/min.  Autodoc's interface only supports charges of anesthetic_kit, any other requirement will have unexpected results.",


### PR DESCRIPTION

#### Summary

SUMMARY: Content. "Ability to create your own hackPRO"

#### Purpose of change

HackPRO is bit too rare. Why shouldn't you be able to write your own hacking software if your skills are high?

#### Describe the solution

Added one coding_standard to toolsets. Created crafting recipe. Coding_standard means just having a laptop as a requirement. I set the crafting time to 12hrs. I guess it could be days or weeks if necessary, since the crafting can be resumed.

#### Describe alternatives you've considered

Thought about adding e-Ink as an alternative to laptop but I figured no one wants to write code without a proper keyboard. Do you think it's possible (or not-annoying) to dictate code verbally and have an AI write it out like a secretary? "Parenthesis, spacebar, two-hundred-and-thirty, spacebar, semi-colon, spacebar...."

#### Testing

Created hackPRO once myself with this. Worked out just fine. Straightforward simple stuff. Can't wait to find out how I screwed it up.

#### Additional context

Your computer skill could go up to lvl 9 or 10 if you do this even once. It's 12hrs of crafting after all.
