### PR TITLE
Add military helipad to military operations map

### DIFF
--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -53,6 +53,7 @@
         "bridge",
         "fema_entrance",
         "bunker",
+        "helipad",
         "outpost",
         { "om_terrain": "silo", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "shelter", "om_terrain_match_type": "TYPE" },


### PR DESCRIPTION
Summary
Military helipads aren't added to your map when using military operations map. This adds them to it.

Purpose of change
Add military helipads to the military operations map.

Describe the solution
See above.

Describe alternatives you've considered
Not adding them but this seems like an oversight.

Testing/Additional context
This is my first time doing something like this in a long time. I'm still trying to figure out how to compile and test, it should work fine thou?