### PR TITLE
raise max charges for tailors kit and sewing kit

### DIFF
--- a/data/json/items/tool/tailoring.json
+++ b/data/json/items/tool/tailoring.json
@@ -152,7 +152,7 @@
     "color": "red",
     "ammo": "thread",
     "initial_charges": 50,
-    "max_charges": 200,
+    "max_charges": 400,
     "charges_per_use": 1,
     "qualities": [ [ "SEW", 3 ] ],
     "use_action": {
@@ -197,7 +197,7 @@
     "ammo": "thread",
     "sub": "sewing_kit",
     "initial_charges": 50,
-    "max_charges": 400,
+    "max_charges": 600,
     "charges_per_use": 1,
     "qualities": [ [ "SEW", 4 ], [ "SEW_CURVED", 1 ], [ "KNIT", 1 ], [ "LEATHER_AWL", 2 ], [ "CUT", 1 ] ],
     "use_action": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Balance "Tailor and sewing kit hold more charges"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
Sewing kit should be some kind of improvement over the basic wooden needle. By raising its max. charges, it doesn't need as many reloads as the wooden needle, but the tailor kit is superior (in reload and in upgrading stuff).
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Raise sewing kit max charge to 400, tailor kit to 600.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Lowering the max charges the wooden needle would take. That would lead to errors to people having more than 100 charges already loaded into the needle. So rather raising the others than nerfing is a more sensible approach.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
