### PR TITLE
Add mod source & id display to recipes

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -473,17 +473,17 @@ const recipe *select_crafting_recipe( int &batch_size )
 
             if( display_mode == 0 ) {
                 if( display_mod_source ) {
-                    std::string source = enumerate_as_string( current[line]->src.begin(),
+                    const std::string source = enumerate_as_string( current[line]->src.begin(),
                     current[line]->src.end(), []( const std::pair<recipe_id, mod_id> &content_source ) {
                         return string_format( "'%s'", content_source.second->name() );
                     }, enumeration_conjunction::arrow );
 
-                    std::string text = string_format( _( "Origin: %s" ), colorize( source, c_light_blue ) );
+                    const std::string text = string_format( _( "Origin: %s" ), colorize( source, c_light_blue ) );
                     print_colored_text( w_data, point( xpos, ypos++ ), col, col, text );
                 }
                 if( display_object_ids ) {
-                    std::string ident = string_format( "[%s]", current[line]->ident() );
-                    std::string text = string_format( _( "ID: %s" ), colorize( ident, c_light_blue ) );
+                    const std::string ident = string_format( "[%s]", current[line]->ident() );
+                    const std::string text = string_format( _( "ID: %s" ), colorize( ident, c_light_blue ) );
                     print_colored_text( w_data, point( xpos, ypos++ ), col, col, text );
                 }
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -26,6 +26,7 @@
 #include "item_contents.h"
 #include "itype.h"
 #include "json.h"
+#include "mod_manager.h"
 #include "optional.h"
 #include "output.h"
 #include "point.h"
@@ -471,6 +472,21 @@ const recipe *select_crafting_recipe( int &batch_size )
             const int xpos = 30;
 
             if( display_mode == 0 ) {
+                if( display_mod_source ) {
+                    std::string source = enumerate_as_string( current[line]->src.begin(),
+                    current[line]->src.end(), []( const std::pair<recipe_id, mod_id> &content_source ) {
+                        return string_format( "'%s'", content_source.second->name() );
+                    }, enumeration_conjunction::arrow );
+
+                    std::string text = string_format( _( "Origin: %s" ), colorize( source, c_light_blue ) );
+                    print_colored_text( w_data, point( xpos, ypos++ ), col, col, text );
+                }
+                if( display_object_ids ) {
+                    std::string ident = string_format( "[%s]", current[line]->ident() );
+                    std::string text = string_format( _( "ID: %s" ), colorize( ident, c_light_blue ) );
+                    print_colored_text( w_data, point( xpos, ypos++ ), col, col, text );
+                }
+
                 print_colored_text(
                     w_data, point( xpos, ypos++ ), col, col,
                     string_format( _( "Primary skill: %s" ),

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -49,6 +49,8 @@ class recipe
             return result_;
         }
 
+        std::vector<std::pair<recipe_id, mod_id>> src;
+
         bool obsolete = false;
 
         std::string category;

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -329,6 +329,11 @@ recipe &recipe_dictionary::load( const JsonObject &jo, const std::string &src,
 
     r.load( jo, src );
 
+    if( !r.src.empty() && r.src.back().first != r.ident() ) {
+        r.src.clear();
+    }
+    r.src.emplace_back( r.ident(), mod_id( src ) );
+
     return out[ r.ident() ] = std::move( r );
 }
 


### PR DESCRIPTION
#### Summary
SUMMARY: Interface "Add mod source & id display to recipes"

#### Purpose of change
Confusion over inability to see recipe source or id has come up multiple times on Discord.

#### Describe the solution
Add mod source tracking & debug id display to crafting recipes.

#### Testing
![image](https://user-images.githubusercontent.com/60584843/226484070-809df712-1120-485d-abba-ed48a867069d.png)
![image](https://user-images.githubusercontent.com/60584843/226484099-3c239403-acb8-4da7-a8a7-f3bdecf0293e.png)

