### PR TITLE
fix typo `Shrubberry` to `Shrubbery`

### DIFF
--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -209,7 +209,7 @@
   {
     "id": "mx_shrubbery",
     "type": "map_extra",
-    "name": "Shrubberry",
+    "name": "Shrubbery",
     "description": "This area is covered with a single type of shrubs.",
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_shrubbery" },
     "sym": "s",


### PR DESCRIPTION

#### Summary

SUMMARY: Content "typo fix: Shrubberry to Shrubbery"

#### Purpose of change

This typo is older than time.

#### Describe the solution

Keyboard smash until typo fix. Groknak fixes typo.

#### Describe alternatives you've considered

Drugs. Violence. Rock 'n roll. Other miscellaneous depravity. Even computer games.

#### Testing

After deleting a single character from a single file, using an advanced text editor, and after playing with this change for dozens of hours, recreating it multiple times in multiple versions over the past years, I can confidently say that I have no idea if this profound change - a downright overhaul - has had any adverse effects. I fully expect the economy to crash if this gets merged.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
