### PR TITLE
Use `std::string_view` for printing functions

### DIFF
--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -1,0 +1,739 @@
+#include "assign.h"
+
+void report_strict_violation( const JsonObject &jo, const std::string &message,
+                              const std::string &name )
+{
+    try {
+        // Let the json class do the formatting, it includes the context of the JSON data.
+        jo.throw_error( message, name );
+    } catch( const JsonError &err ) {
+        // And catch the exception so the loading continues like normal.
+        debugmsg( "(json-error)\n%s", err.what() );
+    }
+}
+
+
+bool assign( const JsonObject &jo, const std::string &name, bool &val, bool strict )
+{
+    bool out;
+
+    if( !jo.read( name, out ) ) {
+        return false;
+    }
+
+    if( strict && out == val ) {
+        report_strict_violation( jo, "cannot assign explicit value the same as default or inherited value",
+                                 name );
+    }
+
+    val = out;
+
+    return true;
+}
+
+bool assign( const JsonObject &jo, const std::string &name, units::volume &val,
+             bool strict,
+             const units::volume lo,
+             const units::volume hi )
+{
+    const auto parse = [&name]( const JsonObject & obj, units::volume & out ) {
+        if( obj.has_int( name ) ) {
+            out = obj.get_int( name ) * units::legacy_volume_factor;
+            return true;
+        }
+
+        if( obj.has_string( name ) ) {
+            units::volume::value_type tmp;
+            std::string suffix;
+            std::istringstream str( obj.get_string( name ) );
+            str.imbue( std::locale::classic() );
+            str >> tmp >> suffix;
+            if( str.peek() != std::istringstream::traits_type::eof() ) {
+                obj.throw_error( "syntax error when specifying volume", name );
+            }
+            if( suffix == "ml" ) {
+                out = units::from_milliliter( tmp );
+            } else if( suffix == "L" ) {
+                out = units::from_milliliter( tmp * 1000 );
+            } else {
+                obj.throw_error( "unrecognized volumetric unit", name );
+            }
+            return true;
+        }
+
+        return false;
+    };
+
+    units::volume out;
+
+    // Object via which to report errors which differs for proportional/relative values
+    JsonObject err = jo;
+    err.allow_omitted_members();
+    JsonObject relative = jo.get_object( "relative" );
+    relative.allow_omitted_members();
+    JsonObject proportional = jo.get_object( "proportional" );
+    proportional.allow_omitted_members();
+
+    // Do not require strict parsing for relative and proportional values as rules
+    // such as +10% are well-formed independent of whether they affect base value
+    if( relative.has_member( name ) ) {
+        units::volume tmp;
+        err = relative;
+        if( !parse( err, tmp ) ) {
+            err.throw_error( "invalid relative value specified", name );
+        }
+        strict = false;
+        out = val + tmp;
+
+    } else if( proportional.has_member( name ) ) {
+        double scalar;
+        err = proportional;
+        if( !err.read( name, scalar ) || scalar <= 0 || scalar == 1 ) {
+            err.throw_error( "multiplier must be a positive number other than 1", name );
+        }
+        strict = false;
+        out = val * scalar;
+
+    } else if( !parse( jo, out ) ) {
+        return false;
+    }
+
+    if( out < lo || out > hi ) {
+        err.throw_error( "value outside supported range", name );
+    }
+
+    if( strict && out == val ) {
+        report_strict_violation( err, "cannot assign explicit value the same as default or inherited value",
+                                 name );
+    }
+
+    val = out;
+
+    return true;
+}
+
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             units::mass &val,
+             bool strict,
+             const units::mass lo,
+             const units::mass hi )
+{
+    const auto parse = [&name]( const JsonObject & obj, units::mass & out ) {
+        if( obj.has_int( name ) ) {
+            out = units::from_gram<std::int64_t>( obj.get_int( name ) );
+            return true;
+        }
+        if( obj.has_string( name ) ) {
+            out = read_from_json_string<units::mass>( *obj.get_raw( name ),
+                    units::mass_units );
+            return true;
+        }
+        return false;
+    };
+
+    units::mass out;
+
+    // Object via which to report errors which differs for proportional/relative
+    // values
+    JsonObject err = jo;
+    err.allow_omitted_members();
+    JsonObject relative = jo.get_object( "relative" );
+    relative.allow_omitted_members();
+    JsonObject proportional = jo.get_object( "proportional" );
+    proportional.allow_omitted_members();
+
+    // Do not require strict parsing for relative and proportional values as
+    // rules such as +10% are well-formed independent of whether they affect
+    // base value
+    if( relative.has_member( name ) ) {
+        units::mass tmp;
+        err = relative;
+        if( !parse( err, tmp ) ) {
+            err.throw_error( "invalid relative value specified", name );
+        }
+        strict = false;
+        out = val + tmp;
+
+    } else if( proportional.has_member( name ) ) {
+        double scalar;
+        err = proportional;
+        if( !err.read( name, scalar ) || scalar <= 0 || scalar == 1 ) {
+            err.throw_error( "multiplier must be a positive number other than 1",
+                             name );
+        }
+        strict = false;
+        out = val * scalar;
+
+    } else if( !parse( jo, out ) ) {
+        return false;
+    }
+
+    if( out < lo || out > hi ) {
+        err.throw_error( "value outside supported range", name );
+    }
+
+    if( strict && out == val ) {
+        report_strict_violation( err,
+                                 "cannot assign explicit value the same as "
+                                 "default or inherited value",
+                                 name );
+    }
+
+    val = out;
+
+    return true;
+}
+
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             units::money &val,
+             bool strict,
+             const units::money lo,
+             const units::money hi )
+{
+    const auto parse = [&name]( const JsonObject & obj, units::money & out ) {
+        if( obj.has_int( name ) ) {
+            out = units::from_cent( obj.get_int( name ) );
+            return true;
+        }
+        if( obj.has_string( name ) ) {
+            out = read_from_json_string<units::money>( *obj.get_raw( name ),
+                    units::money_units );
+            return true;
+        }
+        return false;
+    };
+
+    units::money out;
+
+    // Object via which to report errors which differs for proportional/relative
+    // values
+    JsonObject err = jo;
+    err.allow_omitted_members();
+    JsonObject relative = jo.get_object( "relative" );
+    relative.allow_omitted_members();
+    JsonObject proportional = jo.get_object( "proportional" );
+    proportional.allow_omitted_members();
+
+    // Do not require strict parsing for relative and proportional values as
+    // rules such as +10% are well-formed independent of whether they affect
+    // base value
+    if( relative.has_member( name ) ) {
+        units::money tmp;
+        err = relative;
+        if( !parse( err, tmp ) ) {
+            err.throw_error( "invalid relative value specified", name );
+        }
+        strict = false;
+        out = val + tmp;
+
+    } else if( proportional.has_member( name ) ) {
+        double scalar;
+        err = proportional;
+        if( !err.read( name, scalar ) || scalar <= 0 || scalar == 1 ) {
+            err.throw_error( "multiplier must be a positive number other than 1",
+                             name );
+        }
+        strict = false;
+        out = val * scalar;
+
+    } else if( !parse( jo, out ) ) {
+        return false;
+    }
+
+    if( out < lo || out > hi ) {
+        err.throw_error( "value outside supported range", name );
+    }
+
+    if( strict && out == val ) {
+        report_strict_violation( err,
+                                 "cannot assign explicit value the same as "
+                                 "default or inherited value",
+                                 name );
+    }
+
+    val = out;
+
+    return true;
+}
+
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             units::energy &val,
+             bool strict,
+             const units::energy lo,
+             const units::energy hi )
+{
+    const auto parse = [&name]( const JsonObject & obj, units::energy & out ) {
+        if( obj.has_int( name ) ) {
+            const std::int64_t tmp = obj.get_int( name );
+            if( tmp > units::to_kilojoule( units::energy_max ) ) {
+                out = units::energy_max;
+            } else {
+                out = units::from_kilojoule( tmp );
+            }
+            return true;
+        }
+        if( obj.has_string( name ) ) {
+            out = read_from_json_string<units::energy>( *obj.get_raw( name ),
+                    units::energy_units );
+            return true;
+        }
+        return false;
+    };
+
+    units::energy out;
+
+    // Object via which to report errors which differs for proportional/relative
+    // values
+    JsonObject err = jo;
+    err.allow_omitted_members();
+    JsonObject relative = jo.get_object( "relative" );
+    relative.allow_omitted_members();
+    JsonObject proportional = jo.get_object( "proportional" );
+    proportional.allow_omitted_members();
+
+    // Do not require strict parsing for relative and proportional values as
+    // rules such as +10% are well-formed independent of whether they affect
+    // base value
+    if( relative.has_member( name ) ) {
+        units::energy tmp;
+        err = relative;
+        if( !parse( err, tmp ) ) {
+            err.throw_error( "invalid relative value specified", name );
+        }
+        strict = false;
+        out = val + tmp;
+
+    } else if( proportional.has_member( name ) ) {
+        double scalar;
+        err = proportional;
+        if( !err.read( name, scalar ) || scalar <= 0 || scalar == 1 ) {
+            err.throw_error( "multiplier must be a positive number other than 1",
+                             name );
+        }
+        strict = false;
+        out = val * scalar;
+
+    } else if( !parse( jo, out ) ) {
+        return false;
+    }
+
+    if( out < lo || out > hi ) {
+        err.throw_error( "value outside supported range", name );
+    }
+
+    if( strict && out == val ) {
+        report_strict_violation( err,
+                                 "cannot assign explicit value the same as "
+                                 "default or inherited value",
+                                 name );
+    }
+
+    val = out;
+
+    return true;
+}
+
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             units::probability &val,
+             bool strict,
+             const units::probability lo,
+             const units::probability hi )
+{
+    const auto parse = [&name]( const JsonObject & obj, units::probability & out ) {
+        if( obj.has_string( name ) ) {
+            long double tmp;
+            std::string suffix;
+            std::istringstream str( obj.get_string( name ) );
+            str.imbue( std::locale::classic() );
+            str >> tmp >> suffix;
+            if( str.peek() != std::istringstream::traits_type::eof() ) {
+                obj.throw_error( "syntax error when specifying volume", name );
+            }
+            if( suffix == "pm" ) {
+                out = units::from_one_in_million(
+                          static_cast<units::probability::value_type>( tmp ) );
+            } else if( suffix == "%" ) {
+                out = units::from_percent( tmp );
+            } else {
+                obj.throw_error( "unrecognized volumetric unit", name );
+            }
+            return true;
+        }
+
+        return false;
+    };
+
+    return assign_unit_common( jo, name, val, parse, strict, lo, hi );
+}
+
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             units::temperature &val,
+             bool strict,
+             const units::temperature lo,
+             const units::temperature hi )
+{
+    const auto parse = [&name]( const JsonObject & obj, units::temperature & out ) {
+        if( obj.has_string( name ) ) {
+            long double value;
+            std::string suffix;
+            std::istringstream str( obj.get_string( name ) );
+            str.imbue( std::locale::classic() );
+            str >> value >> suffix;
+            if( str.peek() != std::istringstream::traits_type::eof() ) {
+                obj.throw_error( "syntax error when specifying temperature", name );
+            }
+            const auto &unit_suffixes = units::temperature_units;
+            auto iter = std::find_if(
+                            unit_suffixes.begin(), unit_suffixes.end(),
+                            [&suffix]( const std::pair<std::string, units::temperature> &
+            suffix_value ) {
+                return suffix_value.first == suffix;
+            } );
+            if( iter != unit_suffixes.end() ) {
+                out = mult_unit( obj, name, iter->second, value );
+            } else {
+                obj.throw_error( "unrecognized temperature unit", name );
+            }
+
+            return true;
+        }
+
+        return false;
+    };
+
+    return assign_unit_common( jo, name, val, parse, strict, lo, hi );
+}
+
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             nc_color &val,
+             const bool strict )
+{
+    if( !jo.has_member( name ) ) {
+        return false;
+    }
+    const nc_color out = color_from_string( jo.get_string( name ) );
+    if( out == c_unset ) {
+        jo.throw_error( "invalid color name", name );
+    }
+    if( strict && out == val ) {
+        report_strict_violation( jo,
+                                 "cannot assign explicit value the same as "
+                                 "default or inherited value",
+                                 name );
+    }
+    val = out;
+    return true;
+}
+
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             damage_instance &val,
+             bool strict,
+             const damage_instance &lo,
+             const damage_instance &hi )
+{
+    // What we'll eventually be returning for the damage instance
+    damage_instance out;
+
+    if( jo.has_array( name ) ) {
+        out = load_damage_instance_inherit( jo.get_array( name ), val );
+    } else if( jo.has_object( name ) ) {
+        out = load_damage_instance_inherit( jo.get_object( name ), val );
+    } else {
+        // Legacy: remove after 0.F
+        float amount = 0.0f;
+        float arpen = 0.0f;
+        float dmg_mult = 1.0f;
+        bool with_legacy = false;
+
+        // There will always be either a prop_damage or damage (name)
+        if( jo.has_member( name ) ) {
+            with_legacy = true;
+            amount = jo.get_float( name );
+        } else if( jo.has_member( "prop_damage" ) ) {
+            dmg_mult = jo.get_float( "prop_damage" );
+            with_legacy = true;
+        }
+        // And there may or may not be armor penetration
+        if( jo.has_member( "pierce" ) ) {
+            with_legacy = true;
+            arpen = jo.get_float( "pierce" );
+        }
+
+        if( with_legacy ) {
+            out.add_damage( DT_STAB, amount, arpen, 1.0f, dmg_mult );
+        }
+    }
+
+    // Object via which to report errors which differs for proportional/relative
+    // values
+    const JsonObject &err = jo;
+    JsonObject relative = jo.get_object( "relative" );
+    relative.allow_omitted_members();
+    JsonObject proportional = jo.get_object( "proportional" );
+    proportional.allow_omitted_members();
+
+    // Currently, we load only either relative or proportional when loading
+    // damage There's no good reason for this, but it's simple for now
+    if( relative.has_object( name ) ) {
+        assign_dmg_relative(
+            out, val, load_damage_instance( relative.get_object( name ) ), strict );
+    } else if( relative.has_array( name ) ) {
+        assign_dmg_relative(
+            out, val, load_damage_instance( relative.get_array( name ) ), strict );
+    } else if( proportional.has_object( name ) ) {
+        assign_dmg_proportional(
+            proportional, name, out, val,
+            load_damage_instance( proportional.get_object( name ) ), strict );
+    } else if( proportional.has_array( name ) ) {
+        assign_dmg_proportional(
+            proportional, name, out, val,
+            load_damage_instance( proportional.get_array( name ) ), strict );
+    } else if( relative.has_member( name ) || relative.has_member( "pierce" )
+               || relative.has_member( "prop_damage" ) ) {
+        // Legacy: Remove after 0.F
+        // It is valid for relative to adjust any of pierce, prop_damage, or
+        // damage So check for what it's modifying, and modify that
+        float amt = 0.0f;
+        float arpen = 0.0f;
+        float dmg_mult = 1.0f;
+
+        if( relative.has_member( name ) ) {
+            amt = relative.get_float( name );
+        }
+        if( relative.has_member( "pierce" ) ) {
+            arpen = relative.get_float( "pierce" );
+        }
+        if( relative.has_member( "prop_damage" ) ) {
+            dmg_mult = relative.get_float( "prop_damage" );
+        }
+
+        assign_dmg_relative(
+            out, val, damage_instance( DT_STAB, amt, arpen, 1.0f, dmg_mult ),
+            strict );
+    } else if( proportional.has_member( name )
+               || proportional.has_member( "pierce" )
+               || proportional.has_member( "prop_damage" ) ) {
+        // Legacy: Remove after 0.F
+        // It is valid for proportional to adjust any of pierce, prop_damage, or
+        // damage So check if it's modifying any of the things before going on
+        // to modify it
+        float amt = 0.0f;
+        float arpen = 0.0f;
+        float dmg_mult = 1.0f;
+
+        if( proportional.has_member( name ) ) {
+            amt = proportional.get_float( name );
+        }
+        if( proportional.has_member( "pierce" ) ) {
+            arpen = proportional.get_float( "pierce" );
+        }
+        if( proportional.has_member( "prop_damage" ) ) {
+            dmg_mult = proportional.get_float( "prop_damage" );
+        }
+
+        assign_dmg_proportional(
+            proportional, name, out, val,
+            damage_instance( DT_STAB, amt, arpen, 1.0f, dmg_mult ), strict );
+    } else if( !jo.has_member( name ) && !jo.has_member( "prop_damage" ) ) {
+        // Straight copy-from, not modified by proportional or relative
+        out = val;
+        strict = false;
+    }
+
+    check_assigned_dmg( err, name, out, lo, hi );
+
+    if( strict && out == val ) {
+        report_strict_violation( err,
+                                 "cannot assign explicit damage value the same "
+                                 "as default or inherited value",
+                                 name );
+    }
+
+    if( out.damage_units.empty() ) {
+        out = damage_instance( DT_BULLET, 0.0f );
+    }
+
+    // Now that we've verified everything in out is all good, set val to it
+    val = out;
+
+    return true;
+}
+
+void check_assigned_dmg( const JsonObject &err,
+                         const std::string &name,
+                         const damage_instance &out,
+                         const damage_instance &lo_inst,
+                         const damage_instance &hi_inst )
+{
+    for( const damage_unit &out_dmg : out.damage_units ) {
+        auto lo_iter = std::find_if(
+                           lo_inst.damage_units.begin(), lo_inst.damage_units.end(),
+        [&out_dmg]( const damage_unit & du ) {
+            return du.type == out_dmg.type || du.type == DT_NULL;
+        } );
+
+        auto hi_iter = std::find_if(
+                           hi_inst.damage_units.begin(), hi_inst.damage_units.end(),
+        [&out_dmg]( const damage_unit & du ) {
+            return du.type == out_dmg.type || du.type == DT_NULL;
+        } );
+
+        if( lo_iter == lo_inst.damage_units.end() ) {
+            err.throw_error(
+                "Min damage type used in assign does not match damage type "
+                "assigned",
+                name );
+        }
+        if( hi_iter == hi_inst.damage_units.end() ) {
+            err.throw_error(
+                "Max damage type used in assign does not match damage type "
+                "assigned",
+                name );
+        }
+
+        const damage_unit &hi_dmg = *hi_iter;
+        const damage_unit &lo_dmg = *lo_iter;
+
+        if( out_dmg.amount < lo_dmg.amount || out_dmg.amount > hi_dmg.amount ) {
+            err.throw_error( "value for damage outside supported range", name );
+        }
+        if( out_dmg.res_pen < lo_dmg.res_pen
+            || out_dmg.res_pen > hi_dmg.res_pen ) {
+            err.throw_error(
+                "value for armor penetration outside supported range", name );
+        }
+        if( out_dmg.res_mult < lo_dmg.res_mult
+            || out_dmg.res_mult > hi_dmg.res_mult ) {
+            err.throw_error(
+                "value for armor penetration multiplier outside supported "
+                "range",
+                name );
+        }
+        if( out_dmg.damage_multiplier < lo_dmg.damage_multiplier
+            || out_dmg.damage_multiplier > hi_dmg.damage_multiplier ) {
+            err.throw_error(
+                "value for damage multiplier outside supported range", name );
+        }
+    }
+}
+
+void assign_dmg_proportional( const JsonObject &jo,
+                              const std::string &name,
+                              damage_instance &out,
+                              const damage_instance &val,
+                              damage_instance proportional,
+                              bool &strict )
+{
+    for( const damage_unit &val_dmg : val.damage_units ) {
+        for( damage_unit &scalar : proportional.damage_units ) {
+            if( scalar.type != val_dmg.type ) {
+                continue;
+            }
+
+            // Do not require strict parsing for relative and proportional
+            // values as rules such as +10% are well-formed independent of
+            // whether they affect base value
+            strict = false;
+
+            // Can't have negative percent, and 100% is pointless
+            // If it's 0, it wasn't loaded
+            if( scalar.amount == 1 || scalar.amount < 0 ) {
+                jo.throw_error(
+                    "Proportional damage multiplier must be a positive number "
+                    "other than 1",
+                    name );
+            }
+
+            // If it's 0, it wasn't loaded
+            if( scalar.res_pen < 0 || scalar.res_pen == 1 ) {
+                jo.throw_error(
+                    "Proportional armor penetration multiplier must be a "
+                    "positive number other than 1",
+                    name );
+            }
+
+            // It wasn't loaded, so set it 100%
+            if( scalar.res_pen == 0 ) {
+                scalar.res_pen = 1.0f;
+            }
+
+            // Ditto
+            if( scalar.amount == 0 ) {
+                scalar.amount = 1.0f;
+            }
+
+            // If it's 1, it wasn't loaded (or was loaded as 1)
+            if( scalar.res_mult <= 0 ) {
+                jo.throw_error(
+                    "Proportional armor penetration multiplier must be a "
+                    "positive number",
+                    name );
+            }
+
+            // If it's 1, it wasn't loaded (or was loaded as 1)
+            if( scalar.damage_multiplier <= 0 ) {
+                jo.throw_error(
+                    "Proportional damage multiplier must be a positive number",
+                    name );
+            }
+
+            damage_unit out_dmg( scalar.type, 0.0f );
+
+            out_dmg.amount = val_dmg.amount * scalar.amount;
+            out_dmg.res_pen = val_dmg.res_pen * scalar.res_pen;
+
+            out_dmg.res_mult = val_dmg.res_mult * scalar.res_mult;
+            out_dmg.damage_multiplier =
+                val_dmg.damage_multiplier * scalar.damage_multiplier;
+
+            out.add( out_dmg );
+        }
+    }
+}
+
+void assign_dmg_relative( damage_instance &out,
+                          const damage_instance &val,
+                          damage_instance relative,
+                          bool &strict )
+{
+    for( const damage_unit &val_dmg : val.damage_units ) {
+        for( damage_unit &tmp : relative.damage_units ) {
+            if( tmp.type != val_dmg.type ) {
+                continue;
+            }
+
+            // Do not require strict parsing for relative and proportional
+            // values as rules such as +10% are well-formed independent of
+            // whether they affect base value
+            strict = false;
+
+            // res_mult is set to 1 if it's not specified. Set it to zero so we
+            // don't accidentally add to it
+            if( tmp.res_mult == 1.0f ) {
+                tmp.res_mult = 0;
+            }
+            // Same for damage_multiplier
+            if( tmp.damage_multiplier == 1.0f ) {
+                tmp.damage_multiplier = 0;
+            }
+
+            damage_unit out_dmg( tmp.type, 0.0f );
+
+            out_dmg.amount = tmp.amount + val_dmg.amount;
+            out_dmg.res_pen = tmp.res_pen + val_dmg.res_pen;
+
+            out_dmg.res_mult = tmp.res_mult + val_dmg.res_mult;
+            out_dmg.damage_multiplier =
+                tmp.damage_multiplier + val_dmg.damage_multiplier;
+
+            out.add( out_dmg );
+        }
+    }
+}

--- a/src/assign.h
+++ b/src/assign.h
@@ -43,17 +43,8 @@ class is_optional : public detail::is_optional_helper<typename std::decay<T>::ty
  */
 bool is_strict_enabled( const std::string &src );
 
-inline void report_strict_violation( const JsonObject &jo, const std::string &message,
-                                     const std::string &name )
-{
-    try {
-        // Let the json class do the formatting, it includes the context of the JSON data.
-        jo.throw_error( message, name );
-    } catch( const JsonError &err ) {
-        // And catch the exception so the loading continues like normal.
-        debugmsg( "(json-error)\n%s", err.what() );
-    }
-}
+void report_strict_violation( const JsonObject &jo, const std::string &message,
+                              const std::string &name );
 
 template <typename T, typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
 bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict = false,
@@ -105,23 +96,7 @@ bool assign( const JsonObject &jo, const std::string &name, T &val, bool strict 
 
 // Overload assign specifically for bool to avoid warnings,
 // and also to avoid potentially nonsensical interactions between relative and proportional.
-inline bool assign( const JsonObject &jo, const std::string &name, bool &val, bool strict = false )
-{
-    bool out;
-
-    if( !jo.read( name, out ) ) {
-        return false;
-    }
-
-    if( strict && out == val ) {
-        report_strict_violation( jo, "cannot assign explicit value the same as default or inherited value",
-                                 name );
-    }
-
-    val = out;
-
-    return true;
-}
+bool assign( const JsonObject &jo, const std::string &name, bool &val, bool strict = false );
 
 template <typename T, typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
 bool assign( const JsonObject &jo, const std::string &name, std::pair<T, T> &val,
@@ -276,289 +251,31 @@ bool assign_map_from_array( const JsonObject &jo, const std::string &name, T &va
     return res;
 }
 
-inline bool assign( const JsonObject &jo, const std::string &name, units::volume &val,
-                    bool strict = false,
-                    const units::volume lo = units::volume_min,
-                    const units::volume hi = units::volume_max )
-{
-    const auto parse = [&name]( const JsonObject & obj, units::volume & out ) {
-        if( obj.has_int( name ) ) {
-            out = obj.get_int( name ) * units::legacy_volume_factor;
-            return true;
-        }
+bool assign( const JsonObject &jo, const std::string &name, units::volume &val,
+             bool strict = false,
+             const units::volume lo = units::volume_min,
+             const units::volume hi = units::volume_max );
 
-        if( obj.has_string( name ) ) {
-            units::volume::value_type tmp;
-            std::string suffix;
-            std::istringstream str( obj.get_string( name ) );
-            str.imbue( std::locale::classic() );
-            str >> tmp >> suffix;
-            if( str.peek() != std::istringstream::traits_type::eof() ) {
-                obj.throw_error( "syntax error when specifying volume", name );
-            }
-            if( suffix == "ml" ) {
-                out = units::from_milliliter( tmp );
-            } else if( suffix == "L" ) {
-                out = units::from_milliliter( tmp * 1000 );
-            } else {
-                obj.throw_error( "unrecognized volumetric unit", name );
-            }
-            return true;
-        }
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             units::mass &val,
+             bool strict = false,
+             const units::mass lo = units::mass_min,
+             const units::mass hi = units::mass_max );
 
-        return false;
-    };
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             units::money &val,
+             bool strict = false,
+             const units::money lo = units::money_min,
+             const units::money hi = units::money_max );
 
-    units::volume out;
-
-    // Object via which to report errors which differs for proportional/relative values
-    JsonObject err = jo;
-    err.allow_omitted_members();
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
-
-    // Do not require strict parsing for relative and proportional values as rules
-    // such as +10% are well-formed independent of whether they affect base value
-    if( relative.has_member( name ) ) {
-        units::volume tmp;
-        err = relative;
-        if( !parse( err, tmp ) ) {
-            err.throw_error( "invalid relative value specified", name );
-        }
-        strict = false;
-        out = val + tmp;
-
-    } else if( proportional.has_member( name ) ) {
-        double scalar;
-        err = proportional;
-        if( !err.read( name, scalar ) || scalar <= 0 || scalar == 1 ) {
-            err.throw_error( "multiplier must be a positive number other than 1", name );
-        }
-        strict = false;
-        out = val * scalar;
-
-    } else if( !parse( jo, out ) ) {
-        return false;
-    }
-
-    if( out < lo || out > hi ) {
-        err.throw_error( "value outside supported range", name );
-    }
-
-    if( strict && out == val ) {
-        report_strict_violation( err, "cannot assign explicit value the same as default or inherited value",
-                                 name );
-    }
-
-    val = out;
-
-    return true;
-}
-
-inline bool assign( const JsonObject &jo, const std::string &name, units::mass &val,
-                    bool strict = false,
-                    const units::mass lo = units::mass_min,
-                    const units::mass hi = units::mass_max )
-{
-    const auto parse = [&name]( const JsonObject & obj, units::mass & out ) {
-        if( obj.has_int( name ) ) {
-            out = units::from_gram<std::int64_t>( obj.get_int( name ) );
-            return true;
-        }
-        if( obj.has_string( name ) ) {
-
-            out = read_from_json_string<units::mass> ( *obj.get_raw( name ), units::mass_units );
-            return true;
-        }
-        return false;
-    };
-
-    units::mass out;
-
-    // Object via which to report errors which differs for proportional/relative values
-    JsonObject err = jo;
-    err.allow_omitted_members();
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
-
-    // Do not require strict parsing for relative and proportional values as rules
-    // such as +10% are well-formed independent of whether they affect base value
-    if( relative.has_member( name ) ) {
-        units::mass tmp;
-        err = relative;
-        if( !parse( err, tmp ) ) {
-            err.throw_error( "invalid relative value specified", name );
-        }
-        strict = false;
-        out = val + tmp;
-
-    } else if( proportional.has_member( name ) ) {
-        double scalar;
-        err = proportional;
-        if( !err.read( name, scalar ) || scalar <= 0 || scalar == 1 ) {
-            err.throw_error( "multiplier must be a positive number other than 1", name );
-        }
-        strict = false;
-        out = val * scalar;
-
-    } else if( !parse( jo, out ) ) {
-        return false;
-    }
-
-    if( out < lo || out > hi ) {
-        err.throw_error( "value outside supported range", name );
-    }
-
-    if( strict && out == val ) {
-        report_strict_violation( err, "cannot assign explicit value the same as default or inherited value",
-                                 name );
-    }
-
-    val = out;
-
-    return true;
-}
-
-inline bool assign( const JsonObject &jo, const std::string &name, units::money &val,
-                    bool strict = false,
-                    const units::money lo = units::money_min,
-                    const units::money hi = units::money_max )
-{
-    const auto parse = [&name]( const JsonObject & obj, units::money & out ) {
-        if( obj.has_int( name ) ) {
-            out = units::from_cent( obj.get_int( name ) );
-            return true;
-        }
-        if( obj.has_string( name ) ) {
-
-            out = read_from_json_string<units::money>( *obj.get_raw( name ), units::money_units );
-            return true;
-        }
-        return false;
-    };
-
-    units::money out;
-
-    // Object via which to report errors which differs for proportional/relative values
-    JsonObject err = jo;
-    err.allow_omitted_members();
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
-
-    // Do not require strict parsing for relative and proportional values as rules
-    // such as +10% are well-formed independent of whether they affect base value
-    if( relative.has_member( name ) ) {
-        units::money tmp;
-        err = relative;
-        if( !parse( err, tmp ) ) {
-            err.throw_error( "invalid relative value specified", name );
-        }
-        strict = false;
-        out = val + tmp;
-
-    } else if( proportional.has_member( name ) ) {
-        double scalar;
-        err = proportional;
-        if( !err.read( name, scalar ) || scalar <= 0 || scalar == 1 ) {
-            err.throw_error( "multiplier must be a positive number other than 1", name );
-        }
-        strict = false;
-        out = val * scalar;
-
-    } else if( !parse( jo, out ) ) {
-        return false;
-    }
-
-    if( out < lo || out > hi ) {
-        err.throw_error( "value outside supported range", name );
-    }
-
-    if( strict && out == val ) {
-        report_strict_violation( err, "cannot assign explicit value the same as default or inherited value",
-                                 name );
-    }
-
-    val = out;
-
-    return true;
-}
-
-inline bool assign( const JsonObject &jo, const std::string &name, units::energy &val,
-                    bool strict = false,
-                    const units::energy lo = units::energy_min,
-                    const units::energy hi = units::energy_max )
-{
-    const auto parse = [&name]( const JsonObject & obj, units::energy & out ) {
-        if( obj.has_int( name ) ) {
-            const std::int64_t tmp = obj.get_int( name );
-            if( tmp > units::to_kilojoule( units::energy_max ) ) {
-                out = units::energy_max;
-            } else {
-                out = units::from_kilojoule( tmp );
-            }
-            return true;
-        }
-        if( obj.has_string( name ) ) {
-
-            out = read_from_json_string<units::energy>( *obj.get_raw( name ), units::energy_units );
-            return true;
-        }
-        return false;
-    };
-
-    units::energy out;
-
-    // Object via which to report errors which differs for proportional/relative values
-    JsonObject err = jo;
-    err.allow_omitted_members();
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
-
-    // Do not require strict parsing for relative and proportional values as rules
-    // such as +10% are well-formed independent of whether they affect base value
-    if( relative.has_member( name ) ) {
-        units::energy tmp;
-        err = relative;
-        if( !parse( err, tmp ) ) {
-            err.throw_error( "invalid relative value specified", name );
-        }
-        strict = false;
-        out = val + tmp;
-
-    } else if( proportional.has_member( name ) ) {
-        double scalar;
-        err = proportional;
-        if( !err.read( name, scalar ) || scalar <= 0 || scalar == 1 ) {
-            err.throw_error( "multiplier must be a positive number other than 1", name );
-        }
-        strict = false;
-        out = val * scalar;
-
-    } else if( !parse( jo, out ) ) {
-        return false;
-    }
-
-    if( out < lo || out > hi ) {
-        err.throw_error( "value outside supported range", name );
-    }
-
-    if( strict && out == val ) {
-        report_strict_violation( err, "cannot assign explicit value the same as default or inherited value",
-                                 name );
-    }
-
-    val = out;
-
-    return true;
-}
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             units::energy &val,
+             bool strict = false,
+             const units::energy lo = units::energy_min,
+             const units::energy hi = units::energy_max );
 
 // Kinda hacky way to avoid allowing multiplying temperature
 // For example, in 10 * 0 Fahrenheit, 10 * 0 Celsius - what's the expected result of those?
@@ -631,89 +348,24 @@ inline bool assign_unit_common( const JsonObject &jo, const std::string &name, T
     return true;
 }
 
-inline bool assign( const JsonObject &jo, const std::string &name, units::probability &val,
-                    bool strict = false,
-                    const units::probability lo = units::probability_min,
-                    const units::probability hi = units::probability_max )
-{
-    const auto parse = [&name]( const JsonObject & obj, units::probability & out ) {
-        if( obj.has_string( name ) ) {
-            long double tmp;
-            std::string suffix;
-            std::istringstream str( obj.get_string( name ) );
-            str.imbue( std::locale::classic() );
-            str >> tmp >> suffix;
-            if( str.peek() != std::istringstream::traits_type::eof() ) {
-                obj.throw_error( "syntax error when specifying volume", name );
-            }
-            if( suffix == "pm" ) {
-                out = units::from_one_in_million( static_cast<units::probability::value_type>( tmp ) );
-            } else if( suffix == "%" ) {
-                out = units::from_percent( tmp );
-            } else {
-                obj.throw_error( "unrecognized volumetric unit", name );
-            }
-            return true;
-        }
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             units::probability &val,
+             bool strict = false,
+             const units::probability lo = units::probability_min,
+             const units::probability hi = units::probability_max );
 
-        return false;
-    };
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             units::temperature &val,
+             bool strict = false,
+             const units::temperature lo = units::temperature_min,
+             const units::temperature hi = units::temperature_max );
 
-    return assign_unit_common( jo, name, val, parse, strict, lo, hi );
-}
-
-inline bool assign( const JsonObject &jo, const std::string &name, units::temperature &val,
-                    bool strict = false,
-                    const units::temperature lo = units::temperature_min,
-                    const units::temperature hi = units::temperature_max )
-{
-    const auto parse = [&name]( const JsonObject & obj, units::temperature & out ) {
-        if( obj.has_string( name ) ) {
-            long double value;
-            std::string suffix;
-            std::istringstream str( obj.get_string( name ) );
-            str.imbue( std::locale::classic() );
-            str >> value >> suffix;
-            if( str.peek() != std::istringstream::traits_type::eof() ) {
-                obj.throw_error( "syntax error when specifying temperature", name );
-            }
-            const auto &unit_suffixes = units::temperature_units;
-            auto iter = std::find_if( unit_suffixes.begin(), unit_suffixes.end(),
-            [&suffix]( const std::pair<std::string, units::temperature> &suffix_value ) {
-                return suffix_value.first == suffix;
-            } );
-            if( iter != unit_suffixes.end() ) {
-                out = mult_unit( obj, name, iter->second, value );
-            } else {
-                obj.throw_error( "unrecognized temperature unit", name );
-            }
-
-            return true;
-        }
-
-        return false;
-    };
-
-    return assign_unit_common( jo, name, val, parse, strict, lo, hi );
-}
-
-inline bool assign( const JsonObject &jo, const std::string &name, nc_color &val,
-                    const bool strict = false )
-{
-    if( !jo.has_member( name ) ) {
-        return false;
-    }
-    const nc_color out = color_from_string( jo.get_string( name ) );
-    if( out == c_unset ) {
-        jo.throw_error( "invalid color name", name );
-    }
-    if( strict && out == val ) {
-        report_strict_violation( jo, "cannot assign explicit value the same as default or inherited value",
-                                 name );
-    }
-    val = out;
-    return true;
-}
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             nc_color &val,
+             const bool strict = false );
 
 class time_duration;
 
@@ -802,264 +454,35 @@ inline bool assign( const JsonObject &jo, const std::string &name, cata::optiona
     return assign( jo, name, *val, strict );
 }
 
-static const float float_max = std::numeric_limits<float>::max();
+constexpr float float_max = std::numeric_limits<float>::max();
 
-static void assign_dmg_relative( damage_instance &out, const damage_instance &val,
-                                 damage_instance relative, bool &strict )
-{
-    for( const damage_unit &val_dmg : val.damage_units ) {
-        for( damage_unit &tmp : relative.damage_units ) {
-            if( tmp.type != val_dmg.type ) {
-                continue;
-            }
+void assign_dmg_relative( damage_instance &out,
+                          const damage_instance &val,
+                          damage_instance relative,
+                          bool &strict );
 
-            // Do not require strict parsing for relative and proportional values as rules
-            // such as +10% are well-formed independent of whether they affect base value
-            strict = false;
+void assign_dmg_proportional( const JsonObject &jo,
+                              const std::string &name,
+                              damage_instance &out,
+                              const damage_instance &val,
+                              damage_instance proportional,
+                              bool &strict );
 
-            // res_mult is set to 1 if it's not specified. Set it to zero so we don't accidentally add to it
-            if( tmp.res_mult == 1.0f ) {
-                tmp.res_mult = 0;
-            }
-            // Same for damage_multiplier
-            if( tmp.damage_multiplier == 1.0f ) {
-                tmp.damage_multiplier = 0;
-            }
+void check_assigned_dmg( const JsonObject &err,
+                         const std::string &name,
+                         const damage_instance &out,
+                         const damage_instance &lo_inst,
+                         const damage_instance &hi_inst );
 
-            damage_unit out_dmg( tmp.type, 0.0f );
-
-            out_dmg.amount = tmp.amount + val_dmg.amount;
-            out_dmg.res_pen = tmp.res_pen + val_dmg.res_pen;
-
-            out_dmg.res_mult = tmp.res_mult + val_dmg.res_mult;
-            out_dmg.damage_multiplier = tmp.damage_multiplier + val_dmg.damage_multiplier;
-
-            out.add( out_dmg );
-        }
-    }
-}
-
-static void assign_dmg_proportional( const JsonObject &jo, const std::string &name,
-                                     damage_instance &out,
-                                     const damage_instance &val,
-                                     damage_instance proportional, bool &strict )
-{
-    for( const damage_unit &val_dmg : val.damage_units ) {
-        for( damage_unit &scalar : proportional.damage_units ) {
-            if( scalar.type != val_dmg.type ) {
-                continue;
-            }
-
-            // Do not require strict parsing for relative and proportional values as rules
-            // such as +10% are well-formed independent of whether they affect base value
-            strict = false;
-
-            // Can't have negative percent, and 100% is pointless
-            // If it's 0, it wasn't loaded
-            if( scalar.amount == 1 || scalar.amount < 0 ) {
-                jo.throw_error( "Proportional damage multiplier must be a positive number other than 1", name );
-            }
-
-            // If it's 0, it wasn't loaded
-            if( scalar.res_pen < 0 || scalar.res_pen == 1 ) {
-                jo.throw_error( "Proportional armor penetration multiplier must be a positive number other than 1",
-                                name );
-            }
-
-            // It wasn't loaded, so set it 100%
-            if( scalar.res_pen == 0 ) {
-                scalar.res_pen = 1.0f;
-            }
-
-            // Ditto
-            if( scalar.amount == 0 ) {
-                scalar.amount = 1.0f;
-            }
-
-            // If it's 1, it wasn't loaded (or was loaded as 1)
-            if( scalar.res_mult <= 0 ) {
-                jo.throw_error( "Proportional armor penetration multiplier must be a positive number", name );
-            }
-
-            // If it's 1, it wasn't loaded (or was loaded as 1)
-            if( scalar.damage_multiplier <= 0 ) {
-                jo.throw_error( "Proportional damage multiplier must be a positive number", name );
-            }
-
-            damage_unit out_dmg( scalar.type, 0.0f );
-
-            out_dmg.amount = val_dmg.amount * scalar.amount;
-            out_dmg.res_pen = val_dmg.res_pen * scalar.res_pen;
-
-            out_dmg.res_mult = val_dmg.res_mult * scalar.res_mult;
-            out_dmg.damage_multiplier = val_dmg.damage_multiplier * scalar.damage_multiplier;
-
-            out.add( out_dmg );
-        }
-    }
-}
-
-static void check_assigned_dmg( const JsonObject &err, const std::string &name,
-                                const damage_instance &out, const damage_instance &lo_inst, const damage_instance &hi_inst )
-{
-    for( const damage_unit &out_dmg : out.damage_units ) {
-        auto lo_iter = std::find_if( lo_inst.damage_units.begin(),
-        lo_inst.damage_units.end(), [&out_dmg]( const damage_unit & du ) {
-            return du.type == out_dmg.type || du.type == DT_NULL;
-        } );
-
-        auto hi_iter = std::find_if( hi_inst.damage_units.begin(),
-        hi_inst.damage_units.end(), [&out_dmg]( const damage_unit & du ) {
-            return du.type == out_dmg.type || du.type == DT_NULL;
-        } );
-
-        if( lo_iter == lo_inst.damage_units.end() ) {
-            err.throw_error( "Min damage type used in assign does not match damage type assigned", name );
-        }
-        if( hi_iter == hi_inst.damage_units.end() ) {
-            err.throw_error( "Max damage type used in assign does not match damage type assigned", name );
-        }
-
-        const damage_unit &hi_dmg = *hi_iter;
-        const damage_unit &lo_dmg = *lo_iter;
-
-        if( out_dmg.amount < lo_dmg.amount || out_dmg.amount > hi_dmg.amount ) {
-            err.throw_error( "value for damage outside supported range", name );
-        }
-        if( out_dmg.res_pen < lo_dmg.res_pen || out_dmg.res_pen > hi_dmg.res_pen ) {
-            err.throw_error( "value for armor penetration outside supported range", name );
-        }
-        if( out_dmg.res_mult < lo_dmg.res_mult || out_dmg.res_mult > hi_dmg.res_mult ) {
-            err.throw_error( "value for armor penetration multiplier outside supported range", name );
-        }
-        if( out_dmg.damage_multiplier < lo_dmg.damage_multiplier ||
-            out_dmg.damage_multiplier > hi_dmg.damage_multiplier ) {
-            err.throw_error( "value for damage multiplier outside supported range", name );
-        }
-    }
-}
-
-inline bool assign( const JsonObject &jo, const std::string &name, damage_instance &val,
-                    bool strict = false,
-                    const damage_instance &lo = damage_instance( DT_NULL, 0.0f, 0.0f, 0.0f, 0.0f ),
-                    const damage_instance &hi = damage_instance( DT_NULL, float_max, float_max, float_max,
-                            float_max ) )
-{
-    // What we'll eventually be returning for the damage instance
-    damage_instance out;
-
-    if( jo.has_array( name ) ) {
-        out = load_damage_instance_inherit( jo.get_array( name ), val );
-    } else if( jo.has_object( name ) ) {
-        out = load_damage_instance_inherit( jo.get_object( name ), val );
-    } else {
-        // Legacy: remove after 0.F
-        float amount = 0.0f;
-        float arpen = 0.0f;
-        float dmg_mult = 1.0f;
-        bool with_legacy = false;
-
-        // There will always be either a prop_damage or damage (name)
-        if( jo.has_member( name ) ) {
-            with_legacy = true;
-            amount = jo.get_float( name );
-        } else if( jo.has_member( "prop_damage" ) ) {
-            dmg_mult = jo.get_float( "prop_damage" );
-            with_legacy = true;
-        }
-        // And there may or may not be armor penetration
-        if( jo.has_member( "pierce" ) ) {
-            with_legacy = true;
-            arpen = jo.get_float( "pierce" );
-        }
-
-        if( with_legacy ) {
-            out.add_damage( DT_STAB, amount, arpen, 1.0f, dmg_mult );
-        }
-    }
-
-    // Object via which to report errors which differs for proportional/relative values
-    const JsonObject &err = jo;
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
-
-    // Currently, we load only either relative or proportional when loading damage
-    // There's no good reason for this, but it's simple for now
-    if( relative.has_object( name ) ) {
-        assign_dmg_relative( out, val, load_damage_instance( relative.get_object( name ) ), strict );
-    } else if( relative.has_array( name ) ) {
-        assign_dmg_relative( out, val, load_damage_instance( relative.get_array( name ) ), strict );
-    } else if( proportional.has_object( name ) ) {
-        assign_dmg_proportional( proportional, name, out, val,
-                                 load_damage_instance( proportional.get_object( name ) ),
-                                 strict );
-    } else if( proportional.has_array( name ) ) {
-        assign_dmg_proportional( proportional, name, out, val,
-                                 load_damage_instance( proportional.get_array( name ) ),
-                                 strict );
-    } else if( relative.has_member( name ) || relative.has_member( "pierce" ) ||
-               relative.has_member( "prop_damage" ) ) {
-        // Legacy: Remove after 0.F
-        // It is valid for relative to adjust any of pierce, prop_damage, or damage
-        // So check for what it's modifying, and modify that
-        float amt = 0.0f;
-        float arpen = 0.0f;
-        float dmg_mult = 1.0f;
-
-        if( relative.has_member( name ) ) {
-            amt = relative.get_float( name );
-        }
-        if( relative.has_member( "pierce" ) ) {
-            arpen = relative.get_float( "pierce" );
-        }
-        if( relative.has_member( "prop_damage" ) ) {
-            dmg_mult = relative.get_float( "prop_damage" );
-        }
-
-        assign_dmg_relative( out, val, damage_instance( DT_STAB, amt, arpen, 1.0f, dmg_mult ), strict );
-    } else if( proportional.has_member( name ) || proportional.has_member( "pierce" ) ||
-               proportional.has_member( "prop_damage" ) ) {
-        // Legacy: Remove after 0.F
-        // It is valid for proportional to adjust any of pierce, prop_damage, or damage
-        // So check if it's modifying any of the things before going on to modify it
-        float amt = 0.0f;
-        float arpen = 0.0f;
-        float dmg_mult = 1.0f;
-
-        if( proportional.has_member( name ) ) {
-            amt = proportional.get_float( name );
-        }
-        if( proportional.has_member( "pierce" ) ) {
-            arpen = proportional.get_float( "pierce" );
-        }
-        if( proportional.has_member( "prop_damage" ) ) {
-            dmg_mult = proportional.get_float( "prop_damage" );
-        }
-
-        assign_dmg_proportional( proportional, name, out, val, damage_instance( DT_STAB, amt, arpen, 1.0f,
-                                 dmg_mult ), strict );
-    } else if( !jo.has_member( name ) && !jo.has_member( "prop_damage" ) ) {
-        // Straight copy-from, not modified by proportional or relative
-        out = val;
-        strict = false;
-    }
-
-    check_assigned_dmg( err, name, out, lo, hi );
-
-    if( strict && out == val ) {
-        report_strict_violation( err,
-                                 "cannot assign explicit damage value the same as default or inherited value", name );
-    }
-
-    if( out.damage_units.empty() ) {
-        out = damage_instance( DT_BULLET, 0.0f );
-    }
-
-    // Now that we've verified everything in out is all good, set val to it
-    val = out;
-
-    return true;
-}
+bool assign( const JsonObject &jo,
+             const std::string &name,
+             damage_instance &val,
+             bool strict = false,
+             const damage_instance &lo =
+                 damage_instance( DT_NULL, 0.0f, 0.0f, 0.0f, 0.0f ),
+             const damage_instance &hi = damage_instance( DT_NULL,
+                     float_max,
+                     float_max,
+                     float_max,
+                     float_max ) );
 #endif // CATA_SRC_ASSIGN_H

--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -162,6 +162,11 @@ int utf8_width( const std::string &str, const bool ignore_tags )
     return utf8_width( str.c_str(), ignore_tags );
 }
 
+int utf8_width( std::string_view str, const bool ignore_tags )
+{
+    return utf8_width( str.data(), ignore_tags );
+}
+
 int utf8_width( const utf8_wrapper &str, const bool ignore_tags )
 {
     return utf8_width( str.c_str(), ignore_tags );

--- a/src/catacharset.h
+++ b/src/catacharset.h
@@ -26,6 +26,7 @@ inline uint32_t UTF8_getch( const std::string &str )
 int cursorx_to_position( const char *line, int cursorx, int *prevpos = nullptr, int maxlen = -1 );
 int utf8_width( const char *s, bool ignore_tags = false );
 int utf8_width( const std::string &str, bool ignore_tags = false );
+int utf8_width( std::string_view str, const bool ignore_tags = false );
 int utf8_width( const utf8_wrapper &str, bool ignore_tags = false );
 
 std::string left_justify( const std::string &str, int width, bool ignore_tags = false );

--- a/src/cellular_automata.cpp
+++ b/src/cellular_automata.cpp
@@ -1,0 +1,75 @@
+#include "cellular_automata.h"
+
+int CellularAutomata::neighbor_count( const std::vector<std::vector<int>> &cells,
+                                      const point &size,
+                                      const point &p )
+{
+    int neighbors = 0;
+    for( int ni = -1; ni <= 1; ni++ ) {
+        for( int nj = -1; nj <= 1; nj++ ) {
+            const point n( p + point( ni, nj ) );
+
+            // These neighbors are outside the bounds, so they can't contribute.
+            if( n.x < 0 || n.x >= size.x || n.y < 0 || n.y >= size.y ) {
+                continue;
+            }
+
+            neighbors += cells[n.x][n.y];
+        }
+    }
+    // Because we included ourself in the loop above, subtract ourselves back out.
+    neighbors -= cells[p.x][p.y];
+
+    return neighbors;
+}
+std::vector<std::vector<int>> CellularAutomata::generate_cellular_automaton(
+                               const point &size,
+                               const int alive,
+                               const int iterations,
+                               const int birth_limit,
+                               const int stasis_limit )
+{
+    std::vector<std::vector<int>> current( size.x, std::vector<int>( size.y, 0 ) );
+    std::vector<std::vector<int>> next( size.x, std::vector<int>( size.y, 0 ) );
+
+    // Initialize our initial set of cells.
+    for( int i = 0; i < size.x; i++ ) {
+        for( int j = 0; j < size.y; j++ ) {
+            current[i][j] = x_in_y( alive, 100 );
+        }
+    }
+
+    for( int iteration = 0; iteration < iterations; iteration++ ) {
+        for( int i = 0; i < size.x; i++ ) {
+            for( int j = 0; j < size.y; j++ ) {
+                // Skip the edges--no need to complicate this with more complex neighbor
+                // calculations, just keep them constant.
+                if( i == 0 || i == size.x - 1 || j == 0 || j == size.y - 1 ) {
+                    next[i][j] = 0;
+                    continue;
+                }
+
+                // Count our neighors.
+                const int neighbors = neighbor_count( current, size, point( i, j ) );
+
+                // Dead and > birth_limit neighbors, so become alive.
+                if( ( current[i][j] == 0 ) && ( neighbors > birth_limit ) ) {
+                    next[i][j] = 1;
+                }
+                // Alive and > statis_limit neighbors, so stay alive.
+                else if( ( current[i][j] == 1 ) && ( neighbors > stasis_limit ) ) {
+                    next[i][j] = 1;
+                }
+                // Else, die.
+                else {
+                    next[i][j] = 0;
+                }
+            }
+        }
+
+        // Swap our current and next vectors and repeat.
+        std::swap( current, next );
+    }
+
+    return current;
+}

--- a/src/cellular_automata.h
+++ b/src/cellular_automata.h
@@ -17,27 +17,9 @@ namespace CellularAutomata
 * @param p
 * @returns The number of neighbors that are alive, a value between 0 and 8.
 */
-inline int neighbor_count( const std::vector<std::vector<int>> &cells, const point &size,
-                           const point &p )
-{
-    int neighbors = 0;
-    for( int ni = -1; ni <= 1; ni++ ) {
-        for( int nj = -1; nj <= 1; nj++ ) {
-            const point n( p + point( ni, nj ) );
-
-            // These neighbors are outside the bounds, so they can't contribute.
-            if( n.x < 0 || n.x >= size.x || n.y < 0 || n.y >= size.y ) {
-                continue;
-            }
-
-            neighbors += cells[n.x][n.y];
-        }
-    }
-    // Because we included ourself in the loop above, subtract ourselves back out.
-    neighbors -= cells[p.x][p.y];
-
-    return neighbors;
-}
+int neighbor_count( const std::vector<std::vector<int>> &cells,
+                    const point &size,
+                    const point &p );
 
 /**
 * Generate a cellular automaton using the provided parameters.
@@ -54,53 +36,12 @@ inline int neighbor_count( const std::vector<std::vector<int>> &cells, const poi
 * @param stasis_limit Alive cells with > statis_limit neighbors stay alive
 * @returns The width x height grid of cells. Each cell is a 0 if dead or a 1 if alive.
 */
-inline std::vector<std::vector<int>> generate_cellular_automaton( const point &size,
-                                  const int alive, const int iterations, const int birth_limit, const int stasis_limit )
-{
-    std::vector<std::vector<int>> current( size.x, std::vector<int>( size.y, 0 ) );
-    std::vector<std::vector<int>> next( size.x, std::vector<int>( size.y, 0 ) );
-
-    // Initialize our initial set of cells.
-    for( int i = 0; i < size.x; i++ ) {
-        for( int j = 0; j < size.y; j++ ) {
-            current[i][j] = x_in_y( alive, 100 );
-        }
-    }
-
-    for( int iteration = 0; iteration < iterations; iteration++ ) {
-        for( int i = 0; i < size.x; i++ ) {
-            for( int j = 0; j < size.y; j++ ) {
-                // Skip the edges--no need to complicate this with more complex neighbor
-                // calculations, just keep them constant.
-                if( i == 0 || i == size.x - 1 || j == 0 || j == size.y - 1 ) {
-                    next[i][j] = 0;
-                    continue;
-                }
-
-                // Count our neighors.
-                const int neighbors = neighbor_count( current, size, point( i, j ) );
-
-                // Dead and > birth_limit neighbors, so become alive.
-                if( ( current[i][j] == 0 ) && ( neighbors > birth_limit ) ) {
-                    next[i][j] = 1;
-                }
-                // Alive and > statis_limit neighbors, so stay alive.
-                else if( ( current[i][j] == 1 ) && ( neighbors > stasis_limit ) ) {
-                    next[i][j] = 1;
-                }
-                // Else, die.
-                else {
-                    next[i][j] = 0;
-                }
-            }
-        }
-
-        // Swap our current and next vectors and repeat.
-        std::swap( current, next );
-    }
-
-    return current;
-}
+std::vector<std::vector<int>> generate_cellular_automaton(
+                               const point &size,
+                               const int alive,
+                               const int iterations,
+                               const int birth_limit,
+                               const int stasis_limit );
 } // namespace CellularAutomata
 
 #endif // CATA_SRC_CELLULAR_AUTOMATA_H

--- a/src/color.h
+++ b/src/color.h
@@ -395,8 +395,8 @@ enum class report_color_error {
 class color_manager
 {
     private:
-        void add_color( color_id col, const std::string &name,
-                        const nc_color &color_pair, color_id inv_id );
+        void add_color( const color_id col, const std::string &name,
+                        const nc_color &color_pair, const color_id inv_id );
         void clear();
         void finalize(); // Caches colors properly
 
@@ -431,19 +431,19 @@ class color_manager
         nc_color get_random() const;
 
         color_id color_to_id( const nc_color &color ) const;
-        color_id name_to_id( const std::string &name,
+        color_id name_to_id( std::string_view name,
                              report_color_error color_error = report_color_error::yes ) const;
 
         std::string get_name( const nc_color &color ) const;
         std::string id_to_name( color_id id ) const;
 
-        nc_color name_to_color( const std::string &name,
+        nc_color name_to_color( std::string_view name,
                                 report_color_error color_error = report_color_error::yes ) const;
 
-        nc_color highlight_from_names( const std::string &name, const std::string &bg_name ) const;
+        nc_color highlight_from_names( std::string_view name, std::string_view bg_name ) const;
 
         void load_default();
-        void load_custom( const std::string &sPath = "" );
+        void load_custom( std::string_view sPath = "" );
 
         void show_gui();
 
@@ -498,18 +498,20 @@ nc_color yellow_background( const nc_color &c );
 nc_color magenta_background( const nc_color &c );
 nc_color cyan_background( const nc_color &c );
 
-nc_color color_from_string( const std::string &color,
+nc_color color_from_string( std::string_view color,
                             report_color_error color_error = report_color_error::yes );
 std::string string_from_color( const nc_color &color );
-nc_color bgcolor_from_string( const std::string &color );
-color_tag_parse_result get_color_from_tag( const std::string &s,
+nc_color bgcolor_from_string( std::string_view color );
+color_tag_parse_result get_color_from_tag( std::string_view s,
         report_color_error color_error = report_color_error::yes );
 std::string get_tag_from_color( const nc_color &color );
 std::string colorize( const std::string &text, const nc_color &color );
+std::string colorize( std::string_view text, const nc_color &color );
+std::string colorize( const char *text, const nc_color &color );
 std::string colorize( const translation &text, const nc_color &color );
 
 std::string get_note_string_from_color( const nc_color &color );
-nc_color get_note_color( const std::string &note_id );
+nc_color get_note_color( std::string_view note_id );
 std::list<std::pair<std::string, std::string>> get_note_color_names();
 
 #endif // CATA_SRC_COLOR_H

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -1,0 +1,33 @@
+#include "coordinates.h"
+
+void real_coords::fromabs( const point &abs )
+{
+    const point norm( std::abs( abs.x ), std::abs( abs.y ) );
+    abs_pos = abs;
+
+    if( abs.x < 0 ) {
+        abs_sub.x = ( abs.x - SEEX + 1 ) / SEEX;
+        sub_pos.x = SEEX - 1 - ( ( norm.x - 1 ) % SEEX );
+        abs_om.x = ( abs_sub.x - subs_in_om_n ) / subs_in_om;
+        om_sub.x = subs_in_om_n - ( ( ( norm.x - 1 ) / SEEX ) % subs_in_om );
+    } else {
+        abs_sub.x = norm.x / SEEX;
+        sub_pos.x = abs.x % SEEX;
+        abs_om.x = abs_sub.x / subs_in_om;
+        om_sub.x = abs_sub.x % subs_in_om;
+    }
+    om_pos.x = om_sub.x / 2;
+
+    if( abs.y < 0 ) {
+        abs_sub.y = ( abs.y - SEEY + 1 ) / SEEY;
+        sub_pos.y = SEEY - 1 - ( ( norm.y - 1 ) % SEEY );
+        abs_om.y = ( abs_sub.y - subs_in_om_n ) / subs_in_om;
+        om_sub.y = subs_in_om_n - ( ( ( norm.y - 1 ) / SEEY ) % subs_in_om );
+    } else {
+        abs_sub.y = norm.y / SEEY;
+        sub_pos.y = abs.y % SEEY;
+        abs_om.y = abs_sub.y / subs_in_om;
+        om_sub.y = abs_sub.y % subs_in_om;
+    }
+    om_pos.y = om_sub.y / 2;
+}

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -643,36 +643,7 @@ struct real_coords {
         fromabs( ap );
     }
 
-    void fromabs( const point &abs ) {
-        const point norm( std::abs( abs.x ), std::abs( abs.y ) );
-        abs_pos = abs;
-
-        if( abs.x < 0 ) {
-            abs_sub.x = ( abs.x - SEEX + 1 ) / SEEX;
-            sub_pos.x = SEEX - 1 - ( ( norm.x - 1 ) % SEEX );
-            abs_om.x = ( abs_sub.x - subs_in_om_n ) / subs_in_om;
-            om_sub.x = subs_in_om_n - ( ( ( norm.x - 1 ) / SEEX ) % subs_in_om );
-        } else {
-            abs_sub.x = norm.x / SEEX;
-            sub_pos.x = abs.x % SEEX;
-            abs_om.x = abs_sub.x / subs_in_om;
-            om_sub.x = abs_sub.x % subs_in_om;
-        }
-        om_pos.x = om_sub.x / 2;
-
-        if( abs.y < 0 ) {
-            abs_sub.y = ( abs.y - SEEY + 1 ) / SEEY;
-            sub_pos.y = SEEY - 1 - ( ( norm.y - 1 ) % SEEY );
-            abs_om.y = ( abs_sub.y - subs_in_om_n ) / subs_in_om;
-            om_sub.y = subs_in_om_n - ( ( ( norm.y - 1 ) / SEEY ) % subs_in_om );
-        } else {
-            abs_sub.y = norm.y / SEEY;
-            sub_pos.y = abs.y % SEEY;
-            abs_om.y = abs_sub.y / subs_in_om;
-            om_sub.y = abs_sub.y % subs_in_om;
-        }
-        om_pos.y = om_sub.y / 2;
-    }
+    void fromabs( const point &abs );
 
     // specifically for the subjective position returned by overmap::draw
     void fromomap( const point &rel_om, const point &rel_om_pos ) {

--- a/src/cursesdef.h
+++ b/src/cursesdef.h
@@ -101,17 +101,19 @@ void wrefresh( const window &win );
 void refresh();
 void doupdate();
 void wredrawln( const window &win, int beg_line, int num_lines );
-void mvwprintw( const window &win, const point &p, const std::string &text );
+void mvwprintw( const window &win, const point &p, std::string_view text );
+
 template<typename ...Args>
-inline void mvwprintw( const window &win, const point &p, const char *const fmt,
+inline void mvwprintw( const window &win, const point &p, std::string_view fmt,
                        Args &&... args )
 {
     return mvwprintw( win, p, string_format( fmt, std::forward<Args>( args )... ) );
 }
 
-void wprintw( const window &win, const std::string &text );
+void wprintw( const window &win, std::string_view text );
+
 template<typename ...Args>
-inline void wprintw( const window &win, const char *const fmt, Args &&... args )
+inline void wprintw( const window &win, std::string_view fmt, Args &&... args )
 {
     return wprintw( win, string_format( fmt, std::forward<Args>( args )... ) );
 }

--- a/src/cursesport.cpp
+++ b/src/cursesport.cpp
@@ -267,7 +267,7 @@ inline cata_cursesport::cursecell *cur_cell( cata_cursesport::WINDOW *win )
 }
 
 //The core printing function, prints characters to the array, and sets colors
-inline void printstring( cata_cursesport::WINDOW *win, const std::string &text )
+inline void printstring( cata_cursesport::WINDOW *win, std::string_view text )
 {
     using cata_cursesport::cursecell;
     win->draw = true;
@@ -275,7 +275,7 @@ inline void printstring( cata_cursesport::WINDOW *win, const std::string &text )
     if( len == 0 ) {
         return;
     }
-    const char *fmt = text.c_str();
+    const char *fmt = text.data();
     // avoid having an invalid cursorx, so that cur_cell will only return nullptr
     // when the bottom of the window has been reached.
     if( win->cursor.x >= win->width ) {
@@ -352,7 +352,7 @@ inline void printstring( cata_cursesport::WINDOW *win, const std::string &text )
 }
 
 //Prints a formatted string to a window at the current cursor, base function
-void catacurses::wprintw( const window &win, const std::string &text )
+void catacurses::wprintw( const window &win, std::string_view text )
 {
     if( !win ) {
         // TODO: log this
@@ -363,7 +363,7 @@ void catacurses::wprintw( const window &win, const std::string &text )
 }
 
 //Prints a formatted string to a window, moves the cursor
-void catacurses::mvwprintw( const window &win, const point &p, const std::string &text )
+void catacurses::mvwprintw( const window &win, const point &p, std::string_view text )
 {
     if( !wmove_internal( win, p ) ) {
         return;

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -167,4 +167,24 @@ event::fields_type event::get_fields( event_type type )
                type, std::make_integer_sequence<int, static_cast<int>( event_type::num_event_types )> {} );
 }
 
+cata_variant event::get_variant( const std::string &key ) const
+{
+    auto it = data_.find( key );
+    if( it == data_.end() ) {
+        debugmsg( "No such key %s in event of type %s", key,
+                  io::enum_to_string( type_ ) );
+        abort();
+    }
+    return it->second;
+}
+
+cata_variant event::get_variant_or_void( const std::string &key ) const
+{
+    auto it = data_.find( key );
+    if( it == data_.end() ) {
+        return cata_variant();
+    }
+    return it->second;
+}
+
 } // namespace cata

--- a/src/event.h
+++ b/src/event.h
@@ -580,23 +580,9 @@ class event
             return time_;
         }
 
-        cata_variant get_variant( const std::string &key ) const {
-            auto it = data_.find( key );
-            if( it == data_.end() ) {
-                debugmsg( "No such key %s in event of type %s", key,
-                          io::enum_to_string( type_ ) );
-                abort();
-            }
-            return it->second;
-        }
+        cata_variant get_variant( const std::string &key ) const;
 
-        cata_variant get_variant_or_void( const std::string &key ) const {
-            auto it = data_.find( key );
-            if( it == data_.end() ) {
-                return cata_variant();
-            }
-            return it->second;
-        }
+        cata_variant get_variant_or_void( const std::string &key ) const;
 
         template<cata_variant_type Type>
         auto get( const std::string &key ) const {

--- a/src/font_loader.cpp
+++ b/src/font_loader.cpp
@@ -1,0 +1,70 @@
+#include "font_loader.h"
+
+void ensure_unifont_loaded( std::vector<std::string> &font_list )
+{
+    if( std::find( std::begin( font_list ), std::end( font_list ), "unifont" ) == font_list.end() ) {
+        font_list.emplace_back( PATH_INFO::fontdir() + "unifont.ttf" );
+    }
+}
+
+void font_loader::load_throws( const std::string &path )
+{
+    try {
+        cata_ifstream stream = std::move( cata_ifstream().mode( cata_ios_mode::binary ).open( path ) );
+        JsonIn json( *stream );
+        JsonObject config = json.get_object();
+        if( config.has_string( "typeface" ) ) {
+            typeface.emplace_back( config.get_string( "typeface" ) );
+        } else {
+            config.read( "typeface", typeface );
+        }
+        if( config.has_string( "map_typeface" ) ) {
+            map_typeface.emplace_back( config.get_string( "map_typeface" ) );
+        } else {
+            config.read( "map_typeface", map_typeface );
+        }
+        if( config.has_string( "overmap_typeface" ) ) {
+            overmap_typeface.emplace_back( config.get_string( "overmap_typeface" ) );
+        } else {
+            config.read( "overmap_typeface", overmap_typeface );
+        }
+
+        ensure_unifont_loaded( typeface );
+        ensure_unifont_loaded( map_typeface );
+        ensure_unifont_loaded( overmap_typeface );
+
+    } catch( const std::exception &err ) {
+        throw std::runtime_error( std::string( "loading font settings from " ) + path + " failed: " +
+                                  err.what() );
+    }
+}
+
+void font_loader::load()
+{
+    const std::string user_fontconfig = PATH_INFO::user_fontconfig();
+    const std::string fontconfig = PATH_INFO::fontconfig();
+    bool try_user = true;
+    if( !file_exist( user_fontconfig ) ) {
+        if( !copy_file( fontconfig, user_fontconfig ) ) {
+            try_user = false;
+            DebugLog( DL::Error, DC::SDL ) << "failed to create user font config file "
+                                           << user_fontconfig;
+        }
+    }
+    if( try_user ) {
+        font_loader copy = *this;
+        try {
+            load_throws( user_fontconfig );
+            return;
+        } catch( const std::exception &e ) {
+            DebugLog( DL::Error, DC::SDL ) << e.what();
+        }
+        *this = copy;
+    }
+    try {
+        load_throws( fontconfig );
+    } catch( const std::exception &e ) {
+        DebugLog( DL::Error, DC::SDL ) << e.what();
+        abort();
+    }
+}

--- a/src/font_loader.h
+++ b/src/font_loader.h
@@ -15,12 +15,7 @@
 #include "cata_utility.h"
 
 // Ensure that unifont is always loaded as a fallback font to prevent users from shooting themselves in the foot
-static void ensure_unifont_loaded( std::vector<std::string> &font_list )
-{
-    if( std::find( std::begin( font_list ), std::end( font_list ), "unifont" ) == font_list.end() ) {
-        font_list.emplace_back( PATH_INFO::fontdir() + "unifont.ttf" );
-    }
-}
+void ensure_unifont_loaded( std::vector<std::string> &font_list );
 
 class font_loader
 {
@@ -40,66 +35,10 @@ class font_loader
         int overmap_fontsize = 16;
 
     private:
-        void load_throws( const std::string &path ) {
-            try {
-                cata_ifstream stream = std::move( cata_ifstream().mode( cata_ios_mode::binary ).open( path ) );
-                JsonIn json( *stream );
-                JsonObject config = json.get_object();
-                if( config.has_string( "typeface" ) ) {
-                    typeface.emplace_back( config.get_string( "typeface" ) );
-                } else {
-                    config.read( "typeface", typeface );
-                }
-                if( config.has_string( "map_typeface" ) ) {
-                    map_typeface.emplace_back( config.get_string( "map_typeface" ) );
-                } else {
-                    config.read( "map_typeface", map_typeface );
-                }
-                if( config.has_string( "overmap_typeface" ) ) {
-                    overmap_typeface.emplace_back( config.get_string( "overmap_typeface" ) );
-                } else {
-                    config.read( "overmap_typeface", overmap_typeface );
-                }
-
-                ensure_unifont_loaded( typeface );
-                ensure_unifont_loaded( map_typeface );
-                ensure_unifont_loaded( overmap_typeface );
-
-            } catch( const std::exception &err ) {
-                throw std::runtime_error( std::string( "loading font settings from " ) + path + " failed: " +
-                                          err.what() );
-            }
-        }
+        void load_throws( const std::string &path );
 
     public:
-        void load() {
-            const std::string user_fontconfig = PATH_INFO::user_fontconfig();
-            const std::string fontconfig = PATH_INFO::fontconfig();
-            bool try_user = true;
-            if( !file_exist( user_fontconfig ) ) {
-                if( !copy_file( fontconfig, user_fontconfig ) ) {
-                    try_user = false;
-                    DebugLog( DL::Error, DC::SDL ) << "failed to create user font config file "
-                                                   << user_fontconfig;
-                }
-            }
-            if( try_user ) {
-                font_loader copy = *this;
-                try {
-                    load_throws( user_fontconfig );
-                    return;
-                } catch( const std::exception &e ) {
-                    DebugLog( DL::Error, DC::SDL ) << e.what();
-                }
-                *this = copy;
-            }
-            try {
-                load_throws( fontconfig );
-            } catch( const std::exception &e ) {
-                DebugLog( DL::Error, DC::SDL ) << e.what();
-                abort();
-            }
-        }
+        void load();
 };
 
 #endif // CATA_SRC_FONT_LOADER_H

--- a/src/generic_factory.cpp
+++ b/src/generic_factory.cpp
@@ -1,0 +1,36 @@
+#include "generic_factory.h"
+
+bool one_char_symbol_reader( const JsonObject &jo, const std::string &member_name, int &sym,
+                             bool )
+{
+    std::string sym_as_string;
+    if( !jo.read( member_name, sym_as_string ) ) {
+        return false;
+    }
+    if( sym_as_string.size() != 1 ) {
+        jo.throw_error( member_name + " must be exactly one ASCII character", member_name );
+    }
+    sym = sym_as_string.front();
+    return true;
+}
+
+bool unicode_codepoint_from_symbol_reader( const JsonObject &jo,
+        const std::string &member_name, uint32_t &member, bool )
+{
+    int sym_as_int;
+    std::string sym_as_string;
+    if( !jo.read( member_name, sym_as_string, false ) ) {
+        // Legacy fallback to integer `sym`.
+        if( !jo.read( member_name, sym_as_int ) ) {
+            return false;
+        } else {
+            sym_as_string = string_from_int( sym_as_int );
+        }
+    }
+    uint32_t sym_as_codepoint = UTF8_getch( sym_as_string );
+    if( mk_wcwidth( sym_as_codepoint ) != 1 ) {
+        jo.throw_error( member_name + " must be exactly one console cell wide", member_name );
+    }
+    member = sym_as_codepoint;
+    return true;
+}

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -848,43 +848,14 @@ inline void optional( const JsonObject &jo, const bool was_loaded, const std::st
  * Reads a string and stores the first byte of it in `sym`. Throws if the input contains more
  * or less than one byte.
  */
-inline bool one_char_symbol_reader( const JsonObject &jo, const std::string &member_name, int &sym,
-                                    bool )
-{
-    std::string sym_as_string;
-    if( !jo.read( member_name, sym_as_string ) ) {
-        return false;
-    }
-    if( sym_as_string.size() != 1 ) {
-        jo.throw_error( member_name + " must be exactly one ASCII character", member_name );
-    }
-    sym = sym_as_string.front();
-    return true;
-}
+bool one_char_symbol_reader( const JsonObject &jo, const std::string &member_name, int &sym,
+                             bool );
 
 /**
  * Reads a UTF-8 string (or int as legacy fallback) and stores Unicode codepoint of it in `symbol`.
  * Throws if the inputs width is more than one console cell wide.
  */
-inline bool unicode_codepoint_from_symbol_reader( const JsonObject &jo,
-        const std::string &member_name, uint32_t &member, bool )
-{
-    int sym_as_int;
-    std::string sym_as_string;
-    if( !jo.read( member_name, sym_as_string, false ) ) {
-        // Legacy fallback to integer `sym`.
-        if( !jo.read( member_name, sym_as_int ) ) {
-            return false;
-        } else {
-            sym_as_string = string_from_int( sym_as_int );
-        }
-    }
-    uint32_t sym_as_codepoint = UTF8_getch( sym_as_string );
-    if( mk_wcwidth( sym_as_codepoint ) != 1 ) {
-        jo.throw_error( member_name + " must be exactly one console cell wide", member_name );
-    }
-    member = sym_as_codepoint;
-    return true;
-}
+bool unicode_codepoint_from_symbol_reader( const JsonObject &jo,
+        const std::string &member_name, uint32_t &member, bool );
 
 #endif // CATA_SRC_GENERIC_FACTORY_H

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -43,6 +43,38 @@ itype::itype()
 
 itype::~itype() = default;
 
+int itype::damage_min() const
+{
+    return count_by_charges() ? 0 : damage_min_;
+}
+
+int itype::damage_max() const
+{
+    return count_by_charges() ? 0 : damage_max_;
+}
+
+std::string itype::get_item_type_string() const
+{
+    if( tool ) {
+        return "TOOL";
+    } else if( comestible ) {
+        return "FOOD";
+    } else if( container ) {
+        return "CONTAINER";
+    } else if( armor ) {
+        return "ARMOR";
+    } else if( book ) {
+        return "BOOK";
+    } else if( gun ) {
+        return "GUN";
+    } else if( bionic ) {
+        return "BIONIC";
+    } else if( ammo ) {
+        return "AMMO";
+    }
+    return "misc";
+}
+
 std::string itype::nname( unsigned int quantity ) const
 {
     // Always use singular form for liquids.
@@ -51,6 +83,49 @@ std::string itype::nname( unsigned int quantity ) const
         quantity = 1;
     }
     return name.translated( quantity );
+}
+
+const itype_id &itype::get_id() const
+{
+    return id;
+}
+
+bool itype::count_by_charges() const
+{
+    return stackable_ || ammo || comestible;
+}
+
+int itype::charges_default() const
+{
+    if( tool ) {
+        return tool->def_charges;
+    } else if( comestible ) {
+        return comestible->def_charges;
+    } else if( ammo ) {
+        return ammo->def_charges;
+    }
+    return count_by_charges() ? 1 : 0;
+}
+
+int itype::charges_to_use() const
+{
+    if( tool ) {
+        return static_cast<int>( tool->charges_per_use );
+    }
+    return 1;
+}
+
+int itype::charge_factor() const
+{
+    return tool ? tool->charge_factor : 1;
+}
+
+int itype::maximum_charges() const
+{
+    if( tool ) {
+        return tool->max_charges;
+    }
+    return 0;
 }
 
 int itype::charges_per_volume( const units::volume &vol ) const

--- a/src/itype.h
+++ b/src/itype.h
@@ -890,12 +890,8 @@ struct itype {
         itype();
         virtual ~itype();
 
-        int damage_min() const {
-            return count_by_charges() ? 0 : damage_min_;
-        }
-        int damage_max() const {
-            return count_by_charges() ? 0 : damage_max_;
-        }
+        int damage_min() const;
+        int damage_max() const;
 
         // used for generic_factory for copy-from
         bool was_loaded = false;
@@ -1036,69 +1032,25 @@ struct itype {
 
         FlagsSetType item_tags;
 
-        std::string get_item_type_string() const {
-            if( tool ) {
-                return "TOOL";
-            } else if( comestible ) {
-                return "FOOD";
-            } else if( container ) {
-                return "CONTAINER";
-            } else if( armor ) {
-                return "ARMOR";
-            } else if( book ) {
-                return "BOOK";
-            } else if( gun ) {
-                return "GUN";
-            } else if( bionic ) {
-                return "BIONIC";
-            } else if( ammo ) {
-                return "AMMO";
-            }
-            return "misc";
-        }
+        std::string get_item_type_string() const;
 
         // Returns the name of the item type in the correct language and with respect to its grammatical number,
         // based on quantity (example: item type “anvil”, nname(4) would return “anvils” (as in “4 anvils”).
         std::string nname( unsigned int quantity ) const;
 
         // Allow direct access to the type id for the few cases that need it.
-        const itype_id &get_id() const {
-            return id;
-        }
+        const itype_id &get_id() const;
 
-        bool count_by_charges() const {
-            return stackable_ || ammo || comestible;
-        }
+        bool count_by_charges() const;
 
-        int charges_default() const {
-            if( tool ) {
-                return tool->def_charges;
-            } else if( comestible ) {
-                return comestible->def_charges;
-            } else if( ammo ) {
-                return ammo->def_charges;
-            }
-            return count_by_charges() ? 1 : 0;
-        }
+        int charges_default() const;
 
-        int charges_to_use() const {
-            if( tool ) {
-                return static_cast<int>( tool->charges_per_use );
-            }
-            return 1;
-        }
+        int charges_to_use() const;
 
         // for tools that sub another tool, but use a different ratio of charges
-        int charge_factor() const {
-            return tool ? tool->charge_factor : 1;
-        }
+        int charge_factor() const;
 
-        int maximum_charges() const {
-            if( tool ) {
-                return tool->max_charges;
-            }
-            return 0;
-        }
+        int maximum_charges() const;
         bool can_have_charges() const;
 
         /**

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7345,8 +7345,9 @@ static extended_photo_def photo_def_for_camera_point( const tripoint &aim_point,
         } else {
             photo_text += _( "It is day. " );
         }
-        photo_text += string_format( _( "The weather is %s." ), colorize( get_weather().weather_id->name,
-                                     get_weather().weather_id->color ) );
+        photo_text += string_format( _( "The weather is %s." ),
+                                     colorize( get_weather().weather_id->name,
+                                               get_weather().weather_id->color ) );
     }
 
     for( const auto &figure : description_figures_appearance ) {

--- a/src/map.h
+++ b/src/map.h
@@ -402,96 +402,35 @@ class map
          * doesn't need to be updated.
          */
         /*@{*/
-        void set_transparency_cache_dirty( const int zlev ) {
-            if( inbounds_z( zlev ) ) {
-                get_cache( zlev ).transparency_cache_dirty.set();
-            }
-        }
 
         // more granular version of the transparency cache invalidation
         // preferred over map::set_transparency_cache_dirty( const int zlev )
         // p is in local coords ("ms")
-        void set_transparency_cache_dirty( const tripoint &p ) {
-            if( inbounds( p ) ) {
-                const tripoint smp = ms_to_sm_copy( p );
-                get_cache( smp.z ).transparency_cache_dirty.set( smp.x * MAPSIZE + smp.y );
-            }
-        }
+        void set_transparency_cache_dirty( const int zlev );
 
-        void set_seen_cache_dirty( const tripoint change_location ) {
-            if( inbounds( change_location ) ) {
-                level_cache &cache = get_cache( change_location.z );
-                if( cache.seen_cache_dirty ) {
-                    return;
-                }
-                if( cache.seen_cache[change_location.x][change_location.y] != 0.0 ||
-                    cache.camera_cache[change_location.x][change_location.y] != 0.0 ) {
-                    cache.seen_cache_dirty = true;
-                }
-            }
-        }
+        void set_transparency_cache_dirty( const tripoint &p );
 
         // invalidates seen cache for the whole zlevel unconditionally
-        void set_seen_cache_dirty( const int zlevel ) {
-            if( inbounds_z( zlevel ) ) {
-                level_cache &cache = get_cache( zlevel );
-                cache.seen_cache_dirty = true;
-            }
-        }
 
-        void set_outside_cache_dirty( const int zlev ) {
-            if( inbounds_z( zlev ) ) {
-                get_cache( zlev ).outside_cache_dirty = true;
-            }
-        }
+        void set_seen_cache_dirty( const tripoint change_location );
 
-        void set_floor_cache_dirty( const int zlev ) {
-            if( inbounds_z( zlev ) ) {
-                get_cache( zlev ).floor_cache_dirty = true;
-            }
-        }
+        void set_seen_cache_dirty( const int zlevel );
 
-        void set_suspension_cache_dirty( const int zlev ) {
-            if( inbounds_z( zlev ) ) {
-                get_cache( zlev ).suspension_cache_dirty = true;
-            }
-        }
+        void set_outside_cache_dirty( const int zlev );
+
+        void set_floor_cache_dirty( const int zlev );
+
+        void set_suspension_cache_dirty( const int zlev );
 
         void set_pathfinding_cache_dirty( int zlev );
         /*@}*/
 
-        void set_memory_seen_cache_dirty( const tripoint &p ) {
-            const int offset = p.x + p.y * MAPSIZE_Y;
-            if( offset >= 0 && offset < MAPSIZE_X * MAPSIZE_Y ) {
-                get_cache( p.z ).map_memory_seen_cache.reset( offset );
-            }
-        }
+        void set_memory_seen_cache_dirty( const tripoint &p );
 
-        void invalidate_map_cache( const int zlev ) {
-            if( inbounds_z( zlev ) ) {
-                level_cache &ch = get_cache( zlev );
-                ch.floor_cache_dirty = true;
-                ch.transparency_cache_dirty.set();
-                ch.seen_cache_dirty = true;
-                ch.outside_cache_dirty = true;
-                ch.suspension_cache_dirty = true;
-            }
-        }
+        void invalidate_map_cache( const int zlev );
 
-        bool check_seen_cache( const tripoint &p ) const {
-            std::bitset<MAPSIZE_X *MAPSIZE_Y> &memory_seen_cache =
-                get_cache( p.z ).map_memory_seen_cache;
-            return !memory_seen_cache[ static_cast<size_t>( p.x + p.y * MAPSIZE_Y ) ];
-        }
-        bool check_and_set_seen_cache( const tripoint &p ) const {
-            std::bitset<MAPSIZE_X *MAPSIZE_Y> &memory_seen_cache =
-                get_cache( p.z ).map_memory_seen_cache;
-            if( !memory_seen_cache[ static_cast<size_t>( p.x + p.y * MAPSIZE_Y ) ] ) {
-                memory_seen_cache.set( static_cast<size_t>( p.x + p.y * MAPSIZE_Y ) );
-                return true;
-            }
-            return false;
-        }
+        bool check_seen_cache( const tripoint &p ) const;
+        bool check_and_set_seen_cache( const tripoint &p ) const;
 
         /**
          * Callback invoked when a vehicle has moved.

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -100,15 +100,15 @@ void catacurses::wmove( const window &win, const point &p )
     return curses_check_result( ::wmove( win.get<::WINDOW>(), p.y, p.x ), OK, "wmove" );
 }
 
-void catacurses::mvwprintw( const window &win, const point &p, const std::string &text )
+void catacurses::mvwprintw( const window &win, const point &p, std::string_view text )
 {
-    return curses_check_result( ::mvwprintw( win.get<::WINDOW>(), p.y, p.x, "%s", text.c_str() ),
+    return curses_check_result( ::mvwprintw( win.get<::WINDOW>(), p.y, p.x, "%s", text.data() ),
                                 OK, "mvwprintw" );
 }
 
-void catacurses::wprintw( const window &win, const std::string &text )
+void catacurses::wprintw( const window &win, std::string_view text )
 {
-    return curses_check_result( ::wprintw( win.get<::WINDOW>(), "%s", text.c_str() ),
+    return curses_check_result( ::wprintw( win.get<::WINDOW>(), "%s", text.data() ),
                                 OK, "wprintw" );
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3339,3 +3339,55 @@ void npc_follower_rules::clear_overrides()
     overrides = ally_rule::DEFAULT;
     override_enable = ally_rule::DEFAULT;
 }
+
+bool job_data::set_task_priority( const activity_id &task, int new_priority )
+{
+    auto it = task_priorities.find( task );
+    if( it != task_priorities.end() ) {
+        task_priorities[task] = new_priority;
+        return true;
+    }
+    return false;
+}
+
+void job_data::clear_all_priorities()
+{
+    for( auto &elem : task_priorities ) {
+        elem.second = 0;
+    }
+}
+
+std::vector<activity_id> job_data::get_prioritised_vector() const
+{
+    std::vector<std::pair<activity_id, int>> pairs( begin( task_priorities ), end( task_priorities ) );
+
+    std::vector<activity_id> ret;
+    sort( begin( pairs ), end( pairs ), []( const std::pair<activity_id, int> &a,
+    const std::pair<activity_id, int> &b ) {
+        return a.second > b.second;
+    } );
+    for( std::pair<activity_id, int> elem : pairs ) {
+        ret.push_back( elem.first );
+    }
+    return ret;
+}
+
+int job_data::get_priority_of_job( const activity_id &req_job ) const
+{
+    auto it = task_priorities.find( req_job );
+    if( it != task_priorities.end() ) {
+        return it->second;
+    } else {
+        return 0;
+    }
+}
+
+bool job_data::has_job() const
+{
+    for( auto &elem : task_priorities ) {
+        if( elem.second > 0 ) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/npc.h
+++ b/src/npc.h
@@ -129,48 +129,11 @@ class job_data
             { activity_id( "ACT_TIDY_UP" ), 0 },
         };
     public:
-        bool set_task_priority( const activity_id &task, int new_priority ) {
-            auto it = task_priorities.find( task );
-            if( it != task_priorities.end() ) {
-                task_priorities[task] = new_priority;
-                return true;
-            }
-            return false;
-        }
-        void clear_all_priorities() {
-            for( auto &elem : task_priorities ) {
-                elem.second = 0;
-            }
-        }
-        bool has_job() const {
-            for( auto &elem : task_priorities ) {
-                if( elem.second > 0 ) {
-                    return true;
-                }
-            }
-            return false;
-        }
-        int get_priority_of_job( const activity_id &req_job ) const {
-            auto it = task_priorities.find( req_job );
-            if( it != task_priorities.end() ) {
-                return it->second;
-            } else {
-                return 0;
-            }
-        }
-        std::vector<activity_id> get_prioritised_vector() const {
-            std::vector<std::pair<activity_id, int>> pairs( begin( task_priorities ), end( task_priorities ) );
-
-            std::vector<activity_id> ret;
-            sort( begin( pairs ), end( pairs ), []( const std::pair<activity_id, int> &a,
-            const std::pair<activity_id, int> &b ) {
-                return a.second > b.second;
-            } );
-            for( std::pair<activity_id, int> elem : pairs ) {
-                ret.push_back( elem.first );
-            }
-            return ret;
-        }
+        bool set_task_priority( const activity_id &task, int new_priority );
+        void clear_all_priorities();
+        bool has_job() const;
+        int get_priority_of_job( const activity_id &req_job ) const;
+        std::vector<activity_id> get_prioritised_vector() const;
         void serialize( JsonOut &json ) const;
         void deserialize( JsonIn &jsin );
 };

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1945,6 +1945,52 @@ void scrollingcombattext::removeCreatureHP()
     }
 }
 
+std::string string_from_int( const catacurses::chtype ch )
+{
+    catacurses::chtype charcode = ch;
+    // LINE_NESW  - X for on, O for off
+    switch( ch ) {
+        case LINE_XOXO:
+            charcode = LINE_XOXO_C;
+            break;
+        case LINE_OXOX:
+            charcode = LINE_OXOX_C;
+            break;
+        case LINE_XXOO:
+            charcode = LINE_XXOO_C;
+            break;
+        case LINE_OXXO:
+            charcode = LINE_OXXO_C;
+            break;
+        case LINE_OOXX:
+            charcode = LINE_OOXX_C;
+            break;
+        case LINE_XOOX:
+            charcode = LINE_XOOX_C;
+            break;
+        case LINE_XXOX:
+            charcode = LINE_XXOX_C;
+            break;
+        case LINE_XXXO:
+            charcode = LINE_XXXO_C;
+            break;
+        case LINE_XOXX:
+            charcode = LINE_XOXX_C;
+            break;
+        case LINE_OXXX:
+            charcode = LINE_OXXX_C;
+            break;
+        case LINE_XXXX:
+            charcode = LINE_XXXX_C;
+            break;
+        default:
+            charcode = ch;
+            break;
+    }
+    char buffer[2] = { static_cast<char>( charcode ), '\0' };
+    return buffer;
+}
+
 nc_color msgtype_to_color( const game_message_type type, const bool bOldMsg )
 {
     static const std::map<game_message_type, std::pair<nc_color, nc_color>> colors {

--- a/src/output.h
+++ b/src/output.h
@@ -85,51 +85,8 @@ using chtype = int;
 #define LINE_XXXX_UNICODE 0x253C
 
 // Supports line drawing
-inline std::string string_from_int( const catacurses::chtype ch )
-{
-    catacurses::chtype charcode = ch;
-    // LINE_NESW  - X for on, O for off
-    switch( ch ) {
-        case LINE_XOXO:
-            charcode = LINE_XOXO_C;
-            break;
-        case LINE_OXOX:
-            charcode = LINE_OXOX_C;
-            break;
-        case LINE_XXOO:
-            charcode = LINE_XXOO_C;
-            break;
-        case LINE_OXXO:
-            charcode = LINE_OXXO_C;
-            break;
-        case LINE_OOXX:
-            charcode = LINE_OOXX_C;
-            break;
-        case LINE_XOOX:
-            charcode = LINE_XOOX_C;
-            break;
-        case LINE_XXOX:
-            charcode = LINE_XXOX_C;
-            break;
-        case LINE_XXXO:
-            charcode = LINE_XXXO_C;
-            break;
-        case LINE_XOXX:
-            charcode = LINE_XOXX_C;
-            break;
-        case LINE_OXXX:
-            charcode = LINE_OXXX_C;
-            break;
-        case LINE_XXXX:
-            charcode = LINE_XXXX_C;
-            break;
-        default:
-            charcode = ch;
-            break;
-    }
-    char buffer[2] = { static_cast<char>( charcode ), '\0' };
-    return buffer;
-}
+
+std::string string_from_int( const catacurses::chtype ch );
 
 // a consistent border color
 #define BORDER_COLOR c_light_gray

--- a/src/output.h
+++ b/src/output.h
@@ -158,21 +158,21 @@ nc_color msgtype_to_color( game_message_type type, bool bOldMsg = false );
 /**
  * Removes the prefix starting at the first occurrence of c1 until the first occurrence of c2
  */
-std::string rm_prefix( std::string str, char c1 = '<', char c2 = '>' );
+std::string rm_prefix( std::string_view str, char c1 = '<', char c2 = '>' );
 
 /**
  * Adds the color represented by the next color tag found in the string to the top of the stack.
  * If color_error == report_color_error::yes a debugmsg will be shown when the tag is not valid.
  */
 color_tag_parse_result::tag_type update_color_stack(
-    std::stack<nc_color> &color_stack, const std::string &seg,
+    std::stack<nc_color> &color_stack, std::string_view seg,
     report_color_error color_error = report_color_error::yes );
 
 /**
  * Removes the color tags from the input string. This might be required when the string is to
  * be used for functions that don't handle color tags.
  */
-std::string remove_color_tags( const std::string &s );
+std::string remove_color_tags( std::string_view s );
 /*@}*/
 
 /**
@@ -183,7 +183,7 @@ std::string remove_color_tags( const std::string &s );
  * @return A vector of lines, it may contain empty strings. Each entry is at most `width`
  * console cells width.
  */
-std::vector<std::string> foldstring( const std::string &str, int width, char split = ' ' );
+std::vector<std::string> foldstring( std::string_view str, int width, char split = ' ' );
 
 /**
  * Print text with embedded @ref color_tags, x, y are in curses system.
@@ -199,7 +199,7 @@ std::vector<std::string> foldstring( const std::string &str, int width, char spl
  * @param base_color Base color that is used outside of any color tag.
  **/
 void print_colored_text( const catacurses::window &w, const point &p, nc_color &cur_color,
-                         const nc_color &base_color, const std::string &text,
+                         const nc_color &base_color, std::string_view text,
                          report_color_error color_error = report_color_error::yes );
 /**
  * Print word wrapped text (with @ref color_tags) into the window.
@@ -213,8 +213,8 @@ void print_colored_text( const catacurses::window &w, const point &p, nc_color &
  * @return The maximal scrollable offset ([number of lines to be printed] - [lines available in the window]).
  * This allows the caller to restrict the begin_line number on future calls / when modified by the user.
  */
-int print_scrollable( const catacurses::window &w, int begin_line, const std::string &text,
-                      const nc_color &base_color, const std::string &scroll_msg );
+int print_scrollable( const catacurses::window &w, int begin_line, std::string_view text,
+                      const nc_color &base_color, std::string_view scroll_msg );
 /**
  * Fold and print text in the given window. The function handles @ref color_tags and
  * uses them while printing.
@@ -231,7 +231,7 @@ int print_scrollable( const catacurses::window &w, int begin_line, const std::st
  * the height of the window.
  */
 int fold_and_print( const catacurses::window &w, const point &begin, int width,
-                    const nc_color &base_color, const std::string &text, char split = ' ' );
+                    const nc_color &base_color, std::string_view text, char split = ' ' );
 /**
  * Same as other @ref fold_and_print, but does string formatting via @ref string_format.
  */
@@ -261,7 +261,7 @@ inline int fold_and_print( const catacurses::window &w, const point &begin,
  * value for `begin_line`.
  */
 int fold_and_print_from( const catacurses::window &w, const point &begin, int width,
-                         int begin_line, const nc_color &base_color, const std::string &text );
+                         int begin_line, const nc_color &base_color, std::string_view text );
 /**
  * Same as other @ref fold_and_print_from, but does formatting via @ref string_format.
  */
@@ -284,9 +284,9 @@ inline int fold_and_print_from( const catacurses::window &w, const point &begin,
  * @param text Actual message to print
  */
 void trim_and_print( const catacurses::window &w, const point &begin, int width,
-                     const nc_color &base_color, const std::string &text,
+                     const nc_color &base_color, std::string_view text,
                      report_color_error color_error = report_color_error::yes );
-std::string trim_by_length( const std::string &text, int width );
+std::string trim_by_length( std::string_view text, int width );
 template<typename ...Args>
 inline void trim_and_print( const catacurses::window &w, const point &begin,
                             const int width, const nc_color &base_color,
@@ -306,31 +306,31 @@ inline void trim_and_print( const catacurses::window &w, const point &begin,
                            color_error );
 }
 void center_print( const catacurses::window &w, int y, const nc_color &FG,
-                   const std::string &text );
+                   std::string_view text );
 int right_print( const catacurses::window &w, int line, int right_indent,
-                 const nc_color &FG, const std::string &text );
+                 const nc_color &FG, std::string_view text );
 void insert_table( const catacurses::window &w, int pad, int line, int columns,
-                   const nc_color &FG, const std::string &divider, bool r_align,
+                   const nc_color &FG, std::string_view divider, bool r_align,
                    const std::vector<std::string> &data );
 void scrollable_text( const std::function<catacurses::window()> &init_window,
-                      const std::string &title, const std::string &text );
-std::string name_and_value( const std::string &name, int value, int field_width );
-std::string name_and_value( const std::string &name, const std::string &value, int field_width );
+                      std::string_view title, std::string_view text );
+std::string name_and_value( std::string_view name, int value, int field_width );
+std::string name_and_value( std::string_view name, std::string_view value, int field_width );
 
 void wputch( const catacurses::window &w, nc_color FG, int ch );
 // Using int ch is deprecated, use an UTF-8 encoded string instead
 void mvwputch( const catacurses::window &w, const point &p, nc_color FG, int ch );
-void mvwputch( const catacurses::window &w, const point &p, nc_color FG, const std::string &ch );
+void mvwputch( const catacurses::window &w, const point &p, nc_color FG, std::string_view ch );
 // Using int ch is deprecated, use an UTF-8 encoded string instead
 void mvwputch_inv( const catacurses::window &w, const point &p, nc_color FG, int ch );
 void mvwputch_inv( const catacurses::window &w, const point &p, nc_color FG,
-                   const std::string &ch );
+                   std::string_view ch );
 // Using int ch is deprecated, use an UTF-8 encoded string instead
 void mvwputch_hi( const catacurses::window &w, const point &p, nc_color FG, int ch );
-void mvwputch_hi( const catacurses::window &w, const point &p, nc_color FG, const std::string &ch );
+void mvwputch_hi( const catacurses::window &w, const point &p, nc_color FG, std::string_view ch );
 
 void mvwprintz( const catacurses::window &w, const point &p, const nc_color &FG,
-                const std::string &text );
+                std::string_view text );
 template<typename ...Args>
 inline void mvwprintz( const catacurses::window &w, const point &p, const nc_color &FG,
                        const char *const mes, Args &&... args )
@@ -338,7 +338,7 @@ inline void mvwprintz( const catacurses::window &w, const point &p, const nc_col
     mvwprintz( w, p, FG, string_format( mes, std::forward<Args>( args )... ) );
 }
 
-void wprintz( const catacurses::window &w, const nc_color &FG, const std::string &text );
+void wprintz( const catacurses::window &w, const nc_color &FG, std::string_view text );
 template<typename ...Args>
 inline void wprintz( const catacurses::window &w, const nc_color &FG, const char *const mes,
                      Args &&... args )
@@ -352,7 +352,7 @@ void draw_custom_border(
     catacurses::chtype tr = 1, catacurses::chtype bl = 1, catacurses::chtype br = 1,
     nc_color FG = BORDER_COLOR, const point &pos = point_zero, int height = 0, int width = 0 );
 void draw_border( const catacurses::window &w, nc_color border_color = BORDER_COLOR,
-                  const std::string &title = "", nc_color title_color = c_light_red );
+                  std::string_view title = "", nc_color title_color = c_light_red );
 void draw_border_below_tabs( const catacurses::window &w, nc_color border_color = BORDER_COLOR );
 
 class border_helper
@@ -396,32 +396,32 @@ class border_helper
         std::forward_list<border_info> border_info_list;
 };
 
-std::string word_rewrap( const std::string &ins, int width, uint32_t split = ' ' );
-std::vector<size_t> get_tag_positions( const std::string &s );
-std::vector<std::string> split_by_color( const std::string &s );
+std::string word_rewrap( std::string_view ins, int width, uint32_t split = ' ' );
+std::vector<size_t> get_tag_positions( std::string_view s );
+std::vector<std::string> split_by_color( std::string_view s );
 
-bool query_yn( const std::string &text );
+bool query_yn( std::string_view text );
 template<typename ...Args>
 inline bool query_yn( const char *const msg, Args &&... args )
 {
     return query_yn( string_format( msg, std::forward<Args>( args )... ) );
 }
 
-bool query_int( int &result, int default_val, const std::string &text );
+bool query_int( int &result, int default_val, std::string_view text );
 template<typename ...Args>
 inline bool query_int( int &result, int default_val, const char *const msg, Args &&... args )
 {
     return query_int( result, default_val, string_format( msg, std::forward<Args>( args )... ) );
 }
 
-bool query_int( int &result, const std::string &text );
+bool query_int( int &result, std::string_view text );
 template<typename ...Args>
 inline bool query_int( int &result, const char *const msg, Args &&... args )
 {
     return query_int( result, string_format( msg, std::forward<Args>( args )... ) );
 }
 
-std::vector<std::string> get_hotkeys( const std::string &s );
+std::vector<std::string> get_hotkeys( std::string_view s );
 
 /**
  * @name Popup windows
@@ -468,7 +468,7 @@ inline void popup( const char *mes, Args &&... args )
 {
     popup( string_format( mes, std::forward<Args>( args )... ), PF_NONE );
 }
-int popup( const std::string &text, PopupFlags flags = PF_NONE );
+int popup( std::string_view text, PopupFlags flags = PF_NONE );
 template<typename ...Args>
 inline void full_screen_popup( const char *mes, Args &&... args )
 {
@@ -492,16 +492,16 @@ struct item_info_data {
 
         item_info_data();
         ~item_info_data();
-        item_info_data( const std::string &item_name, const std::string &type_name,
+        item_info_data( std::string_view item_name, std::string_view type_name,
                         const std::vector<iteminfo> &item_display, const std::vector<iteminfo> &item_compare );
-        item_info_data( const std::string &item_name, const std::string &type_name,
+        item_info_data( std::string_view item_name, std::string_view type_name,
                         const std::vector<iteminfo> &item_display, const std::vector<iteminfo> &item_compare,
                         int &ptr_selected );
 
-        const std::string &get_item_name() const {
+        std::string get_item_name() const {
             return item_name;
         }
-        const std::string &get_type_name() const {
+        std::string get_type_name() const {
             return type_name;
         }
         const std::vector<iteminfo> &get_item_display() const {
@@ -549,10 +549,10 @@ char rand_char();
 int special_symbol( int sym );
 
 size_t shortcut_print( const catacurses::window &w, const point &p, nc_color text_color,
-                       nc_color shortcut_color, const std::string &fmt );
+                       nc_color shortcut_color, std::string_view fmt );
 size_t shortcut_print( const catacurses::window &w, nc_color text_color, nc_color shortcut_color,
-                       const std::string &fmt );
-std::string shortcut_text( nc_color shortcut_color, const std::string &fmt );
+                       std::string_view fmt );
+std::string shortcut_text( nc_color shortcut_color, std::string_view fmt );
 
 /**
  * @return Pair of a string containing the bar, and its color
@@ -588,7 +588,7 @@ std::pair<std::string, nc_color> get_light_level( float light );
 // MSVC has problem dealing with template functions.
 // Implementing this function in cpp file results link error.
 template<typename RatingIterator>
-inline std::string get_labeled_bar( const double val, const int width, const std::string &label,
+inline std::string get_labeled_bar( const double val, const int width, std::string_view label,
                                     RatingIterator begin, RatingIterator end )
 {
     std::string result;
@@ -709,11 +709,11 @@ std::string enumerate_as_string( _FIter first, _FIter last, F string_for,
  * @param label Label before the bar. Can be empty.
  * @param c Character to fill the bar with.
  */
-std::string get_labeled_bar( double val, int width, const std::string &label, char c );
+std::string get_labeled_bar( double val, int width, std::string_view label, char c );
 
-void draw_tab( const catacurses::window &w, int iOffsetX, const std::string &sText,
+void draw_tab( const catacurses::window &w, int iOffsetX, std::string_view sText,
                bool bSelected );
-void draw_subtab( const catacurses::window &w, int iOffsetX, const std::string &sText,
+void draw_subtab( const catacurses::window &w, int iOffsetX, std::string_view sText,
                   bool bSelected,
                   bool bDecorate = true, bool bDisabled = false );
 
@@ -728,7 +728,7 @@ void draw_tabs( const catacurses::window &, const std::vector<std::string> &tab_
                 size_t current_tab );
 // As above, but specify current tab by its label rather than position
 void draw_tabs( const catacurses::window &, const std::vector<std::string> &tab_texts,
-                const std::string &current_tab );
+                std::string_view current_tab );
 
 // This overload of draw_tabs is intended for use when you track the current
 // tab via some other value (like an enum) linked to each tab.  Expected use
@@ -831,7 +831,7 @@ class scrolling_text_view
     public:
         scrolling_text_view( catacurses::window &w ) : w_( w ) {}
 
-        void set_text( const std::string & );
+        void set_text( std::string_view );
         void scroll_up();
         void scroll_down();
         void page_up();
@@ -879,9 +879,9 @@ class scrollingcombattext
 
             public:
                 cSCT( const point &pos, direction p_oDir,
-                      const std::string &p_sText, game_message_type p_gmt,
-                      const std::string &p_sText2 = "", game_message_type p_gmt2 = m_neutral,
-                      const std::string &p_sType = "" );
+                      std::string_view p_sText, game_message_type p_gmt,
+                      std::string_view p_sText2 = "", game_message_type p_gmt2 = m_neutral,
+                      std::string_view p_sType = "" );
 
                 int getStep() const {
                     return iStep;
@@ -909,16 +909,16 @@ class scrollingcombattext
                 std::string getType() const {
                     return sType;
                 }
-                std::string getText( const std::string &type = "full" ) const;
-                game_message_type getMsgType( const std::string &type = "first" ) const;
+                std::string getText( std::string_view type = "full" ) const;
+                game_message_type getMsgType( std::string_view type = "first" ) const;
         };
 
         std::vector<cSCT> vSCT;
 
         void add( const point &pos, direction p_oDir,
-                  const std::string &p_sText, game_message_type p_gmt,
-                  const std::string &p_sText2 = "", game_message_type p_gmt2 = m_neutral,
-                  const std::string &p_sType = "" );
+                  std::string_view p_sText, game_message_type p_gmt,
+                  std::string_view p_sText2 = "", game_message_type p_gmt2 = m_neutral,
+                  std::string_view p_sType = "" );
         void advanceAllSteps();
         void removeCreatureHP();
 };
@@ -976,7 +976,7 @@ void refresh_display();
  * @return Colorized string.
  */
 template<typename F>
-std::string colorize_symbols( const std::string &str, F color_of )
+std::string colorize_symbols( std::string_view str, F color_of )
 {
     std::string res;
     nc_color prev_color = c_unset;

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -6,6 +6,24 @@
 
 #include "cata_utility.h"
 
+
+point point::rotate( int turns, const point &dim ) const
+{
+    assert( turns >= 0 );
+    assert( turns <= 4 );
+
+    switch( turns ) {
+        case 1:
+            return { dim.y - y - 1, x };
+        case 2:
+            return { dim.x - x - 1, dim.y - y - 1 };
+        case 3:
+            return { y, dim.x - x - 1 };
+    }
+
+    return *this;
+}
+
 std::string point::to_string() const
 {
     std::ostringstream os;

--- a/src/point.h
+++ b/src/point.h
@@ -86,21 +86,7 @@ struct point {
      * by @param dim
      * By default rotates around the origin (0, 0).
      * NOLINTNEXTLINE(cata-use-named-point-constants) */
-    point rotate( int turns, const point &dim = { 1, 1 } ) const {
-        assert( turns >= 0 );
-        assert( turns <= 4 );
-
-        switch( turns ) {
-            case 1:
-                return { dim.y - y - 1, x };
-            case 2:
-                return { dim.x - x - 1, dim.y - y - 1 };
-            case 3:
-                return { y, dim.x - x - 1 };
-        }
-
-        return *this;
-    }
+    point rotate( int turns, const point &dim = { 1, 1 } ) const;
 
     std::string to_string() const;
 

--- a/src/scent_block.cpp
+++ b/src/scent_block.cpp
@@ -1,0 +1,77 @@
+#include "scent_block.h"
+
+scent_block::scent_block( const tripoint &sub, scent_map &scents )
+// NOLINTNEXTLINE(cata-use-named-point-constants)
+    : origin( sm_to_ms_copy( sub ) + point( -1, -1 ) )
+    , scents( scents )
+    , modification_count( 0 )
+{
+    for( int x = 0; x < SEEX + 2; ++x ) {
+        for( int y = 0; y < SEEY + 2; ++y ) {
+            assignment[x][y] = { NONE, 0 };
+        }
+    }
+}
+
+void scent_block::commit_modifications()
+{
+    if( modification_count == 0 ) {
+        return;
+    }
+    for( int x = 0; x < SEEX + 2; ++x ) {
+        for( int y = 0; y < SEEY + 2; ++y ) {
+            switch( assignment[x][y].mode ) {
+                case NONE:
+                    break;
+                case SET: {
+                    tripoint p = origin + tripoint( x, y, 0 );
+                    if( scents.inbounds( p ) ) {
+                        scents.set_unsafe( p, assignment[x][y].intensity );
+                    }
+                    break;
+                }
+                case MAX: {
+                    tripoint p = origin + tripoint( x, y, 0 );
+                    if( scents.inbounds( p ) ) {
+                        scents.set_unsafe( p, std::max( assignment[x][y].intensity, scents.get_unsafe( p ) ) );
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}
+
+void scent_block::apply_gas( const tripoint &p, const int nintensity )
+{
+    const point ndx = index( p );
+    assignment[ndx.x][ndx.y].mode = SET;
+    assignment[ndx.x][ndx.y].intensity = std::max( 0, assignment[ndx.x][ndx.y].intensity - nintensity );
+    ++modification_count;
+}
+
+void scent_block::apply_slime( const tripoint &p, int intensity )
+{
+    const point ndx = index( p );
+    datum &dat = assignment[ndx.x][ndx.y];
+    switch( dat.mode ) {
+        case NONE: {
+            // we don't know what the current intensity is, so we must do a max operation
+            dat.mode = MAX;
+            dat.intensity = intensity;
+            break;
+        }
+        case SET: {
+            // new intensity is going to be dat.intensity, so we just need to make it larger
+            // but cannot change
+            dat.intensity = std::max( dat.intensity, intensity );
+            break;
+        }
+        case MAX: {
+            // Already max for some reason, shouldn't occur. If it does we want to grow if possible
+            dat.intensity = std::max( dat.intensity, intensity );
+            break;
+        }
+    }
+    ++modification_count;
+}

--- a/src/scent_block.h
+++ b/src/scent_block.h
@@ -29,81 +29,17 @@ struct scent_block {
     scent_map &scents;
     int modification_count;
 
-    scent_block( const tripoint &sub, scent_map &scents )
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-        : origin( sm_to_ms_copy( sub ) + point( -1, -1 ) )
-        , scents( scents )
-        , modification_count( 0 ) {
-        for( int x = 0; x < SEEX + 2; ++x ) {
-            for( int y = 0; y < SEEY + 2; ++y ) {
-                assignment[x][y] = { NONE, 0 };
-            }
-        }
-    }
+    scent_block( const tripoint &sub, scent_map &scents );
 
-    void commit_modifications() {
-        if( modification_count == 0 ) {
-            return;
-        }
-        for( int x = 0; x < SEEX + 2; ++x ) {
-            for( int y = 0; y < SEEY + 2; ++y ) {
-                switch( assignment[x][y].mode ) {
-                    case NONE:
-                        break;
-                    case SET: {
-                        tripoint p = origin + tripoint( x, y, 0 );
-                        if( scents.inbounds( p ) ) {
-                            scents.set_unsafe( p, assignment[x][y].intensity );
-                        }
-                        break;
-                    }
-                    case MAX: {
-                        tripoint p = origin + tripoint( x, y, 0 );
-                        if( scents.inbounds( p ) ) {
-                            scents.set_unsafe( p, std::max( assignment[x][y].intensity, scents.get_unsafe( p ) ) );
-                        }
-                        break;
-                    }
-                }
-            }
-        }
-    }
+    void commit_modifications();
 
     point index( const tripoint &p ) const {
         return -origin.xy() + p.xy();
     }
 
     // We should be working entirely within the range, so don't range check here
-    void apply_gas( const tripoint &p, const int nintensity = 0 ) {
-        const point ndx = index( p );
-        assignment[ndx.x][ndx.y].mode = SET;
-        assignment[ndx.x][ndx.y].intensity = std::max( 0, assignment[ndx.x][ndx.y].intensity - nintensity );
-        ++modification_count;
-    }
-    void apply_slime( const tripoint &p, int intensity ) {
-        const point ndx = index( p );
-        datum &dat = assignment[ndx.x][ndx.y];
-        switch( dat.mode ) {
-            case NONE: {
-                // we don't know what the current intensity is, so we must do a max operation
-                dat.mode = MAX;
-                dat.intensity = intensity;
-                break;
-            }
-            case SET: {
-                // new intensity is going to be dat.intensity, so we just need to make it larger
-                // but cannot change
-                dat.intensity = std::max( dat.intensity, intensity );
-                break;
-            }
-            case MAX: {
-                // Already max for some reason, shouldn't occur. If it does we want to grow if possible
-                dat.intensity = std::max( dat.intensity, intensity );
-                break;
-            }
-        }
-        ++modification_count;
-    }
+    void apply_gas( const tripoint &p, const int nintensity = 0 );
+    void apply_slime( const tripoint &p, int intensity );
 };
 
 #endif // CATA_SRC_SCENT_BLOCK_H

--- a/src/sdl_utils.cpp
+++ b/src/sdl_utils.cpp
@@ -31,6 +31,130 @@ color_pixel_function_pointer get_color_pixel_function( const std::string &name )
     return iter->second;
 }
 
+SDL_Color adjust_color_brightness( const SDL_Color &color, int percent )
+{
+    if( percent <= 0 ) {
+        return { 0x00, 0x00, 0x00, color.a };
+    }
+
+    if( percent == 100 ) {
+        return color;
+    }
+
+    return SDL_Color{
+        static_cast<Uint8>( std::min( color.r *percent / 100, 0xFF ) ),
+        static_cast<Uint8>( std::min( color.g *percent / 100, 0xFF ) ),
+        static_cast<Uint8>( std::min( color.b *percent / 100, 0xFF ) ),
+        color.a
+    };
+}
+
+SDL_Color mix_colors( const SDL_Color &first, const SDL_Color &second, int second_percent )
+{
+    if( second_percent <= 0 ) {
+        return first;
+    }
+
+    if( second_percent >= 100 ) {
+        return second;
+    }
+
+    const int first_percent = 100 - second_percent;
+
+    return SDL_Color{
+        static_cast<Uint8>( std::min( ( first.r * first_percent + second.r * second_percent ) / 100, 0xFF ) ),
+        static_cast<Uint8>( std::min( ( first.g * first_percent + second.g * second_percent ) / 100, 0xFF ) ),
+        static_cast<Uint8>( std::min( ( first.b * first_percent + second.b * second_percent ) / 100, 0xFF ) ),
+        static_cast<Uint8>( std::min( ( first.a * first_percent + second.a * second_percent ) / 100, 0xFF ) )
+    };
+}
+
+SDL_Color color_pixel_grayscale( const SDL_Color &color )
+{
+    if( is_black( color ) ) {
+        return color;
+    }
+
+    const Uint8 av = average_pixel_color( color );
+    const Uint8 result = std::max( av * 5 >> 3, 0x01 );
+
+    return { result, result, result, color.a };
+}
+
+SDL_Color color_pixel_nightvision( const SDL_Color &color )
+{
+    const Uint8 av = average_pixel_color( color );
+    const Uint8 result = std::min( ( av * ( ( av * 3 >> 2 ) + 64 ) >> 8 ) + 16, 0xFF );
+
+    return {
+        static_cast<Uint8>( result >> 2 ),
+        static_cast<Uint8>( result ),
+        static_cast<Uint8>( result >> 3 ),
+        color.a
+    };
+}
+
+SDL_Color color_pixel_overexposed( const SDL_Color &color )
+{
+    const Uint8 av = average_pixel_color( color );
+    const Uint8 result = std::min( 64 + ( av * ( ( av >> 2 ) + 0xC0 ) >> 8 ), 0xFF );
+
+    return {
+        static_cast<Uint8>( result >> 2 ),
+        static_cast<Uint8>( result ),
+        static_cast<Uint8>( result >> 3 ),
+        color.a
+    };
+}
+
+SDL_Color color_pixel_darken( const SDL_Color &color )
+{
+    if( is_black( color ) ) {
+        return color;
+    }
+
+    // 85/256 ~ 1/3
+    return {
+        std::max<Uint8>( 85 * color.r >> 8, 0x01 ),
+        std::max<Uint8>( 85 * color.g >> 8, 0x01 ),
+        std::max<Uint8>( 85 * color.b >> 8, 0x01 ),
+        color.a
+    };
+
+}
+
+SDL_Color color_pixel_sepia( const SDL_Color &color )
+{
+    if( is_black( color ) ) {
+        return color;
+    }
+
+    /*
+     *  Objective is to provide a gradient between two color points
+     *  (sepia_dark and sepia_light) based on the grayscale value.
+     *  This presents an effect intended to mimic a faded sepia photograph.
+     */
+
+    const SDL_Color sepia_dark = { 39, 23, 19, color.a};
+    const SDL_Color sepia_light = { 241, 220, 163, color.a};
+
+    const Uint8 av = average_pixel_color( color );
+    const float gammav = 1.6;
+    const float pv = av / 255.0;
+    const Uint8 finalv =
+        std::min( static_cast<int>( std::round( std::pow( pv, gammav ) * 150 ) ), 100 );
+
+    return mix_colors( sepia_dark, sepia_light, finalv );
+}
+
+SDL_Color color_pixel_z_overlay( const SDL_Color &color )
+{
+    if( static_z_effect ) {
+        return mix_colors( color, {128, 255, 255, color.a}, color.a / 8 );
+    }
+    return { 128, 255, 255, color.a };
+}
+
 SDL_Color curses_color_to_SDL( const nc_color &color )
 {
     const int pair_id = color.to_color_pair_index();

--- a/src/sdl_utils.h
+++ b/src/sdl_utils.h
@@ -17,43 +17,9 @@ using color_pixel_function_map = std::unordered_map<std::string, color_pixel_fun
 
 color_pixel_function_pointer get_color_pixel_function( const std::string &name );
 
-inline SDL_Color adjust_color_brightness( const SDL_Color &color, int percent )
-{
-    if( percent <= 0 ) {
-        return { 0x00, 0x00, 0x00, color.a };
-    }
+SDL_Color adjust_color_brightness( const SDL_Color &color, int percent );
 
-    if( percent == 100 ) {
-        return color;
-    }
-
-    return SDL_Color{
-        static_cast<Uint8>( std::min( color.r *percent / 100, 0xFF ) ),
-        static_cast<Uint8>( std::min( color.g *percent / 100, 0xFF ) ),
-        static_cast<Uint8>( std::min( color.b *percent / 100, 0xFF ) ),
-        color.a
-    };
-}
-
-inline SDL_Color mix_colors( const SDL_Color &first, const SDL_Color &second, int second_percent )
-{
-    if( second_percent <= 0 ) {
-        return first;
-    }
-
-    if( second_percent >= 100 ) {
-        return second;
-    }
-
-    const int first_percent = 100 - second_percent;
-
-    return SDL_Color{
-        static_cast<Uint8>( std::min( ( first.r * first_percent + second.r * second_percent ) / 100, 0xFF ) ),
-        static_cast<Uint8>( std::min( ( first.g * first_percent + second.g * second_percent ) / 100, 0xFF ) ),
-        static_cast<Uint8>( std::min( ( first.b * first_percent + second.b * second_percent ) / 100, 0xFF ) ),
-        static_cast<Uint8>( std::min( ( first.a * first_percent + second.a * second_percent ) / 100, 0xFF ) )
-    };
-}
+SDL_Color mix_colors( const SDL_Color &first, const SDL_Color &second, int second_percent );
 
 inline bool is_black( const SDL_Color &color )
 {
@@ -68,91 +34,17 @@ inline Uint8 average_pixel_color( const SDL_Color &color )
     return 85 * ( color.r + color.g + color.b ) >> 8; // 85/256 ~ 1/3
 }
 
-inline SDL_Color color_pixel_grayscale( const SDL_Color &color )
-{
-    if( is_black( color ) ) {
-        return color;
-    }
+SDL_Color color_pixel_grayscale( const SDL_Color &color );
 
-    const Uint8 av = average_pixel_color( color );
-    const Uint8 result = std::max( av * 5 >> 3, 0x01 );
+SDL_Color color_pixel_nightvision( const SDL_Color &color );
 
-    return { result, result, result, color.a };
-}
+SDL_Color color_pixel_overexposed( const SDL_Color &color );
 
-inline SDL_Color color_pixel_nightvision( const SDL_Color &color )
-{
-    const Uint8 av = average_pixel_color( color );
-    const Uint8 result = std::min( ( av * ( ( av * 3 >> 2 ) + 64 ) >> 8 ) + 16, 0xFF );
+SDL_Color color_pixel_darken( const SDL_Color &color );
 
-    return {
-        static_cast<Uint8>( result >> 2 ),
-        static_cast<Uint8>( result ),
-        static_cast<Uint8>( result >> 3 ),
-        color.a
-    };
-}
+SDL_Color color_pixel_sepia( const SDL_Color &color );
 
-inline SDL_Color color_pixel_overexposed( const SDL_Color &color )
-{
-    const Uint8 av = average_pixel_color( color );
-    const Uint8 result = std::min( 64 + ( av * ( ( av >> 2 ) + 0xC0 ) >> 8 ), 0xFF );
-
-    return {
-        static_cast<Uint8>( result >> 2 ),
-        static_cast<Uint8>( result ),
-        static_cast<Uint8>( result >> 3 ),
-        color.a
-    };
-}
-
-inline SDL_Color color_pixel_darken( const SDL_Color &color )
-{
-    if( is_black( color ) ) {
-        return color;
-    }
-
-    // 85/256 ~ 1/3
-    return {
-        std::max<Uint8>( 85 * color.r >> 8, 0x01 ),
-        std::max<Uint8>( 85 * color.g >> 8, 0x01 ),
-        std::max<Uint8>( 85 * color.b >> 8, 0x01 ),
-        color.a
-    };
-
-}
-
-inline SDL_Color color_pixel_sepia( const SDL_Color &color )
-{
-    if( is_black( color ) ) {
-        return color;
-    }
-
-    /*
-     *  Objective is to provide a gradient between two color points
-     *  (sepia_dark and sepia_light) based on the grayscale value.
-     *  This presents an effect intended to mimic a faded sepia photograph.
-     */
-
-    const SDL_Color sepia_dark = { 39, 23, 19, color.a};
-    const SDL_Color sepia_light = { 241, 220, 163, color.a};
-
-    const Uint8 av = average_pixel_color( color );
-    const float gammav = 1.6;
-    const float pv = av / 255.0;
-    const Uint8 finalv =
-        std::min( static_cast<int>( std::round( std::pow( pv, gammav ) * 150 ) ), 100 );
-
-    return mix_colors( sepia_dark, sepia_light, finalv );
-}
-
-inline SDL_Color color_pixel_z_overlay( const SDL_Color &color )
-{
-    if( static_z_effect ) {
-        return mix_colors( color, {128, 255, 255, color.a}, color.a / 8 );
-    }
-    return { 128, 255, 255, color.a };
-}
+SDL_Color color_pixel_z_overlay( const SDL_Color &color );
 
 SDL_Color curses_color_to_SDL( const nc_color &color );
 

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -53,6 +53,41 @@ submap::~submap() = default;
 
 submap &submap::operator=( submap && ) = default;
 
+void submap::update_lum_rem( const point &p, const item &i )
+{
+    is_uniform = false;
+    if( !i.is_emissive() ) {
+        return;
+    } else if( lum[p.x][p.y] && lum[p.x][p.y] < 255 ) {
+        lum[p.x][p.y]--;
+        return;
+    }
+
+    // Have to scan through all items to be sure removing i will actually lower
+    // the count below 255.
+    int count = 0;
+    for( const auto &it : itm[p.x][p.y] ) {
+        if( it.is_emissive() ) {
+            count++;
+        }
+    }
+
+    if( count <= 256 ) {
+        lum[p.x][p.y] = static_cast<uint8_t>( count - 1 );
+    }
+}
+
+void submap::insert_cosmetic( const point &p, const std::string &type, const std::string &str )
+{
+    cosmetic_t ins;
+
+    ins.pos = p;
+    ins.type = type;
+    ins.str = str;
+
+    cosmetics.push_back( ins );
+}
+
 static const std::string COSMETICS_GRAFFITI( "GRAFFITI" );
 static const std::string COSMETICS_SIGNAGE( "SIGNAGE" );
 // Handle GCC warning: 'warning: returning reference to temporary'

--- a/src/submap.h
+++ b/src/submap.h
@@ -134,28 +134,7 @@ class submap : maptile_soa<SEEX, SEEY>
             }
         }
 
-        void update_lum_rem( const point &p, const item &i ) {
-            is_uniform = false;
-            if( !i.is_emissive() ) {
-                return;
-            } else if( lum[p.x][p.y] && lum[p.x][p.y] < 255 ) {
-                lum[p.x][p.y]--;
-                return;
-            }
-
-            // Have to scan through all items to be sure removing i will actually lower
-            // the count below 255.
-            int count = 0;
-            for( const auto &it : itm[p.x][p.y] ) {
-                if( it.is_emissive() ) {
-                    count++;
-                }
-            }
-
-            if( count <= 256 ) {
-                lum[p.x][p.y] = static_cast<uint8_t>( count - 1 );
-            }
-        }
+        void update_lum_rem( const point &p, const item &i );
 
         // TODO: Replace this as it essentially makes itm public
         cata::colony<item> &get_items( const point &p ) {
@@ -181,15 +160,7 @@ class submap : maptile_soa<SEEX, SEEY>
             std::string str;
         };
 
-        void insert_cosmetic( const point &p, const std::string &type, const std::string &str ) {
-            cosmetic_t ins;
-
-            ins.pos = p;
-            ins.type = type;
-            ins.str = str;
-
-            cosmetics.push_back( ins );
-        }
+        void insert_cosmetic( const point &p, const std::string &type, const std::string &str );
 
         int get_temperature() const {
             return temperature;


### PR DESCRIPTION
#### Summary

SUMMARY: Performance "Use std::string_view for printing functions"

#### Purpose of change

[string_view](https://en.cppreference.com/w/cpp/string/basic_string_view)s are more performant when used as readonly string because it does not construct string every time.

#### Describe the solution

- blocked by #2457

went into rabbit hole that used `const std::string &` as parameter then replaced their usage with `std::string_view`.

#### Describe alternatives you've considered

[RIIR](https://github.com/ansuz/RIIR)
