### PR TITLE
pass `point` by value

### DIFF
--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -105,7 +105,7 @@ std::vector<item_reference> active_item_cache::get_special( special_item_type ty
     return matching_items;
 }
 
-void active_item_cache::subtract_locations( const point &delta )
+void active_item_cache::subtract_locations( point delta )
 {
     for( std::pair<const int, std::list<item_reference>> &pair : active_items ) {
         for( item_reference &ir : pair.second ) {
@@ -114,7 +114,7 @@ void active_item_cache::subtract_locations( const point &delta )
     }
 }
 
-void active_item_cache::rotate_locations( int turns, const point &dim )
+void active_item_cache::rotate_locations( int turns, point dim )
 {
     for( std::pair<const int, std::list<item_reference>> &pair : active_items ) {
         for( item_reference &ir : pair.second ) {

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -80,8 +80,8 @@ class active_item_cache
          */
         std::vector<item_reference> get_special( special_item_type type );
         /** Subtract delta from every item_reference's location */
-        void subtract_locations( const point &delta );
-        void rotate_locations( int turns, const point &dim );
+        void subtract_locations( point delta );
+        void rotate_locations( int turns, point dim );
 };
 
 #endif // CATA_SRC_ACTIVE_ITEM_CACHE_H

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -46,7 +46,7 @@ int advanced_inv_area::get_item_count() const
     }
 }
 
-advanced_inv_area::advanced_inv_area( aim_location id, const point &h, tripoint off,
+advanced_inv_area::advanced_inv_area( aim_location id, point h, tripoint off,
                                       const std::string &name, const std::string &shortname,
                                       std::string minimapname, std::string actionname,
                                       aim_location relative_location ) :

--- a/src/advanced_inv_area.h
+++ b/src/advanced_inv_area.h
@@ -82,7 +82,7 @@ class advanced_inv_area
 
         advanced_inv_area( aim_location id ) : id( id ), relative_location( id ) {}
         advanced_inv_area(
-            aim_location id, const point &hscreen, tripoint off, const std::string &name,
+            aim_location id, point hscreen, tripoint off, const std::string &name,
             const std::string &shortname, std::string minimapname, std::string actionname,
             aim_location relative_location );
 

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -939,7 +939,7 @@ void game::draw_item_override( const tripoint &, const itype_id &, const mtype_i
 #if defined(TILES)
 void game::draw_vpart_override(
     const tripoint &p, const vpart_id &id, const int part_mod, const units::angle veh_dir,
-    const bool hilite, const point &mount )
+    const bool hilite, point mount )
 {
     if( use_tiles ) {
         tilecontext->init_draw_vpart_override( p, id, part_mod, veh_dir, hilite, mount );
@@ -947,7 +947,7 @@ void game::draw_vpart_override(
 }
 #else
 void game::draw_vpart_override( const tripoint &, const vpart_id &, const int,
-                                const units::angle, const bool, const point & )
+                                const units::angle, const bool, point )
 {
 }
 #endif

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -26,7 +26,7 @@ bool eat_here( avatar &you );
 // Standard movement; handles attacks, traps, &c. Returns false if auto move
 // should be canceled
 bool move( avatar &you, map &m, const tripoint &d );
-inline bool move( avatar &you, map &m, const point &d )
+inline bool move( avatar &you, map &m, point d )
 {
     return move( you, m, tripoint( d, 0 ) );
 }

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -164,7 +164,7 @@ void basecamp::add_expansion( const std::string &terrain, const tripoint_abs_omt
 }
 
 void basecamp::add_expansion( const std::string &bldg, const tripoint_abs_omt &new_pos,
-                              const point &dir )
+                              point dir )
 {
     expansion_data e;
     e.type = base_camps::faction_decode( bldg );
@@ -233,7 +233,7 @@ std::string basecamp::om_upgrade_description( const std::string &bldg, bool trun
 
 // upgrade levels
 // legacy next upgrade
-std::string basecamp::next_upgrade( const point &dir, const int offset ) const
+std::string basecamp::next_upgrade( point dir, const int offset ) const
 {
     const auto &e = expansions.find( dir );
     if( e == expansions.end() ) {
@@ -296,7 +296,7 @@ bool basecamp::has_water()
            has_provides( "faction_base_blacksmith_11" );
 }
 
-std::vector<basecamp_upgrade> basecamp::available_upgrades( const point &dir )
+std::vector<basecamp_upgrade> basecamp::available_upgrades( point dir )
 {
     std::vector<basecamp_upgrade> ret_data;
     auto e = expansions.find( dir );
@@ -358,7 +358,7 @@ std::vector<basecamp_upgrade> basecamp::available_upgrades( const point &dir )
 }
 
 // recipes and craft support functions
-std::map<recipe_id, translation> basecamp::recipe_deck( const point &dir ) const
+std::map<recipe_id, translation> basecamp::recipe_deck( point dir ) const
 {
     std::map<recipe_id, translation> recipes;
     const auto &e = expansions.find( dir );
@@ -428,7 +428,7 @@ void basecamp::update_provides( const std::string &bldg, expansion_data &e_data 
     }
 }
 
-void basecamp::update_in_progress( const std::string &bldg, const point &dir )
+void basecamp::update_in_progress( const std::string &bldg, point dir )
 {
     if( !recipe_id( bldg ).is_valid() ) {
         return;
@@ -675,7 +675,7 @@ void basecamp::form_crafting_inventory()
 }
 
 // display names
-std::string basecamp::expansion_tab( const point &dir ) const
+std::string basecamp::expansion_tab( point dir ) const
 {
     if( dir == base_camps::base_dir ) {
         return _( "Base Missions" );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -162,23 +162,23 @@ class basecamp
         void abandon_camp();
         void add_expansion( const std::string &terrain, const tripoint_abs_omt &new_pos );
         void add_expansion( const std::string &bldg, const tripoint_abs_omt &new_pos,
-                            const point &dir );
+                            point dir );
         void define_camp( const tripoint_abs_omt &p, const std::string &camp_type = "default" );
 
-        std::string expansion_tab( const point &dir ) const;
+        std::string expansion_tab( point dir ) const;
         // upgrade levels
         bool has_provides( const std::string &req, const expansion_data &e_data, int level = 0 ) const;
         bool has_provides( const std::string &req, const cata::optional<point> &dir = cata::nullopt,
                            int level = 0 ) const;
         void update_resources( const std::string &bldg );
         void update_provides( const std::string &bldg, expansion_data &e_data );
-        void update_in_progress( const std::string &bldg, const point &dir );
+        void update_in_progress( const std::string &bldg, point dir );
 
         bool can_expand();
         /// Returns the name of the building the current building @ref dir upgrades into,
         /// "null" if there isn't one
-        std::string next_upgrade( const point &dir, int offset = 1 ) const;
-        std::vector<basecamp_upgrade> available_upgrades( const point &dir );
+        std::string next_upgrade( point dir, int offset = 1 ) const;
+        std::vector<basecamp_upgrade> available_upgrades( point dir );
 
         // camp utility functions
         int recruit_evaluation() const;
@@ -201,7 +201,7 @@ class basecamp
 
         // recipes, gathering, and craft support functions
         // from a direction
-        std::map<recipe_id, translation> recipe_deck( const point &dir ) const;
+        std::map<recipe_id, translation> recipe_deck( point dir ) const;
         // from a building
         std::map<recipe_id, translation> recipe_deck( const std::string &bldg ) const;
         int recipe_batch_max( const recipe &making ) const;
@@ -238,7 +238,7 @@ class basecamp
         void place_results( item result );
 
         // mission description functions
-        void add_available_recipes( mission_data &mission_key, const point &dir,
+        void add_available_recipes( mission_data &mission_key, point dir,
                                     const std::map<recipe_id, translation> &craft_recipes );
 
         std::string recruit_description( int npc_count );
@@ -255,7 +255,7 @@ class basecamp
 
         // main mission description collection
         void get_available_missions( mission_data &mission_key );
-        void get_available_missions_by_dir( mission_data &mission_key, const point &dir );
+        void get_available_missions_by_dir( mission_data &mission_key, point dir );
         // available companion list manipulation
         void reset_camp_workers();
         comp_list get_mission_workers( const std::string &mission_id, bool contains = false );
@@ -272,12 +272,12 @@ class basecamp
                                bool must_feed, const std::string &desc, bool group,
                                const std::vector<item *> &equipment,
                                const std::map<skill_id, int> &required_skills = {} );
-        void start_upgrade( const std::string &bldg, const point &dir, const std::string &key );
+        void start_upgrade( const std::string &bldg, point dir, const std::string &key );
         std::string om_upgrade_description( const std::string &bldg, bool trunc = false ) const;
         void start_menial_labor();
         void worker_assignment_ui();
         void job_assignment_ui();
-        void start_crafting( const std::string &cur_id, const point &cur_dir,
+        void start_crafting( const std::string &cur_id, point cur_dir,
                              const std::string &type, const std::string &miss_id );
 
         /// Called when a companion is sent to cut logs
@@ -289,8 +289,8 @@ class basecamp
         void start_fortifications( std::string &bldg_exp );
         void start_combat_mission( const std::string &miss );
         /// Called when a companion starts a chop shop @ref task mission
-        bool start_garage_chop( const point &dir, const tripoint_abs_omt &omt_tgt );
-        void start_farm_op( const point &dir, const tripoint_abs_omt &omt_tgt, farm_ops op );
+        bool start_garage_chop( point dir, const tripoint_abs_omt &omt_tgt );
+        void start_farm_op( point dir, const tripoint_abs_omt &omt_tgt, farm_ops op );
         ///Display items listed in @ref equipment to let the player pick what to give the departing
         ///NPC, loops until quit or empty.
         std::vector<item *> give_equipment( std::vector<item *> equipment, const std::string &msg );
@@ -311,9 +311,9 @@ class basecamp
 
         /// Called to close upgrade missions, @ref miss is the name of the mission id
         /// and @ref dir is the direction of the location to be upgraded
-        bool upgrade_return( const point &dir, const std::string &miss );
+        bool upgrade_return( point dir, const std::string &miss );
         /// As above, but with an explicit blueprint recipe to upgrade
-        bool upgrade_return( const point &dir, const std::string &miss, const std::string &bldg );
+        bool upgrade_return( point dir, const std::string &miss, const std::string &bldg );
 
         /// Choose which expansion you should start, called when a survey mission is completed
         bool survey_return();

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -386,7 +386,7 @@ static void draw_description( const catacurses::window &win, const bionic &bio )
     wnoutrefresh( win );
 }
 
-static void draw_connectors( const catacurses::window &win, const point &start,
+static void draw_connectors( const catacurses::window &win, point start,
                              int last_x, const bionic_id &bio_id, const std::map<bodypart_str_id, size_t> &bp_to_pos )
 {
     const int LIST_START_Y = 7;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -448,7 +448,7 @@ static bool is_contained( const SDL_Rect &smaller, const SDL_Rect &larger )
            smaller.y + smaller.h <= larger.y + larger.h;
 }
 
-bool tileset_loader::copy_surface_to_texture( const SDL_Surface_Ptr &surf, const point &offset,
+bool tileset_loader::copy_surface_to_texture( const SDL_Surface_Ptr &surf, point offset,
         std::vector<texture> &target )
 {
     assert( surf );
@@ -476,7 +476,7 @@ bool tileset_loader::copy_surface_to_texture( const SDL_Surface_Ptr &surf, const
 }
 
 bool tileset_loader::create_textures_from_tile_atlas( const SDL_Surface_Ptr &tile_atlas,
-        const point &offset )
+        point offset )
 {
     assert( tile_atlas );
 
@@ -1123,7 +1123,7 @@ static int divide_round_down( int a, int b )
     }
 }
 
-void cata_tiles::draw( const point &dest, const tripoint &center, int width, int height,
+void cata_tiles::draw( point dest, const tripoint &center, int width, int height,
                        std::multimap<point, formatted_text> &overlay_strings,
                        color_block_overlay_container &color_blocks )
 {
@@ -1751,7 +1751,7 @@ bool cata_tiles::terrain_requires_animation() const
     return idle_animations.enabled() && idle_animations.present();
 }
 
-void cata_tiles::draw_minimap( const point &dest, const tripoint &center, int width, int height )
+void cata_tiles::draw_minimap( point dest, const tripoint &center, int width, int height )
 {
     minimap->draw( SDL_Rect{ dest.x, dest.y, width, height }, center );
 }
@@ -2190,7 +2190,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
             if( vp_overridden ) {
                 const vpart_id &vp_id = std::get<0>( vp_override->second );
                 if( vp_id ) {
-                    const point &mount = std::get<4>( vp_override->second );
+                    point mount = std::get<4>( vp_override->second );
                     seed = simple_point_hash( mount );
                 }
             } else {
@@ -2316,7 +2316,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
 
 bool cata_tiles::draw_sprite_at(
     const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
-    const point &p, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
+    point p, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
     bool apply_night_vision_goggles, int overlay_count )
 {
     int nullint = 0;
@@ -2326,7 +2326,7 @@ bool cata_tiles::draw_sprite_at(
 
 bool cata_tiles::draw_sprite_at(
     const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
-    const point &p, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
+    point p, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
     bool apply_night_vision_goggles, int &height_3d, int overlay_count )
 {
     auto picked = svlist.pick( loc_rand );
@@ -2460,7 +2460,7 @@ bool cata_tiles::draw_sprite_at(
 }
 
 bool cata_tiles::draw_tile_at(
-    const tile_type &tile, const point &p, unsigned int loc_rand, int rota,
+    const tile_type &tile, point p, unsigned int loc_rand, int rota,
     lit_level ll, bool apply_night_vision_goggles, int &height_3d, int overlay_count )
 {
     draw_sprite_at( tile, tile.bg, p, loc_rand, /*fg:*/ false, rota, ll,
@@ -2556,7 +2556,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
     const bool overridden = override != terrain_override.end();
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
-        for( const point &dir : neighborhood ) {
+        for( point dir : neighborhood ) {
             if( terrain_override.find( p + dir ) != terrain_override.end() ) {
                 neighborhood_overridden = true;
                 break;
@@ -2728,7 +2728,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
     const bool overridden = override != furniture_override.end();
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
-        for( const point &dir : neighborhood ) {
+        for( point dir : neighborhood ) {
             if( furniture_override.find( p + dir ) != furniture_override.end() ) {
                 neighborhood_overridden = true;
                 break;
@@ -2802,7 +2802,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
     const bool overridden = override != trap_override.end();
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
-        for( const point &dir : neighborhood ) {
+        for( point dir : neighborhood ) {
             if( trap_override.find( p + dir ) != trap_override.end() ) {
                 neighborhood_overridden = true;
                 break;
@@ -3347,7 +3347,7 @@ void cata_tiles::init_draw_item_override( const tripoint &p, const itype_id &id,
     item_override.emplace( p, std::make_tuple( id, mid, hilite ) );
 }
 void cata_tiles::init_draw_vpart_override( const tripoint &p, const vpart_id &id,
-        const int part_mod, const units::angle veh_dir, const bool hilite, const point &mount )
+        const int part_mod, const units::angle veh_dir, const bool hilite, point mount )
 {
     vpart_override.emplace( p, std::make_tuple( id, part_mod, veh_dir, hilite, mount ) );
 }
@@ -3889,7 +3889,7 @@ void cata_tiles::do_tile_loading_report( std::function<void( std::string )> out 
     tile_loading_report<field_type>( field_type::count(), C_FIELD, out, "" );
 }
 
-point cata_tiles::player_to_screen( const point &p ) const
+point cata_tiles::player_to_screen( point p ) const
 {
     point screen;
     if( tile_iso ) {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -221,11 +221,11 @@ class tileset_loader
         void ensure_default_item_highlight();
 
         /** Returns false if failed to create texture. */
-        bool copy_surface_to_texture( const SDL_Surface_Ptr &surf, const point &offset,
+        bool copy_surface_to_texture( const SDL_Surface_Ptr &surf, point offset,
                                       std::vector<texture> &target );
 
         /** Returns false if failed to create texture(s). */
-        bool create_textures_from_tile_atlas( const SDL_Surface_Ptr &tile_atlas, const point &offset );
+        bool create_textures_from_tile_atlas( const SDL_Surface_Ptr &tile_atlas, point offset );
 
         void process_variations_after_loading( weighted_int_list<std::vector<int>> &v );
 
@@ -360,15 +360,15 @@ class cata_tiles
         void on_options_changed();
 
         /** Draw to screen */
-        void draw( const point &dest, const tripoint &center, int width, int height,
+        void draw( point dest, const tripoint &center, int width, int height,
                    std::multimap<point, formatted_text> &overlay_strings,
                    color_block_overlay_container &color_blocks );
-        void draw_om( const point &dest, const tripoint_abs_omt &center_abs_omt, bool blink );
+        void draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bool blink );
 
         bool terrain_requires_animation() const;
 
         /** Minimap functionality */
-        void draw_minimap( const point &dest, const tripoint &center, int width, int height );
+        void draw_minimap( point dest, const tripoint &center, int width, int height );
         bool minimap_requires_animation() const;
 
     protected:
@@ -439,7 +439,7 @@ class cata_tiles
          */
         bool draw_sprite_at(
             const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
-            const point &, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
+            point, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
             bool apply_night_vision_goggles, int overlay_count );
 
         /**
@@ -451,7 +451,7 @@ class cata_tiles
          */
         bool draw_sprite_at(
             const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
-            const point &, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
+            point, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
             bool apply_night_vision_goggles, int &height_3d, int overlay_count );
 
         /**
@@ -468,7 +468,7 @@ class cata_tiles
          * @param overlay_count how blue the tile looks for lower z levels
          * @return always true.
          */
-        bool draw_tile_at( const tile_type &tile, const point &, unsigned int loc_rand, int rota,
+        bool draw_tile_at( const tile_type &tile, point, unsigned int loc_rand, int rota,
                            lit_level ll, bool apply_night_vision_goggles, int &height_3d, int overlay_count );
 
         /** Tile Picking */
@@ -595,7 +595,7 @@ class cata_tiles
         void void_item_override();
 
         void init_draw_vpart_override( const tripoint &p, const vpart_id &id, int part_mod,
-                                       units::angle veh_dir, bool hilite, const point &mount );
+                                       units::angle veh_dir, bool hilite, point mount );
         void void_vpart_override();
 
         void init_draw_below_override( const tripoint &p, bool draw );
@@ -645,7 +645,7 @@ class cata_tiles
             return tile_ratioy;
         }
         void do_tile_loading_report( std::function<void( std::string )> out );
-        point player_to_screen( const point & ) const;
+        point player_to_screen( point ) const;
         static std::vector<options_manager::id_and_option> build_renderer_list();
         static std::vector<options_manager::id_and_option> build_display_list();
     private:

--- a/src/cellular_automata.cpp
+++ b/src/cellular_automata.cpp
@@ -1,8 +1,8 @@
 #include "cellular_automata.h"
 
 int CellularAutomata::neighbor_count( const std::vector<std::vector<int>> &cells,
-                                      const point &size,
-                                      const point &p )
+                                      point size,
+                                      point p )
 {
     int neighbors = 0;
     for( int ni = -1; ni <= 1; ni++ ) {
@@ -23,7 +23,7 @@ int CellularAutomata::neighbor_count( const std::vector<std::vector<int>> &cells
     return neighbors;
 }
 std::vector<std::vector<int>> CellularAutomata::generate_cellular_automaton(
-                               const point &size,
+                               point size,
                                const int alive,
                                const int iterations,
                                const int birth_limit,

--- a/src/cellular_automata.h
+++ b/src/cellular_automata.h
@@ -18,8 +18,8 @@ namespace CellularAutomata
 * @returns The number of neighbors that are alive, a value between 0 and 8.
 */
 int neighbor_count( const std::vector<std::vector<int>> &cells,
-                    const point &size,
-                    const point &p );
+                    point size,
+                    point p );
 
 /**
 * Generate a cellular automaton using the provided parameters.
@@ -37,7 +37,7 @@ int neighbor_count( const std::vector<std::vector<int>> &cells,
 * @returns The width x height grid of cells. Each cell is a 0 if dead or a 1 if alive.
 */
 std::vector<std::vector<int>> generate_cellular_automaton(
-                               const point &size,
+                               point size,
                                const int alive,
                                const int iterations,
                                const int birth_limit,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10311,7 +10311,7 @@ int Character::print_info( const catacurses::window &w, int vStart, int, int col
     return vStart;
 }
 
-void Character::shift_destination( const point &shift )
+void Character::shift_destination( point shift )
 {
     if( next_expected_position ) {
         *next_expected_position += shift;

--- a/src/character.h
+++ b/src/character.h
@@ -2066,7 +2066,7 @@ class Character : public Creature, public visitable<Character>
         // used in debugging all health
         int get_lowest_hp() const;
         bool has_weapon() const override;
-        void shift_destination( const point &shift );
+        void shift_destination( point shift );
         // Auto move methods
         void set_destination( const std::vector<tripoint> &route,
                               const player_activity &new_destination_activity = player_activity() );

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -959,7 +959,7 @@ const zone_data *zone_manager::get_bottom_zone( const tripoint &where,
 // which constructor of the key-value pair we use which depends on new_zone being an rvalue or lvalue and constness.
 // If you are passing new_zone from a non-const iterator, be prepared for a move! This
 // may break some iterators like map iterators if you are less specific!
-void zone_manager::create_vehicle_loot_zone( vehicle &vehicle, const point &mount_point,
+void zone_manager::create_vehicle_loot_zone( vehicle &vehicle, point mount_point,
         zone_data &new_zone )
 {
     //create a vehicle loot zone

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -380,7 +380,7 @@ class zone_manager
                   const tripoint &start, const tripoint &end,
                   shared_ptr_fast<zone_options> options = nullptr );
         const zone_data *get_zone_at( const tripoint &where, const zone_type_id &type ) const;
-        void create_vehicle_loot_zone( class vehicle &vehicle, const point &mount_point,
+        void create_vehicle_loot_zone( class vehicle &vehicle, point mount_point,
                                        zone_data &new_zone );
 
         bool remove( zone_data &zone );

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1253,7 +1253,7 @@ bool construct::check_no_trap( const tripoint &p )
 bool construct::check_ramp_high( const tripoint &p )
 {
     if( check_up_OK( p ) && check_up_OK( p + tripoint_above ) ) {
-        for( const point &car_d : four_cardinal_directions ) {
+        for( point car_d : four_cardinal_directions ) {
             // check adjacent points on the z-level above for a completed down ramp
             if( get_map().has_flag( TFLAG_RAMP_DOWN, p + car_d + tripoint_above ) ) {
                 return true;
@@ -1791,7 +1791,7 @@ void construction::finalize()
     reqs_using.clear();
 }
 
-int construction::print_time( const catacurses::window &w, const point &p, int width,
+int construction::print_time( const catacurses::window &w, point p, int width,
                               nc_color col ) const
 {
     std::string text = get_time_string();

--- a/src/construction.h
+++ b/src/construction.h
@@ -89,7 +89,7 @@ struct construction {
 
         // NPC assistance adjusted
         int adjusted_time() const;
-        int print_time( const catacurses::window &w, const point &, int width, nc_color col ) const;
+        int print_time( const catacurses::window &w, point, int width, nc_color col ) const;
         std::vector<std::string> get_folded_time_string( int width ) const;
 
         // Result of construction scaling option

--- a/src/coordinate_conversions.cpp
+++ b/src/coordinate_conversions.cpp
@@ -17,7 +17,7 @@ static int divide( int v, int m, int &r )
     return result;
 }
 
-point omt_to_om_copy( const point &p )
+point omt_to_om_copy( point p )
 {
     return point( divide( p.x, OMAPX ), divide( p.y, OMAPY ) );
 }
@@ -38,12 +38,12 @@ point omt_to_om_remain( int &x, int &y )
     return point( divide( x, OMAPX, x ), divide( y, OMAPY, y ) );
 }
 
-point om_to_omt_copy( const point &p )
+point om_to_omt_copy( point p )
 {
     return point( p.x * OMAPX, p.y * OMAPY );
 }
 
-point sm_to_omt_copy( const point &p )
+point sm_to_omt_copy( point p )
 {
     return point( divide( p.x, 2 ), divide( p.y, 2 ) );
 }
@@ -64,7 +64,7 @@ point sm_to_omt_remain( int &x, int &y )
     return point( divide( x, 2, x ), divide( y, 2, y ) );
 }
 
-point sm_to_om_copy( const point &p )
+point sm_to_om_copy( point p )
 {
     return point( divide( p.x, 2 * OMAPX ), divide( p.y, 2 * OMAPY ) );
 }
@@ -85,12 +85,12 @@ point sm_to_om_remain( int &x, int &y )
     return point( divide( x, 2 * OMAPX, x ), divide( y, 2 * OMAPY, y ) );
 }
 
-point omt_to_ms_copy( const point &p )
+point omt_to_ms_copy( point p )
 {
     return point( p.x * 2 * SEEX, p.y * 2 * SEEY );
 }
 
-point omt_to_sm_copy( const point &p )
+point omt_to_sm_copy( point p )
 {
     return point( p.x * 2, p.y * 2 );
 }
@@ -106,7 +106,7 @@ void omt_to_sm( int &x, int &y )
     y *= 2;
 }
 
-point om_to_sm_copy( const point &p )
+point om_to_sm_copy( point p )
 {
     return point( p.x * 2 * OMAPX, p.y * 2 * OMAPX );
 }
@@ -122,7 +122,7 @@ void om_to_sm( int &x, int &y )
     y *= 2 * OMAPY;
 }
 
-point ms_to_sm_copy( const point &p )
+point ms_to_sm_copy( point p )
 {
     return point( divide( p.x, SEEX ), divide( p.y, SEEY ) );
 }
@@ -143,7 +143,7 @@ point ms_to_sm_remain( int &x, int &y )
     return point( divide( x, SEEX, x ), divide( y, SEEY, y ) );
 }
 
-point sm_to_ms_copy( const point &p )
+point sm_to_ms_copy( point p )
 {
     return point( p.x * SEEX, p.y * SEEY );
 }
@@ -159,7 +159,7 @@ void sm_to_ms( int &x, int &y )
     y *= SEEY;
 }
 
-point ms_to_omt_copy( const point &p )
+point ms_to_omt_copy( point p )
 {
     return point( divide( p.x, SEEX * 2 ), divide( p.y, SEEY * 2 ) );
 }

--- a/src/coordinate_conversions.h
+++ b/src/coordinate_conversions.h
@@ -38,7 +38,7 @@
  */
 
 // overmap terrain to overmap
-point omt_to_om_copy( const point &p );
+point omt_to_om_copy( point p );
 tripoint omt_to_om_copy( const tripoint &p );
 void omt_to_om( int &x, int &y );
 inline void omt_to_om( point &p )
@@ -55,9 +55,9 @@ inline point omt_to_om_remain( point &p )
     return omt_to_om_remain( p.x, p.y );
 }
 // overmap to overmap terrain
-point om_to_omt_copy( const point &p );
+point om_to_omt_copy( point p );
 // submap to overmap terrain
-point sm_to_omt_copy( const point &p );
+point sm_to_omt_copy( point p );
 tripoint sm_to_omt_copy( const tripoint &p );
 void sm_to_omt( int &x, int &y );
 inline void sm_to_omt( point &p )
@@ -74,7 +74,7 @@ inline point sm_to_omt_remain( point &p )
     return sm_to_omt_remain( p.x, p.y );
 }
 // submap to overmap, basically: x / (OMAPX * 2)
-point sm_to_om_copy( const point &p );
+point sm_to_om_copy( point p );
 tripoint sm_to_om_copy( const tripoint &p );
 void sm_to_om( int &x, int &y );
 inline void sm_to_om( point &p )
@@ -95,7 +95,7 @@ inline int omt_to_sm_copy( int a )
 {
     return 2 * a;
 }
-point omt_to_sm_copy( const point &p );
+point omt_to_sm_copy( point p );
 tripoint omt_to_sm_copy( const tripoint &p );
 void omt_to_sm( int &x, int &y );
 inline void omt_to_sm( point &p )
@@ -107,9 +107,9 @@ inline void omt_to_sm( tripoint &p )
     omt_to_sm( p.x, p.y );
 }
 // overmap terrain to map square
-point omt_to_ms_copy( const point &p );
+point omt_to_ms_copy( point p );
 // overmap to submap, basically: x *= 2 * OMAPX
-point om_to_sm_copy( const point &p );
+point om_to_sm_copy( point p );
 tripoint om_to_sm_copy( const tripoint &p );
 void om_to_sm( int &x, int &y );
 inline void om_to_sm( point &p )
@@ -121,7 +121,7 @@ inline void om_to_sm( tripoint &p )
     om_to_sm( p.x, p.y );
 }
 // map squares to submap, basically: x /= SEEX
-point ms_to_sm_copy( const point &p );
+point ms_to_sm_copy( point p );
 tripoint ms_to_sm_copy( const tripoint &p );
 void ms_to_sm( int &x, int &y );
 inline void ms_to_sm( point &p )
@@ -144,7 +144,7 @@ inline tripoint ms_to_sm_remain( tripoint &p )
 // submap back to map squares, basically: x *= SEEX
 // Note: this gives you the map square coordinates of the top-left corner
 // of the given submap.
-point sm_to_ms_copy( const point &p );
+point sm_to_ms_copy( point p );
 tripoint sm_to_ms_copy( const tripoint &p );
 void sm_to_ms( int &x, int &y );
 inline void sm_to_ms( point &p )
@@ -156,7 +156,7 @@ inline void sm_to_ms( tripoint &p )
     sm_to_ms( p.x, p.y );
 }
 // map squares to overmap terrain, basically: x /= SEEX * 2
-point ms_to_omt_copy( const point &p );
+point ms_to_omt_copy( point p );
 tripoint ms_to_omt_copy( const tripoint &p );
 void ms_to_omt( int &x, int &y );
 inline void ms_to_omt( point &p )

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -1,6 +1,6 @@
 #include "coordinates.h"
 
-void real_coords::fromabs( const point &abs )
+void real_coords::fromabs( point abs )
 {
     const point norm( std::abs( abs.x ), std::abs( abs.y ) );
     abs_pos = abs;

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -158,12 +158,12 @@ class coord_point
             return *this;
         }
 
-        coord_point &operator+=( const point &r ) {
+        coord_point &operator+=( point r ) {
             raw_ += r;
             return *this;
         }
 
-        coord_point &operator-=( const point &r ) {
+        coord_point &operator-=( point r ) {
             raw_ -= r;
             return *this;
         }
@@ -178,7 +178,7 @@ class coord_point
             return *this;
         }
 
-        friend inline coord_point operator+( const coord_point &l, const point &r ) {
+        friend inline coord_point operator+( const coord_point &l, point r ) {
             return coord_point( l.raw() + r );
         }
 
@@ -186,7 +186,7 @@ class coord_point
             return coord_point( l.raw() + r );
         }
 
-        friend inline coord_point operator-( const coord_point &l, const point &r ) {
+        friend inline coord_point operator-( const coord_point &l, point r ) {
             return coord_point( l.raw() - r );
         }
 
@@ -643,10 +643,10 @@ struct real_coords {
         fromabs( ap );
     }
 
-    void fromabs( const point &abs );
+    void fromabs( point abs );
 
     // specifically for the subjective position returned by overmap::draw
-    void fromomap( const point &rel_om, const point &rel_om_pos ) {
+    void fromomap( point rel_om, point rel_om_pos ) {
         const point a = om_to_omt_copy( rel_om ) + rel_om_pos;
         fromabs( omt_to_ms_copy( a ) );
     }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1804,7 +1804,7 @@ units::mass Creature::weight_capacity() const
 /*
  * Drawing-related functions
  */
-void Creature::draw( const catacurses::window &w, const point &origin, bool inverted ) const
+void Creature::draw( const catacurses::window &w, point origin, bool inverted ) const
 {
     draw( w, tripoint( origin, posz() ), inverted );
 }

--- a/src/creature.h
+++ b/src/creature.h
@@ -572,7 +572,7 @@ class Creature
         virtual std::set<tripoint> get_path_avoid() const = 0;
 
         int moves = 0;
-        void draw( const catacurses::window &w, const point &origin, bool inverted ) const;
+        void draw( const catacurses::window &w, point origin, bool inverted ) const;
         void draw( const catacurses::window &w, const tripoint &origin, bool inverted ) const;
         /**
          * Write information about this creature.

--- a/src/cursesdef.h
+++ b/src/cursesdef.h
@@ -6,10 +6,10 @@
 #include <string>
 #include <utility>
 
+#include "point.h"
 #include "string_formatter.h"
 
 class nc_color;
-struct point;
 
 /**
  * Contains the curses interface used by the whole game.
@@ -91,19 +91,19 @@ using attr_t = unsigned short;
 
 extern window stdscr;
 
-window newwin( int nlines, int ncols, const point &begin );
+window newwin( int nlines, int ncols, point begin );
 void wborder( const window &win, chtype ls, chtype rs, chtype ts, chtype bs, chtype tl, chtype tr,
               chtype bl, chtype br );
-void mvwhline( const window &win, const point &p, chtype ch, int n );
-void mvwvline( const window &win, const point &p, chtype ch, int n );
+void mvwhline( const window &win, point p, chtype ch, int n );
+void mvwvline( const window &win, point p, chtype ch, int n );
 void wnoutrefresh( const window &win );
 void wrefresh( const window &win );
 void refresh();
 void doupdate();
 void wredrawln( const window &win, int beg_line, int num_lines );
-void mvwprintw( const window &win, const point &p, const std::string &text );
+void mvwprintw( const window &win, point p, const std::string &text );
 template<typename ...Args>
-inline void mvwprintw( const window &win, const point &p, const char *const fmt,
+inline void mvwprintw( const window &win, point p, const char *const fmt,
                        Args &&... args )
 {
     return mvwprintw( win, p, string_format( fmt, std::forward<Args>( args )... ) );
@@ -119,11 +119,11 @@ inline void wprintw( const window &win, const char *const fmt, Args &&... args )
 void resizeterm();
 void werase( const window &win );
 void init_pair( short pair, base_color f, base_color b );
-void wmove( const window &win, const point &p );
+void wmove( const window &win, point p );
 void clear();
 void erase();
 void endwin();
-void mvwaddch( const window &win, const point &p, chtype ch );
+void mvwaddch( const window &win, point p, chtype ch );
 void wclear( const window &win );
 void curs_set( int visibility );
 void wattron( const window &win, const nc_color &attrs );

--- a/src/cursesport.cpp
+++ b/src/cursesport.cpp
@@ -36,7 +36,7 @@
 catacurses::window catacurses::stdscr;
 std::array<cata_cursesport::pairs, 100> cata_cursesport::colorpairs;   //storage for pair'ed colored
 
-static bool wmove_internal( const catacurses::window &win_, const point &p )
+static bool wmove_internal( const catacurses::window &win_, point p )
 {
     if( !win_ ) {
         return false;
@@ -62,7 +62,7 @@ static bool wmove_internal( const catacurses::window &win_, const point &p )
 //Pseudo-Curses Functions           *
 //***********************************
 
-catacurses::window catacurses::newwin( int nlines, int ncols, const point &begin )
+catacurses::window catacurses::newwin( int nlines, int ncols, point begin )
 {
     if( begin.y < 0 || begin.x < 0 ) {
         return window(); //it's the caller's problem now (since they have logging functions declared)
@@ -161,7 +161,7 @@ void catacurses::wborder( const window &win_, chtype ls, chtype rs, chtype ts, c
     wattroff( win_, c_white );
 }
 
-void catacurses::mvwhline( const window &win, const point &p, chtype ch, int n )
+void catacurses::mvwhline( const window &win, point p, chtype ch, int n )
 {
     wattron( win, BORDER_COLOR );
     const chtype hline_char = ch ? ch : LINE_OXOX;
@@ -171,7 +171,7 @@ void catacurses::mvwhline( const window &win, const point &p, chtype ch, int n )
     wattroff( win, BORDER_COLOR );
 }
 
-void catacurses::mvwvline( const window &win, const point &p, chtype ch, int n )
+void catacurses::mvwvline( const window &win, point p, chtype ch, int n )
 {
     wattron( win, BORDER_COLOR );
     const chtype vline_char = ch ? ch : LINE_XOXO;
@@ -363,7 +363,7 @@ void catacurses::wprintw( const window &win, const std::string &text )
 }
 
 //Prints a formatted string to a window, moves the cursor
-void catacurses::mvwprintw( const window &win, const point &p, const std::string &text )
+void catacurses::mvwprintw( const window &win, point p, const std::string &text )
 {
     if( !wmove_internal( win, p ) ) {
         return;
@@ -409,7 +409,7 @@ void catacurses::init_pair( const short pair, const base_color f, const base_col
 }
 
 //moves the cursor in a window
-void catacurses::wmove( const window &win_, const point &p )
+void catacurses::wmove( const window &win_, point p )
 {
     if( !wmove_internal( win_, p ) ) {
         return;
@@ -425,7 +425,7 @@ void catacurses::clear()
 }
 
 //adds a character to the window
-void catacurses::mvwaddch( const window &win, const point &p, const chtype ch )
+void catacurses::mvwaddch( const window &win, point p, const chtype ch )
 {
     if( !wmove_internal( win, p ) ) {
         return;

--- a/src/diary_ui.cpp
+++ b/src/diary_ui.cpp
@@ -190,10 +190,10 @@ void diary::show_diary_ui( diary *c_diary )
     ui_adaptor ui_diary;
     ui_diary.on_screen_resize( [&]( ui_adaptor & ui ) {
         const std::pair<point, point> beg_and_max = diary_window_position();
-        const point &beg = ( uis_padding() != 0 ) ? point( uis_padding() + MAX_DAIRY_UI_WIDTH / 4 - 3,
-                           beg_and_max.first.y - 1 ) : beg_and_max.first + point( uis_padding() - 3, -1 );
-        const point &max = point( TERMX - beg.x - 5,
-                                  beg_and_max.second.y ) - point( uis_padding(), 0 );
+        point beg = ( uis_padding() != 0 ) ? point( uis_padding() + MAX_DAIRY_UI_WIDTH / 4 - 3,
+                    beg_and_max.first.y - 1 ) : beg_and_max.first + point( uis_padding() - 3, -1 );
+        point max = point( TERMX - beg.x - 5,
+                           beg_and_max.second.y ) - point( uis_padding(), 0 );
         const int midx = max.x / 2;
 
         w_changes = catacurses::newwin( max.y - 3, midx - 1, beg + point_south );
@@ -228,8 +228,8 @@ void diary::show_diary_ui( diary *c_diary )
     ui_adaptor ui_pages;
     ui_pages.on_screen_resize( [&]( ui_adaptor & ui ) {
         const std::pair<point, point> beg_and_max = diary_window_position();
-        const point &beg = beg_and_max.first;
-        const point &max = beg_and_max.second;
+        point beg = beg_and_max.first;
+        point max = beg_and_max.second;
 
         w_pages = catacurses::newwin( max.y + 5,
                                       ( uis_padding() != 0 ) ? MAX_DAIRY_UI_WIDTH / 4 - 7 : beg.x - 7, point( uis_padding(),
@@ -252,7 +252,7 @@ void diary::show_diary_ui( diary *c_diary )
     ui_adaptor ui_desc;
     ui_desc.on_screen_resize( [&]( ui_adaptor & ui ) {
         const std::pair<point, point> beg_and_max = diary_window_position();
-        const point &beg = beg_and_max.first;
+        point beg = beg_and_max.first;
 
         w_desc = catacurses::newwin( 3, TERMX - uis_padding() * 2, point( uis_padding(), beg.y - 6 ) );
 
@@ -278,8 +278,8 @@ void diary::show_diary_ui( diary *c_diary )
     ui_adaptor ui_info;
     ui_info.on_screen_resize( [&]( ui_adaptor & ui ) {
         const std::pair<point, point> beg_and_max = diary_window_position();
-        const point &beg = beg_and_max.first;
-        const point &max = beg_and_max.second;
+        point beg = beg_and_max.first;
+        point max = beg_and_max.second;
 
         w_info = catacurses::newwin( ( TERMY - beg.y - max.y - 2 ) > 7 ? 7 : TERMY - beg.y - max.y - 2,
                                      TERMX - uis_padding() * 2, point( uis_padding(), beg.y + max.y + 2 ) );

--- a/src/drawing_primitives.cpp
+++ b/src/drawing_primitives.cpp
@@ -9,7 +9,7 @@
 #include "point.h"
 #include "point_float.h"
 
-void draw_line( std::function<void( const point & )>set, const point &p1, const point &p2 )
+void draw_line( std::function<void( point )>set, point p1, point p2 )
 {
     std::vector<point> line = line_to( p1, p2, 0 );
     for( auto &i : line ) {
@@ -18,7 +18,7 @@ void draw_line( std::function<void( const point & )>set, const point &p1, const 
     set( p1 );
 }
 
-void draw_square( std::function<void( const point & )>set, point p1, point p2 )
+void draw_square( std::function<void( point )>set, point p1, point p2 )
 {
     if( p1.x > p2.x ) {
         std::swap( p1.x, p2.x );
@@ -33,7 +33,7 @@ void draw_square( std::function<void( const point & )>set, point p1, point p2 )
     }
 }
 
-void draw_rough_circle( std::function<void( const point & )>set, const point &p, int rad )
+void draw_rough_circle( std::function<void( point )>set, point p, int rad )
 {
     for( int i = p.x - rad; i <= p.x + rad; i++ ) {
         for( int j = p.y - rad; j <= p.y + rad; j++ ) {
@@ -44,7 +44,7 @@ void draw_rough_circle( std::function<void( const point & )>set, const point &p,
     }
 }
 
-void draw_circle( std::function<void( const point & )>set, const rl_vec2d &p, double rad )
+void draw_circle( std::function<void( point )>set, const rl_vec2d &p, double rad )
 {
     for( int i = p.x - rad - 1; i <= p.x + rad + 1; i++ ) {
         for( int j = p.y - rad - 1; j <= p.y + rad + 1; j++ ) {
@@ -55,7 +55,7 @@ void draw_circle( std::function<void( const point & )>set, const rl_vec2d &p, do
     }
 }
 
-void draw_circle( std::function<void( const point & )>set, const point &p, int rad )
+void draw_circle( std::function<void( point )>set, point p, int rad )
 {
     for( int i = p.x - rad; i <= p.x + rad; i++ ) {
         for( int j = p.y - rad; j <= p.y + rad; j++ ) {

--- a/src/drawing_primitives.h
+++ b/src/drawing_primitives.h
@@ -7,14 +7,14 @@
 struct point;
 struct rl_vec2d;
 
-void draw_line( std::function<void( const point & )>set, const point &p1, const point &p2 );
+void draw_line( std::function<void( point )>set, point p1, point p2 );
 
-void draw_square( std::function<void( const point & )>set, point p1, point p2 );
+void draw_square( std::function<void( point )>set, point p1, point p2 );
 
-void draw_rough_circle( std::function<void( const point & )>set, const point &p, int rad );
+void draw_rough_circle( std::function<void( point )>set, point p, int rad );
 
-void draw_circle( std::function<void( const point & )>set, const rl_vec2d &p, double rad );
+void draw_circle( std::function<void( point )>set, const rl_vec2d &p, double rad );
 
-void draw_circle( std::function<void( const point & )>set, const point &p, int rad );
+void draw_circle( std::function<void( point )>set, point p, int rad );
 
 #endif // CATA_SRC_DRAWING_PRIMITIVES_H

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -673,7 +673,7 @@ void talk_function::basecamp_mission( npc &p )
     }
 }
 
-void basecamp::add_available_recipes( mission_data &mission_key, const point &dir,
+void basecamp::add_available_recipes( mission_data &mission_key, point dir,
                                       const std::map<recipe_id, translation> &craft_recipes )
 {
     const std::string dir_id = base_camps::all_directions.at( dir ).id;
@@ -689,7 +689,7 @@ void basecamp::add_available_recipes( mission_data &mission_key, const point &di
     }
 }
 
-void basecamp::get_available_missions_by_dir( mission_data &mission_key, const point &dir )
+void basecamp::get_available_missions_by_dir( mission_data &mission_key, point dir )
 {
     std::string entry;
     std::string gather_bldg = "null";
@@ -1211,7 +1211,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
 {
     std::string entry;
 
-    const point &base_dir = base_camps::base_dir;
+    point base_dir = base_camps::base_dir;
     const base_camps::direction_data &base_data = base_camps::all_directions.at( base_dir );
     const std::string base_dir_id = base_data.id;
     const std::string base_dir_abbr = base_data.bracket_abbr.translated();
@@ -1327,7 +1327,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
     get_available_missions_by_dir( mission_key, base_camps::base_dir );
 
     // Loop over expansions
-    for( const point &dir : directions ) {
+    for( point dir : directions ) {
         get_available_missions_by_dir( mission_key, dir );
     }
 
@@ -1351,7 +1351,7 @@ void basecamp::get_available_missions( mission_data &mission_key )
 bool basecamp::handle_mission( const std::string &miss_id,
                                const cata::optional<point> &opt_miss_dir )
 {
-    const point &miss_dir = opt_miss_dir ? *opt_miss_dir : base_camps::base_dir;
+    point miss_dir = opt_miss_dir ? *opt_miss_dir : base_camps::base_dir;
 
     if( miss_id == "Distribute Food" ) {
         distribute_food();
@@ -1587,7 +1587,7 @@ npc_ptr basecamp::start_mission( const std::string &miss_id, time_duration durat
     return comp;
 }
 
-void basecamp::start_upgrade( const std::string &bldg, const point &dir,
+void basecamp::start_upgrade( const std::string &bldg, point dir,
                               const std::string &key )
 {
     const recipe &making = recipe_id( bldg ).obj();
@@ -2220,7 +2220,7 @@ void basecamp::start_combat_mission( const std::string &miss )
 // it first checks whether the mission id starts with the correct direction prefix,
 // and then search for the mission id without direction prefix in the recipes
 // if there's a match, the player has selected a crafting mission
-void basecamp::start_crafting( const std::string &cur_id, const point &cur_dir,
+void basecamp::start_crafting( const std::string &cur_id, point cur_dir,
                                const std::string &type, const std::string &miss_id )
 {
     const std::string cur_dir_id = base_camps::all_directions.at( cur_dir ).id;
@@ -2398,7 +2398,7 @@ static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_t
     return std::make_pair( plots_cnt, crops );
 }
 
-void basecamp::start_farm_op( const point &dir, const tripoint_abs_omt &omt_tgt, farm_ops op )
+void basecamp::start_farm_op( point dir, const tripoint_abs_omt &omt_tgt, farm_ops op )
 {
     const std::string &dir_id = base_camps::all_directions.at( dir ).id;
     std::pair<size_t, std::string> farm_data = farm_action( omt_tgt, op );
@@ -2446,7 +2446,7 @@ void basecamp::start_farm_op( const point &dir, const tripoint_abs_omt &omt_tgt,
     }
 }
 
-bool basecamp::start_garage_chop( const point &dir, const tripoint_abs_omt &omt_tgt )
+bool basecamp::start_garage_chop( point dir, const tripoint_abs_omt &omt_tgt )
 {
     editmap edit;
     vehicle *car = edit.mapgen_veh_query( omt_tgt );
@@ -2594,7 +2594,7 @@ npc_ptr basecamp::emergency_recall()
 
 }
 
-bool basecamp::upgrade_return( const point &dir, const std::string &miss )
+bool basecamp::upgrade_return( point dir, const std::string &miss )
 {
     const std::string bldg = next_upgrade( dir, 1 );
     if( bldg == "null" ) {
@@ -2603,7 +2603,7 @@ bool basecamp::upgrade_return( const point &dir, const std::string &miss )
     return upgrade_return( dir, miss, bldg );
 }
 
-bool basecamp::upgrade_return( const point &dir, const std::string &miss,
+bool basecamp::upgrade_return( point dir, const std::string &miss,
                                const std::string &bldg )
 {
     auto e = expansions.find( dir );
@@ -3708,7 +3708,7 @@ int basecamp::recruit_evaluation( int &sbase, int &sexpansions, int &sfaction, i
     //How could we ever starve?
     //More than 5 farms at recruiting base
     int farm = 0;
-    for( const point &dir : directions ) {
+    for( point dir : directions ) {
         if( has_provides( "farming", dir ) ) {
             farm++;
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -283,7 +283,7 @@ std::unique_ptr<game> g;
 //The one and only uistate instance
 uistatedata uistate;
 
-bool is_valid_in_w_terrain( const point &p )
+bool is_valid_in_w_terrain( point p )
 {
     return p.x >= 0 && p.x < TERRAIN_WINDOW_WIDTH && p.y >= 0 && p.y < TERRAIN_WINDOW_HEIGHT;
 }
@@ -1595,7 +1595,7 @@ bool game::do_turn()
     return false;
 }
 
-void game::set_driving_view_offset( const point &p )
+void game::set_driving_view_offset( point p )
 {
     // remove the previous driving offset,
     // store the new offset and apply the new offset.
@@ -4952,7 +4952,7 @@ void game::save_cyborg( item *cyborg, const tripoint &couch_pos, player &install
 
 }
 
-void game::exam_vehicle( vehicle &veh, const point &c )
+void game::exam_vehicle( vehicle &veh, point c )
 {
     if( veh.magic ) {
         add_msg( m_info, _( "This is your %s" ), veh.name );
@@ -11979,7 +11979,7 @@ std::string game::get_world_base_save_path() const
     return world_generator->active_world->folder_path();
 }
 
-void game::shift_destination_preview( const point &delta )
+void game::shift_destination_preview( point delta )
 {
     for( tripoint &p : destination_preview ) {
         p += delta;

--- a/src/game.h
+++ b/src/game.h
@@ -135,7 +135,7 @@ struct w_map {
     catacurses::window win;
 };
 
-bool is_valid_in_w_terrain( const point &p );
+bool is_valid_in_w_terrain( point p );
 
 // There is only one game instance, so losing a few bytes of memory
 // due to padding is not much of a concern.
@@ -639,7 +639,7 @@ class game
         /** Get all living player allies */
         std::vector<npc *> allies();
         // Setter for driving_view_offset
-        void set_driving_view_offset( const point &p );
+        void set_driving_view_offset( point p );
         // Calculates the driving_view_offset for the given vehicle
         // and sets it (view set_driving_view_offset), if
         // the options for this feature is deactivated or if veh is NULL,
@@ -689,7 +689,7 @@ class game
         void draw_item_override( const tripoint &p, const itype_id &id, const mtype_id &mid,
                                  bool hilite );
         void draw_vpart_override( const tripoint &p, const vpart_id &id, int part_mod,
-                                  units::angle veh_dir, bool hilite, const point &mount );
+                                  units::angle veh_dir, bool hilite, point mount );
         void draw_below_override( const tripoint &p, bool draw );
         void draw_monster_override( const tripoint &p, const mtype_id &id, int count,
                                     bool more, Creature::Attitude att );
@@ -703,7 +703,7 @@ class game
         void set_safe_mode( safe_mode_type mode );
 
         /** open vehicle interaction screen */
-        void exam_vehicle( vehicle &veh, const point &cp = point_zero );
+        void exam_vehicle( vehicle &veh, point cp = point_zero );
 
         // Forcefully close a door at p.
         // The function checks for creatures/items/vehicles at that point and
@@ -1088,7 +1088,7 @@ class game
         tripoint mouse_edge_scrolling_overmap( input_context &ctxt );
 
         // called on map shifting
-        void shift_destination_preview( const point &delta );
+        void shift_destination_preview( point delta );
 
         /**
         Checks if player is able to successfully climb to/from some terrain and not slip down

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -180,14 +180,14 @@ void gates::toggle_gate( const tripoint &pos )
     bool fail = false;
 
     map &here = get_map();
-    for( const point &wall_offset : four_adjacent_offsets ) {
+    for( point wall_offset : four_adjacent_offsets ) {
         const tripoint wall_pos = pos + wall_offset;
 
         if( !gate.is_suitable_wall( wall_pos ) ) {
             continue;
         }
 
-        for( const point &gate_offset : four_adjacent_offsets ) {
+        for( point gate_offset : four_adjacent_offsets ) {
             const tripoint gate_pos = wall_pos + gate_offset;
 
             if( gate_pos == pos ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -396,7 +396,7 @@ input_context game::get_player_input( std::string &action )
     return ctxt;
 }
 
-inline static void rcdrive( const point &d )
+inline static void rcdrive( point d )
 {
     player &u = g->u;
     map &here = get_map();

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4091,7 +4091,7 @@ std::unique_ptr<iuse_actor> place_trap_actor::clone() const
     return std::make_unique<place_trap_actor>( *this );
 }
 
-static bool is_solid_neighbor( const tripoint &pos, const point &offset )
+static bool is_solid_neighbor( const tripoint &pos, point offset )
 {
     map &here = get_map();
     const tripoint a = pos + offset;

--- a/src/iuse_software_lightson.cpp
+++ b/src/iuse_software_lightson.cpp
@@ -45,17 +45,17 @@ void lightson_game::reset_level()
     position = point_zero;
 }
 
-bool lightson_game::get_value_at( const point &pt )
+bool lightson_game::get_value_at( point pt )
 {
     return level[pt.y * level_size.x + pt.x];
 }
 
-void lightson_game::set_value_at( const point &pt, bool value )
+void lightson_game::set_value_at( point pt, bool value )
 {
     level[pt.y * level_size.x + pt.x] = value;
 }
 
-void lightson_game::toggle_value_at( const point &pt )
+void lightson_game::toggle_value_at( point pt )
 {
     set_value_at( pt, !get_value_at( pt ) );
 }
@@ -108,7 +108,7 @@ void lightson_game::toggle_lights()
     toggle_lights_at( position );
 }
 
-void lightson_game::toggle_lights_at( const point &pt )
+void lightson_game::toggle_lights_at( point pt )
 {
     toggle_value_at( pt );
 

--- a/src/iuse_software_lightson.h
+++ b/src/iuse_software_lightson.h
@@ -26,10 +26,10 @@ class lightson_game
         void draw_level();
         bool check_win();
         void toggle_lights();
-        void toggle_lights_at( const point &pt );
-        bool get_value_at( const point &pt );
-        void set_value_at( const point &pt, bool value );
-        void toggle_value_at( const point &pt );
+        void toggle_lights_at( point pt );
+        bool get_value_at( point pt );
+        void set_value_at( point pt, bool value );
+        void toggle_value_at( point pt );
 
     public:
         int start_game();

--- a/src/iuse_software_minesweeper.cpp
+++ b/src/iuse_software_minesweeper.cpp
@@ -104,7 +104,7 @@ void minesweeper_game::new_level()
     for( int y = 0; y < level.y; y++ ) {
         for( int x = 0; x < level.x; x++ ) {
             if( mLevel[y][x] == bomb ) {
-                for( const point &p : closest_points_first( {x, y}, 1 ) ) {
+                for( point p : closest_points_first( {x, y}, 1 ) ) {
                     if( p.x >= 0 && p.x < level.x && p.y >= 0 && p.y < level.y ) {
                         if( mLevel[p.y][p.x] != bomb ) {
                             mLevel[p.y][p.x]++;
@@ -257,12 +257,12 @@ int minesweeper_game::start_game()
         wnoutrefresh( w_minesweeper );
     } );
 
-    std::function<void ( const point & )> rec_reveal = [&]( const point & pt ) {
+    std::function<void ( point )> rec_reveal = [&]( point  pt ) {
         if( mLevelReveal[pt.y][pt.x] == unknown || mLevelReveal[pt.y][pt.x] == flag ) {
             mLevelReveal[pt.y][pt.x] = seen;
 
             if( mLevel[pt.y][pt.x] == 0 ) {
-                for( const point &p : closest_points_first( pt, 1 ) ) {
+                for( point p : closest_points_first( pt, 1 ) ) {
                     if( p.x >= 0 && p.x < level.x && p.y >= 0 && p.y < level.y ) {
                         if( mLevelReveal[p.y][p.x] != seen ) {
                             rec_reveal( p );

--- a/src/iuse_software_sokoban.cpp
+++ b/src/iuse_software_sokoban.cpp
@@ -101,7 +101,7 @@ void sokoban_game::parse_level( std::istream &fin )
     }
 }
 
-int sokoban_game::get_wall_connection( const point &i )
+int sokoban_game::get_wall_connection( point i )
 {
     bool bTop = false;
     bool bRight = false;

--- a/src/iuse_software_sokoban.h
+++ b/src/iuse_software_sokoban.h
@@ -31,7 +31,7 @@ class sokoban_game
                     sTileOld = " ";
                 }
 
-                cUndo( const point &arg, const std::string &arg_tile ) : old( arg ), sTileOld( arg_tile ) {
+                cUndo( point arg, const std::string &arg_tile ) : old( arg ), sTileOld( arg_tile ) {
                 }
         };
 
@@ -47,7 +47,7 @@ class sokoban_game
 
         void parse_level( std::istream &fin );
         bool check_win();
-        int get_wall_connection( const point & );
+        int get_wall_connection( point );
         void draw_level( const catacurses::window &w_sokoban );
         void print_score( const catacurses::window &w_sokoban, int iScore, int iMoves );
     public:

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -115,7 +115,7 @@ bool map::build_transparency_cache( const int zlev )
 
             // calculates transparency of a single tile
             // x,y - coords in map local coords
-            auto calc_transp = [&]( const point & p ) {
+            auto calc_transp = [&]( point  p ) {
                 const point sp = p - sm_offset;
                 float value = LIGHT_TRANSPARENCY_OPEN_AIR;
 
@@ -173,7 +173,7 @@ bool map::build_vision_transparency_cache( const Character &player )
 
     if( player.movement_mode_is( CMM_CROUCH ) ) {
 
-        const auto check_vehicle_coverage = []( const vehicle * veh, const point & p ) -> bool {
+        const auto check_vehicle_coverage = []( const vehicle * veh, point  p ) -> bool {
             return veh->obstacle_at_position( p ) == -1 && ( veh->part_with_feature( p,  "AISLE", true ) != -1 || veh->part_with_feature( p,  "PROTRUSION", true ) != -1 );
         };
 
@@ -185,7 +185,7 @@ bool map::build_vision_transparency_cache( const Character &player )
         }
 
         int i = 0;
-        for( const point &adjacent : eight_adjacent_offsets ) {
+        for( point adjacent : eight_adjacent_offsets ) {
             vision_transparency_cache[i] = VISION_ADJUST_NONE;
 
             // If we're crouching behind an obstacle, we can't see past it.
@@ -670,7 +670,7 @@ map::apparent_light_info map::apparent_light_helper( const level_cache &map_cach
     const float vis = std::max( map_cache.seen_cache[p.x][p.y], map_cache.camera_cache[p.x][p.y] );
     const bool obstructed = vis <= LIGHT_TRANSPARENCY_SOLID + 0.1;
 
-    auto is_opaque = [&map_cache]( const point & p ) {
+    auto is_opaque = [&map_cache]( point  p ) {
         return map_cache.transparency_cache[p.x][p.y] <= LIGHT_TRANSPARENCY_SOLID &&
                get_player_character().pos().xy() != p;
     };
@@ -1142,7 +1142,7 @@ template<int xx, int xy, int yx, int yy, typename T, typename Out,
 void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                 const T( &input_array )[MAPSIZE_X][MAPSIZE_Y],
                 const diagonal_blocks( &blocked_array )[MAPSIZE_X][MAPSIZE_Y],
-                const point &offset, int offsetDistance,
+                point offset, int offsetDistance,
                 T numerator = VISIBILITY_FULL,
                 int row = 1, float start = 1.0f, float end = 0.0f,
                 T cumulative_transparency = LIGHT_TRANSPARENCY_OPEN_AIR );
@@ -1155,12 +1155,12 @@ template<int xx, int xy, int yx, int yy, typename T, typename Out,
 void castLight( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                 const T( &input_array )[MAPSIZE_X][MAPSIZE_Y],
                 const diagonal_blocks( &blocked_array )[MAPSIZE_X][MAPSIZE_Y],
-                const point &offset, const int offsetDistance, const T numerator,
+                point offset, const int offsetDistance, const T numerator,
                 const int row, float start, const float end, T cumulative_transparency )
 {
     constexpr quadrant quad = quadrant_from_x_y( -xx - xy, -yx - yy );
 
-    const auto check_blocked = [ =, &blocked_array]( const point & p ) {
+    const auto check_blocked = [ =, &blocked_array]( point  p ) {
         switch( quad ) {
             case quadrant::NW:
                 return blocked_array[p.x][p.y].nw;
@@ -1269,7 +1269,7 @@ template<typename T, typename Out, T( *calc )( const T &, const T &, const int &
 void castLightAll( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                    const T( &input_array )[MAPSIZE_X][MAPSIZE_Y],
                    const diagonal_blocks( &blocked_array )[MAPSIZE_X][MAPSIZE_Y],
-                   const point &offset, int offsetDistance, T numerator )
+                   point offset, int offsetDistance, T numerator )
 {
     castLight<0, 1, 1, 0, T, Out, calc, check, update_output, accumulate>(
         output_cache, input_array, blocked_array, offset, offsetDistance, numerator );
@@ -1297,7 +1297,7 @@ template void castLightAll<float, four_quadrants, sight_calc, sight_check,
                                four_quadrants( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                                const float ( &input_array )[MAPSIZE_X][MAPSIZE_Y],
                                const diagonal_blocks( &blocked_array )[MAPSIZE_X][MAPSIZE_Y],
-                               const point &offset, int offsetDistance, float numerator );
+                               point offset, int offsetDistance, float numerator );
 
 template void
 castLightAll<float, float, shrapnel_calc, shrapnel_check,
@@ -1306,7 +1306,7 @@ castLightAll<float, float, shrapnel_calc, shrapnel_check,
     float( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
     const float( &input_array )[MAPSIZE_X][MAPSIZE_Y],
     const diagonal_blocks( &blocked_array )[MAPSIZE_X][MAPSIZE_Y],
-    const point &offset, int offsetDistance, float numerator );
+    point offset, int offsetDistance, float numerator );
 
 
 //Alters the vision caches to the player specific version, the restore caches will be filled so it can be undone with restore_vision_transparency_cache
@@ -1318,7 +1318,7 @@ void map::apply_vision_transparency_cache( const tripoint &center, int target_z,
     diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.vehicle_obscured_cache;
 
     int i = 0;
-    for( const point &adjacent : eight_adjacent_offsets ) {
+    for( point adjacent : eight_adjacent_offsets ) {
         const tripoint p = center + adjacent;
         if( !inbounds( p ) ) {
             continue;
@@ -1357,7 +1357,7 @@ void map::restore_vision_transparency_cache( const tripoint &center, int target_
     diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = map_cache.vehicle_obscured_cache;
 
     int i = 0;
-    for( const point &adjacent : eight_adjacent_offsets ) {
+    for( point adjacent : eight_adjacent_offsets ) {
         const tripoint p = center + adjacent;
         if( !inbounds( p ) ) {
             continue;

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -21,8 +21,8 @@ double iso_tangent( double distance, units::angle vertex )
     return std::sqrt( 2 * std::pow( distance, 2 ) * ( 1 - cos( vertex ) ) );
 }
 
-void bresenham( const point &p1, const point &p2, int t,
-                const std::function<bool( const point & )> &interact )
+void bresenham( point p1, point p2, int t,
+                const std::function<bool( point )> &interact )
 {
     // The slope components.
     const point d = p2 - p1;
@@ -255,7 +255,7 @@ void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
 
 //Trying to pull points out of a tripoint vector is messy and
 //probably slow, so leaving two full functions for now
-std::vector<point> line_to( const point &p1, const point &p2, int t )
+std::vector<point> line_to( point p1, point p2, int t )
 {
     std::vector<point> line;
     // Preallocate the number of cells we need instead of allocating them piecewise.
@@ -264,7 +264,7 @@ std::vector<point> line_to( const point &p1, const point &p2, int t )
         line.push_back( p1 );
     } else {
         line.reserve( numCells );
-        bresenham( p1, p2, t, [&line]( const point & new_point ) {
+        bresenham( p1, p2, t, [&line]( point  new_point ) {
             line.push_back( new_point );
             return true;
         } );
@@ -297,13 +297,13 @@ float rl_dist_exact( const tripoint &loc1, const tripoint &loc2 )
     return square_dist( loc1, loc2 );
 }
 
-int manhattan_dist( const point &loc1, const point &loc2 )
+int manhattan_dist( point loc1, point loc2 )
 {
     const point d = ( loc1 - loc2 ).abs();
     return d.x + d.y;
 }
 
-int octile_dist( const point &loc1, const point &loc2, int multiplier )
+int octile_dist( point loc1, point loc2, int multiplier )
 {
     const point d = ( loc1 - loc2 ).abs();
     const int mind = std::min( d.x, d.y );
@@ -311,14 +311,14 @@ int octile_dist( const point &loc1, const point &loc2, int multiplier )
     return ( d.x + d.y - 2 * mind ) * multiplier + mind * multiplier * 99 / 70;
 }
 
-float octile_dist_exact( const point &loc1, const point &loc2 )
+float octile_dist_exact( point loc1, point loc2 )
 {
     const point d = ( loc1 - loc2 ).abs();
     const int mind = std::min( d.x, d.y );
     return d.x + d.y - 2 * mind + mind * M_SQRT2;
 }
 
-units::angle atan2( const point &p )
+units::angle atan2( point p )
 {
     return units::atan2( p.y, p.x );
 }
@@ -379,7 +379,7 @@ static std::tuple<double, double, double> slope_of( const std::vector<tripoint> 
     return std::make_tuple( normDx, normDy, normDz );
 }
 
-float get_normalized_angle( const point &start, const point &end )
+float get_normalized_angle( point start, point end )
 {
     // Taking the abs value of the difference puts the values in the first quadrant.
     const float absx = std::abs( std::max( start.x, end.x ) - std::min( start.x, end.x ) );
@@ -410,7 +410,7 @@ std::vector<tripoint> continue_line( const std::vector<tripoint> &line, const in
     return line_to( line.back(), move_along_line( line.back(), line, distance ) );
 }
 
-direction direction_from( const point &p ) noexcept
+direction direction_from( point p ) noexcept
 {
     return static_cast<direction>( make_xyz( tripoint( p, 0 ) ) );
 }
@@ -420,7 +420,7 @@ direction direction_from( const tripoint &p ) noexcept
     return static_cast<direction>( make_xyz( p ) );
 }
 
-direction direction_from( const point &p1, const point &p2 ) noexcept
+direction direction_from( point p1, point p2 ) noexcept
 {
     return direction_from( p2 - p1 );
 }
@@ -585,7 +585,7 @@ std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &t
 
 // Returns a vector of the adjacent square in the direction of the target,
 // and the two squares flanking it.
-std::vector<point> squares_in_direction( const point &p1, const point &p2 )
+std::vector<point> squares_in_direction( point p1, point p2 )
 {
     int junk = 0;
     point center_square = line_to( p1, p2, junk )[0];

--- a/src/line.h
+++ b/src/line.h
@@ -104,9 +104,9 @@ constexpr inline bool operator!=( const direction &lhs, const T &rhs )
     return !operator==( lhs, rhs );
 }
 
-direction direction_from( const point &p ) noexcept;
+direction direction_from( point p ) noexcept;
 direction direction_from( const tripoint &p ) noexcept;
-direction direction_from( const point &p1, const point &p2 ) noexcept;
+direction direction_from( point p1, point p2 ) noexcept;
 direction direction_from( const tripoint &p, const tripoint &q );
 
 point direction_XY( direction dir );
@@ -120,15 +120,15 @@ std::string direction_suffix( const tripoint &p, const tripoint &q );
  * The actual Bresenham algorithm in 2D and 3D, everything else should call these
  * and pass in an interact functor to iterate across a line between two points.
  */
-void bresenham( const point &p1, const point &p2, int t,
-                const std::function<bool( const point & )> &interact );
+void bresenham( point p1, point p2, int t,
+                const std::function<bool( point )> &interact );
 void bresenham( const tripoint &loc1, const tripoint &loc2, int t, int t2,
                 const std::function<bool( const tripoint & )> &interact );
 
 tripoint move_along_line( const tripoint &loc, const std::vector<tripoint> &line,
                           int distance );
 // The "t" value decides WHICH Bresenham line is used.
-std::vector<point> line_to( const point &p1, const point &p2, int t = 0 );
+std::vector<point> line_to( point p1, point p2, int t = 0 );
 // t and t2 decide which Bresenham line is used.
 std::vector<tripoint> line_to( const tripoint &loc1, const tripoint &loc2, int t = 0, int t2 = 0 );
 // sqrt(dX^2 + dY^2)
@@ -143,7 +143,7 @@ inline float trig_dist( const tripoint &loc1, const tripoint &loc2 )
 {
     return std::sqrt( static_cast<double>( trig_dist_squared( loc1, loc2 ) ) );
 }
-inline float trig_dist( const point &loc1, const point &loc2 )
+inline float trig_dist( point loc1, point loc2 )
 {
     return trig_dist( tripoint( loc1, 0 ), tripoint( loc2, 0 ) );
 }
@@ -154,7 +154,7 @@ inline int square_dist( const tripoint &loc1, const tripoint &loc2 )
     const tripoint d = ( loc1 - loc2 ).abs();
     return std::max( { d.x, d.y, d.z } );
 }
-inline int square_dist( const point &loc1, const point &loc2 )
+inline int square_dist( point loc1, point loc2 )
 {
     const point d = ( loc1 - loc2 ).abs();
     return std::max( d.x, d.y );
@@ -168,7 +168,7 @@ inline int rl_dist( const tripoint &loc1, const tripoint &loc2 )
     }
     return square_dist( loc1, loc2 );
 }
-inline int rl_dist( const point &a, const point &b )
+inline int rl_dist( point a, point b )
 {
     return rl_dist( tripoint( a, 0 ), tripoint( b, 0 ) );
 }
@@ -223,27 +223,27 @@ inline FastDistanceApproximation rl_dist_fast( const tripoint &loc1, const tripo
     }
     return square_dist_fast( loc1, loc2 );
 }
-inline FastDistanceApproximation rl_dist_fast( const point &a, const point &b )
+inline FastDistanceApproximation rl_dist_fast( point a, point b )
 {
     return rl_dist_fast( tripoint( a, 0 ), tripoint( b, 0 ) );
 }
 
 float rl_dist_exact( const tripoint &loc1, const tripoint &loc2 );
 // Sum of distance in both axes
-int manhattan_dist( const point &loc1, const point &loc2 );
+int manhattan_dist( point loc1, point loc2 );
 
 // Travel distance between 2 points on a square grid, assuming diagonal moves
 // cost sqrt(2) and cardinal moves cost 1.
-int octile_dist( const point &loc1, const point &loc2, int multiplier = 1 );
-float octile_dist_exact( const point &loc1, const point &loc2 );
+int octile_dist( point loc1, point loc2, int multiplier = 1 );
+float octile_dist_exact( point loc1, point loc2 );
 
 // get angle of direction represented by point
-units::angle atan2( const point & );
+units::angle atan2( point );
 
 // Get the magnitude of the slope ranging from 0.0 to 1.0
-float get_normalized_angle( const point &start, const point &end );
+float get_normalized_angle( point start, point end );
 std::vector<tripoint> continue_line( const std::vector<tripoint> &line, int distance );
-std::vector<point> squares_in_direction( const point &p1, const point &p2 );
+std::vector<point> squares_in_direction( point p1, point p2 );
 // Returns a vector of squares adjacent to @from that are closer to @to than @from is.
 // Currently limited to the same z-level as @from.
 std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &to );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -63,7 +63,7 @@ struct line_iterable {
     point delta;
     size_t index;
 
-    line_iterable( const point &origin, const point &delta, const std::vector<point> &dline )
+    line_iterable( point origin, point delta, const std::vector<point> &dline )
         : delta_line( dline ), cur_origin( origin ), delta( delta ), index( 0 ) {}
 
     point get() const {
@@ -79,25 +79,25 @@ struct line_iterable {
         cur_origin = cur_origin - delta * ( index == 0 );
         index = ( index + delta_line.size() - 1 ) % delta_line.size();
     }
-    void reset( const point &origin ) {
+    void reset( point origin ) {
         cur_origin = origin;
         index = 0;
     }
 };
 // Orientation of point C relative to line AB
-static int side_of( const point &a, const point &b, const point &c )
+static int side_of( point a, point b, point c )
 {
     int cross = ( ( b.x - a.x ) * ( c.y - a.y ) - ( b.y - a.y ) * ( c.x - a.x ) );
     return ( cross > 0 ) - ( cross < 0 );
 }
 // Tests if point c is between or on lines (a0, a0 + d) and (a1, a1 + d)
-static bool between_or_on( const point &a0, const point &a1, const point &d, const point &c )
+static bool between_or_on( point a0, point a1, point d, point c )
 {
     return side_of( a0, a0 + d, c ) != 1 && side_of( a1, a1 + d, c ) != -1;
 }
 // Builds line until obstructed or outside of region bound by near and far lines. Stores result in set
 static void build_line( spell_detail::line_iterable line, const tripoint &source,
-                        const point &delta, const point &delta_perp, bool ( *test )( const tripoint &, const tripoint & ),
+                        point delta, point delta_perp, bool ( *test )( const tripoint &, const tripoint & ),
                         std::set<tripoint> &result )
 {
     tripoint last_point = source;
@@ -287,7 +287,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
     if( delta_side == 0 ) { // delta is already axis aligned, only need straight lines
         // cw leg
         point prev_point;
-        for( const point &p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
+        for( point p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
             base_line.reset( p );
             if( !test( source + p, source + prev_point ) ) {
                 break;
@@ -298,7 +298,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
         }
         // ccw leg
         prev_point = point_zero;
-        for( const point &p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
+        for( point p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
             base_line.reset( p );
             if( !test( source + p, source + prev_point ) ) {
                 break;
@@ -310,7 +310,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
     } else if( delta_side == 1 ) { // delta is cw of primary axis
         // ccw leg is behind perp axis
         point prev_point;
-        for( const point &p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
+        for( point p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
             base_line.reset( p );
 
             // forward until in
@@ -325,7 +325,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
         }
         prev_point = point_zero;
         // cw leg is before perp axis
-        for( const point &p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
+        for( point p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
             base_line.reset( p );
 
             // move back
@@ -342,7 +342,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
     } else if( delta_side == -1 ) { // delta is ccw of primary axis
         // ccw leg is before perp axis
         point prev_point;
-        for( const point &p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
+        for( point p : line_to( point_zero, unit_cw_perp_axis * -ccw_len ) ) {
             base_line.reset( p );
 
             // move back
@@ -358,7 +358,7 @@ std::set<tripoint> spell_effect::spell_effect_line( const spell &, const tripoin
         }
         prev_point = point_zero;
         // cw leg is behind perp axis
-        for( const point &p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
+        for( point p : line_to( point_zero, unit_cw_perp_axis * cw_len ) ) {
             base_line.reset( p );
 
             // forward until in

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -119,7 +119,7 @@ void main_menu::print_menu_items( const catacurses::window &w_in,
     fold_and_print( w_in, offset, getmaxx( w_in ), c_light_gray, text, ']' );
 }
 
-void main_menu::print_menu( const catacurses::window &w_open, int iSel, const point &offset )
+void main_menu::print_menu( const catacurses::window &w_open, int iSel, point offset )
 {
     // Clear Lines
     werase( w_open );

--- a/src/main_menu.h
+++ b/src/main_menu.h
@@ -99,7 +99,7 @@ class main_menu
          * @param iSel which index in vMenuItems is selected
          * @param offset Menu location in window
          */
-        void print_menu( const catacurses::window &w_open, int iSel, const point &offset );
+        void print_menu( const catacurses::window &w_open, int iSel, point offset );
 
         void display_text( const std::string &text, const std::string &title, int &selected );
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -665,7 +665,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
                 continue;
             }
 
-            const point &collision_point = veh.part( coll.part ).mount;
+            point collision_point = veh.part( coll.part ).mount;
             const int coll_dmg = coll.imp;
             // Shock damage, if the target part is a rotor treat as an aimed hit.
             if( veh.part_info( coll.part ).rotor_diameter() > 0 ) {
@@ -2639,8 +2639,8 @@ bool map::is_outside( const tripoint &p ) const
     return outside_cache[p.x][p.y];
 }
 
-bool map::is_last_ter_wall( const bool no_furn, const point &p,
-                            const point &max, const direction dir ) const
+bool map::is_last_ter_wall( const bool no_furn, point p,
+                            point max, const direction dir ) const
 {
     point mov;
     switch( dir ) {
@@ -6237,7 +6237,7 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
 
         point last_point = F.xy();
         bresenham( F.xy(), T.xy(), bresenham_slope,
-        [this, &visible, &T, &last_point]( const point & new_point ) {
+        [this, &visible, &T, &last_point]( point  new_point ) {
             // Exit before checking the last square, it's still visible even if opaque.
             if( new_point.x == T.x && new_point.y == T.y ) {
                 return false;
@@ -6481,7 +6481,7 @@ bool map::clear_path( const tripoint &f, const tripoint &t, const int range,
         bool is_clear = true;
         point last_point = f.xy();
         bresenham( f.xy(), t.xy(), 0,
-        [this, &is_clear, cost_min, cost_max, &t, &last_point]( const point & new_point ) {
+        [this, &is_clear, cost_min, cost_max, &t, &last_point]( point  new_point ) {
             // Exit before checking the last square, it's still reachable even if it is an obstacle.
             if( new_point.x == t.x && new_point.y == t.y ) {
                 return false;
@@ -6735,7 +6735,7 @@ void map::shift_traps( const tripoint &shift )
 }
 
 template<int SIZE, int MULTIPLIER>
-void shift_bitset_cache( std::bitset<SIZE *SIZE> &cache, const point &s )
+void shift_bitset_cache( std::bitset<SIZE *SIZE> &cache, point s )
 {
     // sx shifts by MULTIPLIER rows, sy shifts by MULTIPLIER columns.
     int shift_amount = s.x * MULTIPLIER + s.y * SIZE * MULTIPLIER;
@@ -6760,11 +6760,11 @@ void shift_bitset_cache( std::bitset<SIZE *SIZE> &cache, const point &s )
 
 template void
 shift_bitset_cache<MAPSIZE_X, SEEX>( std::bitset<MAPSIZE_X *MAPSIZE_X> &cache,
-                                     const point &s );
+                                     point s );
 template void
-shift_bitset_cache<MAPSIZE, 1>( std::bitset<MAPSIZE *MAPSIZE> &cache, const point &s );
+shift_bitset_cache<MAPSIZE, 1>( std::bitset<MAPSIZE *MAPSIZE> &cache, point s );
 
-static inline void shift_tripoint_set( std::set<tripoint> &set, const point &offset,
+static inline void shift_tripoint_set( std::set<tripoint> &set, point offset,
                                        const half_open_rectangle<point> &boundaries )
 {
     std::set<tripoint> old_set = std::move( set );
@@ -6778,7 +6778,7 @@ static inline void shift_tripoint_set( std::set<tripoint> &set, const point &off
 }
 
 template <typename T>
-static inline void shift_tripoint_map( std::map<tripoint, T> &map, const point &offset,
+static inline void shift_tripoint_map( std::map<tripoint, T> &map, point offset,
                                        const half_open_rectangle<point> &boundaries )
 {
     std::map<tripoint, T> old_map = std::move( map );
@@ -6837,7 +6837,7 @@ void map::shift_vehicle_z( vehicle &veh, int z_shift )
 
 }
 
-void map::shift( const point &sp )
+void map::shift( point sp )
 {
     // Special case of 0-shift; refresh the map
     if( sp == point_zero ) {
@@ -8411,16 +8411,16 @@ tinymap::tinymap( int mapsize, bool zlevels )
 {
 }
 
-void map::draw_line_ter( const ter_id &type, const point &p1, const point &p2 )
+void map::draw_line_ter( const ter_id &type, point p1, point p2 )
 {
-    draw_line( [this, type]( const point & p ) {
+    draw_line( [this, type]( point  p ) {
         this->ter_set( p, type );
     }, p1, p2 );
 }
 
-void map::draw_line_furn( const furn_id &type, const point &p1, const point &p2 )
+void map::draw_line_furn( const furn_id &type, point p1, point p2 )
 {
-    draw_line( [this, type]( const point & p ) {
+    draw_line( [this, type]( point  p ) {
         this->furn_set( p, type );
     }, p1, p2 );
 }
@@ -8452,67 +8452,67 @@ void map::draw_fill_background( const weighted_int_list<ter_id> &f )
     draw_square_ter( f, point_zero, point( SEEX * my_MAPSIZE - 1, SEEY * my_MAPSIZE - 1 ) );
 }
 
-void map::draw_square_ter( const ter_id &type, const point &p1, const point &p2 )
+void map::draw_square_ter( const ter_id &type, point p1, point p2 )
 {
-    draw_square( [this, type]( const point & p ) {
+    draw_square( [this, type]( point  p ) {
         this->ter_set( p, type );
     }, p1, p2 );
 }
 
-void map::draw_square_furn( const furn_id &type, const point &p1, const point &p2 )
+void map::draw_square_furn( const furn_id &type, point p1, point p2 )
 {
-    draw_square( [this, type]( const point & p ) {
+    draw_square( [this, type]( point  p ) {
         this->furn_set( p, type );
     }, p1, p2 );
 }
 
-void map::draw_square_ter( ter_id( *f )(), const point &p1, const point &p2 )
+void map::draw_square_ter( ter_id( *f )(), point p1, point p2 )
 {
-    draw_square( [this, f]( const point & p ) {
+    draw_square( [this, f]( point  p ) {
         this->ter_set( p, f() );
     }, p1, p2 );
 }
 
-void map::draw_square_ter( const weighted_int_list<ter_id> &f, const point &p1,
-                           const point &p2 )
+void map::draw_square_ter( const weighted_int_list<ter_id> &f, point p1,
+                           point p2 )
 {
-    draw_square( [this, f]( const point & p ) {
+    draw_square( [this, f]( point  p ) {
         const ter_id *tid = f.pick();
         this->ter_set( p, tid != nullptr ? *tid : t_null );
     }, p1, p2 );
 }
 
-void map::draw_rough_circle_ter( const ter_id &type, const point &p, int rad )
+void map::draw_rough_circle_ter( const ter_id &type, point p, int rad )
 {
-    draw_rough_circle( [this, type]( const point & q ) {
+    draw_rough_circle( [this, type]( point  q ) {
         this->ter_set( q, type );
     }, p, rad );
 }
 
-void map::draw_rough_circle_furn( const furn_id &type, const point &p, int rad )
+void map::draw_rough_circle_furn( const furn_id &type, point p, int rad )
 {
-    draw_rough_circle( [this, type]( const point & q ) {
+    draw_rough_circle( [this, type]( point  q ) {
         this->furn_set( q, type );
     }, p, rad );
 }
 
 void map::draw_circle_ter( const ter_id &type, const rl_vec2d &p, double rad )
 {
-    draw_circle( [this, type]( const point & q ) {
+    draw_circle( [this, type]( point  q ) {
         this->ter_set( q, type );
     }, p, rad );
 }
 
-void map::draw_circle_ter( const ter_id &type, const point &p, int rad )
+void map::draw_circle_ter( const ter_id &type, point p, int rad )
 {
-    draw_circle( [this, type]( const point & q ) {
+    draw_circle( [this, type]( point  q ) {
         this->ter_set( q, type );
     }, p, rad );
 }
 
-void map::draw_circle_furn( const furn_id &type, const point &p, int rad )
+void map::draw_circle_furn( const furn_id &type, point p, int rad )
 {
-    draw_circle( [this, type]( const point & q ) {
+    draw_circle( [this, type]( point  q ) {
         this->furn_set( q, type );
     }, p, rad );
 }
@@ -8617,11 +8617,11 @@ void map::function_over( const tripoint &start, const tripoint &end, Functor fun
 }
 
 void map::scent_blockers( std::array<std::array<char, MAPSIZE_X>, MAPSIZE_Y> &scent_transfer,
-                          const point &min, const point &max )
+                          point min, point max )
 {
     auto reduce = TFLAG_REDUCE_SCENT;
     auto block = TFLAG_NO_SCENT;
-    auto fill_values = [&]( const tripoint & gp, const submap * sm, const point & lp ) {
+    auto fill_values = [&]( const tripoint & gp, const submap * sm, point  lp ) {
         // We need to generate the x/y coordinates, because we can't get them "for free"
         const point p = lp + sm_to_ms_copy( gp.xy() );
         if( sm->get_ter( lp ).obj().has_flag( block ) ) {

--- a/src/map.h
+++ b/src/map.h
@@ -515,7 +515,7 @@ class map
          * position of the map (@ref abs_sub) plus the shift vector.
          * Note: the map must have been loaded before this can be called.
          */
-        void shift( const point &s );
+        void shift( point s );
         /**
          * Moves the map vertically to (not by!) newz.
          * Does not actually shift anything, only forces cache updates.
@@ -559,15 +559,15 @@ class map
         * n > 0     | x*n turns to move past this
         */
         int move_cost( const tripoint &p, const vehicle *ignored_vehicle = nullptr ) const;
-        int move_cost( const point &p, const vehicle *ignored_vehicle = nullptr ) const {
+        int move_cost( point p, const vehicle *ignored_vehicle = nullptr ) const {
             return move_cost( tripoint( p, abs_sub.z ), ignored_vehicle );
         }
         bool impassable( const tripoint &p ) const;
-        bool impassable( const point &p ) const {
+        bool impassable( point p ) const {
             return !passable( p );
         }
         bool passable( const tripoint &p ) const;
-        bool passable( const point &p ) const {
+        bool passable( point p ) const {
             return passable( tripoint( p, abs_sub.z ) );
         }
         bool is_wall_adjacent( const tripoint &center ) const;
@@ -576,7 +576,7 @@ class map
         * Similar behavior to `move_cost()`, but ignores vehicles.
         */
         int move_cost_ter_furn( const tripoint &p ) const;
-        int move_cost_ter_furn( const point &p ) const {
+        int move_cost_ter_furn( point p ) const {
             return move_cost_ter_furn( tripoint( p, abs_sub.z ) );
         }
         bool impassable_ter_furn( const tripoint &p ) const;
@@ -770,12 +770,12 @@ class map
 
         // Furniture
         void set( const tripoint &p, const ter_id &new_terrain, const furn_id &new_furniture );
-        void set( const point &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
+        void set( point p, const ter_id &new_terrain, const furn_id &new_furniture ) {
             furn_set( p, new_furniture );
             ter_set( p, new_terrain );
         }
         std::string name( const tripoint &p );
-        std::string name( const point &p ) {
+        std::string name( point p ) {
             return name( tripoint( p, abs_sub.z ) );
         }
         std::string disp_name( const tripoint &p );
@@ -785,11 +785,11 @@ class map
         */
         std::string obstacle_name( const tripoint &p );
         bool has_furn( const tripoint &p ) const;
-        bool has_furn( const point &p ) const {
+        bool has_furn( point p ) const {
             return has_furn( tripoint( p, abs_sub.z ) );
         }
         furn_id furn( const tripoint &p ) const;
-        furn_id furn( const point &p ) const {
+        furn_id furn( point p ) const {
             return furn( tripoint( p, abs_sub.z ) );
         }
         /**
@@ -801,18 +801,18 @@ class map
         */
         void furn_set( const tripoint &p, const furn_id &new_furniture,
                        cata::poly_serialized<active_tile_data> new_active = nullptr );
-        void furn_set( const point &p, const furn_id &new_furniture ) {
+        void furn_set( point p, const furn_id &new_furniture ) {
             furn_set( tripoint( p, abs_sub.z ), new_furniture );
         }
         std::string furnname( const tripoint &p );
-        std::string furnname( const point &p ) {
+        std::string furnname( point p ) {
             return furnname( tripoint( p, abs_sub.z ) );
         }
         bool can_move_furniture( const tripoint &pos, player *p = nullptr );
 
         // Terrain
         ter_id ter( const tripoint &p ) const;
-        ter_id ter( const point &p ) const {
+        ter_id ter( point p ) const {
             return ter( tripoint( p, abs_sub.z ) );
         }
 
@@ -837,12 +837,12 @@ class map
         furn_id get_furn_transforms_into( const tripoint &p ) const;
 
         bool ter_set( const tripoint &p, const ter_id &new_terrain );
-        bool ter_set( const point &p, const ter_id &new_terrain ) {
+        bool ter_set( point p, const ter_id &new_terrain ) {
             return ter_set( tripoint( p, abs_sub.z ), new_terrain );
         }
 
         std::string tername( const tripoint &p ) const;
-        std::string tername( const point &p ) const {
+        std::string tername( point p ) const {
             return tername( tripoint( p, abs_sub.z ) );
         }
 
@@ -895,32 +895,32 @@ class map
         // Flags
         // Words relevant to terrain (sharp, etc)
         std::string features( const tripoint &p );
-        std::string features( const point &p ) {
+        std::string features( point p ) {
             return features( tripoint( p, abs_sub.z ) );
         }
         // Checks terrain, furniture and vehicles
         bool has_flag( const std::string &flag, const tripoint &p ) const;
-        bool has_flag( const std::string &flag, const point &p ) const {
+        bool has_flag( const std::string &flag, point p ) const {
             return has_flag( flag, tripoint( p, abs_sub.z ) );
         }
         // True if items can be dropped in this tile
         bool can_put_items( const tripoint &p ) const;
-        bool can_put_items( const point &p ) const {
+        bool can_put_items( point p ) const {
             return can_put_items( tripoint( p, abs_sub.z ) );
         }
         // True if items can be placed in this tile
         bool can_put_items_ter_furn( const tripoint &p ) const;
-        bool can_put_items_ter_furn( const point &p ) const {
+        bool can_put_items_ter_furn( point p ) const {
             return can_put_items_ter_furn( tripoint( p, abs_sub.z ) );
         }
         // Checks terrain
         bool has_flag_ter( const std::string &flag, const tripoint &p ) const;
-        bool has_flag_ter( const std::string &flag, const point &p ) const {
+        bool has_flag_ter( const std::string &flag, point p ) const {
             return has_flag_ter( flag, tripoint( p, abs_sub.z ) );
         }
         // Checks furniture
         bool has_flag_furn( const std::string &flag, const tripoint &p ) const;
-        bool has_flag_furn( const std::string &flag, const point &p ) const {
+        bool has_flag_furn( const std::string &flag, point p ) const {
             return has_flag_furn( flag, tripoint( p, abs_sub.z ) );
         }
         // Checks vehicle part flag
@@ -929,66 +929,66 @@ class map
         bool has_flag_furn_or_vpart( const std::string &flag, const tripoint &p ) const;
         // Checks terrain or furniture
         bool has_flag_ter_or_furn( const std::string &flag, const tripoint &p ) const;
-        bool has_flag_ter_or_furn( const std::string &flag, const point &p ) const {
+        bool has_flag_ter_or_furn( const std::string &flag, point p ) const {
             return has_flag_ter_or_furn( flag, tripoint( p, abs_sub.z ) );
         }
         // Fast "oh hai it's update_scent/lightmap/draw/monmove/self/etc again, what about this one" flag checking
         // Checks terrain, furniture and vehicles
         bool has_flag( ter_bitflags flag, const tripoint &p ) const;
-        bool has_flag( ter_bitflags flag, const point &p ) const {
+        bool has_flag( ter_bitflags flag, point p ) const {
             return has_flag( flag, tripoint( p, abs_sub.z ) );
         }
         // Checks terrain
         bool has_flag_ter( ter_bitflags flag, const tripoint &p ) const;
-        bool has_flag_ter( ter_bitflags flag, const point &p ) const {
+        bool has_flag_ter( ter_bitflags flag, point p ) const {
             return has_flag_ter( flag, tripoint( p, abs_sub.z ) );
         }
         // Checks furniture
         bool has_flag_furn( ter_bitflags flag, const tripoint &p ) const;
-        bool has_flag_furn( ter_bitflags flag, const point &p ) const {
+        bool has_flag_furn( ter_bitflags flag, point p ) const {
             return has_flag_furn( flag, tripoint( p, abs_sub.z ) );
         }
         // Checks terrain or furniture
         bool has_flag_ter_or_furn( ter_bitflags flag, const tripoint &p ) const;
-        bool has_flag_ter_or_furn( ter_bitflags flag, const point &p ) const {
+        bool has_flag_ter_or_furn( ter_bitflags flag, point p ) const {
             return has_flag_ter_or_furn( flag, tripoint( p, abs_sub.z ) );
         }
 
         // Bashable
         /** Returns true if there is a bashable vehicle part or the furn/terrain is bashable at p */
         bool is_bashable( const tripoint &p, bool allow_floor = false ) const;
-        bool is_bashable( const point &p ) const {
+        bool is_bashable( point p ) const {
             return is_bashable( tripoint( p, abs_sub.z ) );
         }
         /** Returns true if the terrain at p is bashable */
         bool is_bashable_ter( const tripoint &p, bool allow_floor = false ) const;
-        bool is_bashable_ter( const point &p ) const {
+        bool is_bashable_ter( point p ) const {
             return is_bashable_ter( tripoint( p, abs_sub.z ) );
         }
         /** Returns true if the furniture at p is bashable */
         bool is_bashable_furn( const tripoint &p ) const;
-        bool is_bashable_furn( const point &p ) const {
+        bool is_bashable_furn( point p ) const {
             return is_bashable_furn( tripoint( p, abs_sub.z ) );
         }
         /** Returns true if the furniture or terrain at p is bashable */
         bool is_bashable_ter_furn( const tripoint &p, bool allow_floor = false ) const;
-        bool is_bashable_ter_furn( const point &p ) const {
+        bool is_bashable_ter_furn( point p ) const {
             return is_bashable_ter_furn( tripoint( p, abs_sub.z ) );
         }
         /** Returns max_str of the furniture or terrain at p */
         int bash_strength( const tripoint &p, bool allow_floor = false ) const;
-        int bash_strength( const point &p ) const {
+        int bash_strength( point p ) const {
             return bash_strength( tripoint( p, abs_sub.z ) );
         }
         /** Returns min_str of the furniture or terrain at p */
         int bash_resistance( const tripoint &p, bool allow_floor = false ) const;
-        int bash_resistance( const point &p ) const {
+        int bash_resistance( point p ) const {
             return bash_resistance( tripoint( p, abs_sub.z ) );
         }
         /** Returns a success rating from -1 to 10 for a given tile based on a set strength, used for AI movement planning
         *  Values roughly correspond to 10% increment chances of success on a given bash, rounded down. -1 means the square is not bashable */
         int bash_rating( int str, const tripoint &p, bool allow_floor = false ) const;
-        int bash_rating( const int str, const point &p ) const {
+        int bash_rating( const int str, point p ) const {
             return bash_rating( str, tripoint( p, abs_sub.z ) );
         }
 
@@ -1005,7 +1005,7 @@ class map
         }
 
         bool is_outside( const tripoint &p ) const;
-        bool is_outside( const point &p ) const {
+        bool is_outside( point p ) const {
             return is_outside( tripoint( p, abs_sub.z ) );
         }
         /**
@@ -1015,11 +1015,11 @@ class map
          * @return true if the terrain can be dived into; false if not.
          */
         bool is_divable( const tripoint &p ) const;
-        bool is_divable( const point &p ) const {
+        bool is_divable( point p ) const {
             return is_divable( tripoint( p, abs_sub.z ) );
         }
         bool is_water_shallow_current( const tripoint &p ) const;
-        bool is_water_shallow_current( const point &p ) const {
+        bool is_water_shallow_current( point p ) const {
             return is_water_shallow_current( tripoint( p, abs_sub.z ) );
         }
 
@@ -1031,8 +1031,8 @@ class map
          *  @param dir Direction of check
          *  @return true if from x to xmax or y to ymax depending on direction
          *  all terrain is floor and the last terrain is a wall */
-        bool is_last_ter_wall( bool no_furn, const point &p,
-                               const point &max, direction dir ) const;
+        bool is_last_ter_wall( bool no_furn, point p,
+                               point max, direction dir ) const;
 
         /**
          * Checks if there are any tinder flagged items on the tile.
@@ -1051,22 +1051,22 @@ class map
         point random_outdoor_tile();
         // mapgen
 
-        void draw_line_ter( const ter_id &type, const point &p1, const point &p2 );
-        void draw_line_furn( const furn_id &type, const point &p1, const point &p2 );
+        void draw_line_ter( const ter_id &type, point p1, point p2 );
+        void draw_line_furn( const furn_id &type, point p1, point p2 );
         void draw_fill_background( const ter_id &type );
         void draw_fill_background( ter_id( *f )() );
         void draw_fill_background( const weighted_int_list<ter_id> &f );
 
-        void draw_square_ter( const ter_id &type, const point &p1, const point &p2 );
-        void draw_square_furn( const furn_id &type, const point &p1, const point &p2 );
-        void draw_square_ter( ter_id( *f )(), const point &p1, const point &p2 );
-        void draw_square_ter( const weighted_int_list<ter_id> &f, const point &p1,
-                              const point &p2 );
-        void draw_rough_circle_ter( const ter_id &type, const point &p, int rad );
-        void draw_rough_circle_furn( const furn_id &type, const point &p, int rad );
+        void draw_square_ter( const ter_id &type, point p1, point p2 );
+        void draw_square_furn( const furn_id &type, point p1, point p2 );
+        void draw_square_ter( ter_id( *f )(), point p1, point p2 );
+        void draw_square_ter( const weighted_int_list<ter_id> &f, point p1,
+                              point p2 );
+        void draw_rough_circle_ter( const ter_id &type, point p, int rad );
+        void draw_rough_circle_furn( const furn_id &type, point p, int rad );
         void draw_circle_ter( const ter_id &type, const rl_vec2d &p, double rad );
-        void draw_circle_ter( const ter_id &type, const point &p, int rad );
-        void draw_circle_furn( const furn_id &type, const point &p, int rad );
+        void draw_circle_ter( const ter_id &type, point p, int rad );
+        void draw_circle_furn( const furn_id &type, point p, int rad );
 
         void add_corpse( const tripoint &p );
 
@@ -1150,7 +1150,7 @@ class map
         // Radiation
         int get_radiation( const tripoint &p ) const;
         void set_radiation( const tripoint &p, int value );
-        void set_radiation( const point &p, const int value ) {
+        void set_radiation( point p, const int value ) {
             set_radiation( tripoint( p, abs_sub.z ), value );
         }
 
@@ -1158,7 +1158,7 @@ class map
         *  (decrement it if delta is negative)
         */
         void adjust_radiation( const tripoint &p, int delta );
-        void adjust_radiation( const point &p, const int delta ) {
+        void adjust_radiation( point p, const int delta ) {
             adjust_radiation( tripoint( p, abs_sub.z ), delta );
         }
 
@@ -1167,7 +1167,7 @@ class map
         int get_temperature( const tripoint &p ) const;
         // Set temperature for all four submap quadrants
         void set_temperature( const tripoint &p, int temperature );
-        void set_temperature( const point &p, int new_temperature ) {
+        void set_temperature( point p, int new_temperature ) {
             set_temperature( tripoint( p, abs_sub.z ), new_temperature );
         }
 
@@ -1176,22 +1176,22 @@ class map
         std::vector<tripoint> check_submap_active_item_consistency();
         // Accessor that returns a wrapped reference to an item stack for safe modification.
         map_stack i_at( const tripoint &p );
-        map_stack i_at( const point &p ) {
+        map_stack i_at( point p ) {
             return i_at( tripoint( p, abs_sub.z ) );
         }
         item water_from( const tripoint &p );
         void i_clear( const tripoint &p );
-        void i_clear( const point &p ) {
+        void i_clear( point p ) {
             i_clear( tripoint( p, abs_sub.z ) );
         }
         // i_rem() methods that return values act like container::erase(),
         // returning an iterator to the next item after removal.
         map_stack::iterator i_rem( const tripoint &p, map_stack::const_iterator it );
-        map_stack::iterator i_rem( const point &location, map_stack::const_iterator it ) {
+        map_stack::iterator i_rem( point location, map_stack::const_iterator it ) {
             return i_rem( tripoint( location, abs_sub.z ), it );
         }
         void i_rem( const tripoint &p, item *it );
-        void i_rem( const point &p, item *it ) {
+        void i_rem( point p, item *it ) {
             i_rem( tripoint( p, abs_sub.z ), it );
         }
         void spawn_artifact( const tripoint &p );
@@ -1199,7 +1199,7 @@ class map
         void spawn_item( const tripoint &p, const itype_id &type_id,
                          unsigned quantity = 1, int charges = 0,
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0 );
-        void spawn_item( const point &p, const itype_id &type_id,
+        void spawn_item( point p, const itype_id &type_id,
                          unsigned quantity = 1, int charges = 0,
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0 ) {
             spawn_item( tripoint( p, abs_sub.z ), type_id, quantity, charges, birthday, damlevel );
@@ -1212,7 +1212,7 @@ class map
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0 ) {
             spawn_item( p, itype_id( type_id ), quantity, charges, birthday, damlevel );
         }
-        void spawn_item( const point &p, const std::string &type_id,
+        void spawn_item( point p, const std::string &type_id,
                          unsigned quantity = 1, int charges = 0,
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0 ) {
             spawn_item( tripoint( p, abs_sub.z ), type_id, quantity, charges, birthday, damlevel );
@@ -1230,7 +1230,7 @@ class map
          *  @warning function is relatively expensive and meant for user initiated actions, not mapgen
          */
         item &add_item_or_charges( const tripoint &pos, item obj, bool overflow = true );
-        item &add_item_or_charges( const point &p, item obj, bool overflow = true ) {
+        item &add_item_or_charges( point p, item obj, bool overflow = true ) {
             return add_item_or_charges( tripoint( p, abs_sub.z ), obj, overflow );
         }
 
@@ -1242,11 +1242,11 @@ class map
          * @returns The item that got added, or nulitem.
          */
         item &add_item( const tripoint &p, item new_item );
-        void add_item( const point &p, item new_item ) {
+        void add_item( point p, item new_item ) {
             add_item( tripoint( p, abs_sub.z ), new_item );
         }
         item &spawn_an_item( const tripoint &p, item new_item, int charges, int damlevel );
-        void spawn_an_item( const point &p, item new_item, int charges, int damlevel ) {
+        void spawn_an_item( point p, item new_item, int charges, int damlevel ) {
             spawn_an_item( tripoint( p, abs_sub.z ), new_item, charges, damlevel );
         }
 
@@ -1303,8 +1303,8 @@ class map
         std::vector<item *> place_items( const item_group_id &loc, int chance, const tripoint &p1,
                                          const tripoint &p2, bool ongrass, const time_point &turn,
                                          int magazine = 0, int ammo = 0 );
-        std::vector<item *> place_items( const item_group_id &loc, int chance, const point &p1,
-                                         const point &p2, bool ongrass, const time_point &turn,
+        std::vector<item *> place_items( const item_group_id &loc, int chance, point p1,
+                                         point p2, bool ongrass, const time_point &turn,
                                          int magazine = 0, int ammo = 0 ) {
             return place_items( loc, chance, tripoint( p1, abs_sub.z ), tripoint( p2, abs_sub.z ), ongrass,
                                 turn, magazine, ammo );
@@ -1322,12 +1322,12 @@ class map
 
         // Similar to spawn_an_item, but spawns a list of items, or nothing if the list is empty.
         std::vector<item *> spawn_items( const tripoint &p, const std::vector<item> &new_items );
-        void spawn_items( const point &p, const std::vector<item> &new_items ) {
+        void spawn_items( point p, const std::vector<item> &new_items ) {
             spawn_items( tripoint( p, abs_sub.z ), new_items );
         }
 
         void create_anomaly( const tripoint &p, artifact_natural_property prop, bool create_rubble = true );
-        void create_anomaly( const point &cp, artifact_natural_property prop, bool create_rubble = true ) {
+        void create_anomaly( point cp, artifact_natural_property prop, bool create_rubble = true ) {
             create_anomaly( tripoint( cp, abs_sub.z ), prop, create_rubble );
         }
 
@@ -1461,7 +1461,7 @@ class map
          * Should be way faster than if done in `game.cpp` using public map functions.
          */
         void scent_blockers( std::array<std::array<char, MAPSIZE_X>, MAPSIZE_Y> &scent_transfer,
-                             const point &min, const point &max );
+                             point min, point max );
 
         // Computers
         computer *computer_at( const tripoint &p );
@@ -1522,18 +1522,18 @@ class map
         // mapgen.cpp functions
         void generate( const tripoint &p, const time_point &when );
         void place_spawns( const mongroup_id &group, int chance,
-                           const point &p1, const point &p2, float density,
+                           point p1, point p2, float density,
                            bool individual = false, bool friendly = false, const std::string &name = "NONE",
                            int mission_id = -1 );
-        void place_gas_pump( const point &p, int charges, const std::string &fuel_type );
-        void place_gas_pump( const point &p, int charges );
+        void place_gas_pump( point p, int charges, const std::string &fuel_type );
+        void place_gas_pump( point p, int charges );
         // 6 liters at 250 ml per charge
-        void place_toilet( const point &p, int charges = 6 * 4 );
-        void place_vending( const point &p, const item_group_id &type, bool reinforced = false );
+        void place_toilet( point p, int charges = 6 * 4 );
+        void place_vending( point p, const item_group_id &type, bool reinforced = false );
         // places an NPC, if static NPCs are enabled or if force is true
-        character_id place_npc( const point &p, const string_id<npc_template> &type,
+        character_id place_npc( point p, const string_id<npc_template> &type,
                                 bool force = false );
-        void apply_faction_ownership( const point &p1, const point &p2, const faction_id &id );
+        void apply_faction_ownership( point p1, point p2, const faction_id &id );
         void add_spawn( const mtype_id &type, int count, const tripoint &p,
                         bool friendly = false, int faction_id = -1, int mission_id = -1,
                         const std::string &name = "NONE" ) const;
@@ -1547,13 +1547,13 @@ class map
         vehicle *add_vehicle( const vgroup_id &type, const tripoint &p, units::angle dir,
                               int init_veh_fuel = -1, int init_veh_status = -1,
                               bool merge_wrecks = true );
-        vehicle *add_vehicle( const vgroup_id &type, const point &p, units::angle dir,
+        vehicle *add_vehicle( const vgroup_id &type, point p, units::angle dir,
                               int init_veh_fuel = -1, int init_veh_status = -1,
                               bool merge_wrecks = true );
         vehicle *add_vehicle( const vproto_id &type, const tripoint &p, units::angle dir,
                               int init_veh_fuel = -1, int init_veh_status = -1,
                               bool merge_wrecks = true );
-        vehicle *add_vehicle( const vproto_id &type, const point &p, units::angle dir,
+        vehicle *add_vehicle( const vproto_id &type, point p, units::angle dir,
                               int init_veh_fuel = -1, int init_veh_status = -1,
                               bool merge_wrecks = true );
         // Light/transparency
@@ -1593,18 +1593,18 @@ class map
          * Output is in the same scale, but in global system.
          */
         tripoint getabs( const tripoint &p ) const;
-        point getabs( const point &p ) const {
+        point getabs( point p ) const {
             return getabs( tripoint( p, abs_sub.z ) ).xy();
         }
         /**
          * Inverse of @ref getabs
          */
         tripoint getlocal( const tripoint &p ) const;
-        point getlocal( const point &p ) const {
+        point getlocal( point p ) const {
             return getlocal( tripoint( p, abs_sub.z ) ).xy();
         }
         virtual bool inbounds( const tripoint &p ) const;
-        bool inbounds( const point &p ) const {
+        bool inbounds( point p ) const {
             return inbounds( tripoint( p, 0 ) );
         }
 
@@ -1658,7 +1658,7 @@ class map
     protected:
         void saven( const tripoint &grid );
         void loadn( const tripoint &grid, bool update_vehicles );
-        void loadn( const point &grid, bool update_vehicles ) {
+        void loadn( point grid, bool update_vehicles ) {
             if( zlevels ) {
                 for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
                     loadn( tripoint( grid, gridz ), update_vehicles );
@@ -1799,7 +1799,7 @@ class map
          * (p) must be a valid coordinate, check with @ref inbounds.
          */
         submap *get_submap_at( const tripoint &p ) const;
-        submap *get_submap_at( const point &p ) const {
+        submap *get_submap_at( point p ) const {
             return get_submap_at( tripoint( p, abs_sub.z ) );
         }
         /**
@@ -1808,7 +1808,7 @@ class map
          * Also writes the position within the submap to offset_p
          */
         submap *get_submap_at( const tripoint &p, point &offset_p ) const;
-        submap *get_submap_at( const point &p, point &offset_p ) const {
+        submap *get_submap_at( point p, point &offset_p ) const {
             return get_submap_at( { p, abs_sub.z }, offset_p );
         }
         /**
@@ -1816,7 +1816,7 @@ class map
          * be valid: 0 <= x < my_MAPSIZE, same for y.
          * z must be between -OVERMAP_DEPTH and OVERMAP_HEIGHT
          */
-        submap *get_submap_at_grid( const point &gridp ) const {
+        submap *get_submap_at_grid( point gridp ) const {
             return getsubmap( get_nonant( gridp ) );
         }
         submap *get_submap_at_grid( const tripoint &gridp ) const;
@@ -1827,7 +1827,7 @@ class map
          * Version with z-levels checks for z between -OVERMAP_DEPTH and OVERMAP_HEIGHT
          */
         size_t get_nonant( const tripoint &gridp ) const;
-        size_t get_nonant( const point &gridp ) const {
+        size_t get_nonant( point gridp ) const {
             return get_nonant( { gridp, abs_sub.z } );
         }
         /**
@@ -2041,7 +2041,7 @@ class map
 map &get_map();
 
 template<int SIZE, int MULTIPLIER>
-void shift_bitset_cache( std::bitset<SIZE *SIZE> &cache, const point &s );
+void shift_bitset_cache( std::bitset<SIZE *SIZE> &cache, point s );
 
 bool ter_furn_has_flag( const ter_t &ter, const furn_t &furn, ter_bitflags flag );
 class tinymap : public map

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -615,7 +615,7 @@ static bool mx_roadblock( map &m, const tripoint &abs_sub )
     const bool road_at_west = is_ot_match( "road", west, ot_match_type::type );
     const bool road_at_east = is_ot_match( "road", east, ot_match_type::type );
 
-    const auto spawn_turret = [&]( const point & p ) {
+    const auto spawn_turret = [&]( point  p ) {
         if( one_in( 3 ) ) {
             m.add_spawn( mon_turret_longrange, 1, { p, abs_sub.z } );
         } else if( one_in( 2 ) ) {
@@ -1624,7 +1624,7 @@ static bool mx_crater( map &m, const tripoint &abs_sub )
     return true;
 }
 
-static void place_fumarole( map &m, const point &p1, const point &p2, std::set<point> &ignited )
+static void place_fumarole( map &m, point p1, point p2, std::set<point> &ignited )
 {
     // Tracks points nearby for ignition after the lava is placed
     //std::set<point> ignited;

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1128,7 +1128,7 @@ void map::process_fields_in_submap( submap *const current_submap,
 
                             std::vector<point> candidate_positions =
                                 squares_in_direction( p.xy(), point( g->u.posx(), g->u.posy() ) );
-                            for( const point &candidate_position : candidate_positions ) {
+                            for( point candidate_position : candidate_positions ) {
                                 field &target_field = get_field( tripoint( candidate_position, p.z ) );
                                 // Only shift if there are no bees already there.
                                 // TODO: Figure out a way to merge bee fields without allowing

--- a/src/map_memory.h
+++ b/src/map_memory.h
@@ -40,7 +40,7 @@ struct mm_submap {
             return tiles.empty() && symbols.empty();
         }
 
-        inline const memorized_terrain_tile &tile( const point &p ) const {
+        inline const memorized_terrain_tile &tile( point p ) const {
             if( tiles.empty() ) {
                 return default_tile;
             } else {
@@ -48,7 +48,7 @@ struct mm_submap {
             }
         }
 
-        inline void set_tile( const point &p, const memorized_terrain_tile &value ) {
+        inline void set_tile( point p, const memorized_terrain_tile &value ) {
             if( tiles.empty() ) {
                 // call 'reserve' first to force allocation of exact size
                 tiles.reserve( SEEX * SEEY );
@@ -57,7 +57,7 @@ struct mm_submap {
             tiles[p.y * SEEX + p.x] = value;
         }
 
-        inline int symbol( const point &p ) const {
+        inline int symbol( point p ) const {
             if( symbols.empty() ) {
                 return default_symbol;
             } else {
@@ -65,7 +65,7 @@ struct mm_submap {
             }
         }
 
-        inline void set_symbol( const point &p, int value ) {
+        inline void set_symbol( point p, int value ) {
             if( symbols.empty() ) {
                 // call 'reserve' first to force allocation of exact size
                 symbols.reserve( SEEX * SEEY );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -100,7 +100,7 @@ static const trait_id trait_NPC_STATIC_NPC( "NPC_STATIC_NPC" );
 
 static constexpr int MON_RADIUS = 3;
 
-static void science_room( map *m, const point &p1, const point &p2, int z, int rotate );
+static void science_room( map *m, point p1, point p2, int z, int rotate );
 
 // (x,y,z) are absolute coordinates of a submap
 // x%2 and y%2 must be 0!
@@ -426,7 +426,7 @@ static void set_mapgen_defer( const JsonObject &jsi, const std::string &member,
  * load a single mapgen json structure; this can be inside an overmap_terrain, or on it's own.
  */
 std::shared_ptr<mapgen_function>
-load_mapgen_function( const JsonObject &jio, const point &offset, const point &total )
+load_mapgen_function( const JsonObject &jio, point offset, point total )
 {
     int mgweight = jio.get_int( "weight", 1000 );
     if( mgweight <= 0 || jio.get_bool( "disabled", false ) ) {
@@ -452,7 +452,7 @@ load_mapgen_function( const JsonObject &jio, const point &offset, const point &t
 }
 
 void load_and_add_mapgen_function( const JsonObject &jio, const std::string &id_base,
-                                   const point &offset, const point &total )
+                                   point offset, point total )
 {
     std::shared_ptr<mapgen_function> f = load_mapgen_function( jio, offset, total );
     if( f ) {
@@ -557,7 +557,7 @@ void reset_mapgens()
 ///// 2 - right after init() finishes parsing all game json and terrain info/etc is set..
 /////   ...parse more json! (mapgen_function_json)
 
-size_t mapgen_function_json_base::calc_index( const point &p ) const
+size_t mapgen_function_json_base::calc_index( point p ) const
 {
     if( p.x >= mapgensize.x ) {
         debugmsg( "invalid value %zu for x in calc_index", p.x );
@@ -569,7 +569,7 @@ size_t mapgen_function_json_base::calc_index( const point &p ) const
 }
 
 static bool common_check_bounds( const jmapgen_int &x, const jmapgen_int &y,
-                                 const point &mapgensize, const JsonObject &jso )
+                                 point mapgensize, const JsonObject &jso )
 {
     half_open_rectangle<point> bounds( point_zero, mapgensize );
     if( !bounds.contains( point( x.val, y.val ) ) ) {
@@ -608,7 +608,7 @@ mapgen_function_json_base::mapgen_function_json_base( const json_source_location
 mapgen_function_json_base::~mapgen_function_json_base() = default;
 
 mapgen_function_json::mapgen_function_json( const json_source_location &jsrcloc, const int w,
-        const point &grid_offset, const point &grid_total )
+        point grid_offset, point grid_total )
     : mapgen_function( w )
     , mapgen_function_json_base( jsrcloc )
     , fill_ter( t_null )
@@ -799,7 +799,7 @@ jmapgen_place::jmapgen_place( const JsonObject &jsi )
 {
 }
 
-void jmapgen_place::offset( const point &offset )
+void jmapgen_place::offset( point offset )
 {
     x.val -= offset.x;
     x.valmax -= offset.x;
@@ -839,7 +839,7 @@ class jmapgen_alternativly : public jmapgen_piece
                 chosen->get().apply( dat, x, y );
             }
         }
-        bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
+        bool has_vehicle_collision( mapgendata &dat, point p ) const override {
             return dat.m.veh_at( tripoint( p, dat.zlevel() ) ).has_value();
         }
 };
@@ -971,7 +971,7 @@ class jmapgen_sign : public jmapgen_piece
             replace_name_tags( signtext );
             return signtext;
         }
-        bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
+        bool has_vehicle_collision( mapgendata &dat, point p ) const override {
             return dat.m.veh_at( tripoint( p, dat.zlevel() ) ).has_value();
         }
 };
@@ -1045,7 +1045,7 @@ class jmapgen_vending_machine : public jmapgen_piece
             dat.m.furn_set( r, f_null );
             dat.m.place_vending( r, item_group, reinforced );
         }
-        bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
+        bool has_vehicle_collision( mapgendata &dat, point p ) const override {
             return dat.m.veh_at( tripoint( p, dat.zlevel() ) ).has_value();
         }
 };
@@ -1070,7 +1070,7 @@ class jmapgen_toilet : public jmapgen_piece
                 dat.m.place_toilet( r, charges );
             }
         }
-        bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
+        bool has_vehicle_collision( mapgendata &dat, point p ) const override {
             return dat.m.veh_at( tripoint( p, dat.zlevel() ) ).has_value();
         }
 };
@@ -1107,7 +1107,7 @@ class jmapgen_gaspump : public jmapgen_piece
                 dat.m.place_gas_pump( r, charges );
             }
         }
-        bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
+        bool has_vehicle_collision( mapgendata &dat, point p ) const override {
             return dat.m.veh_at( tripoint( p, dat.zlevel() ) ).has_value();
         }
 };
@@ -1390,7 +1390,7 @@ class jmapgen_vehicle : public jmapgen_piece
             }
             dat.m.add_vehicle( type, point( x.get(), y.get() ), random_entry( rotation ), fuel, status );
         }
-        bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
+        bool has_vehicle_collision( mapgendata &dat, point p ) const override {
             return dat.m.veh_at( tripoint( p, dat.zlevel() ) ).has_value();
         }
 };
@@ -1459,7 +1459,7 @@ class jmapgen_trap : public jmapgen_piece
             const tripoint actual_loc = tripoint( x.get(), y.get(), dat.m.get_abs_sub().z );
             dat.m.trap_set( actual_loc, id );
         }
-        bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
+        bool has_vehicle_collision( mapgendata &dat, point p ) const override {
             return dat.m.veh_at( tripoint( p, dat.zlevel() ) ).has_value();
         }
 };
@@ -1476,7 +1476,7 @@ class jmapgen_furniture : public jmapgen_piece
         void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const override {
             dat.m.furn_set( point( x.get(), y.get() ), id );
         }
-        bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
+        bool has_vehicle_collision( mapgendata &dat, point p ) const override {
             return dat.m.veh_at( tripoint( p, dat.zlevel() ) ).has_value();
         }
 };
@@ -1501,7 +1501,7 @@ class jmapgen_terrain : public jmapgen_piece
                 }
             }
         }
-        bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
+        bool has_vehicle_collision( mapgendata &dat, point p ) const override {
             return dat.m.veh_at( tripoint( p, dat.zlevel() ) ).has_value();
         }
 };
@@ -1598,7 +1598,7 @@ class jmapgen_computer : public jmapgen_piece
                 cpu->set_access_denied_msg( access_denied.translated() );
             }
         }
-        bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
+        bool has_vehicle_collision( mapgendata &dat, point p ) const override {
             return dat.m.veh_at( tripoint( p, dat.zlevel() ) ).has_value();
         }
 };
@@ -1720,7 +1720,7 @@ class jmapgen_sealed_item : public jmapgen_piece
             }
             dat.m.furn_set( point( x.get(), y.get() ), furniture );
         }
-        bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
+        bool has_vehicle_collision( mapgendata &dat, point p ) const override {
             return dat.m.veh_at( tripoint( p, dat.zlevel() ) ).has_value();
         }
 };
@@ -1878,7 +1878,7 @@ class jmapgen_nested : public jmapgen_piece
 
             ( *ptr )->nest( dat, point( x.get(), y.get() ) );
         }
-        bool has_vehicle_collision( mapgendata &dat, const point &p ) const override {
+        bool has_vehicle_collision( mapgendata &dat, point p ) const override {
             const weighted_int_list<std::string> &selected_entries = neighbors.test(
                         dat ) ? entries : else_entries;
             if( selected_entries.empty() ) {
@@ -1904,7 +1904,7 @@ class jmapgen_nested : public jmapgen_piece
         }
 };
 
-jmapgen_objects::jmapgen_objects( const point &offset, const point &mapsize, const point &tot_size )
+jmapgen_objects::jmapgen_objects( point offset, point mapsize, point tot_size )
     : m_offset( offset )
     , mapgensize( mapsize )
     , total_size( tot_size )
@@ -2601,7 +2601,7 @@ void jmapgen_objects::check( const std::string &oter_name ) const
  * (set|line|square)_(ter|furn|trap|radiation); simple (x, y, int) or (x1,y1,x2,y2, int) functions
  * TODO: optimize, though gcc -O2 optimizes enough that splitting the switch has no effect
  */
-bool jmapgen_setmap::apply( mapgendata &dat, const point &offset ) const
+bool jmapgen_setmap::apply( mapgendata &dat, point offset ) const
 {
     if( chance != 1 && !one_in( chance ) ) {
         return true;
@@ -2712,7 +2712,7 @@ bool jmapgen_setmap::apply( mapgendata &dat, const point &offset ) const
     return true;
 }
 
-bool jmapgen_setmap::has_vehicle_collision( mapgendata &dat, const point &offset ) const
+bool jmapgen_setmap::has_vehicle_collision( mapgendata &dat, point offset ) const
 {
     const auto get = []( const jmapgen_int & v, int v_offset ) {
         return v.get() + v_offset;
@@ -2750,7 +2750,7 @@ bool jmapgen_setmap::has_vehicle_collision( mapgendata &dat, const point &offset
     return false;
 }
 
-void mapgen_function_json_base::formatted_set_incredibly_simple( map &m, const point &offset ) const
+void mapgen_function_json_base::formatted_set_incredibly_simple( map &m, point offset ) const
 {
     for( int y = 0; y < mapgensize.y; y++ ) {
         for( int x = 0; x < mapgensize.x; x++ ) {
@@ -2771,7 +2771,7 @@ void mapgen_function_json_base::formatted_set_incredibly_simple( map &m, const p
     }
 }
 
-bool mapgen_function_json_base::has_vehicle_collision( mapgendata &dat, const point &offset ) const
+bool mapgen_function_json_base::has_vehicle_collision( mapgendata &dat, point offset ) const
 {
     if( do_format ) {
         for( int y = 0; y < mapgensize.y; y++ ) {
@@ -2841,7 +2841,7 @@ void mapgen_function_json::generate( mapgendata &md )
     }
 }
 
-void mapgen_function_json_nested::nest( mapgendata &dat, const point &offset ) const
+void mapgen_function_json_nested::nest( mapgendata &dat, point offset ) const
 {
     // TODO: Make rotation work for submaps, then pass this value into elem & objects apply.
     //int chosen_rotation = rotation.get() % 4;
@@ -2876,7 +2876,7 @@ void jmapgen_objects::apply( mapgendata &dat ) const
     }
 }
 
-void jmapgen_objects::apply( mapgendata &dat, const point &offset ) const
+void jmapgen_objects::apply( mapgendata &dat, point offset ) const
 {
     if( offset == point_zero ) {
         // It's a bit faster
@@ -2898,7 +2898,7 @@ void jmapgen_objects::apply( mapgendata &dat, const point &offset ) const
     }
 }
 
-bool jmapgen_objects::has_vehicle_collision( mapgendata &dat, const point &offset ) const
+bool jmapgen_objects::has_vehicle_collision( mapgendata &dat, point offset ) const
 {
     for( auto &obj : objects ) {
         auto where = obj.first;
@@ -4085,7 +4085,7 @@ void map::draw_lab( mapgendata &dat )
                     }
                     auto fluid_type = one_in( 3 ) ? t_sewage : t_water_sh;
                     for( int i = 0; i < 2; ++i ) {
-                        draw_rough_circle( [this, fluid_type]( const point & p ) {
+                        draw_rough_circle( [this, fluid_type]( point  p ) {
                             if( t_thconc_floor == ter( p ) || t_strconc_floor == ter( p ) ||
                                 t_thconc_floor_olight == ter( p ) ) {
                                 ter_set( p, fluid_type );
@@ -4128,7 +4128,7 @@ void map::draw_lab( mapgendata &dat )
                         ARTPROP_WHISPERING,
                         ARTPROP_GLOWING
                     };
-                    draw_rough_circle( [this]( const point & p ) {
+                    draw_rough_circle( [this]( point  p ) {
                         if( has_flag_ter( "GOES_DOWN", p ) ||
                             has_flag_ter( "GOES_UP", p ) ||
                             has_flag_ter( "CONSOLE", p ) ) {
@@ -4149,19 +4149,19 @@ void map::draw_lab( mapgendata &dat )
                         // just skip it, we don't want to risk embedding radiation out of sight.
                         break;
                     }
-                    draw_rough_circle( [this]( const point & p ) {
+                    draw_rough_circle( [this]( point  p ) {
                         set_radiation( p, 10 );
                     }, center.xy(), rng( 7, 12 ) );
-                    draw_circle( [this]( const point & p ) {
+                    draw_circle( [this]( point  p ) {
                         set_radiation( p, 20 );
                     }, center.xy(), rng( 5, 8 ) );
-                    draw_circle( [this]( const point & p ) {
+                    draw_circle( [this]( point  p ) {
                         set_radiation( p, 30 );
                     }, center.xy(), rng( 2, 4 ) );
-                    draw_circle( [this]( const point & p ) {
+                    draw_circle( [this]( point  p ) {
                         set_radiation( p, 50 );
                     }, center.xy(), 1 );
-                    draw_circle( [this]( const point & p ) {
+                    draw_circle( [this]( point  p ) {
                         if( has_flag_ter( "GOES_DOWN", p ) ||
                             has_flag_ter( "GOES_UP", p ) ||
                             has_flag_ter( "CONSOLE", p ) ) {
@@ -4211,7 +4211,7 @@ void map::draw_lab( mapgendata &dat )
                     tripoint center( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ), abs_sub.z );
 
                     // Make a portal surrounded by more dense fungal stuff and a fungaloid.
-                    draw_rough_circle( [this]( const point & p ) {
+                    draw_rough_circle( [this]( point  p ) {
                         if( has_flag_ter( "GOES_DOWN", p ) ||
                             has_flag_ter( "GOES_UP", p ) ||
                             has_flag_ter( "CONSOLE", p ) ) {
@@ -5418,7 +5418,7 @@ void map::draw_connections( mapgendata &dat )
 }
 
 void map::place_spawns( const mongroup_id &group, const int chance,
-                        const point &p1, const point &p2, const float density,
+                        point p1, point p2, const float density,
                         const bool individual, const bool friendly, const std::string &name, const int mission_id )
 {
     if( !group.is_valid() ) {
@@ -5467,7 +5467,7 @@ void map::place_spawns( const mongroup_id &group, const int chance,
     }
 }
 
-void map::place_gas_pump( const point &p, int charges, const std::string &fuel_type )
+void map::place_gas_pump( point p, int charges, const std::string &fuel_type )
 {
     item fuel( fuel_type, calendar::start_of_cataclysm );
     fuel.charges = charges;
@@ -5475,12 +5475,12 @@ void map::place_gas_pump( const point &p, int charges, const std::string &fuel_t
     ter_set( p, ter_id( fuel.fuel_pump_terrain() ) );
 }
 
-void map::place_gas_pump( const point &p, int charges )
+void map::place_gas_pump( point p, int charges )
 {
     place_gas_pump( p, charges, one_in( 4 ) ? "diesel" : "gasoline" );
 }
 
-void map::place_toilet( const point &p, int charges )
+void map::place_toilet( point p, int charges )
 {
     item water( "water", calendar::start_of_cataclysm );
     water.charges = charges;
@@ -5488,7 +5488,7 @@ void map::place_toilet( const point &p, int charges )
     furn_set( p, f_toilet );
 }
 
-void map::place_vending( const point &p, const item_group_id &type, bool reinforced )
+void map::place_vending( point p, const item_group_id &type, bool reinforced )
 {
     if( reinforced ) {
         furn_set( p, f_vending_reinforced );
@@ -5508,7 +5508,7 @@ void map::place_vending( const point &p, const item_group_id &type, bool reinfor
     }
 }
 
-character_id map::place_npc( const point &p, const string_id<npc_template> &type, bool force )
+character_id map::place_npc( point p, const string_id<npc_template> &type, bool force )
 {
     if( !force && !get_option<bool>( "STATIC_NPC" ) ) {
         return character_id(); //Do not generate an npc.
@@ -5521,7 +5521,7 @@ character_id map::place_npc( const point &p, const string_id<npc_template> &type
     return temp->getID();
 }
 
-void map::apply_faction_ownership( const point &p1, const point &p2, const faction_id &id )
+void map::apply_faction_ownership( point p1, point p2, const faction_id &id )
 {
     for( const tripoint &p : points_in_rectangle( tripoint( p1, abs_sub.z ), tripoint( p2,
             abs_sub.z ) ) ) {
@@ -5566,7 +5566,7 @@ std::vector<item *> map::place_items( const item_group_id &loc, const int chance
     for( int i = 0; i < spawn_count; i++ ) {
         // Might contain one item or several that belong together like guns & their ammo
         int tries = 0;
-        auto is_valid_terrain = [this, ongrass]( const point & p ) {
+        auto is_valid_terrain = [this, ongrass]( point  p ) {
             auto &terrain = ter( p ).obj();
             return terrain.movecost == 0           &&
                    !terrain.has_flag( "PLACE_ITEM" ) &&
@@ -5633,13 +5633,13 @@ vehicle *map::add_vehicle( const vgroup_id &type, const tripoint &p, const units
     return add_vehicle( type.obj().pick(), p, dir, veh_fuel, veh_status, merge_wrecks );
 }
 
-vehicle *map::add_vehicle( const vgroup_id &type, const point &p, units::angle dir,
+vehicle *map::add_vehicle( const vgroup_id &type, point p, units::angle dir,
                            int veh_fuel, int veh_status, bool merge_wrecks )
 {
     return add_vehicle( type.obj().pick(), p, dir, veh_fuel, veh_status, merge_wrecks );
 }
 
-vehicle *map::add_vehicle( const vproto_id &type, const point &p, units::angle dir,
+vehicle *map::add_vehicle( const vproto_id &type, point p, units::angle dir,
                            int veh_fuel, int veh_status, bool merge_wrecks )
 {
     return add_vehicle( type, tripoint( p, abs_sub.z ), dir, veh_fuel, veh_status, merge_wrecks );
@@ -5976,7 +5976,7 @@ bool connects_to( const oter_id &there, int dir )
     }
 }
 
-void science_room( map *m, const point &p1, const point &p2, int z, int rotate )
+void science_room( map *m, point p1, point p2, int z, int rotate )
 {
     int height = p2.y - p1.y;
     int width  = p2.x - p1.x;
@@ -6482,11 +6482,11 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
 }
 ///////////////////// part of map
 
-void line( map *m, const ter_id &type, const point &p1, const point &p2 )
+void line( map *m, const ter_id &type, point p1, point p2 )
 {
     m->draw_line_ter( type, p1, p2 );
 }
-void line_furn( map *m, const furn_id &type, const point &p1, const point &p2 )
+void line_furn( map *m, const furn_id &type, point p1, point p2 )
 {
     m->draw_line_furn( type, p1, p2 );
 }
@@ -6498,27 +6498,27 @@ void fill_background( map *m, ter_id( *f )() )
 {
     m->draw_fill_background( f );
 }
-void square( map *m, const ter_id &type, const point &p1, const point &p2 )
+void square( map *m, const ter_id &type, point p1, point p2 )
 {
     m->draw_square_ter( type, p1, p2 );
 }
-void square_furn( map *m, const furn_id &type, const point &p1, const point &p2 )
+void square_furn( map *m, const furn_id &type, point p1, point p2 )
 {
     m->draw_square_furn( type, p1, p2 );
 }
-void square( map *m, ter_id( *f )(), const point &p1, const point &p2 )
+void square( map *m, ter_id( *f )(), point p1, point p2 )
 {
     m->draw_square_ter( f, p1, p2 );
 }
-void square( map *m, const weighted_int_list<ter_id> &f, const point &p1, const point &p2 )
+void square( map *m, const weighted_int_list<ter_id> &f, point p1, point p2 )
 {
     m->draw_square_ter( f, p1, p2 );
 }
-void rough_circle( map *m, const ter_id &type, const point &p, int rad )
+void rough_circle( map *m, const ter_id &type, point p, int rad )
 {
     m->draw_rough_circle_ter( type, p, rad );
 }
-void rough_circle_furn( map *m, const furn_id &type, const point &p, int rad )
+void rough_circle_furn( map *m, const furn_id &type, point p, int rad )
 {
     m->draw_rough_circle_furn( type, p, rad );
 }
@@ -6526,15 +6526,15 @@ void circle( map *m, const ter_id &type, double x, double y, double rad )
 {
     m->draw_circle_ter( type, rl_vec2d( x, y ), rad );
 }
-void circle( map *m, const ter_id &type, const point &p, int rad )
+void circle( map *m, const ter_id &type, point p, int rad )
 {
     m->draw_circle_ter( type, p, rad );
 }
-void circle_furn( map *m, const furn_id &type, const point &p, int rad )
+void circle_furn( map *m, const furn_id &type, point p, int rad )
 {
     m->draw_circle_furn( type, p, rad );
 }
-void add_corpse( map *m, const point &p )
+void add_corpse( map *m, point p )
 {
     m->add_corpse( tripoint( p, m->get_abs_sub().z ) );
 }
@@ -6562,7 +6562,7 @@ bool update_mapgen_function_json::setup_internal( const JsonObject &/*jo*/ )
     return true;
 }
 
-bool update_mapgen_function_json::update_map( const tripoint_abs_omt &omt_pos, const point &offset,
+bool update_mapgen_function_json::update_map( const tripoint_abs_omt &omt_pos, point offset,
         mission *miss, bool verify ) const
 {
     if( omt_pos == overmap::invalid_tripoint ) {
@@ -6579,7 +6579,7 @@ bool update_mapgen_function_json::update_map( const tripoint_abs_omt &omt_pos, c
     return update_map( md, offset, verify );
 }
 
-bool update_mapgen_function_json::update_map( mapgendata &md, const point &offset,
+bool update_mapgen_function_json::update_map( mapgendata &md, point offset,
         const bool verify ) const
 {
     class rotation_guard

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -119,12 +119,12 @@ struct jmapgen_setmap {
         x( ix ), y( iy ), x2( ix2 ), y2( iy2 ), op( iop ), val( ival ), chance( ione_in ),
         repeat( irepeat ), rotation( irotation ),
         fuel( ifuel ), status( istatus ) {}
-    bool apply( mapgendata &dat, const point &offset ) const;
+    bool apply( mapgendata &dat, point offset ) const;
     /**
      * checks if applying these objects to data would cause cause a collision with vehicles
      * on the same map
      **/
-    bool has_vehicle_collision( mapgendata &dat, const point &offset ) const;
+    bool has_vehicle_collision( mapgendata &dat, point offset ) const;
 };
 
 /**
@@ -159,7 +159,7 @@ class jmapgen_piece
         virtual void apply( mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y ) const = 0;
         virtual ~jmapgen_piece() = default;
         jmapgen_int repeat;
-        virtual bool has_vehicle_collision( mapgendata &/*dat*/, const point &/*offset*/ ) const {
+        virtual bool has_vehicle_collision( mapgendata &/*dat*/, point /*offset*/ ) const {
             return false;
         }
 };
@@ -171,9 +171,9 @@ class jmapgen_place
 {
     public:
         jmapgen_place() : x( 0, 0 ), y( 0, 0 ), repeat( 1, 1 ) { }
-        jmapgen_place( const point &p ) : x( p.x ), y( p.y ), repeat( 1, 1 ) { }
+        jmapgen_place( point p ) : x( p.x ), y( p.y ), repeat( 1, 1 ) { }
         jmapgen_place( const JsonObject &jsi );
-        void offset( const point & );
+        void offset( point );
         jmapgen_int x;
         jmapgen_int y;
         jmapgen_int repeat;
@@ -265,7 +265,7 @@ class mapgen_palette
 
 struct jmapgen_objects {
 
-        jmapgen_objects( const point &offset, const point &mapsize, const point &tot_size );
+        jmapgen_objects( point offset, point mapsize, point tot_size );
 
         bool check_bounds( const jmapgen_place &place, const JsonObject &jso );
 
@@ -289,13 +289,13 @@ struct jmapgen_objects {
         void check( const std::string &oter_name ) const;
 
         void apply( mapgendata &dat ) const;
-        void apply( mapgendata &dat, const point &offset ) const;
+        void apply( mapgendata &dat, point offset ) const;
 
         /**
          * checks if applying these objects to data would cause cause a collision with vehicles
          * on the same map
          **/
-        bool has_vehicle_collision( mapgendata &dat, const point &offset ) const;
+        bool has_vehicle_collision( mapgendata &dat, point offset ) const;
 
     private:
         /**
@@ -312,8 +312,8 @@ class mapgen_function_json_base
 {
     public:
         bool check_inbounds( const jmapgen_int &x, const jmapgen_int &y, const JsonObject &jso ) const;
-        size_t calc_index( const point &p ) const;
-        bool has_vehicle_collision( mapgendata &dat, const point &offset ) const;
+        size_t calc_index( point p ) const;
+        bool has_vehicle_collision( mapgendata &dat, point offset ) const;
 
     private:
         pimpl<json_source_location> jsrcloc;
@@ -331,7 +331,7 @@ class mapgen_function_json_base
 
         void check_common( const std::string &oter_name ) const;
 
-        void formatted_set_incredibly_simple( map &m, const point &offset ) const;
+        void formatted_set_incredibly_simple( map &m, point offset ) const;
 
         bool do_format;
         bool is_ready;
@@ -351,8 +351,8 @@ class mapgen_function_json : public mapgen_function_json_base, public virtual ma
         void setup() override;
         void check( const std::string &oter_name ) const override;
         void generate( mapgendata & ) override;
-        mapgen_function_json( const json_source_location &jsrcloc, int w, const point &grid_offset,
-                              const point &grid_total );
+        mapgen_function_json( const json_source_location &jsrcloc, int w, point grid_offset,
+                              point grid_total );
         ~mapgen_function_json() override = default;
 
         ter_id fill_ter;
@@ -374,9 +374,9 @@ class update_mapgen_function_json : public mapgen_function_json_base
         void setup();
         bool setup_update( const JsonObject &jo );
         void check( const std::string &oter_name ) const;
-        bool update_map( const tripoint_abs_omt &omt_pos, const point &offset,
+        bool update_map( const tripoint_abs_omt &omt_pos, point offset,
                          mission *miss, bool verify = false ) const;
-        bool update_map( mapgendata &md, const point &offset = point_zero,
+        bool update_map( mapgendata &md, point offset = point_zero,
                          bool verify = false ) const;
 
     protected:
@@ -392,7 +392,7 @@ class mapgen_function_json_nested : public mapgen_function_json_base
         explicit mapgen_function_json_nested( const json_source_location &jsrcloc );
         ~mapgen_function_json_nested() override = default;
 
-        void nest( mapgendata &dat, const point &offset ) const;
+        void nest( mapgendata &dat, point offset ) const;
     protected:
         bool setup_internal( const JsonObject &jo ) override;
 
@@ -405,10 +405,10 @@ class mapgen_function_json_nested : public mapgen_function_json_base
 /*
  * Load mapgen function of any type from a json object
  */
-std::shared_ptr<mapgen_function> load_mapgen_function( const JsonObject &jio, const point &offset,
-        const point &total );
+std::shared_ptr<mapgen_function> load_mapgen_function( const JsonObject &jio, point offset,
+        point total );
 void load_and_add_mapgen_function(
-    const JsonObject &jio, const std::string &id_base, const point &offset, const point &total );
+    const JsonObject &jio, const std::string &id_base, point offset, point total );
 /*
  * Load the above directly from a file via init, as opposed to riders attached to overmap_terrain. Added check
  * for oter_mapgen / oter_mapgen_weights key, multiple possible ( i.e., [ "house_w_1", "duplex" ] )
@@ -458,19 +458,19 @@ enum room_type {
 bool connects_to( const oter_id &there, int dir );
 void mapgen_rotate( map *m, oter_id terrain_type, bool north_is_down = false );
 // wrappers for map:: functions
-void line( map *m, const ter_id &type, const point &p1, const point &p2 );
-void line_furn( map *m, const furn_id &type, const point &p1, const point &p2 );
+void line( map *m, const ter_id &type, point p1, point p2 );
+void line_furn( map *m, const furn_id &type, point p1, point p2 );
 void fill_background( map *m, const ter_id &type );
 void fill_background( map *m, ter_id( *f )() );
-void square( map *m, const ter_id &type, const point &p1, const point &p2 );
-void square( map *m, ter_id( *f )(), const point &p1, const point &p2 );
-void square( map *m, const weighted_int_list<ter_id> &f, const point &p1, const point &p2 );
-void square_furn( map *m, const furn_id &type, const point &p1, const point &p2 );
-void rough_circle( map *m, const ter_id &type, const point &, int rad );
-void rough_circle_furn( map *m, const furn_id &type, const point &, int rad );
+void square( map *m, const ter_id &type, point p1, point p2 );
+void square( map *m, ter_id( *f )(), point p1, point p2 );
+void square( map *m, const weighted_int_list<ter_id> &f, point p1, point p2 );
+void square_furn( map *m, const furn_id &type, point p1, point p2 );
+void rough_circle( map *m, const ter_id &type, point, int rad );
+void rough_circle_furn( map *m, const furn_id &type, point, int rad );
 void circle( map *m, const ter_id &type, double x, double y, double rad );
-void circle( map *m, const ter_id &type, const point &, int rad );
-void circle_furn( map *m, const furn_id &type, const point &, int rad );
-void add_corpse( map *m, const point & );
+void circle( map *m, const ter_id &type, point, int rad );
+void circle_furn( map *m, const furn_id &type, point, int rad );
+void add_corpse( map *m, point );
 
 #endif // CATA_SRC_MAPGEN_H

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -228,7 +228,7 @@ void mapgen_crater( mapgendata &dat )
 }
 
 // TODO: make void map::ter_or_furn_set(const int x, const int y, const ter_furn_id & tfid);
-static void ter_or_furn_set( map *m, const point &p, const ter_furn_id &tfid )
+static void ter_or_furn_set( map *m, point p, const ter_furn_id &tfid )
 {
     if( tfid.ter != t_null ) {
         m->ter_set( p, tfid.ter );
@@ -2488,7 +2488,7 @@ void mapgen_forest( mapgendata &dat )
     static constexpr int margin_y = SEEY * 2 / 3;
 
     const auto get_blended_feature = [&no_ter_furn, &max_factor, &factor,
-                  &get_feature_for_neighbor, &dat]( const point & p ) {
+                  &get_feature_for_neighbor, &dat]( point  p ) {
         // Pick one random feature from each biome according to the biome defs and save it into a lookup.
         // We'll blend these features together below based on the current and adjacent terrains.
         std::map<oter_id, ter_furn_id> biome_features;
@@ -2627,7 +2627,7 @@ void mapgen_forest( mapgendata &dat )
 
     // There is a chance of placing terrain dependent furniture, e.g. f_cattails on t_water_sh.
     const auto set_terrain_dependent_furniture = [&current_biome_def, &m]( const ter_id & tid,
-    const point & p ) {
+    point  p ) {
         const auto terrain_dependent_furniture_it = current_biome_def.terrain_dependent_furniture.find(
                     tid );
         if( terrain_dependent_furniture_it == current_biome_def.terrain_dependent_furniture.end() ) {
@@ -3154,10 +3154,10 @@ void mapgen_lake_shore( mapgendata &dat )
     // This will draw our shallow water coastline from the "from" point to the "to" point.
     // It buffers the points a bit for a thicker line. It also clears any furniture that might
     // be in the location as a result of our extending adjacent mapgen.
-    const auto draw_shallow_water = [&]( const point & from, const point & to ) {
+    const auto draw_shallow_water = [&]( point  from, point  to ) {
         std::vector<point> points = line_to( from, to );
         for( auto &p : points ) {
-            for( const point &bp : closest_points_first( p, 1 ) ) {
+            for( point bp : closest_points_first( p, 1 ) ) {
                 if( !map_boundaries.contains( bp ) ) {
                     continue;
                 }
@@ -3171,7 +3171,7 @@ void mapgen_lake_shore( mapgendata &dat )
 
     // Given two points, return a point that is midway between the two points and then
     // jittered by a random amount in proportion to the length of the line segment.
-    const auto jittered_midpoint = [&]( const point & from, const point & to ) {
+    const auto jittered_midpoint = [&]( point  from, point  to ) {
         const int jitter = rl_dist( from, to ) / 4;
         const point midpoint( ( from.x + to.x ) / 2 + rng( -jitter, jitter ),
                               ( from.y + to.y ) / 2 + rng( -jitter, jitter ) );
@@ -3197,14 +3197,14 @@ void mapgen_lake_shore( mapgendata &dat )
     // out any furniture that we placed by the extended mapgen.
     std::unordered_set<point> visited;
 
-    const auto should_fill = [&]( const point & p ) {
+    const auto should_fill = [&]( point  p ) {
         if( !map_boundaries.contains( p ) ) {
             return false;
         }
         return m->ter( p ) != t_null;
     };
 
-    const auto fill_deep_water = [&]( const point & starting_point ) {
+    const auto fill_deep_water = [&]( point  starting_point ) {
         std::vector<point> water_points = ff::point_flood_fill_4_connected( starting_point, visited,
                                           should_fill );
         for( auto &wp : water_points ) {
@@ -3236,19 +3236,19 @@ void mapgen_lake_shore( mapgendata &dat )
     m->translate( t_null, t_water_sh );
 }
 
-void mremove_trap( map *m, const point &p )
+void mremove_trap( map *m, point p )
 {
     tripoint actual_location( p, m->get_abs_sub().z );
     m->remove_trap( actual_location );
 }
 
-void mtrap_set( map *m, const point &p, trap_id type )
+void mtrap_set( map *m, point p, trap_id type )
 {
     tripoint actual_location( p, m->get_abs_sub().z );
     m->trap_set( actual_location, type );
 }
 
-void madd_field( map *m, const point &p, field_type_id type, int intensity )
+void madd_field( map *m, point p, field_type_id type, int intensity )
 {
     tripoint actual_location( p, m->get_abs_sub().z );
     m->add_field( actual_location, type, intensity, 0_turns );

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -78,9 +78,9 @@ void mapgen_tutorial( mapgendata &dat );
 void mapgen_lake_shore( mapgendata &dat );
 
 // Temporary wrappers
-void mremove_trap( map *m, const point & );
-void mtrap_set( map *m, const point &, trap_id type );
-void madd_field( map *m, const point &, field_type_id type, int intensity );
+void mremove_trap( map *m, point );
+void mtrap_set( map *m, point, trap_id type );
+void madd_field( map *m, point, field_type_id type, int intensity );
 
 mapgen_update_func add_mapgen_update_func( const JsonObject &jo, bool &defer );
 bool run_mapgen_update_func( const std::string &update_mapgen_id, const tripoint_abs_omt &omt_pos,

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -117,7 +117,7 @@ int &mapgendata::dir( int dir_in )
     }
 }
 
-void mapgendata::square_groundcover( const point &p1, const point &p2 )
+void mapgendata::square_groundcover( point p1, point p2 )
 {
     m.draw_square_ter( default_groundcover, p1, p2 );
 }

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -136,7 +136,7 @@ class mapgendata
         }
         const oter_id &neighbor_at( om_direction::type dir ) const;
         void fill_groundcover();
-        void square_groundcover( const point &p1, const point &p2 );
+        void square_groundcover( point p1, point p2 );
         ter_id groundcover();
         bool is_groundcover( const ter_id &iid ) const;
 };

--- a/src/mapgenformat.cpp
+++ b/src/mapgenformat.cpp
@@ -11,7 +11,7 @@
 namespace mapf
 {
 
-void formatted_set_simple( map *m, const point &start, const char *cstr,
+void formatted_set_simple( map *m, point start, const char *cstr,
                            const format_effect<ter_id> &ter_b, const format_effect<furn_id> &furn_b )
 {
     const char *p = cstr;

--- a/src/mapgenformat.h
+++ b/src/mapgenformat.h
@@ -28,7 +28,7 @@ class format_effect;
  *   A newline character continues on the next line (resets `x` to \p startx and increments `y`).
  * @param start Coordinates in the map where to start drawing \p cstr.
  */
-void formatted_set_simple( map *m, const point &start, const char *cstr,
+void formatted_set_simple( map *m, point start, const char *cstr,
                            const format_effect<ter_id> &ter_b, const format_effect<furn_id> &furn_b );
 
 template<typename ID>

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1370,7 +1370,7 @@ static std::vector<tripoint> get_bashing_zone( const tripoint &bashee, const tri
     tripoint previous = bashee;
     for( const tripoint &p : path ) {
         std::vector<point> swath = squares_in_direction( previous.xy(), p.xy() );
-        for( const point &q : swath ) {
+        for( point q : swath ) {
             zone.push_back( tripoint( q, bashee.z ) );
         }
 
@@ -2015,7 +2015,7 @@ void monster::knock_back_to( const tripoint &to )
          Make sure that non-smashing monsters won't "teleport" through windows
          Injure monsters if they're gonna be walking through pits or whatever
  */
-bool monster::will_reach( const point &p )
+bool monster::will_reach( point p )
 {
     monster_attitude att = attitude( &g->u );
     if( att != MATT_FOLLOW && att != MATT_ATTACK && att != MATT_FRIEND && att != MATT_ZLAVE ) {
@@ -2052,7 +2052,7 @@ bool monster::will_reach( const point &p )
     return false;
 }
 
-int monster::turns_to_reach( const point &p )
+int monster::turns_to_reach( point p )
 {
     // HACK: This function is a(n old) temporary hack that should soon be removed
     auto path = g->m.route( pos(), tripoint( p, posz() ), get_pathfinding_settings() );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1004,7 +1004,7 @@ void monster::set_goal( const tripoint &p )
     goal = p;
 }
 
-void monster::shift( const point &sm_shift )
+void monster::shift( point sm_shift )
 {
     const point ms_shift = sm_to_ms_copy( sm_shift );
     position -= ms_shift;

--- a/src/monster.h
+++ b/src/monster.h
@@ -173,7 +173,7 @@ class monster : public Creature, public visitable<monster>
         Creature *attack_target(); // Returns the creature at the end of plans (if hostile)
 
         // Movement
-        void shift( const point &sm_shift ); // Shifts the monster to the appropriate submap
+        void shift( point sm_shift ); // Shifts the monster to the appropriate submap
         void set_goal( const tripoint &p );
         // Updates current pos AND our plans
         bool wander(); // Returns true if we have no plans
@@ -193,8 +193,8 @@ class monster : public Creature, public visitable<monster>
         bool will_move_to( const tripoint &p ) const;
         bool can_squeeze_to( const tripoint &p ) const;
 
-        bool will_reach( const point &p ); // Do we have plans to get to (x, y)?
-        int  turns_to_reach( const point &p ); // How long will it take?
+        bool will_reach( point p ); // Do we have plans to get to (x, y)?
+        int  turns_to_reach( point p ); // How long will it take?
 
         // Go in a straight line to p
         void set_dest( const tripoint &p );

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -31,7 +31,7 @@ static void curses_check_result( const int result, const int expected, const cha
     }
 }
 
-catacurses::window catacurses::newwin( const int nlines, const int ncols, const point &begin )
+catacurses::window catacurses::newwin( const int nlines, const int ncols, point begin )
 {
     // TODO: check for errors
     const auto w = ::newwin( nlines, ncols, begin.y, begin.x );
@@ -95,12 +95,12 @@ void catacurses::wattron( const window &win, const nc_color &attrs )
     return curses_check_result( ::wattron( win.get<::WINDOW>(), attrs ), OK, "wattron" );
 }
 
-void catacurses::wmove( const window &win, const point &p )
+void catacurses::wmove( const window &win, point p )
 {
     return curses_check_result( ::wmove( win.get<::WINDOW>(), p.y, p.x ), OK, "wmove" );
 }
 
-void catacurses::mvwprintw( const window &win, const point &p, const std::string &text )
+void catacurses::mvwprintw( const window &win, point p, const std::string &text )
 {
     return curses_check_result( ::mvwprintw( win.get<::WINDOW>(), p.y, p.x, "%s", text.c_str() ),
                                 OK, "mvwprintw" );
@@ -149,19 +149,19 @@ void catacurses::wborder( const window &win, const chtype ls, const chtype rs, c
                                 "wborder" );
 }
 
-void catacurses::mvwhline( const window &win, const point &p, const chtype ch, const int n )
+void catacurses::mvwhline( const window &win, point p, const chtype ch, const int n )
 {
     return curses_check_result( ::mvwhline( win.get<::WINDOW>(), p.y, p.x, ch, n ), OK,
                                 "mvwhline" );
 }
 
-void catacurses::mvwvline( const window &win, const point &p, const chtype ch, const int n )
+void catacurses::mvwvline( const window &win, point p, const chtype ch, const int n )
 {
     return curses_check_result( ::mvwvline( win.get<::WINDOW>(), p.y, p.x, ch, n ), OK,
                                 "mvwvline" );
 }
 
-void catacurses::mvwaddch( const window &win, const point &p, const chtype ch )
+void catacurses::mvwaddch( const window &win, point p, const chtype ch )
 {
     return curses_check_result( ::mvwaddch( win.get<::WINDOW>(), p.y, p.x, ch ), OK, "mvwaddch" );
 }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -733,7 +733,7 @@ void npc::spawn_at_sm( const tripoint &p )
     spawn_at_precise( p.xy(), tripoint( rng( 0, SEEX - 1 ), rng( 0, SEEY - 1 ), p.z ) );
 }
 
-void npc::spawn_at_precise( const point &submap_offset, const tripoint &square )
+void npc::spawn_at_precise( point submap_offset, const tripoint &square )
 {
     submap_coords = submap_offset;
     submap_coords.x += square.x / SEEX;
@@ -2390,21 +2390,21 @@ std::string npc::opinion_text() const
     return ret;
 }
 
-static void maybe_shift( cata::optional<tripoint> &pos, const point &d )
+static void maybe_shift( cata::optional<tripoint> &pos, point d )
 {
     if( pos ) {
         *pos += d;
     }
 }
 
-static void maybe_shift( tripoint &pos, const point &d )
+static void maybe_shift( tripoint &pos, point d )
 {
     if( pos != tripoint_min ) {
         pos += d;
     }
 }
 
-void npc::shift( const point &s )
+void npc::shift( point s )
 {
     const point shift = sm_to_ms_copy( s );
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -789,7 +789,7 @@ class npc : public player
          * Note: final submap may differ from submap_offset if @ref square has
          * x/y values outside [0, SEEX-1]/[0, SEEY-1] range.
          */
-        void spawn_at_precise( const point &submap_offset, const tripoint &square );
+        void spawn_at_precise( point submap_offset, const tripoint &square );
         /**
          * Places the NPC on the @ref map. This update its
          * pos values to fit the current offset of
@@ -1012,7 +1012,7 @@ class npc : public player
          * from one submap to an adjacent submap.  It updates our position (shifting by
          * 12 tiles), as well as our plans.
          */
-        void shift( const point &s );
+        void shift( point s );
 
         // Movement; the following are defined in npcmove.cpp
         void move(); // Picks an action & a target and calls execute_action

--- a/src/om_direction.h
+++ b/src/om_direction.h
@@ -72,7 +72,7 @@ const std::string &id( type dir );
 std::string name( type dir );
 
 /** Various rotations. */
-point rotate( const point &p, type dir );
+point rotate( point p, type dir );
 tripoint rotate( const tripoint &p, type dir );
 uint32_t rotate_symbol( uint32_t sym, type dir );
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -182,7 +182,7 @@ color_tag_parse_result::tag_type update_color_stack(
     return tag.type;
 }
 
-void print_colored_text( const catacurses::window &w, const point &p, nc_color &color,
+void print_colored_text( const catacurses::window &w, point p, nc_color &color,
                          const nc_color &base_color, const std::string &text,
                          const report_color_error color_error )
 {
@@ -211,7 +211,7 @@ void print_colored_text( const catacurses::window &w, const point &p, nc_color &
     }
 }
 
-void trim_and_print( const catacurses::window &w, const point &begin,
+void trim_and_print( const catacurses::window &w, point begin,
                      const int width, const nc_color &base_color,
                      const std::string &text,
                      const report_color_error color_error )
@@ -296,7 +296,7 @@ int print_scrollable( const catacurses::window &w, int begin_line, const std::st
 }
 
 // returns number of printed lines
-int fold_and_print( const catacurses::window &w, const point &begin, int width,
+int fold_and_print( const catacurses::window &w, point begin, int width,
                     const nc_color &base_color, const std::string &text, const char split )
 {
     nc_color color = base_color;
@@ -308,7 +308,7 @@ int fold_and_print( const catacurses::window &w, const point &begin, int width,
     return textformatted.size();
 }
 
-int fold_and_print_from( const catacurses::window &w, const point &begin, int width,
+int fold_and_print_from( const catacurses::window &w, point begin, int width,
                          int begin_line, const nc_color &base_color, const std::string &text )
 {
     const int iWinHeight = getmaxy( w );
@@ -474,21 +474,21 @@ void wputch( const catacurses::window &w, nc_color FG, int ch )
     wattroff( w, FG );
 }
 
-void mvwputch( const catacurses::window &w, const point &p, nc_color FG, int ch )
+void mvwputch( const catacurses::window &w, point p, nc_color FG, int ch )
 {
     wattron( w, FG );
     mvwaddch( w, p, ch );
     wattroff( w, FG );
 }
 
-void mvwputch( const catacurses::window &w, const point &p, nc_color FG, const std::string &ch )
+void mvwputch( const catacurses::window &w, point p, nc_color FG, const std::string &ch )
 {
     wattron( w, FG );
     mvwprintw( w, p, ch );
     wattroff( w, FG );
 }
 
-void mvwputch_inv( const catacurses::window &w, const point &p, nc_color FG, int ch )
+void mvwputch_inv( const catacurses::window &w, point p, nc_color FG, int ch )
 {
     nc_color HC = invert_color( FG );
     wattron( w, HC );
@@ -496,7 +496,7 @@ void mvwputch_inv( const catacurses::window &w, const point &p, nc_color FG, int
     wattroff( w, HC );
 }
 
-void mvwputch_inv( const catacurses::window &w, const point &p, nc_color FG,
+void mvwputch_inv( const catacurses::window &w, point p, nc_color FG,
                    const std::string &ch )
 {
     nc_color HC = invert_color( FG );
@@ -505,7 +505,7 @@ void mvwputch_inv( const catacurses::window &w, const point &p, nc_color FG,
     wattroff( w, HC );
 }
 
-void mvwputch_hi( const catacurses::window &w, const point &p, nc_color FG, int ch )
+void mvwputch_hi( const catacurses::window &w, point p, nc_color FG, int ch )
 {
     nc_color HC = hilite( FG );
     wattron( w, HC );
@@ -513,7 +513,7 @@ void mvwputch_hi( const catacurses::window &w, const point &p, nc_color FG, int 
     wattroff( w, HC );
 }
 
-void mvwputch_hi( const catacurses::window &w, const point &p, nc_color FG, const std::string &ch )
+void mvwputch_hi( const catacurses::window &w, point p, nc_color FG, const std::string &ch )
 {
     nc_color HC = hilite( FG );
     wattron( w, HC );
@@ -525,7 +525,7 @@ void draw_custom_border(
     const catacurses::window &w, const catacurses::chtype ls, const catacurses::chtype rs,
     const catacurses::chtype ts, const catacurses::chtype bs, const catacurses::chtype tl,
     const catacurses::chtype tr, const catacurses::chtype bl, const catacurses::chtype br,
-    const nc_color FG, const point &pos, int height, int width )
+    const nc_color FG, point pos, int height, int width )
 {
     wattron( w, FG );
 
@@ -604,7 +604,7 @@ border_helper::border_info::border_info( border_helper &helper )
 {
 }
 
-void border_helper::border_info::set( const point &pos, const point &size )
+void border_helper::border_info::set( point pos, point size )
 {
     this->pos = pos;
     this->size = size;
@@ -1312,7 +1312,7 @@ void draw_tabs( const catacurses::window &w, const std::vector<std::string> &tab
  *   If true, iCurrentLine can be at most iNumLines - iContentHeight.
  **/
 void draw_scrollbar( const catacurses::window &window, const int iCurrentLine,
-                     const int iContentHeight, const int iNumLines, const point &offset,
+                     const int iContentHeight, const int iNumLines, point offset,
                      nc_color bar_color, const bool bDoNotScrollToEnd )
 {
     scrollbar()
@@ -1540,7 +1540,7 @@ std::string rm_prefix( std::string str, char c1, char c2 )
 // draw a menu-item-like string with highlighted shortcut character
 // Example: <w>ield, m<o>ve
 // returns: output length (in console cells)
-size_t shortcut_print( const catacurses::window &w, const point &p, nc_color text_color,
+size_t shortcut_print( const catacurses::window &w, point p, nc_color text_color,
                        nc_color shortcut_color, const std::string &fmt )
 {
     wmove( w, p );
@@ -1710,7 +1710,7 @@ void insert_table( const catacurses::window &w, int pad, int line, int columns,
     wattroff( w, FG );
 }
 
-scrollingcombattext::cSCT::cSCT( const point &p_pos, const direction p_oDir,
+scrollingcombattext::cSCT::cSCT( point p_pos, const direction p_oDir,
                                  const std::string &p_sText, const game_message_type p_gmt,
                                  const std::string &p_sText2, const game_message_type p_gmt2,
                                  const std::string &p_sType )
@@ -1754,7 +1754,7 @@ scrollingcombattext::cSCT::cSCT( const point &p_pos, const direction p_oDir,
 
 }
 
-void scrollingcombattext::add( const point &pos, direction p_oDir,
+void scrollingcombattext::add( point pos, direction p_oDir,
                                const std::string &p_sText, const game_message_type p_gmt,
                                const std::string &p_sText2, const game_message_type p_gmt2,
                                const std::string &p_sType )
@@ -2078,7 +2078,7 @@ bool is_draw_tiles_mode()
 }
 #endif
 
-void mvwprintz( const catacurses::window &w, const point &p, const nc_color &FG,
+void mvwprintz( const catacurses::window &w, point p, const nc_color &FG,
                 const std::string &text )
 {
     wattron( w, FG );

--- a/src/output.h
+++ b/src/output.h
@@ -198,7 +198,7 @@ std::vector<std::string> foldstring( const std::string &str, int width, char spl
  * change to a color according to the color tags that are in the text.
  * @param base_color Base color that is used outside of any color tag.
  **/
-void print_colored_text( const catacurses::window &w, const point &p, nc_color &cur_color,
+void print_colored_text( const catacurses::window &w, point p, nc_color &cur_color,
                          const nc_color &base_color, const std::string &text,
                          report_color_error color_error = report_color_error::yes );
 /**
@@ -230,13 +230,13 @@ int print_scrollable( const catacurses::window &w, int begin_line, const std::st
  * @return The number of lines of the formatted text (after folding). This may be larger than
  * the height of the window.
  */
-int fold_and_print( const catacurses::window &w, const point &begin, int width,
+int fold_and_print( const catacurses::window &w, point begin, int width,
                     const nc_color &base_color, const std::string &text, char split = ' ' );
 /**
  * Same as other @ref fold_and_print, but does string formatting via @ref string_format.
  */
 template<typename ...Args>
-inline int fold_and_print( const catacurses::window &w, const point &begin,
+inline int fold_and_print( const catacurses::window &w, point begin,
                            const int width, const nc_color &base_color,
                            const char *const mes, Args &&... args )
 {
@@ -260,13 +260,13 @@ inline int fold_and_print( const catacurses::window &w, const point &begin,
  * always the same value, regardless of `begin_line`, it can be used to determine the maximal
  * value for `begin_line`.
  */
-int fold_and_print_from( const catacurses::window &w, const point &begin, int width,
+int fold_and_print_from( const catacurses::window &w, point begin, int width,
                          int begin_line, const nc_color &base_color, const std::string &text );
 /**
  * Same as other @ref fold_and_print_from, but does formatting via @ref string_format.
  */
 template<typename ...Args>
-inline int fold_and_print_from( const catacurses::window &w, const point &begin,
+inline int fold_and_print_from( const catacurses::window &w, point begin,
                                 const int width, const int begin_line, const nc_color &base_color,
                                 const char *const mes, Args &&... args )
 {
@@ -283,12 +283,12 @@ inline int fold_and_print_from( const catacurses::window &w, const point &begin,
  * @param base_color The initially used color. This can be overridden using color tags.
  * @param text Actual message to print
  */
-void trim_and_print( const catacurses::window &w, const point &begin, int width,
+void trim_and_print( const catacurses::window &w, point begin, int width,
                      const nc_color &base_color, const std::string &text,
                      report_color_error color_error = report_color_error::yes );
 std::string trim_by_length( const std::string &text, int width );
 template<typename ...Args>
-inline void trim_and_print( const catacurses::window &w, const point &begin,
+inline void trim_and_print( const catacurses::window &w, point begin,
                             const int width, const nc_color &base_color,
                             const char *const mes, Args &&... args )
 {
@@ -296,7 +296,7 @@ inline void trim_and_print( const catacurses::window &w, const point &begin,
                            string_format( mes, std::forward<Args>( args )... ) );
 }
 template<typename ...Args>
-inline void trim_and_print( const catacurses::window &w, const point &begin,
+inline void trim_and_print( const catacurses::window &w, point begin,
                             const int width, const nc_color &base_color,
                             const report_color_error color_error,
                             const char *const mes, Args &&... args )
@@ -319,20 +319,20 @@ std::string name_and_value( const std::string &name, const std::string &value, i
 
 void wputch( const catacurses::window &w, nc_color FG, int ch );
 // Using int ch is deprecated, use an UTF-8 encoded string instead
-void mvwputch( const catacurses::window &w, const point &p, nc_color FG, int ch );
-void mvwputch( const catacurses::window &w, const point &p, nc_color FG, const std::string &ch );
+void mvwputch( const catacurses::window &w, point p, nc_color FG, int ch );
+void mvwputch( const catacurses::window &w, point p, nc_color FG, const std::string &ch );
 // Using int ch is deprecated, use an UTF-8 encoded string instead
-void mvwputch_inv( const catacurses::window &w, const point &p, nc_color FG, int ch );
-void mvwputch_inv( const catacurses::window &w, const point &p, nc_color FG,
+void mvwputch_inv( const catacurses::window &w, point p, nc_color FG, int ch );
+void mvwputch_inv( const catacurses::window &w, point p, nc_color FG,
                    const std::string &ch );
 // Using int ch is deprecated, use an UTF-8 encoded string instead
-void mvwputch_hi( const catacurses::window &w, const point &p, nc_color FG, int ch );
-void mvwputch_hi( const catacurses::window &w, const point &p, nc_color FG, const std::string &ch );
+void mvwputch_hi( const catacurses::window &w, point p, nc_color FG, int ch );
+void mvwputch_hi( const catacurses::window &w, point p, nc_color FG, const std::string &ch );
 
-void mvwprintz( const catacurses::window &w, const point &p, const nc_color &FG,
+void mvwprintz( const catacurses::window &w, point p, const nc_color &FG,
                 const std::string &text );
 template<typename ...Args>
-inline void mvwprintz( const catacurses::window &w, const point &p, const nc_color &FG,
+inline void mvwprintz( const catacurses::window &w, point p, const nc_color &FG,
                        const char *const mes, Args &&... args )
 {
     mvwprintz( w, p, FG, string_format( mes, std::forward<Args>( args )... ) );
@@ -350,7 +350,7 @@ void draw_custom_border(
     const catacurses::window &w, catacurses::chtype ls = 1, catacurses::chtype rs = 1,
     catacurses::chtype ts = 1, catacurses::chtype bs = 1, catacurses::chtype tl = 1,
     catacurses::chtype tr = 1, catacurses::chtype bl = 1, catacurses::chtype br = 1,
-    nc_color FG = BORDER_COLOR, const point &pos = point_zero, int height = 0, int width = 0 );
+    nc_color FG = BORDER_COLOR, point pos = point_zero, int height = 0, int width = 0 );
 void draw_border( const catacurses::window &w, nc_color border_color = BORDER_COLOR,
                   const std::string &title = "", nc_color title_color = c_light_red );
 void draw_border_below_tabs( const catacurses::window &w, nc_color border_color = BORDER_COLOR );
@@ -361,7 +361,7 @@ class border_helper
         class border_info
         {
             public:
-                void set( const point &pos, const point &size );
+                void set( point pos, point size );
 
                 // Prevent accidentally copying the return value from border_helper::add_border
                 border_info( const border_info & ) = delete;
@@ -548,7 +548,7 @@ void draw_item_filter_rules( const catacurses::window &win, int starty, int heig
 char rand_char();
 int special_symbol( int sym );
 
-size_t shortcut_print( const catacurses::window &w, const point &p, nc_color text_color,
+size_t shortcut_print( const catacurses::window &w, point p, nc_color text_color,
                        nc_color shortcut_color, const std::string &fmt );
 size_t shortcut_print( const catacurses::window &w, nc_color text_color, nc_color shortcut_color,
                        const std::string &fmt );
@@ -778,7 +778,7 @@ void draw_tabs( const catacurses::window &w, const TabList &tab_list, const TabK
 
 // Legacy function, use class scrollbar instead!
 void draw_scrollbar( const catacurses::window &window, int iCurrentLine,
-                     int iContentHeight, int iNumLines, const point &offset = point_zero,
+                     int iContentHeight, int iNumLines, point offset = point_zero,
                      nc_color bar_color = c_white, bool bDoNotScrollToEnd = false );
 void calcStartPos( int &iStartPos, int iCurrentLine, int iContentHeight,
                    int iNumEntries );
@@ -878,7 +878,7 @@ class scrollingcombattext
                 bool iso_mode;
 
             public:
-                cSCT( const point &pos, direction p_oDir,
+                cSCT( point pos, direction p_oDir,
                       const std::string &p_sText, game_message_type p_gmt,
                       const std::string &p_sText2 = "", game_message_type p_gmt2 = m_neutral,
                       const std::string &p_sType = "" );
@@ -915,7 +915,7 @@ class scrollingcombattext
 
         std::vector<cSCT> vSCT;
 
-        void add( const point &pos, direction p_oDir,
+        void add( point pos, direction p_oDir,
                   const std::string &p_sText, game_message_type p_gmt,
                   const std::string &p_sText2 = "", game_message_type p_gmt2 = m_neutral,
                   const std::string &p_sType = "" );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3392,7 +3392,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
                 }
                 generated_lab.push_back( cand );
                 // add new candidates, don't backtrack
-                for( const point &offset : four_adjacent_offsets ) {
+                for( point offset : four_adjacent_offsets ) {
                     const tripoint_om_omt new_cand = cand + offset;
                     const int new_dist = manhattan_dist( p.xy(), new_cand.xy() );
                     if( closed_candidates.count( new_cand ) == 0 && new_dist > dist ) {
@@ -3460,7 +3460,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
         if( endgame_finale ) {
             for( const tripoint_om_omt &c : closest_points_first( p, 2 * s + 1 ) ) {
                 if( is_ot_match( labt.id().str(), ter( c ), ot_match_type::contains ) ) {
-                    for( const point &offset : four_adjacent_offsets ) {
+                    for( point offset : four_adjacent_offsets ) {
                         if( inbounds( c + offset ) && ter( c + offset ) != labt_stairs ) {
                             secondary_candidates.insert( c + offset );
                         }
@@ -3499,7 +3499,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
             tries++;
 
             adjacent_labs = 0;
-            for( const point &offset : four_adjacent_offsets ) {
+            for( point offset : four_adjacent_offsets ) {
                 if( is_ot_match( "lab", ter( train + offset ), ot_match_type::contains ) ) {
                     ++adjacent_labs;
                 }
@@ -3512,7 +3512,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
         if( tries < 50 ) {
             lab_train_points.push_back( train.xy() ); // possible train depot
             // next is rail connection
-            for( const point &offset : four_adjacent_offsets ) {
+            for( point offset : four_adjacent_offsets ) {
                 if( is_ot_match( "lab", ter( train + offset ), ot_match_type::contains ) ) {
                     lab_train_points.push_back( train.xy() - offset );
                     break;
@@ -3533,7 +3533,7 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
             tries++;
 
             adjacent_labs = 0;
-            for( const point &offset : four_adjacent_offsets ) {
+            for( point offset : four_adjacent_offsets ) {
                 if( is_ot_match( "lab", ter( cell + offset ), ot_match_type::contains ) ) {
                     ++adjacent_labs;
                 }
@@ -3704,7 +3704,7 @@ void overmap::build_mine( const tripoint_om_omt &origin, int s )
     while( built < s ) {
         ter_set( p, mine );
         std::vector<tripoint_om_omt> next;
-        for( const point &offset : four_adjacent_offsets ) {
+        for( point offset : four_adjacent_offsets ) {
             if( ter( p + offset ) == empty_rock ) {
                 next.push_back( p + offset );
             }
@@ -3985,7 +3985,7 @@ void overmap::chip_rock( const tripoint_om_omt &p )
     const oter_id rock( "rock" );
     const oter_id empty_rock( "empty_rock" );
 
-    for( const point &offset : four_adjacent_offsets ) {
+    for( point offset : four_adjacent_offsets ) {
         if( ter( p + offset ) == empty_rock ) {
             ter_set( p + offset, rock );
         }
@@ -4147,7 +4147,7 @@ std::string om_direction::name( type dir )
     (0,2)(1,2)(2,2)    (-2,0)(-2,1)(-2,2)    (-2,2)(-1,2)(0,2)
 */
 
-point om_direction::rotate( const point &p, type dir )
+point om_direction::rotate( point p, type dir )
 {
     switch( dir ) {
         case om_direction::type::invalid:

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -510,7 +510,7 @@ std::vector<mongroup *> overmapbuffer::monsters_at( const tripoint_abs_omt &p )
     // but monster groups are defined with submap coordinates.
     tripoint_abs_sm p_sm = project_to<coords::sm>( p );
     std::vector<mongroup *> result;
-    for( const point &offset : std::array<point, 4> { { { point_zero }, { point_south }, { point_east }, { point_south_east } } } ) {
+    for( point offset : std::array<point, 4> { { { point_zero }, { point_south }, { point_east }, { point_south_east } } } ) {
         std::vector<mongroup *> tmp = groups_at( p_sm + offset );
         result.insert( result.end(), tmp.begin(), tmp.end() );
     }

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -154,7 +154,7 @@ std::string window_panel::get_name() const
 }
 
 void overmap_ui::draw_overmap_chunk( const catacurses::window &w_minimap, const avatar &you,
-                                     const tripoint_abs_omt &global_omt, const point &start_input,
+                                     const tripoint_abs_omt &global_omt, point start_input,
                                      const int width, const int height )
 {
     const point_abs_omt curs = global_omt.xy();

--- a/src/panels.h
+++ b/src/panels.h
@@ -30,7 +30,7 @@ enum face_type : int {
 namespace overmap_ui
 {
 void draw_overmap_chunk( const catacurses::window &w_minimap, const avatar &you,
-                         const tripoint_abs_omt &global_omt, const point &start, int width,
+                         const tripoint_abs_omt &global_omt, point start, int width,
                          int height );
 } // namespace overmap_ui
 

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -44,7 +44,7 @@ struct path_data_layer {
     std::array< int, MAPSIZE_X *MAPSIZE_Y > gscore;
     std::array< tripoint, MAPSIZE_X *MAPSIZE_Y > parent;
 
-    void init( const point &min, const point &max ) {
+    void init( point min, point max ) {
         tripoint p;
         for( p.x = min.x; p.x <= max.x; p.x++ ) {
             for( p.y = min.y; p.y <= max.y; p.y++ ) {
@@ -58,7 +58,7 @@ struct path_data_layer {
 struct pathfinder {
     point min;
     point max;
-    pathfinder( const point &_min, const point &_max ) :
+    pathfinder( point _min, point _max ) :
         min( _min ), max( _max ) {
     }
 

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -42,7 +42,7 @@ namespace
 
 const point total_tiles_count = { ( MAPSIZE - 2 ) *SEEX, ( MAPSIZE - 2 ) *SEEY };
 
-point get_pixel_size( const point &tile_size, pixel_minimap_mode mode )
+point get_pixel_size( point tile_size, pixel_minimap_mode mode )
 {
     switch( mode ) {
         case pixel_minimap_mode::solid:
@@ -197,7 +197,7 @@ struct pixel_minimap::submap_cache {
 
     submap_cache( submap_cache && ) = default;
 
-    SDL_Color &color_at( const point &p ) {
+    SDL_Color &color_at( point p ) {
         assert( p.x < SEEX );
         assert( p.y < SEEY );
 
@@ -285,7 +285,7 @@ void pixel_minimap::flush_cache_updates()
             }
         }
 
-        for( const point &p : mcp.second.update_list ) {
+        for( point p : mcp.second.update_list ) {
             const point tile_pos = projector->get_tile_pos( p, { SEEX, SEEY } );
             const SDL_Color tile_color = mcp.second.color_at( p );
 

--- a/src/pixel_minimap_projectors.cpp
+++ b/src/pixel_minimap_projectors.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 
 pixel_minimap_ortho_projector::pixel_minimap_ortho_projector(
-    const point &total_tiles_count,
+    point total_tiles_count,
     const SDL_Rect &max_screen_rect,
     bool square_pixels )
 {
@@ -18,8 +18,8 @@ pixel_minimap_ortho_projector::pixel_minimap_ortho_projector(
 }
 
 SDL_Rect pixel_minimap_ortho_projector::get_chunk_rect(
-    const point &p,
-    const point &tiles_count ) const
+    point p,
+    point tiles_count ) const
 {
     return {
         p.x * tile_size.x,
@@ -34,7 +34,7 @@ point pixel_minimap_ortho_projector::get_tile_size() const
     return tile_size;
 }
 
-point pixel_minimap_ortho_projector::get_tiles_size( const point &tiles_count ) const
+point pixel_minimap_ortho_projector::get_tiles_size( point tiles_count ) const
 {
     return {
         tiles_count.x * tile_size.x,
@@ -42,14 +42,14 @@ point pixel_minimap_ortho_projector::get_tiles_size( const point &tiles_count ) 
     };
 }
 
-point pixel_minimap_ortho_projector::get_tile_pos( const point &p,
-        const point &/*tiles_count*/ ) const
+point pixel_minimap_ortho_projector::get_tile_pos( point p,
+        point /*tiles_count*/ ) const
 {
     return { p.x * tile_size.x, p.y * tile_size.y };
 }
 
 pixel_minimap_iso_projector::pixel_minimap_iso_projector(
-    const point &total_tiles_count,
+    point total_tiles_count,
     const SDL_Rect &max_screen_rect,
     bool square_pixels ) :
 
@@ -64,8 +64,8 @@ pixel_minimap_iso_projector::pixel_minimap_iso_projector(
 }
 
 SDL_Rect pixel_minimap_iso_projector::get_chunk_rect(
-    const point &p,
-    const point &tiles_count ) const
+    point p,
+    point tiles_count ) const
 {
     const point size = get_tiles_size( tiles_count );
     const point offset = point{ 0, tile_size.y *tiles_count.y / 2 };
@@ -79,7 +79,7 @@ point pixel_minimap_iso_projector::get_tile_size() const
     return tile_size;
 }
 
-point pixel_minimap_iso_projector::get_tiles_size( const point &tiles_count ) const
+point pixel_minimap_iso_projector::get_tiles_size( point tiles_count ) const
 {
     return {
         tile_size.x *( 2 * tiles_count.x - 1 ),
@@ -87,7 +87,7 @@ point pixel_minimap_iso_projector::get_tiles_size( const point &tiles_count ) co
     };
 }
 
-point pixel_minimap_iso_projector::get_tile_pos( const point &p, const point &tiles_count ) const
+point pixel_minimap_iso_projector::get_tile_pos( point p, point tiles_count ) const
 {
     return {
         tile_size.x *( p.x + p.y ),

--- a/src/pixel_minimap_projectors.h
+++ b/src/pixel_minimap_projectors.h
@@ -12,24 +12,24 @@ class pixel_minimap_projector
         virtual ~pixel_minimap_projector() = default;
 
         virtual point get_tile_size() const = 0;
-        virtual point get_tiles_size( const point &tiles_count ) const = 0;
-        virtual point get_tile_pos( const point &p, const point &tiles_count ) const = 0;
+        virtual point get_tiles_size( point tiles_count ) const = 0;
+        virtual point get_tile_pos( point p, point tiles_count ) const = 0;
 
-        virtual SDL_Rect get_chunk_rect( const point &p, const point &tiles_count ) const = 0;
+        virtual SDL_Rect get_chunk_rect( point p, point tiles_count ) const = 0;
 };
 
 class pixel_minimap_ortho_projector : public pixel_minimap_projector
 {
     public:
-        pixel_minimap_ortho_projector( const point &total_tiles_count,
+        pixel_minimap_ortho_projector( point total_tiles_count,
                                        const SDL_Rect &max_screen_rect,
                                        bool square_pixels );
 
         point get_tile_size() const override;
-        point get_tiles_size( const point &tiles_count ) const override;
-        point get_tile_pos( const point &p, const point &tiles_count ) const override;
+        point get_tiles_size( point tiles_count ) const override;
+        point get_tile_pos( point p, point tiles_count ) const override;
 
-        SDL_Rect get_chunk_rect( const point &p, const point &tiles_count ) const override;
+        SDL_Rect get_chunk_rect( point p, point tiles_count ) const override;
 
     private:
         point tile_size;
@@ -38,15 +38,15 @@ class pixel_minimap_ortho_projector : public pixel_minimap_projector
 class pixel_minimap_iso_projector : public pixel_minimap_projector
 {
     public:
-        pixel_minimap_iso_projector( const point &total_tiles_count,
+        pixel_minimap_iso_projector( point total_tiles_count,
                                      const SDL_Rect &max_screen_rect,
                                      bool square_pixels );
 
         point get_tile_size() const override;
-        point get_tiles_size( const point &tiles_count ) const override;
-        point get_tile_pos( const point &p, const point &tiles_count ) const override;
+        point get_tiles_size( point tiles_count ) const override;
+        point get_tile_pos( point p, point tiles_count ) const override;
 
-        SDL_Rect get_chunk_rect( const point &p, const point &tiles_count ) const override;
+        SDL_Rect get_chunk_rect( point p, point tiles_count ) const override;
 
     private:
         point total_tiles_count;

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -7,7 +7,7 @@
 #include "cata_utility.h"
 
 
-point point::rotate( int turns, const point &dim ) const
+point point::rotate( int turns, point dim ) const
 {
     assert( turns >= 0 );
     assert( turns <= 4 );
@@ -38,7 +38,7 @@ std::string tripoint::to_string() const
     return os.str();
 }
 
-std::ostream &operator<<( std::ostream &os, const point &pos )
+std::ostream &operator<<( std::ostream &os, point pos )
 {
     return os << "(" << pos.x << "," << pos.y << ")";
 }
@@ -60,19 +60,19 @@ std::vector<tripoint> closest_points_first( const tripoint &center, int min_dist
     std::vector<tripoint> result;
     result.reserve( points.size() );
 
-    for( const point &p : points ) {
+    for( point p : points ) {
         result.emplace_back( p, center.z );
     }
 
     return result;
 }
 
-std::vector<point> closest_points_first( const point &center, int max_dist )
+std::vector<point> closest_points_first( point center, int max_dist )
 {
     return closest_points_first( center, 0, max_dist );
 }
 
-std::vector<point> closest_points_first( const point &center, int min_dist, int max_dist )
+std::vector<point> closest_points_first( point center, int min_dist, int max_dist )
 {
     min_dist = std::max( min_dist, 0 );
     max_dist = std::max( max_dist, 0 );

--- a/src/point.h
+++ b/src/point.h
@@ -40,10 +40,10 @@ struct point {
     constexpr point() = default;
     constexpr point( int X, int Y ) : x( X ), y( Y ) {}
 
-    constexpr point operator+( const point &rhs ) const {
+    constexpr point operator+( point rhs ) const {
         return point( x + rhs.x, y + rhs.y );
     }
-    point &operator+=( const point &rhs ) {
+    point &operator+=( point rhs ) {
         x += rhs.x;
         y += rhs.y;
         return *this;
@@ -51,10 +51,10 @@ struct point {
     constexpr point operator-() const {
         return point( -x, -y );
     }
-    constexpr point operator-( const point &rhs ) const {
+    constexpr point operator-( point rhs ) const {
         return point( x - rhs.x, y - rhs.y );
     }
-    point &operator-=( const point &rhs ) {
+    point &operator-=( point rhs ) {
         x -= rhs.x;
         y -= rhs.y;
         return *this;
@@ -62,7 +62,7 @@ struct point {
     constexpr point operator*( const int rhs ) const {
         return point( x * rhs, y * rhs );
     }
-    friend constexpr point operator*( int lhs, const point &rhs ) {
+    friend constexpr point operator*( int lhs, point rhs ) {
         return rhs * lhs;
     }
     point &operator*=( const int rhs ) {
@@ -86,24 +86,24 @@ struct point {
      * by @param dim
      * By default rotates around the origin (0, 0).
      * NOLINTNEXTLINE(cata-use-named-point-constants) */
-    point rotate( int turns, const point &dim = { 1, 1 } ) const;
+    point rotate( int turns, point dim = { 1, 1 } ) const;
 
     std::string to_string() const;
 
     void serialize( JsonOut &jsout ) const;
     void deserialize( JsonIn &jsin );
 
-    friend inline constexpr bool operator<( const point &a, const point &b ) {
+    friend inline constexpr bool operator<( point a, point b ) {
         return a.x < b.x || ( a.x == b.x && a.y < b.y );
     }
-    friend inline constexpr bool operator==( const point &a, const point &b ) {
+    friend inline constexpr bool operator==( point a, point b ) {
         return a.x == b.x && a.y == b.y;
     }
-    friend inline constexpr bool operator!=( const point &a, const point &b ) {
+    friend inline constexpr bool operator!=( point a, point b ) {
         return !( a == b );
     }
 
-    friend std::ostream &operator<<( std::ostream &, const point & );
+    friend std::ostream &operator<<( std::ostream &, point );
 };
 
 inline int divide_round_to_minus_infinity( int n, int d )
@@ -118,12 +118,12 @@ inline int divide_round_to_minus_infinity( int n, int d )
     return ( n - d + 1 ) / d; // NOLINT(clang-analyzer-core.DivideZero)
 }
 
-inline point multiply_xy( const point &p, int f )
+inline point multiply_xy( point p, int f )
 {
     return point( p.x * f, p.y * f );
 }
 
-inline point divide_xy_round_to_minus_infinity( const point &p, int d )
+inline point divide_xy_round_to_minus_infinity( point p, int d )
 {
     return point( divide_round_to_minus_infinity( p.x, d ),
                   divide_round_to_minus_infinity( p.y, d ) );
@@ -138,7 +138,7 @@ struct tripoint {
     int z = 0;
     constexpr tripoint() = default;
     constexpr tripoint( int X, int Y, int Z ) : x( X ), y( Y ), z( Z ) {}
-    constexpr tripoint( const point &p, int Z ) : x( p.x ), y( p.y ), z( Z ) {}
+    constexpr tripoint( point p, int Z ) : x( p.x ), y( p.y ), z( Z ) {}
 
     constexpr tripoint operator+( const tripoint &rhs ) const {
         return tripoint( x + rhs.x, y + rhs.y, z + rhs.z );
@@ -171,21 +171,21 @@ struct tripoint {
         return tripoint( x / rhs, y / rhs, z / rhs );
     }
     /*** some point operators and functions ***/
-    constexpr tripoint operator+( const point &rhs ) const {
+    constexpr tripoint operator+( point rhs ) const {
         return tripoint( x + rhs.x, y + rhs.y, z );
     }
-    friend constexpr tripoint operator+( const point &lhs, const tripoint &rhs ) {
+    friend constexpr tripoint operator+( point lhs, const tripoint &rhs ) {
         return rhs + lhs;
     }
-    constexpr tripoint operator-( const point &rhs ) const {
+    constexpr tripoint operator-( point rhs ) const {
         return tripoint( x - rhs.x, y - rhs.y, z );
     }
-    tripoint &operator+=( const point &rhs ) {
+    tripoint &operator+=( point rhs ) {
         x += rhs.x;
         y += rhs.y;
         return *this;
     }
-    tripoint &operator-=( const point &rhs ) {
+    tripoint &operator-=( point rhs ) {
         x -= rhs.x;
         y -= rhs.y;
         return *this;
@@ -215,7 +215,7 @@ struct tripoint {
      * the dimensions specified by @param dim.
      * By default rotates around the origin (0, 0).
      * NOLINTNEXTLINE(cata-use-named-point-constants) */
-    inline tripoint rotate_2d( int turns, const point &dim = { 1, 1 } ) const {
+    inline tripoint rotate_2d( int turns, point dim = { 1, 1 } ) const {
         return tripoint( xy().rotate( turns, dim ), z );
     }
 
@@ -298,8 +298,8 @@ struct sphere {
 std::vector<tripoint> closest_points_first( const tripoint &center, int max_dist );
 std::vector<tripoint> closest_points_first( const tripoint &center, int min_dist, int max_dist );
 
-std::vector<point> closest_points_first( const point &center, int max_dist );
-std::vector<point> closest_points_first( const point &center, int min_dist, int max_dist );
+std::vector<point> closest_points_first( point center, int max_dist );
+std::vector<point> closest_points_first( point center, int min_dist, int max_dist );
 
 static constexpr tripoint tripoint_min { INT_MIN, INT_MIN, INT_MIN };
 static constexpr tripoint tripoint_max{ INT_MAX, INT_MAX, INT_MAX };
@@ -313,7 +313,7 @@ namespace std
 {
 template <>
 struct hash<point> {
-    std::size_t operator()( const point &k ) const noexcept {
+    std::size_t operator()( point k ) const noexcept {
         constexpr uint64_t a = 2862933555777941757;
         size_t result = k.y;
         result *= a;

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -388,7 +388,7 @@ query_popup::query_option::query_option(
 {
 }
 
-query_popup::button::button( const std::string &text, const point &p )
+query_popup::button::button( const std::string &text, point p )
     : text( text ), pos( p )
 {
 }

--- a/src/popup.h
+++ b/src/popup.h
@@ -219,7 +219,7 @@ class query_popup
         bool fullscr;
 
         struct button {
-            button( const std::string &text, const point & );
+            button( const std::string &text, point );
 
             std::string text;
             point pos;

--- a/src/rect_range.h
+++ b/src/rect_range.h
@@ -15,7 +15,7 @@ class rect_range
         point count;
 
     public:
-        rect_range( const int w, const int h, const point &c ) : width( w ), height( h ),
+        rect_range( const int w, const int h, point c ) : width( w ), height( h ),
             count( c ) {
         }
 

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -79,7 +79,7 @@ void scent_map::draw( const catacurses::window &win, const int div, const tripoi
     }
 }
 
-void scent_map::shift( const point &sm_shift )
+void scent_map::shift( point sm_shift )
 {
     scent_array<int> new_scent;
     for( size_t x = 0; x < MAPSIZE_X; ++x ) {

--- a/src/scent_map.h
+++ b/src/scent_map.h
@@ -63,7 +63,7 @@ class scent_map
         void update( const tripoint &center, map &m );
         void reset();
         void decay();
-        void shift( const point &sm_shift );
+        void shift( point sm_shift );
 
         /**
          * Get the scent value at the given position.
@@ -80,7 +80,7 @@ class scent_map
         scenttype_id get_type( const tripoint &p ) const;
 
         bool inbounds( const tripoint &p ) const;
-        bool inbounds( const point &p ) const {
+        bool inbounds( point p ) const {
             return inbounds( tripoint( p, 0 ) );
         }
 };

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<Font> Font::load_font( SDL_Renderer_Ptr &renderer, SDL_PixelForm
 // line_id is one of the LINE_*_C constants
 // FG is a curses color
 void Font::draw_ascii_lines( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &geometry,
-                             unsigned char line_id, const point &p, unsigned char color ) const
+                             unsigned char line_id, point p, unsigned char color ) const
 {
     SDL_Color sdl_color = palette[color];
     switch( line_id ) {
@@ -330,7 +330,7 @@ bool CachedTTFFont::isGlyphProvided( const std::string &ch ) const
 }
 
 void CachedTTFFont::OutputChar( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &,
-                                const std::string &ch, const point &p,
+                                const std::string &ch, point p,
                                 unsigned char color, const float opacity )
 {
     key_t    key {ch, static_cast<unsigned char>( color & 0xf )};
@@ -407,7 +407,7 @@ BitmapFont::BitmapFont(
 
 void BitmapFont::draw_ascii_lines( const SDL_Renderer_Ptr &renderer,
                                    const GeometryRenderer_Ptr &geometry,
-                                   unsigned char line_id, const point &p, unsigned char color ) const
+                                   unsigned char line_id, point p, unsigned char color ) const
 {
     BitmapFont *t = const_cast<BitmapFont *>( this );
     switch( line_id ) {
@@ -482,7 +482,7 @@ bool BitmapFont::isGlyphProvided( const std::string &ch ) const
 }
 
 void BitmapFont::OutputChar( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &geometry,
-                             const std::string &ch, const point &p,
+                             const std::string &ch, point p,
                              unsigned char color, const float opacity )
 {
     const int t = UTF8_getch( ch );
@@ -490,7 +490,7 @@ void BitmapFont::OutputChar( const SDL_Renderer_Ptr &renderer, const GeometryRen
 }
 
 void BitmapFont::OutputChar( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &geometry,
-                             const int t, const point &p,
+                             const int t, point p,
                              unsigned char color, const float opacity )
 {
     if( t <= 256 ) {
@@ -582,7 +582,7 @@ bool FontFallbackList::isGlyphProvided( const std::string & ) const
 
 void FontFallbackList::OutputChar( const SDL_Renderer_Ptr &renderer,
                                    const GeometryRenderer_Ptr &geometry,
-                                   const std::string &ch, const point &p,
+                                   const std::string &ch, point p,
                                    unsigned char color, const float opacity )
 {
     auto cached = glyph_font.find( ch );

--- a/src/sdl_font.h
+++ b/src/sdl_font.h
@@ -41,7 +41,7 @@ class Font
         /// @param color Curses color to use when drawing
         /// @param opacity Optional opacity of the character
         virtual void OutputChar( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &geometry,
-                                 const std::string &ch, const point &p,
+                                 const std::string &ch, point p,
                                  unsigned char color, float opacity = 1.0f ) = 0;
 
         /// Draw an ascii line using font's palette.
@@ -50,7 +50,7 @@ class Font
         /// @param color Curses color to use when drawing
         virtual void draw_ascii_lines( const SDL_Renderer_Ptr &renderer,
                                        const GeometryRenderer_Ptr &geometry,
-                                       unsigned char line_id, const point &p, unsigned char color ) const;
+                                       unsigned char line_id, point p, unsigned char color ) const;
 
         /// Try to load a font by typeface (Bitmap or Truetype).
         static std::unique_ptr<Font> load_font(
@@ -82,7 +82,7 @@ class CachedTTFFont : public Font
         bool isGlyphProvided( const std::string &ch ) const override;
         void OutputChar( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &geometry,
                          const std::string &ch,
-                         const point &p,
+                         point p,
                          unsigned char color, float opacity = 1.0f ) override;
     protected:
         SDL_Texture_Ptr create_glyph( const SDL_Renderer_Ptr &renderer, const std::string &ch, int color );
@@ -134,13 +134,13 @@ class BitmapFont : public Font
         bool isGlyphProvided( const std::string &ch ) const override;
         void OutputChar( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &geometry,
                          const std::string &ch,
-                         const point &p,
+                         point p,
                          unsigned char color, float opacity = 1.0f ) override;
         void OutputChar( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &geometry,  int t,
-                         const point &p,
+                         point p,
                          unsigned char color, float opacity = 1.0f );
         void draw_ascii_lines( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &geometry,
-                               unsigned char line_id, const point &p, unsigned char color ) const override;
+                               unsigned char line_id, point p, unsigned char color ) const override;
     protected:
         std::array<SDL_Texture_Ptr, color_loader<SDL_Color>::COLOR_NAMES_COUNT> ascii;
         int tilewidth;
@@ -162,7 +162,7 @@ class FontFallbackList : public Font
         bool isGlyphProvided( const std::string &ch ) const override;
         void OutputChar( const SDL_Renderer_Ptr &renderer, const GeometryRenderer_Ptr &geometry,
                          const std::string &ch,
-                         const point &p,
+                         point p,
                          unsigned char color, float opacity = 1.0f ) override;
     protected:
         std::vector<std::unique_ptr<Font>> fonts;

--- a/src/sdl_geometry.cpp
+++ b/src/sdl_geometry.cpp
@@ -4,21 +4,21 @@
 
 #define dbg(x) DebugLogFL((x),DC::SDL)
 
-void GeometryRenderer::horizontal_line( const SDL_Renderer_Ptr &renderer, const point &pos, int x2,
+void GeometryRenderer::horizontal_line( const SDL_Renderer_Ptr &renderer, point pos, int x2,
                                         int thickness, const SDL_Color &color ) const
 {
     SDL_Rect rect { pos.x, pos.y, x2 - pos.x, thickness };
     this->rect( renderer, rect, color );
 }
 
-void GeometryRenderer::vertical_line( const SDL_Renderer_Ptr &renderer, const point &pos, int y2,
+void GeometryRenderer::vertical_line( const SDL_Renderer_Ptr &renderer, point pos, int y2,
                                       int thickness, const SDL_Color &color ) const
 {
     SDL_Rect rect { pos.x, pos.y, thickness, y2 - pos.y };
     this->rect( renderer, rect, color );
 }
 
-void GeometryRenderer::rect( const SDL_Renderer_Ptr &renderer, const point &pos, int width,
+void GeometryRenderer::rect( const SDL_Renderer_Ptr &renderer, point pos, int width,
                              int height, const SDL_Color &color ) const
 {
     SDL_Rect rect { pos.x, pos.y, width, height };

--- a/src/sdl_geometry.h
+++ b/src/sdl_geometry.h
@@ -19,15 +19,15 @@ class GeometryRenderer
                            const SDL_Color &color ) const = 0;
 
         /// Renders a point+width+height defined rectangle with given color.
-        void rect( const SDL_Renderer_Ptr &renderer, const point &pos, int width, int height,
+        void rect( const SDL_Renderer_Ptr &renderer, point pos, int width, int height,
                    const SDL_Color &color ) const;
 
         /// Renders a straight horizontal line with given thickness and color.
-        void horizontal_line( const SDL_Renderer_Ptr &renderer, const point &pos, int x2, int thickness,
+        void horizontal_line( const SDL_Renderer_Ptr &renderer, point pos, int x2, int thickness,
                               const SDL_Color &color ) const;
 
         /// Renders a straight vertical line with given thickness and color.
-        void vertical_line( const SDL_Renderer_Ptr &renderer, const point &pos, int y2, int thickness,
+        void vertical_line( const SDL_Renderer_Ptr &renderer, point pos, int y2, int thickness,
                             const SDL_Color &color ) const;
 };
 using GeometryRenderer_Ptr = std::unique_ptr<GeometryRenderer>;

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -89,7 +89,7 @@ void SetRenderDrawColor( const SDL_Renderer_Ptr &renderer, const Uint8 r, const 
                   "SDL_SetRenderDrawColor failed" );
 }
 
-void RenderDrawPoint( const SDL_Renderer_Ptr &renderer, const point &p )
+void RenderDrawPoint( const SDL_Renderer_Ptr &renderer, point p )
 {
     printErrorIf( SDL_RenderDrawPoint( renderer.get(), p.x, p.y ) != 0, "SDL_RenderDrawPoint failed" );
 }

--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -93,7 +93,7 @@ SDL_Texture_Ptr CreateTexture( const SDL_Renderer_Ptr &renderer, Uint32 format, 
 SDL_Texture_Ptr CreateTextureFromSurface( const SDL_Renderer_Ptr &renderer,
         const SDL_Surface_Ptr &surface );
 void SetRenderDrawColor( const SDL_Renderer_Ptr &renderer, Uint8 r, Uint8 g, Uint8 b, Uint8 a );
-void RenderDrawPoint( const SDL_Renderer_Ptr &renderer, const point &p );
+void RenderDrawPoint( const SDL_Renderer_Ptr &renderer, point p );
 void RenderFillRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect );
 void FillRect( const SDL_Surface_Ptr &surface, const SDL_Rect *rect, Uint32 color );
 void SetTextureBlendMode( const SDL_Texture_Ptr &texture, SDL_BlendMode blendMode );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -575,7 +575,7 @@ void set_displaybuffer_rendertarget()
     SetRenderTarget( renderer, display_buffer );
 }
 
-static void invalidate_framebuffer( std::vector<curseline> &framebuffer, const point &p, int width,
+static void invalidate_framebuffer( std::vector<curseline> &framebuffer, point p, int width,
                                     int height )
 {
     for( int j = 0, fby = p.y; j < height; j++, fby++ ) {
@@ -827,7 +827,7 @@ static point draw_string( Font &font,
     return p;
 }
 
-void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_omt, bool blink )
+void cata_tiles::draw_om( point dest, const tripoint_abs_omt &center_abs_omt, bool blink )
 {
     if( !g ) {
         return;
@@ -1148,7 +1148,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     if( !notes_window_text.empty() ) {
         constexpr int padding = 2;
 
-        const auto draw_note_text = [&]( const point & draw_pos, const std::string & name,
+        const auto draw_note_text = [&]( point  draw_pos, const std::string & name,
         nc_color & color ) {
             char note_fg_color = color == c_yellow ? 11 :
                                  cata_cursesport::colorpairs[color.to_color_pair_index()].FG;
@@ -1230,7 +1230,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                   "SDL_RenderSetClipRect failed" );
 }
 
-static bool draw_window( Font_Ptr &font, const catacurses::window &w, const point &offset )
+static bool draw_window( Font_Ptr &font, const catacurses::window &w, point offset )
 {
     if( scaling_factor > 1 ) {
         SDL_RenderSetLogicalSize( renderer.get(), WindowWidth / scaling_factor,
@@ -3713,7 +3713,7 @@ void rescale_tileset( int size )
 }
 
 static window_dimensions get_window_dimensions( const catacurses::window &win,
-        const point &pos, const point &size )
+        point pos, point size )
 {
     window_dimensions dim;
     if( use_tiles && g && win == g->w_terrain ) {
@@ -3766,7 +3766,7 @@ window_dimensions get_window_dimensions( const catacurses::window &win )
     return get_window_dimensions( win, point_zero, point_zero );
 }
 
-window_dimensions get_window_dimensions( const point &pos, const point &size )
+window_dimensions get_window_dimensions( point pos, point size )
 {
     return get_window_dimensions( {}, pos, size );
 }
@@ -3782,8 +3782,8 @@ cata::optional<tripoint> input_context::get_coordinates( const catacurses::windo
 
     const int &fw = dim.scaled_font_size.x;
     const int &fh = dim.scaled_font_size.y;
-    const point &win_min = dim.window_pos_pixel;
-    const point &win_size = dim.window_size_pixel;
+    point win_min = dim.window_pos_pixel;
+    point win_size = dim.window_size_pixel;
     const point win_max = win_min + win_size;
 
     // Translate mouse coordinates to map coordinates based on tile size

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -40,7 +40,7 @@ struct window_dimensions {
 window_dimensions get_window_dimensions( const catacurses::window &win );
 // Get dimensional info of an imaginary normal catacurses::window with the given
 // position and size. Unlike real catacurses::window, size can be zero.
-window_dimensions get_window_dimensions( const point &pos, const point &size );
+window_dimensions get_window_dimensions( point pos, point size );
 
 const SDL_Renderer_Ptr &get_sdl_renderer();
 

--- a/src/shadowcasting.h
+++ b/src/shadowcasting.h
@@ -111,7 +111,7 @@ template<typename T, typename Out, T( *calc )( const T &, const T &, const int &
 void castLightAll( Out( &output_cache )[MAPSIZE_X][MAPSIZE_Y],
                    const T( &input_array )[MAPSIZE_X][MAPSIZE_Y],
                    const diagonal_blocks( &blocked_array )[MAPSIZE_X][MAPSIZE_Y],
-                   const point &offset, int offsetDistance = 0,
+                   point offset, int offsetDistance = 0,
                    T numerator = 1.0 );
 
 template<typename T>

--- a/src/simple_pathfinding.cpp
+++ b/src/simple_pathfinding.cpp
@@ -40,14 +40,14 @@ struct point_node {
 
 } // namespace
 
-directed_path<point> greedy_path( const point &source, const point &dest, const point &max,
+directed_path<point> greedy_path( point source, point dest, point max,
                                   two_node_scoring_fn<point> scorer )
 {
     using Node = point_node;
-    const auto inbounds = [ max ]( const point & p ) {
+    const auto inbounds = [ max ]( point  p ) {
         return p.x >= 0 && p.x < max.x && p.y >= 0 && p.y < max.y;
     };
-    const auto map_index = [ max ]( const point & p ) {
+    const auto map_index = [ max ]( point  p ) {
         return p.y * max.x + p.x;
     };
 

--- a/src/simple_pathfinding.h
+++ b/src/simple_pathfinding.h
@@ -67,7 +67,7 @@ using two_node_scoring_fn =
     std::function<node_score( directed_node<Point>, cata::optional<directed_node<Point>> )>;
 
 // non-templated implementation
-directed_path<point> greedy_path( const point &source, const point &dest, const point &max,
+directed_path<point> greedy_path( point source, point dest, point max,
                                   two_node_scoring_fn<point> scorer );
 
 /**

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -482,7 +482,7 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
     return _text;
 }
 
-string_input_popup &string_input_popup::window( const catacurses::window &w, const point &start,
+string_input_popup &string_input_popup::window( const catacurses::window &w, point start,
         int endx )
 {
     if( !custom_window && this->w ) {

--- a/src/string_input_popup.h
+++ b/src/string_input_popup.h
@@ -188,7 +188,7 @@ class string_input_popup // NOLINT(cata-xy)
          * This method only has effect before the default window is initialized.
          * After that calls to this method are just ignored.
          */
-        string_input_popup &window( const catacurses::window &w, const point &start, int endx );
+        string_input_popup &window( const catacurses::window &w, point start, int endx );
         /**
          * Set / get the input context that is used to gather user input.
          * The class will create its own context if none is set here.

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -14,7 +14,7 @@
 #include "vehicle.h"
 
 template<int sx, int sy>
-void maptile_soa<sx, sy>::swap_soa_tile( const point &p1, const point &p2 )
+void maptile_soa<sx, sy>::swap_soa_tile( point p1, point p2 )
 {
     std::swap( ter[p1.x][p1.y], ter[p2.x][p2.y] );
     std::swap( frn[p1.x][p1.y], frn[p2.x][p2.y] );
@@ -26,7 +26,7 @@ void maptile_soa<sx, sy>::swap_soa_tile( const point &p1, const point &p2 )
 }
 
 template<int sx, int sy>
-void maptile_soa<sx, sy>::swap_soa_tile( const point &p, maptile_soa<1, 1> &other )
+void maptile_soa<sx, sy>::swap_soa_tile( point p, maptile_soa<1, 1> &other )
 {
     std::swap( ter[p.x][p.y], **other.ter );
     std::swap( frn[p.x][p.y], **other.frn );
@@ -53,7 +53,7 @@ submap::~submap() = default;
 
 submap &submap::operator=( submap && ) = default;
 
-void submap::update_lum_rem( const point &p, const item &i )
+void submap::update_lum_rem( point p, const item &i )
 {
     is_uniform = false;
     if( !i.is_emissive() ) {
@@ -77,7 +77,7 @@ void submap::update_lum_rem( const point &p, const item &i )
     }
 }
 
-void submap::insert_cosmetic( const point &p, const std::string &type, const std::string &str )
+void submap::insert_cosmetic( point p, const std::string &type, const std::string &str )
 {
     cosmetic_t ins;
 
@@ -105,7 +105,7 @@ static cosmetic_find_result make_result( bool b, int ndx )
     return result;
 }
 static cosmetic_find_result find_cosmetic(
-    const std::vector<submap::cosmetic_t> &cosmetics, const point &p, const std::string &type )
+    const std::vector<submap::cosmetic_t> &cosmetics, point p, const std::string &type )
 {
     for( size_t i = 0; i < cosmetics.size(); ++i ) {
         if( cosmetics[i].pos == p && cosmetics[i].type == type ) {
@@ -115,12 +115,12 @@ static cosmetic_find_result find_cosmetic(
     return make_result( false, -1 );
 }
 
-bool submap::has_graffiti( const point &p ) const
+bool submap::has_graffiti( point p ) const
 {
     return find_cosmetic( cosmetics, p, COSMETICS_GRAFFITI ).result;
 }
 
-const std::string &submap::get_graffiti( const point &p ) const
+const std::string &submap::get_graffiti( point p ) const
 {
     const auto fresult = find_cosmetic( cosmetics, p, COSMETICS_GRAFFITI );
     if( fresult.result ) {
@@ -129,7 +129,7 @@ const std::string &submap::get_graffiti( const point &p ) const
     return STRING_EMPTY;
 }
 
-void submap::set_graffiti( const point &p, const std::string &new_graffiti )
+void submap::set_graffiti( point p, const std::string &new_graffiti )
 {
     is_uniform = false;
     // Find signage at p if available
@@ -141,7 +141,7 @@ void submap::set_graffiti( const point &p, const std::string &new_graffiti )
     }
 }
 
-void submap::delete_graffiti( const point &p )
+void submap::delete_graffiti( point p )
 {
     is_uniform = false;
     const auto fresult = find_cosmetic( cosmetics, p, COSMETICS_GRAFFITI );
@@ -150,7 +150,7 @@ void submap::delete_graffiti( const point &p )
         cosmetics.pop_back();
     }
 }
-bool submap::has_signage( const point &p ) const
+bool submap::has_signage( point p ) const
 {
     if( frn[p.x][p.y].obj().has_flag( "SIGN" ) ) {
         return find_cosmetic( cosmetics, p, COSMETICS_SIGNAGE ).result;
@@ -158,7 +158,7 @@ bool submap::has_signage( const point &p ) const
 
     return false;
 }
-std::string submap::get_signage( const point &p ) const
+std::string submap::get_signage( point p ) const
 {
     if( frn[p.x][p.y].obj().has_flag( "SIGN" ) ) {
         const auto fresult = find_cosmetic( cosmetics, p, COSMETICS_SIGNAGE );
@@ -169,7 +169,7 @@ std::string submap::get_signage( const point &p ) const
 
     return STRING_EMPTY;
 }
-void submap::set_signage( const point &p, const std::string &s )
+void submap::set_signage( point p, const std::string &s )
 {
     is_uniform = false;
     // Find signage at p if available
@@ -180,7 +180,7 @@ void submap::set_signage( const point &p, const std::string &s )
         insert_cosmetic( p, COSMETICS_SIGNAGE, s );
     }
 }
-void submap::delete_signage( const point &p )
+void submap::delete_signage( point p )
 {
     is_uniform = false;
     const auto fresult = find_cosmetic( cosmetics, p, COSMETICS_SIGNAGE );
@@ -204,12 +204,12 @@ void submap::update_legacy_computer()
     }
 }
 
-bool submap::has_computer( const point &p ) const
+bool submap::has_computer( point p ) const
 {
     return computers.find( p ) != computers.end() || ( legacy_computer && ter[p.x][p.y] == t_console );
 }
 
-const computer *submap::get_computer( const point &p ) const
+const computer *submap::get_computer( point p ) const
 {
     // the returned object will not get modified (should not, at least), so we
     // don't yet need to update to std::map
@@ -223,7 +223,7 @@ const computer *submap::get_computer( const point &p ) const
     return nullptr;
 }
 
-computer *submap::get_computer( const point &p )
+computer *submap::get_computer( point p )
 {
     // need to update to std::map first so modifications to the returned object
     // only affects the exact point p
@@ -235,7 +235,7 @@ computer *submap::get_computer( const point &p )
     return nullptr;
 }
 
-void submap::set_computer( const point &p, const computer &c )
+void submap::set_computer( point p, const computer &c )
 {
     update_legacy_computer();
     const auto it = computers.find( p );
@@ -246,7 +246,7 @@ void submap::set_computer( const point &p, const computer &c )
     }
 }
 
-void submap::delete_computer( const point &p )
+void submap::delete_computer( point p )
 {
     update_legacy_computer();
     computers.erase( p );
@@ -270,7 +270,7 @@ void submap::rotate( int turns )
         return;
     }
 
-    const auto rotate_point = [turns]( const point & p ) {
+    const auto rotate_point = [turns]( point  p ) {
         return p.rotate( turns, { SEEX, SEEY } );
     };
 

--- a/src/submap.h
+++ b/src/submap.h
@@ -57,8 +57,8 @@ struct maptile_soa {
     trap_id            trp[sx][sy];  // Trap on each square
     int                rad[sx][sy];  // Irradiation of each square
 
-    void swap_soa_tile( const point &p1, const point &p2 );
-    void swap_soa_tile( const point &p, maptile_soa<1, 1> &other );
+    void swap_soa_tile( point p1, point p2 );
+    void swap_soa_tile( point p, maptile_soa<1, 1> &other );
 };
 
 class submap : maptile_soa<SEEX, SEEY>
@@ -70,11 +70,11 @@ class submap : maptile_soa<SEEX, SEEY>
 
         submap &operator=( submap && );
 
-        trap_id get_trap( const point &p ) const {
+        trap_id get_trap( point p ) const {
             return trp[p.x][p.y];
         }
 
-        void set_trap( const point &p, trap_id trap ) {
+        void set_trap( point p, trap_id trap ) {
             is_uniform = false;
             trp[p.x][p.y] = trap;
         }
@@ -83,11 +83,11 @@ class submap : maptile_soa<SEEX, SEEY>
             std::uninitialized_fill_n( &trp[0][0], elements, trap );
         }
 
-        furn_id get_furn( const point &p ) const {
+        furn_id get_furn( point p ) const {
             return frn[p.x][p.y];
         }
 
-        void set_furn( const point &p, furn_id furn ) {
+        void set_furn( point p, furn_id furn ) {
             is_uniform = false;
             frn[p.x][p.y] = furn;
         }
@@ -96,11 +96,11 @@ class submap : maptile_soa<SEEX, SEEY>
             std::uninitialized_fill_n( &frn[0][0], elements, furn );
         }
 
-        ter_id get_ter( const point &p ) const {
+        ter_id get_ter( point p ) const {
             return ter[p.x][p.y];
         }
 
-        void set_ter( const point &p, ter_id terr ) {
+        void set_ter( point p, ter_id terr ) {
             is_uniform = false;
             ter[p.x][p.y] = terr;
         }
@@ -109,48 +109,48 @@ class submap : maptile_soa<SEEX, SEEY>
             std::uninitialized_fill_n( &ter[0][0], elements, terr );
         }
 
-        int get_radiation( const point &p ) const {
+        int get_radiation( point p ) const {
             return rad[p.x][p.y];
         }
 
-        void set_radiation( const point &p, const int radiation ) {
+        void set_radiation( point p, const int radiation ) {
             is_uniform = false;
             rad[p.x][p.y] = radiation;
         }
 
-        uint8_t get_lum( const point &p ) const {
+        uint8_t get_lum( point p ) const {
             return lum[p.x][p.y];
         }
 
-        void set_lum( const point &p, uint8_t luminance ) {
+        void set_lum( point p, uint8_t luminance ) {
             is_uniform = false;
             lum[p.x][p.y] = luminance;
         }
 
-        void update_lum_add( const point &p, const item &i ) {
+        void update_lum_add( point p, const item &i ) {
             is_uniform = false;
             if( i.is_emissive() && lum[p.x][p.y] < 255 ) {
                 lum[p.x][p.y]++;
             }
         }
 
-        void update_lum_rem( const point &p, const item &i );
+        void update_lum_rem( point p, const item &i );
 
         // TODO: Replace this as it essentially makes itm public
-        cata::colony<item> &get_items( const point &p ) {
+        cata::colony<item> &get_items( point p ) {
             return itm[p.x][p.y];
         }
 
-        const cata::colony<item> &get_items( const point &p ) const {
+        const cata::colony<item> &get_items( point p ) const {
             return itm[p.x][p.y];
         }
 
         // TODO: Replace this as it essentially makes fld public
-        field &get_field( const point &p ) {
+        field &get_field( point p ) {
             return fld[p.x][p.y];
         }
 
-        const field &get_field( const point &p ) const {
+        const field &get_field( point p ) const {
             return fld[p.x][p.y];
         }
 
@@ -160,7 +160,7 @@ class submap : maptile_soa<SEEX, SEEY>
             std::string str;
         };
 
-        void insert_cosmetic( const point &p, const std::string &type, const std::string &str );
+        void insert_cosmetic( point p, const std::string &type, const std::string &str );
 
         int get_temperature() const {
             return temperature;
@@ -170,27 +170,27 @@ class submap : maptile_soa<SEEX, SEEY>
             temperature = new_temperature;
         }
 
-        bool has_graffiti( const point &p ) const;
-        const std::string &get_graffiti( const point &p ) const;
-        void set_graffiti( const point &p, const std::string &new_graffiti );
-        void delete_graffiti( const point &p );
+        bool has_graffiti( point p ) const;
+        const std::string &get_graffiti( point p ) const;
+        void set_graffiti( point p, const std::string &new_graffiti );
+        void delete_graffiti( point p );
 
         // Signage is a pretend union between furniture on a square and stored
         // writing on the square. When both are present, we have signage.
         // Its effect is meant to be cosmetic and atmospheric only.
-        bool has_signage( const point &p ) const;
+        bool has_signage( point p ) const;
         // Dependent on furniture + cosmetics.
-        std::string get_signage( const point &p ) const;
+        std::string get_signage( point p ) const;
         // Can be used anytime (prevents code from needing to place sign first.)
-        void set_signage( const point &p, const std::string &s );
+        void set_signage( point p, const std::string &s );
         // Can be used anytime (prevents code from needing to place sign first.)
-        void delete_signage( const point &p );
+        void delete_signage( point p );
 
-        bool has_computer( const point &p ) const;
-        const computer *get_computer( const point &p ) const;
-        computer *get_computer( const point &p );
-        void set_computer( const point &p, const computer &c );
-        void delete_computer( const point &p );
+        bool has_computer( point p ) const;
+        const computer *get_computer( point p ) const;
+        computer *get_computer( point p );
+        void set_computer( point p, const computer &c );
+        void delete_computer( point p );
 
         bool contains_vehicle( vehicle * );
 
@@ -242,11 +242,11 @@ struct maptile {
         submap *const sm;
         point pos_;
 
-        inline const point &pos() const {
+        inline point pos() const {
             return pos_;
         }
 
-        maptile( submap *sub, const point &p ) :
+        maptile( submap *sub, point p ) :
             sm( sub ), pos_( p ) { }
     public:
         trap_id get_trap() const {

--- a/src/tileray.cpp
+++ b/src/tileray.cpp
@@ -14,7 +14,7 @@ tileray::tileray(): leftover( 0 ), direction( 0_degrees ), steps( 0 ), infinite(
 {
 }
 
-tileray::tileray( const point &ad )
+tileray::tileray( point ad )
 {
     init( ad );
 }
@@ -24,7 +24,7 @@ tileray::tileray( units::angle adir ): direction( adir )
     init( adir );
 }
 
-void tileray::init( const point &ad )
+void tileray::init( point ad )
 {
     delta = ad;
     abs_d = delta.abs();

--- a/src/tileray.h
+++ b/src/tileray.h
@@ -35,10 +35,10 @@ class tileray
         bool infinite = false;  // ray is infinite (end will always return true)
     public:
         tileray();
-        tileray( const point &ad );
+        tileray( point ad );
         tileray( units::angle adir );
 
-        void init( const point &ad );   // init ray with ad
+        void init( point ad );   // init ray with ad
         void init( units::angle adir ); // init ray with direction
 
         int dx() const;       // return dx of last advance (-1 to 1)

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -109,7 +109,7 @@ void ui_adaptor::position_from_window( const catacurses::window &win )
     }
 }
 
-void ui_adaptor::position( const point &topleft, const point &size )
+void ui_adaptor::position( point topleft, point size )
 {
     const rectangle<point> old_dimensions = dimensions;
     // ensure position is updated before calling invalidate

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -115,7 +115,7 @@ class ui_adaptor
          * Note that `topleft` and `size` are in console cells on both tiles
          * and curses builds.
          **/
-        void position( const point &topleft, const point &size );
+        void position( point topleft, point size );
         /**
          * Set redraw and resize callbacks. The resize callback should
          * call `position` or `position_from_window` to set the size of the UI,

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -165,7 +165,7 @@ player_activity veh_interact::serialize_activity()
     return res;
 }
 
-player_activity veh_interact::run( vehicle &veh, const point &p )
+player_activity veh_interact::run( vehicle &veh, point p )
 {
     veh_interact vehint( veh, p );
     vehint.do_main_loop();
@@ -203,7 +203,7 @@ vehicle_part &veh_interact::select_part( const vehicle &veh, const part_selector
 /**
  * Creates a blank veh_interact window.
  */
-veh_interact::veh_interact( vehicle &veh, const point &p )
+veh_interact::veh_interact( vehicle &veh, point p )
     : dd( p ), veh( &veh ), main_context( "VEH_INTERACT" )
 {
     // Only build the shapes map and the wheel list once
@@ -2106,7 +2106,7 @@ void veh_interact::do_relabel()
  * @param d The coordinates, relative to the viewport's 0-point (?)
  * @return The first vehicle part at the specified coordinates.
  */
-int veh_interact::part_at( const point &d )
+int veh_interact::part_at( point d )
 {
     const point vd = -dd + d.rotate( 1 );
     return veh->part_displayed_at( vd );
@@ -2128,7 +2128,7 @@ bool veh_interact::can_potentially_install( const vpart_info &vpart )
  * @param d How far to move the cursor.
  * @param dstart_at How far to change the start position for vehicle part descriptions
  */
-void veh_interact::move_cursor( const point &d, int dstart_at )
+void veh_interact::move_cursor( point d, int dstart_at )
 {
     dd += d.rotate( 3 );
     if( d != point_zero ) {
@@ -2253,8 +2253,8 @@ void veh_interact::display_veh()
     if( debug_mode ) {
         // show CoM, pivot in debug mode
 
-        const point &pivot = veh->pivot_point();
-        const point &com = veh->local_center_of_mass();
+        point pivot = veh->pivot_point();
+        point com = veh->local_center_of_mass();
         const point cur = -dd;
 
         mvwprintz( w_disp, point_zero, c_green, "CoM   %d,%d", com.x, com.y );

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -47,7 +47,7 @@ class veh_interact
         using part_selector = std::function<bool( const vehicle_part &pt )>;
 
     public:
-        static player_activity run( vehicle &veh, const point &p );
+        static player_activity run( vehicle &veh, point p );
 
         /** Prompt for a part matching the selector function */
         static vehicle_part &select_part( const vehicle &veh, const part_selector &sel,
@@ -56,7 +56,7 @@ class veh_interact
         static void complete_vehicle( player &p );
 
     private:
-        veh_interact( vehicle &veh, const point &p = point_zero );
+        veh_interact( vehicle &veh, point p = point_zero );
         ~veh_interact();
 
         item_location target;
@@ -119,8 +119,8 @@ class veh_interact
         bool format_reqs( std::string &msg, const requirement_data &reqs,
                           const std::map<skill_id, int> &skills, int moves ) const;
 
-        int part_at( const point &d );
-        void move_cursor( const point &d, int dstart_at = 0 );
+        int part_at( point d );
+        void move_cursor( point d, int dstart_at = 0 );
         task_reason cant_do( char mode );
         bool can_potentially_install( const vpart_info &vpart );
         /** Move index (parameter pos) according to input action:

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -780,7 +780,7 @@ std::set<point> vehicle::immediate_path( units::angle rotate )
     point top_right_actual = global_pos3().xy() + coord_translate( front_right );
     std::vector<point> front_row = line_to( g->m.getabs( top_left_actual ),
                                             g->m.getabs( top_right_actual ) );
-    for( const point &elem : front_row ) {
+    for( point elem : front_row ) {
         for( int i = 0; i < distance_to_check; ++i ) {
             collision_vector.advance( i );
             point point_to_add = elem + point( collision_vector.dx(), collision_vector.dy() );
@@ -827,7 +827,7 @@ void vehicle::drive_to_local_target( const tripoint &target, bool follow_protoco
     // Check the tileray in the direction we need to head towards.
     std::set<point> points_to_check = immediate_path( angle );
     bool stop = false;
-    for( const point &pt_elem : points_to_check ) {
+    for( point pt_elem : points_to_check ) {
         point elem = g->m.getlocal( pt_elem );
         if( stop ) {
             break;
@@ -1237,7 +1237,7 @@ int vehicle::vhp_to_watts( const int power_vhp )
     return power_vhp * conversion_factor;
 }
 
-bool vehicle::has_structural_part( const point &dp ) const
+bool vehicle::has_structural_part( point dp ) const
 {
     for( const int elem : parts_at_relative( dp, false ) ) {
         if( part_info( elem ).location == part_location_structure &&
@@ -1269,7 +1269,7 @@ bool vehicle::is_structural_part_removed() const
  * @param id The id of the part to install.
  * @return true if the part can be mounted, false if not.
  */
-bool vehicle::can_mount( const point &dp, const vpart_id &id ) const
+bool vehicle::can_mount( point dp, const vpart_id &id ) const
 {
     //The part has to actually exist.
     if( !id.is_valid() ) {
@@ -1500,7 +1500,7 @@ bool vehicle::is_connected( const vehicle_part &to, const vehicle_part &from,
         discovered.pop_front();
         auto current = current_part.mount;
 
-        for( const point &offset : four_adjacent_offsets ) {
+        for( point offset : four_adjacent_offsets ) {
             point next = current + offset;
 
             if( next == target ) {
@@ -1552,7 +1552,7 @@ bool vehicle::is_connected( const vehicle_part &to, const vehicle_part &from,
  * @param force Skip check of whether we can mount the part here.
  * @return false if the part could not be installed, true otherwise.
  */
-int vehicle::install_part( const point &dp, const vpart_id &id, bool force )
+int vehicle::install_part( point dp, const vpart_id &id, bool force )
 {
     if( !( force || can_mount( dp, id ) ) ) {
         return -1;
@@ -1560,7 +1560,7 @@ int vehicle::install_part( const point &dp, const vpart_id &id, bool force )
     return install_part( dp, vehicle_part( id, dp, item( id.obj().item ) ) );
 }
 
-int vehicle::install_part( const point &dp, const vpart_id &id, item &&obj, bool force )
+int vehicle::install_part( point dp, const vpart_id &id, item &&obj, bool force )
 {
     if( !( force || can_mount( dp, id ) ) ) {
         return -1;
@@ -1568,7 +1568,7 @@ int vehicle::install_part( const point &dp, const vpart_id &id, item &&obj, bool
     return install_part( dp, vehicle_part( id, dp, std::move( obj ) ) );
 }
 
-int vehicle::install_part( const point &dp, const vehicle_part &new_part )
+int vehicle::install_part( point dp, const vehicle_part &new_part )
 {
     // Should be checked before installing the part
     bool enable = false;
@@ -1632,7 +1632,7 @@ bool vehicle::try_to_rack_nearby_vehicle( const std::vector<std::vector<int>> &l
         for( auto rack_part : this_bike_rack ) {
             tripoint rack_pos = global_part_pos3( rack_part );
             int i = 0;
-            for( const point &offset : four_cardinal_directions ) {
+            for( point offset : four_cardinal_directions ) {
                 tripoint search_pos( rack_pos + offset );
                 test_veh = veh_pointer_or_null( g->m.veh_at( search_pos ) );
                 if( test_veh == nullptr || test_veh == this ) {
@@ -1718,7 +1718,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
             // There's no mathematical transform from global pos3 to vehicle mount, so search for the
             // carry part in global pos3 after translating
             point carry_mount;
-            for( const point &offset : four_cardinal_directions ) {
+            for( point offset : four_cardinal_directions ) {
                 carry_mount = parts[ rack_part ].mount + offset;
                 tripoint possible_pos = mount_to_tripoint( carry_mount );
                 if( possible_pos == carry_pos ) {
@@ -1914,7 +1914,7 @@ bool vehicle::remove_part( const int p, RemovePartHandler &handler )
 
     handler.removed( *this, p );
 
-    const point &vp_mount = parts[p].mount;
+    point vp_mount = parts[p].mount;
     const auto iter = labels.find( label( vp_mount ) );
     if( iter != labels.end() && parts_at_relative( vp_mount, false ).empty() ) {
         labels.erase( iter );
@@ -2162,7 +2162,7 @@ bool vehicle::find_and_split_vehicles( int exclude )
                 veh_parts.push_back( p );
             }
             checked_parts.insert( test_part );
-            for( const point &offset : four_adjacent_offsets ) {
+            for( point offset : four_adjacent_offsets ) {
                 const point dp = parts[test_part].mount + offset;
                 std::vector<int> all_neighbor_parts = parts_at_relative( dp, true );
                 int neighbor_struct_part = -1;
@@ -2414,7 +2414,7 @@ item_group::ItemList vehicle_part::pieces_for_broken_part() const
     return item_group::items_from( group, calendar::turn );
 }
 
-std::vector<int> vehicle::parts_at_relative( const point &dp,
+std::vector<int> vehicle::parts_at_relative( point dp,
         const bool use_cache ) const
 {
     if( !use_cache ) {
@@ -2523,7 +2523,7 @@ int vehicle::part_with_feature( int part, const std::string &flag, bool unbroken
     return part_with_feature( parts[part].mount, flag, unbroken );
 }
 
-int vehicle::part_with_feature( const point &pt, const std::string &flag, bool unbroken ) const
+int vehicle::part_with_feature( point pt, const std::string &flag, bool unbroken ) const
 {
     std::vector<int> parts_here = parts_at_relative( pt, false );
     for( auto &elem : parts_here ) {
@@ -2548,7 +2548,7 @@ int vehicle::avail_part_with_feature( int part, const std::string &flag, bool un
     return avail_part_with_feature( parts[ part ].mount, flag, unbroken );
 }
 
-int vehicle::avail_part_with_feature( const point &pt, const std::string &flag,
+int vehicle::avail_part_with_feature( point pt, const std::string &flag,
                                       bool unbroken ) const
 {
     int part_a = part_with_feature( pt, flag, unbroken );
@@ -2580,7 +2580,7 @@ bool vehicle::has_part( const tripoint &pos, const std::string &flag, bool enabl
     return false;
 }
 
-int vehicle::obstacle_at_position( const point &pos ) const
+int vehicle::obstacle_at_position( point pos ) const
 {
     int i = part_with_feature( pos, "OBSTACLE", true );
 
@@ -2597,7 +2597,7 @@ int vehicle::obstacle_at_position( const point &pos ) const
     return i;
 }
 
-int vehicle::opaque_at_position( const point &pos ) const
+int vehicle::opaque_at_position( point pos ) const
 {
     int i = part_with_feature( pos, "OPAQUE", true );
 
@@ -2927,7 +2927,7 @@ bool vehicle::part_flag( int part, const vpart_bitflags flag ) const
     }
 }
 
-int vehicle::part_at( const point &dp ) const
+int vehicle::part_at( point dp ) const
 {
     for( const vpart_reference &vp : get_all_parts() ) {
         if( vp.part().precalc[0].xy() == dp && !vp.part().removed ) {
@@ -2968,7 +2968,7 @@ int vehicle::index_of_part( const vehicle_part *const part, const bool check_rem
  * @param dp The local coordinate.
  * @return The index of the part that will be displayed.
  */
-int vehicle::part_displayed_at( const point &dp ) const
+int vehicle::part_displayed_at( point dp ) const
 {
     // Z-order is implicitly defined in game::load_vehiclepart, but as
     // numbers directly set on parts rather than constants that can be
@@ -3022,7 +3022,7 @@ int vehicle::roof_at_part( const int part ) const
     return -1;
 }
 
-point vehicle::coord_translate( const point &p ) const
+point vehicle::coord_translate( point p ) const
 {
     tripoint q;
     coord_translate( pivot_rotation[0], pivot_anchor[0], p, q );
@@ -3061,7 +3061,7 @@ const struct {
     {static_cast<float>( -tan( units::to_radians( 15_degrees ) ) ), false,  false, false},
 };
 
-void vehicle::coord_translate( units::angle dir, const point &pivot, const point &p,
+void vehicle::coord_translate( units::angle dir, point pivot, point p,
                                tripoint &q ) const
 {
 
@@ -3085,7 +3085,7 @@ void vehicle::coord_translate( units::angle dir, const point &pivot, const point
     }
 }
 
-void vehicle::coord_translate_reverse( units::angle dir, const point &pivot, const tripoint &p,
+void vehicle::coord_translate_reverse( units::angle dir, point pivot, const tripoint &p,
                                        point &q ) const
 {
     int increment = angle_to_increment( dir );
@@ -3116,12 +3116,12 @@ void vehicle::coord_translate_reverse( units::angle dir, const point &pivot, con
 
 }
 
-tripoint vehicle::mount_to_tripoint( const point &mount ) const
+tripoint vehicle::mount_to_tripoint( point mount ) const
 {
     return mount_to_tripoint( mount, point_zero );
 }
 
-tripoint vehicle::mount_to_tripoint( const point &mount, const point &offset ) const
+tripoint vehicle::mount_to_tripoint( point mount, point offset ) const
 {
     tripoint mnt_translated;
     coord_translate( pivot_rotation[0], pivot_anchor[ 0 ], mount + offset, mnt_translated );
@@ -3148,7 +3148,7 @@ int vehicle::angle_to_increment( units::angle dir )
 }
 
 
-void vehicle::precalc_mounts( int idir, units::angle dir, const point &pivot )
+void vehicle::precalc_mounts( int idir, units::angle dir, point pivot )
 {
     if( idir < 0 || idir > 1 ) {
         idir = 0;
@@ -3171,8 +3171,8 @@ void vehicle::precalc_mounts( int idir, units::angle dir, const point &pivot )
     pivot_rotation[idir] = dir;
 }
 
-bool vehicle::check_rotated_intervening( const point &from, const point &to,
-        bool( *check )( const vehicle *, const point & ) ) const
+bool vehicle::check_rotated_intervening( point from, point to,
+        bool( *check )( const vehicle *, point ) ) const
 {
     point delta = to - from;
     if( abs( delta.x ) <= 1 && abs( delta.y ) <= 1 ) { //Just a normal move
@@ -3211,16 +3211,16 @@ bool vehicle::check_rotated_intervening( const point &from, const point &to,
     return false;
 }
 
-bool vehicle::allowed_light( const point &from, const point &to ) const
+bool vehicle::allowed_light( point from, point to ) const
 {
-    return check_rotated_intervening( from, to, []( const vehicle * veh, const point & p ) {
+    return check_rotated_intervening( from, to, []( const vehicle * veh, point  p ) {
         return ( veh->opaque_at_position( p ) == -1 );
     } );
 }
 
-bool vehicle::allowed_move( const point &from, const point &to ) const
+bool vehicle::allowed_move( point from, point to ) const
 {
-    return check_rotated_intervening( from, to, []( const vehicle * veh, const point & p ) {
+    return check_rotated_intervening( from, to, []( const vehicle * veh, point  p ) {
         return ( veh->obstacle_at_position( p ) == -1 );
     } );
 }
@@ -3325,7 +3325,7 @@ units::volume vehicle::total_folded_volume() const
     return m;
 }
 
-const point &vehicle::rotated_center_of_mass() const
+point vehicle::rotated_center_of_mass() const
 {
     // TODO: Bring back caching of this point
     calc_mass_center( true );
@@ -3333,7 +3333,7 @@ const point &vehicle::rotated_center_of_mass() const
     return mass_center_precalc;
 }
 
-const point &vehicle::local_center_of_mass() const
+point vehicle::local_center_of_mass() const
 {
     if( mass_center_no_precalc_dirty ) {
         calc_mass_center( false );
@@ -4453,7 +4453,7 @@ bool vehicle::balanced_wheel_config() const
     }
 
     // Check center of mass inside support of wheels (roughly)
-    const point &com = local_center_of_mass();
+    point com = local_center_of_mass();
     const inclusive_rectangle<point> support( min, max );
     return support.contains( com );
 }
@@ -5825,7 +5825,7 @@ void vehicle::refresh_position()
     }
 }
 
-const point &vehicle::pivot_point() const
+point vehicle::pivot_point() const
 {
     if( pivot_dirty ) {
         refresh_pivot();
@@ -6316,7 +6316,7 @@ void vehicle::refresh_insides()
         // inside if not otherwise
         parts[p].inside = true;
         // let's check four neighbor parts
-        for( const point &offset : four_adjacent_offsets ) {
+        for( point offset : four_adjacent_offsets ) {
             point near_mount = parts[ p ].mount + offset;
             std::vector<int> parts_n3ar = parts_at_relative( near_mount, true );
             // if we aren't covered from sides, the roof at p won't save us
@@ -6441,7 +6441,7 @@ int vehicle::damage( int p, int dmg, damage_type type, bool aimed )
     return damage_dealt;
 }
 
-void vehicle::damage_all( int dmg1, int dmg2, damage_type type, const point &impact )
+void vehicle::damage_all( int dmg1, int dmg2, damage_type type, point impact )
 {
     if( dmg2 < dmg1 ) {
         std::swap( dmg1, dmg2 );
@@ -6468,7 +6468,7 @@ void vehicle::damage_all( int dmg1, int dmg2, damage_type type, const point &imp
  * (0, 0) part is always present.
  * @param delta How much to shift along each axis
  */
-void vehicle::shift_parts( const point &delta )
+void vehicle::shift_parts( point delta )
 {
     // Don't invalidate the active item cache's location!
     active_items.subtract_locations( delta );
@@ -7096,7 +7096,7 @@ bool vehicle::valid_part( int part_num ) const
     return part_num >= 0 && part_num < static_cast<int>( parts.size() );
 }
 
-std::set<int> vehicle::advance_precalc_mounts( const point &new_pos, const tripoint &src )
+std::set<int> vehicle::advance_precalc_mounts( point new_pos, const tripoint &src )
 {
     map &here = get_map();
     std::set<int> smzs;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -200,7 +200,7 @@ struct vehicle_part {
 
         vehicle_part(); /** DefaultConstructible */
 
-        vehicle_part( const vpart_id &vp, const point &dp, item &&obj );
+        vehicle_part( const vpart_id &vp, point dp, item &&obj );
 
         /** Check this instance is non-null (not default constructed) */
         explicit operator bool() const;
@@ -578,8 +578,8 @@ class turret_data
  */
 struct label : public point {
     label() = default;
-    explicit label( const point &p ) : point( p ) {}
-    label( const point &p, std::string text ) : point( p ), text( std::move( text ) ) {}
+    explicit label( point p ) : point( p ) {}
+    label( point p, std::string text ) : point( p ), text( std::move( text ) ) {}
 
     std::string text;
 
@@ -675,7 +675,7 @@ class RemovePartHandler;
 class vehicle
 {
     private:
-        bool has_structural_part( const point &dp ) const;
+        bool has_structural_part( point dp ) const;
         bool is_structural_part_removed() const;
         void open_or_close( int part_index, bool opening );
         bool is_connected( const vehicle_part &to, const vehicle_part &from,
@@ -713,10 +713,10 @@ class vehicle
         units::volume total_folded_volume() const;
 
         // Vehicle fuel indicator (by fuel)
-        void print_fuel_indicator( const catacurses::window &w, const point &p,
+        void print_fuel_indicator( const catacurses::window &w, point p,
                                    const itype_id &fuel_type,
                                    bool verbose = false, bool desc = false );
-        void print_fuel_indicator( const catacurses::window &w, const point &p,
+        void print_fuel_indicator( const catacurses::window &w, point p,
                                    const itype_id &fuel_type,
                                    std::map<itype_id, float> fuel_usages,
                                    bool verbose = false, bool desc = false );
@@ -892,20 +892,20 @@ class vehicle
         const vpart_info &part_info( int index, bool include_removed = false ) const;
 
         // check if certain part can be mounted at certain position (not accounting frame direction)
-        bool can_mount( const point &dp, const vpart_id &id ) const;
+        bool can_mount( point dp, const vpart_id &id ) const;
 
         // check if certain part can be unmounted
         bool can_unmount( int p ) const;
         bool can_unmount( int p, std::string &reason ) const;
 
         // install a new part to vehicle
-        int install_part( const point &dp, const vpart_id &id, bool force = false );
+        int install_part( point dp, const vpart_id &id, bool force = false );
 
         // Install a copy of the given part, skips possibility check
-        int install_part( const point &dp, const vehicle_part &part );
+        int install_part( point dp, const vehicle_part &part );
 
         /** install item specified item to vehicle as a vehicle part */
-        int install_part( const point &dp, const vpart_id &id, item &&obj, bool force = false );
+        int install_part( point dp, const vpart_id &id, item &&obj, bool force = false );
 
         // find a single tile wide vehicle adjacent to a list of part indices
         bool try_to_rack_nearby_vehicle( const std::vector<std::vector<int>> &list_of_racks );
@@ -997,20 +997,20 @@ class vehicle
         /**@}*/
 
         // returns the list of indices of parts at certain position (not accounting frame direction)
-        std::vector<int> parts_at_relative( const point &dp, bool use_cache ) const;
+        std::vector<int> parts_at_relative( point dp, bool use_cache ) const;
 
         // returns index of part, inner to given, with certain flag, or -1
         int part_with_feature( int p, const std::string &f, bool unbroken ) const;
-        int part_with_feature( const point &pt, const std::string &f, bool unbroken ) const;
+        int part_with_feature( point pt, const std::string &f, bool unbroken ) const;
         int part_with_feature( int p, vpart_bitflags f, bool unbroken ) const;
 
         // returns index of part, inner to given, with certain flag, or -1
         int avail_part_with_feature( int p, const std::string &f, bool unbroken ) const;
-        int avail_part_with_feature( const point &pt, const std::string &f, bool unbroken ) const;
+        int avail_part_with_feature( point pt, const std::string &f, bool unbroken ) const;
         int avail_part_with_feature( int p, vpart_bitflags f, bool unbroken ) const;
 
-        int obstacle_at_position( const point &pos ) const;
-        int opaque_at_position( const point &pos ) const;
+        int obstacle_at_position( point pos ) const;
+        int opaque_at_position( point pos ) const;
 
         /**
          *  Check if vehicle has at least one unbroken part with specified flag
@@ -1079,25 +1079,25 @@ class vehicle
         bool part_flag( int p, vpart_bitflags f ) const;
 
         // Translate mount coordinates "p" using current pivot direction and anchor and return tile coordinates
-        point coord_translate( const point &p ) const;
+        point coord_translate( point p ) const;
 
         // Translate mount coordinates "p" into tile coordinates "q" using given pivot direction and anchor
-        void coord_translate( units::angle dir, const point &pivot, const point &p,
+        void coord_translate( units::angle dir, point pivot, point p,
                               tripoint &q ) const;
 
         // Translate rotated tile coordinates "p" into mount coordinates "q" using given pivot direction and anchor
-        void coord_translate_reverse( units::angle dir, const point &pivot, const tripoint &p,
+        void coord_translate_reverse( units::angle dir, point pivot, const tripoint &p,
                                       point &q ) const;
 
-        tripoint mount_to_tripoint( const point &mount ) const;
-        tripoint mount_to_tripoint( const point &mount, const point &offset ) const;
+        tripoint mount_to_tripoint( point mount ) const;
+        tripoint mount_to_tripoint( point mount, point offset ) const;
 
         //Translate tile coordinates into mount coordinates
         point tripoint_to_mount( const tripoint &p ) const;
 
         // Seek a vehicle part which obstructs tile with given coordinates relative to vehicle position
-        int part_at( const point &dp ) const;
-        int part_displayed_at( const point &dp ) const;
+        int part_at( point dp ) const;
+        int part_displayed_at( point dp ) const;
         int roof_at_part( int p ) const;
 
         // Given a part, finds its index in the vehicle
@@ -1115,7 +1115,7 @@ class vehicle
 
         // Vehicle fuel indicators (all of them)
         void print_fuel_indicators(
-            const catacurses::window &win, const point &, int start_index = 0,
+            const catacurses::window &win, point, int start_index = 0,
             bool fullsize = false, bool verbose = false, bool desc = false,
             bool isHorizontal = false );
 
@@ -1123,7 +1123,7 @@ class vehicle
         void refresh_position();
 
         // Pre-calculate mount points for (idir=0) - current direction or (idir=1) - next turn direction
-        void precalc_mounts( int idir, units::angle dir, const point &pivot );
+        void precalc_mounts( int idir, units::angle dir, point pivot );
 
         // get a list of part indices where is a passenger inside
         std::vector<int> boarded_parts() const;
@@ -1239,13 +1239,13 @@ class vehicle
         units::mass total_mass() const;
 
         // Gets the center of mass calculated for precalc[0] coordinates
-        const point &rotated_center_of_mass() const;
+        point rotated_center_of_mass() const;
         // Gets the center of mass calculated for mount point coordinates
-        const point &local_center_of_mass() const;
+        point local_center_of_mass() const;
 
         // Get the pivot point of vehicle; coordinates are unrotated mount coordinates.
         // This may result in refreshing the pivot point if it is currently stale.
-        const point &pivot_point() const;
+        point pivot_point() const;
 
         // Get the (artificial) displacement of the vehicle due to the pivot point changing
         // between precalc[0] and precalc[1]. This needs to be subtracted from any actual
@@ -1474,7 +1474,7 @@ class vehicle
             }
         }
 
-        inline void set_pivot( const point &pivot, bool refresh = true ) {
+        inline void set_pivot( point pivot, bool refresh = true ) {
             pivot_cache = pivot;
             pivot_anchor[0] = pivot;
             if( refresh ) {
@@ -1482,7 +1482,7 @@ class vehicle
             }
         }
 
-        inline void set_facing_and_pivot( units::angle deg, const point &pivot, bool refresh = true ) {
+        inline void set_facing_and_pivot( units::angle deg, point pivot, bool refresh = true ) {
             set_facing( deg, false );
             set_pivot( pivot, refresh );
         }
@@ -1504,7 +1504,7 @@ class vehicle
         /**
          * vehicle is driving itself
          */
-        void selfdrive( const point & );
+        void selfdrive( point );
         /**
          * can the helicopter descend/ascend here?
          */
@@ -1516,7 +1516,7 @@ class vehicle
          * @param p direction player is steering
          * @param z for vertical movement - e.g helicopters
          */
-        void pldrive( Character &driver, const point &p, int z = 0 );
+        void pldrive( Character &driver, point p, int z = 0 );
 
         // stub for per-vpart limit
         units::volume max_volume( int part ) const;
@@ -1574,10 +1574,10 @@ class vehicle
         int damage( int p, int dmg, damage_type type = DT_BASH, bool aimed = true );
 
         // damage all parts (like shake from strong collision), range from dmg1 to dmg2
-        void damage_all( int dmg1, int dmg2, damage_type type, const point &impact );
+        void damage_all( int dmg1, int dmg2, damage_type type, point impact );
 
         //Shifts the coordinates of all parts and moves the vehicle in the opposite direction.
-        void shift_parts( const point &delta );
+        void shift_parts( point delta );
         bool shift_if_needed();
 
         void shed_loose_parts();
@@ -1773,14 +1773,14 @@ class vehicle
         void interact_with( const tripoint &pos, int interact_part );
 
         //Check if a movement is blocked, must be adjacent points
-        bool allowed_move( const point &from, const point &to ) const;
+        bool allowed_move( point from, point to ) const;
 
         //Check if light is blocked, must be adjacent points
-        bool allowed_light( const point &from, const point &to ) const;
+        bool allowed_light( point from, point to ) const;
 
         //Checks if the conditional holds for tiles that can be skipped due to rotation
-        bool check_rotated_intervening( const point &from, const point &to, bool( *check )( const vehicle *,
-                                        const point & ) ) const;
+        bool check_rotated_intervening( point from, point to, bool( *check )( const vehicle *,
+                                        point ) ) const;
 
         std::string disp_name() const;
 
@@ -1826,7 +1826,7 @@ class vehicle
         bool valid_part( int part_num ) const;
         // Updates the internal precalculated mount offsets after the vehicle has been displaced
         // used in map::displace_vehicle()
-        std::set<int> advance_precalc_mounts( const point &new_pos, const tripoint &src );
+        std::set<int> advance_precalc_mounts( point new_pos, const tripoint &src );
         // Adjust the vehicle's global z-level to match its center
         void shift_zlevel();
 

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -348,7 +348,7 @@ std::vector<itype_id> vehicle::get_printable_fuel_types() const
  * @param desc true if the name of the fuel should be at the end
  * @param isHorizontal true if the menu is not vertical
  */
-void vehicle::print_fuel_indicators( const catacurses::window &win, const point &p, int start_index,
+void vehicle::print_fuel_indicators( const catacurses::window &win, point p, int start_index,
                                      bool fullsize, bool verbose, bool desc, bool isHorizontal )
 {
     auto fuels = get_printable_fuel_types();
@@ -396,14 +396,14 @@ void vehicle::print_fuel_indicators( const catacurses::window &win, const point 
  * @param desc true if the name of the fuel should be at the end
  * @param fuel_usages map of fuel types to consumption for verbose
  */
-void vehicle::print_fuel_indicator( const catacurses::window &win, const point &p,
+void vehicle::print_fuel_indicator( const catacurses::window &win, point p,
                                     const itype_id &fuel_type, bool verbose, bool desc )
 {
     std::map<itype_id, float> fuel_usages;
     print_fuel_indicator( win, p, fuel_type, fuel_usages, verbose, desc );
 }
 
-void vehicle::print_fuel_indicator( const catacurses::window &win, const point &p,
+void vehicle::print_fuel_indicator( const catacurses::window &win, point p,
                                     const itype_id &fuel_type,
                                     std::map<itype_id, float> fuel_usages,
                                     bool verbose, bool desc )

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -931,7 +931,7 @@ bool vehicle::has_harnessed_animal() const
     return false;
 }
 
-void vehicle::selfdrive( const point &p )
+void vehicle::selfdrive( point p )
 {
     if( !is_towed() && !magic ) {
         for( size_t e = 0; e < parts.size(); e++ ) {
@@ -1083,7 +1083,7 @@ bool vehicle::check_heli_ascend( player &p )
     return true;
 }
 
-void vehicle::pldrive( Character &driver, const point &p, int z )
+void vehicle::pldrive( Character &driver, point p, int z )
 {
     if( z != 0 && is_rotorcraft() ) {
         driver.moves = std::min( driver.moves, 0 );
@@ -1770,7 +1770,7 @@ static bool scan_rails_from_veh_internal(
 }
 
 // Get number of rotations of identity vector
-static inline int get_num_cw_rots_of_ray_delta( const point &v )
+static inline int get_num_cw_rots_of_ray_delta( point v )
 {
     if( v == point_north_east ) {
         return 0;

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -37,7 +37,7 @@ static const itype_id itype_muscle( "muscle" );
 vehicle_part::vehicle_part()
     : id( vpart_id::NULL_ID() ) {}
 
-vehicle_part::vehicle_part( const vpart_id &vp, const point &dp, item &&obj )
+vehicle_part::vehicle_part( const vpart_id &vp, point dp, item &&obj )
     : mount( dp ), id( vp ), base( std::move( obj ) )
 {
     // Mark base item as being installed as a vehicle part

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1865,7 +1865,7 @@ void vehicle::use_bike_rack( int part )
                 cur_vehicle.clear();
                 continue;
             }
-            for( const point &mount_dir : five_cardinal_directions ) {
+            for( point mount_dir : five_cardinal_directions ) {
                 point near_loc = parts[ rack_part ].mount + mount_dir;
                 std::vector<int> near_parts = parts_at_relative( near_loc, true );
                 if( near_parts.empty() ) {


### PR DESCRIPTION
#### Summary

SUMMARY: Performance "Pass point by value"

#### Purpose of change

point only have two int member, x and y. that makes its size 8 bytes (64bit), the same size as pointer address in 64bit machine. passing value directly is faster for points because references needs to be dereferenced.

|                 point                 |                 tripoint                 |
| :-----------------------------------: | :--------------------------------------: |
|            ![point][point]            |          ![tripoint][tripoint]           |
| byValue is [1.2x faster][bench-point] | byValue is [1.2x slower][bench-tripoint] |

- passing point by value is [1.2x faster][bench-point] than by reference.
- we don't do that for tripoints because it's [1.2x slower][bench-tripoint]

#### Describe the solution

regex-replace `const point &` to `point`. couldn't change `point_traits.h` cause it uses references and cause weird ambiguities.

#### Describe alternatives you've considered

![](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSdcY5JkqA0DJRad4tN25M_A5zGNZZLLuxQR1R2kV2tLJz2vQFS92UUdeuXofCfGIklGOo&usqp=CAU)

become average slow life enjoyer

#### Testing

![image](https://user-images.githubusercontent.com/54838975/226910754-b8fd0692-a6d0-4b86-96e0-68deaa62e260.png)

|      before       |      after      |
| :---------------: | :-------------: |
| ![before][before] | ![after][after] |

had a break with debug monsters. it was on max ~13% faster. it could be due to other reasons, such as background processes, but gotta be optimistic here.

[before]: https://user-images.githubusercontent.com/54838975/226910181-1315d710-dc31-4a53-8781-e5fde8cece8e.png
[after]: https://user-images.githubusercontent.com/54838975/226910116-4941bc02-8393-4891-a24f-33a26f91ab3c.png
[point]: https://user-images.githubusercontent.com/54838975/226915665-641b1203-5d86-49a8-9d33-c003814b0993.png
[tripoint]: https://user-images.githubusercontent.com/54838975/226915673-43af46f6-28ba-4fc1-9606-e4e87d0fa08e.png
[bench-point]: https://quick-bench.com/q/lddGjYhey8mf-aurNuCoVvMMmtk
[bench-tripoint]: https://quick-bench.com/q/RrwXYyWElioxu8Rm3t3KyWH2wQw

#### Additional context

- blocked by #2457