### PR TITLE
remove cmake `-Wunused-macros`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,6 @@ ELSE()
        -Woverloaded-virtual \
        -Wpedantic \
        -Wsuggest-override \
-       -Wunused-macros \
        -Wzero-as-null-pointer-constant \
        -Wno-unknown-warning-option \
        -Wno-range-loop-analysis")


### PR DESCRIPTION
#### Summary

SUMMARY: Build "remove cmake -Wunused-macros"

#### Purpose of change

`-Wunused-macros` pollutes vscode warnings because there's so much unused macros.

