### PR TITLE
feat: `No Explosive Zombies` also removes bloated zombies

### DIFF
--- a/data/mods/No_Explosive_Zombies/modinfo.json
+++ b/data/mods/No_Explosive_Zombies/modinfo.json
@@ -9,6 +9,13 @@
   },
   {
     "type": "MONSTER_BLACKLIST",
-    "monsters": [ "mon_zombie_grenadier", "mon_zombie_grenadier_elite", "mon_zombie_flamer", "mon_gas_zombie" ]
+    "monsters": [
+      "mon_zombie_grenadier",
+      "mon_zombie_grenadier_elite",
+      "mon_zombie_flamer",
+      "mon_gas_zombie",
+      "mon_zombie_gasbag",
+      "mon_zombie_gasbag_fungus"
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary

SUMMARY: Mods "No Explosive Zombies mod also removes bloated zombies"

#### Purpose of change

- fixes #2391

#### Describe the solution

remove bloated zombie and fungal bloated zombie.

#### Describe alternatives you've considered

![_02](https://user-images.githubusercontent.com/54838975/227083902-cd835bdf-2258-47ba-abfe-8264e90dc03a.png)

maybe also remove all zeds with `emit_fields`, but that feels too broad.