### PR TITLE
Only run lint workflow when relevent files are modified

### DIFF
--- a/.github/workflows/astyle.yml
+++ b/.github/workflows/astyle.yml
@@ -2,7 +2,7 @@ name: astyle
 
 on:
   pull_request_target:
-    paths: ["**.cpp", "**.hpp", "**.h", "**.c"]
+    paths: [".github/workflows/astyle.yml", "Makefile", ".astylerc", "**.cpp", "**.h", "**.c"]
 
 jobs:
   skip-duplicates:

--- a/.github/workflows/astyle.yml
+++ b/.github/workflows/astyle.yml
@@ -1,6 +1,8 @@
 name: astyle
 
-on: pull_request
+on:
+  pull_request_target:
+    paths: ["**.cpp", "**.hpp", "**.h", "**.c"]
 
 jobs:
   skip-duplicates:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -2,11 +2,11 @@ name: Clang-tidy (clang-12, tiles)
 
 on:
   push:
-    branches:
-      - upload
+    branches: [upload]
+    paths: ["**.cpp", "**.hpp", "**.h", "**.c"]
   pull_request:
-    branches:
-      - upload
+    branches: [upload]
+    paths: ["**.cpp", "**.hpp", "**.h", "**.c"]
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
 concurrency:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -3,10 +3,10 @@ name: Clang-tidy (clang-12, tiles)
 on:
   push:
     branches: [upload]
-    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**" ]
+    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml" ]
   pull_request:
     branches: [upload]
-    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**" ]
+    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml" ]
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
 concurrency:
@@ -25,7 +25,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           cancel_others: "true"
-          paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**" ]'
+          paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml" ]'
   build:
     needs: skip-duplicates
     if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -3,10 +3,10 @@ name: Clang-tidy (clang-12, tiles)
 on:
   push:
     branches: [upload]
-    paths: ["**.cpp", "**.hpp", "**.h", "**.c"]
+    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**" ]
   pull_request:
     branches: [upload]
-    paths: ["**.cpp", "**.hpp", "**.h", "**.c"]
+    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**" ]
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
 concurrency:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -3,10 +3,10 @@ name: Clang-tidy (clang-12, tiles)
 on:
   push:
     branches: [upload]
-    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]
+    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/**","tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]
   pull_request:
     branches: [upload]
-    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]
+    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/**", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
 concurrency:
@@ -25,7 +25,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           cancel_others: "true"
-          paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]'
+          paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/**", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]'
   build:
     needs: skip-duplicates
     if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -3,10 +3,10 @@ name: Clang-tidy (clang-12, tiles)
 on:
   push:
     branches: [upload]
-    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml" ]
+    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]
   pull_request:
     branches: [upload]
-    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml" ]
+    paths: [ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
 concurrency:
@@ -25,7 +25,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           cancel_others: "true"
-          paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml" ]'
+          paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "tools/clang-tidy-plugin/**", ".github/workflows/clang-tidy.yml", "**/.clang-tidy" ]'
   build:
     needs: skip-duplicates
     if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -1,6 +1,8 @@
 name: JSON Validation
 
-on: pull_request
+on:
+  pull_request:
+    paths: ["**.json"]
 
 jobs:
   skip-duplicates:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,7 +1,6 @@
 name: Label Pull Requests
 
-on:
-  - pull_request_target
+on: pull_request_target
 
 jobs:
   triage:


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Only run lint workflow when relevent files are modified"

#### Purpose of change

- astyle doesn't needs to be ran on pure json changes.
- style-json doesn't needs to be ran on pure src changes.

#### Describe the solution

add [`paths` filter](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) for lint workflows.

#### Describe alternatives you've considered

skip build matrix could be skipped for json only changes

