### PR TITLE
Fix tidy

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -109,24 +109,18 @@ then
         cd ..
         ln -s build/compile_commands.json
 
-        num_jobs=1
-
         # TODO: first analyze all files that changed in this PR
-        # set +x
+        set +x
         all_cpp_files="$( \
             grep '"file": "' build/compile_commands.json | \
             sed "s+.*$PWD/++;s+\",\?$++")"
-        # set -x
-
-        echo FILE_BEGIN
-        cat build/compile_commands.json
-        echo FILE_END
+        set -x
 
         function analyze_files_in_random_order
         {
             if [ -n "$1" ]
             then
-                echo "$1" | \
+                echo "$1" | shuf | \
                     xargs -P "$num_jobs" -n 1 ./build-scripts/clang-tidy-wrapper.sh -quiet
             else
                 echo "No files to analyze"

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -110,11 +110,11 @@ then
         ln -s build/compile_commands.json
 
         # TODO: first analyze all files that changed in this PR
-        set +x
+        # set +x
         all_cpp_files="$( \
             grep '"file": "' build/compile_commands.json | \
             sed "s+.*$PWD/++;s+\"$++")"
-        set -x
+        # set -x
 
         function analyze_files_in_random_order
         {

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -106,12 +106,6 @@ then
         # And the same for clang-tidy
         "$CATA_CLANG_TIDY" ../src/version.cpp -- -v
 
-        # Run clang-tidy analysis instead of regular build & test
-        # We could use CMake to create compile_commands.json, but that's super
-        # slow, so use compiledb <https://github.com/nickdiego/compiledb>
-        # instead.
-        compiledb -n make
-
         cd ..
         ln -s build/compile_commands.json
 

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -126,7 +126,7 @@ then
         {
             if [ -n "$1" ]
             then
-                echo "$1" | shuf | \
+                echo "$1" | \
                     xargs -P "$num_jobs" -n 1 ./build-scripts/clang-tidy-wrapper.sh -quiet
             else
                 echo "No files to analyze"

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -115,7 +115,7 @@ then
         # set +x
         all_cpp_files="$( \
             grep '"file": "' build/compile_commands.json | \
-            sed "s+.*$PWD/++;s+\"$++")"
+            sed "s+.*$PWD/++;s+\",\?$++")"
         # set -x
 
         echo FILE_BEGIN

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -109,12 +109,18 @@ then
         cd ..
         ln -s build/compile_commands.json
 
+        num_jobs=1
+
         # TODO: first analyze all files that changed in this PR
         # set +x
         all_cpp_files="$( \
             grep '"file": "' build/compile_commands.json | \
             sed "s+.*$PWD/++;s+\"$++")"
         # set -x
+
+        echo FILE_BEGIN
+        cat build/compile_commands.json
+        echo FILE_END
 
         function analyze_files_in_random_order
         {

--- a/build-scripts/requirements.sh
+++ b/build-scripts/requirements.sh
@@ -5,7 +5,7 @@ set -x
 
 if [ -n "$CATA_CLANG_TIDY" ]; then
   pip install --user wheel --upgrade
-  pip install --user compiledb 'lit==0.11.1' 'click==7.1.2'
+  pip install --user 'lit==0.11.1' 'click==7.1.2'
 fi
 
 if [ -n "$LANGUAGES" ]; then

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -148,7 +148,6 @@ static const itype_id itype_water( "water" );
 static const itype_id itype_water_acid( "water_acid" );
 static const itype_id itype_water_acid_weak( "water_acid_weak" );
 
-static const skill_id skill_cooking( "cooking" );
 static const skill_id skill_survival( "survival" );
 static const skill_id skill_unarmed( "unarmed" );
 static const skill_id skill_weapon( "weapon" );

--- a/src/rot.cpp
+++ b/src/rot.cpp
@@ -70,4 +70,4 @@ temperature_flag temperature_flag_for_part( const vehicle &veh, size_t part_inde
     return temperature_flag::TEMP_NORMAL;
 }
 
-}
+} // namespace rot

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -192,5 +192,5 @@ TEST_CASE( "Items don't rot away on map load if in a freezer" )
     auto sealed_stack_after = m.i_at( sealed_pnt );
     REQUIRE( sealed_stack_after.size() == 1 );
     auto normal_stack_after = m.i_at( normal_pnt );
-    REQUIRE( normal_stack_after.size() == 0 );
+    REQUIRE( normal_stack_after.empty() );
 }


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Fix clang-tidy.

Something changed with either `CMake` or `compiledb`, and the resulting `build/compile_commands.json` had its members rearranged. This resulted in extra comma at the end of `"file":` lines that `sed` did not expect, so `sed` appended `",` to the end of file name in the resulting file list. `xargs` did not like it, which resulted in an error.

I've added handling for potential optional comma in `sed` pattern, and also got rid of `compiledb`. The latter looks like a legacy extra step, because `CMake` can automatically produce `compile_commands.json` since version `3.5`.

#### Testing
Waiting on CI
