### PR TITLE
Add problem matcher for clang-tidy

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -30,7 +30,7 @@ jobs:
     needs: skip-duplicates
     if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CMAKE: 1
       CLANG: clang++-12

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -55,5 +55,6 @@ jobs:
 
       - name: prepare
         run: bash ./build-scripts/requirements.sh
+      - uses: ammaraskar/gcc-problem-matcher@master
       - name: run clang-tidy
         run: bash ./build-scripts/build.sh

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -38,6 +38,7 @@ jobs:
       CATA_CLANG_TIDY: plugin
       TILES: 1
       SOUND: 1
+
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
@@ -51,6 +52,7 @@ jobs:
           sudo apt-get install libncursesw5-dev clang-12 libclang-12-dev llvm-12-dev llvm-12-tools \
             libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev ccache \
             gettext
+
       - name: prepare
         run: bash ./build-scripts/requirements.sh
       - name: run clang-tidy


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Add problem matcher for clang-tidy"

#### Purpose of change

Make arcane fails from clang-tidy more managable

#### Describe the solution

- ci: bump ubuntu version
- style: add some newlines
- ci: add problem matcher for clang-tidy

#### Describe alternatives you've considered

port this PR from DDA: https://github.com/CleverRaven/Cataclysm-DDA/pull/56454
