### PR TITLE
use eol=lf for `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Automatically normalize line endings for all files
 # detected as text (Convert CRLF => LF).
-*         text=auto
+*         text=auto eol=lf
 
 # Explicitly normalize files with these extensions in
 # case Git doesn't detect them as text for some reason.


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Force using LF for text files"

#### Purpose of change

hopefully fixes CRLF-LF issues for windows users.

#### Describe the solution

see https://git-scm.com/docs/gitattributes#Documentation/gitattributes.txt-Settostringvaluelf

#### Describe alternatives you've considered

become linux master race
