### PR TITLE
Adjustments to mine and zombie miner item spawns

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -1181,6 +1181,7 @@
   {
     "type": "item_group",
     "id": "mine_materials",
+    "subtype": "distribution",
     "entries": [
       { "item": "coal_lump", "prob": 20, "count": [ 1, 10 ] },
       { "item": "rock", "prob": 40, "count": [ 1, 10 ] },

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -1181,7 +1181,6 @@
   {
     "type": "item_group",
     "id": "mine_materials",
-    "subtype": "collection",
     "entries": [
       { "item": "coal_lump", "prob": 20, "count": [ 1, 10 ] },
       { "item": "rock", "prob": 40, "count": [ 1, 10 ] },

--- a/data/json/monsterdrops/zombie_technician.json
+++ b/data/json/monsterdrops/zombie_technician.json
@@ -35,7 +35,11 @@
         ]
       },
       { "group": "underwear", "damage": [ 1, 4 ] },
-      { "item": "miner_hat", "prob": 90, "damage": [ 1, 4 ] }
+      { "item": "miner_hat", "prob": 90, "damage": [ 1, 4 ] },
+      {
+        "distribution": [ { "group": "mine_equipment", "prob": 50 }, { "group": "mine_materials", "prob": 50 } ],
+        "prob": 60
+      }
     ]
   }
 ]

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4852,6 +4852,13 @@ void map::draw_mine( mapgendata &dat )
                     int ly2 = end_location.y + rng( -1, 1 );
                     line( this, t_lava, point( lx1, ly1 ), point( lx2, ly2 ) );
                 }
+                if( one_in( 3 ) ) {
+                    if( const auto ore = random_point( *this, [this]( const tripoint & p ) {
+                    return move_cost( p ) == 2;
+                    } ) ) {
+                        spawn_item( *ore, "chunk_sulfur" );
+                    }
+                }
             }
             break;
 
@@ -4878,7 +4885,7 @@ void map::draw_mine( mapgendata &dat )
                     return move_cost( p ) == 2;
                     } ) ) {
                         add_item( *body, item::make_corpse() );
-                        place_items( item_group_id( "mine_equipment" ), 60, *body, *body,
+                        place_items( item_group_id( "mon_zombie_miner_death_drops" ), 100, *body, *body,
                                      false, calendar::start_of_cataclysm );
                     }
                 }
@@ -5045,7 +5052,7 @@ void map::draw_mine( mapgendata &dat )
         for( int i = 0; i < num_bodies; i++ ) {
             point p3( rng( 4, SEEX * 2 - 5 ), rng( 4, SEEX * 2 - 5 ) );
             add_item( p3, item::make_corpse() );
-            place_items( item_group_id( "mine_equipment" ), 60, p3,
+            place_items( item_group_id( "mon_zombie_miner_death_drops" ), 60, p3,
                          p3, false, calendar::start_of_cataclysm );
         }
         place_spawns( GROUP_DOG_THING, 1, point( SEEX, SEEX ), point( SEEX + 1, SEEX + 1 ), 1, true, true );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4852,11 +4852,11 @@ void map::draw_mine( mapgendata &dat )
                     int ly2 = end_location.y + rng( -1, 1 );
                     line( this, t_lava, point( lx1, ly1 ), point( lx2, ly2 ) );
                 }
-                if( one_in( 3 ) ) {
-                    if( const auto ore = random_point( *this, [this]( const tripoint & p ) {
-                    return move_cost( p ) == 2;
-                    } ) ) {
-                        spawn_item( *ore, "chunk_sulfur" );
+                for( const tripoint &ore : points_in_rectangle( tripoint( start_location, abs_sub.z ),
+                        tripoint( end_location,
+                                  abs_sub.z ) ) ) {
+                    if( ter( ore ) == t_rock_floor && one_in( 5 ) ) {
+                        spawn_item( ore, "chunk_sulfur" );
                     }
                 }
             }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4855,7 +4855,7 @@ void map::draw_mine( mapgendata &dat )
                 for( const tripoint &ore : points_in_rectangle( tripoint( start_location, abs_sub.z ),
                         tripoint( end_location,
                                   abs_sub.z ) ) ) {
-                    if( ter( ore ) == t_rock_floor && one_in( 5 ) ) {
+                    if( ter( ore ) == t_rock_floor && one_in( 10 ) ) {
                         spawn_item( ore, "chunk_sulfur" );
                     }
                 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Dead bodies in mines use same gear as zombie miner death drops, miner zeds actually have potential loot, sulfur can spawn near lava in mines"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

A few of the relatively simple parts of my todo list I was reminded up recently by stuff, while trying and failing to go the fuck to sleep.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Set it so the dead bodies that spawn in the mines call `mon_zombie_miner_death_drops` instead of a simple chance of spawning `mine_equipment`.
2. Miner death drops now include a chance (60%, same as the chance bodies would have of calling `mine_equipment`) of spawning an extra item. This is now 50/50 odds of either `mine_equipment` or `mine_materials`, adding a bit more variety to loot and reducing relative odds of getting extra tools or CBMs or the like now that the miners also drop them.
3. Set it so that lava hotspots in the mines spawn sulfur chunks in the area near the lava itself, a 10% chance per valid floor tile in the general bounding box of the lava's endpoints.
4. Changed `mine_materials` to be a distribution instead of a collection. The item spawns in the mine entrance were clearly designed with a distribution in mind (you don't normally call below-100% multiple items with collections) and the low-weight items like niter were anomalously rare due to their weighting. This also ensures that dead bodies and dead zombie miners don't have fat stacks of minerals on their person, just a potential single selection of material.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Removing any clothing items present in `mon_zombie_miner_death_drops` from `mine_equipment` to remove chance of redundant gear spawns, or splitting that group up into tools vs clothes.
2. Porting over veins from Mining Mod and working them into vanilla mines.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load tested.
3. Visited a mine, confirmed the occasional sulfur spawning near lava rifts, and that the dead bodies come with clothes, sometimes dropping minerals instead.
5. Checked affected C++ file for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

https://www.youtube.com/watch?v=34CZjsEI1yU

![image](https://user-images.githubusercontent.com/11582235/228026267-d05550d0-9e0b-4a14-b301-943eb2259b67.png)