### PR TITLE
Make all carpets destroyable and easily deconstructable

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2476,24 +2476,13 @@
   },
   {
     "type": "construction",
-    "id": "constr_revert_carpet",
-    "group": "remove_carpet",
-    "category": "DECORATE",
-    "required_skills": [ [ "fabrication", 0 ] ],
-    "time": "10 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
-    "pre_flags": "RUG",
-    "post_terrain": "t_floor"
-  },
-  {
-    "type": "construction",
     "id": "constr_carpet_red",
     "group": "carpet_floor_red",
     "category": "DECORATE",
     "required_skills": [ [ "fabrication", 1 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
-    "components": [ [ [ "nail", 5 ] ], [ [ "r_carpet", 1 ] ] ],
+    "components": [ [ [ "nail", 4 ] ], [ [ "r_carpet", 1 ] ] ],
     "pre_terrain": "t_floor",
     "post_terrain": "t_carpet_red"
   },
@@ -2505,7 +2494,7 @@
     "required_skills": [ [ "fabrication", 1 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
-    "components": [ [ [ "nail", 5 ] ], [ [ "p_carpet", 1 ] ] ],
+    "components": [ [ [ "nail", 4 ] ], [ [ "p_carpet", 1 ] ] ],
     "pre_terrain": "t_floor",
     "post_terrain": "t_carpet_purple"
   },
@@ -2517,7 +2506,7 @@
     "required_skills": [ [ "fabrication", 1 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
-    "components": [ [ [ "nail", 5 ] ], [ [ "y_carpet", 1 ] ] ],
+    "components": [ [ [ "nail", 4 ] ], [ [ "y_carpet", 1 ] ] ],
     "pre_terrain": "t_floor",
     "post_terrain": "t_carpet_yellow"
   },
@@ -2529,7 +2518,7 @@
     "required_skills": [ [ "fabrication", 1 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
-    "components": [ [ [ "nail", 5 ] ], [ [ "g_carpet", 1 ] ] ],
+    "components": [ [ [ "nail", 4 ] ], [ [ "g_carpet", 1 ] ] ],
     "pre_terrain": "t_floor",
     "post_terrain": "t_carpet_green"
   },

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1236,11 +1236,6 @@
   },
   {
     "type": "construction_group",
-    "id": "remove_carpet",
-    "name": "Remove Carpet"
-  },
-  {
-    "type": "construction_group",
     "id": "remove_concrete_column",
     "name": "Remove concrete column"
   },

--- a/data/json/furniture_and_terrain/terrain-floors_indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors_indoor.json
@@ -421,49 +421,6 @@
   },
   {
     "type": "terrain",
-    "id": "t_carpet_concrete",
-    "name": "industrial carpet",
-    "description": "Firm, low-pile, high-durability carpet in a neutral gray color, for laying down on bare concrete.",
-    "symbol": ".",
-    "color": "light_gray",
-    "looks_like": "t_carpet_red",
-    "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "EASY_DECONSTRUCT" ],
-    "deconstruct": {
-      "ter_set": "t_thconc_floor",
-      "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "plastic_chunk", "count": 2 } ]
-    },
-    "bash": {
-      "sound": "rrrrip!",
-      "ter_set": "t_thconc_floor",
-      "str_min": 10,
-      "str_max": 15,
-      "str_min_supported": 150,
-      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "plastic_chunk", "count": [ 0, 1 ] } ]
-    }
-  },
-  {
-    "type": "terrain",
-    "id": "t_carpet_metal",
-    "name": "bunker carpet",
-    "description": "Firm, low-pile, totally non-flammable carpet in a neutral cream color, with an insulation layer beneath.",
-    "symbol": ".",
-    "color": "white",
-    "looks_like": "t_carpet_yellow",
-    "move_cost": 2,
-    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "ter_set": "t_metal_floor", "items": [ { "item": "y_carpet", "charges": 1 }, { "item": "felt_patch", "count": 2 } ] },
-    "bash": {
-      "sound": "rrrrip!",
-      "ter_set": "t_metal_floor",
-      "str_min": 10,
-      "str_max": 15,
-      "str_min_supported": 200,
-      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "felt_patch", "count": [ 0, 1 ] } ]
-    }
-  },
-  {
-    "type": "terrain",
     "id": "t_carpet_red",
     "name": "red carpet",
     "description": "Soft red carpet.",
@@ -485,62 +442,69 @@
   {
     "type": "terrain",
     "id": "t_carpet_yellow",
+    "copy-from": "t_carpet_red",
     "name": "yellow carpet",
     "description": "Soft yellow carpet.",
     "symbol": ".",
     "color": "yellow",
-    "move_cost": 2,
-    "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "y_carpet", "charges": 1 }, { "item": "nail", "charges": 4 } ] },
-    "bash": {
-      "sound": "rrrrip!",
-      "ter_set": "t_floor",
-      "str_min": 5,
-      "str_max": 15,
-      "str_min_supported": 100,
-      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "nail", "charges": [ 1, 4 ] } ]
-    }
+    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "y_carpet", "charges": 1 }, { "item": "nail", "charges": 4 } ] }
   },
   {
     "type": "terrain",
     "id": "t_carpet_green",
+    "copy-from": "t_carpet_red",
     "name": "green carpet",
     "description": "Soft green carpet.",
     "symbol": ".",
     "color": "green",
-    "move_cost": 2,
-    "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "g_carpet", "charges": 1 }, { "item": "nail", "charges": 4 } ] },
-    "bash": {
-      "sound": "rrrrip!",
-      "ter_set": "t_floor",
-      "str_min": 5,
-      "str_max": 15,
-      "str_min_supported": 100,
-      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "nail", "charges": [ 1, 4 ] } ]
-    }
+    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "g_carpet", "charges": 1 }, { "item": "nail", "charges": 4 } ] }
   },
   {
     "type": "terrain",
     "id": "t_carpet_purple",
+    "copy-from": "t_carpet_red",
     "name": "purple carpet",
     "description": "Soft purple carpet.",
     "symbol": ".",
     "color": "magenta",
-    "move_cost": 2,
-    "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "p_carpet", "charges": 1 }, { "item": "nail", "charges": 4 } ] },
+    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "p_carpet", "charges": 1 }, { "item": "nail", "charges": 4 } ] }
+  },
+  {
+    "type": "terrain",
+    "id": "t_carpet_concrete",
+    "copy-from": "t_carpet_red",
+    "name": "industrial carpet",
+    "description": "Firm, low-pile, high-durability carpet in a neutral gray color, for laying down on bare concrete.",
+    "symbol": ".",
+    "color": "light_gray",
+    "looks_like": "t_carpet_red",
+    "deconstruct": {
+      "ter_set": "t_thconc_floor",
+      "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "plastic_chunk", "count": 2 } ]
+    },
     "bash": {
-      "sound": "rrrrip!",
-      "ter_set": "t_floor",
-      "str_min": 5,
-      "str_max": 15,
-      "str_min_supported": 100,
-      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "nail", "charges": [ 1, 4 ] } ]
-    }
+      "ter_set": "t_thconc_floor",
+      "str_min_supported": 150,
+      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "plastic_chunk", "count": [ 0, 1 ] } ]
+    },
+    "delete": { "flags": [ "FLAMMABLE_HARD" ] }
+  },
+  {
+    "type": "terrain",
+    "id": "t_carpet_metal",
+    "copy-from": "t_carpet_red",
+    "name": "bunker carpet",
+    "description": "Firm, low-pile, totally non-flammable carpet in a neutral cream color, with an insulation layer beneath.",
+    "symbol": ".",
+    "color": "white",
+    "looks_like": "t_carpet_yellow",
+    "deconstruct": { "ter_set": "t_metal_floor", "items": [ { "item": "y_carpet", "charges": 1 }, { "item": "felt_patch", "count": 2 } ] },
+    "bash": {
+      "ter_set": "t_metal_floor",
+      "str_min_supported": 200,
+      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "felt_patch", "count": [ 0, 1 ] } ]
+    },
+    "delete": { "flags": [ "FLAMMABLE_HARD" ] }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-floors_indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors_indoor.json
@@ -428,18 +428,18 @@
     "color": "light_gray",
     "looks_like": "t_carpet_red",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "EASY_DECONSTRUCT" ],
+    "deconstruct": {
+      "ter_set": "t_thconc_floor",
+      "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "plastic_chunk", "count": 2 } ]
+    },
     "bash": {
-      "sound": "SMASH!",
-      "ter_set": "t_null",
-      "str_min": 100,
-      "str_max": 400,
+      "sound": "rrrrip!",
+      "ter_set": "t_thconc_floor",
+      "str_min": 10,
+      "str_max": 15,
       "str_min_supported": 150,
-      "items": [
-        { "item": "rock", "count": [ 5, 10 ] },
-        { "item": "scrap", "count": [ 5, 8 ] },
-        { "item": "rebar", "count": [ 0, 2 ] }
-      ]
+      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "plastic_chunk", "count": [ 0, 1 ] } ]
     }
   },
   {
@@ -451,18 +451,15 @@
     "color": "white",
     "looks_like": "t_carpet_yellow",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG" ],
+    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "ter_set": "t_metal_floor", "items": [ { "item": "y_carpet", "charges": 1 }, { "item": "felt_patch", "count": 2 } ] },
     "bash": {
-      "sound": "thump",
-      "ter_set": "t_null",
-      "str_min": 200,
-      "str_max": 500,
+      "sound": "rrrrip!",
+      "ter_set": "t_metal_floor",
+      "str_min": 10,
+      "str_max": 15,
       "str_min_supported": 200,
-      "items": [
-        { "item": "steel_lump", "count": [ 1, 4 ] },
-        { "item": "steel_chunk", "count": [ 3, 12 ] },
-        { "item": "scrap", "count": [ 9, 36 ] }
-      ]
+      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "felt_patch", "count": [ 0, 1 ] } ]
     }
   },
   {
@@ -474,14 +471,15 @@
     "color": "red",
     "move_cost": 2,
     "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "nail", "charges": 4 } ] },
     "bash": {
-      "sound": "SMASH!",
-      "ter_set": "t_null",
-      "str_min": 50,
-      "str_max": 400,
+      "sound": "rrrrip!",
+      "ter_set": "t_floor",
+      "str_min": 5,
+      "str_max": 15,
       "str_min_supported": 100,
-      "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 6, 13 ] } ]
+      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "nail", "charges": [ 1, 4 ] } ]
     }
   },
   {
@@ -493,14 +491,15 @@
     "color": "yellow",
     "move_cost": 2,
     "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "y_carpet", "charges": 1 }, { "item": "nail", "charges": 4 } ] },
     "bash": {
-      "sound": "SMASH!",
-      "ter_set": "t_null",
-      "str_min": 50,
-      "str_max": 400,
+      "sound": "rrrrip!",
+      "ter_set": "t_floor",
+      "str_min": 5,
+      "str_max": 15,
       "str_min_supported": 100,
-      "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 6, 13 ] } ]
+      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "nail", "charges": [ 1, 4 ] } ]
     }
   },
   {
@@ -512,14 +511,15 @@
     "color": "green",
     "move_cost": 2,
     "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "g_carpet", "charges": 1 }, { "item": "nail", "charges": 4 } ] },
     "bash": {
-      "sound": "SMASH!",
-      "ter_set": "t_null",
-      "str_min": 50,
-      "str_max": 400,
+      "sound": "rrrrip!",
+      "ter_set": "t_floor",
+      "str_min": 5,
+      "str_max": 15,
       "str_min_supported": 100,
-      "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 6, 13 ] } ]
+      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "nail", "charges": [ 1, 4 ] } ]
     }
   },
   {
@@ -531,14 +531,15 @@
     "color": "magenta",
     "move_cost": 2,
     "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "p_carpet", "charges": 1 }, { "item": "nail", "charges": 4 } ] },
     "bash": {
-      "sound": "SMASH!",
-      "ter_set": "t_null",
-      "str_min": 50,
-      "str_max": 400,
+      "sound": "rrrrip!",
+      "ter_set": "t_floor",
+      "str_min": 5,
+      "str_max": 15,
       "str_min_supported": 100,
-      "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 6, 13 ] } ]
+      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "nail", "charges": [ 1, 4 ] } ]
     }
   },
   {

--- a/data/mods/No_Hope/terrain.json
+++ b/data/mods/No_Hope/terrain.json
@@ -253,14 +253,15 @@
     "move_cost": 2,
     "roof": "t_flat_roof",
     "connects_to": "RAIL",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "nail", "charges": 4 } ] },
     "bash": {
-      "sound": "SMASH!",
-      "ter_set": "t_null",
-      "str_min": 50,
-      "str_max": 400,
+      "sound": "rrrrip!",
+      "ter_set": "t_floor",
+      "str_min": 5,
+      "str_max": 15,
       "str_min_supported": 100,
-      "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 6, 13 ] } ]
+      "items": [ { "item": "rag", "count": [ 0, 1 ] }, { "item": "nail", "charges": [ 1, 4 ] } ]
     }
   },
   {
@@ -275,7 +276,7 @@
     "light_emitted": 120,
     "roof": "t_flat_roof",
     "connects_to": "RAIL",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT" ],
     "bash": {
       "str_min": 4,
       "str_max": 12,


### PR DESCRIPTION
#### Summary

SUMMARY: Balance "Make all carpets destroyable and easily deconstructable"


#### Purpose of change

Being able to salvage carpets found in different structures to either cut them into rags or lay them elsewhere.


#### Describe the solution

- Got rid of the generic Remove Carpet construction recipe which didn't yield anything, as well as `RUG` flag used by all carpets to utilize said recipe.
- Made all carpets `EASY_DECONSTRUCT`able.
	- Deconstructing Red, Purple, Green, and Yellow carpets yields corresponding carpet types and 4 nails. Additionally, Concrete and Bunker carpets return 2 plastic chunks and 2 felt patches correspondingly.
- Made all carpets `bash`-able.
- Made Concrete and Bunker carpets turn into their corresponding terrain type once they're deconstructed/destroyed, unlike Remove Carpet which converted everything to wooden floor.
- Changed carpet construction recipe to utilize 4 nails instead of 5. 1 nail for each corner.
	- *\* Concrete and Bunker carpets still cannot be constructed*

#### Describe alternatives you've considered

Utilize the *(removed by this PR)* `remove_carpet` group for deconstruction, and create separate entries for each type of carpet.

Pros:

- Can add `PRY: 1` quality requirement.
- Can decrease deconstruction time to 5 minutes.

Cons:

- Excessive cluttering of player interface and JSON data while not adding that much to balance.

#### Testing

Roamed around the world, bashed/deconstructed different types of carpets. Also, manually spawned them and tested.

#### Additional context

- ⚠️ Soundpacks will have to change the carpet terrain destruction sounds to sounds of ripping cloth: `t_carpet_concrete`, `t_carpet_metal`, `t_carpet_red`, `t_carpet_yellow`, `t_carpet_green`, `t_carpet_purple`
- ⚠️ Mods should get rid of the `RUG` flag, and make their carpets `EASY_DECONSTRUCT`able.
- If anyone's interested, carpets are not that good of a rag source. Cutting 5 carpet items yields roughly 6 rags.
- Also, carpets do not spawn anywhere as a standalone item *(in the base game, at least)*, so prying them off different surfaces is the only way to obtain them.

![image](https://user-images.githubusercontent.com/85341530/228602102-13c18dae-3137-4494-80b1-7c7e13398bc0.png)
