### PR TITLE
Further C.R.I.T. Expansion updates

### DIFF
--- a/data/mods/CRT_EXPANSION/items/crt_ammo.json
+++ b/data/mods/CRT_EXPANSION/items/crt_ammo.json
@@ -3,7 +3,7 @@
     "type": "AMMO",
     "id": "pellet",
     "price": 1000,
-    "name": "lead pellets",
+    "name": ".117 lead pellets",
     "symbol": "=",
     "color": "light_gray",
     "description": "A round tin of small light grain .177 lead pellets.  These are common, tipped field pellets that can deal some light damage but are generally used for plinking.",
@@ -11,7 +11,7 @@
     "volume": "200ml",
     "weight": "2 g",
     "ammo_type": "pellets",
-    "damage": { "damage_type": "stab", "amount": 4 },
+    "damage": { "damage_type": "bullet", "amount": 4 },
     "dispersion": 100,
     "count": 100,
     "stack_size": 200,
@@ -23,35 +23,35 @@
     "id": "dhp_pellet",
     "copy-from": "pellet",
     "type": "AMMO",
-    "name": "domed HP pellets",
+    "name": ".117 domed HP pellets",
     "description": "A stable, heavier grain lead pellet with the purpose of expanding upon hitting a target for maximized damage, the dome shape allows it to pack quite a punch for something so small",
     "material": "steel",
     "symbol": "=",
     "color": "dark_gray",
-    "relative": { "price": 300, "damage": { "damage_type": "stab", "amount": 6, "armor_penetration": 1 }, "dispersion": -20 }
+    "relative": { "price": 300, "damage": { "damage_type": "bullet", "amount": 6, "armor_penetration": 1 }, "dispersion": -20 }
   },
   {
     "id": "hp_pellet",
     "copy-from": "pellet",
     "type": "AMMO",
-    "name": "tipped HP pellets",
+    "name": ".117 tipped HP pellets",
     "//": "Based off of the Gamo Redfire pellet, the plastic tip pushes back into the lead pleet to cause a greater deformation and ballooning effect; makes birds explode!",
     "description": "A medium grain lead pellet tipped with a pointed bit of hard plastic with the purpose of maximum expansion upon hitting a target.",
     "material": "steel",
     "symbol": "=",
     "color": "dark_gray",
-    "relative": { "price": 200, "damage": { "damage_type": "stab", "amount": 3, "armor_penetration": 3 } }
+    "relative": { "price": 200, "damage": { "damage_type": "bullet", "amount": 3, "armor_penetration": 3 } }
   },
   {
     "id": "alloy_pellet",
     "copy-from": "pellet",
     "type": "AMMO",
-    "name": "alloy pellets",
+    "name": ".117 alloy pellets",
     "description": "An gimmicky alloy pellet with the purpose of reaching a higher velocity than a normal lead pellet for breaking the sound barrier resulting in an extremely loud crack, not so useful for stealth.",
     "material": "steel",
     "symbol": "=",
     "color": "dark_gray",
-    "relative": { "price": 500, "damage": { "damage_type": "stab", "armor_penetration": 2 }, "loudness": 25, "dispersion": 20 }
+    "relative": { "price": 500, "damage": { "damage_type": "bullet", "armor_penetration": 2 }, "loudness": 25, "dispersion": 20 }
   },
   {
     "type": "AMMO",

--- a/data/mods/CRT_EXPANSION/items/crt_ammotypes.json
+++ b/data/mods/CRT_EXPANSION/items/crt_ammotypes.json
@@ -2,7 +2,7 @@
   {
     "type": "ammunition_type",
     "id": "pellets",
-    "name": "lead pellets",
+    "name": ".117 pellets",
     "default": "pellet"
   },
   {

--- a/data/mods/CRT_EXPANSION/items/crt_armor.json
+++ b/data/mods/CRT_EXPANSION/items/crt_armor.json
@@ -318,7 +318,7 @@
     "warmth": 5,
     "material_thickness": 3,
     "environmental_protection": 4,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "OUTER", "OVERSIZE" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "BELTED", "OVERSIZE" ]
   },
   {
     "id": "crt_sarmor",

--- a/data/mods/CRT_EXPANSION/items/crt_gun.json
+++ b/data/mods/CRT_EXPANSION/items/crt_gun.json
@@ -18,7 +18,7 @@
     "dispersion": 150,
     "durability": 9,
     "loudness": 14,
-    "ups_charges": 11,
+    "ups_charges": 8,
     "reload": 220,
     "modes": [ [ "DEFAULT", "double", 2 ] ],
     "valid_mod_locations": [
@@ -209,14 +209,14 @@
     "bashing": 10,
     "to_hit": -1,
     "range": 17,
-    "ranged_damage": { "damage_type": "stab", "amount": 5 },
+    "ranged_damage": { "damage_type": "bullet", "amount": 5 },
     "dispersion": 120,
     "durability": 8,
     "loudness": 18,
     "clip_size": 1,
     "reload": 300,
     "modes": [ [ "DEFAULT", "single", 1 ] ],
-    "valid_mod_locations": [ [ "accessories", 2 ], [ "sights", 1 ], [ "stock", 1 ] ]
+    "valid_mod_locations": [ [ "accessories", 2 ], [ "sling", 1 ], [ "sights", 1 ], [ "stock", 1 ] ]
   },
   {
     "id": "ds_plasma_cutter",
@@ -249,7 +249,7 @@
     "id": "ds_rivet_gun",
     "type": "GUN",
     "name": "C.R.I.T. Rivet Driver",
-    "description": "Experimental double purpose tool under development in C.R.I.T. R&D.  It takes a regular nail and then enlongates it within a fraction of a second before firing it out, upon reaching a target, the fragile stake explodes into shards.",
+    "description": "Experimental double purpose tool under development in C.R.I.T. R&D.  It takes a regular nail and then elongates it within a fraction of a second before firing it out, upon reaching a target, the fragile stake explodes into shards.",
     "weight": "1650 g",
     "volume": "750 ml",
     "price": 1000000,

--- a/data/mods/CRT_EXPANSION/items/crt_item_groups.json
+++ b/data/mods/CRT_EXPANSION/items/crt_item_groups.json
@@ -13,39 +13,23 @@
   },
   {
     "type": "item_group",
-    "id": "guns_energy",
-    "//": "Assorted factory crafted energy weapons.",
-    "items": [ { "item": "crt_laser_pistol", "prob": 5 }, { "item": "crt_laser_carbine", "prob": 10 } ]
-  },
-  {
-    "id": "clothing_soldier_set",
-    "type": "item_group",
-    "subtype": "collection",
-    "//": "Standard (non-winter) set of clothes worn by soldiers and paramilitary forces.",
-    "items": [
-      { "group": "clothing_soldier_shirt" },
-      { "item": "crt_jacket" },
-      { "item": "crt_pants" },
-      { "item": "crt_boots", "prob": 5 },
-      { "item": "crt_helmet", "prob": 5 },
-      { "item": "crt_gloves", "prob": 5 }
-    ]
-  },
-  {
-    "type": "item_group",
     "id": "military",
-    "items": [
-      [ "crt_belt", 20 ],
-      [ "crt_jacket", 40 ],
-      [ "crt_pants", 50 ],
-      [ "crt_boots", 10 ],
-      [ "crt_helmet", 10 ],
-      [ "crt_gloves", 10 ],
-      [ "crt_gasmask", 3 ],
-      [ "crt_em_vest", 3 ],
-      [ "flare_gmod", 10 ],
-      [ "crt_backpack", 8 ],
-      [ "crt_laser_pistol", 1 ]
+    "subtype": "distribution",
+    "entries": [
+      { "item": "crt_fire_glove", "prob": 5 },
+      { "item": "crt_laser_pistol", "prob": 5 },
+      { "item": "ds_ripper", "prob": 10 },
+      { "item": "ds_pulse_rifle", "prob": 10 },
+      { "item": "pulsesb", "prob": 10 },
+      { "item": "crt_gasmask", "prob": 25 },
+      { "item": "crt_em_vest", "prob": 50 },
+      { "item": "knife_crt", "prob": 5 },
+      { "item": "flare_gmod", "prob": 5 },
+      { "item": "crt_knuckledusters", "prob": 5 },
+      { "item": "sword_crt", "prob": 15 },
+      { "item": "blade_crt", "prob": 15 },
+      { "item": "crt_hatchet", "prob": 10 },
+      { "item": "crt_nstick", "prob": 10 }
     ]
   },
   {
@@ -71,43 +55,38 @@
   },
   {
     "type": "item_group",
-    "id": "military",
-    "subtype": "distribution",
-    "entries": [
-      { "item": "crt_fire_glove", "prob": 5 },
-      { "item": "ds_ripper", "prob": 10 },
-      { "item": "crt_em_vest", "prob": 50 },
-      { "item": "knife_crt", "prob": 5 },
-      { "item": "crt_knuckledusters", "prob": 5 },
-      { "item": "sword_crt", "prob": 15 },
-      { "item": "blade_crt", "prob": 15 },
-      { "item": "crt_hatchet", "prob": 10 },
-      { "item": "crt_nstick", "prob": 10 }
-    ]
-  },
-  {
-    "type": "item_group",
     "id": "guns_energy",
     "//": "Assorted factory crafted energy weapons.",
     "items": [
-      { "item": "ds_pulse_rifle", "prob": 20 },
-      { "item": "ds_line_gun", "prob": 10 },
-      { "item": "v29", "prob": 25 },
-      { "item": "plasma_gun", "prob": 10 },
+      { "item": "crt_laser_pistol", "prob": 10 },
       { "item": "crt_laser_gatling", "prob": 5 },
-      { "item": "crt_laser_carbine", "prob": 15 },
-      { "item": "crt_energy_rifle", "prob": 10 },
-      { "item": "ds_plasma_cutter", "prob": 15 },
-      { "item": "ds_rivet_gun", "prob": 10 }
+      { "item": "crt_laser_carbine", "prob": 5 },
+      { "item": "crt_energy_rifle", "prob": 5 },
+      { "item": "ds_plasma_cutter", "prob": 5 },
+      { "item": "ds_pulse_rifle", "prob": 10 },
+      { "item": "ds_line_gun", "prob": 5 },
+      { "item": "ds_rivet_gun", "prob": 5 }
     ]
   },
   {
     "type": "item_group",
     "id": "guns_rifle_milspec",
     "//": "Military specification rifles only ever found at military sites.",
+    "items": [ { "item": "crt_cqb_si", "prob": 15, "charges-min": 0, "charges-max": 20 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "guns_rifle_rare",
+    "items": [ { "item": "pelletgun", "prob": 25, "charges-min": 0, "charges-max": 1 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "ammo_rifle_rare",
     "items": [
-      { "item": "pelletgun", "prob": 5, "charges-min": 0, "charges-max": 10 },
-      { "item": "crt_cqb_si", "prob": 15, "charges-min": 0, "charges-max": 20 }
+      { "item": "pellet", "prob": 25 },
+      { "item": "dhp_pellet", "prob": 10 },
+      { "item": "hp_pellet", "prob": 10 },
+      { "item": "alloy_pellet", "prob": 5 }
     ]
   },
   {
@@ -116,16 +95,44 @@
     "subtype": "collection",
     "//": "Standard (non-winter) set of clothes worn by soldiers and paramilitary forces.",
     "items": [
-      { "item": "crt_legguard" },
-      { "item": "crt_armguard" },
-      { "item": "crt_aarmor" },
-      { "item": "crt_sarmor" },
-      { "item": "crt_warmor" }
+      {
+        "distribution": [
+          { "collection": [ { "item": "crt_legguard" }, { "item": "crt_legguard" } ], "prob": 75 },
+          { "item": "crt_aarmor", "prob": 15 },
+          {
+            "collection": [ { "item": "crt_sarmor" }, { "distribution": [ { "item": "crt_earmor" }, { "item": "crt_warmor" } ] } ],
+            "prob": 10
+          }
+        ],
+        "prob": 5
+      }
     ]
   },
   {
     "type": "item_group",
     "id": "mil_accessories",
     "items": [ [ "crt_mess_kit", 10 ], [ "crt_etool", 15 ], [ "crt_canteen", 10 ], [ "crt_gasmask", 10 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "camping",
+    "items": [ [ "pellet", 4 ], [ "dhp_pellet", 2 ], [ "hp_pellet", 1 ], [ "alloy_pellet", 1 ], [ "pelletgun", 10 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "bedroom",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "pellet", "prob": 4 },
+      { "item": "dhp_pellet", "prob": 2 },
+      { "item": "hp_pellet", "prob": 1 },
+      { "item": "alloy_pellet", "prob": 1 },
+      { "item": "pelletgun", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "lab_dorm",
+    "items": [ [ "pellet", 4 ], [ "dhp_pellet", 2 ], [ "hp_pellet", 1 ], [ "alloy_pellet", 1 ], [ "pelletgun", 10 ] ]
   }
 ]

--- a/data/mods/CRT_EXPANSION/items/crt_recipes.json
+++ b/data/mods/CRT_EXPANSION/items/crt_recipes.json
@@ -15,5 +15,19 @@
     "type": "uncraft",
     "time": 300,
     "components": [ [ [ "withered", 3 ] ] ]
+  },
+  {
+    "result": "pellet",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_RIFLE",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "skills_required": [ "gun", 2 ],
+    "time": "90 s",
+    "batch_time_factors": [ 60, 5 ],
+    "book_learn": [ [ "recipe_bullets", 2 ], [ "mag_rifle", 4 ] ],
+    "charges": 1,
+    "using": [ [ "bullet_forming", 1 ], [ "ammo_bullet", 1 ] ]
   }
 ]

--- a/data/mods/CRT_EXPANSION/items/crt_tools.json
+++ b/data/mods/CRT_EXPANSION/items/crt_tools.json
@@ -88,7 +88,7 @@
     "to_hit": 2,
     "symbol": ";",
     "qualities": [ [ "BUTCHER", 7 ] ],
-    "flags": [ "UNBREAKABLE_MELEE" ],
+    "flags": [ "UNBREAKABLE_MELEE", "SHEATH_SWORD" ],
     "techniques": [ "WBLOCK_2", "tec_feint", "tec_counter", "BERSERK", "DSINERTIAL" ]
   },
   {

--- a/data/mods/CRT_EXPANSION/scenarios/crt_classes.json
+++ b/data/mods/CRT_EXPANSION/scenarios/crt_classes.json
@@ -1,5 +1,26 @@
 [
   {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "crit_mags_scarh",
+    "entries": [
+      { "item": "scarhmag", "ammo-item": "762_51", "charges": 20 },
+      { "item": "scarhmag", "ammo-item": "762_51", "charges": 20 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "crit_mags_m9",
+    "entries": [ { "item": "m9mag", "ammo-item": "9mm", "charges": 15 }, { "item": "m9mag", "ammo-item": "9mm", "charges": 15 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "crit_gun_specops",
+    "entries": [ { "item": "crt_laser_pistol", "contents-item": [ "flare_gmod", "bthk_stock", "beam_difractor" ] } ]
+  },
+  {
     "type": "profession",
     "id": "crt_rotc",
     "name": "C.R.I.T. ROTC Member",
@@ -17,11 +38,12 @@
     ],
     "items": {
       "both": {
-        "items": [ "bandana", "crt_chestrig", "crt_iduster", "army_top", "crt_canteen", "crt_pants", "socks", "crt_la_boots" ],
+        "ammo": 100,
+        "items": [ "bandana", "crt_iduster", "army_top", "crt_canteen", "crt_pants", "socks", "crt_la_boots" ],
         "entries": [
           { "item": "knife_crt", "container-item": "crt_belt" },
-          { "item": "scar_h", "ammo-item": "308", "contents-item": "shoulder_strap" },
-          { "item": "scarhmag", "ammo-item": "308", "count": 2 }
+          { "item": "scar_h", "ammo-item": "762_51", "contents-item": "shoulder_strap" },
+          { "item": "crt_chestrig", "contents-group": "crit_mags_scarh" }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -48,18 +70,16 @@
           "crt_rec_hat",
           "crt_rec_duster",
           "crt_jacket",
-          "polo_shirt",
           "crt_rec_gloves",
           "crt_dress_pants",
+          "crt_belt",
           "socks",
           "crt_dress_shoes",
           "id_military",
+          "knife_swissarmy",
           "cell_phone"
         ],
-        "entries": [
-          { "item": "water_clean", "ammo-item": "water_clean", "container-item": "thermos" },
-          { "item": "knife_swissarmy", "container-item": "crt_belt" }
-        ]
+        "entries": [ { "item": "water_clean", "container-item": "thermos" } ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boxer_shorts" ]
@@ -86,7 +106,6 @@
         "ammo": 100,
         "items": [
           "beret",
-          "modularvestkevlar",
           "jacket_army",
           "army_top",
           "legguard_hard",
@@ -104,8 +123,8 @@
         "entries": [
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "knife_crt", "container-item": "sheath" },
-          { "item": "m4a1", "ammo-item": "223", "contents-item": [ "grip", "holo_sight" ] },
-          { "item": "stanag30", "ammo-item": "223", "count": 1 }
+          { "item": "m4a1", "ammo-item": "556", "contents-item": [ "shoulder_strap", "grip", "holo_sight" ] },
+          { "item": "modularvestsuper", "contents-group": "army_mags_m4" }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -124,7 +143,7 @@
       "both": {
         "ammo": 100,
         "items": [
-          "modularvestkevlar",
+          "modularvest",
           "crt_chestrig",
           "crt_pants",
           "legguard_hard",
@@ -144,8 +163,8 @@
         "entries": [
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "knife_rm42", "container-item": "sheath" },
-          { "item": "scar_h", "ammo-item": "308", "contents-item": "shoulder_strap" },
-          { "item": "scarhmag", "ammo-item": "308", "count": 2 }
+          { "item": "scar_h", "ammo-item": "762_51", "contents-item": "shoulder_strap" },
+          { "item": "modularvestsuper", "contents-group": "crit_mags_scarh" }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -173,8 +192,6 @@
           "helmet_army",
           "crt_helmet_liner",
           "crt_aarmor",
-          "armguard_hard",
-          "legguard_hard",
           "gloves_tactical",
           "crt_gloves_liner",
           "crt_canteen",
@@ -185,13 +202,13 @@
           "two_way_radio",
           "1st_aid",
           "bandages",
+          "knife_swissarmy",
           "crt_backpack",
           "UPS_off"
         ],
         "entries": [
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "sleeping_bag", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_swissarmy", "container-item": "sheath" },
+          { "item": "sleeping_bag_roll", "custom-flags": [ "no_auto_equip" ] },
           { "item": "crt_laser_pistol", "container-item": "holster" }
         ]
       },
@@ -214,8 +231,6 @@
           "crt_helmet",
           "crt_helmet_liner",
           "glasses_bal",
-          "balclava",
-          "modularvestkevlar",
           "jacket_army",
           "army_top",
           "crt_armguard",
@@ -229,12 +244,11 @@
         ],
         "entries": [
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "sleeping_bag", "custom-flags": [ "no_auto_equip" ] },
+          { "item": "sleeping_bag_roll", "custom-flags": [ "no_auto_equip" ] },
           { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "l_lmg_223", "ammo-item": "223" },
-          { "item": "lw223bigmag", "count": 1 },
+          { "item": "m249", "ammo-item": "556", "contents-item": "shoulder_strap" },
           { "item": "m9", "ammo-item": "9mm", "container-item": "holster" },
-          { "item": "m9mag", "ammo-item": "9mm", "count": 2 }
+          { "item": "modularvestsuper", "contents-group": "crit_mags_m9" }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -262,7 +276,6 @@
           "beret",
           "crt_helmet_liner",
           "fancy_sunglasses",
-          "crt_chestrig",
           "crt_iduster",
           "army_top",
           "crt_pants",
@@ -278,7 +291,7 @@
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "knife_rm42", "container-item": "sheath" },
           { "item": "m9", "ammo-item": "9mm", "container-item": "holster" },
-          { "item": "m9mag", "ammo-item": "9mm", "count": 2 }
+          { "item": "crt_chestrig", "contents-group": "crit_mags_m9" }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -312,18 +325,19 @@
           "army_top",
           "crt_gloves_liner",
           "crt_gloves",
-          "crt_canteen",
+          "crt_belt",
           "crt_legrig",
           "socks",
-          "crt_boots",
+          "crt_la_boots",
+          "crt_earmor_boots",
           "two_way_radio",
           "crt_nstick",
           "badge_marshal",
-          "lighter"
+          "lighter",
+          "knife_swissarmy"
         ],
         "entries": [
-          { "item": "water_clean", "ammo-item": "water_clean", "container-item": "crt_canteen" },
-          { "item": "knife_swissarmy", "container-item": "crt_belt" },
+          { "item": "water_clean", "container-item": "crt_canteen" },
           { "item": "knife_crt", "container-item": "sheath" },
           { "item": "m9", "ammo-item": "9mm", "container-item": "holster" },
           { "item": "m9mag", "ammo-item": "9mm", "count": 2 }
@@ -383,7 +397,7 @@
           "army_top",
           "crt_gloves_liner",
           "crt_gloves",
-          "crt_canteen",
+          "crt_belt",
           "crt_legrig",
           "socks",
           "crt_boots",
@@ -391,11 +405,11 @@
           "crt_laser_gatling",
           "crt_nstick",
           "badge_marshal",
-          "lighter"
+          "lighter",
+          "knife_swissarmy"
         ],
         "entries": [
-          { "item": "water_clean", "ammo-item": "water_clean", "container-item": "crt_canteen" },
-          { "item": "knife_swissarmy", "container-item": "crt_belt" },
+          { "item": "water_clean", "container-item": "crt_canteen" },
           { "item": "crt_mask", "custom-flags": [ "no_auto_equip" ] },
           { "item": "knife_crt", "container-item": "sheath" },
           { "item": "m9", "ammo-item": "9mm", "container-item": "holster" },
@@ -447,7 +461,6 @@
           "crt_gloves_liner",
           "crt_gloves",
           "crt_legguard",
-          "crt_canteen",
           "crt_legrig",
           "socks",
           "crt_boots",
@@ -458,21 +471,16 @@
           "mre_veggy_box",
           "crt_mess_kit",
           "lighter",
+          "knife_swissarmy",
           "badge_marshal",
           "crt_etool"
         ],
         "entries": [
-          { "item": "sleeping_bag", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "water_clean", "ammo-item": "water_clean", "container-item": "crt_canteen" },
+          { "item": "sleeping_bag_roll", "custom-flags": [ "no_auto_equip" ] },
+          { "item": "water_clean", "container-item": "crt_canteen" },
           { "item": "knife_crt", "container-item": "crt_belt" },
-          { "item": "knife_swissarmy", "container-item": "sheath" },
-          {
-            "item": "crt_laser_pistol",
-            "contents-item": [ "flare_gmod", "bthk_stock", "beam_difractor" ],
-            "container-item": "holster"
-          },
-          { "item": "signal_flare", "ammo-item": "signal_flare", "count": 5 },
-          { "item": "battery", "ammo-item": "battery", "count": 25 }
+          { "item": "holster", "contents-group": "crit_gun_specops" },
+          { "item": "signal_flare", "charges": 5 }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -514,7 +522,6 @@
           "crt_gloves",
           "crt_legguard",
           "crt_legrig",
-          "crt_canteen",
           "crt_pants",
           "socks",
           "crt_boots",
@@ -522,13 +529,13 @@
           "crt_hatchet",
           "mre_veggy_box",
           "lighter",
-          "pellet",
-          "pelletgun",
-          "crt_etool"
+          "knife_swissarmy",
+          "pellet"
         ],
         "entries": [
-          { "item": "water_clean", "ammo-item": "water_clean", "container-item": "crt_canteen" },
-          { "item": "knife_swissarmy", "container-item": "crt_belt" },
+          { "item": "pelletgun", "ammo-item": "pellet", "contents-item": "shoulder_strap" },
+          { "item": "water_clean", "container-item": "crt_canteen" },
+          { "item": "crt_etool", "container-item": "crt_belt" },
           { "item": "knife_crt", "container-item": "sheath" }
         ]
       },
@@ -566,17 +573,17 @@
           "crt_pants",
           "socks",
           "crt_la_boots",
-          "crt_hatchet",
           "mre_veggy_box",
           "lighter",
           "crt_mess_kit",
           "id_military",
-          "pelletgun",
+          "knife_swissarmy",
           "pellet"
         ],
         "entries": [
-          { "item": "water_clean", "ammo-item": "water_clean", "container-item": "canteen" },
-          { "item": "knife_swissarmy", "container-item": "crt_belt" }
+          { "item": "pelletgun", "ammo-item": "pellet", "contents-item": "shoulder_strap" },
+          { "item": "crt_hatchet", "container-item": "crt_belt" },
+          { "item": "water_clean", "container-item": "canteen" }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -610,16 +617,15 @@
           "dress_shirt",
           "crt_rec_gloves",
           "crt_dress_pants",
+          "crt_belt",
           "socks",
           "crt_dress_shoes",
           "lighter",
+          "knife_swissarmy",
           "thorazine",
           "id_military"
         ],
-        "entries": [
-          { "item": "water_clean", "ammo-item": "water_clean", "container-item": "thermos" },
-          { "item": "knife_swissarmy", "container-item": "crt_belt" }
-        ]
+        "entries": [ { "item": "water_clean", "container-item": "thermos" } ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boxer_shorts" ]
@@ -646,18 +652,13 @@
           "rucksack",
           "ds_armor",
           "ds_monitor",
-          "crt_jacket",
           "army_top",
           "crt_rec_gloves",
           "crt_canteen",
           "crt_belt",
-          "crt_pants",
           "socks",
           "ds_plasma_cutter",
-          "ds_line_gun",
-          "ds_pulse_rifle",
           "ds_rivet_gun",
-          "ds_ripper",
           "toolbox",
           "mre_veggy_box",
           "lighter",
@@ -665,7 +666,11 @@
           "id_military",
           "id_science"
         ],
-        "entries": [ { "item": "water_clean", "ammo-item": "water_clean", "container-item": "canteen" } ]
+        "entries": [
+          { "item": "water_clean", "container-item": "canteen" },
+          { "item": "plasma", "charges": 13 },
+          { "item": "nail", "charges": 75 }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boxer_shorts" ]
@@ -730,7 +735,6 @@
           "ds_monitor",
           "crt_gloves",
           "crt_gloves_liner",
-          "crt_canteen",
           "crt_pants",
           "socks",
           "crt_la_boots",
@@ -738,15 +742,13 @@
           "mre_veggy_box",
           "crt_mess_kit",
           "lighter",
-          "knife_swissarmy",
-          "sword_crt",
-          "battery",
           "crt_etool",
           "id_military",
           "id_science"
         ],
         "entries": [
-          { "item": "water_clean", "ammo-item": "water_clean", "container-item": "canteen" },
+          { "item": "water_clean", "container-item": "crt_canteen" },
+          { "item": "sword_crt", "container-item": "scabbard" },
           { "item": "knife_crt", "container-item": "crt_belt" }
         ]
       },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Mods "Update C.R.I.T. Expansion professions, itemgroups, further rebalances"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Follow-up improvements to C.R.I.T. Expanision mod, fixing and/or rebalancing assorted things spotted along the way.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Profession fixes:
1. C.R.I.T. ROTC Member: SCAR-H now actually starts loaded and with mil-spec ammotype, spare mags start off in their chestrig via defining new contents group `crit_mags_scarh`. Uses `"ammo": 100,` like the other professions so gun now actually starts loaded.
2. C.R.I.T. Janitor: Removed polo shirt since the belt is on the same slot, split off the swiss army knife and belt since that item's a pocket knife without valid holster flags, removed redundant specification of clean water having clean water as its ammotype.
3. C.R.I.T. NCO: Swapped the now-obsoleted kevlar-plated MBR vest with the superalloy version, it being tied with the steel variant as the next step up. Puts it in between the vanilla military recruit with their empty vest, and the vanilla bionic soldier who gets ceramic. Set their spare mag to spawn in the vest via using the vanilla contents group `army_mags_m4`, made sure their M4 spawns loaded with correct ammotype.
4. C.R.I.T. Grunt: Likewise swapped their kevlar vest for a superalloy one that now holds their extra SCAR-H mags, also makes sure their SCAR-H uses right ammo.
5. C.R.I.T. Combat Medic: Set swiss army knife in inventory and removed the now-unused sheath, set sleeping bag to spawn rolled up, removed hard arm and leg guards since unlike the other professions that use them they start with quality armor for the limbs, plus this no longer clashes with the leg pouch.
6. C.R.I.T. Automatic Rifleman: Rolled up their sleeping bag, replaced their kevlar MBR vest with superalloy. Swapped their long-obsoleted Leadworks LMG for the M249. Since this caps off at 100 rounds, instead of a spare belt they instead get a pair of spare M9 mags moved to their vest via defining new contents group `crit_mags_m9`. The automatic rifleman may now have a sling for their LMG, as a treat. Removed balaclava since clashes with C.R.I.T. helmet liner.
7. C.R.I.T. Commanding Officer: Moved M9 mag to contents of chestrig.
8. C.R.I.T. Enforcer: Split off swiss army knife from the belt, removed redundant ammotype of water in canteen, removed redundant spawn of a second canteen, swapped C.R.I.T. boots in favor of light boots with enforcer boots over them.
9. C.R.I.T. Lone Wolf: Split off swiss army knife from the belt, removed redundant ammotype of water in canteen, removed redundant spawn of a second canteen.
10. C.R.I.T. Spec Ops: Moved swiss army knife out of sheath and removed the sheath, rolled up sleeping bag, removed redundant ammotype of ammo in canteen, removed extra canteen, removed loose battery charges from inventory since several items of their gear all spawn with a full battery in them, removed leg pouch since it clashes with the arm and leg guards and the soldier suit gives relatively low total protection (plus start with a backpack already), converted signal flare ammo in inventory to use charges. Defined contents group `crit_specops_pistol` to fix the holster being loaded with the gun and its gunmods individually shoved inside the holster instead of a holstered gun with several mods on it.
11. C.R.I.T. Survivalist: Moved swiss army knife off the belt in favor of storing the entrenching tool on it, removed redunant ammotype of ammo in canteen, removed extra canteen, pellet gun now starts with a sling.
12. C.R.I.T. Recruit: Moved swiss army knife off the belt in favor of storing the hatchet on it, removed redundant ammotype of ammo in canteen, removed extra canteen, pellet gun now starts with a sling.
13. C.R.I.T. Employee: Split off swiss army knife from the belt, removed redundant ammotype of water in thermos.
14. C.R.I.T. Engineer: Removed redundant ammotype in canteen. Removed blouse and pants since these clash with the engineering suit. Nerfed their loadout down to just the plasma cutter and rivet gun, idea being one each of a plasma weapon and the nail-fed weapon. In exchange, they now actually start with spare plasma and nails for their weapons to use.
15. C.R.I.T. Night Walker: Fixed redundant ammotype in canteen, removed redundant C.R.I.T. canteen in favor of the water being in one instead of a normal canteen, moved their reso-blade from loose inventory to a scabbard removed loose battery charge spawn, removed swiss army knife since already has a service knife.

Item changes:
1. Changed layer of enforcer boots from outer to strapped, consistent with enforcer armor and fixing it so they can actually be worn over other boots (as just outer layer still counts as clashing with boots).
2. Added sling mod slot to pellet gun, updated damage type of from stab to bullet since that's now what BBs use.
3. Updated pellet ammo to use bullet damage instead of stab, added .117 to the item names and ammotype name to make it more clear these are airgun pellets.
4. Set it so you can sheathe the reso-blade. May or may not be fitting for a vibroblade-type item but does seem okay if you can store it loose in inventory.
5. Rebalanced the UPS efficiency of the .5 LP, specifically to balance it relative to the vanilla V29 pistol. The laser pistol is one of the only laser weapons in the game that has a 100% efficiency of damage to UPS cost, set it so the .5 has 75% efficiency via lowering its UPS cost to 8. This means its double shot will deal 20% more raw damage than the V29 with decent heat-arpen, for 60% more UPS cost.

Itemgroup changes:
1. Pellet gun can now spawn wherever BB guns can, and moreover pellets actually spawn period.
2. Pellet gun moved from `guns_rifle_milspec` and instead placed in `guns_rifle_rare`, in exchange pellets can spawn in `ammo_rifle_rare`. One of these days if I ever add a proper set of item spawns for rural guns to speciate weapon/ammo spawns better it will fit better there instead. Also fixes it trying to spawn loaded with 10 rounds when it's a single-shot weapon.
3. Merged redundant double instance of adding to `guns_energy`, weights adjusted to allow removing counterweight injections of vanilla items already in the itemgroup.
4. Merged redundant double instance of adding to `military`.
5. Injection of items into `clothing_soldier_set` removed as that's a collection, and a fairly redundant one since C.R.I.T. items get used in a subgroup of the collection too.
6. Reworked injection of items into `clothing_military` to make the item injections make a bit more sense as rare occurrences of C.R.I.T. armor items.
7. Pulse rounds added to `energy_weapon_armory`.

Recipe changes:
1. Recipe for basic .177 pellets added.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Cleaning up the professions having both MBR vest and army jacket due to both being on outer slot. Vanilla professions do this too so seems non-essential.
2. Switching out more uses of pocket and combat knives for the special C.R.I.T. knives.
3. Making the max volume of C.R.I.T. web belt high enough that the enforcer's nightstick will clip to it.
4. Removing swiss army knives from more professions that start with one plus a C.R.I.T. knife already.
5. Giving enforcer and lone wolf armor, or the underlying soldier suit, magazine pouches so they can stash their M9 mags there instead of loose in inventory. Vanilla security guards do this too so probably fine.
6. Changing it so the reso-blade has to be turned on to get full damage, and can only be sheathed if off. Might just be pointless annoyance unless it's also used to make the stat boosts only trigger when fueled by UPS or relic recharge.
7. Adding a single shot mode to the .5 LP.
8. Allowing the pellet gun to also fire BBs.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Loaded in test release to check that stuff works and eyeball professions.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
