### PR TITLE
Enable Rule of Cool explosions by default

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -830,10 +830,10 @@ void explosion_funcs::regular( const queued_explosion &qe )
     }
 
     if( ex.radius >= 0.0f && ex.damage > 0.0f ) {
-        if( get_option<bool>( "NEW_EXPLOSIONS" ) && !ex.fire ) {
-            damaged_by_blast = do_blast_new( p, ex.damage, ex.radius, qe.source );
-        } else {
+        if( get_option<bool>( "OLD_EXPLOSIONS" ) || ex.fire ) {
             damaged_by_blast = do_blast( p, ex.damage, ex.radius, ex.fire, qe.source );
+        } else {
+            damaged_by_blast = do_blast_new( p, ex.damage, ex.radius, qe.source );
         }
     }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2202,9 +2202,9 @@ void options_manager::add_options_debug()
          true
        );
 
-    add( "NEW_EXPLOSIONS", "debug", translate_marker( "Rule of Cool explosions" ),
-         translate_marker( "If true, utilizes raycasting based explosive system.  Obstacles (impassable terrain, furniture or vehicle parts) will block shrapnel, while blast will bash obstacles and throw creatures outward.  If obstacles are destroyed, blast continues outward." ),
-         true );
+    add( "OLD_EXPLOSIONS", "debug", translate_marker( "Old explosion system" ),
+         translate_marker( "If true, it disables new raycasting based explosive system in favor of old flood fill system.  With new system obstacles (impassable terrain, furniture or vehicle parts) will block shrapnel, while blast will bash obstacles and throw creatures outward.  If obstacles are destroyed, blast continues outward." ),
+         false );
 }
 
 void options_manager::add_options_world_default()

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2202,7 +2202,7 @@ void options_manager::add_options_debug()
          true
        );
 
-    add( "OLD_EXPLOSIONS", "debug", translate_marker( "Old explosion system" ),
+    add( "OLD_EXPLOSIONS", "debug", translate_marker( "Old explosions system" ),
          translate_marker( "If true, it disables new raycasting based explosive system in favor of old system.  With new system obstacles (impassable terrain, furniture or vehicle parts) will block shrapnel, while blast will bash obstacles and throw creatures outward.  If obstacles are destroyed, blast continues outward." ),
          false );
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2203,7 +2203,7 @@ void options_manager::add_options_debug()
        );
 
     add( "OLD_EXPLOSIONS", "debug", translate_marker( "Old explosion system" ),
-         translate_marker( "If true, it disables new raycasting based explosive system in favor of old flood fill system.  With new system obstacles (impassable terrain, furniture or vehicle parts) will block shrapnel, while blast will bash obstacles and throw creatures outward.  If obstacles are destroyed, blast continues outward." ),
+         translate_marker( "If true, it disables new raycasting based explosive system in favor of old system.  With new system obstacles (impassable terrain, furniture or vehicle parts) will block shrapnel, while blast will bash obstacles and throw creatures outward.  If obstacles are destroyed, blast continues outward." ),
          false );
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2203,7 +2203,7 @@ void options_manager::add_options_debug()
        );
 
     add( "OLD_EXPLOSIONS", "debug", translate_marker( "Old explosions system" ),
-         translate_marker( "If true, it disables new raycasting based explosive system in favor of old system.  With new system obstacles (impassable terrain, furniture or vehicle parts) will block shrapnel, while blast will bash obstacles and throw creatures outward.  If obstacles are destroyed, blast continues outward." ),
+         translate_marker( "If true, disables new raycasting based explosive system in favor of old system.  With new system obstacles (impassable terrain, furniture or vehicle parts) will block shrapnel, while blast will bash obstacles and throw creatures outward.  If obstacles are destroyed, blast continues outward." ),
          false );
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2204,7 +2204,7 @@ void options_manager::add_options_debug()
 
     add( "NEW_EXPLOSIONS", "debug", translate_marker( "Rule of Cool explosions" ),
          translate_marker( "If true, utilizes raycasting based explosive system.  Obstacles (impassable terrain, furniture or vehicle parts) will block shrapnel, while blast will bash obstacles and throw creatures outward.  If obstacles are destroyed, blast continues outward." ),
-         false );
+         true );
 }
 
 void options_manager::add_options_world_default()


### PR DESCRIPTION
Enable Rule of Cool explosions by default

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
SUMMARY: Content "Enable Rule of Cool explosions by default"
<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

#### Purpose of change
Rule of Cool explosions is useful addition, but it require testing. For the long time we had this option as disabled by default. It is time to feature more public to get more test results. Otherwise we are having a risk to forget about that feature.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
1) Create new option called Old explosions that is  to false by default. 
2) Use that option in inverted sate to check if  new explosions is enabled

This way new explosions system will be enabled for all players, but with ability to disable it if needed.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Forget about feature.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Observe effect of new options. If true - old explosions system should be used. If false - new explosion system should be used. Default should be false.

Save for quick testing: 
[Mount Dora.zip](https://github.com/cataclysmbnteam/Cataclysm-BN/files/11115139/Mount.Dora.zip)
Load the save and wait 2 turns. If window exactly to the right from player will be destroyed - then OLD system is enabled. If windows ended up unharmed - then it is new system.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context
Obviously bugs are expected. But we should not abandon implemented features.

Original PR for the reference. https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1348
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
