### PR TITLE
Allow installing and removing bionics through debug menu

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6351,26 +6351,6 @@
   },
   {
     "type": "mutation",
-    "id": "DEBUG_BIONIC_POWER",
-    "name": { "str": "Debug Bionic Power" },
-    "points": 99,
-    "valid": false,
-    "description": "For fueling your inner cybug.  Activate to increase power capacity by 100 (can be repeated.)",
-    "debug": true,
-    "active": true
-  },
-  {
-    "type": "mutation",
-    "id": "DEBUG_BIONIC_POWERGEN",
-    "name": { "str": "Debug Bionic Powergen" },
-    "points": 99,
-    "valid": false,
-    "description": "Activate to increase power by an amount you specify (can be repeated).",
-    "debug": true,
-    "active": true
-  },
-  {
-    "type": "mutation",
     "id": "SQUEAMISH",
     "name": { "str": "Squeamish" },
     "points": -1,

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -37,7 +37,6 @@ static const trait_id trait_CHITIN2( "CHITIN2" );
 static const trait_id trait_CHITIN3( "CHITIN3" );
 static const trait_id trait_COLDBLOOD4( "COLDBLOOD4" );
 static const trait_id trait_COMPOUND_EYES( "COMPOUND_EYES" );
-static const trait_id trait_DEBUG_BIONIC_POWER( "DEBUG_BIONIC_POWER" );
 static const trait_id trait_EATHEALTH( "EATHEALTH" );
 static const trait_id trait_FAT( "FAT" );
 static const trait_id trait_FELINE_FUR( "FELINE_FUR" );
@@ -186,10 +185,6 @@ void Character::process_turn()
     process_items();
     // Didn't just pick something up
     last_item = itype_id( "null" );
-
-    if( !is_npc() && has_trait( trait_DEBUG_BIONIC_POWER ) ) {
-        mod_power_level( get_max_power_level() );
-    }
 
     visit_items( [this]( item * e ) {
         e->process_artifact( as_player(), pos() );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -548,7 +548,7 @@ void character_edit_menu( Character &c )
     enum edit_character {
         pick, desc, skills, stats, items, delete_items, item_worn,
         hp, stamina, morale, pain, needs, healthy, status, mission_add, mission_edit,
-        tele, mutate, npc_class, attitude, opinion, effects,
+        tele, mutate, bionics, npc_class, attitude, opinion, effects,
         learn_ma, unlock_recipes, learn_spells, level_spells
     };
 
@@ -568,6 +568,7 @@ void character_edit_menu( Character &c )
             uilist_entry( edit_character::healthy, true, 'a',  _( "Set he[a]lth" ) ),
             uilist_entry( edit_character::needs, true, 'n',  _( "Set [n]eeds" ) ),
             uilist_entry( edit_character::mutate, true, 'u',  _( "M[u]tate" ) ),
+            uilist_entry( edit_character::bionics, true, 'b',  _( "Edit [b]ionics" ) ),
             uilist_entry( edit_character::status, true, '@',  _( "Status Window [@]" ) ),
             uilist_entry( edit_character::tele, true, 'e',  _( "t[e]leport" ) ),
             uilist_entry( edit_character::mission_edit, true, 'M',  _( "Edit [M]issions (WARNING: Unstable!)" ) ),
@@ -915,6 +916,9 @@ void character_edit_menu( Character &c )
         break;
         case edit_character::mutate:
             wishmutate( &p );
+            break;
+        case edit_character::bionics:
+            wishbionics( *p.as_character() );
             break;
         case edit_character::healthy: {
             uilist smenu;

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -32,6 +32,7 @@ void wishitem( player *p = nullptr );
 void wishitem( player *p, const tripoint & );
 void wishmonster( const cata::optional<tripoint> &p );
 void wishmutate( player *p );
+void wishbionics( Character &c );
 void wishskill( player *p );
 void mutation_wish();
 void benchmark( int max_difference, bench_kind kind );

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -50,8 +50,6 @@ static const efftype_id effect_stunned( "stunned" );
 static const trait_id trait_BURROW( "BURROW" );
 static const trait_id trait_CARNIVORE( "CARNIVORE" );
 static const trait_id trait_CHAOTIC_BAD( "CHAOTIC_BAD" );
-static const trait_id trait_DEBUG_BIONIC_POWER( "DEBUG_BIONIC_POWER" );
-static const trait_id trait_DEBUG_BIONIC_POWERGEN( "DEBUG_BIONIC_POWERGEN" );
 static const trait_id trait_DEX_ALPHA( "DEX_ALPHA" );
 static const trait_id trait_GLASSJAW( "GLASSJAW" );
 static const trait_id trait_INT_ALPHA( "INT_ALPHA" );
@@ -580,19 +578,6 @@ void Character::activate_mutation( const trait_id &mut )
             activity.values.push_back( to_turns<int>( startup_time ) );
             return;
         }
-    } else if( mut == trait_DEBUG_BIONIC_POWER ) {
-        mod_max_power_level( 100_kJ );
-        add_msg_if_player( m_good, _( "Bionic power storage increased by 100." ) );
-        tdata.powered = false;
-        return;
-    } else if( mut == trait_DEBUG_BIONIC_POWERGEN ) {
-        int npower;
-        if( query_int( npower, "Modify bionic power by how much?  (Values are in joules)" ) ) {
-            mod_power_level( units::from_joule( npower ) );
-            add_msg_if_player( m_good, "Bionic power increased by %dJ.", npower );
-            tdata.powered = false;
-        }
-        return;
     } else if( !mdata.spawn_item.is_empty() ) {
         item tmpitem( mdata.spawn_item );
         i_add_or_drop( tmpitem );

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -427,30 +427,6 @@ void debug_menu::wishbionics( Character &c )
             }
         }
     }
-
-    /*
-    ui_adaptor ui;
-    catacurses::window w;
-
-    ui.on_screen_resize([&](ui_adaptor& ui) {
-        constexpr int height = 23;
-        constexpr int width = 40;
-
-        w = catacurses::newwin( height, width, point_zero );
-        ui.position( point_zero, point( TERMX - width, TERMY - height ) / 2 );
-    });
-
-    ui.on_redraw( [&]( const ui_adaptor & ) {
-        draw_border( w );
-
-        units::energy max_power = c.get_max_power_level();
-
-        wnoutrefresh( w );
-    } );
-
-    input_context ctxt = input_context( "WISHBIONIC" );
-    ctxt.register_action()
-    */
 }
 
 class wish_monster_callback: public uilist_callback


### PR DESCRIPTION
#### Summary
SUMMARY: Interface "Allow installing and removing bionics through debug menu"

#### Purpose of change
We already have 3 debug mutations that help with debugging bionics, but they have multiple shortcomings:
1. Are clunky to use
2. Don't allow removing bionics
3. Don't work on NPCs

#### Describe the solution
Add new debug menu entry in Character section that allows installing and removing bionics, as well as editing power level and power cap.
For convenience, power manipulation functions can prompt in both joules and kilojoules.
Delete the clunkier debug mutations.

#### Describe alternatives you've considered
Leave debug mutations in - someone's bound to try to use them by mistake, and it's not really a mutation you're supposed to have, so I think it's fine to delete them outright. Test saves with that mutation will show a debugmsg on first load, but then they fix themselves.