### PR TITLE
Fix possible segfault caused by #2468 when guns are fired

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -842,8 +842,8 @@ int ranged::fire_gun( Character &who, const tripoint &target, int max_shots, ite
     int shots = max_shots;
     // Number of shots to fire is limited by the amount of remaining ammo
     if( gun.ammo_required() ) {
-        shots = std::min( shots, ( !ammo ? gun.ammo_remaining() : ammo.get_item()->count() ) /
-                          gun.ammo_required() );
+        const int ammo_left = ammo ? ammo.get_item()->count() : gun.ammo_remaining();
+        shots = std::min( shots, ammo_left / gun.ammo_required() );
     }
 
     // cap our maximum burst size by the amount of UPS power left

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -841,10 +841,9 @@ int ranged::fire_gun( Character &who, const tripoint &target, int max_shots, ite
 
     int shots = max_shots;
     // Number of shots to fire is limited by the amount of remaining ammo
-    if( gun.ammo_required() && !ammo ) {
-        shots = std::min( shots, static_cast<int>( gun.ammo_remaining() / gun.ammo_required() ) );
-    } else {
-        shots = std::min( shots, ammo.get_item()->count() / gun.ammo_required() );
+    if( gun.ammo_required() ) {
+        shots = std::min( shots, ( !ammo ? gun.ammo_remaining() : ammo.get_item()->count() ) /
+                          gun.ammo_required() );
     }
 
     // cap our maximum burst size by the amount of UPS power left


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix possible segfault caused by #2468 when guns are fired."

#### Purpose of change

Fixes #2512 

#2468 has an apparent issue due to how I structured an if block. Fix that ASAP.

Basically, if the gun doesn't use ammo, it will still try to check the amount of ammo passed by the ammo item_location, which will lead to a null reference that crashes the game.

#### Describe the solution

Restructures it so it doesn't route through ammo.get_item()->count() unless the item actually exists.

#### Describe alternatives you've considered

#### Testing

Fire A7 laser rifle, it doesn't crash.

#### Additional context

I'm an idiot and I should've playtested this a lot fucking more.