### PR TITLE
perf: port `std::moving` items

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -305,7 +305,7 @@ item &inventory::add_item( item newit, bool keep_invlet, bool assign_invlet, boo
                 } else {
                     newit.invlet = it_ref->invlet;
                 }
-                elem.push_back( newit );
+                elem.emplace_back( std::move( newit ) );
                 return elem.back();
             } else if( keep_invlet && assign_invlet && it_ref->invlet == newit.invlet &&
                        it_ref->invlet != '\0' ) {
@@ -321,7 +321,7 @@ item &inventory::add_item( item newit, bool keep_invlet, bool assign_invlet, boo
     }
     update_cache_with_item( newit );
 
-    items.push_back( {newit} );
+    items.emplace_back( std::list<item> { std::move( newit ) } );
     return items.back().back();
 }
 

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -400,12 +400,14 @@ std::list<item> profession::items( bool male, const std::vector<trait_id> &trait
     add_legacy_items( legacy_starting_items );
     add_legacy_items( male ? legacy_starting_items_male : legacy_starting_items_female );
 
-    const std::vector<item> group_both = item_group::items_from( _starting_items,
-                                         advanced_spawn_time() );
-    const std::vector<item> group_gender = item_group::items_from( male ? _starting_items_male :
-                                           _starting_items_female, advanced_spawn_time() );
-    result.insert( result.begin(), group_both.begin(), group_both.end() );
-    result.insert( result.begin(), group_gender.begin(), group_gender.end() );
+    std::vector<item> group_both = item_group::items_from( _starting_items,
+                                   advanced_spawn_time() );
+    std::vector<item> group_gender = item_group::items_from( male ? _starting_items_male :
+                                     _starting_items_female, advanced_spawn_time() );
+    result.insert( result.begin(), std::make_move_iterator( group_both.begin() ),
+                   std::make_move_iterator( group_both.end() ) );
+    result.insert( result.begin(), std::make_move_iterator( group_gender.begin() ),
+                   std::make_move_iterator( group_gender.end() ) );
 
     std::vector<itype_id> bonus = item_substitutions.get_bonus_items( traits );
     for( const itype_id &elem : bonus ) {


### PR DESCRIPTION
#### Summary

SUMMARY: Performance "Use move semantics for some items in profession and inventory"

#### Purpose of change

- port https://github.com/CleverRaven/Cataclysm-DDA/pull/55100
- port https://github.com/CleverRaven/Cataclysm-DDA/pull/55127
