### PR TITLE
Fix more segfault behaviour for turrets.

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3093,12 +3093,9 @@ void target_ui::update_ammo_range_from_gun_mode()
     if( mode == TargetMode::TurretManual ) {
         itype_id ammo_current = turret->ammo_current();
         // Test no-ammo and not a UPS weapon
-        if( !ammo_current && !activity->reload_loc && ( relevant->get_gun_ups_drain() == 0 ) ) {
+        if( !ammo_current && ( relevant->get_gun_ups_drain() == 0 ) ) {
             ammo = nullptr;
             range = 0;
-        } else if( !!activity->reload_loc ) {
-            ammo = activity->reload_loc.get_item()->type;
-            range = turret->range();
         } else {
             ammo = &*ammo_current;
             range = turret->range();


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix more segfault behaviour for turrets."

#### Purpose of change

Fix #2468 causing issues with manually aimed turrets because they don't use the aim_activity_actor, so activity in target_ui leads to a nullptr.

#### Describe the solution

Removes that consideration entirely for turret aiming.

#### Describe alternatives you've considered

Make turrets route through same aim_activity_actor code.
- One day maybe? Dunno if it's worth it or not.

#### Testing

Need to stand on the location of the turret in the vehicle part and fire it manually.

#### Additional context

Probably the worst PR I've screwed up yet.
