### PR TITLE
Stop NPCs from using arms to pseudo-block.

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1244,7 +1244,7 @@ bool Character::is_limb_disabled( const bodypart_id &limb ) const
 // if a limb is broken should point here to make any future changes to breaking easier
 bool Character::is_limb_broken( const bodypart_id &limb ) const
 {
-    return get_part_hp_cur( limb ) == 0;
+    return get_part_hp_cur( limb ) <= 0;
 }
 
 bool Character::can_run()

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1659,16 +1659,15 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
             return get_part_hp_cur( bpid ) <= 0;
         } ), block_parts.end() );
 
-        if( block_parts.empty() ) {
+        const auto part_hp_cmp = [this]( const bodypart_id & lhs, const bodypart_id & rhs ) {
+            return get_part_hp_cur( lhs ) < get_part_hp_cur( rhs );
+        };
+        auto healthiest = std::max_element( block_parts.begin(), block_parts.end(), part_hp_cmp );
+        if( healthiest == block_parts.end() ) {
             // We have no parts with HP to block with.
-            blocks_left = 0;
             return false;
-        } else {
-            std::sort( block_parts.begin(), block_parts.end(), [this]( bodypart_id & lhs, bodypart_id & rhs ) {
-                return get_part_hp_cur( lhs ) > get_part_hp_cur( rhs );
-            } );
-            bp_hit = block_parts[0];
         }
+        bp_hit = *healthiest;
 
         thing_blocked_with = body_part_name( bp_hit->token );
     }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1649,6 +1649,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         }
         // If you have no martial arts you can still try to block with your arms.
         // But martial arts with leg blocks only don't magically get arm blocks.
+        // Edge case: Leg block only martial arts gain arm blocks if both legs broken.
         if( martial_arts_data->can_arm_block( *this ) || block_parts.empty() ) {
             block_parts.push_back( bodypart_id( "arm_l" ) );
             block_parts.push_back( bodypart_id( "arm_r" ) );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1661,6 +1661,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
 
         if( block_parts.empty() ) {
             // We have no parts with HP to block with.
+            blocks_left = 0;
             return false;
         } else {
             std::sort( block_parts.begin(), block_parts.end(), [this]( bodypart_id & lhs, bodypart_id & rhs ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1651,8 +1651,8 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         // But martial arts with leg blocks only don't magically get arm blocks.
         // Edge case: Leg block only martial arts gain arm blocks if both legs broken.
         if( martial_arts_data->can_arm_block( *this ) || block_parts.empty() ) {
-            block_parts.push_back( bodypart_id( "arm_l" ) );
-            block_parts.push_back( bodypart_id( "arm_r" ) );
+            block_parts.emplace_back( bodypart_id( "arm_l" ) );
+            block_parts.emplace_back( bodypart_id( "arm_r" ) );
         }
         block_parts.erase( std::remove_if( block_parts.begin(),
         block_parts.end(), [this]( bodypart_id & bpid ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1656,10 +1656,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         }
         block_parts.erase( std::remove_if( block_parts.begin(),
         block_parts.end(), [this]( bodypart_id & bpid ) {
-            if( get_part_hp_cur( bpid ) <= 0 ) {
-                return true;
-            }
-            return false;
+            return get_part_hp_cur( bpid ) <= 0;
         } ), block_parts.end() );
 
         if( block_parts.empty() ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1665,6 +1665,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         auto healthiest = std::max_element( block_parts.begin(), block_parts.end(), part_hp_cmp );
         if( healthiest == block_parts.end() ) {
             // We have no parts with HP to block with.
+            blocks_left = 0;
             return false;
         }
         bp_hit = *healthiest;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1644,8 +1644,8 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     } else {
         std::vector<bodypart_id> block_parts;
         if( martial_arts_data->can_leg_block( *this ) ) {
-            block_parts.push_back( bodypart_id( "leg_l" ) );
-            block_parts.push_back( bodypart_id( "leg_r" ) );
+            block_parts.emplace_back( bodypart_id( "leg_l" ) );
+            block_parts.emplace_back( bodypart_id( "leg_r" ) );
         }
         // If you have no martial arts you can still try to block with your arms.
         // But martial arts with leg blocks only don't magically get arm blocks.


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Stop NPCs from using arms to pseudo-block."

#### Purpose of change

#1883 Cancelled the blocking action when NPCs had no arms, but stopped it too late, where `bp_hit` had already been updated to one of the limbs.

As a consequence, NPCs would also always block every single hit to their bodies with their arms even when they should get hit elsewhere.

#2534 is a different take that could still live alongside this one, but may not be necessary, since the solution _should_ make NPCs much less tanky.

#### Describe the solution

Rewrites limb selection so `bp_hit` is only updated when there is a viable limb to block with.

#### Describe alternatives you've considered

#### Testing

Spawn NPC, get a baton, reduce their arm HP to half and wail on them until limb breaks (checking that we always use the highest HP limb to block when possible)

Check that once arms were broken blocking messages ceased and damage could land on other body parts (damage should still fall on other body parts in between, hence reducing arm HP to half, so we're more likely to break the limbs before any other part)

#### Additional context