### PR TITLE
Expand profession options for scenarios a bit

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -169,7 +169,7 @@
       "sloc_church",
       "sloc_cemetery"
     ],
-    "professions": [ "svictim", "tweaker" ],
+    "professions": [ "svictim", "naked", "tweaker", "crackhead", "convict_ratman", "broken_cyborg" ],
     "flags": [ "FIRE_START", "INFECTED", "BAD_DAY", "CHALLENGE", "CITY_START" ]
   },
   {
@@ -192,7 +192,16 @@
     "points": -8,
     "description": "The scientists stopped their experiments on you abruptly, leaving you behind while they evacuated before lockdown.  Find a way to escape or starve to death.",
     "start_name": "Locked Lab",
-    "professions": [ "unemployed", "mutant_patient", "mutant_volunteer", "labtech", "broken_cyborg" ],
+    "professions": [
+      "unemployed",
+      "mutant_patient",
+      "mutant_volunteer",
+      "labtech",
+      "broken_cyborg",
+      "faulty_bionic",
+      "cykotic",
+      "convict_political"
+    ],
     "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale" ],
     "traits": [
       "ELFAEYES",
@@ -245,7 +254,7 @@
     "points": -8,
     "description": "You were deemed non-essential and made to stay behind during the lab evacuation.  Find a way to escape or starve to death.",
     "start_name": "Locked Lab",
-    "professions": [ "labtech", "security", "medic" ],
+    "professions": [ "labtech", "security", "medic", "bionic_installer", "bio_medic" ],
     "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale" ],
     "flags": [ "CHALLENGE", "CITY_START", "LONE_START" ]
   },
@@ -306,23 +315,34 @@
     "id": "alone",
     "name": "Sheltered",
     "points": -3,
-    "description": "When the apocalypse broke out, you were funneled into a nearby shelter.  Here you have lived, never leaving, lest the unknowns of the outside world hurt you.  Supplies are running low, and for the first time since the Cataclysm, you will be forced to face the outside world.",
+    "description": "When the apocalypse broke out, you were funneled into the nearest shelter.  Here you have lived, never leaving, lest the unknowns of the outside world hurt you.  Supplies are running low, and for the first time since the Cataclysm, you will be forced to face the outside world.",
     "allowed_locs": [ "sloc_lmoe_empty", "sloc_shelter" ],
     "start_name": "Enclosed Shelter",
     "flags": [ "WIN_START", "LONE_START" ],
-    "professions": [ "sheltered_militia", "sheltered_survivor", "bionic_prepper", "unemployed" ]
+    "professions": [
+      "sheltered_militia",
+      "sheltered_survivor",
+      "bionic_prepper",
+      "jr_survivalist",
+      "farmer",
+      "rancher",
+      "lumberjack",
+      "lawyer",
+      "politician",
+      "unemployed"
+    ]
   },
   {
     "type": "scenario",
     "id": "patient",
     "name": "Challenge - Abandoned",
     "points": -8,
-    "description": "Sickly and frail, you have spent most of your life in the patient's ward of the hospital.  When yours was evacuated, you were left behind because you were a lost cause.  You awaken to the sound of movement around the hospital.",
+    "description": "Sickly and frail, you have spent years in the patient's ward of the hospital.  When yours was evacuated, you were left behind because you were a lost cause.  You awaken to the sound of movement around the hospital.",
     "allowed_locs": [ "sloc_hospital" ],
     "start_name": "Hospital",
     "forced_traits": [ "FLIMSY2" ],
     "forbidden_traits": [ "TOUGH" ],
-    "professions": [ "unemployed", "bionic_patient", "patient", "broken_cyborg" ],
+    "professions": [ "unemployed", "bionic_patient", "patient", "broken_cyborg", "senior" ],
     "flags": [ "CHALLENGE", "CITY_START", "LONE_START" ]
   },
   {
@@ -384,7 +404,16 @@
     "description": "Since birth, your sole purpose in life has been the advancement of genetic science, willingly or not.  Once the Cataclysm struck, you left the lab, and wandered aimlessly, ending up in a forest.",
     "start_name": "Wilderness",
     "allowed_locs": [ "sloc_forest", "sloc_field" ],
-    "professions": [ "unemployed", "mutant_patient", "mutant_volunteer", "broken_cyborg", "faulty_bionic", "cykotic" ],
+    "professions": [
+      "unemployed",
+      "mutant_patient",
+      "mutant_volunteer",
+      "labtech",
+      "broken_cyborg",
+      "faulty_bionic",
+      "cykotic",
+      "convict_political"
+    ],
     "traits": [
       "ELFAEYES",
       "URSINE_EYE",
@@ -434,7 +463,7 @@
     "points": 0,
     "description": "You just finished your shift and got back in the break room when you heard the alarms and the security door shutting down behind you.  There's a lot of customers out there and you're not sure Foodplace's delicious food™ is going to be enough for them.",
     "allowed_locs": [ "sloc_restaraunt_foodplace_break_room" ],
-    "professions": [ "true_foodperson", "unemployed" ],
+    "professions": [ "true_foodperson", "fastfoodcook", "chef", "unemployed" ],
     "start_name": "Foodplace Break Room",
     "flags": [ "CITY_START" ]
   },
@@ -445,7 +474,7 @@
     "points": 2,
     "description": "While the world was falling apart someone called to order some of Foodplace's delicious food™ and they sent you to do the delivery.  You're not sure about much, but one thing is certain: that delicious food™ is going to get delivered even if that's the last thing you do!",
     "vehicle": "food_truck_delivery_mission",
-    "professions": [ "true_foodperson", "unemployed" ],
+    "professions": [ "true_foodperson", "pizzaboy", "unemployed" ],
     "start_name": "A Stop On The Road",
     "allowed_locs": [ "sloc_gas_station" ],
     "missions": [ "MISSION_LAST_DELIVERY" ],
@@ -481,7 +510,7 @@
     "description": "You were participating in a mining operation when you found… something.  You're not sure what, but it sure is dark down here.",
     "start_name": "Bottom of a mine",
     "allowed_locs": [ "sloc_mine_finale" ],
-    "professions": [ "miner", "labtech", "security", "bionic_worker", "archaeologist", "drone_op" ],
+    "professions": [ "miner", "labtech", "security", "bionic_worker", "archaeologist", "drone_op", "demolition_expert" ],
     "flags": [ "CITY_START", "LONE_START" ]
   },
   {
@@ -506,7 +535,21 @@
     "points": 2,
     "start_name": "Shady Basement",
     "allowed_locs": [ "sloc_basement_bionic" ],
-    "professions": [ "cyberjunkie", "faulty_bionic", "cykotic", "razorgirl", "bionic_installer" ]
+    "professions": [
+      "cyberjunkie",
+      "faulty_bionic",
+      "cykotic",
+      "broken_cyborg",
+      "bio_gangster",
+      "razorgirl",
+      "bionic_thief",
+      "bionic_customer",
+      "bionic_worker",
+      "bionic_athlete",
+      "bionic_runner",
+      "bionic_prepper",
+      "bionic_installer"
+    ]
   },
   {
     "type": "scenario",
@@ -527,7 +570,20 @@
     "description": "You thought things couldn't get any worse when the cops came over to bust your wild party, even though you booked it at a private resort.  When the guests started fighting with the police you tried to get them to calm down, only to find out they hungered for more.",
     "start_name": "Private resort",
     "allowed_locs": [ "sloc_private_resort" ],
-    "professions": [ "frat", "gangster", "lost_sub", "lawyer", "politician", "dancer", "bio_gangster" ],
+    "professions": [
+      "frat",
+      "gangster",
+      "punkrockgirl",
+      "skaboy",
+      "scoundrel",
+      "lost_sub",
+      "lawyer",
+      "politician",
+      "dancer",
+      "musician",
+      "roadie",
+      "bio_gangster"
+    ],
     "flags": [ "CHALLENGE", "LONE_START" ]
   },
   {

--- a/data/mods/more_classes_scenarios/cs_scenarios.json
+++ b/data/mods/more_classes_scenarios/cs_scenarios.json
@@ -35,13 +35,6 @@
   },
   {
     "type": "scenario",
-    "id": "cyberpunk",
-    "copy-from": "cyberpunk",
-    "add_professions": true,
-    "extend": { "professions": [ "bio_gangster", "bionic_hitman" ] }
-  },
-  {
-    "type": "scenario",
     "id": "missed",
     "copy-from": "missed",
     "extend": {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Add more existing professions to scenarios with a low variety of available professions"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This aims to add a few more profession options to some of the scenarios that lack variety, as once more failing to go the fuck to sleep proves to be the best time to work on an idea.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added crackhead, naked and afraid, rat prince, and prototype cyborg to Really Bad Day scenario. The first since tweaker is already allowed, the second because it's even worse off than shower victim, rat prince mostly because it'd be humorous trying to wrangle a baker's dozen of pet rats in what is already the quintessential meme scenario. And finally, broken cyborg is the most infamous and challenging profession I ever added, so it'd allow players to opt into just a bit more masochism if they so desired.
2. Added political prisoner to the Lab Patient scenario. Of the prisoner professions it's the most directly fitting, referencing the labs and not making as much direct mention of being in prison instead of being an experiment. Also added failed cyborg and bionic monster for consistency with experiment scenario.
3. Added augmentation associate and bionic surgeon to Lab Staff challenge, being fitting technical professions that might mesh well with an autodoc if one gets lucky.
4. Added senior citizen to Abandoned challenge, and reworded description slightly to allow for professions that imply having been in good condition in the past. Still not many of professions that seem an good fit for an inpatient, but it's an extra option at least.
5. Added farmer, rancher, lumberjack, jr. survivalist, career politician, and lawyer to the sheltered scenario. This adds some variety with professions ready to go out and live off the land but not highly experienced in combat, another survivalist profession as a foil to the bionic prepper (who'd have reason to hunker down due to youth, unlike other survivalist professions), and two professions woefully unprepared for post-cataclysm reality for RP value.
6. Added fast food cook and chef to The Mascot Rises, on the basis that it allows normal survivors and not just True Foodpeople. Allowing a few more fast-food-related options seems fitting.
7. Added musician, roadie, punk rocker, ska person, and scoundrel to Crazy Party scenario. The first two to imply having been involved in DJing for the party, the others as additional party-goers.
8. Added demolition expert to mine scenario. Never gets old when something blows up.
9. Added political prisoner and lab technician to Experiment, for consistency with lab patient challenge.
10. Added pizza delivery profession to The Last Delivery to add a slight hint more variety to it.
11. Added prototype cyborg, bionic thief, bionic gangster, commercial cyborg, industrial cyborg, bionic athlete, bionic runner, and bionic prepper to High Tech, Low Life. Basically more illegal/failed cyborgs plus a couple civilian options that may have gotten their augs by shady means due to not mentioning being wealthy or having their augs provided by a corporation/government agency.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding psychosis trait to rat prince to balance them starting with Animal Empathy. Plus being the giant rat that makes all the rules.
2. Adding standard convicts to lab patient scenario.
3. Adding all other professions that start with an addiction to RBD.
4. Adding True Foodperson to RBD because discount Burger King/Queen being drunk off his/her ass in a burning building would be an amusing compliment to RBD.
5. Reflavoring crazy party in some way to allow mansions, private parks, music venues, bars, and/or strip clubs as starting locations.
6. Changing the name of prototype cyborg back to broken cyborg like I originally had it, "bionic catastrophe" or something else that better conveys what a glorious clusterfuck it is to play.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

If we keep medieval peasant challenge, it might be feasible to rework it to be a general "temporally displaced survivor" scenario. If we keep it to the English theme then additional professions to add to it could be a few basic things like a village smith, Yeoman archer as a more combat-capable profession, outlaw, etc. Otherwise dropping the specific choice of flavor language would allow making it a more general "anachronistic professions go here" scenario.

We'd probably want to shift forced illiteracy to the profession level instead of scenario level either way though, since that allows adding historical professions from backgrounds with a higher literacy rate.

Additionally, the mi-go captive scenario is a bit lacking in good profession options and I wasn't sure what else exists that'd be fitting. Conversely, the rescuer profession would be good to adapt by changing its description to not refer to the scenario, for use in the other post-cata scenarios since its gear is a bit more distinct.

Also, we could probably merge Ride of The Valkyries and Last Flight scenarios, both of them start you in a field with the "go find fuel" mission. The only practical difference is Ride of The Valkyries has its vehicle at the profession level, while Last Flight has it at the scenario level. Merging them would necessitate using the former.