### PR TITLE
build: Add deno typescript support to repository

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,0 +1,11 @@
+{
+    "tasks": {
+        "tools": "deno run --watch -A"
+    },
+    "test": { "files": { "include": ["./tools"] } },
+    "lint": { "files": { "include": ["./tools"] } },
+    "fmt": {
+        "files": { "include": ["./tools"] },
+        "options": { "semiColons": false, "lineWidth": 100 }
+    }
+}


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Add deno typescript support to repository"


#### Purpose of change

[deno](deno.land/) is a cross-platform runtime for running typescript in local environment. some of its benefits:

> **TypeScript out of the box**
> First-class support for TypeScript – no need to spend hours configuring things that break as soon as you update a dependency.

> **Great all-in-one tooling**
> Built in linter, code formatter, ability to build a self-contained executable, test runner, IDE integration, and more.

also, packages are imported from URL, making deno script very portable.
```ts
import { brightGreen } from "https://deno.land/std@0.182.0/fmt/colors.ts"

const world = "World"
console.log(`Hello, ${brightGreen(world)}!`)
```

some examples of deno's benefits in #2544: 
- [fully type safe argument parsing](https://github.com/scarf005/Cataclysm-BN/blob/6d76bf2ec829e7623b08ab2054c355ce6f6daa1e/tools/json_tools/gunmod/run_migration.ts)
- [type definitions](https://github.com/scarf005/Cataclysm-BN/blob/6d76bf2ec829e7623b08ab2054c355ce6f6daa1e/tools/json_tools/gunmod/types.ts)
- [built in testing support](https://github.com/scarf005/Cataclysm-BN/blob/6d76bf2ec829e7623b08ab2054c355ce6f6daa1e/tools/json_tools/gunmod/crossbow_test.ts)
- comments allowd in config file (`deno.jsonc`)

#### Describe the solution

cherry-picked config from #2544
