### PR TITLE
fix: add more monster blacklist for fungi

### DIFF
--- a/data/mods/No_Fungi/modinfo.json
+++ b/data/mods/No_Fungi/modinfo.json
@@ -30,7 +30,8 @@
       "mon_fungaloid_seeder",
       "mon_zombie_gasbag_fungus",
       "mon_zombie_smoker_fungus",
-      "mon_skeleton_hulk_fungus"
+      "mon_skeleton_hulk_fungus",
+      "mon_spider_fungus"
     ]
   },
   {

--- a/data/mods/No_Fungi/modinfo.json
+++ b/data/mods/No_Fungi/modinfo.json
@@ -10,7 +10,7 @@
   },
   {
     "type": "MONSTER_BLACKLIST",
-    "categories": [ "GROUP_FUNGI", "GROUP_FUNGI_TOWER", "GROUP_FUNGI_FLOWERS" ]
+    "categories": [ "GROUP_FUNGI", "GROUP_FUNGI_FUNGALOID", "GROUP_FUNGI_TOWER", "GROUP_FUNGI_FLOWERS" ]
   },
   {
     "type": "MONSTER_BLACKLIST",
@@ -27,7 +27,10 @@
       "mon_fungal_hedgerow",
       "mon_fungaloid_tower",
       "mon_fungal_blossom",
-      "mon_fungaloid_seeder"
+      "mon_fungaloid_seeder",
+      "mon_zombie_gasbag_fungus",
+      "mon_zombie_smoker_fungus",
+      "mon_skeleton_hulk_fungus"
     ]
   },
   {


### PR DESCRIPTION
#### Summary

SUMMARY: Mods "add more monster blacklist for No Fungal Monsters mod"

#### Purpose of change

https://gall.dcinside.com/board/view/?id=rlike&no=437222&page=1

no fungi mod was missing some fungal monsters.

#### Describe the solution

searched and added new fungal monsters to blacklist.
