### PR TITLE
Enable No Rail Stations mod by default, tweak description

### DIFF
--- a/data/mods/No_Rail_Stations/modinfo.json
+++ b/data/mods/No_Rail_Stations/modinfo.json
@@ -4,7 +4,7 @@
     "id": "No_Rail_Stations",
     "name": "No Rail Stations",
     "authors": [ "Inglonias" ],
-    "description": "Removes above-ground rail stations from the game.",
+    "description": "Removes above-ground rail stations from the game.  They are supposed to connect to the railroad, but railroads haven't been implemented yet.",
     "category": "buildings",
     "dependencies": [ "bn" ]
   }

--- a/data/mods/default.json
+++ b/data/mods/default.json
@@ -2,5 +2,6 @@
   "bn",
   "no_npc_food",
   "novitamins",
+  "No_Rail_Stations",
   "elevated_bridges"
 ]


### PR DESCRIPTION
#### Summary
SUMMARY: Content "Enable No Rail Stations mod by default, tweak description"

#### Purpose of change
Rail stations exist, with rails leading to nowhere.

#### Describe the solution
Disable them by default until something is done to the railroads.

#### Testing
Should require no testing.