### PR TITLE
Nerf nerf bats

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -73,6 +73,7 @@
     "name": { "str": "foam rubber bat" },
     "description": "A baseball bat made out of foam rubber with a plastic handle.  Light, well-balanced, and easy to wield, but almost completely ineffective.",
     "weight": "225 g",
+    "bashing": 0,
     "to_hit": 2,
     "color": "yellow",
     "price_postapoc": "50 cent",


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Nerf nerf bats"

#### Purpose of change

#1709 accidentally made Foam Rubber Bats as powerful as regular bats for less weight.

#### Describe the solution

Set it back to the default bashing damage of 0.

#### Describe alternatives you've considered

Cry?

#### Testing

An 8 strength character with 0 skill shows the foam rubber bat to have bashing damage of 3 and critical bashing of 6.

#### Additional context