### PR TITLE
feat: allow cancelling activity with `main_menu(ESC)` key

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1973,7 +1973,7 @@ void game::handle_key_blocking_activity()
     input_context ctxt = get_default_mode_input_context();
     const std::string action = ctxt.handle_input( 0 );
     bool refresh = true;
-    if( action == "pause" ) {
+    if( action == "pause" || action == "main_menu" ) {
         if( u.activity.interruptable_with_kb ) {
             cancel_activity_query( _( "Confirm:" ) );
         }


### PR DESCRIPTION
#### Summary

SUMMARY: Interface "Allow cancelling waiting with main_menu(ESC) key"

#### Purpose of change

- fix #2128

over 4+ years of cata i wondered why it was not allowed to cancel `wait N hours` activity.
it was only a few weeks ago i found out there was a `pause` keybinding (default: `.`, `5`).
probably there were lots of people like me who instinctively presses ESC to cancel waiting when things get laggy only to find out they don't.

#### Describe the solution

made `game::handle_key_blocking_activity` also check for `main_menu` keybindings for keyboard interruptable activities.

#### Describe alternatives you've considered

remove `pause` keybinding altogether, but it'd probably have its uses.

#### Testing

waited 3 hours, pressed ESC during waiting and `Confirm: cancel waiting?` prompt popped up.

