### PR TITLE
refactor: fahrenheit to celsius in codebase, part 1

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -636,7 +636,6 @@ bool game::start_game()
     }
     u.process_turn(); // process_turn adds the initial move points
     u.set_stamina( u.get_stamina_max() );
-    get_weather().temperature = SPRING_TEMPERATURE;
     get_weather().update_weather();
     u.next_climate_control_check = calendar::before_time_starts; // Force recheck at startup
     u.last_climate_control_ret = false;

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -76,12 +76,12 @@ static constexpr int VEHICLE_HANDLING_PENALTY = 80;
 static constexpr int PLUTONIUM_CHARGES = 500;
 
 // Temperature constants.
-
-/// Average annual temperature used for climate, weather and temperature calculation.
-constexpr units::temperature average_annual_termperature = 6_c;
-
 namespace temperatures
 {
+
+/// Average annual temperature used for climate, weather and temperature calculation.
+constexpr units::temperature annual_average = 6_c;
+
 // temperature at which something starts is considered HOT.
 constexpr units::temperature hot = 38_c;
 
@@ -101,7 +101,7 @@ constexpr units::temperature freezer = -5_c;
 constexpr units::temperature freezing = 0_c;
 
 // Arbitrary constant for root cellar temperature
-constexpr units::temperature root_cellar = average_annual_termperature;
+constexpr units::temperature root_cellar = annual_average;
 } // namespace temperatures
 
 // Weight per level of LIFT/JACK tool quality.

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -76,6 +76,10 @@ static constexpr int VEHICLE_HANDLING_PENALTY = 80;
 static constexpr int PLUTONIUM_CHARGES = 500;
 
 // Temperature constants.
+
+/// Average annual temperature used for climate, weather and temperature calculation.
+constexpr units::temperature average_annual_termperature = 6_c;
+
 namespace temperatures
 {
 // temperature at which something starts is considered HOT.
@@ -97,8 +101,7 @@ constexpr units::temperature freezer = -5_c;
 constexpr units::temperature freezing = 0_c;
 
 // Arbitrary constant for root cellar temperature
-// Should be equal to AVERAGE_ANNUAL_TEMPERATURE, but is declared before it...
-constexpr units::temperature root_cellar = 6_c;
+constexpr units::temperature root_cellar = average_annual_termperature;
 } // namespace temperatures
 
 // Weight per level of LIFT/JACK tool quality.
@@ -138,12 +141,6 @@ static constexpr int BIO_CQB_LEVEL = 5;
 
 // Minimum size of a horde to show up on the minimap.
 static constexpr int HORDE_VISIBILITY_SIZE = 3;
-
-/**
- * Average annual temperature in F used for climate, weather and temperature calculation.
- * Average New England temperature = 43F/6C rounded to int.
-*/
-static constexpr int AVERAGE_ANNUAL_TEMPERATURE = 43;
 
 /**
  * Base starting spring temperature in F used for climate, weather and temperature calculation.

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -102,10 +102,10 @@ constexpr units::temperature root_cellar = 43_f;
 } // namespace temperatures
 
 // Weight per level of LIFT/JACK tool quality.
-#define TOOL_LIFT_FACTOR 500_kilogram // 500kg/level
+static constexpr units::mass TOOL_LIFT_FACTOR = 500_kilogram; // 500kg/level
 
 // Cap JACK requirements to support arbitrarily large vehicles.
-#define JACK_LIMIT 8500_kilogram // 8500kg ( 8.5 metric tonnes )
+static constexpr units::mass JACK_LIMIT = 8500_kilogram;
 
 // Slowest speed at which a gun can be aimed.
 static constexpr int MAX_AIM_COST = 10;

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -143,12 +143,6 @@ static constexpr int BIO_CQB_LEVEL = 5;
 static constexpr int HORDE_VISIBILITY_SIZE = 3;
 
 /**
- * Base starting spring temperature in F used for climate, weather and temperature calculation.
- * New England base spring temperature = 65F/18C rounded to int.
-*/
-static constexpr int SPRING_TEMPERATURE = 65;
-
-/**
  * Used to limit the random seed during noise calculation. A large value flattens the noise generator to zero.
  * Windows has a rand limit of 32768, other operating systems can have higher limits.
 */

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -79,26 +79,26 @@ static constexpr int PLUTONIUM_CHARGES = 500;
 namespace temperatures
 {
 // temperature at which something starts is considered HOT.
-constexpr units::temperature hot = 100_f; // ~ 38 Celsius
+constexpr units::temperature hot = 38_c;
 
 // the "normal" temperature midpoint between cold and hot.
-constexpr units::temperature normal = 70_f; // ~ 21 Celsius
+constexpr units::temperature normal = 21_c;
 
-// Temperature inside an active fridge in Fahrenheit.
-constexpr units::temperature fridge = 37_f; // ~ 2.7 Celsius
+// Temperature inside an active fridge
+constexpr units::temperature fridge = 2_c;
 
 // Temperature at which things are considered "cold".
-constexpr units::temperature cold = 40_f; // ~4.4 C
+constexpr units::temperature cold = 5_c;
 
-// Temperature inside an active freezer in Fahrenheit.
-constexpr units::temperature freezer = 23_f; // -5 Celsius
+// Temperature inside an active freezer.
+constexpr units::temperature freezer = -5_c;
 
-// Temperature in which water freezes in Fahrenheit.
-constexpr units::temperature freezing = 32_f; // 0 Celsius
+// Temperature in which water freezes.
+constexpr units::temperature freezing = 0_c;
 
 // Arbitrary constant for root cellar temperature
 // Should be equal to AVERAGE_ANNUAL_TEMPERATURE, but is declared before it...
-constexpr units::temperature root_cellar = 43_f;
+constexpr units::temperature root_cellar = 6_c;
 } // namespace temperatures
 
 // Weight per level of LIFT/JACK tool quality.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9040,7 +9040,7 @@ bool item::process_rot( const bool seals, const tripoint &pos,
                         calendar::config, seed );
                 env_temperature_raw = weather_temperature + local_mod;
             } else {
-                env_temperature_raw = units::from_fahrenheit( AVERAGE_ANNUAL_TEMPERATURE ) + local_mod;
+                env_temperature_raw = average_annual_termperature + local_mod;
             }
 
             units::temperature env_temperature_clipped = clip_by_temperature_flag( env_temperature_raw, flag );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9024,7 +9024,7 @@ bool item::process_rot( const bool seals, const tripoint &pos,
                         calendar::config, seed );
                 env_temperature_raw = weather_temperature + local_mod;
             } else {
-                env_temperature_raw = average_annual_termperature + local_mod;
+                env_temperature_raw = temperatures::annual_average + local_mod;
             }
 
             units::temperature env_temperature_clipped = clip_by_temperature_flag( env_temperature_raw, flag );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5681,7 +5681,7 @@ time_duration item::calc_rot( time_point time, int temp ) const
     // is in a sealed container they won't rot away, this avoids needlessly
     // calculating their rot in that case.
     if( !is_corpse() && get_relative_rot() > 2.0 ) {
-        return time_duration::from_seconds( 0 );
+        return 0_seconds;
     }
 
     // rot modifier
@@ -5690,7 +5690,7 @@ time_duration item::calc_rot( time_point time, int temp ) const
         factor = 0.75;
     }
 
-    time_duration added_rot = time_duration::from_seconds( 0 );
+    time_duration added_rot = 0_seconds;
     // simulation of different age of food at the start of the game and good/bad storage
     // conditions by applying starting variation bonus/penalty of +/- 20% of base shelf-life
     // positive = food was produced some time before calendar::start and/or bad storage
@@ -9008,7 +9008,7 @@ bool item::process_rot( const bool seals, const tripoint &pos,
 
     // process rot at most once every 100_turns (10 min)
     // note we're also gated by item::processing_speed
-    time_duration smallest_interval = 10_minutes;
+    constexpr time_duration smallest_interval = 10_minutes;
 
     units::temperature temp = units::from_fahrenheit( weather.get_temperature( pos ) );
     temp = clip_by_temperature_flag( temp, flag );

--- a/src/item.h
+++ b/src/item.h
@@ -771,7 +771,7 @@ class item : public visitable<item>
          * @param time Time point to which rot is calculated
          * @param temp Temperature at which the rot is calculated
          */
-        time_duration calc_rot( time_point time, int temp ) const;
+        auto calc_rot( time_point time, const units::temperature temp ) const -> time_duration;
 
         /**
          * Time that this item is guaranteed to stay fresh.

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -283,7 +283,7 @@ void timed_event::per_turn()
                 }
             }
 
-            if( calendar::once_every( time_duration::from_seconds( 10 ) ) && faults ) {
+            if( calendar::once_every( 10_seconds ) && faults ) {
                 add_msg( m_info, "You hear someone whispering \"%s\"",
                          SNIPPET.random_from_category( "amigara_whispers" ).value_or( translation() ) );
             }

--- a/src/units_temperature.h
+++ b/src/units_temperature.h
@@ -148,6 +148,11 @@ inline constexpr units::temperature operator"" _c( const unsigned long long v )
     return units::from_celsius<int>( v );
 }
 
+inline constexpr units::temperature operator"" _c( const long double v )
+{
+    return units::from_celsius<double>( static_cast<double>( v ) );
+}
+
 inline constexpr units::temperature operator"" _f( const unsigned long long v )
 {
     return units::from_fahrenheit<int>( v );

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -1119,7 +1119,8 @@ int weather_manager::get_temperature( const tripoint &location ) const
         temp_mod += get_convection_temperature( location );
     }
     //underground temperature = average New England temperature = 43F/6C rounded to int
-    const int temp = ( location.z < 0 ? AVERAGE_ANNUAL_TEMPERATURE : temperature ) +
+    const int temp = ( location.z < 0 ? units::to_fahrenheit( average_annual_termperature ) :
+                       temperature ) +
                      ( g->new_game ? 0 : g->m.get_temperature( location ) + temp_mod );
 
     temperature_cache.emplace( std::make_pair( location, temp ) );
@@ -1129,7 +1130,7 @@ int weather_manager::get_temperature( const tripoint &location ) const
 int weather_manager::get_temperature( const tripoint_abs_omt &location )
 {
     if( location.z() < 0 ) {
-        return AVERAGE_ANNUAL_TEMPERATURE;
+        return units::to_fahrenheit( average_annual_termperature );
     }
 
     tripoint abs_ms = project_to<coords::ms>( location ).raw();

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -1124,10 +1124,12 @@ int weather_manager::get_temperature( const tripoint &location ) const
         temp_mod += get_heat_radiation( location, false );
         temp_mod += get_convection_temperature( location );
     }
-    //underground temperature = average New England temperature = 43F/6C rounded to int
-    const int temp = ( location.z < 0 ? units::to_fahrenheit( temperatures::annual_average ) :
-                       temperature ) +
-                     ( g->new_game ? 0 : g->m.get_temperature( location ) + temp_mod );
+    const int temp = ( location.z < 0
+                       ? units::to_fahrenheit( temperatures::annual_average )
+                       : temperature ) +
+                     ( g->new_game
+                       ? 0
+                       : g->m.get_temperature( location ) + temp_mod );
 
     temperature_cache.emplace( std::make_pair( location, temp ) );
     return temp;

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -487,24 +487,27 @@ void weather_effect::light_acid( int intensity )
  */
 void weather_effect::acid( int intensity )
 {
-    if( calendar::once_every( time_duration::from_seconds( intensity ) ) && is_player_outside() ) {
-        if( g->u.primary_weapon().has_flag( "RAIN_PROTECT" ) && one_in( 4 ) ) {
-            add_msg( _( "Your umbrella protects you from the acid rain." ) );
-        } else {
-            if( g->u.worn_with_flag( "RAINPROOF" ) && one_in( 2 ) ) {
-                add_msg( _( "Your clothing protects you from the acid rain." ) );
-            } else {
-                bool has_helmet = false;
-                if( g->u.is_wearing_power_armor( &has_helmet ) && ( has_helmet || !one_in( 2 ) ) ) {
-                    add_msg( _( "Your power armor protects you from the acid rain." ) );
-                } else {
-                    add_msg( m_bad, _( "The acid rain burns!" ) );
-                    if( one_in( 2 ) && ( g->u.get_pain() < 100 ) ) {
-                        g->u.mod_pain( rng( 1, 5 ) );
-                    }
-                }
-            }
-        }
+    if( !( calendar::once_every( time_duration::from_seconds( intensity ) ) && is_player_outside() ) ) {
+        return;
+    }
+
+    auto &you = get_avatar();
+    if( you.primary_weapon().has_flag( "RAIN_PROTECT" ) && one_in( 4 ) ) {
+        return add_msg( _( "Your umbrella protects you from the acid rain." ) );
+    }
+
+    if( you.worn_with_flag( "RAINPROOF" ) && one_in( 2 ) ) {
+        return add_msg( _( "Your clothing protects you from the acid rain." ) );
+    }
+
+    bool has_helmet = false;
+    if( you.is_wearing_power_armor( &has_helmet ) && ( has_helmet || !one_in( 2 ) ) ) {
+        return add_msg( _( "Your power armor protects you from the acid rain." ) );
+    }
+
+    add_msg( m_bad, _( "The acid rain burns!" ) );
+    if( one_in( 2 ) && ( you.get_pain() < 100 ) ) {
+        you.mod_pain( rng( 1, 5 ) );
     }
 }
 

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -1122,7 +1122,7 @@ int weather_manager::get_temperature( const tripoint &location ) const
         temp_mod += get_convection_temperature( location );
     }
     //underground temperature = average New England temperature = 43F/6C rounded to int
-    const int temp = ( location.z < 0 ? units::to_fahrenheit( average_annual_termperature ) :
+    const int temp = ( location.z < 0 ? units::to_fahrenheit( temperatures::annual_average ) :
                        temperature ) +
                      ( g->new_game ? 0 : g->m.get_temperature( location ) + temp_mod );
 
@@ -1133,7 +1133,7 @@ int weather_manager::get_temperature( const tripoint &location ) const
 int weather_manager::get_temperature( const tripoint_abs_omt &location )
 {
     if( location.z() < 0 ) {
-        return units::to_fahrenheit( average_annual_termperature );
+        return units::to_fahrenheit( temperatures::annual_average );
     }
 
     tripoint abs_ms = project_to<coords::ms>( location ).raw();

--- a/src/weather.h
+++ b/src/weather.h
@@ -145,7 +145,7 @@ nc_color get_wind_color( double );
 /**
 * Calculates rot per hour at given temperature. Reference in weather_data.cpp
 */
-int get_hourly_rotpoints_at_temp( int temp );
+auto get_hourly_rotpoints_at_temp( const units::temperature temp ) -> int;
 
 /**
  * Is it warm enough to plant seeds?

--- a/tests/ranged_aiming_test.cpp
+++ b/tests/ranged_aiming_test.cpp
@@ -104,7 +104,7 @@ TEST_CASE( "Aiming at a target behind wall", "[ranged][aiming]" )
     clear_all_state();
     player &shooter = g->u;
     clear_character( shooter, true );
-    shooter.add_effect( efftype_id( "debug_clairvoyance" ), time_duration::from_seconds( 1 ) );
+    shooter.add_effect( efftype_id( "debug_clairvoyance" ), 1_seconds );
     arm_character( shooter, "glock_19" );
     int max_range = shooter.primary_weapon().gun_range( &shooter );
     REQUIRE( max_range >= 5 );


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Replace fahrenheit usage to celsius in codebase, part 1"

#### Purpose of change

- partially fixes #2569 

#### Describe the solution

- used `units::temperatures` for `temperatures` constants
- used `units::temperatures` for item rotpoint calculation
- hardcoded `rot_chart` as conversion from fahrenheit to celsius was tricky
- also simplified if-else pyramid of doom in acid rain function

#### Describe alternatives you've considered

screm

#### Testing

all local test passed.

#### Additional context

help