### PR TITLE
Allow monsters to attack directly up/down

### DIFF
--- a/src/line.cpp
+++ b/src/line.cpp
@@ -555,7 +555,7 @@ std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &t
     const tripoint d( -from + to );
     const point a( std::abs( d.x ), std::abs( d.y ) );
     if( d.z != 0 ) {
-        adjacent_closer_squares.push_back( from + tripoint( sgn( d.x ), sgn( d.y ), sgn( d.z ) ) );
+        adjacent_closer_squares.push_back( from + tripoint( 0, 0, sgn( d.z ) ) );
     }
     if( a.x > a.y ) {
         // X dominant.

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -549,6 +549,7 @@ std::string direction_suffix( const tripoint &p, const tripoint &q )
 // Sub-sub-cardinals are direction && abs(x) > abs(y) or vice versa.
 // Result is adjacent cardinal and sub-cardinals, plus the nearest other cardinal.
 // e.g. if the direction is NNE, also include E.
+// Plus the z-level cardinal, if z != 0.
 std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &to )
 {
     std::vector<tripoint> adjacent_closer_squares;

--- a/src/line.h
+++ b/src/line.h
@@ -245,7 +245,6 @@ float get_normalized_angle( point start, point end );
 std::vector<tripoint> continue_line( const std::vector<tripoint> &line, int distance );
 std::vector<point> squares_in_direction( point p1, point p2 );
 // Returns a vector of squares adjacent to @from that are closer to @to than @from is.
-// Currently limited to the same z-level as @from.
 std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &to );
 void calc_ray_end( units::angle, int range, const tripoint &p, tripoint &out );
 /**

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -854,6 +854,7 @@ void monster::move()
             }
         }
     }
+
     // If true, don't try to greedily avoid locally bad paths
     bool pathed = false;
     if( try_to_move ) {
@@ -944,23 +945,24 @@ void monster::move()
             }
             tripoint candidate_abs = g->m.getabs( candidate );
 
+            bool can_z_move = true;
             if( candidate.z != posz() ) {
-                bool can_z_move = true;
+                bool can_z_attack = true;
                 if( !here.valid_move( pos(), candidate, false, true, via_ramp ) ) {
                     // Can't phase through floor
                     can_z_move = false;
+                    can_z_attack = false;
                 }
 
                 // If we're trying to go up but can't fly, check if we can climb. If we can't, then don't
                 // This prevents non-climb/fly enemies running up walls
-                if( candidate.z > posz() && !( via_ramp || flies() ) ) {
-                    if( !can_climb() || !here.has_floor_or_support( candidate ) ) {
-                        // Can't "jump" up a whole z-level
-                        can_z_move = false;
-                    }
+                if( can_z_move && candidate.z > posz() && !( via_ramp || flies() ) &&
+                    ( !can_climb() || !here.has_floor_or_support( candidate ) ) ) {
+                    // Can't "jump" up a whole z-level
+                    can_z_move = false;
                 }
 
-                // Last chance - we can still do the z-level stair teleport bullshit that isn't removed yet
+                // We can still do the z-level stair teleport bullshit that isn't removed yet
                 // TODO: Remove z-level stair bullshit teleport after aligning all stairs
                 if( !can_z_move &&
                     posx() / ( SEEX * 2 ) == candidate.x / ( SEEX * 2 ) &&
@@ -972,7 +974,7 @@ void monster::move()
                     }
                 }
 
-                if( !can_z_move ) {
+                if( !can_z_attack ) {
                     continue;
                 }
             }
@@ -996,6 +998,10 @@ void monster::move()
                 }
                 // Friendly fire and pushing are always bad choices - they take a lot of time
                 bad_choice = true;
+            }
+
+            if( !can_z_move ) {
+                continue;
             }
 
             map &here = g->m;
@@ -1485,8 +1491,7 @@ bool monster::attack_at( const tripoint &p )
     if( has_flag( MF_PACIFIST ) ) {
         return false;
     }
-    if( p.z != posz() ) {
-        // TODO: Remove this
+    if( p.z != posz() && !get_map().valid_move( pos(), p, false, true, false ) ) {
         return false;
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Allow monsters to attack directly up/down"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fix #1317

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Changed `std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &to )` in `line.{h,cpp}` when it's given a pair of points that differ on z axis.
Before: Adds `from + tripoint( sgn( diff.x ), sgn( diff.y ), sgn( diff.z ) )` (full diagonal) as first option
Now: Adds `from + tripoint( 0, 0, sgn( diff.z ) )` (just up/down) as first option

This function was used in exactly one place: monsters picking next point to move to.

Monster movement code in z cases split into:
* Z movement allowed
* Z movement not allowed, but attack allowed (new one)
* No Z interactions at all

There may be an issue in that completely surrounded zombies may fail to pick new targets or even attack the old ones, because of some weird code that prevents attempts to move if all adjacent (on x/y axes) squares are unpassable or occupied.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

* Having things only fight on same z-level - would require figuring out how to handle stairs, especially ones with no nearby free spots on either side
* Allowing fully diagonal attacks as well - there's lots of ambiguity regarding path of the attack: west, north, then up? Up, west, then north? Only allow cases where all paths are possible? Allow cases where at least one path is possible?
* Redesigning flight to prevent this case from ever happening outside staircases - staircases still exist, also lots of work

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

* Spawn a horde of zombies
* Spawn an eyebot above them
* Wait few turns
* Check eyebot position to verify it's still above
* Check msg log to verify that zombies tried attacking the eyebot

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
