### PR TITLE
Update Transifex links in docs, cli version in actions

### DIFF
--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: "Install Transifex CLI"
         run: |
-          curl -sL https://github.com/transifex/cli/releases/download/v1.0.0/tx-linux-amd64.tar.gz | sudo tar zxvf - -C /usr/bin tx
+          curl -sL https://github.com/transifex/cli/releases/download/v1.6.7/tx-linux-amd64.tar.gz | sudo tar zxvf - -C /usr/bin tx
       - name: "Checkout"
         uses: actions/checkout@v3
       - name: "Get current date"

--- a/.github/workflows/push-translation-template.yml
+++ b/.github/workflows/push-translation-template.yml
@@ -21,7 +21,7 @@ jobs:
         run: sudo apt install gettext
       - name: "Install Transifex CLI"
         run: |
-          curl -sL https://github.com/transifex/cli/releases/download/v1.0.0/tx-linux-amd64.tar.gz | sudo tar zxvf - -C /usr/bin tx
+          curl -sL https://github.com/transifex/cli/releases/download/v1.6.7/tx-linux-amd64.tar.gz | sudo tar zxvf - -C /usr/bin tx
       - name: "Install Python3"
         run: |
           sudo apt install python3-pip

--- a/doc/CONTRIBUTING.ko.md
+++ b/doc/CONTRIBUTING.ko.md
@@ -66,7 +66,7 @@
 ## 번역
 
 카타클리즘: 밝은 밤의 번역은 Transifex에서 진행중입니다.
-[번역 프로젝트](https://www.transifex.com/bn-team/cataclysm-bright-nights/)에서 지원되는 언어를 실시간으로 확인할 수 있습니다.
+[번역 프로젝트](https://app.transifex.com/bn-team/cataclysm-bright-nights/)에서 지원되는 언어를 실시간으로 확인할 수 있습니다.
 
 [TRANSLATING](../doc/TRANSLATING.md)에서 더 자세한 내용을 확인할 수 있습니다:
 

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -62,7 +62,7 @@ See [CODE_STYLE](../doc/CODE_STYLE.md) for details.
 ## Translations
 
 The translation of Cataclysm: BN is done using Transifex.
-Look at the [translation project](https://www.transifex.com/bn-team/cataclysm-bright-nights/) for an up-to-date list of supported languages.
+Look at the [translation project](https://app.transifex.com/bn-team/cataclysm-bright-nights/) for an up-to-date list of supported languages.
 
 See [TRANSLATING](../doc/TRANSLATING.md) for more information:
 

--- a/doc/TRANSLATING.md
+++ b/doc/TRANSLATING.md
@@ -391,7 +391,7 @@ When `System language` is selected in settings, the game tries to use language t
 If you're testing translations for a new language, or the language does not show up in settings, make sure it has its own entry in the definitions file.
 
 
-[1]: https://www.transifex.com/bn-team/cataclysm-bright-nights
+[1]: https://app.transifex.com/bn-team/cataclysm-bright-nights
 [2]: https://docs.transifex.com/
 [3]: ../lang/notes
 [4]: https://www.gnu.org/software/gettext/


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Transifex are changing their domain for the web interface
https://help.transifex.com/en/articles/7171815-web-application-s-domain-change

#### Describe the solution
Change `www.` -> `app.`
Bump transifex cli to version that uses the new domain ([1.6.7](https://github.com/transifex/cli/releases/tag/v1.6.7))