### PR TITLE
feat: prompt player to return to main menu on character death

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2391,6 +2391,12 @@ bool game::is_game_over()
     }
     // is_dead_state() already checks hp_torso && hp_head, no need to for loop it
     if( u.is_dead_state() ) {
+        if( get_option<bool>( "PROMPT_ON_CHARACTER_DEATH" ) &&
+            !query_yn(
+                _( "Your character is dead, do you accept it?\n\nSelect Yes to abandon the character, select No to return to main menu." ) ) ) {
+            return true;
+        }
+
         Messages::deactivate();
         if( get_option<std::string>( "DEATHCAM" ) == "always" ) {
             uquit = QUIT_WATCH;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2393,7 +2393,7 @@ bool game::is_game_over()
     if( u.is_dead_state() ) {
         if( get_option<bool>( "PROMPT_ON_CHARACTER_DEATH" ) &&
             !query_yn(
-                _( "Your character is dead, do you accept it?\n\nSelect Yes to abandon the character, select No to return to main menu." ) ) ) {
+                _( "Your character is dead, do you accept this?\n\nSelect Yes to abandon the character to their fate, select No to return to main menu." ) ) ) {
             return true;
         }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1206,7 +1206,7 @@ void options_manager::add_options_general()
     };
 
     add( "PROMPT_ON_CHARACTER_DEATH", "general", translate_marker( "Prompt on character death" ),
-         translate_marker( "If false, when your character die, it's unavoidable: savefile is automatically deleted and character is put into the graveyard.  If true, on character death the player is prompted to cancel savefile deletion and return to main menu instead." ),
+         translate_marker( "If enabled, when your character dies, the player is given a prompt that gives the option to cancel savefile deletion and other death effects, returning to the main menu without saving instead." ),
          false
        );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1205,6 +1205,13 @@ void options_manager::add_options_general()
         this->add_empty_line( "general" );
     };
 
+    add( "PROMPT_ON_CHARACTER_DEATH", "general", translate_marker( "Prompt on character death" ),
+         translate_marker( "If false, when your character die, it's unavoidable: savefile is automatically deleted and character is put into the graveyard.  If true, on character death the player is prompted to cancel savefile deletion and return to main menu instead." ),
+         false
+       );
+
+    add_empty_line();
+
     add( "DEF_CHAR_NAME", "general", translate_marker( "Default character name" ),
          translate_marker( "Set a default character name that will be used instead of a random name on character creation." ),
          "", 30


### PR DESCRIPTION
#### Summary

SUMMARY: Interface "Prompt player to return to main menu on character death"

#### Purpose of change

port https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/pull/9 by Night-Pryanik  

#### Testing

![Cataclysm: Bright Nights - cbn-experimental-2023-04-07-1345-21-g226035efbc1_01](https://user-images.githubusercontent.com/54838975/230632059-613248a8-c8e1-43ba-b4a1-e0f8a681c7d8.png)

[output.webm](https://user-images.githubusercontent.com/54838975/230632032-0f129eb4-d555-4573-ae11-8a2318e8b66e.webm)

turned the option on, attempted suicide and returned to main menu. the save was not removed.
