### PR TITLE
ci(fix): bump images version to latest

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -104,7 +104,7 @@ jobs:
             ext: zip
             content: application/zip
           - name: Linux Tiles x64
-            os: ubuntu-18.04
+            os: ubuntu-22.04
             mxe: none
             android: none
             tiles: 1
@@ -112,7 +112,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: linux-curses-x64
-            os: ubuntu-18.04
+            os: ubuntu-22.04
             mxe: none
             android: none
             tiles: 0

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -120,14 +120,14 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: osx-curses-x64
-            os: macos-11
+            os: macos-12
             mxe: none
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
-            os: macos-11
+            os: macos-12
             mxe: none
             tiles: 1
             artifact: osx-tiles-x64

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Build CBN (osx)
         if: runner.os == 'macOS'
         run: |
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LANGUAGES=all USE_HOME_DIR=1 OSX_MIN=10.12 PCH=0 dmgdist COMPILER=clang++
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LANGUAGES=all USE_HOME_DIR=1 OSX_MIN=11 PCH=0 dmgdist COMPILER=clang++
           mv CataclysmBN-${{ inputs.version }}.dmg cbn-${{ matrix.artifact }}-${{ inputs.version }}.dmg
       - name: Set up JDK 8 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -59,13 +59,13 @@ jobs:
             native: linux64
             title: Clang 14, Ubuntu, Tiles, NoSound, ASan, UBSan
           - compiler: clang++
-            os: macos-11
+            os: macos-12
             cmake: 0
             tiles: 1
             sound: 1
             native: osx
-            grep_clang_version_rxp: "13\\.[0-9]+\\.[0-9]+"
-            title: Clang 13, macOS 11, Tiles, Localize
+            grep_clang_version_rxp: "14\\.[0-9]+\\.[0-9]+"
+            title: Clang 14, macOS 12, Tiles, Localize
     name: ${{ matrix.title }}
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -26,30 +26,30 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: g++-11
+          - compiler: g++-12
             os: ubuntu-22.04
             cmake: 0
             tiles: 0
             sound: 0
             test-stage: 1
-            title: GCC 11, Ubuntu, Curses
+            title: GCC 12, Ubuntu, Curses
             native: linux64
-          - compiler: g++-11
+          - compiler: g++-12
             os: ubuntu-22.04
             cmake: 1
             tiles: 1
             sound: 1
             languages: all
             native: linux64
-            title: GCC 11, Ubuntu, Tiles, CMake, Languages
-          - compiler: g++-11
+            title: GCC 12, Ubuntu, Tiles, CMake, Languages
+          - compiler: g++-12
             os: ubuntu-22.04
             cmake: 0
             tiles: 1
             sound: 0
             sanitize: address
             native: linux64
-            title: GCC 11, Ubuntu, Tiles, NoSound, ASan
+            title: GCC 12, Ubuntu, Tiles, NoSound, ASan
           - compiler: clang++-14
             os: ubuntu-22.04
             cmake: 0
@@ -94,7 +94,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libncursesw5-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
             libsdl2-mixer-dev libpulse-dev ccache gettext parallel
-      # ubuntu 22.04 has GCC 11 and clang 14
+      # ubuntu 22.04 has GCC 12 and clang 14
       # - name: install missing compiler (ubuntu)
       #   if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && matrix.compiler == 'g++-11' }}
       #   run: sudo apt-get install ${{ matrix.compiler }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,14 +118,14 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: osx-curses-x64
-            os: macos-11
+            os: macos-12
             mxe: none
             tiles: 0
             artifact: osx-curses-x64
             ext: dmg
             content: application/x-apple-diskimage
           - name: osx-tiles-x64
-            os: macos-11
+            os: macos-12
             mxe: none
             tiles: 1
             artifact: osx-tiles-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Build CBN (osx)
         if: runner.os == 'macOS'
         run: |
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LANGUAGES=all USE_HOME_DIR=1 OSX_MIN=10.12 PCH=0 dmgdist COMPILER=clang++
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LANGUAGES=all USE_HOME_DIR=1 OSX_MIN=11 PCH=0 dmgdist COMPILER=clang++
           mv CataclysmBN-unstable.dmg cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Set up JDK 8 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@
 # Win32 (non-Cygwin)
 #   Run: make NATIVE=win32
 # OS X
-#   Run: make NATIVE=osx OSX_MIN=10.12
+#   Run: make NATIVE=osx OSX_MIN=11
 #     It is highly recommended to supply OSX_MIN > 10.11
 #     otherwise optimizations are automatically disabled with -O0
 

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -139,7 +139,7 @@ then
         [ -f "${bin_path}cata_test-tiles" ] && run_tests "${bin_path}cata_test-tiles"
     fi
 else
-    if [ "$OS" == "macos-11" ]
+    if [ "$OS" == "macos-12" ]
     then
         export NATIVE=osx
         # if OSX_MIN we specify here is lower than 11 then linker is going
@@ -152,7 +152,7 @@ else
     make -j "$num_jobs" RELEASE=1 CCACHE=1 CROSS="$CROSS_COMPILATION" LANGUAGES="all" LINTJSON=0
 
     export UBSAN_OPTIONS=print_stacktrace=1
-    if [ "$OS" == "macos-11" ]
+    if [ "$OS" == "macos-12" ]
     then
         run_tests ./tests/cata_test
     else

--- a/doc/COMPILING/COMPILER_SUPPORT.md
+++ b/doc/COMPILING/COMPILER_SUPPORT.md
@@ -18,11 +18,11 @@ the set of supported compilers should be reviewed when Xenial ceases support in
 
 ## GCC
 
-We support and test gcc from version 5.3.
+We support and test gcc from version 12.
 
 ## Clang
 
-We support and test Clang from version 3.8.
+We support and test Clang from version 14.
 
 ## Mingw and Mingw-w64
 

--- a/doc/COMPILING/COMPILING.md
+++ b/doc/COMPILING/COMPILING.md
@@ -40,7 +40,6 @@
     - [Test suite](#test-suite)
     - [dmg distribution](#dmg-distribution)
   - [Mac OS X Troubleshooting](#mac-os-x-troubleshooting)
-    - [ISSUE: Game runs very slowly when built for Mac OS X 10.11 or earlier](#issue-game-runs-very-slowly-when-built-for-mac-os-x-1011-or-earlier)
     - [ISSUE: Colors don't show up correctly](#issue-colors-dont-show-up-correctly)
 - [Windows](#windows)
   - [Building with MSYS2](#building-with-msys2)
@@ -320,7 +319,7 @@ Frameworks were obtained from SDL official website as described in the next [sec
 
 To build full feature tiles and sound enabled version with localizations enabled:
 
-    make dmgdist CROSS=x86_64-apple-darwin15- NATIVE=osx OSX_MIN=10.7 USE_HOME_DIR=1 CLANG=1
+    make dmgdist CROSS=x86_64-apple-darwin15- NATIVE=osx USE_HOME_DIR=1 CLANG=1
       RELEASE=1 LANGUAGES=all TILES=1 SOUND=1 FRAMEWORK=1
       OSXCROSS=1 LIBSDIR=../libs FRAMEWORKSDIR=../Frameworks
 
@@ -330,7 +329,7 @@ Make sure that `x86_64-apple-darwin15-clang++` is in `PATH` environment variable
 
 To build full curses version with localizations enabled:
 
-    make dmgdist CROSS=x86_64-apple-darwin15- NATIVE=osx OSX_MIN=10.7 USE_HOME_DIR=1 CLANG=1
+    make dmgdist CROSS=x86_64-apple-darwin15- NATIVE=osx USE_HOME_DIR=1 CLANG=1
       RELEASE=1 LANGUAGES=all OSXCROSS=1 LIBSDIR=../libs FRAMEWORKSDIR=../Frameworks
 
 Make sure that `x86_64-apple-darwin15-clang++` is in `PATH` environment variable.
@@ -500,16 +499,16 @@ The version of gcc/g++ installed with the [Command Line Tools for Xcode](https:/
 
     brew install gcc
 
-However, homebrew installs gcc as gcc-8 (where 6 is the version) to avoid conflicts. The simplest way to use the homebrew version at `/usr/local/bin/gcc-8` instead of the Apple LLVM version at `/usr/bin/gcc` is to symlink the necessary.
+However, homebrew installs gcc as gcc-{version} (where {version} is the version) to avoid conflicts. The simplest way to use the homebrew version at `/usr/local/bin/gcc-{version}` instead of the Apple LLVM version at `/usr/bin/gcc` is to symlink the necessary.
 
     cd /usr/local/bin
-    ln -s gcc-8 gcc
-    ln -s g++-8 g++
-    ln -s c++-8 c++
+    ln -s gcc-12 gcc
+    ln -s g++-12 g++
+    ln -s c++-12 c++
 
-Or, to do this for everything in `/usr/local/bin/` ending with `-8`,
+Or, to do this for everything in `/usr/local/bin/` ending with `-12`,
 
-    find /usr/local/bin -name "*-8" -exec sh -c 'ln -s "$1" $(echo "$1" | sed "s/..$//")' _ {} \;
+    find /usr/local/bin -name "*-12" -exec sh -c 'ln -s "$1" $(echo "$1" | sed "s/..$//")' _ {} \;
 
 Also, you need to make sure that `/usr/local/bin` appears before `/usr/bin` in your `$PATH`, or else this will not work.
 
@@ -522,7 +521,7 @@ The Cataclysm source is compiled using `make`.
 ### Make options
 
 * `NATIVE=osx` build for OS X. Required for all Mac builds.
-* `OSX_MIN=version` sets `-mmacosx-version-min=` (for OS X > 10.5 set it to 10.6 or higher); omit for 10.5. 10.12 or higher is highly recommended (see ISSUES below).
+* `OSX_MIN=version` sets `-mmacosx-version-min=`; default is 11.
 * `TILES=1` build the SDL version with graphical tiles (and graphical ASCII); omit to build with `ncurses`.
 * `SOUND=1` - if you want sound; this requires `TILES=1` and the additional dependencies mentioned above.
 * `FRAMEWORK=1` (tiles only) link to SDL libraries under the OS X Frameworks folders; omit to use SDL shared libraries from Homebrew or Macports.
@@ -541,15 +540,15 @@ For more info, see the comments in the `Makefile`.
 
 Build a release SDL version using Clang:
 
-    make NATIVE=osx OSX_MIN=10.12 RELEASE=1 TILES=1 CLANG=1
+    make NATIVE=osx RELEASE=1 TILES=1 CLANG=1
 
 Build a release SDL version using Clang, link to libraries in the OS X Frameworks folders, build all language files, and package it into `Cataclysm.app`:
 
-    make app NATIVE=osx OSX_MIN=10.12 RELEASE=1 TILES=1 FRAMEWORK=1 LANGUAGES=all CLANG=1
+    make app NATIVE=osx RELEASE=1 TILES=1 FRAMEWORK=1 LANGUAGES=all CLANG=1
 
 Build a release curses version with curses supplied by Macports:
 
-    make NATIVE=osx OSX_MIN=10.12 RELEASE=1 MACPORTS=1 CLANG=1
+    make NATIVE=osx RELEASE=1 MACPORTS=1 CLANG=1
 
 ### Running
 
@@ -580,17 +579,11 @@ You can build a nice dmg distribution file with the `dmgdist` target. You will n
 
 Once `dmgbuild` is installed, you will be able to use the `dmgdist` target like this. The use of `USE_HOME_DIR=1` is important here because it will allow for an easy upgrade of the game while keeping the user config and his saves in his home directory.
 
-    make dmgdist NATIVE=osx OSX_MIN=10.12 RELEASE=1 TILES=1 FRAMEWORK=1 CLANG=1 USE_HOME_DIR=1
+    make dmgdist NATIVE=osx RELEASE=1 TILES=1 FRAMEWORK=1 CLANG=1 USE_HOME_DIR=1
 
 You should see a `Cataclysm.dmg` file.
 
 ## Mac OS X Troubleshooting
-
-### ISSUE: Game runs very slowly when built for Mac OS X 10.11 or earlier
-
-For versions of OS X 10.11 and earlier, run-time optimizations are disabled for native builds (`-O0` is specified as a compilation flag) due to errors that can occur in compilation. See [Pull Request #26564](https://github.com/CleverRaven/Cataclysm-DDA/pull/26564) for details.
-
-If you're on a newer version of OS X, please use an appropriate value for the `OSX_MIN=` option, i.e. `OSX_MIN=10.14` if you are on Mojave.
 
 ### ISSUE: Colors don't show up correctly
 


### PR DESCRIPTION
#### Summary

SUMMARY: Build "Bump images version to latest"

#### Purpose of change

fix regresssion in  https://github.com/cataclysmbnteam/Cataclysm-BN/actions/runs/4638418360/jobs/8208653611#step:15:78
 found out by [@olanti-p](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2525#issuecomment-1500477778)

#### Describe the solution
cherry-pick latest image version from #2341 
