### PR TITLE
Touchups to spellcasting behavior and UI

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1435,6 +1435,7 @@ static void cast_spell()
     if( !can_cast_spells ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
                  _( "You can't cast any of the spells you know!" ) );
+        return;
     }
 
     const int spell_index = u.magic->select_spell( u );

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -2005,7 +2005,15 @@ static void draw_mana_wide( const player &u, const catacurses::window &w )
 
 static bool spell_panel()
 {
-    return get_avatar().magic->knows_spell();
+    std::vector<spell_id> spells = get_avatar().magic->spells();
+    bool has_manacasting = false;
+    for( spell_id sp : spells ) {
+        spell temp_spell = get_avatar().magic->get_spell( sp );
+        if( temp_spell.energy_source() == mana_energy ) {
+            has_manacasting = true;
+        }
+    }
+    return has_manacasting;
 }
 
 bool default_render()


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Spellcasting menu cancels out early if all spells out of energy, don't show max mana unless you actually know a mana-casting spell"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes two bits of weirdness with spellcasting and associated UI.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In handle_action.cpp, changed `cast_spell` so that the "check if you're too out of energy to cast any spells" check to properly return out of the function instead of continuing, fixing the issue where it would say "you can't cast any of the spells you know" but still open to a menu of currently-uncastable spells.
2. In panels.cpp, changed `spell_panel` to check the player's known spells for any mana-casting spells to determine if it returns true. This fixes it so that mana and max mana only shows on your sidebar if one of your spells actually costs mana.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

I'm not 100% sure if vector-ifying avatar's known spells and running some `for` logic on them will have any performance impact over the previous "check a bool on the avatar that will in turn check their known spells" method.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Started up a world with Magiclysm.
3. Tried to cast with no spells available, same message as usual shows up.
3. Read up a scroll of Megablast, confirmed mana display did not show up since it costs stamina.
4. Rigged my stats and skills so I could actually cast it, confirmed it prevents opening the spell menu after I drain my stamina.
5. Read a scroll of Mana Beam, confirmed that now the mana display pops up.
6. Spammed my way through my mana reserves and depleted stamina again, confirmed that spell menu only cancels early when I don't have the resources for any of my spells.
7. Checked affected files for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
