### PR TITLE
Allow stripping bot chassis for parts, potentially superalloy

### DIFF
--- a/data/json/items/robot_parts.json
+++ b/data/json/items/robot_parts.json
@@ -193,21 +193,21 @@
     "volume": "10 L",
     "price": 100000,
     "price_postapoc": 100,
-    "material": [ "steel", "plastic" ],
+    "material": [ "steel" ],
     "category": "spare_parts"
   },
   {
     "type": "GENERIC",
     "id": "copbot_chassis",
-    "name": { "str_sp": "police bot chassis" },
-    "description": "What's left when you remove all moving parts and electronics.  It's the skeleton and armor of the police bot.",
+    "name": { "str_sp": "secubot chassis" },
+    "description": "What's left when you remove all moving parts and electronics.  It's the skeleton and armor of a police or military bot.",
     "symbol": "c",
     "color": "light_gray",
     "weight": "20000 g",
     "volume": "40000 ml",
     "price": 100000,
     "price_postapoc": 100,
-    "material": [ "steel" ],
+    "material": [ "steel", "superalloy" ],
     "category": "spare_parts"
   },
   {

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -1489,6 +1489,33 @@
     "components": [ [ [ "motor", 2 ] ], [ [ "power_supply", 6 ] ], [ [ "cable", 4 ] ], [ [ "steel_lump", 6 ] ], [ [ "steel_chunk", 6 ] ] ]
   },
   {
+    "result": "turret_chassis",
+    "type": "uncraft",
+    "skill_used": "mechanics",
+    "difficulty": 4,
+    "time": "4 h",
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "sheet_metal_small", 10 ] ], [ [ "scrap", 30 ] ], [ [ "steel_chunk", 10 ] ] ]
+  },
+  {
+    "result": "copbot_chassis",
+    "type": "uncraft",
+    "skill_used": "mechanics",
+    "difficulty": 4,
+    "time": "4 h",
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "alloy_sheet", 10 ] ], [ [ "scrap", 60 ] ], [ [ "steel_chunk", 20 ] ] ]
+  },
+  {
+    "result": "android_chassis",
+    "type": "uncraft",
+    "skill_used": "mechanics",
+    "difficulty": 4,
+    "time": "4 h",
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "plastic_chunk", 40 ] ], [ [ "scrap", 40 ] ], [ [ "steel_chunk", 20 ] ] ]
+  },
+  {
     "result": "cable",
     "type": "uncraft",
     "time": "1 m",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Allow uncrafting robot chassis for raw materials, make police/military secubot chassis a source of alloy sheets"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

While looking into where else superalloy could be made obtainable in vanilla, I noticed that copbots have a slight chance of dropping an alloy sheet. Deciding to take this idea and run with it, I then noticed that robot chassis were the only leftovers from broken robots you could not salvage for materials.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed materials of broken copbot chassis to steel and superalloy to hint at being a source of the material. Also updated name and description to reflect that it's also used in military secubots, dispatch, and the like.
2. Changed materials of turret chassis to all-steel, to reflect its uncraft recipe below.
3. Added uncrafts for the three chassis items. Bot chassis mainly gives steel with some superalloy sheets, android chassis favors steel and plastic, while turret chassis favors a smaller amount of steel (some in sheet metal form) due to being half the weight of the other two.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Honestly, the big one as far as superalloy goes likely should be burnt-out bionics, since superalloy is likely titanium-based and it would make sense for cutting-edge implants to use something in the vein. This would require phasing out Aftershock's bionic uncrafts and likely the recipes too, along with picking replacements for their bespoke components that exist solely for CBM crafting to favor existing vanilla high-tech components.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Related to this PR, which benefits from superalloy actually being obtainable: https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2458