### PR TITLE
Fix an incorrect use of TALK_NONE instead of TALK_DONE in mission dialogue

### DIFF
--- a/data/json/npcs/TALK_COMMON_MISSION.json
+++ b/data/json/npcs/TALK_COMMON_MISSION.json
@@ -142,7 +142,7 @@
         "success": { "topic": "TALK_MISSION_SUCCESS", "effect": "mission_success" },
         "failure": { "topic": "TALK_MISSION_SUCCESS_LIE", "opinion": { "trust": -5, "value": -1, "anger": 5 } }
       },
-      { "text": "No.  I'll get back to it, bye!", "condition": "mission_incomplete", "topic": "TALK_NONE" },
+      { "text": "No.  I'll get back to it, bye!", "condition": "mission_incomplete", "topic": "TALK_DONE" },
       {
         "text": "Yup!  Here it is!",
         "topic": "TALK_MISSION_SUCCESS",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix dialogue saying goodbye but still using TALK_NONE"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fixed an annoyance in NPC dialogue I keep forgetting to fix.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Set it so selecting "I'll get back to it, bye!" when asked about an active mission correctly calls `TALK_DONE`  instead of `TALK_NONE` because there's already an option to dismiss the mission prompt and go to the NPC's normal dialogue.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Putting the laptop away and actually trying to get some sleep.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Double-checked that I hit `D` instead of any of the other letters on my keyboard, and that I'm actually in the response where the PC says goodbye to the NPC in question. It's a one letter change.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

DDA's got the same issue: https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/json/npcs/common_chat/TALK_COMMON_MISSION.json#L146