### PR TITLE
feat: Rule Of Cool explosions v0.2: Made of explodium

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -436,6 +436,8 @@ static std::map<const Creature *, int> do_blast_new( const tripoint &blast_cente
     std::map<const Creature *, int> blasted;
     std::set<const Creature *> already_flung;
     player *player_flung = nullptr;
+    const auto explode_threshold = get_option<int>( "MADE_OF_EXPLODIUM" );
+    const bool is_explodium = explode_threshold != 0;
 
     for( const dist_point_pair &pair : blast_map ) {
         float distance;
@@ -476,7 +478,8 @@ static std::map<const Creature *, int> do_blast_new( const tripoint &blast_cente
         const std::string cause = _( "The force of the explosion" );
 
         const trap &tr = get_map().tr_at( position );
-        if( !tr.is_benign() && !tr.is_null() && tr.vehicle_data.do_explosion ) {
+        if( is_explodium && smash_force >= explode_threshold && !tr.is_benign() && !tr.is_null() &&
+            tr.vehicle_data.do_explosion ) {
             // make a fake NPC to trigger the trap
             npc dummy;
             dummy.set_fake( true );

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -21,6 +21,7 @@
 #include "bodypart.h"
 #include "calendar.h"
 #include "cata_utility.h"
+#include "character.h"
 #include "color.h"
 #include "creature.h"
 #include "damage.h"
@@ -472,7 +473,19 @@ static std::map<const Creature *, int> do_blast_new( const tripoint &blast_cente
 
         // Item damage comes first in order to prevent dropped loot from being destroyed immediately.
         const int smash_force = raw_blast_force * item_blast_percentage( raw_blast_radius, distance );
-        get_map().smash_items( position, smash_force, _( "force of the explosion" ), true );
+        const std::string cause = _( "The force of the explosion" );
+
+        const trap &tr = get_map().tr_at( position );
+        if( !tr.is_benign() && !tr.is_null() && tr.vehicle_data.do_explosion ) {
+            // make a fake NPC to trigger the trap
+            npc dummy;
+            dummy.set_fake( true );
+            dummy.name = cause;
+            dummy.setpos( position );
+            tr.trigger( position, &dummy );
+        }
+
+        get_map().smash_items( position, smash_force, cause, true );
 
         // Critter damage occurs next to reduce the amount of flung enemies, leading to much less predictable damage output
         if( Creature *critter = g->critter_at( position, true ) ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3885,6 +3885,7 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
         damage_message = _( "flying projectile" );
     }
 
+    smash_trap( p, dam, damage_message );
     smash_items( p, dam, damage_message, false );
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3032,6 +3032,8 @@ void map::smash_items( const tripoint &p, const int power, const std::string &ca
 
     // TODO: Bullets should be pretty much corpse-only
     constexpr const int min_destroy_threshold = 50;
+    const auto explode_threshold = get_option<int>( "MADE_OF_EXPLODIUM" );
+    const bool is_explodium = explode_threshold != 0;
 
     std::vector<item> contents;
     map_stack items = i_at( p );
@@ -3039,7 +3041,7 @@ void map::smash_items( const tripoint &p, const int power, const std::string &ca
         // detonate them if they can be exploded
         // We need to make a copy because the iterator validity is not predictable
         // see map_field.cpp process_fields_in_submap
-        if( it->will_explode_in_fire() ) {
+        if( is_explodium && power >= explode_threshold && it->will_explode_in_fire() ) {
             item copy = *it;
             it = items.erase( it );
             if( copy.detonate( p, contents ) ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3035,57 +3035,57 @@ void map::smash_items( const tripoint &p, const int power, const std::string &ca
 
     std::vector<item> contents;
     map_stack items = i_at( p );
-    for( auto i = items.begin(); i != items.end(); ) {
+    for( auto it = items.begin(); it != items.end(); ) {
         // If the power is low or it's not an explosion, only pulp rezing corpses
-        if( ( power < min_destroy_threshold || !do_destroy ) && !i->can_revive() ) {
-            i++;
+        if( ( power < min_destroy_threshold || !do_destroy ) && !it->can_revive() ) {
+            it++;
             continue;
         }
 
         // Active explosives arbitrarily get double the destroy threshold
-        bool is_active_explosive = i->active && i->type->get_use( "explosion" ) != nullptr;
-        if( is_active_explosive && i->charges == 0 ) {
-            i++;
+        bool is_active_explosive = it->active && it->type->get_use( "explosion" ) != nullptr;
+        if( is_active_explosive && it->charges == 0 ) {
+            it++;
             continue;
         }
 
-        const float material_factor = i->chip_resistance( true );
+        const float material_factor = it->chip_resistance( true );
         // Intact non-rezing get a boost
         const float intact_mult = 2.0f -
-                                  ( static_cast<float>( i->damage_level( i->max_damage() ) ) / i->max_damage() );
+                                  ( static_cast<float>( it->damage_level( it->max_damage() ) ) / it->max_damage() );
         const float destroy_threshold = min_destroy_threshold
                                         + material_factor * intact_mult
                                         + ( is_active_explosive ? min_destroy_threshold : 0 );
         // For pulping, only consider material resistance. Non-rezing can only be destroyed.
-        const float pulp_threshold = i->can_revive() ? material_factor : destroy_threshold;
+        const float pulp_threshold = it->can_revive() ? material_factor : destroy_threshold;
         // Active explosives that will explode this turn are indestructible (they are exploding "now")
         if( power < pulp_threshold ) {
-            i++;
+            it++;
             continue;
         }
 
         bool item_was_destroyed = false;
         float destroy_chance = ( power - pulp_threshold ) / 4.0;
 
-        const bool by_charges = i->count_by_charges();
+        const bool by_charges = it->count_by_charges();
         if( by_charges ) {
-            destroy_chance *= i->charges_per_volume( 250_ml );
+            destroy_chance *= it->charges_per_volume( 250_ml );
             if( x_in_y( destroy_chance, destroy_threshold ) ) {
                 item_was_destroyed = true;
             }
         } else {
-            const field_type_id type_blood = i->is_corpse() ? i->get_mtype()->bloodType() : fd_null;
+            const field_type_id type_blood = it->is_corpse() ? it->get_mtype()->bloodType() : fd_null;
             float roll = rng_float( 0.0, destroy_chance );
             if( roll >= destroy_threshold ) {
                 item_was_destroyed = true;
             } else if( roll >= pulp_threshold ) {
                 // Only pulp
-                i->set_damage( i->max_damage() );
+                it->set_damage( it->max_damage() );
                 // TODO: Blood streak cone away from explosion
                 add_splash( type_blood, p, 1, destroy_chance );
                 // If it was the first item to be damaged, note it
                 if( items_damaged == 0 ) {
-                    damaged_item_name = i->tname();
+                    damaged_item_name = it->tname();
                 }
                 items_damaged++;
             }
@@ -3094,20 +3094,20 @@ void map::smash_items( const tripoint &p, const int power, const std::string &ca
         // Remove them if they were damaged too much
         if( item_was_destroyed ) {
             // But save the contents, except for irremovable gunmods
-            for( item *elem : i->contents.all_items_top() ) {
+            for( item *elem : it->contents.all_items_top() ) {
                 if( !elem->is_irremovable() ) {
                     contents.push_back( item( *elem ) );
                 }
             }
 
             if( items_damaged == 0 ) {
-                damaged_item_name = i->tname();
+                damaged_item_name = it->tname();
             }
-            i = i_rem( p, i );
+            it = i_rem( p, it );
             items_damaged++;
             items_destroyed++;
         } else {
-            i++;
+            it++;
         }
     }
 

--- a/src/map.h
+++ b/src/map.h
@@ -1099,6 +1099,8 @@ class map
         void collapse_invalid_suspension( const tripoint &point );
         /** Checks the four orientations in which a suspended tile could be valid, and returns if the tile is valid*/
         bool is_suspension_valid( const tripoint &point );
+        /** Tries to smash the trap at the given tripoint. */
+        void smash_trap( const tripoint &p, const int power, const std::string &cause_message );
         /** Tries to smash the items at the given tripoint. */
         void smash_items( const tripoint &p, int power, const std::string &cause_message, bool do_destroy );
         /**

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2207,7 +2207,7 @@ void options_manager::add_options_debug()
        );
 
     add( "MADE_OF_EXPLODIUM", "debug", translate_marker( "Made of explodium" ),
-         translate_marker( "If the number is higher than 0, explosive items and traps will detonate when hit by damage exceeding the threshold." ),
+         translate_marker( "Explosive items and traps will detonate when hit by damage exceeding the threshold.  A higher number means more damage is required to detonate.  Set to 0 to disable." ),
          0, 1000, 30 );
 
     add( "OLD_EXPLOSIONS", "debug", translate_marker( "Old explosions system" ),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2207,7 +2207,7 @@ void options_manager::add_options_debug()
        );
 
     add( "MADE_OF_EXPLODIUM", "debug", translate_marker( "Made of explodium" ),
-         translate_marker( "If the number is higher than 0, explosive items and traps will detonate when damage exceeds the threshold." ),
+         translate_marker( "If the number is higher than 0, explosive items and traps will detonate when hit by damage exceeding the threshold." ),
          0, 1000, 0 );
 
     add( "OLD_EXPLOSIONS", "debug", translate_marker( "Old explosions system" ),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2208,7 +2208,7 @@ void options_manager::add_options_debug()
 
     add( "MADE_OF_EXPLODIUM", "debug", translate_marker( "Made of explodium" ),
          translate_marker( "If the number is higher than 0, explosive items and traps will detonate when hit by damage exceeding the threshold." ),
-         0, 1000, 0 );
+         0, 1000, 30 );
 
     add( "OLD_EXPLOSIONS", "debug", translate_marker( "Old explosions system" ),
          translate_marker( "If true, disables new raycasting based explosive system in favor of old system.  With new system obstacles (impassable terrain, furniture or vehicle parts) will block shrapnel, while blast will bash obstacles and throw creatures outward.  If obstacles are destroyed, blast continues outward." ),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2208,7 +2208,7 @@ void options_manager::add_options_debug()
 
     add( "MADE_OF_EXPLODIUM", "debug", translate_marker( "Made of explodium" ),
          translate_marker( "If the number is higher than 0, explosive items and traps will detonate when damage exceeds the threshold." ),
-         0, 100, 0 );
+         0, 1000, 0 );
 
     add( "OLD_EXPLOSIONS", "debug", translate_marker( "Old explosions system" ),
          translate_marker( "If true, disables new raycasting based explosive system in favor of old system.  With new system obstacles (impassable terrain, furniture or vehicle parts) will block shrapnel, while blast will bash obstacles and throw creatures outward.  If obstacles are destroyed, blast continues outward." ),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2206,9 +2206,15 @@ void options_manager::add_options_debug()
          true
        );
 
+    add( "MADE_OF_EXPLODIUM", "debug", translate_marker( "Made of explodium" ),
+         translate_marker( "If the number is higher than 0, explosive items and traps will detonate when damage exceeds the threshold." ),
+         0, 100, 0 );
+
     add( "OLD_EXPLOSIONS", "debug", translate_marker( "Old explosions system" ),
          translate_marker( "If true, disables new raycasting based explosive system in favor of old system.  With new system obstacles (impassable terrain, furniture or vehicle parts) will block shrapnel, while blast will bash obstacles and throw creatures outward.  If obstacles are destroyed, blast continues outward." ),
          false );
+
+    get_option( "MADE_OF_EXPLODIUM" ).setPrerequisite( "OLD_EXPLOSIONS", "false" );
 }
 
 void options_manager::add_options_world_default()


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Debug option for explosive traps and items to detonate on impact"

#### Purpose of change

continuation of #1348 by @DeltaEpsilon7787 

1. allow clearing minefield with [explosives](https://www.youtube.com/watch?v=a52-rOC8_Zk) and guns
2. chain reaction

#### Describe the solution

adds an option `MADE_OF_EXPLODIUM`, which gets disabled if value is 0.
if explosive power exceeds MADE_OF_EXPLODIUM value, trap or item will detonate.

#### Describe alternatives you've considered

1. currently only items that explodes on fire will explode. maybe create more generic member function to check if item will explode?
2. mines could be JSONized.

#### Testing

https://user-images.githubusercontent.com/54838975/230722499-74ee7ee7-6ce5-4d16-a20f-fffa602990ce.mp4

chain reaction of traps(landmine).

https://user-images.githubusercontent.com/54838975/230722503-2aad109e-22e6-439b-ae03-7616112e1d88.mp4

chain reaction of both traps and explosive ammo(93mm rocket).

https://user-images.githubusercontent.com/54838975/230722504-cc8813f9-95a8-4df9-9e2e-77c70b833fa0.mp4

using gun to detonate traps and explosive ammo.

https://user-images.githubusercontent.com/54838975/230723361-e2b332ce-0bc6-4396-9d94-007baf6207d1.mp4

nearby mine not being detonated on threshold 30 (mine damage is 40).
it will detonate on threshold 20.

#### Additional context
![image](https://user-images.githubusercontent.com/54838975/230723158-a2b6ec91-1a68-4269-beb8-1c2a3918eb52.png)

debug option panel

![](https://mediaproxy.tvtropes.org/width/350/https://static.tvtropes.org/pmwiki/pub/images/ExplodingTuesday_2350.jpg)
https://tvtropes.org/pmwiki/pmwiki.php/Main/MadeOfExplodium