### PR TITLE
test: missing translation hotfix from #2519

### DIFF
--- a/tests/translations_test.cpp
+++ b/tests/translations_test.cpp
@@ -133,13 +133,13 @@ struct trans_test_case {
 TEST_CASE( "translations_actually_translate", "[translations][i18n]" )
 {
     const std::vector<trans_test_case> test_cases = {{
-            { "en_US", "Play <N|n>ow!", false },
-            { "fr_FR", "Jouer <M|m>aintenant!", true },
-            { "ru_RU", "Сразу в игру!", true },
+            { "en_US", "<R|r>andom Character", false },
+            { "fr_FR", "Personnage <A|a>léatoire", true },
+            { "ru_RU", "Случайный персонаж", true },
         }
     };
 
-    const char *test_msgid = "Play <N|n>ow!";
+    const char *test_msgid = "<R|r>andom Character";
     const char *test_msgctx = "Main Menu|New Game";
 
     if( !try_set_utf8_locale() ) {


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Missing translation hotfix from #2519"

#### Purpose of change

title text got changed to `Play <N|n>ow!` in #2519. however, other translation files haven't translated them (yet), hence test regression.

#### Describe the solution

test with `<R|r>andom Character` instead

#### Testing

<details><summary>Succeded after changing.</summary>

```
[2/2] Linking CXX executable /home/scarf/repo/cata/Cataclysm/cata_test-tiles
23:17:24.756 INFO : Randomness seeded to: 0
23:17:24.756 INFO : C locale on startup: 'ko_KR.UTF-8'
23:17:24.757 INFO : C++ locale on startup: 'ko_KR.UTF-8'
23:17:24.757 WARNING : Failed to detect system UI language.
23:17:24.757 INFO : Number of render drivers on your system: 3
23:17:24.757 INFO : Render driver: 0/opengl
23:17:24.757 INFO : Render driver: 1/opengles2
23:17:24.757 INFO : Render driver: 2/software

Starting the actual test at Sat Apr  8 23:17:29 2023
Filters: translations_actually_translate
23:17:29.379 INFO : Language set to 'en_US'
23:17:29.379 INFO : C locale set to 'en_US.UTF-8'
23:17:29.379 INFO : C++ locale set to 'en_US.UTF-8'
23:17:29.506 INFO : Language set to 'fr_FR'
23:17:29.506 INFO : C locale set to 'en_US.UTF-8'
23:17:29.506 INFO : C++ locale set to 'en_US.UTF-8'
23:17:29.649 INFO : Language set to 'ru_RU'
23:17:29.649 INFO : C locale set to 'en_US.UTF-8'
23:17:29.649 INFO : C++ locale set to 'en_US.UTF-8'
23:17:29.752 INFO : Language set to 'en'
23:17:29.752 INFO : C locale set to 'ko_KR.UTF-8'
23:17:29.752 INFO : C++ locale set to 'ko_KR.UTF-8'
===============================================================================
All tests passed (9 assertions in 1 test case)

Ended test at Sat Apr  8 23:17:29 2023
The test took 0.501 seconds
```

</details> 
