### PR TITLE
test: fix yet another translation fail

### DIFF
--- a/tests/translations_test.cpp
+++ b/tests/translations_test.cpp
@@ -135,7 +135,7 @@ TEST_CASE( "translations_actually_translate", "[translations][i18n]" )
     const std::vector<trans_test_case> test_cases = {{
             { "en_US", "<R|r>andom Character", false },
             { "fr_FR", "Personnage <A|a>léatoire", true },
-            { "ru_RU", "Случайный персонаж", true },
+            { "ru_RU", "<R|r> Случайный персонаж", true },
         }
     };
 


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix yet another translation fail"

#### Purpose of change

for some reason local po and CI po are different so #2602 was not enough

#### Describe the solution

"Случайный персонаж" to "<R|r> Случайный персонаж"

#### Testing

for some reason local test fails while CI test works