### PR TITLE
More use of heat-type damage for flares, torches, and dragon's breath

### DIFF
--- a/data/json/items/ammo/20x66mm.json
+++ b/data/json/items/ammo/20x66mm.json
@@ -68,7 +68,7 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "count": 10,
     "range": 20,
-    "damage": { "damage_type": "bullet", "amount": 16 },
+    "damage": { "damage_type": "heat", "amount": 16 },
     "dispersion": 200,
     "recoil": 100,
     "drop": "handflare_lit",

--- a/data/json/items/ammo/shot.json
+++ b/data/json/items/ammo/shot.json
@@ -13,7 +13,7 @@
     "copy-from": "shot_dragon",
     "type": "AMMO",
     "name": { "str": "dragon's breath shell, black powder" },
-    "proportional": { "price": 0.6, "damage": { "damage_type": "bullet", "amount": 0.8 }, "dispersion": 1.2 },
+    "proportional": { "price": 0.6, "damage": { "damage_type": "heat", "amount": 0.8 }, "dispersion": 1.2 },
     "extend": { "effects": [ "RECYCLED", "MUZZLE_SMOKE", "BLACKPOWDER" ] },
     "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
   },
@@ -104,13 +104,8 @@
     "price": 1000,
     "price_postapoc": 1600,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
-    "proportional": {
-      "damage": { "damage_type": "bullet", "amount": 0.2 },
-      "recoil": 0.6,
-      "loudness": 0.8,
-      "dispersion": 1.2,
-      "range": 0.5
-    },
+    "damage": { "damage_type": "heat", "amount": 10 },
+    "proportional": { "recoil": 0.6, "loudness": 0.8, "dispersion": 1.2, "range": 0.5 },
     "extend": { "effects": [ "INCENDIARY", "STREAM", "NOGIB" ] }
   },
   {

--- a/data/json/items/ammo/signal_flare.json
+++ b/data/json/items/ammo/signal_flare.json
@@ -16,7 +16,7 @@
     "ammo_type": "signal_flare",
     "casing": "shot_hull",
     "range": 30,
-    "damage": { "damage_type": "bullet", "amount": 16 },
+    "damage": { "damage_type": "heat", "amount": 16 },
     "dispersion": 200,
     "recoil": 100,
     "drop": "handflare_lit",

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -375,6 +375,7 @@
     "revert_to": "handflare_dead",
     "revert_msg": "The flare sputters out",
     "use_action": { "type": "firestarter", "moves": 50 },
+    "thrown_damage": [ { "damage_type": "heat", "amount": 8 } ],
     "flags": [ "FIRE", "LIGHT_240", "CHARGEDIM", "FLAMING", "TRADER_AVOID", "FIRESTARTER" ]
   },
   {
@@ -704,6 +705,7 @@
     "max_charges": 75,
     "turns_per_charge": 40,
     "revert_to": "torch_done",
+    "thrown_damage": [ { "damage_type": "heat", "amount": 4 } ],
     "use_action": [
       { "type": "firestarter", "moves": 30 },
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Flare ammo and dragon's breath deal heat-type damage like other incendiaries, lit flares and torches gain fire damage when thrown"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Another minor item on the "easy stuff that'd be interesting to add" list.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Main changes:
1. Set it so that lit hand flares deal heat-type damage when thrown. Went with 8 damage, half what the signal flare ammo deals when fired out of a flaregun. This is also the max roll of the bonus damage the `FLAMING` flag adds to melee.
2. Related, changed it so that flaregun ammo and 20x66mm flare shells deals heat-type damage instead of bullet, for consistency.

Secondary changes:
3. Being the only other item involving an open flame potentially big enough to throw at things, additionally added heat damage to lit torches when thrown. Set it to 4, half again that of a lit flare.
4. Set dragon's breath rounds to deal heat-type damage instead of bullet, for consistency. Only other incendiary ammo left that seemed more likely to warrant it.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

JSONizing the bonus fire damage of the `FLAMING` flag some day so lit hand flares and torches can deal more specific amounts of fire damage instead of a fixed 1d8 in melee.

I'm aware DDA has bonus melee damage as a relic data option but ideally we'd want ones that actually show up on the stat block.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Tested chucking a hand flare at a debug monster, observed it was only damaging when lit.

Also aware from prior testing with Arcana that guns can handle having their ammo deal a different damage type.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
