### PR TITLE
ci: bump actions versions and use `GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,19 +3,19 @@ name: Cataclysm Android build
 on:
   pull_request:
     branches:
-    - upload
+      - upload
     paths-ignore:
-    - 'build-data/osx/**'
-    - 'doc/**'
-    - 'doxygen_doc/**'
-    - 'gfx/**'
-    - 'lang/**'
-    - 'lgtm/**'
-    - 'msvc-object_creator/**'
-    - 'object_creator/**'
-    - 'tools/**'
-    - '!tools/format/**'
-    - 'utilities/**'
+      - "build-data/osx/**"
+      - "doc/**"
+      - "doxygen_doc/**"
+      - "gfx/**"
+      - "lang/**"
+      - "lgtm/**"
+      - "msvc-object_creator/**"
+      - "object_creator/**"
+      - "tools/**"
+      - "!tools/format/**"
+      - "utilities/**"
 
 # We only care about the latest revision of a PR, so cancel previous instances.
 concurrency:
@@ -29,24 +29,24 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 1
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
 
-    - name: Set up JDK 8 (android)
-      uses: actions/setup-java@v2
-      with:
-        java-version: "8"
-        distribution: "adopt"
+      - name: Set up JDK 8 (android)
+        uses: actions/setup-java@v3
+        with:
+          java-version: "8"
+          distribution: "adopt"
 
-    - name: Setup build and dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install gettext
+      - name: Setup build and dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install gettext
 
-    - name: Build
-      working-directory: ./android
-      run: |
-        chmod +x gradlew
-        ./gradlew -Pj=$((`nproc`+0)) -Pabi_arm_32=false assembleExperimentalRelease
+      - name: Build
+        working-directory: ./android
+        run: |
+          chmod +x gradlew
+          ./gradlew -Pj=$((`nproc`+0)) -Pabi_arm_32=false assembleExperimentalRelease

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -171,7 +171,7 @@ jobs:
           EOL
       - name: Install dependencies (windows msvc) (1/3)
         if: runner.os == 'Windows'
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.3.1
       - name: Install dependencies (windows msvc) (2/3)
         if: runner.os == 'Windows'
         uses: lukka/run-vcpkg@main

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Generate environmental variables
         id: generate_env_vars
         run: |
-          echo "::set-output name=tag_name::cbn-${{ inputs.version }}"
-          echo "::set-output name=release_name::Cataclysm-BN ${{ inputs.version }}"
+          echo "tag_name=cbn-${{ inputs.version }}" >> $GITHUB_OUTPUT
+          echo "release_name=Cataclysm-BN ${{ inputs.version }}" >> $GITHUB_OUTPUT
       - name: Check if there is existing git tag
         id: tag_check
         uses: mukunku/tag-exists-action@v1.0.0

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -250,7 +250,7 @@ jobs:
           mv CataclysmBN-${{ inputs.version }}.dmg cbn-${{ matrix.artifact }}-${{ inputs.version }}.dmg
       - name: Set up JDK 8 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: "8"
           distribution: "adopt"

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -119,7 +119,7 @@ jobs:
         shell: bash
       - name: ccache cache files (ubuntu)
         if: ${{ env.SKIP == 'false' && runner.os == 'Linux' }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.ccache
           key: ccache-linux-${{ matrix.compiler }}-${{ steps.get-date.outputs.date }}
@@ -127,7 +127,7 @@ jobs:
             ccache-linux-${{ matrix.compiler }}-
       - name: ccache cache files (mac)
         if: ${{ env.SKIP == 'false' && runner.os == 'macOS' }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /Users/runner/Library/Caches/ccache
           key: ccache-mac-${{ matrix.compiler }}-${{ steps.get-date.outputs.date }}

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -115,7 +115,7 @@ jobs:
         id: get-date
         if: ${{ env.SKIP == 'false' }}
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d%H%M")"
+          echo "date=$(/bin/date -u "+%Y%m%d%H%M")" >> $GITHUB_OUTPUT
         shell: bash
       - name: ccache cache files (ubuntu)
         if: ${{ env.SKIP == 'false' && runner.os == 'Linux' }}

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -59,7 +59,7 @@ jobs:
         fetch-depth: 1
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.3.1
 
     - name: Restore artifacts, or run vcpkg, build and cache artifacts
       uses: lukka/run-vcpkg@v10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Generate environmental variables
         id: generate_env_vars
         run: |
-          echo "::set-output name=tag_name::cbn-experimental-${{ steps.get-timestamp.outputs.time }}"
-          echo "::set-output name=release_name::Cataclysm-BN experimental build ${{ steps.get-timestamp.outputs.time }}"
+          echo "tag_name=cbn-experimental-${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
+          echo "release_name=Cataclysm-BN experimental build ${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
       - name: Check if there is existing git tag
         id: tag_check
         uses: mukunku/tag-exists-action@v1.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - upload
 
 env:
-  VCPKG_BINARY_SOURCES: 'default'
+  VCPKG_BINARY_SOURCES: "default"
 jobs:
   release:
     name: Create Release
@@ -248,7 +248,7 @@ jobs:
           mv CataclysmBN-unstable.dmg cbn-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Set up JDK 8 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: "8"
           distribution: "adopt"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
           EOL
       - name: Install dependencies (windows msvc) (1/3)
         if: runner.os == 'Windows'
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.3.1
       - name: Install dependencies (windows msvc) (2/3)
         if: runner.os == 'Windows'
         uses: lukka/run-vcpkg@main


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "bump versionas and use new output syntax GITHUB_OUTPUT on CI"

#### Purpose of change

old syntax for setting output is getting deprecated: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples

actions are using node16: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

#### Describe the solution

- uses shiny new `echo "foo=bar" >> $GITHUB_OUTPUT` syntax
- bump workflow versions to latest