### PR TITLE
Fix weird speed buff/penalty stacking. Add Speed Mult. Update Character display for speed.

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4100,7 +4100,7 @@ int Character::get_int_bonus() const
     return int_bonus;
 }
 
-static int get_speedydex_bonus( const int dex )
+int get_speedydex_bonus( const int dex )
 {
     static const std::string speedydex_min_dex( "SPEEDYDEX_MIN_DEX" );
     static const std::string speedydex_dex_speed( "SPEEDYDEX_DEX_SPEED" );
@@ -4111,7 +4111,7 @@ static int get_speedydex_bonus( const int dex )
 
 int Character::get_speed() const
 {
-    return Creature::get_speed() + get_speedydex_bonus( get_dex() );
+    return Creature::get_speed();
 }
 
 int Character::ranged_dex_mod() const

--- a/src/character.h
+++ b/src/character.h
@@ -2303,4 +2303,7 @@ std::map<bodypart_id, int> wind_resistance_from_clothing(
 /** Returns true if the player has a psyshield artifact, or sometimes if wearing tinfoil */
 bool has_psy_protection( const Character &c, int partial_chance );
 
+/** Returns value of speedydex bonus if enabled */
+int get_speedydex_bonus( const int dex );
+
 #endif // CATA_SRC_CHARACTER_H

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -772,33 +772,37 @@ static void draw_speed_tab( const catacurses::window &w_speed,
     unsigned int line = 3;
     if( you.weight_carried() > you.weight_capacity() ) {
         pen = 25 * ( you.weight_carried() - you.weight_capacity() ) / ( you.weight_capacity() );
-        mvwprintz( w_speed, point( 1, line ), c_red,
-                   pgettext( "speed penalty", "Overburdened        -%2d%%" ), pen );
+        //~ %s: Overburdened (already left-justified), %2d%%: speed penalty
+        mvwprintz( w_speed, point( 1, line ), c_red, pgettext( "speed penalty", "%s-%2d%%" ),
+                   left_justify( _( "Overburdened" ), 20 ), pen );
         line++;
     }
     pen = character_effects::get_pain_penalty( you ).speed;
     if( pen >= 1 ) {
-        mvwprintz( w_speed, point( 1, line ), c_red,
-                   pgettext( "speed penalty", "Pain                -%2d%%" ), pen );
+        //~ %s: Pain (already left-justified), %2d%%: speed penalty
+        mvwprintz( w_speed, point( 1, line ), c_red, pgettext( "speed penalty", "%s-%2d%%" ),
+                   left_justify( _( "Pain" ), 20 ), pen );
         line++;
     }
     if( you.get_thirst() > thirst_levels::very_thirsty ) {
         pen = std::abs( character_effects::get_thirst_speed_penalty( you.get_thirst() ) );
-        mvwprintz( w_speed, point( 1, line ), c_red,
-                   pgettext( "speed penalty", "Thirst              -%2d%%" ), pen );
+        //~ %s: Thirsty/Parched (already left-justified), %2d%%: speed penalty
+        mvwprintz( w_speed, point( 1, line ), c_red, pgettext( "speed penalty", "%s-%2d%%" ),
+                   left_justify( _( "Thirst" ), 20 ), pen );
         line++;
     }
     if( character_effects::get_kcal_speed_penalty( you.get_kcal_percent() ) < 0 ) {
         pen = std::abs( character_effects::get_kcal_speed_penalty( you.get_kcal_percent() ) );
-        //~ %s: Starving/Underfed (already left-justified), %2d: speed penalty
+        //~ %s: Starving/Underfed (already left-justified), %2d%%: speed penalty
         mvwprintz( w_speed, point( 1, line ), c_red, pgettext( "speed penalty", "%s-%2d%%" ),
                    left_justify( _( "Starving" ), 20 ), pen );
         line++;
     }
     if( you.has_trait( trait_id( "SUNLIGHT_DEPENDENT" ) ) && !g->is_in_sunlight( you.pos() ) ) {
         pen = ( g->light_level( you.posz() ) >= 12 ? 5 : 10 );
-        mvwprintz( w_speed, point( 1, line ), c_red,
-                   pgettext( "speed penalty", "Out of Sunlight     -%2d%%" ), pen );
+        //~ %s: Out of Sunlight (already left-justified), %2d%%: speed penalty
+        mvwprintz( w_speed, point( 1, line ), c_red, pgettext( "speed penalty", "%s-%2d%%" ),
+                   left_justify( _( "Out of Sunlight" ), 20 ), pen );
         line++;
     }
 
@@ -816,22 +820,21 @@ static void draw_speed_tab( const catacurses::window &w_speed,
         }
         if( !pen_sign.empty() ) {
             pen = ( player_local_temp - 65 ) * temperature_speed_modifier;
-            mvwprintz( w_speed, point( 1, line ), pen_color,
-                       //~ %s: sign of bonus/penalty, %2d: speed bonus/penalty
-                       pgettext( "speed modifier", "Cold-Blooded        %s%2d%%" ), pen_sign, std::abs( pen ) );
+            //~ %s: Cold-Blooded (already left-justified), %s: sign of bonus/penalty, %2d%%: speed modifier
+            mvwprintz( w_speed, point( 1, line ), pen_color, pgettext( "speed modifier", "%s%s%2d%%" ),
+                       left_justify( _( "Cold-Blooded" ), 20 ), pen_sign, std::abs( pen ) );
             line++;
         }
     }
 
-    int quick_bonus = static_cast<int>( newmoves - ( newmoves / 1.1 ) );
-    int bio_speed_bonus = quick_bonus;
-    if( you.has_trait( trait_id( "QUICK" ) ) && you.has_bionic( bionic_id( "bio_speed" ) ) ) {
-        bio_speed_bonus = static_cast<int>( newmoves / 1.1 - ( newmoves / 1.1 / 1.1 ) );
-        std::swap( quick_bonus, bio_speed_bonus );
-    }
-    if( you.has_trait( trait_id( "QUICK" ) ) ) {
-        mvwprintz( w_speed, point( 1, line ), c_green,
-                   pgettext( "speed bonus", "Quick               +%2d%%" ), quick_bonus );
+    int quick_bonus = static_cast<int>( round( ( you.mutation_value( "speed_modifier" ) - 1 ) * 100 ) );
+    int bio_speed_bonus = 10;
+    if( quick_bonus != 0 ) {
+        std::string pen_sign = quick_bonus >= 0 ? "+" : "-";
+        nc_color pen_color = quick_bonus >= 0 ? c_green : c_red;
+        //~ %s: Mutations (already left-justified), %s: sign of bonus/penalty, %2d%%: speed modifier
+        mvwprintz( w_speed, point( 1, line ), pen_color, pgettext( "speed bonus", "%s%s%2d%%" ),
+                   left_justify( _( "Mutations" ), 20 ), pen_sign, std::abs( quick_bonus ) );
         line++;
     }
     if( you.has_bionic( bionic_id( "bio_speed" ) ) ) {

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -144,21 +144,17 @@ void Character::recalc_speed_bonus()
         mod_speed_bonus( -20 );
     }
 
+    mod_speed_bonus( get_speedydex_bonus( get_dex() ) );
+
     float speed_modifier = Character::mutation_value( "speed_modifier" );
-    mod_speed_bonus( static_cast<int>( get_speed() * ( speed_modifier - 1 ) ) );
+    mod_speed_mult( speed_modifier - 1 );
 
     if( has_bionic( bio_speed ) ) { // add 10% speed bonus
-        mod_speed_bonus( static_cast<int>( get_speed() * 0.1 ) );
+        mod_speed_mult( 0.1 );
     }
 
     double ench_bonus = enchantment_cache->calc_bonus( enchant_vals::mod::SPEED, get_speed() );
     mod_speed_bonus( ench_bonus );
-
-    // Speed cannot be less than 25% of base speed, so minimal speed bonus is -75% base speed.
-    const int min_speed_bonus = static_cast<int>( -0.75 * get_speed_base() );
-    if( get_speed_bonus() < min_speed_bonus ) {
-        set_speed_bonus( min_speed_bonus );
-    }
 }
 
 void Character::process_turn()

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -145,14 +145,14 @@ void Character::recalc_speed_bonus()
     }
 
     float speed_modifier = Character::mutation_value( "speed_modifier" );
-    set_speed_bonus( static_cast<int>( get_speed() * speed_modifier ) - get_speed_base() );
+    mod_speed_bonus( static_cast<int>( get_speed() * ( speed_modifier - 1 ) ) );
 
-    if( has_bionic( bio_speed ) ) { // multiply by 1.1
-        set_speed_bonus( static_cast<int>( get_speed() * 1.1 ) - get_speed_base() );
+    if( has_bionic( bio_speed ) ) { // add 10% speed bonus
+        mod_speed_bonus( static_cast<int>( get_speed() * 0.1 ) );
     }
 
     double ench_bonus = enchantment_cache->calc_bonus( enchant_vals::mod::SPEED, get_speed() );
-    set_speed_bonus( get_speed() + ench_bonus - get_speed_base() );
+    mod_speed_bonus( ench_bonus );
 
     // Speed cannot be less than 25% of base speed, so minimal speed bonus is -75% base speed.
     const int min_speed_bonus = static_cast<int>( -0.75 * get_speed_base() );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -144,6 +144,7 @@ void Creature::reset_bonuses()
     armor_bullet_bonus = 0;
 
     speed_bonus = 0;
+    speed_mult = 0;
     dodge_bonus = 0;
     block_bonus = 0;
     hit_bonus = 0;
@@ -1509,7 +1510,8 @@ int Creature::get_armor_bullet_bonus() const
 
 int Creature::get_speed() const
 {
-    return get_speed_base() + get_speed_bonus();
+    int speed = round( ( get_speed_base() + get_speed_bonus() ) * ( 1 + get_speed_mult() ) );
+    return std::max( static_cast<int>( round( 0.25 * get_speed_base() ) ), speed );
 }
 float Creature::get_dodge() const
 {
@@ -1685,6 +1687,10 @@ int Creature::get_speed_bonus() const
 {
     return speed_bonus;
 }
+float Creature::get_speed_mult() const
+{
+    return speed_mult;
+}
 float Creature::get_dodge_bonus() const
 {
     return dodge_bonus;
@@ -1747,6 +1753,10 @@ void Creature::set_speed_bonus( int nspeed )
 {
     speed_bonus = nspeed;
 }
+void Creature::set_speed_mult( float nspeed )
+{
+    speed_mult = nspeed;
+}
 void Creature::set_dodge_bonus( float ndodge )
 {
     dodge_bonus = ndodge;
@@ -1763,6 +1773,10 @@ void Creature::set_hit_bonus( float nhit )
 void Creature::mod_speed_bonus( int nspeed )
 {
     speed_bonus += nspeed;
+}
+void Creature::mod_speed_mult( float nspeed )
+{
+    speed_mult += nspeed;
 }
 void Creature::mod_dodge_bonus( float ndodge )
 {

--- a/src/creature.h
+++ b/src/creature.h
@@ -530,6 +530,7 @@ class Creature
 
         virtual int get_speed_base() const;
         virtual int get_speed_bonus() const;
+        virtual float get_speed_mult() const;
         virtual int get_block_bonus() const;
 
         virtual float get_dodge_base() const = 0;
@@ -553,9 +554,11 @@ class Creature
 
         virtual void set_speed_base( int nspeed );
         virtual void set_speed_bonus( int nspeed );
+        virtual void set_speed_mult( float nspeed );
         virtual void set_block_bonus( int nblock );
 
         virtual void mod_speed_bonus( int nspeed );
+        virtual void mod_speed_mult( float nspeed );
         virtual void mod_block_bonus( int nblock );
 
         virtual void set_dodge_bonus( float ndodge );
@@ -827,6 +830,7 @@ class Creature
         int speed_base = 0; // only speed needs a base, the rest are assumed at 0 and calculated off skills
 
         int speed_bonus = 0;
+        float speed_mult = 0.f;
         float dodge_bonus = 0.0;
         int block_bonus = 0;
         float hit_bonus = 0.0;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2551,12 +2551,6 @@ void monster::process_effects_internal()
         }
     }
 
-    // Like with player/NPCs - keep the speed above 0
-    const int min_speed_bonus = -0.75 * get_speed_base();
-    if( get_speed_bonus() < min_speed_bonus ) {
-        set_speed_bonus( min_speed_bonus );
-    }
-
     //If this monster has the ability to heal in combat, do it now.
     int regeneration_amount = type->regenerates;
     float regen_multiplier = 0;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix weird speed buff/penalty stacking. Add Speed Mult. Update Character display for speed."

#### Purpose of change

Fixes #2620.

Issue is that in `recalc_speed_bonus` the math is wrong because it's trying it's damnedest to use `set_speed_bonus` for `mod_speed_bonus()`

It also does this weird thing where it multiplies the current speed by the multiplier then modifies the speed bonus, which looks weird to me and may have weird behaviour down the line as we've already seen.

Character display for speed is somewhat inconsistent, and assumes Quick is the only mutation that modifies player speed.

#### Describe the solution

Swap to `mod_speed_bonus()` so we don't need to do more than basic math.

Add speed_mult that is used where appropriate.

Reorganize character display so it supports translation and also accounts for more mutations than quick affecting it.

#### Describe alternatives you've considered

Alter the mutation speed modifier such that it indicates the percentage increase directly ( 0.1 instead of 1.1 )
- Would be nice but we'd need to make sure we tell the modders or things will break hilariously.

~Have the multipliers be added to a separate thing instead of the current weird system where it converts percentage increases into numeric bonuses.~
- ~Probably a good idea, might do it later.~
- Done

#### Testing

Use speedy_dex mod, increase dexterity to 13, notice that speed is 102 not 104 or 106. Give player the Mycus threshold and Mycus Fireproofing, check that penalty displays appropriately and reflects actual situation.

#### Additional context