### PR TITLE
Fix spellcasting items consuming charges when canceled

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4808,6 +4808,12 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
             }
         }
     }
+    if( !act->targets.empty() ) {
+        item &it = *act->targets.front();
+        if( !it.has_flag( "USE_PLAYER_ENERGY" ) ) {
+            p->consume_charges( it, it.type->charges_to_use() );
+        }
+    }
 }
 
 void activity_handlers::study_spell_do_turn( player_activity *act, player *p )

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2602,7 +2602,6 @@ int cast_spell_actor::use( player &p, item &it, bool, const tripoint & ) const
     }
 
     spell casting = spell( spell_id( item_spell ) );
-    int charges = it.type->charges_to_use();
 
     player_activity cast_spell( ACT_SPELLCASTING, casting.casting_time( p ) );
     // [0] this is used as a spell level override for items casting spells
@@ -2618,13 +2617,14 @@ int cast_spell_actor::use( player &p, item &it, bool, const tripoint & ) const
     if( it.has_flag( "USE_PLAYER_ENERGY" ) ) {
         // [2] this value overrides the mana cost if set to 0
         cast_spell.values.emplace_back( 1 );
-        charges = 0;
     } else {
         // [2]
         cast_spell.values.emplace_back( 0 );
     }
     p.assign_activity( cast_spell, false );
-    return charges;
+    p.activity.targets.push_back( item_location( p, &it ) );
+    // Actual handling of charges_to_use is in activity_handlers::spellcasting_finish
+    return 0;
 }
 
 std::unique_ptr<iuse_actor> holster_actor::clone() const


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Spellcasting tools no longer waste charges if you cancel out and don't actually cast the spell"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So, working on https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2617 revealed to me exactly what's needed to fix the "spellcasting items always consume charges, even if you back out of the spell aim menu or if it's interrupted" bug.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In activity_handlers.cpp, changed `activity_handlers::spellcasting_finish` to have a check at the end for if the activity was assigned an item target, and if so checking whether the item has `USE_PLAYER_ENERGY` (since if it does, energy draw is already handled by the spell menu stuff). If the flag is absent, then call up `charges_to_use` like normal. Based off the finisher functions as seen with jackhammering and shearing.
2. In iuse_actor.cpp, changed `cast_spell_actor::use` to go ahead and not call `charges_to_use` even for items lacking `USE_PLAYER_ENERGY`, because we're deferring it to the activity finisher. Handling of player-energy spells, as noted, is handled via the `value` change in the if statement.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Waiting for someone on DDA's end to finally notice a bug that's been in this game basically since spellcasting items have existed, then porting over their fix for it.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load tested.
2. Started up a world with magiclysm on, debugged me a wand of fireballs and a potion of cat's grace.
3. Tried activating the fireball, then choosing to cancel out of the spellcasting menu. Didn't consume a charge.
4. Activated again and actually fired it, consumed a charge as normal.
5. Consumed potion of cat's grace, spell correctly triggers and potion is consumed.
6. Debugged in a cougar voodoo doll, activated it and canceled out of the spellcasting menu, it correctly doesn't consume the doll.
7. Went ahead and actually used the doll, it correctly vanishes and spawns decayed pouncers.
8. Temporarily ported over Arcana to test more spellcasting items, in particular `USE_PLAYER_ENERGY` items.
9. Debugged in an offering chalice and uses its ritual.
10. Confirmed it didn't try to somehow eat the chalice, and that my fatigue in the needs screen had gone up by 63 (60 from the casting cost, 3 from the spell taking 15 minutes to cast).

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

@KorGgenT, @GuardianDll in case either of you want to port over this fix since you're both listed as authors on the DDA version of Magiclysm, confirmed via testing this bug is still present in DDA so.