### PR TITLE
Digging quality affects tiredness from digging/filling pits

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -55,6 +55,8 @@ static const itype_id itype_electrohack( "electrohack" );
 
 static const skill_id skill_computer( "computer" );
 
+static const quality_id qual_DIG( "DIG" );
+
 static const mtype_id mon_zombie( "mon_zombie" );
 static const mtype_id mon_zombie_fat( "mon_zombie_fat" );
 static const mtype_id mon_zombie_rot( "mon_zombie_rot" );
@@ -455,10 +457,18 @@ void dig_activity_actor::finish( player_activity &act, Character &who )
                                   calendar::turn ) );
     }
 
+    // Quality of tool used and assistants can together both reduce intensity of work, to a minimum of one.
+    item_location &loc = act.targets[ 0 ];
+    item *it = loc.get_item();
+    if( it == nullptr ) {
+        debugmsg( "shovel item location lost" );
+        return;
+    }
     const int helpersize = character_funcs::get_crafting_helpers( who, 3 ).size();
-    who.mod_stored_nutr( 5 - helpersize );
-    who.mod_thirst( 5 - helpersize );
-    who.mod_fatigue( 10 - ( helpersize * 2 ) );
+    int act_exertion = std::max( 1, 5 - helpersize - it->get_quality( qual_DIG ) );
+    who.mod_stored_nutr( act_exertion );
+    who.mod_thirst( act_exertion );
+    who.mod_fatigue( act_exertion * 2 );
     if( grave ) {
         who.add_msg_if_player( m_good, _( "You finish exhuming a grave." ) );
     } else {
@@ -526,9 +536,18 @@ void dig_channel_activity_actor::finish( player_activity &act, Character &who )
                                   calendar::turn ) );
     }
 
-    who.mod_stored_kcal( -40 );
-    who.mod_thirst( 5 );
-    who.mod_fatigue( 10 );
+    // Quality of tool used and assistants can together both reduce intensity of work, to a minimum of one.
+    item_location &loc = act.targets[ 0 ];
+    item *it = loc.get_item();
+    if( it == nullptr ) {
+        debugmsg( "shovel item location lost" );
+        return;
+    }
+    const int helpersize = character_funcs::get_crafting_helpers( who, 3 ).size();
+    int act_exertion = std::max( 1, 5 - helpersize - it->get_quality( qual_DIG ) );
+    who.mod_stored_nutr( act_exertion );
+    who.mod_thirst( act_exertion );
+    who.mod_fatigue( act_exertion * 2 );
     who.add_msg_if_player( m_good, _( "You finish digging up %s." ),
                            here.ter( location ).obj().name() );
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2802,7 +2802,7 @@ int iuse::dig( player *p, item *it, bool t, const tripoint & )
             moves_and_byproducts.spawn_count,
             moves_and_byproducts.byproducts_item_group
                                          ) ) );
-
+    p->activity.targets.push_back( item_location( *p, it ) );
     return it->type->charges_to_use();
 }
 
@@ -2869,6 +2869,7 @@ int iuse::dig_channel( player *p, item *it, bool t, const tripoint & )
             moves_and_byproducts.spawn_count,
             moves_and_byproducts.byproducts_item_group
                                          ) ) );
+    p->activity.targets.push_back( item_location( *p, it ) );
     return it->type->charges_to_use();
 }
 
@@ -2933,6 +2934,7 @@ int iuse::fill_pit( player *p, item *it, bool t, const tripoint & )
     moves = moves * ( 10 - helpers.size() ) / 10;
 
     p->assign_activity( ACT_FILL_PIT, moves, -1, p->get_item_position( it ) );
+    p->activity.targets.push_back( item_location( *p, it ) );
     p->activity.placement = pnt;
 
     return it->type->charges_to_use();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Tool quality affects hunger/thirst/fatigue gain from digging and filling pits"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This implements the lessons learned in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2617 to another activity with hardcoded exertion, this time to focusing on shovel activities.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In activity_actor.cpp, set `dig_activity_actor::finish` and `dig_channel_activity_actor::finish` to grab tool quality and take that into account when determining exertion from digging. Size the fixed values were the same as what woodcutting started with, I applied the same scaling as used in the woodcutting PR above.
2. In activity_handlers.cpp, implemented the same change with same degree of scaling for `activity_handlers::fill_pit_finish`.
3. In iuse.cpp, set it so that `iuse::dig`, `iuse::dig_channel`, and `iuse::fill_pit` all pass along what item was used for it.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Honestly we should probably do something about that giant block of code spaghetti and justifying wall of text comment concerning how the time needed to dig a pit is calculated. We made tool quality a direct division operation with https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1487 so we could for example axe the `baseline_dig_quality` nonsense while still keeping the base time in the general vicinity of 2 hours for a deep pit like it already is.

Alternatively, since digging quality of 1 can't actually be used for making deep pits, we could balance around changing `baseline_dig_quality` to 2 instead of 3.

Either way we probably also don't need to specify material density of soil as a fixed value that just gets multiplied against the size of a pit. Maybe I can do this as a separate PR...

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested, testing digging pits and checking that fatigue went up as expected, along with filling pits afterward.
2. Checked for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
