### PR TITLE
Updates/fixes to factions and epilogues

### DIFF
--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -22,7 +22,7 @@
       }
     },
     "mon_faction": "player",
-    "epilogues": [ { "power_min": 0, "id": "epilogue_faction_your_followers_0" } ],
+    "epilogues": [ { "power_min": 0, "power_max": 149, "id": "epilogue_faction_your_followers_0" } ],
     "description": "The survivors who have entrusted you with their well-being.  If morale drops, poor performance and mutiny may become issues."
   },
   {
@@ -74,6 +74,10 @@
       },
       "marloss": { "kill on sight": true }
     },
+    "epilogues": [
+      { "power_min": 0, "power_max": 149, "id": "epilogue_faction_robofac_0" },
+      { "power_min": 150, "id": "epilogue_faction_robofac_150" }
+    ],
     "description": "The surviving staff of Hub 01, a pre-Cataclysm research lab.  They rarely leave their lab, if at all, and rely on their robots and advanced technology to survive."
   },
   {
@@ -135,8 +139,9 @@
       "hells_raiders": { "kill on sight": true }
     },
     "epilogues": [
-      { "power_min": 0, "id": "epilogue_faction_old_guard_0" },
-      { "power_max": 150, "id": "epilogue_faction_old_guard_150" }
+      { "power_min": 0, "power_max": 99, "id": "epilogue_faction_old_guard_0" },
+      { "power_min": 115, "power_max": 139, "id": "epilogue_faction_old_guard_115" },
+      { "power_min": 140, "id": "epilogue_faction_old_guard_140" }
     ],
     "description": "The remains of the federal government.  The extent of their strength is unknown but squads of patrolling soldiers have been seen under their banner."
   },
@@ -210,8 +215,8 @@
       "hells_raiders": { "kill on sight": true }
     },
     "epilogues": [
-      { "power_min": 0, "id": "epilogue_faction_free_merchants_0" },
-      { "power_max": 150, "id": "epilogue_faction_free_merchants_150" }
+      { "power_min": 0, "power_max": 149, "id": "epilogue_faction_free_merchants_0" },
+      { "power_min": 150, "id": "epilogue_faction_free_merchants_150" }
     ],
     "description": "A conglomeration of entrepreneurs and businessmen that stand together to hammer-out an existence through trade and industry."
   },
@@ -299,8 +304,8 @@
       }
     },
     "epilogues": [
-      { "power_min": 0, "id": "epilogue_faction_tacoma_commune_0" },
-      { "power_max": 150, "id": "epilogue_faction_tacoma_commune_150" }
+      { "power_min": 0, "power_max": 149, "id": "epilogue_faction_tacoma_commune_0" },
+      { "power_min": 150, "id": "epilogue_faction_tacoma_commune_150" }
     ],
     "description": "An outpost started by the Free Merchants to provide a source of food and raw materials."
   },
@@ -368,8 +373,8 @@
       "no_faction": { "knows your voice": true }
     },
     "epilogues": [
-      { "power_min": 0, "id": "epilogue_faction_wasteland_scavengers_0" },
-      { "power_max": 150, "id": "epilogue_faction_wasteland_scavengers_150" }
+      { "power_min": 0, "power_max": 149, "id": "epilogue_faction_wasteland_scavengers_0" },
+      { "power_min": 150, "id": "epilogue_faction_wasteland_scavengers_150" }
     ],
     "description": "Autonomous bands or individuals who make their living raiding the ruins of the old-world for gear and provisions."
   },
@@ -399,8 +404,8 @@
       "your_followers": { "kill on sight": true }
     },
     "epilogues": [
-      { "power_min": 0, "id": "epilogue_faction_hells_raiders_0" },
-      { "power_max": 150, "id": "epilogue_faction_hells_raiders_150" }
+      { "power_min": 0, "power_max": 149, "id": "epilogue_faction_hells_raiders_0" },
+      { "power_min": 150, "id": "epilogue_faction_hells_raiders_150" }
     ],
     "description": "The largest gang of hooligans and bandits that preys upon other survivors.  Even if you have no gear, there is always a need for slaves and fresh meat."
   },
@@ -498,6 +503,10 @@
       },
       "hells_raiders": { "kill on sight": true }
     },
+    "epilogues": [
+      { "power_min": 0, "power_max": 149, "id": "epilogue_faction_isherwoods_0" },
+      { "power_min": 150, "id": "epilogue_faction_isherwoods_150" }
+    ],
     "description": "A small family surviving on their generational land."
   },
   {

--- a/data/json/snippets/epilogue_factions.json
+++ b/data/json/snippets/epilogue_factions.json
@@ -13,8 +13,12 @@
         "text": "    Locked in an endless battle, the Old Guard was forced to consolidate their resources in a handful of fortified bases along the coast.  Without the men or material to rebuild, the soldiers that remained lost all hope…"
       },
       {
-        "id": "epilogue_faction_old_guard_150",
-        "text": "    The steadfastness of individual survivors after the cataclysm impressed the tattered remains of the once glorious union.  Spurred on by small successes, a number of operations to re-secure facilities met with limited success.  Forced to eventually consolidate to large bases, the Old Guard left these facilities in the hands of the few survivors that remained.  As the years passed, little materialized from the hopes of rebuilding civilization…"
+        "id": "epilogue_faction_old_guard_115",
+        "text": "    Though partially successful in restoring a semblance of order, the forces of the Old Guard remained stretched thin and faced with threats on all sides.  Over time the facade of being the last vestige of old America faded, absorbed into the communities they once watched over.  The idea of New England being just one part of a nation spanning from coast to coast would gradually become a faded memory, passed down through oral history…"
+      },
+      {
+        "id": "epilogue_faction_old_guard_140",
+        "text": "    The steadfastness of individual survivors after the cataclysm impressed the tattered remains of the once glorious union.  Spurred on by small successes, a number of operations to re-secure facilities met with limited success.  Though the nation itself was dead and gone, people still carried on as best as they could, and the soldiers of the Old Guard still struggled along with them…"
       },
       {
         "id": "epilogue_faction_free_merchants_0",
@@ -22,7 +26,7 @@
       },
       {
         "id": "epilogue_faction_free_merchants_150",
-        "text": "    The Free Merchants struggled for years to keep themselves fed but their once profitable trade routes were plundered by bandits and thugs.  In squalor and filth the first generations born after the cataclysm are told stories of the old days when food was abundant and the children were allowed to play in the sun…"
+        "text": "    Despite constant threats of banditry, life continued on and the refugee center slowly grew into a struggling community.  Food and overcrowding remained a constant worry, the next generation faced with either hard work in relative safety or a dangerous yet potentially lucrative life as a scavenger.  They learned to live day by day, hopeful for the future despite uncertainty…"
       },
       {
         "id": "epilogue_faction_tacoma_commune_0",
@@ -47,6 +51,22 @@
       {
         "id": "epilogue_faction_hells_raiders_150",
         "text": "    Fueled by drugs and rage, the Hell's Raiders fought tooth and nail to overthrow the last strongholds of the Old Guard.  The costly victories brought the warlords abundant territory and slaves but little in the way of stability.  Within weeks, infighting led to civil war as tribes vied for leadership of the faction.  When only one warlord finally secured control, there was nothing left to fight for… just endless cities full of the dead."
+      },
+      {
+        "id": "epilogue_faction_robofac_0",
+        "text": "    Despite all the wonders of science, shortages and crises plagued Hub-01 from the first day of the Cataclysm.  The researchers and administrators among the surviving staff lacked the practical skills to survive in the savage new world.  As Hub-01's systems collapsed from a lack of maintenance, the few survivors fled the building to be killed by the zombies and bandits."
+      },
+      {
+        "id": "epilogue_faction_robofac_150",
+        "text": "       Though reclusive and often brusque with the few people to reach out to them, over time the scientists of Hub-01 developed a network of scavengers and mercenaries, always on the lookout for more materials to keep them in working order.  There they continued what research they could, always limited by what little scraps of old-world technology they could get their hands on.  Their knowledge however remained, closely-guarded yet from time to time proving useful to the occasional survivor willing to part with some forgotten scrap of technology."
+      },
+      {
+        "id": "epilogue_faction_isherwoods_0",
+        "text": "    Life on the farm grew tense as new horrors sprung from the world.  The Isherwoods were plagued by undead hordes and the encroachment of triffids.  When an otherworldly mold took over the fields, the family was forced to move.  The farm was later found abandoned, the fields black with ash…"
+      },
+      {
+        "id": "epilogue_faction_isherwoods_150",
+        "text": "    The generational land of the Isherwoods came to flourish following <the_cataclysm>, helping to feed nearby settlements.  Survivors flocked to learn botany, animal handling, and backwoods remedies, eventually forming a small community…"
       }
     ]
   }

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -489,6 +489,8 @@ void faction::faction_display( const catacurses::window &fac_w, const int width 
     int y = 2;
     mvwprintz( fac_w, point( width, ++y ), c_light_gray, _( "Attitude to you:           %s" ),
                fac_ranking_text( likes_u ) );
+    mvwprintz( fac_w, point( width, ++y ), c_light_gray, _( "Faction strength:       %s" ),
+               power );
     fold_and_print( fac_w, point( width, ++y ), getmaxx( fac_w ) - width - 2, c_light_gray, _( desc ) );
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Content "Add faction strength to faction window, fix redundant faction epilogues, rewrite some epilogues and flesh out Old Guard epilogues"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Port over what turns out to be an easy JSON fix for faction epilogues being broken. Also port over a couple epilogues for factions lacking them. And what I'd been particularly eager to do, make the writing for the "good" endings either actually good or ideally ambiguous. Bare minimum being "not as bad or worse than the baseline ending"

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Ported over faction epilogues for Hub 01 and the Isherwoods.
2. Fix faction epilogues potentially displaying both the good end and bad end due to the bad end not having `power_max` defined.
3. Rewrote the good epilogues for factions to shift the tone to more ambiguous outcomes, leaning towards "they continue to exist but the future is chaotic and uncertain" instead of ye olde standard "shit's fucked and you wasted your time"
4. Wrote a mid-tier epliogue for the Old Guard, since completing just one of the main mission chains wasn't enough to actually max it out.
5. Added a value to the faction window that prints the faction's power rating, to make this easier to test.

The Old Guard has had its epilogue ranges adjusted such that completing the mission chain of either the representative or the doctor will bump their faction power up enough to trigger the mid-tier ending. Doing the necropolis mission chain in addition to either of the first two chains will, combined, push faction power up enough to hit the good ending.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Also writing a high-power-value faction epilogue for "your faction" since the epilogue fix includes a `power_max` value for that faction, even though it doesn't define a high-power epilogue for it.
2. Also porting over Mr. Lapin's ending, will require also hunting down the PR that gives him his own faction since right now he's in the "no faction" group.
3. Futzing about with reward values, or even better expanding the necropolis, so that you can do enough stuff down there to trigger their good ending purely through Vault Boy's Wild Ride.
4. Making the faction strength number only show up if you have debug mode on? Seems fine to me, just dunno how best to phrase it in a way that both doesn't confuse players who dunno what they're looking at while still giving a useful number to players actively testing a faction's progression.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested changes.
3. Met the Old Guard rep then immediately committed sudoku, confirmed the bad end epilogue showed.
4. Repeated this but instead cheated my way through his mission chain before banishing myself to the shadow realm, confirmed the mid-level epilogue showed. Faction power rating was 116.
5. Fucked off to do the necropolis mission chain and confirmed that this was enough to bump faction power to 144, triggering the good ending on succumbing to ennui.
6. Checked affected C++ file for astyle.

So, one issue I encountered while testing is the old guard doctor's second mission is broken. I couldn't find any sign of a working console spawning in the mission target area.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Sources:
* "Fix faction epilogues displaying incorrectly" by @MNG-cataclysm: https://github.com/CleverRaven/Cataclysm-DDA/pull/60673 (with tuning for OLd Guard's factions, sanity-checking of power required for other factions to come soonish)
* "Add Faction Endings to Hub 01" by @ghost: https://github.com/CleverRaven/Cataclysm-DDA/pull/48007 (scrapped their "good" ending because it manages to actively be a more grimdark ending than their genuine Bad End).
* "Add faction epilogues" by @MNG-cataclysm: https://github.com/CleverRaven/Cataclysm-DDA/pull/61305 (just the Isherwoods for now since we lack the prisoners and valhallists, and Lapin presently lacks his own faction, kept the Isherwood endings as-is since the good ending is an actual improvement over the bad ending).

I still need to hit the other factions with a similar in-depth dive to see what power ratings their missions push them to, and adjust faction epilogues accordingly. It's a start at least.