### PR TITLE
feat: fallback and flame for cone aoe

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -1032,7 +1032,8 @@ bucketed_points optimal_bucketing( const bucketed_points &buckets, size_t max_bu
     return optimal;
 }
 
-static void draw_cone_aoe_curses( const tripoint &, const bucketed_points &waves )
+static void draw_cone_aoe_curses( const tripoint &, const bucketed_points &waves,
+                                  const projectile & )
 {
     // Calculate screen offset relative to player + view offset position
     const avatar &u = get_avatar();
@@ -1095,7 +1096,7 @@ void draw_cone_aoe( const tripoint &origin, const std::map<tripoint, double> &ao
 
 #if defined(TILES)
     if( !use_tiles ) {
-        draw_cone_aoe_curses( origin, waves );
+        draw_cone_aoe_curses( origin, waves, proj );
         return;
     }
 
@@ -1128,7 +1129,7 @@ void draw_cone_aoe( const tripoint &origin, const std::map<tripoint, double> &ao
 
     tilecontext->void_cone_aoe();
 #else
-    draw_cone_aoe_curses( origin, waves );
+    draw_cone_aoe_curses( origin, waves, proj );
 #endif
 }
 } // namespace ranged

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -1081,7 +1081,8 @@ static void draw_cone_aoe_curses( const tripoint &, const bucketed_points &waves
 
 namespace ranged
 {
-void draw_cone_aoe( const tripoint &origin, const std::map<tripoint, double> &aoe )
+void draw_cone_aoe( const tripoint &origin, const std::map<tripoint, double> &aoe,
+                    const projectile &proj )
 {
     if( test_mode ) {
         return;
@@ -1107,7 +1108,7 @@ void draw_cone_aoe( const tripoint &origin, const std::map<tripoint, double> &ao
 
     shared_ptr_fast<game::draw_callback_t> wave_cb =
     make_shared_fast<game::draw_callback_t>( [&]() {
-        tilecontext->init_draw_cone_aoe( origin, combined_layer );
+        tilecontext->init_draw_cone_aoe( origin, combined_layer, proj );
     } );
     g->add_draw_callback( wave_cb );
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -20,6 +20,7 @@
 #include "options.h"
 #include "pimpl.h"
 #include "point.h"
+#include "projectile.h"
 #include "sdl_wrappers.h"
 #include "sdl_geometry.h"
 #include "type_id.h"
@@ -532,7 +533,7 @@ class cata_tiles
         void draw_custom_explosion_frame();
         void void_custom_explosion();
 
-        void init_draw_cone_aoe( const tripoint &origin, const one_bucket &layer );
+        void init_draw_cone_aoe( const tripoint &origin, const one_bucket &layer, const projectile &proj );
         void draw_cone_aoe_frame();
         void void_cone_aoe();
 
@@ -711,6 +712,7 @@ class cata_tiles
 
         std::map<tripoint, explosion_tile> custom_explosion_layer;
 
+        std::optional<projectile> proj;
         tripoint cone_aoe_origin;
         one_bucket cone_aoe_layer;
 

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -108,7 +108,8 @@ std::map<tripoint, double> expected_coverage( const shape &sh, const map &here, 
 
 dealt_damage_instance hit_with_aoe( Creature &target, Creature *source, const damage_instance &di );
 
-void draw_cone_aoe( const tripoint &origin, const std::map<tripoint, double> &aoe );
+void draw_cone_aoe( const tripoint &origin, const std::map<tripoint, double> &aoe,
+                    const projectile &proj );
 
 enum class hit_tier : int {
     grazing = 0,

--- a/src/ranged_aoe.cpp
+++ b/src/ranged_aoe.cpp
@@ -113,7 +113,7 @@ void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &a
         }
     }
 
-    draw_cone_aoe( origin, final_coverage );
+    draw_cone_aoe( origin, final_coverage, proj );
 
     // Here and not above because we want the animation first
     // Terrain will be shown damaged, but having it in unknown state would complicate timing the animation


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Fallback and flame sprite support for cone aoe animation"

#### Purpose of change

- currently UDP tileset lacks "shot_cone_weak", "shot_cone_medium", and "shot_cone_strong". until these tiles are drawn, using default fallback would help.
- distinguish between normal shrapnels and flame shots.

#### Describe the solution

- added yet another field to cata_tiles: optional projectile. it's used to check if the tile should be flame.
- added "shot_flame_cone_weak", "shot_flame_cone_medium", "shot_flame_cone_strong" for posterity

#### Describe alternatives you've considered

cache fallback availability result at tileset instead but haven't had the time to check.

#### Testing

https://user-images.githubusercontent.com/54838975/231764908-32386295-9ab9-4046-8ed7-df3fb1d75c7a.webm
fallback for normal shots
https://user-images.githubusercontent.com/54838975/231764900-dc840da4-9042-4704-a5a3-fdab78d5d521.webm
fallback for incendiary
