### PR TITLE
Rule of Cool explosions v0.2: Impressive Pyrotechnics

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -236,7 +236,7 @@
     "description_affix": "on",
     "decay_amount_factor": 3,
     "has_fire": true,
-    "priority": 4,
+    "priority": 9,
     "half_life": "30 minutes",
     "phase": "plasma",
     "stacking_type": "duration",

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -290,7 +290,7 @@
     "move_cost": 0,
     "coverage": 100,
     "roof": "t_flat_roof",
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
+    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND", "CLIMBABLE" ],
     "connects_to": "WALL",
     "bash": {
       "str_min": 80,
@@ -1129,7 +1129,7 @@
     "color": "white",
     "move_cost": 0,
     "coverage": 100,
-    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "MINEABLE", "BLOCK_WIND" ],
+    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "MINEABLE", "BLOCK_WIND", "CLIMBABLE" ],
     "roof": "t_rock_floor_no_roof",
     "bash": {
       "str_min": 100,

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -13,6 +13,7 @@
 #include <random>
 #include <set>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "animation.h"
@@ -48,8 +49,10 @@
 #include "mtype.h"
 #include "npc.h"
 #include "options.h"
+#include "output.h"
 #include "player.h"
 #include "point.h"
+#include "posix_time.h"
 #include "projectile.h"
 #include "rng.h"
 #include "shadowcasting.h"
@@ -59,6 +62,7 @@
 #include "trap.h"
 #include "type_id.h"
 #include "units.h"
+#include "ui_manager.h"
 #include "vehicle.h"
 #include "vpart_position.h"
 
@@ -154,12 +158,1090 @@ explosion_data load_explosion_data( const JsonObject &jo )
     return ret;
 }
 
+
+// Programmer-friendly numbers to tweak
+namespace ExplosionConstants
+{
+// Assumed distance between z-levels.
+// Affects depths of craters and such.
+constexpr int Z_LEVEL_DIST = 4;
+
+// Shrapnel hitting terrain and vehicle parts should not inflict full damage
+// This constant specifies by how much the damage of shrapnel is multiplied
+//   on terrain/vehicle hits.
+constexpr float SHRAPNEL_OBSTACLE_REDUCTION = 0.25;
+
+// To destroy terrain consistently, we bash it several times
+//   at linearly dissipating strength.
+// This determines how many times.
+constexpr int MULTIBASH_COUNT = 5;
+
+// Even though bash the terrain several times, we want to limit
+//   the total amount of damage inflicted
+// For terrain and furniture this doesn't matter, but it does
+//   for vehicles
+// This coeff specifies total amount of damage inflicted after every bash
+constexpr float VEHICLE_DAMAGE_MULT = 2.0;
+
+// We use this upper bound for the linear interpolation of terfurn strength
+// The intent is to make explosions consistent, but have jagged edges
+constexpr float BASH_RANDOM_FACTOR = 0.3;
+
+// Flinging entities
+// Whenever an entity is struck by the blast wave
+//   it is given velocity
+// Velocity is the range the object will fly
+
+// Refer to MOB_FLING_FACTOR & ITEM_FLING_FACTOR
+constexpr int EXPLOSION_CALIBRATION_POWER = 100;
+
+// This is the amount of grams a mob staying at the
+//   blast center has to weight
+//   in order to fly exactly one blast radius away when struck by
+//   an explosion of strength EXPLOSION_CALIBRATION_STRENGTH
+constexpr int MOB_FLING_FACTOR = 40750;
+
+// This is the amount of grams an item staying at the
+//   blast center has to weight
+//   in order to fly exactly one blast radius away when struck by
+//   an explosion of strength EXPLOSION_CALIBRATION_STRENGTH
+constexpr int ITEM_FLING_FACTOR = 1500;
+
+// To make items propagate a bit more interestingly, we add a random amount to effective distance
+//   as rng_float(-ITEM_FLING_RANDOM_FACTOR, +ITEM_FLING_RANDOM_FACTOR);
+constexpr float ITEM_FLING_RANDOM_FACTOR = 2.5;
+
+// If the entity strikes an obstacle, we multiply its velocity by this factor
+//   and reflect it back
+constexpr float RESTITUTION_COEFF = 0.3;
+
+// If a flung entity would get more than this speed,
+//   it instead will choose a random value between
+//   FLING_THRESHOLD and FLING_MAX_RANGE
+constexpr float FLING_THRESHOLD = 30.0;
+
+// See above
+constexpr float FLING_MAX_RANGE = 50.0;
+}; // namespace ExplosionConstants
+
 namespace explosion_handler
 {
+class ExplosionEvent
+{
+    public:
+        struct PropelledEntity {
+            std::variant<Creature *, safe_reference<item>> target;
+
+            rl_vec2d position;
+            float angle;
+            float velocity;
+
+            int cur_time;
+        };
+        struct FieldToAdd {
+            field_type_id field;
+            int intensity;
+            bool hit_player;
+        };
+        using target_types =
+            std::variant<std::monostate, PropelledEntity, FieldToAdd, field_type_id, int>;
+
+        enum class Kind { ITEM_MOVEMENT, MOB_MOVEMENT, BLAST, SHRAPNEL, FIELD_ADDITION, FIELD_REMOVAL } kind;
+        target_types target;
+        tripoint position;
+
+        static ExplosionEvent mob_movement( const tripoint position, Creature *mob, float angle,
+                                            float velocity, int cur_time ) {
+            return ExplosionEvent( Kind::MOB_MOVEMENT, position,
+            PropelledEntity{
+                mob,
+                rl_vec2d( position.x + 0.5, position.y + 0.5 ),
+                angle,
+                velocity,
+                cur_time
+            } );
+        }
+        static ExplosionEvent item_movement( const tripoint position, safe_reference<item> item,
+                                             float angle, float velocity, int cur_time ) {
+            return ExplosionEvent( Kind::ITEM_MOVEMENT, position,
+            PropelledEntity{
+                item,
+                rl_vec2d( position.x + 0.5, position.y + 0.5 ),
+                angle,
+                velocity,
+                cur_time
+            } );
+        }
+        static ExplosionEvent tile_blast( const tripoint position, const int distance ) {
+            return ExplosionEvent( Kind::BLAST, position, distance );
+        }
+        static ExplosionEvent tile_shrapnel( const tripoint position ) {
+            return ExplosionEvent( Kind::SHRAPNEL, position );
+        }
+        static ExplosionEvent field_addition(
+            const tripoint position, field_type_id target,
+            const int intensity = INT_MAX, const bool hit_player = false
+        ) {
+            return ExplosionEvent( Kind::FIELD_ADDITION, position, FieldToAdd{target, intensity, hit_player} );
+        }
+        static ExplosionEvent field_removal( const tripoint position, field_type_id target ) {
+            return ExplosionEvent( Kind::FIELD_REMOVAL, position, target );
+        }
+
+    private:
+        ExplosionEvent( Kind kind, const tripoint position ) :
+            kind( kind ), position( position ) {};
+        ExplosionEvent( Kind kind, const tripoint position, target_types target ) :
+            kind( kind ), target( target ), position( position ) {};
+};
+
+class ExplosionProcess
+{
+    public:
+        // Where did the explosion originate from?
+        const tripoint center;
+
+        // Explosion damage.
+        const int blast_power;
+
+        // Explosion radius, 0 to disable
+        const int blast_radius;
+
+        // Is the fire created by the explosion actually left behind?
+        const bool is_fiery;
+
+        // Shrapnel data, nullopt to disable
+        const std::optional<projectile> shrapnel;
+
+        // Who do we attribute the explosion & shrapnel to? nullopt to disable
+        const std::optional<Creature *> emitter;
+    private:
+        using dist_point_pair = std::pair<float, tripoint>;
+        using time_event_pair = std::pair<int, ExplosionEvent>;
+
+        std::vector<dist_point_pair> blast_map;
+        std::vector<dist_point_pair> shrapnel_map;
+        std::priority_queue<time_event_pair, std::vector<time_event_pair>, pair_greater_cmp_first>
+        event_queue;
+
+        std::optional<player *> player_flung;
+        std::map<const Creature *, int> mobs_blasted;
+        std::map<const Creature *, int> mobs_shrapneled;
+        std::set<const Creature *> flung_set;
+        std::vector<tripoint> recombination_targets;
+
+        const int radius_step_delay;
+        int cur_time;
+        bool request_redraw;
+    public:
+        void run();
+
+        std::map<const Creature *, int> get_blasted() {
+            return mobs_blasted;
+        };
+        std::map<const Creature *, int> get_shrapneled() {
+            return mobs_shrapneled;
+        };
+
+        ExplosionProcess(
+            const tripoint blast_center,
+            const int blast_power,
+            const int blast_radius,
+            const std::optional<projectile> proj = std::nullopt,
+            const bool is_fiery = false,
+            const std::optional<Creature *> responsible = std::nullopt
+        ) : center( blast_center ),
+            blast_power( blast_power ),
+            blast_radius( blast_radius ),
+            is_fiery( is_fiery ),
+            shrapnel( proj ),
+            emitter( responsible ),
+            player_flung( std::nullopt ),
+            // We want to ensure the delay is at least some small value at least to make sure propagation occurs correctly
+            radius_step_delay( std::max( get_option<int>( "ANIMATION_DELAY" ), 5 ) ),
+            cur_time( 0 ),
+            request_redraw( false ) {}
+    private:
+        static bool dist_comparator( dist_point_pair a, dist_point_pair b ) {
+            return a.first < b.first;
+        };
+        static bool time_comparator( time_event_pair a, time_event_pair b ) {
+            return a.first < b.first;
+        };
+
+        void fill_maps();
+        void init_event_queue();
+        float generate_fling_angle( const tripoint from, const tripoint to );
+        bool is_occluded( const tripoint from, const tripoint to );
+        void add_event( const int delay, const ExplosionEvent event ) {
+            assert( delay >= 0 );
+            event_queue.push( { cur_time + 1 + delay, event } );
+        }
+
+        bool process_next();
+        void blast_tile( const tripoint position, const int rl_distance );
+        void project_shrapnel( const tripoint position );
+        void add_field( const tripoint position, const field_type_id field,
+                        const int intensity, const bool hit_player );
+        void remove_field( const tripoint position, const field_type_id target );
+        void move_entity( const tripoint position, const ExplosionEvent::PropelledEntity &datum,
+                          bool is_mob );
+
+        // How long should it take for an entity to travel 1 unit of distance at `velocity`?
+        int one_tile_at_vel( float velocity ) {
+            assert( velocity > 0 );
+            return radius_step_delay / velocity;
+        };
+};
+
+void ExplosionProcess::fill_maps()
+{
+    map &here = get_map();
+
+    const int shrapnel_range = shrapnel.has_value() ? shrapnel.value().range : 0;
+    const int aoe_radius = std::max( blast_radius, shrapnel_range );
+    const int z_levels_affected = aoe_radius / ExplosionConstants::Z_LEVEL_DIST;
+    const tripoint_range<tripoint> affected_block(
+        center + tripoint( -aoe_radius, -aoe_radius, -z_levels_affected ),
+        center + tripoint( aoe_radius, aoe_radius, z_levels_affected )
+    );
+
+    for( const tripoint &target : affected_block ) {
+        if( !here.inbounds( target ) ) {
+            continue;
+        }
+
+        // Uses this ternany check instead of rl_dist because it converts trig_dist's distance to int implicitly
+        const float distance = (
+                                   trigdist ?
+                                   trig_dist( center, target ) :
+                                   square_dist( center, target )
+                               );
+        const float z_distance = abs( target.z - center.z );
+        const float z_aware_distance = distance + ( ExplosionConstants::Z_LEVEL_DIST - 1 ) * z_distance;
+        // We static_cast<int> in order to keep parity with legacy blasts using rl_dist for distance
+        //   which, as stated above, converts trig_dist into int implicitly
+        if( blast_radius > 0 && static_cast<int>( z_aware_distance ) <= blast_radius ) {
+            blast_map.push_back( { z_aware_distance, target } );
+        }
+
+        if( shrapnel && static_cast<int>( distance ) <= shrapnel_range && target.z == center.z &&
+            !is_occluded( center, target ) ) {
+            shrapnel_map.push_back( { distance, target } );
+        }
+    }
+
+    std::stable_sort( blast_map.begin(), blast_map.end(), dist_comparator );
+    std::stable_sort( shrapnel_map.begin(), shrapnel_map.end(), dist_comparator );
+};
+void ExplosionProcess::init_event_queue()
+{
+    // Start with shrapnel first
+    // In how many blast steps should the animation for shrapnel complete?
+    const float SHRAPNEL_EQUIV = 3.0;
+    const float shrapnel_delay = shrapnel.has_value() ? radius_step_delay * SHRAPNEL_EQUIV : 0.0;
+
+    for( const auto &[distance, position] : shrapnel_map ) {
+        const float random_factor = rng_float( -0.2, 0.2 );
+        const float range_percent = distance / shrapnel.value().range;
+        const float timing = std::min( std::max( range_percent + random_factor, 0.0f ), 1.0f );
+        const int time_taken = static_cast<int>( SHRAPNEL_EQUIV * radius_step_delay * timing );
+
+        add_event( time_taken, ExplosionEvent::tile_shrapnel( position ) );
+    }
+
+    // Then apply blasting
+    for( const auto &[distance, position] : blast_map ) {
+        const int time_taken = static_cast<int>( shrapnel_delay + distance * radius_step_delay );
+        // We static_cast<int> in order to keep parity with legacy blasts using rl_dist for distance
+        //   which, as stated before, converts trig_dist into int implicitly
+        add_event( time_taken, ExplosionEvent::tile_blast( position, static_cast<int>( distance ) ) );
+    }
+};
+bool ExplosionProcess::is_occluded( const tripoint from, const tripoint to )
+{
+    if( from == to ) {
+        return false;
+    }
+
+    map &here = get_map();
+    tripoint last_position = from;
+
+    std::vector<tripoint> line_of_movement = line_to( from, to );
+    // Annoyingly, line_to does not include the origin point
+    //   so it has to be added manually
+    line_of_movement.insert( line_of_movement.begin(), from );
+    for( const auto &position : line_of_movement ) {
+        // position != to necessary because we do want to strike the
+        //   target obstacle
+        if( position != to && here.impassable( position ) ) {
+            return true;
+        }
+        // position != to is unneeded here though because we want to
+        //   make sure stuff does not fly into vehicles
+        if( here.obstructed_by_vehicle_rotation( last_position, position ) ) {
+            return true;
+        }
+        last_position = position;
+    }
+    return false;
+};
+
+float ExplosionProcess::generate_fling_angle( const tripoint from, const tripoint to )
+{
+    if( from != to ) {
+        // -+ 0.95 added to add a half-arc
+        // It should be noted that this mathematically has a bias towards diagonal directions
+        //   but this is the shortest way to get good enough results
+        return units::atan2(
+                   to.y - from.y + rng_float( -0.95, 0.95 ),
+                   to.x - from.x + rng_float( -0.95, 0.95 )
+               ).value();
+    } else {
+        return rng_float( -M_PI, M_PI );
+    }
+}
+
+bool ExplosionProcess::process_next()
+{
+    if( event_queue.empty() ) {
+        return false;
+    }
+    const int time = event_queue.top().first;
+
+    // We don't need to wait in testing mode
+    if( !test_mode ) {
+        const long int anim_delay = ( time - cur_time ) * 1000000L;
+        const timespec delay = timespec{ 0, anim_delay };
+        nanosleep( &delay, nullptr );
+    }
+
+    // You can change this to adjust the step size
+    //   to make the animation have fewer rerenders
+    cur_time = time;
+
+    while( !event_queue.empty() && event_queue.top().first <= cur_time ) {
+        const auto &event = event_queue.top().second;
+
+        switch( event.kind ) {
+            case ExplosionEvent::Kind::SHRAPNEL:
+                project_shrapnel( event.position );
+                break;
+            case ExplosionEvent::Kind::BLAST:
+                blast_tile( event.position, std::get<int>( event.target ) );
+                break;
+            case ExplosionEvent::Kind::FIELD_ADDITION: {
+                const auto &[field, intensity,
+                                    hit_player] = std::get<ExplosionEvent::FieldToAdd>( event.target );
+                add_field( event.position, field, intensity, hit_player );
+                break;
+            }
+            case ExplosionEvent::Kind::FIELD_REMOVAL:
+                remove_field( event.position, std::get<field_type_id>( event.target ) );
+                break;
+            case ExplosionEvent::Kind::ITEM_MOVEMENT:
+            case ExplosionEvent::Kind::MOB_MOVEMENT:
+                move_entity(
+                    event.position,
+                    std::get<ExplosionEvent::PropelledEntity>( event.target ),
+                    event.kind == ExplosionEvent::Kind::MOB_MOVEMENT
+                );
+                break;
+        };
+        event_queue.pop();
+    }
+
+    return true;
+}
+
+void ExplosionProcess::project_shrapnel( const tripoint position )
+{
+    map &here = get_map();
+
+    assert( shrapnel );
+
+    if( is_occluded( center, position ) ) {
+        return;
+    }
+
+    projectile fragment = shrapnel.value();
+    fragment.add_effect( ammo_effect_NULL_SOURCE );
+
+    auto critter = g->critter_at( position );
+    if( critter && !critter->is_dead_state() ) {
+        int damage_taken = 0;
+        const auto bps = critter->get_all_body_parts( true );
+        // Humans get hit in all body parts
+        if( critter->is_player() ) {
+            for( bodypart_id bp : bps ) {
+                if( Character::bp_to_hp( bp->token ) == num_hp_parts ) {
+                    continue;
+                }
+                // TODO: Apply projectile effects
+                // TODO: Penalize low coverage armor
+                // Halve damage to be closer to what monsters take
+                damage_instance half_impact = fragment.impact;
+                half_impact.mult_damage( 0.5f );
+                dealt_damage_instance dealt = critter->deal_damage( emitter.value_or( nullptr ), bp,
+                                              fragment.impact );
+                if( dealt.total_damage() > 0 ) {
+                    damage_taken += dealt.total_damage();
+                }
+            }
+        } else {
+            dealt_damage_instance dealt = critter->deal_damage( emitter.value_or( nullptr ), bps[0],
+                                          fragment.impact );
+            if( dealt.total_damage() > 0 ) {
+                damage_taken += dealt.total_damage();
+            }
+            critter->check_dead_state();
+        }
+        mobs_shrapneled[critter] = damage_taken;
+    }
+
+    if( here.impassable( position ) ) {
+        const int damage = fragment.impact.total_damage() * ExplosionConstants::SHRAPNEL_OBSTACLE_REDUCTION;
+        if( optional_vpart_position vp = here.veh_at( position ) ) {
+            vp->vehicle().damage( vp->part_index(), damage );
+        } else {
+            // Terrain should be affected by shrapnel less
+            here.bash( position, damage, true );
+        }
+    }
+
+    if( !test_mode ) {
+        std::vector<tripoint> buf = line_to( position, center );
+        buf.resize( 2 );
+        g->draw_line( position, buf );
+    }
+    request_redraw |= true;
+}
+
+void ExplosionProcess::blast_tile( const tripoint position, const int rl_distance )
+{
+    assert( blast_radius > 0 );
+    // Verify we have view of the center
+    if( is_occluded( center, position ) ) {
+        return;
+    }
+
+    map &here = get_map();
+
+    // Item damage comes first in order to prevent dropped loot from being destroyed immediately.
+    {
+        const int smash_force = blast_power * item_blast_percentage( blast_radius, rl_distance );
+        here.smash_items( position, smash_force, _( "force of the explosion" ), true );
+        // Don't forget to mark them as explosion smashed already
+        for( auto &item : here.i_at( position ) ) {
+            item.set_flag( "EXPLOSION_SMASHED" );
+        }
+    }
+
+    // Damage creatures. Done first to reduce the amount of flung enemies.
+    {
+        Creature *critter = g->critter_at( position );
+
+        if( critter != nullptr && !mobs_blasted.count( critter ) ) {
+            const int blast_damage = blast_power * critter_blast_percentage( critter, blast_radius,
+                                     rl_distance );
+            const auto shockwave_dmg = damage_instance::physical( blast_damage, 0, 0, 0.4f );
+
+            player *player_ptr = critter->as_player();
+            if( player_ptr != nullptr ) {
+                player_ptr->add_msg_if_player( m_bad, _( "You're caught in the explosion!" ) );
+
+                struct blastable_part {
+                    bodypart_id bp;
+                    float low_mul;
+                    float high_mul;
+                    float armor_mul;
+                };
+
+                static const std::array<blastable_part, 6> blast_parts = { {
+                        { bodypart_id( "torso" ), 0.5f, 1.0f, 0.5f },
+                        { bodypart_id( "head" ),  0.5f, 1.0f, 0.5f },
+                        { bodypart_id( "leg_l" ), 0.75f, 1.25f, 0.4f },
+                        { bodypart_id( "leg_r" ), 0.75f, 1.25f, 0.4f },
+                        { bodypart_id( "arm_l" ), 0.75f, 1.25f, 0.4f },
+                        { bodypart_id( "arm_r" ), 0.75f, 1.25f, 0.4f },
+                    }
+                };
+
+                for( const auto &blast_part : blast_parts ) {
+                    const int part_dam = rng( blast_damage * blast_part.low_mul, blast_damage * blast_part.high_mul );
+                    const std::string hit_part_name = body_part_name_accusative( blast_part.bp->token );
+                    const auto dmg_instance = damage_instance( DT_BASH, part_dam, 0, blast_part.armor_mul );
+                    const auto result = player_ptr->deal_damage( emitter.value_or( nullptr ), blast_part.bp,
+                                        dmg_instance );
+                    const int res_dmg = result.total_damage();
+
+                    if( res_dmg > 0 ) {
+                        mobs_blasted[critter] = res_dmg;
+                    }
+                }
+            } else {
+                critter->deal_damage( emitter.value_or( nullptr ), bodypart_id( "torso" ), shockwave_dmg );
+                critter->check_dead_state();
+                mobs_blasted[critter] = blast_damage;
+            }
+        }
+    }
+
+    // Fling creatures
+    {
+        Creature *critter = g->critter_at( position );
+        player *player_ptr = dynamic_cast<player *>( critter );
+
+        if( critter != nullptr && !flung_set.count( critter ) ) {
+            const int push_strength = ( blast_radius - rl_distance ) * blast_power;
+            const float move_power = ExplosionConstants::MOB_FLING_FACTOR * push_strength;
+
+            const int weight = to_gram( critter->get_weight() );
+            const int inertia = std::max( weight, 1 ) * ExplosionConstants::EXPLOSION_CALIBRATION_POWER;
+            const float real_velocity = move_power / inertia;
+            const float velocity = real_velocity > ExplosionConstants::FLING_THRESHOLD ?
+                                   rng_float( ExplosionConstants::FLING_THRESHOLD, ExplosionConstants::FLING_MAX_RANGE ) :
+                                   real_velocity;
+
+            if( velocity >= 1.0 ) {
+                if( player_ptr != nullptr ) {
+                    player_flung = std::make_optional( player_ptr );
+                }
+
+                add_event( one_tile_at_vel( velocity ),
+                           ExplosionEvent::mob_movement(
+                               position, critter,
+                               generate_fling_angle( center, position ), velocity, cur_time
+                           )
+                         );
+                flung_set.insert( critter );
+            }
+        }
+    }
+
+    {
+        // This reduces the randomness factor in terrain bash significantly
+        // Which makes explosions have a more well-defined shape.
+        const float offset_distance = std::max( rl_distance - 1.0, 0.0 );
+        const float terrain_random_factor = rng_float( 0.0, ExplosionConstants::BASH_RANDOM_FACTOR );
+        const float terrain_factor = std::min( std::max( offset_distance / blast_radius -
+                                               terrain_random_factor, 0.0f ), 1.0f );
+        float terrain_blast_force = blast_power * obstacle_blast_percentage( blast_radius, rl_distance );
+
+        // Multibash is done by bashing the tile with decaying force.
+        // The reason for this existing is because a number of tiles undergo multiple bashed states
+        // Things like doors and wall -> floor -> ground.
+
+        const float blast_force_decay = ( ExplosionConstants::VEHICLE_DAMAGE_MULT - 1.0 ) *
+                                        blast_power / ExplosionConstants::MULTIBASH_COUNT;
+        assert( blast_force_decay > 0 );
+        while( terrain_blast_force > 0 ) {
+            bash_params bash{
+                static_cast<int>( terrain_blast_force ),
+                true,
+                false,
+                here.passable( position + tripoint_below ),
+                terrain_factor,
+                center.z > position.z,
+                true
+            };
+            // Despite what you might expect, this is NOT the same as smash_items
+            here.bash_items( position, bash );
+            here.bash_field( position, bash );
+            here.bash_vehicle( position, bash );
+            here.bash_ter_furn( position, bash );
+            terrain_blast_force -= blast_force_decay;
+        }
+    }
+
+    {
+        // Split items here into stacks
+        std::vector<item> stacks;
+
+        for( auto &it : here.i_at( position ) ) {
+            while( true ) {
+                const int amt = it.count();
+                const int split_cnt = rng( 1, amt - 1 );
+                const bool is_final = amt <= 1;
+
+                // If the item is already propelled, ignore it
+                if( !is_final && !it.has_flag( "EXPLOSION_PROPELLED" ) ) {
+                    stacks.push_back( it.split( split_cnt ) );
+                } else {
+                    stacks.push_back( item( it ) );
+                    break;
+                }
+            }
+        }
+        here.i_clear( position );
+
+        for( const auto &it : stacks ) {
+            here.add_item( position, it );
+        }
+        recombination_targets.push_back( position );
+    }
+
+    // Now give items velocity
+    for( auto &it : here.i_at( position ) ) {
+        // If the item is already propelled, ignore it
+        if( it.has_flag( "EXPLOSION_PROPELLED" ) ) {
+            continue;
+        };
+
+        const float random_factor = rng_float( -ExplosionConstants::ITEM_FLING_RANDOM_FACTOR,
+                                               ExplosionConstants::ITEM_FLING_RANDOM_FACTOR );
+        const float push_strength = std::max( blast_radius - rl_distance + random_factor,
+                                              0.0f ) * blast_power;
+        const float move_power = ExplosionConstants::ITEM_FLING_FACTOR * push_strength;
+
+        const int weight = to_gram( it.weight() );
+        const float inertia = std::max( weight, 1 ) * ExplosionConstants::EXPLOSION_CALIBRATION_POWER;
+        const float real_velocity = move_power / inertia;
+        const float velocity = real_velocity > ExplosionConstants::FLING_THRESHOLD ?
+                               rng_float( ExplosionConstants::FLING_THRESHOLD, ExplosionConstants::FLING_MAX_RANGE ) :
+                               real_velocity;
+
+        if( velocity < 1.0 ) {
+            continue;
+        }
+
+        it.set_flag( "EXPLOSION_PROPELLED" );
+
+        add_event(
+            one_tile_at_vel( velocity ),
+            ExplosionEvent::item_movement(
+                position, it.get_safe_reference(),
+                generate_fling_angle( center, position ), velocity, cur_time )
+        );
+    }
+
+    // Finally, add fields if we can
+    if( here.passable( position ) ) {
+        const float radius_percent = static_cast<float>( rl_distance ) / blast_radius;
+        // Create fresh smoke
+        // 50% of the radius is guaranteed to be covered in thin smoke afterwards
+        if( here.get_field( position, fd_smoke ) == nullptr ) {
+            const float radius_offset = 2 * radius_percent - 1;
+            add_event( 0, ExplosionEvent::field_addition( position, fd_smoke ) );
+            if( radius_offset > 0 ) {
+                const int delay = static_cast<int>( blast_radius * radius_step_delay *
+                                                    rng_float( 0.0, 1.1 - radius_offset ) );
+                add_event( delay, ExplosionEvent::field_removal( position, fd_smoke ) );
+            }
+        }
+
+        // Create fresh fire fields
+        if( here.get_field( position, fd_fire ) == nullptr ) {
+            add_event(
+                radius_step_delay,
+                ExplosionEvent::field_addition( position, fd_fire,
+                                                1 + ( blast_power > 10 ) + ( blast_power > 30 ),
+                                                is_fiery
+                                              )
+            );
+            if( !is_fiery ) {
+                // Remove at an accelerating pace
+                const int delay = static_cast<int>( rng_float( 2.0, 4.0 ) *
+                                                    radius_step_delay * ( 1.1 - radius_percent ) );
+                add_event( delay + radius_step_delay, ExplosionEvent::field_removal( position, fd_fire ) );
+            }
+        }
+    }
+    request_redraw |= position.z == g->u.posz();
+};
+
+void ExplosionProcess::add_field( const tripoint position,
+                                  const field_type_id field,
+                                  const int intensity,
+                                  const bool hit_player )
+{
+    map &here = get_map();
+    here.add_field( position, field, intensity, 0_turns, hit_player );
+    request_redraw |= position.z == g->u.posz();
+};
+
+void ExplosionProcess::remove_field( const tripoint position, field_type_id target )
+{
+    map &here = get_map();
+    here.remove_field( position, target );
+    request_redraw |= position.z == g->u.posz();
+};
+
+void ExplosionProcess::move_entity( const tripoint position,
+                                    const ExplosionEvent::PropelledEntity &datum,
+                                    const bool is_mob )
+{
+    if( datum.velocity < 1 ) {
+        return;
+    }
+
+    std::variant<Creature *, safe_reference<item>> cur_target = datum.target;
+
+    if( !is_mob && !std::get<safe_reference<item>>( cur_target ) ) {
+        return;
+    }
+
+    map &here = get_map();
+
+
+    const int time_delta = cur_time - datum.cur_time;
+    const float distance_to_travel = std::min(
+                                         datum.velocity * time_delta / radius_step_delay,
+                                         datum.velocity
+                                     );
+
+    tripoint new_position = position;
+    float new_velocity = datum.velocity;
+    float new_angle = datum.angle;
+
+    // Sometimes items fly more than one tile at once
+    //   so we want to make sure we do not hit any obstacles on the way
+    // Hence this complication
+    {
+        const int intermediate_steps = ceil( 1.5 * distance_to_travel );
+
+        for( int step = 0; step <= intermediate_steps; step++ ) {
+            const float progress = static_cast<float>( step ) / static_cast<float>( intermediate_steps );
+            const float cur_distance_travelled = distance_to_travel * progress;
+            rl_vec2d new_position_vec = datum.position +
+                                        rl_vec2d( cur_distance_travelled, 0.0 ).rotated( datum.angle );
+            tripoint maybe_new_position = tripoint( static_cast<int>( new_position_vec.x ),
+                                                    static_cast<int>( new_position_vec.y ),
+                                                    position.z );
+            if( !here.inbounds( maybe_new_position ) ||
+                here.impassable( maybe_new_position ) ||
+                ( is_mob && maybe_new_position != position && g->critter_at( maybe_new_position ) ) ||
+                here.obstructed_by_vehicle_rotation( position, maybe_new_position ) ) {
+                // TODO: Bash the obstacle with whatever is flung?
+
+                new_angle += M_PI;
+                new_velocity = datum.velocity - cur_distance_travelled;
+                new_velocity *= ExplosionConstants::RESTITUTION_COEFF;
+                break;
+            }
+            new_position = maybe_new_position;
+            new_velocity = datum.velocity - cur_distance_travelled;
+        }
+    }
+
+    bool do_next = new_velocity >= 1;
+
+    if( new_position != position ) {
+        if( is_mob ) {
+            std::get<Creature *>( cur_target )->setpos( new_position );
+        } else {
+            item *target = std::get<safe_reference<item>>( cur_target ).get();
+            item copy = *target;
+
+            if( !copy.is_null() ) {
+                here.i_rem( position, target );
+
+                item *new_item = &here.add_item( new_position, copy );
+                recombination_targets.push_back( position );
+                recombination_targets.push_back( new_position );
+
+                // add_item may in fact change the item in a number of ways
+                //   so we _have_ to check if it's in the location we expect
+                // It's slow, but what can you do?
+                new_item->set_flag( "IS_EXPLOSION_PROPELLED" );
+                bool is_safe = false;
+                for( auto &it : here.i_at( new_position ) ) {
+                    if( it.has_flag( "IS_EXPLOSION_PROPELLED" ) ) {
+                        is_safe = true;
+                        break;
+                    }
+                }
+                new_item->unset_flag( "IS_EXPLOSION_PROPELLED" );
+                if( !is_safe ) {
+                    do_next = false;
+                } else {
+                    cur_target = new_item->get_safe_reference();
+                }
+            }
+        }
+        request_redraw |= position.z == g->u.posz();
+        request_redraw |= new_position.z == g->u.posz();
+    }
+
+    if( do_next ) {
+        add_event(
+            one_tile_at_vel( new_velocity ),
+            is_mob ?
+            ExplosionEvent::mob_movement( new_position,
+                                          std::get<Creature *>( cur_target ), new_angle, new_velocity, cur_time ) :
+            ExplosionEvent::item_movement( new_position,
+                                           std::get<safe_reference<item>>( cur_target ), new_angle, new_velocity, cur_time )
+        );
+    }
+};
+
+void ExplosionProcess::run()
+{
+    fill_maps();
+    init_event_queue();
+
+    // We need to temporary disable it because
+    //   larger explosions may end up filling
+    //   the texture pool, causing a crash
+    bool disable_minimap = !test_mode && pixel_minimap_option;
+    if( disable_minimap ) {
+        g->toggle_pixel_minimap();
+    }
+
+    map &here = get_map();
+    while( process_next() ) {
+        // No need to redraw in testing mode
+        if( !test_mode && request_redraw ) {
+            ui_manager::redraw();
+            refresh_display();
+            request_redraw = false;
+        }
+    };
+
+    // Reenable disabled options
+    if( disable_minimap ) {
+        g->toggle_pixel_minimap();
+    }
+
+    // Remove temporary flags
+    for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+        for( const auto &pos : here.points_on_zlevel( z ) ) {
+            for( auto &it : here.i_at( pos ) ) {
+                it.unset_flag( "EXPLOSION_SMASHED" );
+                it.unset_flag( "EXPLOSION_PROPELLED" );
+            }
+        }
+    }
+
+    // Make sure the map is centered around the player
+    if( player_flung.has_value() ) {
+        g->update_map( *player_flung.value() );
+    }
+
+    // Finally, recombine thrown items into full stacks again
+    std::sort( recombination_targets.begin(), recombination_targets.end() );
+    auto end = std::unique( recombination_targets.begin(), recombination_targets.end() );
+    recombination_targets.erase( end, recombination_targets.end() );
+
+    for( const auto &position : recombination_targets ) {
+        std::vector<item> storage;
+        for( item &it : here.i_at( position ) ) {
+            storage.push_back( it );
+        }
+        here.i_clear( position );
+        for( item &it : storage ) {
+            here.add_item_or_charges( position, it );
+        }
+    }
+}
+
+void explosion( const tripoint &p, Creature *source, float power, float factor, bool fire,
+                int legacy_casing_mass,
+                float )
+{
+    if( factor >= 1.0f ) {
+        debugmsg( "called game::explosion with factor >= 1.0 (infinite size)" );
+    }
+    explosion_data data;
+    data.damage = power * explosion_handler::power_to_dmg_mult;
+    data.radius = explosion_handler::blast_radius_from_legacy( power, factor );
+    data.fire = fire;
+    if( legacy_casing_mass > 0 ) {
+        data.fragment = explosion_handler::shrapnel_from_legacy( power, data.radius );
+    }
+    explosion( p, data, source );
+}
+
+void explosion( const tripoint &p, const explosion_data &ex, Creature *source )
+{
+    queued_explosion qe( p, ExplosionType::Regular, source );
+    qe.exp_data = ex;
+    get_explosion_queue().add( std::move( qe ) );
+}
+
+static std::map<const Creature *, int> legacy_shrapnel( const tripoint &src,
+        const projectile &fragment,
+        Creature *source )
+{
+    std::map<const Creature *, int> damaged;
+
+    projectile proj = fragment;
+    proj.add_effect( ammo_effect_NULL_SOURCE );
+
+    float obstacle_cache[MAPSIZE_X][MAPSIZE_Y] = {};
+    float visited_cache[MAPSIZE_X][MAPSIZE_Y] = {};
+
+    map &here = get_map();
+
+    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = here.access_cache(
+                src.z ).vehicle_obstructed_cache;
+
+    // TODO: Calculate range based on max effective range for projectiles.
+    // Basically bisect between 0 and map diameter using shrapnel_calc().
+    // Need to update shadowcasting to support limiting range without adjusting initial distance.
+    const tripoint_range<tripoint> area = here.points_on_zlevel( src.z );
+
+    here.build_obstacle_cache( area.min(), area.max() + tripoint_south_east, obstacle_cache );
+
+    // Shadowcasting normally ignores the origin square,
+    // so apply it manually to catch monsters standing on the explosive.
+    // This "blocks" some fragments, but does not apply deceleration.
+    visited_cache[src.x][src.y] = 1.0f;
+
+    // This is used to limit radius
+    // By default, the radius is 60, so negative values can be helpful here
+    const int offset_distance = 60 - 1 - fragment.range;
+    castLightAll<float, float, shrapnel_calc, shrapnel_check,
+                 update_fragment_cloud, accumulate_fragment_cloud>
+                 ( visited_cache, obstacle_cache, blocked_cache, src.xy(),
+                   offset_distance, fragment.range + 1.0f );
+
+    // Now visited_caches are populated with density and velocity of fragments.
+    for( const tripoint &target : area ) {
+        if( visited_cache[target.x][target.y] <= 0.0f || rl_dist( src, target ) > fragment.range ) {
+            continue;
+        }
+        auto critter = g->critter_at( target );
+        if( critter && !critter->is_dead_state() ) {
+            // dealt_dag->m.total_damage() == 0 means armor block
+            // dealt_dag->m.total_damage() > 0 means took damage
+            // Need to diffentiate target among player, npc, and monster
+            int damage_taken = 0;
+            auto bps = critter->get_all_body_parts( true );
+            // Humans get hit in all body parts
+            if( critter->is_player() ) {
+                for( bodypart_id bp : bps ) {
+                    // TODO: This shouldn't be needed, get_bps should do it
+                    if( Character::bp_to_hp( bp->token ) == num_hp_parts ) {
+                        continue;
+                    }
+                    // TODO: Apply projectile effects
+                    // TODO: Penalize low coverage armor
+                    // Halve damage to be closer to what monsters take
+                    damage_instance half_impact = proj.impact;
+                    half_impact.mult_damage( 0.5f );
+                    dealt_damage_instance dealt = critter->deal_damage( source, bp, proj.impact );
+                    if( dealt.total_damage() > 0 ) {
+                        damage_taken += dealt.total_damage();
+                    }
+                }
+            } else {
+                dealt_damage_instance dealt = critter->deal_damage( source, bps[0], proj.impact );
+                if( dealt.total_damage() > 0 ) {
+                    damage_taken += dealt.total_damage();
+                }
+            }
+            damaged[critter] = damage_taken;
+        }
+        if( here.impassable( target ) ) {
+            int damage = proj.impact.total_damage();
+            if( optional_vpart_position vp = here.veh_at( target ) ) {
+                vp->vehicle().damage( vp->part_index(), damage / 100 );
+            } else {
+                here.bash( target, damage / 100, true );
+            }
+        }
+    }
+
+    const tripoint &blast_center = src;
+    const float raw_blast_radius = fragment.range;
+
+    using dist_point_pair = std::pair<float, tripoint>;
+    const int Z_LEVEL_DIST = 4;
+
+    const int z_levels_affected = raw_blast_radius / Z_LEVEL_DIST;
+    const tripoint_range<tripoint> affected_block(
+        blast_center + tripoint( -raw_blast_radius, -raw_blast_radius, -z_levels_affected ),
+        blast_center + tripoint( raw_blast_radius, raw_blast_radius, z_levels_affected )
+    );
+
+    static std::vector<dist_point_pair> blast_map( MAPSIZE_X * MAPSIZE_Y );
+    static std::map<tripoint, nc_color> explosion_colors;
+    blast_map.clear();
+    explosion_colors.clear();
+
+    for( const tripoint &target : affected_block ) {
+        if( !get_map().inbounds( target ) ) {
+            continue;
+        }
+
+        // Uses this ternany check instead of rl_dist because it converts trig_dist's distance to int implicitly
+        const float distance = (
+                                   trigdist ?
+                                   trig_dist( blast_center, target ) :
+                                   square_dist( blast_center, target )
+                               );
+        const float z_distance = abs( target.z - blast_center.z );
+        const float z_aware_distance = distance + ( Z_LEVEL_DIST - 1 ) * z_distance;
+        if( z_aware_distance <= raw_blast_radius ) {
+            blast_map.emplace_back( std::make_pair( z_aware_distance, target ) );
+        }
+    }
+
+    std::stable_sort( blast_map.begin(), blast_map.end(), []( dist_point_pair pair1,
+    dist_point_pair pair2 ) {
+        return pair1.first < pair2.first;
+    } );
+
+    int animated_explosion_range = 0.0f;
+    std::map<const Creature *, int> blasted;
+
+    int i = 0;
+    for( const dist_point_pair &pair : blast_map ) {
+        float distance;
+        tripoint position;
+        tripoint last_position = blast_center;
+        std::tie( distance, position ) = pair;
+
+        const std::vector<tripoint> line_of_movement = line_to( blast_center, position );
+        const bool has_obstacles = std::any_of( line_of_movement.begin(),
+        line_of_movement.end(), [position, &last_position]( tripoint ray_position ) {
+            if( get_map().obstructed_by_vehicle_rotation( last_position, ray_position ) ) {
+                return true;
+            }
+            last_position = ray_position;
+            return ray_position != position && get_map().impassable( ray_position );
+        } );
+
+        // Don't bother animating explosions that are on other levels
+        const bool to_animate = get_player_character().posz() == position.z;
+
+        // Animate the explosion by drawing the shock wave rather than the whole explosion
+        if( to_animate && distance > animated_explosion_range ) {
+            // Draw only 1/2 rings to speed up the animation
+            if( i % 2 == 0 ) {
+                draw_custom_explosion( blast_center, explosion_colors, "fd_smoke" );
+            }
+            i++;
+            explosion_colors.clear();
+            animated_explosion_range++;
+        }
+
+        if( has_obstacles ) {
+            continue;
+        }
+
+        if( to_animate ) {
+            explosion_colors[position] = c_white;
+        }
+    }
+    // Final blast wave points
+    draw_custom_explosion( blast_center, explosion_colors, "fd_smoke" );
+    // END DRAWING EXPLOSION
+
+    return damaged;
+}
+
 // (C1001) Compiler Internal Error on Visual Studio 2015 with Update 2
-static std::map<const Creature *, int> do_blast( const tripoint &p, const float power,
+static std::map<const Creature *, int> legacy_blast( const tripoint &p, const float power,
         const float radius, const bool fire, Creature *source )
 {
+    std::map<const Creature *, int> blasted;
+
+    if( radius <= 0.0f ) {
+        return blasted; // Just return an empty one
+    }
+
     const float tile_dist = 1.0f;
     const float diag_dist = trigdist ? M_SQRT2 * tile_dist : 1.0f * tile_dist;
     const float zlev_dist = 4.0f; // Penalty for going up/down
@@ -172,8 +1254,6 @@ static std::map<const Creature *, int> do_blast( const tripoint &p, const float 
     static const int z_offset[10] = { 0, 0,  0, 0,  0,  0,  0, 0, 1, -1 };
     map &here = get_map();
     const size_t max_index = here.has_zlevels() ? 10 : 8;
-
-    std::map<const Creature *, int> blasted;
 
     here.bash( p, fire ? power : ( 2 * power ), true, false, false );
 
@@ -342,470 +1422,6 @@ static std::map<const Creature *, int> do_blast( const tripoint &p, const float 
     return blasted;
 }
 
-static std::map<const Creature *, int> do_blast_new( const tripoint &blast_center,
-        const float raw_blast_force,
-        const float raw_blast_radius, Creature *source )
-{
-    /*
-    Explosions are completed in 3 stages.
-
-    1. Shrapnel
-    The very first component: shrapnel is thrown all around.
-    Impassable terrain around has not yet been broken down by the blast, so it will shield mobs.
-
-    2. Blast wave
-    This propagates the explosion outwards and:
-        1. Damage all items in the tile. Done first to prevent loot from being destroyed too much.
-        2. Bashes critters (unless they had already been bashed before) in the tile.
-        The main bulk of damage is inflicted here.
-        3. Flings still alive critters.
-        This causes some extra damage depending on how the explosion is set up and may fling the same mob several times.
-        This is effective inside buildings since this causes the mobs to be thrown against walls.
-        4. Bashes terrain (and vehicles).
-        All vehicle parts in the tile are bashed 2 times at full force,
-        both to compensate for their tankiness and to make sure they get actually destroyed.
-        Terrain is destroyed in a consistent manner.
-    */
-    using dist_point_pair = std::pair<float, tripoint>;
-
-    // TODO: Move the consts outside the function and make static when this information becomes needed for UI
-
-    // Distance between z-levels
-    const int Z_LEVEL_DIST = 4;
-
-    // Since terrain is bashed multiple times, the blast power needs to dissipate with each blast.
-    // This factor determines by how much it is dissipated (thus determining multibash amt).
-    const float TERRAIN_DISSIPATION_FACTOR = 0.15;
-
-    // Terrain bashing uses relative distance from the epicenter to determine the force needed to break down a piece of furniture
-    // By default this makes explosives predictable. To counteract it, a small random value is added
-    // to add slightly more jaggedness. This factor determines the maximum value added.
-    const float TERRAIN_RANDOM_FACTOR = 0.1;
-
-    // Flinging creatures uses a different scale to determine its damage and range.
-    // More specifically, FLING_POWER_FACTOR * FORCE * RADIUS determines the weight
-    // in grams that a fling will move by one tile. Half of the weight will move 2 tiles and so on...
-
-    // Calibrated to this value as regular zombies weigh 40750 grams and we want to throw them a bit more than one radius away per 100 blast damage.
-    // With 100 blast damage coming from baseline dynamite explosion.
-    const float FLING_POWER_FACTOR = 420.0;
-
-    // Flinging light creatures causes them to fly the entire reality and inflicts insane damage
-    // This constant limits the maximum fling distance (and indirectly damage) to FLING_HARD_CAP * BLAST RADIUS.
-    const float FLING_HARD_CAP = 2.0;
-
-    const int z_levels_affected = raw_blast_radius / Z_LEVEL_DIST;
-    const tripoint_range<tripoint> affected_block(
-        blast_center + tripoint( -raw_blast_radius, -raw_blast_radius, -z_levels_affected ),
-        blast_center + tripoint( raw_blast_radius, raw_blast_radius, z_levels_affected )
-    );
-
-    static std::vector<dist_point_pair> blast_map( MAPSIZE_X * MAPSIZE_Y );
-    static std::map<tripoint, bool> blast_shield_map;
-    static std::map<tripoint, nc_color> explosion_colors;
-    blast_map.clear();
-    explosion_colors.clear();
-    blast_shield_map.clear();
-
-    for( const tripoint &target : affected_block ) {
-        if( !get_map().inbounds( target ) ) {
-            continue;
-        }
-
-        // Uses this ternany check instead of rl_dist because it converts trig_dist's distance to int implicitly
-        const float distance = (
-                                   trigdist ?
-                                   trig_dist( blast_center, target ) :
-                                   square_dist( blast_center, target )
-                               );
-        const float z_distance = abs( target.z - blast_center.z );
-        const float z_aware_distance = distance + ( Z_LEVEL_DIST - 1 ) * z_distance;
-        if( z_aware_distance <= raw_blast_radius ) {
-            blast_map.emplace_back( std::make_pair( z_aware_distance, target ) );
-        }
-    }
-
-    std::stable_sort( blast_map.begin(), blast_map.end(), []( dist_point_pair pair1,
-    dist_point_pair pair2 ) {
-        return pair1.first <= pair2.first;
-    } );
-
-
-    int animated_explosion_range = 0.0f;
-    std::map<const Creature *, int> blasted;
-    std::set<const Creature *> already_flung;
-    player *player_flung = nullptr;
-
-    for( const dist_point_pair &pair : blast_map ) {
-        float distance;
-        tripoint position;
-        tripoint last_position = blast_center;
-        std::tie( distance, position ) = pair;
-
-        const std::vector<tripoint> line_of_movement = line_to( blast_center, position );
-        const bool has_obstacles = std::any_of( line_of_movement.begin(),
-        line_of_movement.end(), [position, &last_position]( tripoint ray_position ) {
-            if( get_map().obstructed_by_vehicle_rotation( last_position, ray_position ) ) {
-                return true;
-            }
-            last_position = ray_position;
-            return ray_position != position && get_map().impassable( ray_position );
-        } );
-
-        // Don't bother animating explosions that are on other levels
-        const bool to_animate = get_player_character().posz() == position.z;
-
-        // Animate the explosion by drawing the shock wave rather than the whole explosion
-        if( to_animate && distance > animated_explosion_range ) {
-            draw_custom_explosion( blast_center, explosion_colors, "explosion" );
-            explosion_colors.clear();
-            animated_explosion_range++;
-        }
-
-        if( has_obstacles ) {
-            continue;
-        }
-
-        if( to_animate ) {
-            explosion_colors[position] = c_white;
-        }
-
-        // Item damage comes first in order to prevent dropped loot from being destroyed immediately.
-        const int smash_force = raw_blast_force * item_blast_percentage( raw_blast_radius, distance );
-        get_map().smash_items( position, smash_force, _( "force of the explosion" ), true );
-
-        // Critter damage occurs next to reduce the amount of flung enemies, leading to much less predictable damage output
-        if( Creature *critter = g->critter_at( position, true ) ) {
-            if( blasted.count( critter ) ) {
-                // Prevent multibashes to monsters due to flinging.
-                continue;
-            }
-
-            const int blast_force = raw_blast_force * critter_blast_percentage( critter, raw_blast_radius,
-                                    distance );
-            const auto shockwave_dmg = damage_instance::physical( blast_force, 0, 0, 0.4f );
-
-            if( player *player_ptr = dynamic_cast<player *>( critter ) ) {
-                player_ptr->add_msg_if_player( m_bad, _( "You're caught in the explosion!" ) );
-
-                struct blastable_part {
-                    bodypart_id bp;
-                    float low_mul;
-                    float high_mul;
-                    float armor_mul;
-                };
-
-                static const std::array<blastable_part, 6> blast_parts = { {
-                        { bodypart_id( "torso" ), 0.5f, 1.0f, 0.5f },
-                        { bodypart_id( "head" ),  0.5f, 1.0f, 0.5f },
-                        // Hit limbs harder so that it hurts more without being much more deadly
-                        { bodypart_id( "leg_l" ), 0.75f, 1.25f, 0.4f },
-                        { bodypart_id( "leg_r" ), 0.75f, 1.25f, 0.4f },
-                        { bodypart_id( "arm_l" ), 0.75f, 1.25f, 0.4f },
-                        { bodypart_id( "arm_r" ), 0.75f, 1.25f, 0.4f },
-                    }
-                };
-
-                for( const auto &blast_part : blast_parts ) {
-                    const int part_dam = rng( blast_force * blast_part.low_mul, blast_force * blast_part.high_mul );
-                    const std::string hit_part_name = body_part_name_accusative( blast_part.bp->token );
-                    const auto dmg_instance = damage_instance( DT_BASH, part_dam, 0, blast_part.armor_mul );
-                    const auto result = player_ptr->deal_damage( source, blast_part.bp, dmg_instance );
-                    const int res_dmg = result.total_damage();
-
-                    if( res_dmg > 0 ) {
-                        blasted[critter] += res_dmg;
-                    }
-                }
-            } else {
-                critter->deal_damage( source, bodypart_id( "torso" ), shockwave_dmg );
-                critter->check_dead_state();
-                blasted[critter] = blast_force;
-            }
-        }
-
-        // rng_float is needed to make sure critters at the center get thrown in a random direction.
-        units::angle angle = units::atan2( position.y - blast_center.y + rng_float( -0.5f, 0.5f ),
-                                           position.x - blast_center.x + rng_float( -0.5f, 0.5f ) );
-
-        // How many grams can the blast fling 1 tile away?
-        // Multiplied by ten because this is coupled with fling_creature
-        const float move_power = 10 * FLING_POWER_FACTOR * ( raw_blast_radius - distance ) *
-                                 raw_blast_force;
-
-        if( Creature *critter = g->critter_at( position, true ) ) {
-            if( !already_flung.count( critter ) ) {
-                player *pl = dynamic_cast<player *>( critter );
-
-                const int weight = to_gram( critter->get_weight() );
-                const int fling_vel = std::min( move_power / std::max( weight, 1 ),
-                                                10 * FLING_HARD_CAP * raw_blast_radius );
-
-                if( pl == nullptr ) {
-                    g->fling_creature( critter, angle, fling_vel );
-                } else {
-                    player_flung = pl;
-                    g->fling_creature( pl, angle, fling_vel, false, true );
-                }
-                // Prevent multiflings
-                already_flung.insert( critter );
-            }
-        }
-
-        // Terrain bashes occur last to ensure enemies being bashed against walls if flung.
-
-        // This reduces the randomness factor in terrain bash significantly
-        // Which makes explosions have a more well-defined shape.
-        const float terrain_factor = std::max( distance - 1.0, 0.0 ) / raw_blast_radius + rng_float( 0.0,
-                                     TERRAIN_RANDOM_FACTOR );
-        const int terrain_blast_force = raw_blast_force * obstacle_blast_percentage( raw_blast_radius,
-                                        distance );
-
-        bash_params shockwave_bash{
-            terrain_blast_force,
-            false, // Bashing down terrain should not be silent
-            false,
-            !get_map().impassable( position + tripoint_below ), // We will only try to break the floor down if there is nothing underneath
-            terrain_factor,
-            blast_center.z > position.z
-        };
-
-        if( const optional_vpart_position &vp = get_map().veh_at( position ) ) {
-            // HP values of vehicle parts aren't really on the same scale
-
-            // Would be better if explosives had a separate damage value for vehicle parts
-            // But for now, this will suffice.
-
-            vehicle &veh_ptr = vp->vehicle();
-
-            const std::vector<int> &affected_part_nums = veh_ptr.parts_at_relative( vp->mount(), false );
-
-            for( const auto part_indx : affected_part_nums ) {
-                // Double bash to bypass XX state if possible.
-                veh_ptr.damage( part_indx, shockwave_bash.strength, DT_BASH, true );
-                veh_ptr.damage( part_indx, shockwave_bash.strength, DT_BASH, true );
-            }
-        } else {
-            // Multibash is done by bashing the tile with decaying force.
-            // The reason for this existing is because a number of tiles undergo multiple bashed states
-            // Things like doors and wall -> floor -> ground.
-            while( shockwave_bash.strength > 0 ) {
-                get_map().bash_ter_furn( position, shockwave_bash );
-                shockwave_bash.strength = std::max( static_cast<int>( shockwave_bash.strength -
-                                                    TERRAIN_DISSIPATION_FACTOR * raw_blast_force ), 0 );
-            }
-        }
-    }
-
-    // Final blast wave points
-    draw_custom_explosion( blast_center, explosion_colors, "explosion" );
-
-    if( player_flung ) {
-        g->update_map( *player_flung );
-    }
-
-    return blasted;
-}
-
-
-static std::map<const Creature *, int> shrapnel( const tripoint &src, const projectile &fragment,
-        Creature *source )
-{
-    std::map<const Creature *, int> damaged;
-
-    projectile proj = fragment;
-    proj.add_effect( ammo_effect_NULL_SOURCE );
-
-    float obstacle_cache[MAPSIZE_X][MAPSIZE_Y] = {};
-    float visited_cache[MAPSIZE_X][MAPSIZE_Y] = {};
-
-    map &here = get_map();
-
-    diagonal_blocks( &blocked_cache )[MAPSIZE_X][MAPSIZE_Y] = here.access_cache(
-                src.z ).vehicle_obstructed_cache;
-
-    // TODO: Calculate range based on max effective range for projectiles.
-    // Basically bisect between 0 and map diameter using shrapnel_calc().
-    // Need to update shadowcasting to support limiting range without adjusting initial distance.
-    const tripoint_range<tripoint> area = here.points_on_zlevel( src.z );
-
-    here.build_obstacle_cache( area.min(), area.max() + tripoint_south_east, obstacle_cache );
-
-    // Shadowcasting normally ignores the origin square,
-    // so apply it manually to catch monsters standing on the explosive.
-    // This "blocks" some fragments, but does not apply deceleration.
-    visited_cache[src.x][src.y] = 1.0f;
-
-    // This is used to limit radius
-    // By default, the radius is 60, so negative values can be helpful here
-    const int offset_distance = 60 - 1 - fragment.range;
-    castLightAll<float, float, shrapnel_calc, shrapnel_check,
-                 update_fragment_cloud, accumulate_fragment_cloud>
-                 ( visited_cache, obstacle_cache, blocked_cache, src.xy(),
-                   offset_distance, fragment.range + 1.0f );
-
-    // Now visited_caches are populated with density and velocity of fragments.
-    for( const tripoint &target : area ) {
-        if( visited_cache[target.x][target.y] <= 0.0f || rl_dist( src, target ) > fragment.range ) {
-            continue;
-        }
-        auto critter = g->critter_at( target );
-        if( critter && !critter->is_dead_state() ) {
-            // dealt_dag->m.total_damage() == 0 means armor block
-            // dealt_dag->m.total_damage() > 0 means took damage
-            // Need to diffentiate target among player, npc, and monster
-            int damage_taken = 0;
-            auto bps = critter->get_all_body_parts( true );
-            // Humans get hit in all body parts
-            if( critter->is_player() ) {
-                for( bodypart_id bp : bps ) {
-                    // TODO: This shouldn't be needed, get_bps should do it
-                    if( Character::bp_to_hp( bp->token ) == num_hp_parts ) {
-                        continue;
-                    }
-                    // TODO: Apply projectile effects
-                    // TODO: Penalize low coverage armor
-                    // Halve damage to be closer to what monsters take
-                    damage_instance half_impact = proj.impact;
-                    half_impact.mult_damage( 0.5f );
-                    dealt_damage_instance dealt = critter->deal_damage( source, bp, proj.impact );
-                    if( dealt.total_damage() > 0 ) {
-                        damage_taken += dealt.total_damage();
-                    }
-                }
-            } else {
-                dealt_damage_instance dealt = critter->deal_damage( source, bps[0], proj.impact );
-                if( dealt.total_damage() > 0 ) {
-                    damage_taken += dealt.total_damage();
-                }
-            }
-            damaged[critter] = damage_taken;
-        }
-        if( here.impassable( target ) ) {
-            int damage = proj.impact.total_damage();
-            if( optional_vpart_position vp = here.veh_at( target ) ) {
-                vp->vehicle().damage( vp->part_index(), damage / 100 );
-            } else {
-                here.bash( target, damage / 100, true );
-            }
-        }
-    }
-
-    // BEGIN DRAWING EXPLOSION
-    // Go see do_blast_new for detailled explanations
-    const tripoint &blast_center = src;
-    const float raw_blast_radius = fragment.range;
-
-    using dist_point_pair = std::pair<float, tripoint>;
-    const int Z_LEVEL_DIST = 4;
-
-    const int z_levels_affected = raw_blast_radius / Z_LEVEL_DIST;
-    const tripoint_range<tripoint> affected_block(
-        blast_center + tripoint( -raw_blast_radius, -raw_blast_radius, -z_levels_affected ),
-        blast_center + tripoint( raw_blast_radius, raw_blast_radius, z_levels_affected )
-    );
-
-    static std::vector<dist_point_pair> blast_map( MAPSIZE_X * MAPSIZE_Y );
-    static std::map<tripoint, nc_color> explosion_colors;
-    blast_map.clear();
-    explosion_colors.clear();
-
-    for( const tripoint &target : affected_block ) {
-        if( !get_map().inbounds( target ) ) {
-            continue;
-        }
-
-        // Uses this ternany check instead of rl_dist because it converts trig_dist's distance to int implicitly
-        const float distance = (
-                                   trigdist ?
-                                   trig_dist( blast_center, target ) :
-                                   square_dist( blast_center, target )
-                               );
-        const float z_distance = abs( target.z - blast_center.z );
-        const float z_aware_distance = distance + ( Z_LEVEL_DIST - 1 ) * z_distance;
-        if( z_aware_distance <= raw_blast_radius ) {
-            blast_map.emplace_back( std::make_pair( z_aware_distance, target ) );
-        }
-    }
-
-    std::stable_sort( blast_map.begin(), blast_map.end(), []( dist_point_pair pair1,
-    dist_point_pair pair2 ) {
-        return pair1.first < pair2.first;
-    } );
-
-    int animated_explosion_range = 0.0f;
-    std::map<const Creature *, int> blasted;
-
-    int i = 0;
-    for( const dist_point_pair &pair : blast_map ) {
-        float distance;
-        tripoint position;
-        tripoint last_position = blast_center;
-        std::tie( distance, position ) = pair;
-
-        const std::vector<tripoint> line_of_movement = line_to( blast_center, position );
-        const bool has_obstacles = std::any_of( line_of_movement.begin(),
-        line_of_movement.end(), [position, &last_position]( tripoint ray_position ) {
-            if( get_map().obstructed_by_vehicle_rotation( last_position, ray_position ) ) {
-                return true;
-            }
-            last_position = ray_position;
-            return ray_position != position && get_map().impassable( ray_position );
-        } );
-
-        // Don't bother animating explosions that are on other levels
-        const bool to_animate = get_player_character().posz() == position.z;
-
-        // Animate the explosion by drawing the shock wave rather than the whole explosion
-        if( to_animate && distance > animated_explosion_range ) {
-            // Draw only 1/2 rings to speed up the animation
-            if( i % 2 == 0 ) {
-                draw_custom_explosion( blast_center, explosion_colors, "fd_smoke" );
-            }
-            i++;
-            explosion_colors.clear();
-            animated_explosion_range++;
-        }
-
-        if( has_obstacles ) {
-            continue;
-        }
-
-        if( to_animate ) {
-            explosion_colors[position] = c_white;
-        }
-    }
-    // Final blast wave points
-    draw_custom_explosion( blast_center, explosion_colors, "fd_smoke" );
-    // END DRAWING EXPLOSION
-
-    return damaged;
-}
-
-void explosion( const tripoint &p, Creature *source, float power, float factor, bool fire,
-                int legacy_casing_mass,
-                float )
-{
-    if( factor >= 1.0f ) {
-        debugmsg( "called game::explosion with factor >= 1.0 (infinite size)" );
-    }
-    explosion_data data;
-    data.damage = power * explosion_handler::power_to_dmg_mult;
-    data.radius = explosion_handler::blast_radius_from_legacy( power, factor );
-    data.fire = fire;
-    if( legacy_casing_mass > 0 ) {
-        data.fragment = explosion_handler::shrapnel_from_legacy( power, data.radius );
-    }
-    explosion( p, data, source );
-}
-
-void explosion( const tripoint &p, const explosion_data &ex, Creature *source )
-{
-    queued_explosion qe( p, ExplosionType::Regular, source );
-    qe.exp_data = ex;
-    get_explosion_queue().add( std::move( qe ) );
-}
-
 void explosion_funcs::regular( const queued_explosion &qe )
 {
     const tripoint &p = qe.pos;
@@ -824,17 +1440,18 @@ void explosion_funcs::regular( const queued_explosion &qe )
 
     std::map<const Creature *, int> damaged_by_blast;
     std::map<const Creature *, int> damaged_by_shrapnel;
-    const auto &shr = ex.fragment;
-    if( shr ) {
-        damaged_by_shrapnel = shrapnel( p, shr.value(), qe.source );
-    }
+    auto &shr = ex.fragment;
 
-    if( ex.radius >= 0.0f && ex.damage > 0.0f ) {
-        if( get_option<bool>( "OLD_EXPLOSIONS" ) || ex.fire ) {
-            damaged_by_blast = do_blast( p, ex.damage, ex.radius, ex.fire, qe.source );
-        } else {
-            damaged_by_blast = do_blast_new( p, ex.damage, ex.radius, qe.source );
+    if( get_option<bool>( "OLD_EXPLOSIONS" ) ) {
+        if( shr ) {
+            damaged_by_shrapnel = legacy_shrapnel( p, shr.value(), qe.source );
         }
+        damaged_by_blast = legacy_blast( p, ex.damage, ex.radius, ex.fire, qe.source );
+    } else {
+        ExplosionProcess process( p, ex.damage, ex.radius, shr, ex.fire, std::make_optional( qe.source ) );
+        process.run();
+        damaged_by_blast = process.get_blasted();
+        damaged_by_shrapnel = process.get_shrapneled();
     }
 
     // Not the cleanest way to do it

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9724,8 +9724,7 @@ void game::on_options_changed()
     grid_tracker_ptr->on_options_changed();
 }
 
-void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bool controlled,
-                           bool suppress_map_update )
+void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bool controlled )
 {
     if( c == nullptr ) {
         debugmsg( "game::fling_creature invoked on null target" );
@@ -9829,7 +9828,7 @@ void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
                     m.unboard_vehicle( p->pos() );
                 }
                 // If we're flinging the player around, make sure the map stays centered on them.
-                if( is_u && !suppress_map_update ) {
+                if( is_u ) {
                     update_map( pt.x, pt.y );
                 } else {
                     p->setpos( pt );

--- a/src/game.h
+++ b/src/game.h
@@ -515,8 +515,7 @@ class game
         std::vector<monster *> get_fishable_monsters( std::unordered_set<tripoint> &fishable_locations );
 
         /** Flings the input creature in the given direction. */
-        void fling_creature( Creature *c, const units::angle &dir, float flvel, bool controlled = false,
-                             bool suppress_map_update = false );
+        void fling_creature( Creature *c, const units::angle &dir, float flvel, bool controlled = false );
 
         float natural_light_level( int zlev ) const;
         /** Returns coarse number-of-squares of visibility at the current light level.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3053,6 +3053,11 @@ void map::smash_items( const tripoint &p, const int power, const std::string &ca
     std::vector<item> contents;
     map_stack items = i_at( p );
     for( auto i = items.begin(); i != items.end(); ) {
+        if( i->has_flag( "EXPLOSION_SMASHED" ) ) {
+            i++;
+            continue;
+        }
+
         // If the power is low or it's not an explosion, only pulp rezing corpses
         if( ( power < min_destroy_threshold || !do_destroy ) && !i->can_revive() ) {
             i++;


### PR DESCRIPTION
#### Summary

SUMMARY: [Feature] "Explosions are made more spectacular; also make it possible to climb solid rock (thus craters too)"

#### Purpose of change
https://tvtropes.org/pmwiki/pmwiki.php/Main/ImpressivePyrotechnics

This is a further improvement to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1348, with the intention to both improve the appearance of explosions, make them have a bit more instrumental value and address a few issues that were reported.

#### Describe the solution
1. The whole explosion function is rewritten to now be a process with an event queue. Thanks to this, the explosion can animate itself. This addressed the growing complexity of "do_blast_new".
2. Shrapnel functionality is merged with the explosion process as just one of the events. This addresses the duplication of functionality that was necessary to animate the shrapnel.
3. Implement own ways to move entities around within the explosion process. This both removes the dependency on `fling_creature` method that has arcane things in it for mobs and implement a novel feature of items being thrown around as was suggested in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1348.
4. The explosion is now animated using fire and smoke fields and does in fact leave some smoke afterwards, but not too much. This addresses a reliance on arcane, almost magical `draw_custom_explosion` method which prevented animations from occurring at different speeds.
5. Constants rewritten a bit to be a bit more understandable in how they affect stuff. This addressed a few constants being hard to understand previously.
6. Terrain bashing functionality rewritten again to be a bit more straightforward.
7. Fire is now drawn OVER smoke. Was needed to make the explosion visible, but also incidentally makes an objectively more dangerous field visible to the player outside of explosions.
8. Solid rock and rock walls are now climbable. Addresses the issue of craters not being easily escapable.

#### Describe alternatives you've considered

N/A

#### Testing

Unaddressed issues/complaints.
1. Flung items deal no damage and flung creatures are dealt no damage. This is a a balancing nightmare, but a number of players have reported disappointment over the lack of damage from this and, honestly, it makes sense, for items to be thrown yet do nothing sorta removes a significant player-controlled way to inflict extra damage and set up impromptu shotguns with nails or something.
2. The animation method I use is done entirely within the process and I give no guarantees it doesn't fuck with some other internals. From my testing, only pixel minimap had a critical issue with texture pool so it's temporarily disabled.
3. I suck at C++ and I give no guarantees I didn't fuck up pointers and shit somewhere. Near a review from someone who knows what they're doing.
4. Shrapnel and blasts are hilariously more dangerous to the player than they are to mobs due to how the damage is inflicted, refer to BN's #development channel, search for "incomprehensibly more dangerous". This needs addressing in a separate PR.
5. Due to leaving traces of old system in, some duplicate code still remains.
6. Header files probably need updating.
7. I give no guarantees the old system and the new system produce equivalent damage.
8. Mininuke is still retarded due to using a separate system to place fd_nuke_gas. Improvement would probably be needed to ExplosionProcess to be able to place arbitrary gas.
9. Z-level vision does not get drawn consistently. Currently interrogating Jove about it.

#### Additional context
Barrel bomb (showcasing issue 9 and also that explosions do in fact get drawn on other Z-levels)
https://cdn.discordapp.com/attachments/830916451517857894/1097472879202947072/2023-04-17_15-44-23.mp4

Mininuke (showcasing issue 8)
https://cdn.discordapp.com/attachments/830916451517857894/1097472895485218886/2023-04-17_15-42-15.mp4