### PR TITLE
Update laser_items.json

### DIFF
--- a/data/mods/DinoMod/items/laser_items.json
+++ b/data/mods/DinoMod/items/laser_items.json
@@ -1,24 +1,5 @@
 [
   {
-    "id": "light_minus_battery_cell",
-    "type": "MAGAZINE",
-    "category": "battery",
-    "name": { "str": "ultra-light battery", "str_pl": "ultra-light batteries" },
-    "description": "This is a light battery cell designed for small size over everything else.  It retains its universal compatibility, though.",
-    "ascii_picture": "ultra_light_battery",
-    "weight": "5 g",
-    "volume": "1 ml",
-    "price": 1500,
-    "price_postapoc": 50,
-    "material": [ "iron", "plastic" ],
-    "symbol": "=",
-    "color": "yellow",
-    "ammo_type": [ "battery" ],
-    "capacity": 50,
-    "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "RECHARGE" ]
-  },
-  {
     "id": "laser_rifle_dino2",
     "type": "GUN",
     "symbol": "(",

--- a/data/mods/DinoMod/items/laser_items.json
+++ b/data/mods/DinoMod/items/laser_items.json
@@ -2,7 +2,7 @@
   {
     "id": "light_minus_battery_cell",
     "type": "MAGAZINE",
-    "category": "spare_parts",
+    "category": "battery",
     "name": { "str": "ultra-light battery", "str_pl": "ultra-light batteries" },
     "description": "This is a light battery cell designed for small size over everything else.  It retains its universal compatibility, though.",
     "ascii_picture": "ultra_light_battery",


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Ultra-light battery item recategorized from spare parts to battery."

#### Purpose of change

Fix#12345: Ultra-light batteries are included in Dinomod, but as spare parts rather than batteries. This change is to allow them to be correctly placed using autosort functions.

#### Describe the solution

I changed one line of code, specifically the "category" section of the "light_minus_battery_cell" item.

#### Describe alternatives you've considered

Because ultra-light batteries are now included in the base game for Bright Nights, we _could_ simply remove the item from Dinomod entirely.

#### Testing

It's a fairly simple edit, but I've personally tried it out to make sure the item works with the autosort function afterwards.
