### PR TITLE
Reimplement and rebalance post-apoc professions

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -172,6 +172,12 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "quiver_player_bandit",
+    "entries": [ { "item": "bolt_wood", "charges": 19 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "bandolier_roadwarrior",
     "entries": [ { "item": "shot_00", "charges": 18 } ]
   },
@@ -3241,7 +3247,7 @@
     "type": "profession",
     "id": "road_warrior",
     "name": "Road Warrior",
-    "description": "You lived by your wheels during the first few months of the apocalypse, now your custom ride is out of gas, your ammo is low, and your situation is dire.  You've been reduced to a scavenger, living off the corpse of the old world.",
+    "description": "You lived by your wheels during the first few months of the apocalypse, now you're running low on ammo and fuel, and your situation is dire.  You've been reduced to a scavenger, living off the corpse of the old world.",
     "points": 6,
     "vehicle": "car_roadwarrior",
     "skills": [
@@ -3332,6 +3338,58 @@
           { "item": "357mag_jhp", "charges": 29 },
           { "item": "light_battery_cell", "charges": 100, "container-item": "wearable_light" },
           { "item": "survivor_mess_kit", "charges": [ 20, 30 ] }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "sports_bra", "boy_shorts" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "id": "player_bandit",
+    "name": "Veteran Bandit",
+    "description": "After the cities exploded there was a whirlwind of looting; a firestorm of fear.  Men began to feed on men.  On the roads it was a white line nightmare.  Looting, killing, drug-running, one way or another you'll live and die on your bike.",
+    "points": 6,
+    "vehicle": "motorcycle_methcart",
+    "skills": [
+      { "level": 5, "name": "cooking" },
+      { "level": 3, "name": "mechanics" },
+      { "level": 2, "name": "driving" },
+      { "level": 2, "name": "gun" },
+      { "level": 2, "name": "pistol" },
+      { "level": 2, "name": "melee" },
+      { "level": 2, "name": "bashing" },
+      { "level": 2, "name": "dodge" },
+      { "level": 2, "name": "tailor" },
+      { "level": 1, "name": "fabrication" },
+      { "level": 1, "name": "firstaid" },
+      { "level": 1, "name": "survival" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "gold_ear",
+          "motorbike_armor",
+          "pants_leather",
+          "chaps_leather",
+          "motorbike_boots",
+          "vambrace_larmor",
+          "gauntlets_larmor",
+          "pickelhaube",
+          "mask_hockey",
+          "camelbak",
+          "dump_pouch",
+          "survivor_scope",
+          "ref_lighter",
+          "wristwatch"
+        ],
+        "entries": [
+          { "item": "hand_crossbow", "ammo-item": "bolt_wood", "charges": 1, "container-item": "holster" },
+          { "item": "quiver", "contents-group": "quiver_player_bandit" },
+          { "item": "makeshift_knife", "container-item": "bootsheath" },
+          { "item": "bwirebat", "custom-flags": [ "auto_wield" ] },
+          { "item": "light_battery_cell", "charges": 100, "container-item": "heavy_flashlight" }
         ]
       },
       "male": [ "boxer_shorts" ],

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -91,6 +91,21 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "mags_waste_ranger",
+    "entries": [ { "item": "blrmag", "ammo-item": "3006", "charges": 4 }, { "item": "blrmag", "ammo-item": "3006", "charges": 4 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "speedloaders_waste_ranger",
+    "entries": [
+      { "item": "38_speedloader", "ammo-item": "357mag_jhp", "charges": 7 },
+      { "item": "38_speedloader", "ammo-item": "357mag_jhp", "charges": 7 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "quiver_bow_hunter",
     "entries": [ { "item": "arrow_cf", "charges": 8 } ]
   },
@@ -3264,6 +3279,59 @@
           { "item": "XL_holster", "contents-group": "shotgun_d_roadwarrior" },
           { "item": "bandolier_shotgun", "contents-group": "bandolier_roadwarrior" },
           { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "mess_kit" }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "sports_bra", "boy_shorts" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "ident": "waste_ranger",
+    "name": "Wasteland Ranger",
+    "description": "If the human race is to survive, the threats facing its existence must be eliminated, no matter the cost.  If it's hostile, you kill it.",
+    "points": 6,
+    "skills": [
+      { "level": 6, "name": "tailor" },
+      { "level": 5, "name": "fabrication" },
+      { "level": 3, "name": "survival" },
+      { "level": 3, "name": "gun" },
+      { "level": 2, "name": "cooking" },
+      { "level": 2, "name": "rifle" },
+      { "level": 1, "name": "dodge" },
+      { "level": 1, "name": "melee" },
+      { "level": 1, "name": "pistol" },
+      { "level": 1, "name": "stabbing" }
+    ],
+    "items": {
+      "both": {
+        "ammo": 100,
+        "items": [
+          "sheriffshirt",
+          "duster_survivor",
+          "pants_survivor",
+          "boots_lsurvivor",
+          "gloves_lsurvivor",
+          "mask_gas",
+          "helmet_survivor",
+          "badge_deputy",
+          "canteen",
+          "wristwatch",
+          "puller",
+          "press",
+          "ref_lighter"
+        ],
+        "entries": [
+          { "item": "knife_trench", "container-item": "sheath" },
+          { "item": "browning_blr", "ammo-item": "3006", "charges": 4, "contents-item": "shoulder_strap" },
+          { "item": "legpouch_large", "contents-group": "mags_waste_ranger" },
+          { "item": "3006", "charges": 8 },
+          { "item": "sw_619", "ammo-item": "357mag_jhp", "charges": 7, "container-item": "holster" },
+          { "item": "legpouch_large", "contents-group": "speedloaders_waste_ranger" },
+          { "item": "357mag_jhp", "charges": 29 },
+          { "item": "light_battery_cell", "charges": 100, "container-item": "wearable_light" },
+          { "item": "survivor_mess_kit", "charges": [ 20, 30 ] }
         ]
       },
       "male": [ "boxer_shorts" ],

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -79,6 +79,12 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "shotgun_d_roadwarrior",
+    "entries": [ { "item": "shotgun_d", "ammo-item": "shot_00", "charges": 2, "contents-item": [ "barrel_small", "stock_small" ] } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "quiver_bow_hunter",
     "entries": [ { "item": "arrow_cf", "charges": 8 } ]
   },
@@ -135,6 +141,12 @@
     "subtype": "collection",
     "id": "bandolier_ww_gunslinger",
     "entries": [ { "item": "45colt_jhp", "charges": 34 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "bandolier_roadwarrior",
+    "entries": [ { "item": "shot_00", "charges": 18 } ]
   },
   {
     "type": "profession_item_substitutions",
@@ -3156,6 +3168,55 @@
       },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "panties" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
+    "ident": "road_warrior",
+    "name": "Road Warrior",
+    "description": "You lived by your wheels during the first few months of the apocalypse, now your custom ride is out of gas, your ammo is low, and your situation is dire.  You've been reduced to a scavenger, living off the corpse of the old world.",
+    "points": 6,
+    "vehicle": "car_roadwarrior",
+    "skills": [
+      { "level": 3, "name": "driving" },
+      { "level": 3, "name": "mechanics" },
+      { "level": 2, "name": "survival" },
+      { "level": 2, "name": "fabrication" },
+      { "level": 2, "name": "gun" },
+      { "level": 1, "name": "shotgun" },
+      { "level": 1, "name": "melee" },
+      { "level": 1, "name": "stabbing" },
+      { "level": 1, "name": "firstaid" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "tank_top",
+          "pants_leather",
+          "jacket_leather_mod",
+          "boots_steel",
+          "gloves_fingerless_mod",
+          "hat_cotton",
+          "survivor_goggles",
+          "long_patchwork_scarf",
+          "legrig",
+          "canteen",
+          "binoculars",
+          "ref_lighter",
+          "press_dowel",
+          "pliers",
+          "makeshift_hose",
+          "wristwatch"
+        ],
+        "entries": [
+          { "item": "knife_combat", "container-item": "survivor_belt_notools" },
+          { "item": "XL_holster", "contents-group": "shotgun_d_roadwarrior" },
+          { "item": "bandolier_shotgun", "contents-group": "bandolier_roadwarrior" }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "sports_bra", "boy_shorts" ]
     },
     "flags": [ "SCEN_ONLY" ]
   },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -79,6 +79,12 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "crossbow_hardened_survivor",
+    "entries": [ { "item": "crossbow", "ammo-item": "bolt_wood", "charges": 1 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "shotgun_d_roadwarrior",
     "entries": [ { "item": "shotgun_d", "ammo-item": "shot_00", "charges": 2, "contents-item": [ "barrel_small", "stock_small" ] } ]
   },
@@ -141,6 +147,12 @@
     "subtype": "collection",
     "id": "bandolier_ww_gunslinger",
     "entries": [ { "item": "45colt_jhp", "charges": 34 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "quiver_hardened_survivor",
+    "entries": [ { "item": "bolt_wood", "charges": 29 } ]
   },
   {
     "type": "item_group",
@@ -3137,6 +3149,45 @@
   },
   {
     "type": "profession",
+    "id": "hardened_survivor",
+    "name": "Hardened Survivor",
+    "description": "One of the lucky few who escaped the cataclysm, you made a life for yourself living off nature's bounties and what you could get outside the death traps of the large cities.",
+    "points": 6,
+    "skills": [
+      { "level": 6, "name": "survival" },
+      { "level": 6, "name": "fabrication" },
+      { "level": 6, "name": "tailor" },
+      { "level": 5, "name": "melee" },
+      { "level": 3, "name": "gun" },
+      { "level": 3, "name": "rifle" }
+    ],
+    "items": {
+      "both": {
+        "items": [
+          "survivor_suit",
+          "socks",
+          "boots_survivor",
+          "hood_survivor",
+          "gloves_survivor",
+          "wristwatch",
+          "ref_lighter",
+          "hand_crank_charger"
+        ],
+        "entries": [
+          { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "mess_kit" },
+          { "item": "kukri", "container-item": "sheath" },
+          { "item": "survivor_vest", "contents-group": "crossbow_hardened_survivor" },
+          { "item": "quiver_large", "contents-group": "quiver_hardened_survivor" },
+          { "item": "light_battery_cell", "charges": 100, "container-item": "wearable_light" }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "sports_bra", "panties" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
     "id": "winter_scavenger",
     "name": "Hardened Scavenger",
     "description": "One of the lucky few who escaped the Cataclysm, you made a life for yourself on the ruins of others.  Whether by force, guile, or luck, you've obtained the best gear you could find.",
@@ -3173,16 +3224,17 @@
   },
   {
     "type": "profession",
-    "ident": "road_warrior",
+    "id": "road_warrior",
     "name": "Road Warrior",
     "description": "You lived by your wheels during the first few months of the apocalypse, now your custom ride is out of gas, your ammo is low, and your situation is dire.  You've been reduced to a scavenger, living off the corpse of the old world.",
     "points": 6,
     "vehicle": "car_roadwarrior",
     "skills": [
       { "level": 3, "name": "driving" },
+      { "level": 3, "name": "fabrication" },
       { "level": 3, "name": "mechanics" },
+      { "level": 3, "name": "tailor" },
       { "level": 2, "name": "survival" },
-      { "level": 2, "name": "fabrication" },
       { "level": 2, "name": "gun" },
       { "level": 1, "name": "shotgun" },
       { "level": 1, "name": "melee" },
@@ -3198,7 +3250,6 @@
           "boots_steel",
           "gloves_fingerless_mod",
           "hat_cotton",
-          "survivor_goggles",
           "long_patchwork_scarf",
           "legrig",
           "canteen",
@@ -3206,13 +3257,13 @@
           "ref_lighter",
           "press_dowel",
           "pliers",
-          "makeshift_hose",
-          "wristwatch"
+          "makeshift_hose"
         ],
         "entries": [
-          { "item": "knife_combat", "container-item": "survivor_belt_notools" },
+          { "item": "tool_belt", "contents-item": [ "knife_combat", "pliers", "wrench", "hacksaw" ] },
           { "item": "XL_holster", "contents-group": "shotgun_d_roadwarrior" },
-          { "item": "bandolier_shotgun", "contents-group": "bandolier_roadwarrior" }
+          { "item": "bandolier_shotgun", "contents-group": "bandolier_roadwarrior" },
+          { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "mess_kit" }
         ]
       },
       "male": [ "boxer_shorts" ],

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -286,7 +286,7 @@
     "start_name": "Outside Town",
     "flags": [ "SUR_START", "WIN_START", "LONE_START" ],
     "add_professions": true,
-    "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army", "road_warrior" ]
+    "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army", "hardened_survivor", "road_warrior" ]
   },
   {
     "type": "scenario",
@@ -308,7 +308,7 @@
     "start_name": "Outside Town",
     "flags": [ "SUM_ADV_START", "LONE_START" ],
     "add_professions": true,
-    "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army", "road_warrior" ]
+    "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army", "hardened_survivor", "road_warrior" ]
   },
   {
     "type": "scenario",

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -293,7 +293,8 @@
       "winter_army",
       "hardened_survivor",
       "road_warrior",
-      "waste_ranger"
+      "waste_ranger",
+      "player_bandit"
     ]
   },
   {
@@ -323,7 +324,8 @@
       "winter_army",
       "hardened_survivor",
       "road_warrior",
-      "waste_ranger"
+      "waste_ranger",
+      "player_bandit"
     ]
   },
   {

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -286,7 +286,7 @@
     "start_name": "Outside Town",
     "flags": [ "SUR_START", "WIN_START", "LONE_START" ],
     "add_professions": true,
-    "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ]
+    "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army", "road_warrior" ]
   },
   {
     "type": "scenario",
@@ -308,7 +308,7 @@
     "start_name": "Outside Town",
     "flags": [ "SUM_ADV_START", "LONE_START" ],
     "add_professions": true,
-    "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ]
+    "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army", "road_warrior" ]
   },
   {
     "type": "scenario",

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -286,7 +286,15 @@
     "start_name": "Outside Town",
     "flags": [ "SUR_START", "WIN_START", "LONE_START" ],
     "add_professions": true,
-    "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army", "hardened_survivor", "road_warrior" ]
+    "professions": [
+      "sheltered_survivor",
+      "sheltered_militia",
+      "winter_scavenger",
+      "winter_army",
+      "hardened_survivor",
+      "road_warrior",
+      "waste_ranger"
+    ]
   },
   {
     "type": "scenario",
@@ -308,7 +316,15 @@
     "start_name": "Outside Town",
     "flags": [ "SUM_ADV_START", "LONE_START" ],
     "add_professions": true,
-    "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army", "hardened_survivor", "road_warrior" ]
+    "professions": [
+      "sheltered_survivor",
+      "sheltered_militia",
+      "winter_scavenger",
+      "winter_army",
+      "hardened_survivor",
+      "road_warrior",
+      "waste_ranger"
+    ]
   },
   {
     "type": "scenario",

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -156,6 +156,7 @@
       [ "armored_car", 300 ],
       [ "superbike", 50 ],
       [ "surv_car", 2 ],
+      [ "car_roadwarrior", 2 ],
       [ "wienermobile", 5 ],
       [ "tatra_truck", 300 ],
       [ "4x4_car", 400 ]
@@ -353,7 +354,7 @@
     "id": "bandit_vehicles",
     "type": "vehicle_group",
     "//": "Vehicles used by Hell's Raiders for scouting and assaults",
-    "vehicles": [ [ "pickup_technical", 150 ], [ "quad_bike", 150 ], [ "motorcycle", 300 ] ]
+    "vehicles": [ [ "pickup_technical", 150 ], [ "quad_bike", 150 ], [ "motorcycle", 300 ], [ "motorcycle_methcart", 50 ] ]
   },
   {
     "type": "vehicle_group",

--- a/data/json/vehicles/custom_vehicles.json
+++ b/data/json/vehicles/custom_vehicles.json
@@ -267,8 +267,16 @@
         "y": 2,
         "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "headlight" ]
       },
-      { "x": -2, "y": 0, "parts": [ "frame_vertical", "trunk", "medium_storage_battery", "roof", "afs_small_roof_external_tank" ] },
-      { "x": -2, "y": 1, "parts": [ "frame_vertical", "trunk", "battery_charger", "roof", "afs_small_roof_external_tank" ] },
+      {
+        "x": -2,
+        "y": 0,
+        "parts": [ "frame_vertical", "trunk", "medium_storage_battery", "roof", "afs_small_roof_external_tank" ]
+      },
+      {
+        "x": -2,
+        "y": 1,
+        "parts": [ "frame_vertical", "trunk", "battery_charger", "roof", "afs_small_roof_external_tank" ]
+      },
       { "x": -2, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
       { "x": -2, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical", "muffler" ] },
       { "x": -3, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw", "wheel_mount_medium", "wheel" ] },

--- a/data/json/vehicles/custom_vehicles.json
+++ b/data/json/vehicles/custom_vehicles.json
@@ -267,8 +267,8 @@
         "y": 2,
         "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "headlight" ]
       },
-      { "x": -2, "y": 0, "parts": [ "frame_vertical", "trunk", "roof", "afs_small_roof_external_tank" ] },
-      { "x": -2, "y": 1, "parts": [ "frame_vertical", "trunk", "roof", "afs_small_roof_external_tank" ] },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "trunk", "medium_storage_battery", "roof", "afs_small_roof_external_tank" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "trunk", "battery_charger", "roof", "afs_small_roof_external_tank" ] },
       { "x": -2, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
       { "x": -2, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical", "muffler" ] },
       { "x": -3, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw", "wheel_mount_medium", "wheel" ] },

--- a/data/json/vehicles/custom_vehicles.json
+++ b/data/json/vehicles/custom_vehicles.json
@@ -277,7 +277,11 @@
         "y": 1,
         "parts": [ "frame_vertical", "trunk", "battery_charger", "roof", "afs_small_roof_external_tank" ]
       },
-      { "x": -2, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      {
+        "x": -2,
+        "y": -1,
+        "parts": [ "frame_vertical", "halfboard_vertical", { "part": "tank", "fuel": "gasoline" } ]
+      },
       { "x": -2, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical", "muffler" ] },
       { "x": -3, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw", "wheel_mount_medium", "wheel" ] },
       { "x": -3, "y": 0, "parts": [ "frame_horizontal", "door_trunk" ] },
@@ -285,5 +289,46 @@
       { "x": -3, "y": 2, "parts": [ "frame_horizontal", "halfboard_se", "wheel_mount_medium", "wheel" ] }
     ],
     "items": [ { "x": -2, "y": 1, "chance": 100, "items": [ "jerrycan" ] } ]
+  },
+  {
+    "id": "motorcycle_methcart",
+    "type": "vehicle",
+    "name": "Meth Bike",
+    "blueprint": [
+      [ "o#>o-" ],
+      [ " #>- " ]
+    ],
+    "parts": [
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame_vertical_2",
+          "saddle_motor",
+          "controls",
+          "controls_electronic",
+          "vehicle_alarm",
+          "horn_car",
+          "engine_1cyl_large",
+          "alternator_motorbike"
+        ]
+      },
+      {
+        "x": -1,
+        "y": 0,
+        "parts": [ "frame_vertical", "wheel_mount_light", "wheel_motorbike_rear", "muffler", "box" ]
+      },
+      { "x": 1, "y": 0, "parts": [ "frame_handle", { "part": "tank", "fuel": "gasoline" }, "headlight" ] },
+      { "x": 2, "y": 0, "parts": [ "frame_vertical", "wheel_mount_light_steerable", "wheel_motorbike" ] },
+      { "x": 3, "y": 0, "parts": [ "ram_spiked" ] },
+      {
+        "x": 0,
+        "y": 1,
+        "parts": [ "frame_cross", "wheel_mount_light", "wheel_motorbike", "chemlab", "medium_storage_battery" ]
+      },
+      { "x": 1, "y": 1, "parts": [ "frame_handle", "box" ] },
+      { "x": 2, "y": 1, "parts": [ "ram_spiked" ] }
+    ],
+    "items": [ { "x": 0, "y": 1, "chance": 50, "item_groups": [ "meth_ingredients", "meth_ingredients" ] } ]
   }
 ]

--- a/data/json/vehicles/custom_vehicles.json
+++ b/data/json/vehicles/custom_vehicles.json
@@ -223,5 +223,59 @@
       { "x": -2, "y": 0, "chance": 10, "items": [ "308", "308" ] },
       { "x": -2, "y": 0, "chance": 5, "items": [ "308", "308" ] }
     ]
+  },
+  {
+    "id": "car_roadwarrior",
+    "type": "vehicle",
+    "name": "Wasteland Interceptor",
+    "blueprint": [
+      [ "o--+-o" ],
+      [ "_=##'|" ],
+      [ "_=#k'|" ],
+      [ "o--+-o" ]
+    ],
+    "parts": [
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [ "frame_vertical_2", "seat", "seatbelt", "controls", "dashboard", "vehicle_clock", "horn_car", "roof" ]
+      },
+      { "x": 0, "y": 1, "parts": [ "frame_vertical_2", "animal_compartment", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame_vertical", "door" ] },
+      { "x": 0, "y": 2, "parts": [ "frame_vertical", "door" ] },
+      { "x": -1, "y": 0, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": -1, "y": 1, "parts": [ "frame_vertical_2", "seat", "seatbelt", "roof" ] },
+      { "x": -1, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -1, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": 1, "y": 0, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": 1, "y": 1, "parts": [ "frame_horizontal", "windshield" ] },
+      { "x": 1, "y": -1, "parts": [ "frame_vertical", "windshield" ] },
+      { "x": 1, "y": 2, "parts": [ "frame_vertical", "windshield" ] },
+      {
+        "x": 2,
+        "y": 0,
+        "parts": [ "frame_horizontal", "engine_v8", "alternator_truck", "battery_car", "halfboard_horizontal" ]
+      },
+      { "x": 2, "y": 1, "parts": [ "frame_horizontal", "halfboard_horizontal" ] },
+      {
+        "x": 2,
+        "y": -1,
+        "parts": [ "frame_nw", "halfboard_nw", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      {
+        "x": 2,
+        "y": 2,
+        "parts": [ "frame_ne", "halfboard_ne", "wheel_mount_medium_steerable", "wheel", "headlight" ]
+      },
+      { "x": -2, "y": 0, "parts": [ "frame_vertical", "trunk", "roof", "afs_small_roof_external_tank" ] },
+      { "x": -2, "y": 1, "parts": [ "frame_vertical", "trunk", "roof", "afs_small_roof_external_tank" ] },
+      { "x": -2, "y": -1, "parts": [ "frame_vertical", "halfboard_vertical" ] },
+      { "x": -2, "y": 2, "parts": [ "frame_vertical", "halfboard_vertical", "muffler" ] },
+      { "x": -3, "y": -1, "parts": [ "frame_horizontal", "halfboard_sw", "wheel_mount_medium", "wheel" ] },
+      { "x": -3, "y": 0, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": -3, "y": 1, "parts": [ "frame_horizontal", "door_trunk" ] },
+      { "x": -3, "y": 2, "parts": [ "frame_horizontal", "halfboard_se", "wheel_mount_medium", "wheel" ] }
+    ],
+    "items": [ { "x": -2, "y": 1, "chance": 100, "items": [ "jerrycan" ] } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Content "Restore old post-apoc professions previously removed from the game"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Follow up PR to https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2540, bringing back some interesting post-apoc professions that DDA had dummied out.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

- [X] Re-added the road warrior. Set them to spawn with a vehicle (see below). Said car has some fitting post-apoc modifications in exchange for not spawning with fuel. Also touched up their shotgun so the stock is sawn off too, added a makeshift shotshell press and pliers to their inventory so they have the potential means to put together more reloaded shells. Their starting skills have been beefed up a bit to allow them to start with the skills needed to have made the basics of their gear and to make shells, and their gear has been trimmed down to re-orient around living in the car along with the basic tools for vehicle part modifications and what they need to keep their shotgun fed. Phased out the survivor goggles and swapped the survivor belt for a toolbelt, mainly so the tailoring skill they logically need isn't as high, but also because since the other professions will already offer a decent display of survivor gear.
- [X] Re-add the hardened survivor. Beefed up their tailoring and inebriation skill so they can actually make the survivor gear they start with, along with actually starting with marksmanship skill. Their gear has been tweaked a bit, shifting towards regular survivor gear instead of winter since they're also used in Next Summer. They've also gained a lighter for basic firestarting, a headlamp (road warrior got theirs removed because their vehicle is a fine light source), and a hand-crank charger since their basic setup relies on keeping a mess kit running. Their crossbow also now starts actually slung on the survivor harness.
- [X] Re-add the wasteland ranger. Reworked the starting gear to revolve around a loadout that suits the "ranger" appellation, favoring the survivor duster instead of light survivor suit. Likewise, to avoid having to bump skills up even more than already needed to enable crafting the survivor duster, I shifted from the fairly advanced pneumatic bolt driver to instead focusing on a pair of fittingly yeehaw factory-made guns, along with the needed ammo and mag/speedloader pouches. Likewise tweaked skills and gear to ensure they had the basics needed to keep themselves in lamp oil and bullets, gaining a basic bullet puller and press (warranted upgrade over the road warrior's more basic handload setup since that profession starts off with a ride that's fully self-sufficient outside of being out of fuel). Additionally favor a standard gas mask and survivor helmet to keep more of their gear inside their skill bracket, plus it gives us an in-repo demonstration of survivor helmets being back in the game (with some NCR Ranger vibes as a bonus).
- [X] Re-add the veteran bandit. Merged the gear into a more consistent loadout fitting a mix of Mad Max biker gang plus makeshift leather materials mixed in. Weaponry also adjusted, favoring a barbed wire bat (a touch of Walking Dead) and pistol crossbow (based on Wez's use of a wrist crossbow in Mad Max 2) as main weapons, with cutting tool moved to a makeshift knife in a boot sheath. Also starts with a vehicle, this plus the skills and description are meant to imply the player's attitude towards other NPCs can be whatever they like, depending on if they feel like hunting them for sport or cooking drugs for trade.
- [X] Added the wasteland interceptor as a vehicle specific to the road warrior profession. It's based off the FBI vehicle (being the only police car with a V8 engine), with some adjustments to lean towards resembling the vehicle depicted in Mad Max 2. Its layout has been changed to a 2-door design instead of 4-door, the trunk doors have been taken out with larger fuel tanks installed to replace the original fuel tank, the muffler moved to the outside, a battery charger and spare medium storage battery have been added, and the front passenger's seat replaced with a dog cage, and a few extraneous parts like the security system and police lights removed. The vehicle spawns without fuel to make the player have to go scavenge, but does spawn with a plastic jerrycan in the trunk.
- [X] Implemented the meth bike as a custom ride for the bandit, further cementing them as a foil to the road warrior. Takes the basic layout of a motorcycle with sidecart, rips out the engine to add a slightly larger one, tacks on a larger fuel tank and battery, adds spiked rams, then of course adds a chemlab in place of the sidecar's seat.
 - [X] Added the new vehicles to relevant vehicle groups. The wasteland interceptor in the same rare spot as the survivor car, and meth bike in bandit vehicles at a better rate.
- [X] Added professions back into Ambushed and The Next Summer.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Giving the road warrior a dog instead of or in addition to a car.
2. Some missions could maybe be set to spawn a wasteland interceptor later on as a bandit vehicle maybe, or just say "fuck it" and allow spawning one in bandit vehiclegroup maybe?
3. Adding a tank part that goes on the center vehiclepart slot so it's visible in the back.
4. If we ever work on that idea of being able to talk your way into being on speaking terms with Hells Raiders, I plan for certain professions to have a profession trait that makes that easier to accomplish, with the veteran bandit being an obvious example.
5. Likewise, some sort of law enforcement profession trait could be given to the wasteland ranger, possibly a self-declared post-apoc one. This logically should have no impact on eyebot response but could be perhaps useful in the future for smooth-talking the Old Guard into putting up with your shenanigans without needing to become a marshal.
6. Converting a good chunk of the survivor gear to comparable standard items anyway. No Survivor Items mod is obsolete but allowing it to play nice should anyone preserve it in a mod compilation could be smart?
7. Or conversely, giving the rescuer profession their survivor gear back. Personally I feel the fur armor is interesting as it's not something used much normally.
8. Giving the hardened survivor a survivor mess kit instead of standard.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Loaded up as a road warrior, confirmed vehicle loaded in nearby and looked the way I expected it to.
3. Confirmed shotgun spawned in the holster with a cut-down stock and barrel.

Testing to continue as the other professions get re-added.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

PR that removed said professions: https://github.com/CleverRaven/Cataclysm-DDA/pull/35844