### PR TITLE
Aftershock butcher fixes

### DIFF
--- a/data/mods/Aftershock/mobs/uplifted_monsters.json
+++ b/data/mods/Aftershock/mobs/uplifted_monsters.json
@@ -51,7 +51,7 @@
     "death_function": [ "NORMAL" ],
     "zombify_into": "mon_zombie_upliftedbear",
     "death_drops": "xl_uplift_death_drop",
-    "harvest": "demihuman_large_fur",
+    "harvest": "mammal_large_fur",
     "reproduction": { "baby_monster": "mon_uplifted_bear_cub", "baby_count": 1, "baby_timer": 700 },
     "baby_flags": [ "SPRING" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "BASHES", "ATTACKMON" ]
@@ -74,7 +74,7 @@
     "melee_dice_sides": 3,
     "melee_cut": 2,
     "dodge": 2,
-    "harvest": "demihuman_fur",
+    "harvest": "mammal_fur",
     "special_attacks": [ [ "EAT_FOOD", 60 ] ],
     "upgrades": { "age_grow": 480, "into": "mon_bear" }
   },
@@ -104,7 +104,7 @@
     "dodge": 4,
     "vision_day": 30,
     "death_drops": "xl_uplift_death_drop",
-    "harvest": "demihuman_large_fur",
+    "harvest": "mammal_large_fur",
     "special_attacks": [ [ "scratch", 20 ] ],
     "death_function": [ "NORMAL" ],
     "zombify_into": "mon_uplifted_ape_zed",


### PR DESCRIPTION
SUMMARY: [Bugfixes] "Fixes invalid harvest targets in uplifted Aftershock animals"

#### Purpose of change

The uplifted animals from Aftershock had invalid harvests, and butchered into nothing. This replaces those with their mammal equivalents. 

#### Describe the solution

I replaced demihuman_fur and demihuman_large_fur with mammal_fur and mammal_large_fur to make them have a valid harvest target, so butchery could work.

#### Describe alternatives you've considered

Demihuman seems to imply they are closer to human, so maybe it should be cannibalism. I see no reason why it would be considered cannibalism however, an uplifted bear is still a bear. An uplifted monkey is more questionable and maybe that one could be close enough to cannibalism.

#### Testing

I changed the JSON, launched the game with it, and butchered the 3 animals in question. No crashes, butchery worked.

#### Additional context

Aftershock is pain.
