### PR TITLE
fix: incorrect temperature for vehicle parts

### DIFF
--- a/src/rot.cpp
+++ b/src/rot.cpp
@@ -56,15 +56,16 @@ temperature_flag temperature_flag_for_location( const map &m, const item_locatio
 temperature_flag temperature_flag_for_part( const vehicle &veh, size_t part_index )
 {
     const vehicle_part &part = veh.cpart( part_index );
+    const vpart_info &info = part.info();
     if( !part.enabled ) {
         return temperature_flag::TEMP_NORMAL;
     }
 
-    if( part.has_flag( VPFLAG_FREEZER ) ) {
+    if( info.has_flag( VPFLAG_FREEZER ) ) {
         return temperature_flag::TEMP_FREEZER;
     }
 
-    if( part.has_flag( VPFLAG_FRIDGE ) ) {
+    if( info.has_flag( VPFLAG_FRIDGE ) ) {
         return temperature_flag::TEMP_FRIDGE;
     }
     return temperature_flag::TEMP_NORMAL;


### PR DESCRIPTION

#### Summary

SUMMARY: Bugfixes "Incorrect storage conditions display for vehicle freezer and fridges"

#### Purpose of change

- fix #2647

#### Describe the solution

looks like `vpart_info` caches `vehicle_part` struct each time. previously, the flags were always 0 because it was uninitialized. tracked in #2651.
changed to use `vpart_info` to get correct vehicle part info.

#### Testing

![Cataclysm: Bright Nights - cbn-experimental-2023-04-15-1839_04](https://user-images.githubusercontent.com/54838975/232319411-f394aad5-9ccf-4ca7-904c-efe0ac948e4b.png)

created test vehicle with minifridge. it correctly displayed that it partially prevented the food from rot.

#### Additional context

i'm getting gaslighted by the codebase
