### PR TITLE
Broken Generator deconstruct port from DDA

### DIFF
--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -278,6 +278,18 @@
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 3, 7 ] }
       ]
+    },
+    "deconstruct": {
+      "ter_set": "t_pavement",
+      "items": [
+        { "item": "cable", "charges": [ 1, 2 ] },
+        { "item": "steel_chunk", "count": [ 1, 2 ] },
+        { "item": "scrap", "count": [ 5, 7 ] },
+        { "item": "motor_small", "count": [ 0, 1 ] },
+        { "item": "jerrycan", "count": [ 0, 1 ] },
+        { "item": "pipe", "count": [ 0, 1 ] },
+        { "item": "frame", "count": [ 0, 1 ] }
+      ]
     }
   },
   {


### PR DESCRIPTION
SUMMARY: Balance "Ported the Broken Generator deconstruct from DDA"

#### Purpose of change

The broken generator is one of few furnitures/furniture terrains that have no deconstruct recipe. This ports the [DDA](https://github.com/CleverRaven/Cataclysm-DDA/pull/41731) deconstruct. 

#### Describe the solution

I copied their deconstruct recipe but replaced pipe fittings with 0-1 scrap metal as this item does not exist in BN. 


#### Describe alternatives you've considered

Changing the resulting items so it doesn't give a whole plastic jerrycan. Leaving it as smashing required.

#### Testing

I opened the game with the changes and successfully deconstructed a broken generator for parts. No crashes or errors.

#### Additional context

If I run into any other common furnitures that isn't deconstructible but should, I'll be sure to tackle them.
