### PR TITLE
Auto-move uses distraction manager, prompts on danger-close

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1703,8 +1703,7 @@ bool game::cancel_activity_or_ignore_query( const distraction_type type, const s
     if( u.has_distant_destination() ) {
         if( u.activity.is_distraction_ignored( type ) ) {
             return false;
-        }
-        else if( cancel_auto_move( u, text ) ) {
+        } else if( cancel_auto_move( u, text ) ) {
             return true;
         } else {
             u.set_destination( u.get_auto_move_route(), player_activity( activity_id( "ACT_TRAVELLING" ) ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1636,7 +1636,7 @@ void game::process_voluntary_act_interrupt()
     // If player is performing a task and a monster is dangerously close, warn them
     // regardless of previous safemode warnings.
     // Distraction Manager can change this.
-    if( ( has_activity && !u.has_activity( activity_id( "ACT_AIM" ) ) || is_travelling ) &&
+    if( ( has_activity || is_travelling ) && !u.has_activity( activity_id( "ACT_AIM" ) ) &&
         !u.activity.is_distraction_ignored( distraction_type::hostile_spotted_near ) ) {
         Creature *hostile_critter = is_hostile_very_close();
         if( hostile_critter != nullptr ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1700,18 +1700,16 @@ static bool cancel_auto_move( player &p, const std::string &text )
 bool game::cancel_activity_or_ignore_query( const distraction_type type, const std::string &text )
 {
     invalidate_main_ui_adaptor();
+    if( !u.activity && !u.has_distant_destination() || u.activity.is_distraction_ignored( type ) ) {
+        return false;
+    }
     if( u.has_distant_destination() ) {
-        if( u.activity.is_distraction_ignored( type ) ) {
-            return false;
-        } else if( cancel_auto_move( u, text ) ) {
+        if( cancel_auto_move( u, text ) ) {
             return true;
         } else {
             u.set_destination( u.get_auto_move_route(), player_activity( activity_id( "ACT_TRAVELLING" ) ) );
             return false;
         }
-    }
-    if( !u.activity || u.activity.is_distraction_ignored( type ) ) {
-        return false;
     }
     const bool force_uc = get_option<bool>( "FORCE_CAPITAL_YN" );
     const auto &allow_key = force_uc ? input_context::disallow_lower_case

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1636,7 +1636,7 @@ void game::process_voluntary_act_interrupt()
     // If player is performing a task and a monster is dangerously close, warn them
     // regardless of previous safemode warnings.
     // Distraction Manager can change this.
-    if( has_activity && !u.has_activity( activity_id( "ACT_AIM" ) ) &&
+    if( ( has_activity && !u.has_activity( activity_id( "ACT_AIM" ) ) || is_travelling ) &&
         !u.activity.is_distraction_ignored( distraction_type::hostile_spotted_near ) ) {
         Creature *hostile_critter = is_hostile_very_close();
         if( hostile_critter != nullptr ) {
@@ -1701,7 +1701,10 @@ bool game::cancel_activity_or_ignore_query( const distraction_type type, const s
 {
     invalidate_main_ui_adaptor();
     if( u.has_distant_destination() ) {
-        if( cancel_auto_move( u, text ) ) {
+        if( u.activity.is_distraction_ignored( type ) ) {
+            return false;
+        }
+        else if( cancel_auto_move( u, text ) ) {
             return true;
         } else {
             u.set_destination( u.get_auto_move_route(), player_activity( activity_id( "ACT_TRAVELLING" ) ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1700,7 +1700,7 @@ static bool cancel_auto_move( player &p, const std::string &text )
 bool game::cancel_activity_or_ignore_query( const distraction_type type, const std::string &text )
 {
     invalidate_main_ui_adaptor();
-    if( !u.activity && !u.has_distant_destination() || u.activity.is_distraction_ignored( type ) ) {
+    if( ( !u.activity && !u.has_distant_destination() ) || u.activity.is_distraction_ignored( type ) ) {
         return false;
     }
     if( u.has_distant_destination() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Features "Auto-move now takes distraction manager into account, "

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I was getting sick of "monster spotted" queries constantly interrupting fast-travel, testing how to fix it turned out to be easy enough even for someone with my level of inexperienced.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In `game::process_voluntary_act_interrupt`, changed the check for monsters that're dangerously close to also occur if you're fast traveling, and not just performing standard activities. I'm going to hope that doesn't cause performance issues, but it's needed to prevent fast-travel with "monster spotted" disabled from letting you walk face-first into zombies.
2. In `game::cancel_activity_or_ignore_query`, added a check in the fast-travel section that has it bail out if the current distraction is one you've set to ignore.
3. Also implemented a bit less clunky if-else logic for `game::cancel_activity_or_ignore_query` as provided by Kheir.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Letting players accidentally get into melee range with zeds if it turns out checking for nearby monsters makes fast-travel chug. Didn't seem to in my experience but.
2. Trying to jury-rig a proximity check into `game::mon_info_update` where spotting monsters in general is handled. This seems like a bad idea since that'd be making a three-layer if/else chain even more clunky than it already is and the least annoying ways to do that will most likely cause the distraction to not trigger correctly if you already saw the offending monster beforehand and they get closer.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Fast-traveled into a city with all distractions enabled, still got interrupted when a hostile comes into view.
4. Turned "hostile spotted" distraction off and repeated this, now only got interrupted when I got too close to one of them.
5. Turned "hostile close" distraction off too and kept on trucking, happily blunder into zed and get attacked (unless they stopped me EXACTLY in their path without me getting hit immediately, then it cancels automove because monster's in the way).
6. Checked affected file for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Tested DDA and at some point they also set auto-move to take distraction manager into account, but it of course has the "blindly walk right into attacks because it's not checking for `hostile_spotted_near`" problem.