### PR TITLE
Prevent range 1 from diagonal-z-attacks

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2118,6 +2118,13 @@ std::vector<Creature *> targetable_creatures( const Character &c, const int rang
             return false;
         }
 
+        // Special case: if range is 1, it's a melee attack.
+        // Melee attacks can only target on same z-level or directly up/down, not "z-diagonally".
+        if( range <= 1 && c.posz() != critter.posz() && c.pos().xy() != critter.pos().xy() )
+        {
+            return false;
+        }
+
         if( !c.sees( critter ) && !c.sees_with_infrared( critter ) )
         {
             return false;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Prevent range 1 autoattacks from non-directly-up/down z-level attacks"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Preventing the unintended and hard to balance trick, where you stand on a roof and autoattack the zombies below with fully melee (not reach) attacks.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Special-cased the range 1 autoattacks to allow attacks only if the target is on same z-level, or directly up/down.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

* Spawn a 1 tile wall and zombie next to it
* Teleport onto the wall
* Confirm autoattack won't target the zombie
* Repeat with a spear to confirm that spears can still autoattack "z-diagonally"
* Spawn a cylinder of 3x3 metal walls, with hole in the middle, 2 z-levels tall
* Teleport to the middle
* Spawn a zombie above yourself
* Confirm the autoattack targets the zombie

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Related to: #2575
Ensures symmetry by having both the player and monsters obey the same rules.