### PR TITLE
Added tool category to blood draw kit

### DIFF
--- a/data/json/items/tool/med.json
+++ b/data/json/items/tool/med.json
@@ -172,6 +172,7 @@
   {
     "id": "vacutainer",
     "type": "CONTAINER",
+    "category": "tools",
     "name": { "str": "blood draw kit" },
     "description": "This is a kit for drawing blood, including a test tube for holding the sample.  Use this tool to draw blood, either from yourself or from a corpse you are standing on.",
     "weight": "13 g",


### PR DESCRIPTION
#### Summary
SUMMARY: Infrastructure "Made blood draw kit a tool, not a weapon"

#### Purpose of change
Blood draw kit is used as a tool, it shouldn't be in the weapons category

#### Describe the solution
Added "category": "tools" to the item

#### Describe alternatives you've considered
Ponder on why this is the only item in the entire tool folder that does not have its category defined.

#### Testing
Spawn the item, it is now in the tool category