### PR TITLE
feat: allow changing gender in debug menu

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6469,7 +6469,7 @@ std::string Character::extended_description() const
         // <bad>This is me, <player_name>.</bad>
         ss += string_format( _( "This is you - %s." ), name );
     } else {
-        ss += string_format( _( "This is %s, %s" ), name, male ? _( "male" ) : _( "female" ) );
+        ss += string_format( _( "This is %s, %s" ), name, male ? _( "Male" ) : _( "Female" ) );
     }
 
     ss += "\n--\n";
@@ -10285,7 +10285,7 @@ std::vector<std::string> Character::short_description_parts() const
 {
     std::vector<std::string> result;
 
-    std::string gender = male ? _( "male" ) : _( "female" );
+    std::string gender = male ? _( "Male" ) : _( "Female" );
     result.push_back( name +  ", "  + gender );
     if( is_armed() ) {
         result.push_back( _( "Wielding: " ) + weapon.tname() );

--- a/src/character_display.cpp
+++ b/src/character_display.cpp
@@ -898,24 +898,26 @@ static void draw_tip( const catacurses::window &w_tip, const Character &you,
 {
     werase( w_tip );
 
+    auto gender = you.male ? _( "Male" ) : _( "Female" );
+
     // Print name and header
     if( you.custom_profession.empty() ) {
         if( you.crossed_threshold() ) {
             //~ player info window: 1s - name, 2s - gender, 3s - Prof or Mutation name
-            mvwprintz( w_tip, point_zero, c_white, _( " %1$s | %2$s | %3$s" ), you.name,
-                       you.male ? _( "Male" ) : _( "Female" ), race );
+            mvwprintz( w_tip, point_zero, c_white, _( " %1$s | %2$s | %3$s" ),
+                       you.name, gender, race );
         } else if( !you.prof.is_valid() || you.prof == profession::generic() ) {
             // Regular person. Nothing interesting.
             //~ player info window: 1s - name, 2s - gender '|' - field separator.
-            mvwprintz( w_tip, point_zero, c_white, _( " %1$s | %2$s" ), you.name,
-                       you.male ? _( "Male" ) : _( "Female" ) );
+            mvwprintz( w_tip, point_zero, c_white, _( " %1$s | %2$s" ),
+                       you.name, gender );
         } else {
-            mvwprintz( w_tip, point_zero, c_white, _( " %1$s | %2$s | %3$s" ), you.name,
-                       you.male ? _( "Male" ) : _( "Female" ), you.prof->gender_appropriate_name( you.male ) );
+            mvwprintz( w_tip, point_zero, c_white, _( " %1$s | %2$s | %3$s" ),
+                       you.name, gender, you.prof->gender_appropriate_name( you.male ) );
         }
     } else {
-        mvwprintz( w_tip, point_zero, c_white, _( " %1$s | %2$s | %3$s" ), you.name,
-                   you.male ? _( "Male" ) : _( "Female" ), you.custom_profession );
+        mvwprintz( w_tip, point_zero, c_white, _( " %1$s | %2$s | %3$s" ),
+                   you.name,  gender, you.custom_profession );
     }
 
     right_print( w_tip, 0, 1, c_white, string_format(

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -555,7 +555,7 @@ void character_edit_menu( Character &c )
     // Maybe TODO: this could actually be static if not for translations
     const std::vector<uilist_entry> static_entries = {{
             uilist_entry( edit_character::pick, true, 'p', _( "[p]ick different character" ) ),
-            uilist_entry( edit_character::desc, true, 'D',  _( "Edit [D]escription - Name, Age, Height" ) ),
+            uilist_entry( edit_character::desc, true, 'D',  _( "Edit [D]escription - Name, Age, Height, Gender" ) ),
             uilist_entry( edit_character::skills, true, 's',  _( "Edit [s]kills" ) ),
             uilist_entry( edit_character::stats, true, 't',  _( "Edit s[t]ats" ) ),
             uilist_entry( edit_character::items, true, 'i',  _( "Grant [i]tems" ) ),
@@ -809,6 +809,8 @@ void character_edit_menu( Character &c )
             smenu.addentry( 1, true, 'n', "%s: %s", _( "Current pre-Cataclysm name" ), p.name );
             smenu.addentry( 2, true, 'a', "%s: %d", _( "Current age" ), p.base_age() );
             smenu.addentry( 3, true, 'h', "%s: %d", _( "Current height in cm" ), p.base_height() );
+            smenu.addentry( 4, true, 'h', "%s: %s", _( "Current gender" ),
+                            p.male ? _( "Male" ) : _( "Female" ) );
             smenu.query();
             switch( smenu.ret ) {
                 case 0: {
@@ -857,6 +859,10 @@ void character_edit_menu( Character &c )
                     if( result != 0 ) {
                         p.set_base_height( clamp( result, 145, 200 ) );
                     }
+                }
+                break;
+                case 4: {
+                    p.male = !p.male;
                 }
                 break;
             }


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Allow changing gender in debug menu"

#### Purpose of change

because why not? 
gender is purely cosmetic like name, age, and height but it wasn't configurable unlike others. allowing it makes roleplaying easier.

#### Describe the solution
player can now change their gender in `player` - `Edit [D]escription` in the debug menu. selecting it toggles between `male` <-> `female`.

#### Describe alternatives you've considered

use the uncivilized method, savefile editing

#### Testing
![Cataclysm: Bright Nights - cbn-experimental-2023-04-19-1517_01](https://user-images.githubusercontent.com/54838975/233126930-c48a4624-5356-492a-a080-5d57c8074e36.png)
how the debug menu looks like

| Setting the gender to male | tileset uses male portrait |
|--------|--------|
| ![Cataclysm: Bright Nights - cbn-experimental-2023-04-19-1517_02](https://user-images.githubusercontent.com/54838975/233126940-6ab1b199-4845-4e34-a725-c24c2443900b.png) | ![Cataclysm: Bright Nights - cbn-experimental-2023-04-19-1517_03](https://user-images.githubusercontent.com/54838975/233126944-561a7ee8-decb-482b-afba-faee1afe9600.png) | 

| Setting the gender to female | tileset uses female portrait |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/54838975/233127278-cd5fda6e-5a68-4be5-ba8a-7cc0d07df9ff.png) | ![image](https://user-images.githubusercontent.com/54838975/233127240-f73a5fbf-6bf6-4d98-b82a-602051521fd5.png) |

