### PR TITLE
feat: allow installing non-sterile CBM when `Infection Immune`

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2547,7 +2547,7 @@
     "id": "INFRESIST",
     "name": { "str": "Infection Immune" },
     "points": 1,
-    "description": "Your immune system is particularly good at resisting infections.  Your wounds will no longer become infected, altough existing infections are still dangerous.",
+    "description": "Your immune system is particularly good at resisting infections.  Your wounds will no longer become infected, altough existing infections are still dangerous.  You will also be able to install non-sterile CBMs.",
     "starting_trait": true,
     "category": [ "TROGLOBITE", "RAT", "MEDICAL" ]
   },

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <set>
 #include <string>
@@ -1792,7 +1793,6 @@ static item_location autodoc_internal( player &u, player &patient,
 {
     inventory_pick_selector inv_s( u, preset );
     std::string hint;
-    int drug_count = 0;
 
     if( !surgeon ) {//surgeon use their own anesthetic, player just need money
         if( patient.has_trait( trait_NOPAIN ) ) {
@@ -1804,11 +1804,10 @@ static item_location autodoc_internal( player &u, player &patient,
             std::vector<const item *> a_filter = crafting_inv.items_with( []( const item & it ) {
                 return it.has_quality( qual_ANESTHESIA );
             } );
-            for( const item *anesthesia_item : a_filter ) {
-                if( anesthesia_item->ammo_remaining() >= 1 ) {
-                    drug_count += anesthesia_item->ammo_remaining();
-                }
-            }
+            const int drug_count = std::accumulate( a_filter.begin(), a_filter.end(), 0,
+            []( int sum, const item * it ) {
+                return sum + it->ammo_remaining();
+            } );
             hint = string_format( _( "<color_yellow>Available anesthetic: %i mL</color>" ), drug_count );
         }
     }

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -78,6 +78,7 @@ static const trait_id trait_DEBUG_BIONICS( "DEBUG_BIONICS" );
 static const trait_id trait_NOPAIN( "NOPAIN" );
 static const trait_id trait_SAPROPHAGE( "SAPROPHAGE" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
+static const trait_id trait_INFRESIST( "INFRESIST" );
 
 static const std::string flag_ALLOWS_REMOTE_USE( "ALLOWS_REMOTE_USE" );
 static const std::string flag_FILTHY( "FILTHY" );
@@ -1881,7 +1882,7 @@ class bionic_install_preset: public inventory_selector_preset
             const itype *itemtype = it->type;
             const bionic_id &bid = itemtype->bionic->id;
 
-            if( it->has_fault( fault_bionic_nonsterile ) ) {
+            if( it->has_fault( fault_bionic_nonsterile ) && !p.has_trait( trait_INFRESIST ) ) {
                 // NOLINTNEXTLINE(cata-text-style): single space after the period for symmetry
                 return _( "/!\\ CBM is not sterile. /!\\ Please use autoclave or other methods to sterilize." );
             } else if( pa.has_bionic( bid ) ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1820,11 +1820,9 @@ static item_location autodoc_internal( player &u, player &patient,
                     _( "\n<color_light_green>Found bionic installation data.  Affected CBMs are marked with an asterisk.</color>" ) );
     }
 
-    if( uninstall ) {
-        inv_s.set_title( string_format( _( "Bionic removal patient: %s" ), patient.get_name() ) );
-    } else {
-        inv_s.set_title( string_format( _( "Bionic installation patient: %s" ), patient.get_name() ) );
-    }
+    const auto title = uninstall
+                       ? _( "Bionic removal patient: %s" ) : _( "Bionic installation patient: %s" );
+    inv_s.set_title( string_format( title, patient.get_name() ) );
 
     inv_s.set_hint( hint );
     inv_s.set_display_stats( false );


### PR DESCRIPTION
#### Summary

SUMMARY: Features "allow installing non-sterile CBM when `Infection Immune`"

#### Purpose of change

inspired by https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/pull/60

#### Describe the solution

`Infection Immune`(INFRESIST) trait will ignore checking for CBM sterileness.

#### Testing

| Before `Infection Immune` | After `Infection Immune` |
|--------|--------|
| ![Cataclysm: Bright Nights - cbn-experimental-2023-04-19-1517_06](https://user-images.githubusercontent.com/54838975/233318327-25a75000-53dc-416a-98c4-f090fe8fdfcb.png) |  ![Cataclysm: Bright Nights - cbn-experimental-2023-04-19-1517_07](https://user-images.githubusercontent.com/54838975/233318339-624c3f28-5604-47dc-abe9-e32a1b975ecd.png) |
