### PR TITLE
refactor: registering actions/categories in action.cpp

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -683,7 +683,6 @@ static auto make_register_categories( std::vector<uilist_entry> &entries,
 action_id handle_action_menu()
 {
     const input_context ctxt = get_default_mode_input_context();
-    std::string catgname;
 
     // Calculate weightings for the various actions to give the player suggestions
     // Weight >= 200: Special action only available right now
@@ -878,7 +877,7 @@ action_id handle_action_menu()
 
         std::string title = _( "Actions" );
         if( category != "back" ) {
-            catgname = category;
+            std::string catgname = category;
             capitalize_letter( catgname, 0 );
             title += ": " + catgname;
         }

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -741,11 +741,11 @@ action_id handle_action_menu()
         std::map<int, std::string> categories_by_int;
         int last_category = NUM_ACTIONS + 1;
 
-        const auto REGISTER_ACTION = [&]( action_id name ) -> void {
+        const auto register_action = [&]( action_id name ) -> void {
             entries.emplace_back( name, true, hotkey_for_action( name ), ctxt.get_action_name( action_ident( name ) ) );
         };
 
-        const auto REGISTER_CATEGORY = [&]( const std::string & name ) -> void {
+        const auto register_category = [&]( const std::string & name ) -> void {
             categories_by_int[last_category] = name;
             catgname = name;
             catgname += "…";
@@ -756,68 +756,68 @@ action_id handle_action_menu()
         if( category == "back" ) {
             for( const auto &[ action, weight ] : sorted_pairs ) {
                 if( weight >= 200 ) {
-                    REGISTER_ACTION( action );
+                    register_action( action );
                 }
             }
 
-            REGISTER_CATEGORY( _( "Look" ) );
-            REGISTER_CATEGORY( _( "Interact" ) );
-            REGISTER_CATEGORY( _( "Inventory" ) );
-            REGISTER_CATEGORY( _( "Combat" ) );
-            REGISTER_CATEGORY( _( "Craft" ) );
-            REGISTER_CATEGORY( _( "Info" ) );
-            REGISTER_CATEGORY( _( "Misc" ) );
+            register_category( _( "Look" ) );
+            register_category( _( "Interact" ) );
+            register_category( _( "Inventory" ) );
+            register_category( _( "Combat" ) );
+            register_category( _( "Craft" ) );
+            register_category( _( "Info" ) );
+            register_category( _( "Misc" ) );
             if( hotkey_for_action( ACTION_QUICKSAVE ) > -1 ) {
-                REGISTER_ACTION( ACTION_QUICKSAVE );
+                register_action( ACTION_QUICKSAVE );
             }
-            REGISTER_ACTION( ACTION_SAVE );
+            register_action( ACTION_SAVE );
             if( hotkey_for_action( ACTION_QUICKLOAD ) > -1 ) {
-                REGISTER_ACTION( ACTION_QUICKLOAD );
+                register_action( ACTION_QUICKLOAD );
             }
             if( hotkey_for_action( ACTION_SUICIDE ) > -1 ) {
-                REGISTER_ACTION( ACTION_SUICIDE );
+                register_action( ACTION_SUICIDE );
             }
-            REGISTER_ACTION( ACTION_HELP );
+            register_action( ACTION_HELP );
             if( ( entry = &entries.back() ) ) {
                 // help _is_a menu.
                 entry->txt += "…";
             }
             if( hotkey_for_action( ACTION_DEBUG ) > -1 ) {
                 // register with global key
-                REGISTER_CATEGORY( _( "Debug" ) );
+                register_category( _( "Debug" ) );
                 if( ( entry = &entries.back() ) ) {
                     entry->hotkey = hotkey_for_action( ACTION_DEBUG );
                 }
             }
         } else if( category == _( "Look" ) ) {
-            REGISTER_ACTION( ACTION_LOOK );
-            REGISTER_ACTION( ACTION_PEEK );
-            REGISTER_ACTION( ACTION_LIST_ITEMS );
-            REGISTER_ACTION( ACTION_ZONES );
-            REGISTER_ACTION( ACTION_MAP );
-            REGISTER_ACTION( ACTION_SKY );
+            register_action( ACTION_LOOK );
+            register_action( ACTION_PEEK );
+            register_action( ACTION_LIST_ITEMS );
+            register_action( ACTION_ZONES );
+            register_action( ACTION_MAP );
+            register_action( ACTION_SKY );
         } else if( category == _( "Inventory" ) ) {
-            REGISTER_ACTION( ACTION_INVENTORY );
-            REGISTER_ACTION( ACTION_ADVANCEDINV );
-            REGISTER_ACTION( ACTION_SORT_ARMOR );
-            REGISTER_ACTION( ACTION_DIR_DROP );
+            register_action( ACTION_INVENTORY );
+            register_action( ACTION_ADVANCEDINV );
+            register_action( ACTION_SORT_ARMOR );
+            register_action( ACTION_DIR_DROP );
 
             // Everything below here can be accessed through
             // the inventory screen, so it's sorted to the
             // end of the list.
-            REGISTER_ACTION( ACTION_DROP );
-            REGISTER_ACTION( ACTION_COMPARE );
-            REGISTER_ACTION( ACTION_ORGANIZE );
-            REGISTER_ACTION( ACTION_USE );
-            REGISTER_ACTION( ACTION_WEAR );
-            REGISTER_ACTION( ACTION_TAKE_OFF );
-            REGISTER_ACTION( ACTION_EAT );
-            REGISTER_ACTION( ACTION_OPEN_CONSUME );
-            REGISTER_ACTION( ACTION_READ );
-            REGISTER_ACTION( ACTION_WIELD );
-            REGISTER_ACTION( ACTION_UNLOAD );
+            register_action( ACTION_DROP );
+            register_action( ACTION_COMPARE );
+            register_action( ACTION_ORGANIZE );
+            register_action( ACTION_USE );
+            register_action( ACTION_WEAR );
+            register_action( ACTION_TAKE_OFF );
+            register_action( ACTION_EAT );
+            register_action( ACTION_OPEN_CONSUME );
+            register_action( ACTION_READ );
+            register_action( ACTION_WIELD );
+            register_action( ACTION_UNLOAD );
         } else if( category == _( "Debug" ) ) {
-            REGISTER_ACTION( ACTION_DEBUG );
+            register_action( ACTION_DEBUG );
             if( ( entry = &entries.back() ) ) {
                 // debug _is_a menu.
                 entry->txt += "…";
@@ -826,84 +826,84 @@ action_id handle_action_menu()
             REGISTER_ACTION( ACTION_TOGGLE_FULLSCREEN );
 #endif
 #if defined(TILES)
-            REGISTER_ACTION( ACTION_TOGGLE_PIXEL_MINIMAP );
-            REGISTER_ACTION( ACTION_RELOAD_TILESET );
+            register_action( ACTION_TOGGLE_PIXEL_MINIMAP );
+            register_action( ACTION_RELOAD_TILESET );
 #endif // TILES
-            REGISTER_ACTION( ACTION_TOGGLE_PANEL_ADM );
-            REGISTER_ACTION( ACTION_DISPLAY_SCENT );
-            REGISTER_ACTION( ACTION_DISPLAY_SCENT_TYPE );
-            REGISTER_ACTION( ACTION_DISPLAY_TEMPERATURE );
-            REGISTER_ACTION( ACTION_DISPLAY_VEHICLE_AI );
-            REGISTER_ACTION( ACTION_DISPLAY_VISIBILITY );
-            REGISTER_ACTION( ACTION_DISPLAY_LIGHTING );
-            REGISTER_ACTION( ACTION_DISPLAY_TRANSPARENCY );
-            REGISTER_ACTION( ACTION_DISPLAY_RADIATION );
-            REGISTER_ACTION( ACTION_DISPLAY_SUBMAP_GRID );
-            REGISTER_ACTION( ACTION_TOGGLE_DEBUG_MODE );
+            register_action( ACTION_TOGGLE_PANEL_ADM );
+            register_action( ACTION_DISPLAY_SCENT );
+            register_action( ACTION_DISPLAY_SCENT_TYPE );
+            register_action( ACTION_DISPLAY_TEMPERATURE );
+            register_action( ACTION_DISPLAY_VEHICLE_AI );
+            register_action( ACTION_DISPLAY_VISIBILITY );
+            register_action( ACTION_DISPLAY_LIGHTING );
+            register_action( ACTION_DISPLAY_TRANSPARENCY );
+            register_action( ACTION_DISPLAY_RADIATION );
+            register_action( ACTION_DISPLAY_SUBMAP_GRID );
+            register_action( ACTION_TOGGLE_DEBUG_MODE );
         } else if( category == _( "Interact" ) ) {
-            REGISTER_ACTION( ACTION_EXAMINE );
-            REGISTER_ACTION( ACTION_SMASH );
-            REGISTER_ACTION( ACTION_MOVE_DOWN );
-            REGISTER_ACTION( ACTION_MOVE_UP );
-            REGISTER_ACTION( ACTION_OPEN );
-            REGISTER_ACTION( ACTION_CLOSE );
-            REGISTER_ACTION( ACTION_CHAT );
-            REGISTER_ACTION( ACTION_PICKUP );
-            REGISTER_ACTION( ACTION_PICKUP_FEET );
-            REGISTER_ACTION( ACTION_GRAB );
-            REGISTER_ACTION( ACTION_HAUL );
-            REGISTER_ACTION( ACTION_BUTCHER );
-            REGISTER_ACTION( ACTION_LOOT );
+            register_action( ACTION_EXAMINE );
+            register_action( ACTION_SMASH );
+            register_action( ACTION_MOVE_DOWN );
+            register_action( ACTION_MOVE_UP );
+            register_action( ACTION_OPEN );
+            register_action( ACTION_CLOSE );
+            register_action( ACTION_CHAT );
+            register_action( ACTION_PICKUP );
+            register_action( ACTION_PICKUP_FEET );
+            register_action( ACTION_GRAB );
+            register_action( ACTION_HAUL );
+            register_action( ACTION_BUTCHER );
+            register_action( ACTION_LOOT );
         } else if( category == _( "Combat" ) ) {
-            REGISTER_ACTION( ACTION_CYCLE_MOVE );
-            REGISTER_ACTION( ACTION_RESET_MOVE );
-            REGISTER_ACTION( ACTION_TOGGLE_RUN );
-            REGISTER_ACTION( ACTION_TOGGLE_CROUCH );
-            REGISTER_ACTION( ACTION_OPEN_MOVEMENT );
-            REGISTER_ACTION( ACTION_FIRE );
-            REGISTER_ACTION( ACTION_RELOAD_ITEM );
-            REGISTER_ACTION( ACTION_RELOAD_WEAPON );
-            REGISTER_ACTION( ACTION_RELOAD_WIELDED );
-            REGISTER_ACTION( ACTION_CAST_SPELL );
-            REGISTER_ACTION( ACTION_SELECT_FIRE_MODE );
-            REGISTER_ACTION( ACTION_SELECT_DEFAULT_AMMO );
-            REGISTER_ACTION( ACTION_THROW );
-            REGISTER_ACTION( ACTION_FIRE_BURST );
-            REGISTER_ACTION( ACTION_PICK_STYLE );
-            REGISTER_ACTION( ACTION_TOGGLE_AUTO_TRAVEL_MODE );
-            REGISTER_ACTION( ACTION_TOGGLE_SAFEMODE );
-            REGISTER_ACTION( ACTION_TOGGLE_AUTOSAFE );
-            REGISTER_ACTION( ACTION_IGNORE_ENEMY );
-            REGISTER_ACTION( ACTION_TOGGLE_AUTO_FEATURES );
-            REGISTER_ACTION( ACTION_TOGGLE_AUTO_PULP_BUTCHER );
-            REGISTER_ACTION( ACTION_TOGGLE_AUTO_MINING );
-            REGISTER_ACTION( ACTION_TOGGLE_AUTO_FORAGING );
+            register_action( ACTION_CYCLE_MOVE );
+            register_action( ACTION_RESET_MOVE );
+            register_action( ACTION_TOGGLE_RUN );
+            register_action( ACTION_TOGGLE_CROUCH );
+            register_action( ACTION_OPEN_MOVEMENT );
+            register_action( ACTION_FIRE );
+            register_action( ACTION_RELOAD_ITEM );
+            register_action( ACTION_RELOAD_WEAPON );
+            register_action( ACTION_RELOAD_WIELDED );
+            register_action( ACTION_CAST_SPELL );
+            register_action( ACTION_SELECT_FIRE_MODE );
+            register_action( ACTION_SELECT_DEFAULT_AMMO );
+            register_action( ACTION_THROW );
+            register_action( ACTION_FIRE_BURST );
+            register_action( ACTION_PICK_STYLE );
+            register_action( ACTION_TOGGLE_AUTO_TRAVEL_MODE );
+            register_action( ACTION_TOGGLE_SAFEMODE );
+            register_action( ACTION_TOGGLE_AUTOSAFE );
+            register_action( ACTION_IGNORE_ENEMY );
+            register_action( ACTION_TOGGLE_AUTO_FEATURES );
+            register_action( ACTION_TOGGLE_AUTO_PULP_BUTCHER );
+            register_action( ACTION_TOGGLE_AUTO_MINING );
+            register_action( ACTION_TOGGLE_AUTO_FORAGING );
         } else if( category == _( "Craft" ) ) {
-            REGISTER_ACTION( ACTION_CRAFT );
-            REGISTER_ACTION( ACTION_RECRAFT );
-            REGISTER_ACTION( ACTION_LONGCRAFT );
-            REGISTER_ACTION( ACTION_CONSTRUCT );
-            REGISTER_ACTION( ACTION_DISASSEMBLE );
+            register_action( ACTION_CRAFT );
+            register_action( ACTION_RECRAFT );
+            register_action( ACTION_LONGCRAFT );
+            register_action( ACTION_CONSTRUCT );
+            register_action( ACTION_DISASSEMBLE );
         } else if( category == _( "Info" ) ) {
-            REGISTER_ACTION( ACTION_PL_INFO );
-            REGISTER_ACTION( ACTION_MISSIONS );
-            REGISTER_ACTION( ACTION_SCORES );
-            REGISTER_ACTION( ACTION_FACTIONS );
-            REGISTER_ACTION( ACTION_MORALE );
-            REGISTER_ACTION( ACTION_MESSAGES );
-            REGISTER_ACTION( ACTION_DIARY );
+            register_action( ACTION_PL_INFO );
+            register_action( ACTION_MISSIONS );
+            register_action( ACTION_SCORES );
+            register_action( ACTION_FACTIONS );
+            register_action( ACTION_MORALE );
+            register_action( ACTION_MESSAGES );
+            register_action( ACTION_DIARY );
         } else if( category == _( "Misc" ) ) {
-            REGISTER_ACTION( ACTION_WAIT );
-            REGISTER_ACTION( ACTION_SLEEP );
-            REGISTER_ACTION( ACTION_BIONICS );
-            REGISTER_ACTION( ACTION_MUTATIONS );
-            REGISTER_ACTION( ACTION_CONTROL_VEHICLE );
-            REGISTER_ACTION( ACTION_ITEMACTION );
-            REGISTER_ACTION( ACTION_TOGGLE_THIEF_MODE );
+            register_action( ACTION_WAIT );
+            register_action( ACTION_SLEEP );
+            register_action( ACTION_BIONICS );
+            register_action( ACTION_MUTATIONS );
+            register_action( ACTION_CONTROL_VEHICLE );
+            register_action( ACTION_ITEMACTION );
+            register_action( ACTION_TOGGLE_THIEF_MODE );
 #if defined(TILES)
             if( use_tiles ) {
-                REGISTER_ACTION( ACTION_ZOOM_OUT );
-                REGISTER_ACTION( ACTION_ZOOM_IN );
+                register_action( ACTION_ZOOM_OUT );
+                register_action( ACTION_ZOOM_IN );
             }
 #endif
         }

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -659,11 +659,11 @@ bool can_interact_at( action_id action, const tripoint &p )
 
 static auto make_register_actions( std::vector<uilist_entry> &entries, const input_context &ctxt )
 {
-    return [&entries, &ctxt]( std::set<action_id> &&names ) -> void {
-        std::transform( names.begin(), names.end(), std::back_inserter( entries ), [&]( action_id name ) -> uilist_entry
-        {
+    return [&]( std::set<action_id> &&names ) -> void {
+        const auto fn = [&]( action_id name ) -> uilist_entry {
             return { name, true, hotkey_for_action( name ), ctxt.get_action_name( action_ident( name ) ) };
-        } );
+        };
+        std::transform( names.begin(), names.end(), std::back_inserter( entries ), fn );
     };
 }
 
@@ -671,12 +671,12 @@ static auto make_register_categories( std::vector<uilist_entry> &entries,
                                       std::map<int, std::string> &categories_by_int,
                                       int &last_category )
 {
-    return [&entries, &categories_by_int, &last_category]( std::set<std::string> &&names ) -> void {
-        std::transform( names.begin(), names.end(), std::back_inserter( entries ), [&]( std::string name ) -> uilist_entry
-        {
+    return [&]( std::set<std::string> &&names ) -> void {
+        const auto fn = [&]( std::string name ) -> uilist_entry {
             categories_by_int[last_category] = name;
             return { last_category++, true, -1, name + "…" };
-        } );
+        };
+        std::transform( names.begin(), names.end(), std::back_inserter( entries ),  fn );
     };
 }
 

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -662,14 +662,6 @@ action_id handle_action_menu()
     const input_context ctxt = get_default_mode_input_context();
     std::string catgname;
 
-#define REGISTER_ACTION( name ) entries.emplace_back( name, true, hotkey_for_action(name), \
-        ctxt.get_action_name( action_ident( name ) ) );
-#define REGISTER_CATEGORY( name )  categories_by_int[last_category] = name; \
-    catgname = name; \
-    catgname += "…"; \
-    entries.emplace_back( last_category, true, -1, catgname ); \
-    last_category++;
-
     // Calculate weightings for the various actions to give the player suggestions
     // Weight >= 200: Special action only available right now
     std::map<action_id, int> action_weightings;
@@ -749,11 +741,22 @@ action_id handle_action_menu()
         std::map<int, std::string> categories_by_int;
         int last_category = NUM_ACTIONS + 1;
 
+        const auto REGISTER_ACTION = [&]( action_id name ) -> void {
+            entries.emplace_back( name, true, hotkey_for_action( name ), ctxt.get_action_name( action_ident( name ) ) );
+        };
+
+        const auto REGISTER_CATEGORY = [&]( const std::string & name ) -> void {
+            categories_by_int[last_category] = name;
+            catgname = name;
+            catgname += "…";
+            entries.emplace_back( last_category, true, -1, catgname );
+            last_category++;
+        };
+
         if( category == "back" ) {
-            std::vector<std::pair<action_id, int> >::iterator it;
-            for( it = sorted_pairs.begin(); it != sorted_pairs.end(); ++it ) {
-                if( it->second >= 200 ) {
-                    REGISTER_ACTION( it->first );
+            for( const auto &[ action, weight ] : sorted_pairs ) {
+                if( weight >= 200 ) {
+                    REGISTER_ACTION( action );
                 }
             }
 
@@ -939,9 +942,6 @@ action_id handle_action_menu()
             return static_cast<action_id>( selection );
         }
     }
-
-#undef REGISTER_ACTION
-#undef REGISTER_CATEGORY
 }
 
 action_id handle_main_menu()

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -672,7 +672,7 @@ static auto make_register_categories( std::vector<uilist_entry> &entries,
                                       int &last_category )
 {
     return [&]( std::set<std::string> &&names ) -> void {
-        const auto fn = [&]( std::string name ) -> uilist_entry {
+        const auto fn = [&]( const std::string & name ) -> uilist_entry {
             categories_by_int[last_category] = name;
             return { last_category++, true, -1, name + "…" };
         };

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -753,6 +753,12 @@ action_id handle_action_menu()
             last_category++;
         };
 
+        const auto register_action_if_hotkey_assigned = [&]( action_id action ) {
+            if( hotkey_for_action( action ) > -1 ) {
+                register_action( action );
+            }
+        };
+
         if( category == "back" ) {
             for( const auto &[ action, weight ] : sorted_pairs ) {
                 if( weight >= 200 ) {
@@ -767,16 +773,10 @@ action_id handle_action_menu()
             register_category( _( "Craft" ) );
             register_category( _( "Info" ) );
             register_category( _( "Misc" ) );
-            if( hotkey_for_action( ACTION_QUICKSAVE ) > -1 ) {
-                register_action( ACTION_QUICKSAVE );
-            }
+            register_action_if_hotkey_assigned( ACTION_QUICKSAVE );
             register_action( ACTION_SAVE );
-            if( hotkey_for_action( ACTION_QUICKLOAD ) > -1 ) {
-                register_action( ACTION_QUICKLOAD );
-            }
-            if( hotkey_for_action( ACTION_SUICIDE ) > -1 ) {
-                register_action( ACTION_SUICIDE );
-            }
+            register_action_if_hotkey_assigned( ACTION_QUICKLOAD );
+            register_action_if_hotkey_assigned( ACTION_SUICIDE );
             register_action( ACTION_HELP );
             if( ( entry = &entries.back() ) ) {
                 // help _is_a menu.

--- a/src/character.h
+++ b/src/character.h
@@ -81,7 +81,7 @@ template <typename E> struct enum_traits;
 
 enum class character_stat : char;
 
-#define MAX_CLAIRVOYANCE 40
+constexpr int MAX_CLAIRVOYANCE = 40;
 
 enum vision_modes {
     DEBUG_NIGHTVISION,


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Refactor registering actions/categories in action.cpp"

#### Purpose of change

i was bored and the code looked bad.

#### Describe the solution
replaced `REGISTER_ACTION` and `REGISTER_CATEGORY` macro with `make_register_actions` and `make_register_categories`.

they are curried functions which capture state then return another function which you can conveniently name `register_actions` and `register_categories`. pass it a set and you're good to go. also, it should be fairly performant because it's rvalue refed and uses std::transform under the hood.

#### Describe alternatives you've considered

put registering action and action for it in same function, because current system is very bug prone
```c++
// before

register("SOME_KEY");
// ...
if ( key == "SOME_KEY" ) {
	// do something
}
```
```c++
// after
register("SOME_KEY", [&]() -> void {
	// do something
})
```

#### Testing

idk i guess it'd pass tests?

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
