### PR TITLE
No stripping non-ally NPCs.

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5264,7 +5264,7 @@ bool game::npc_menu( npc &who )
     amenu.addentry( push, obeys && !who.is_mounted(), 'p', _( "Push away" ) );
     amenu.addentry( examine_wounds, true, 'w', _( "Examine wounds" ) );
     amenu.addentry( use_item, true, 'i', _( "Use item on" ) );
-    amenu.addentry( sort_armor, true, 'r', _( "Sort armor" ) );
+    amenu.addentry( sort_armor, obeys, 'r', _( "Sort armor" ) );
     amenu.addentry( attack, true, 'a', _( "Attack" ) );
     if( !who.is_player_ally() ) {
         amenu.addentry( disarm, who.is_armed(), 'd', _( "Disarm" ) );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "No stripping non-ally NPCs."

#### Purpose of change

Xindage on the Discord noted that you can strip down non-allied NPCs, this includes hostiles you are in combat with.

#### Describe the solution

You can no longer access the sort armour menu for non-allied NPCs.

#### Describe alternatives you've considered

Expand on NPC menu to account for hostility instead of just "is ally" and "not mounted".
- Probably something to do _eventually_, but not right now.

#### Testing

Spawn into world, spawn NPC, check that I can't access the sort armour menu. Using debug mind control, convert them into an ally, then note that I can strip them down and dress them up.

#### Additional context

You know, maybe one day we can simulate a bit of DF's systems, if only so we can engage in [strip combat.](https://www.youtube.com/watch?v=y4fKibUs9jg)