### PR TITLE
ci: use concurrency in documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,6 +8,10 @@ on:
     branches: [upload]
   workflow_dispatch:
 
+concurrency:
+  group: documentation
+  cancel-in-progress: true
+
 jobs:
   documentation:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Use concurrency in documentation"

#### Purpose of change

hopefully fix documentation build failure when merging multiple PRs in succession

#### Describe the solution

use [concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency)
