### PR TITLE
Removed "to_hit" from punch dagger

### DIFF
--- a/data/json/items/melee/unarmed_weapons.json
+++ b/data/json/items/melee/unarmed_weapons.json
@@ -109,7 +109,6 @@
     "name": { "str": "punch dagger" },
     "description": "A short and sharp double-edged dagger made to be gripped in the palm, with the blade protruding between the fingers.",
     "weight": "168 g",
-    "to_hit": -1,
     "price_postapoc": 50,
     "color": "dark_gray",
     "symbol": "{",


### PR DESCRIPTION
SUMMARY: [Balance] "Changed the punch dagger to no longer have a to-hit penalty."

#### Purpose of change

The punch dagger is, effectively, a blade protruding between two fingers; it would make your punches hit harder thanks to the blade, but it wouldn't hamper your ability to punch.

#### Describe the solution

I removed a single line from the json, thus removing its attack penalty.