### PR TITLE
Old Guard expansion: a trip to the necropolis

### DIFF
--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -214,6 +214,13 @@
     "fun": -2
   },
   {
+    "id": "necropolis_datasheet",
+    "type": "BOOK",
+    "name": { "str": "reclamation team report" },
+    "description": "A short written report on the findings of a team sent to reclaim an underground civil defense shelter.  It lists several hazards and technical problems encountered during their exploration of the site, but mentions several military systems they expect could be repaired and used for communication.",
+    "copy-from": "necropolis_freq"
+  },
+  {
     "id": "news_regional",
     "type": "BOOK",
     "name": { "str": "Rural Digest-Examiner", "str_pl": "issues of Rural Digest-Examiner" },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6162,6 +6162,16 @@
   },
   {
     "type": "mutation",
+    "id": "PROF_MILITARY",
+    "name": { "str": "Military Remnant" },
+    "points": 0,
+    "description": "You are a member of the United States Armed Forces, or what's left of it at least.",
+    "valid": false,
+    "purifiable": false,
+    "profession": true
+  },
+  {
+    "type": "mutation",
     "id": "NPC_BRANDY",
     "name": { "str": "Carries Brandy" },
     "points": 0,

--- a/data/json/npcs/necropolis/NPC_Old_Guard_Captain.json
+++ b/data/json/npcs/necropolis/NPC_Old_Guard_Captain.json
@@ -31,6 +31,17 @@
     },
     "responses": [
       {
+        "text": "[MISSION] I was asked to get a report from you to send to your superiors.",
+        "topic": "TALK_OLD_GUARD_NEC_CPT_REPORT",
+        "condition": {
+          "and": [
+            { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" },
+            { "u_has_mission": "MISSION_OLD_GUARD_REP_5" },
+            { "not": { "u_has_item": "necropolis_datasheet" } }
+          ]
+        }
+      },
+      {
         "text": "What are you doing down here?",
         "topic": "TALK_OLD_GUARD_NEC_CPT_GOAL",
         "condition": { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" }
@@ -98,6 +109,12 @@
     "dynamic_line": "Not like I could look up personnel records from down here.  Our team in the comms center might be able to uplink with some old registries but then I'd have to give you clearance to go wandering around down here anyway.  I'll take your word for it but watch yourself down here, this place is dangerous.",
     "speaker_effect": { "effect": { "u_add_var": "npc_necro_gave_clearance", "type": "dialogue", "context": "necropolis", "value": "yes" } },
     "responses": [ { "text": "Understood.", "topic": "TALK_OLD_GUARD_NEC_CPT" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_OLD_GUARD_NEC_CPT_REPORT",
+    "dynamic_line": "Alright, I've got a sitrep written out.  As helpful as it'd be to have you here, getting this back to the others could also help get us reinforcements somewhere down the line.  Not a lot of this place is operational anymore, but we're expecting comms to provide a link to other assets in the region if we can get it in full working order.",
+    "responses": [ { "text": "Thank you.", "topic": "TALK_NONE" }, { "text": "Thank you, that's all for now.", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/necropolis/NPC_Old_Guard_Captain.json
+++ b/data/json/npcs/necropolis/NPC_Old_Guard_Captain.json
@@ -15,7 +15,7 @@
     "type": "talk_topic",
     "id": "TALK_OLD_GUARD_NEC_CPT",
     "dynamic_line": {
-      "npc_has_var": "npc_necro_gave_clearance",
+      "u_has_var": "npc_necro_gave_clearance",
       "type": "dialogue",
       "context": "necropolis",
       "value": "yes",
@@ -65,7 +65,7 @@
       },
       {
         "text": "This seems like a military matter to me, I'm here to assist.",
-        "topic": "TALK_OLD_GUARD_NEC_CPT_MIL",
+        "topic": "TALK_OLD_GUARD_NEC_CPT_MILITARY",
         "switch": true,
         "condition": { "u_has_trait": "PROF_MILITARY" }
       },
@@ -105,7 +105,7 @@
   },
   {
     "type": "talk_topic",
-    "id": "TALK_OLD_GUARD_NEC_CPT_MILITARRY",
+    "id": "TALK_OLD_GUARD_NEC_CPT_MILITARY",
     "dynamic_line": "Not like I could look up personnel records from down here.  Our team in the comms center might be able to uplink with some old registries but then I'd have to give you clearance to go wandering around down here anyway.  I'll take your word for it but watch yourself down here, this place is dangerous.",
     "speaker_effect": { "effect": { "u_add_var": "npc_necro_gave_clearance", "type": "dialogue", "context": "necropolis", "value": "yes" } },
     "responses": [ { "text": "Understood.", "topic": "TALK_OLD_GUARD_NEC_CPT" } ]
@@ -114,6 +114,7 @@
     "type": "talk_topic",
     "id": "TALK_OLD_GUARD_NEC_CPT_REPORT",
     "dynamic_line": "Alright, I've got a sitrep written out.  As helpful as it'd be to have you here, getting this back to the others could also help get us reinforcements somewhere down the line.  Not a lot of this place is operational anymore, but we're expecting comms to provide a link to other assets in the region if we can get it in full working order.",
+    "speaker_effect": { "effect": { "u_buy_item": "necropolis_datasheet" } },
     "responses": [ { "text": "Thank you.", "topic": "TALK_NONE" }, { "text": "Thank you, that's all for now.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/necropolis/NPC_Old_Guard_Captain.json
+++ b/data/json/npcs/necropolis/NPC_Old_Guard_Captain.json
@@ -61,12 +61,22 @@
       {
         "text": "About the mission…",
         "topic": "TALK_MISSION_INQUIRE",
-        "condition": { "and": [ "has_assigned_mission", { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" } ] }
+        "condition": {
+          "and": [
+            "has_assigned_mission",
+            { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" }
+          ]
+        }
       },
       {
         "text": "About one of those missions…",
         "topic": "TALK_MISSION_LIST_ASSIGNED",
-        "condition": { "and": [ "has_many_assigned_missions", { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" } ] }
+        "condition": {
+          "and": [
+            "has_many_assigned_missions",
+            { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" }
+          ]
+        }
       },
       { "text": "I've got to go…", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/necropolis/NPC_Old_Guard_Captain.json
+++ b/data/json/npcs/necropolis/NPC_Old_Guard_Captain.json
@@ -15,41 +15,79 @@
     "type": "talk_topic",
     "id": "TALK_OLD_GUARD_NEC_CPT",
     "dynamic_line": {
-      "u_is_wearing": "badge_marshal",
-      "yes": "Marshal, I hope you're here to assist us.",
+      "npc_has_var": "npc_necro_gave_clearance",
+      "type": "dialogue",
+      "context": "necropolis",
+      "value": "yes",
+      "yes": "I hope you're here to assist us.",
       "no": {
-        "u_male": "Sir, I don't know how the hell you got down here but if you have any sense you'll get out while you can.",
-        "no": "Ma'am, I don't know how the hell you got down here but if you have any sense you'll get out while you can."
+        "u_is_wearing": "badge_marshal",
+        "yes": "I don't know how you got down here Marshal, but if Command sent you we could use your help.",
+        "no": {
+          "u_male": "Sir, I don't know how the hell you got down here but if you have any sense you'll get out while you can.",
+          "no": "Ma'am, I don't know how the hell you got down here but if you have any sense you'll get out while you can."
+        }
       }
     },
     "responses": [
       {
         "text": "What are you doing down here?",
         "topic": "TALK_OLD_GUARD_NEC_CPT_GOAL",
-        "condition": { "u_is_wearing": "badge_marshal" }
+        "condition": { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" }
       },
       {
         "text": "Can you tell me about this facility?",
         "topic": "TALK_OLD_GUARD_NEC_CPT_VAULT",
-        "condition": { "u_is_wearing": "badge_marshal" }
+        "condition": { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" }
       },
       {
         "text": "What do you need done?",
         "topic": "TALK_MISSION_LIST",
-        "condition": { "u_is_wearing": "badge_marshal" }
+        "switch": true,
+        "condition": { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" }
+      },
+      {
+        "text": "I've had experience with Old Guard matters before, I can help.",
+        "topic": "TALK_OLD_GUARD_NEC_CPT_MARSHAL",
+        "switch": true,
+        "condition": { "or": [ { "u_is_wearing": "badge_marshal" }, { "u_has_trait": "PROF_FED" } ] }
+      },
+      {
+        "text": "This seems like a military matter to me, I'm here to assist.",
+        "topic": "TALK_OLD_GUARD_NEC_CPT_MIL",
+        "switch": true,
+        "condition": { "u_has_trait": "PROF_MILITARY" }
       },
       {
         "text": "About the mission…",
         "topic": "TALK_MISSION_INQUIRE",
-        "condition": { "and": [ "has_assigned_mission", { "u_is_wearing": "badge_marshal" } ] }
+        "condition": { "and": [ "has_assigned_mission", { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" } ] }
       },
       {
         "text": "About one of those missions…",
         "topic": "TALK_MISSION_LIST_ASSIGNED",
-        "condition": { "and": [ "has_many_assigned_missions", { "u_is_wearing": "badge_marshal" } ] }
+        "condition": { "and": [ "has_many_assigned_missions", { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" } ] }
       },
       { "text": "I've got to go…", "topic": "TALK_DONE" }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_OLD_GUARD_NEC_CPT_MARSHAL",
+    "dynamic_line": {
+      "u_is_wearing": "badge_marshal",
+      "yes": "We can use all the help we can get.  I'll send word out to the others that you're cleared to be here, but be careful.  There are still some hotspots contaminated with radiation in this sector, and the lower level is in even worse shape.",
+      "no": "I was expecting someone wearing their badge, but alright.  I'll give you clearance but try to be careful down here.  I don't want over-eager civilian contractors, or whatever you may be, getting themselves killed just for our sake."
+    },
+    "speaker_effect": { "effect": { "u_add_var": "npc_necro_gave_clearance", "type": "dialogue", "context": "necropolis", "value": "yes" } },
+    "responses": [ { "text": "I'll do what I can.", "topic": "TALK_OLD_GUARD_NEC_CPT" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_OLD_GUARD_NEC_CPT_MILITARRY",
+    "dynamic_line": "Not like I could look up personnel records from down here.  Our team in the comms center might be able to uplink with some old registries but then I'd have to give you clearance to go wandering around down here anyway.  I'll take your word for it but watch yourself down here, this place is dangerous.",
+    "speaker_effect": { "effect": { "u_add_var": "npc_necro_gave_clearance", "type": "dialogue", "context": "necropolis", "value": "yes" } },
+    "responses": [ { "text": "Understood.", "topic": "TALK_OLD_GUARD_NEC_CPT" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/necropolis/NPC_Old_Guard_Commo.json
+++ b/data/json/npcs/necropolis/NPC_Old_Guard_Commo.json
@@ -15,12 +15,15 @@
     "type": "talk_topic",
     "id": "TALK_OLD_GUARD_NEC_COMMO",
     "dynamic_line": {
-      "u_is_wearing": "badge_marshal",
-      "yes": "Marshal, I'm rather surprised to see you here.",
+      "u_has_effect": "has_og_comm_freq",
+      "yes": "Welcome back.",
       "no": {
-        "u_male": true,
-        "yes": "Sir you are not authorized to be here… you should leave.",
-        "no": "Ma'am you are not authorized to be here… you should leave."
+        "u_is_wearing": "badge_marshal",
+        "yes": "Marshal, I'm rather surprised to see you here.",
+        "no": {
+          "yes": "Sir, I'm not sure you're authorized to be here…",
+          "no": "Ma'am, I'm not sure you're authorized to be here…"
+        }
       }
     },
     "responses": [
@@ -29,7 +32,7 @@
         "topic": "TALK_OLD_GUARD_NEC_COMMO_FREQ",
         "condition": {
           "and": [
-            { "u_is_wearing": "badge_marshal" },
+            { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" },
             { "u_has_mission": "MISSION_OLD_GUARD_NEC_1" },
             { "not": { "u_has_effect": "has_og_comm_freq" } }
           ]
@@ -38,22 +41,37 @@
       {
         "text": "What are you doing here?",
         "topic": "TALK_OLD_GUARD_NEC_COMMO_GOAL",
-        "condition": { "u_is_wearing": "badge_marshal" }
+        "condition": { "u_has_effect": "has_og_comm_freq" }
       },
       {
         "text": "Do you need any help?",
         "topic": "TALK_MISSION_LIST",
-        "condition": { "and": [ { "u_has_effect": "has_og_comm_freq" }, { "u_is_wearing": "badge_marshal" } ] }
+        "condition": {
+          "and": [
+            { "u_has_effect": "has_og_comm_freq" },
+            { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" }
+          ]
+        }
       },
       {
         "text": "About the mission…",
         "topic": "TALK_MISSION_INQUIRE",
-        "condition": { "and": [ "has_assigned_mission", { "u_is_wearing": "badge_marshal" } ] }
+        "condition": {
+          "and": [
+            "has_assigned_mission",
+            { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" }
+          ]
+        }
       },
       {
         "text": "About one of those missions…",
         "topic": "TALK_MISSION_LIST_ASSIGNED",
-        "condition": { "and": [ "has_many_assigned_missions", { "u_is_wearing": "badge_marshal" } ] }
+        "condition": {
+          "and": [
+            "has_many_assigned_missions",
+            { "u_has_var": "npc_necro_gave_clearance", "value": "yes", "type": "dialogue", "context": "necropolis" }
+          ]
+        }
       },
       { "text": "I should be going", "topic": "TALK_DONE" }
     ]
@@ -67,7 +85,11 @@
   {
     "type": "talk_topic",
     "id": "TALK_OLD_GUARD_NEC_COMMO_FREQ",
-    "dynamic_line": "I was expecting the captain to send a runner.  Here is the list you are looking for.  What we can identify from here are simply the frequencies that have traffic on them.  Many of the transmissions are indecipherable without repairing or replacing the equipment here.  When the facility was being overrun, standard procedure was to destroy encryption hardware to protect federal secrets and maintain the integrity of the comms network.  We are hoping a few plain text messages can get picked up though.",
+    "dynamic_line": {
+      "u_is_wearing": "badge_marshal",
+      "yes": "I was expecting the captain to send a runner.  Here is the list you are looking for.  What we can identify from here are simply the frequencies that have traffic on them.  Many of the transmissions are indecipherable without repairing or replacing the equipment here.  When the facility was being overrun, standard procedure was to destroy encryption hardware to protect federal secrets and maintain the integrity of the comms network.  We are hoping a few plain text messages can get picked up though.",
+      "no": "I hope that means you're cleared to be here.  Here is the list you are looking for.  What we can identify from here are simply the frequencies that have traffic on them.  Many of the transmissions are indecipherable without repairing or replacing the equipment here.  When the facility was being overrun, standard procedure was to destroy encryption hardware to protect federal secrets and maintain the integrity of the comms network.  We are hoping a few plain text messages can get picked up though."
+    },
     "responses": [
       {
         "text": "Thanks.",

--- a/data/json/npcs/necropolis/NPC_Old_Guard_Commo.json
+++ b/data/json/npcs/necropolis/NPC_Old_Guard_Commo.json
@@ -21,6 +21,7 @@
         "u_is_wearing": "badge_marshal",
         "yes": "Marshal, I'm rather surprised to see you here.",
         "no": {
+          "u_male": true,
           "yes": "Sir, I'm not sure you're authorized to be here…",
           "no": "Ma'am, I'm not sure you're authorized to be here…"
         }

--- a/data/json/npcs/necropolis/NPC_Old_Guard_Soldier.json
+++ b/data/json/npcs/necropolis/NPC_Old_Guard_Soldier.json
@@ -14,7 +14,7 @@
     "type": "talk_topic",
     "id": "TALK_OLD_GUARD_SOLDIER",
     "dynamic_line": {
-      "npc_has_var": "npc_necro_gave_clearance",
+      "u_has_var": "npc_necro_gave_clearance",
       "type": "dialogue",
       "context": "necropolis",
       "value": "yes",

--- a/data/json/npcs/necropolis/NPC_Old_Guard_Soldier.json
+++ b/data/json/npcs/necropolis/NPC_Old_Guard_Soldier.json
@@ -14,23 +14,38 @@
     "type": "talk_topic",
     "id": "TALK_OLD_GUARD_SOLDIER",
     "dynamic_line": {
-      "u_is_wearing": "badge_marshal",
+      "npc_has_var": "npc_necro_gave_clearance",
+      "type": "dialogue",
+      "context": "necropolis",
+      "value": "yes",
       "yes": [
-        "Hello, marshal.",
-        "Marshal, I'm afraid I can't talk now.",
-        "I'm not in charge here, marshal.",
-        "I'm supposed to direct all questions to my leadership, marshal."
+        "Glad to see we're not on our own down here…",
+        "I'm afraid I can't talk now, check with the captain or our comms officer.",
+        "Not much I can tell you, I'm not in charge here",
+        "I'm supposed to direct all questions to my leadership.",
+        "Be careful out there, the lower levels are still a mess."
       ],
-      "no": [
-        "Hey, citizen… I'm not sure you belong here.",
-        "You should mind your own business, nothing to see here.",
-        "If you need something you'll need to talk to someone else.",
-        {
-          "u_male": true,
-          "yes": [ "Sir.", "Dude, if you can hold your own you should look into enlisting." ],
-          "no": [ "Ma'am", "Hey miss, don't you think it would be safer if you stuck with me?" ]
-        }
-      ]
+      "no": {
+        "u_is_wearing": "badge_marshal",
+        "yes": [
+          "Hello, marshal.  You should check in with the captain.",
+          "I'm afraid I can't talk now, speak with my commanding officer.",
+          "A marshal, huh?  The captain would like a word with you.",
+          "Are you our reinforcements?  I'd suggest you talk to our CO.",
+          "Sorry marshal, I'm on duty.  Check in with our commander."
+        ],
+        "no": [
+          "Hey, citizen… I'm not sure you belong here.",
+          "You should mind your own business, nothing to see here.",
+          "If you need something you'll need to talk to someone else.",
+          {
+            "u_male": true,
+            "yes": [ "Sir.", "Dude, if you can hold your own you should look into enlisting." ],
+            "no": [ "Ma'am", "Hey miss, don't you think it would be safer if you stuck with me?" ]
+          },
+          "I don't know how bad things have gotten out there, but this place seriously isn't safe for civilians."
+        ]
+      }
     },
     "responses": [ { "text": "Don't mind me…", "topic": "TALK_DONE" } ]
   }

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
@@ -231,6 +231,7 @@
       ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],
+    "followup": "MISSION_OLD_GUARD_REP_4",
     "dialogue": {
       "describe": "We need help…",
       "offer": "I've located a Hell's Raiders encampment in the region that appears to be coordinating operations against the Free Merchants.  We know almost nothing about the command structure in the 'gang' so I need to send someone in to decapitate the leadership.  The raid will be held under orders of the U.S. Marshals Service and by agreeing to the mission you will become a marshal, swearing to assist the federal government in regaining order.",
@@ -238,7 +239,33 @@
       "rejected": "Come back when you get a chance, we could use a few good men.",
       "advice": "I'd recommend having two deputies… it would be a death trap if a single man got surrounded.",
       "inquire": "Has the leadership been dealt with?",
-      "success": "Marshal, you continue to impress us.  If you are interested, I recently received a message that a unit was deploying into our AO.  I don't have the exact coordinates but they said they were securing an underground facility and may require assistance.  The bird dropped them off next to a pump station.  Can't tell you much more.  If you could locate the captain in charge, I'm sure he could use your skills.  Don't forget to wear your badge when meeting with them.  Thank you once again marshal.",
+      "success": "Marshal, you continue to impress us.  With their leadership broken it will be easier to establish a foothold in the area, secure resources for rebuilding.  I've been keeping Command informed and while there is certainly a lot you could do to help here, they might have missions for me to offer you that will take you farther afield.  In any case, thank you once again marshal.",
+      "success_lie": "What good does this do us?",
+      "failure": "It was a lost cause anyways…"
+    }
+  },
+  {
+    "id": "MISSION_OLD_GUARD_REP_5",
+    "type": "mission_definition",
+    "name": { "str": "Link Up With Vault Expedition" },
+    "description": "Find the team securing an installation under a city, return with the captain's report on the location.",
+    "goal": "MGOAL_FIND_ITEM",
+    "difficulty": 8,
+    "value": 200000,
+    "item": "necropolis_datasheet",
+    "start": {
+      "assign_mission_target": { "om_terrain": "necropolis_a_29", "om_special": "Necropolis", "reveal_radius": 5, "search_range": 360 }
+    },
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "followup": "MISSION_FREE_MERCHANTS_EVAC_4",
+    "dialogue": {
+      "describe": "We need help…",
+      "offer": "If you are interested, I recently received a message that a unit was deploying into our AO.  I've been informed of an underground facility they're attempting to secure, and they may require assistance.  The bird dropped them off next to a pump station.  Not much more I can tell you.  We've had difficulty keeping in contact with them, so command has requested you give us a status report when you return.  If you could locate the captain in charge, I'm sure he could use your skills.",
+      "accepted": "It's a small urban center with a fortified vault underneath it.  The sewage network most likely contains access tunnels to enter the facility itself, and if they're going to actually get any use out of the place they'll likely focus their efforts on any communications hub or command-and-control systems inside.  We last heard contact from them shortly before they ventured underground, if they are still alive the lack of radio silence means they probably got tied up trying to get comms online.  If you can, get a full sit-rep from their commanding officer.",
+      "rejected": "Come back when you get a chance, we need someone with experience like you.",
+      "advice": "That place had to have been staffed when this started, so if they had to try and re-take it you should expect trouble of some sort.  They last reports also mentioned damage from what might be artillery or some other ordinance, so infrastructure on the surface might be damaged.  Might even be contaminated, the conditions are currently an unknown at present.",
+      "inquire": "What do you have for me?",
+      "success": "Great, I'll work on sending word to my superiors about this.  I'm going to guess it was a mess down there, but hopefully their report will tell us more about what's still functional and could be brought back online.",
       "success_lie": "What good does this do us?",
       "failure": "It was a lost cause anyways…"
     }

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
@@ -231,7 +231,7 @@
       ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],
-    "followup": "MISSION_OLD_GUARD_REP_4",
+    "followup": "MISSION_OLD_GUARD_REP_5",
     "dialogue": {
       "describe": "We need help…",
       "offer": "I've located a Hell's Raiders encampment in the region that appears to be coordinating operations against the Free Merchants.  We know almost nothing about the command structure in the 'gang' so I need to send someone in to decapitate the leadership.  The raid will be held under orders of the U.S. Marshals Service and by agreeing to the mission you will become a marshal, swearing to assist the federal government in regaining order.",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -789,6 +789,7 @@
     "name": "Military Recruit",
     "description": "You were a high school drop-out with one goal in mind: to join the military.  You finally got in, just in time for your training to get interrupted by a national emergency.  As far as you can tell, military command abandoned you in this hellhole when you missed the emergency evac.",
     "points": 4,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 2, "name": "gun" },
       { "level": 1, "name": "rifle" },
@@ -829,6 +830,7 @@
     "name": "Special Operator",
     "description": "You were the best of the best, the military's finest.  That's why you're still alive, even after all your comrades fell to the undead.  As far as you can tell, military command abandoned you in this hellhole when you missed the emergency evac.",
     "points": 5,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "smg" },
@@ -2091,6 +2093,7 @@
       "bio_power_storage_mkII",
       "bio_taste_blocker"
     ],
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 2, "name": "gun" },
       { "level": 2, "name": "melee" },
@@ -2144,6 +2147,7 @@
       "bio_lighter",
       "bio_night_vision"
     ],
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 5, "name": "gun" },
       { "level": 4, "name": "rifle" },
@@ -3158,6 +3162,7 @@
     "name": "National Guard",
     "description": "Your National Guard unit was activated when the epidemic struck.  Despite your best efforts you did not manage to meet up with them before all communications ceased and you found yourself alone amongst the dead.",
     "points": 3,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [ { "level": 1, "name": "gun" }, { "level": 1, "name": "firstaid" } ],
     "items": {
       "both": {
@@ -3403,6 +3408,7 @@
     "name": "Military Holdout",
     "description": "You must have paid attention to your survival training in boot camp, otherwise you would never have lived long enough to outlast the chain of command and find yourself in this predicament.  The only mission left now is to survive.",
     "points": 6,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 4, "name": "survival" },
       { "level": 4, "name": "gun" },
@@ -4426,6 +4432,7 @@
     "name": "Military Pilot",
     "description": "You got to see things fall apart from the sky, transporting soldiers and survivors from one holdout to the next.  You knew it was only a matter of time before the horrors patrolling the skies shot you down.",
     "points": 5,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 4, "name": "driving" },
       { "level": 3, "name": "pistol" },

--- a/data/mods/CRT_EXPANSION/scenarios/crt_classes.json
+++ b/data/mods/CRT_EXPANSION/scenarios/crt_classes.json
@@ -26,7 +26,7 @@
     "name": "C.R.I.T. ROTC Member",
     "description": "You were training ahead of time to become a C.R.I.T officer in the upcoming war.  Your call to arms arrived dead on arrival and already plastered in the all-too vibrant gore of your squadmates.  In the midst of panic, you bugged out lest you join the remnants of your friends.  Now it's up to your wits and short years of training to keep you alive in this Cataclysm.",
     "points": 7,
-    "traits": [ "MARTIAL_CRT" ],
+    "traits": [ "MARTIAL_CRT", "PROF_MILITARY" ],
     "skills": [
       { "level": 2, "name": "gun" },
       { "level": 2, "name": "rifle" },
@@ -91,7 +91,7 @@
     "name": "C.R.I.T. NCO",
     "description": "You were a senior NCO, relaying orders to your squad was an everyday task.  When the cataclysm struck, your expertise helped save everyone time and time again until it all fell apart.",
     "points": 10,
-    "traits": [ "MARTIAL_CRT" ],
+    "traits": [ "MARTIAL_CRT", "PROF_MILITARY" ],
     "skills": [
       { "level": 2, "name": "gun" },
       { "level": 2, "name": "rifle" },
@@ -137,7 +137,7 @@
     "name": "C.R.I.T. Grunt",
     "description": "You were part of the infantry; first to hit the ground running, clear a FOB and then come back to relax with your squad.  Those days ended when the cataclysm reared its ugly head.  Your lines were torn through like wet paper when the otherworldly abominations arrived.  Now fleeing for your life, will you have what it takes to survive or is this hellish landscape your resting place?",
     "points": 8,
-    "traits": [ "MARTIAL_CRT" ],
+    "traits": [ "MARTIAL_CRT", "PROF_MILITARY" ],
     "skills": [ { "level": 3, "name": "gun" }, { "level": 3, "name": "rifle" }, { "level": 1, "name": "stabbing" } ],
     "items": {
       "both": {
@@ -177,7 +177,7 @@
     "name": "C.R.I.T. Combat Medic",
     "description": "You were the team nerd.  A combat medic taught on how to engage strange anomalies.  However, your main focus was  keeping your squadmates in one piece.  For weeks, you slogged through hell and back and ensured that everyone made it.  Caught in between a tide of the undead and the crossfire of apparently rogue government robots, you were left stranded as a distraction.  Forced to flee, will you have what it takes to survive or will you join the horde to haunt them for their cardinal sin?",
     "points": 8,
-    "traits": [ "MARTIAL_CRT" ],
+    "traits": [ "MARTIAL_CRT", "PROF_MILITARY" ],
     "skills": [
       { "level": 1, "name": "gun" },
       { "level": 1, "name": "pistol" },
@@ -222,7 +222,7 @@
     "name": "C.R.I.T. Automatic Rifleman",
     "description": "You were assigned the billet of specializing in creating dead zones and providing support fire.  When the cataclysm struck, your trusty LMG couldn't keep the veritable tide of undead from overtaking your squad.  Now running with all the strength your body can muster, will you have what it takes to survive or is this hellish landscape something you just can't suppress?",
     "points": 10,
-    "traits": [ "MARTIAL_CRT" ],
+    "traits": [ "MARTIAL_CRT", "PROF_MILITARY" ],
     "skills": [ { "level": 3, "name": "gun" }, { "level": 3, "name": "rifle" }, { "level": 1, "name": "pistol" } ],
     "items": {
       "both": {
@@ -261,7 +261,7 @@
     "name": "C.R.I.T. Commanding Officer",
     "description": "As a top-ranking CO, you didn't see much in the way of combat other than when you felt like it.  Your charisma and sharp intellect helped you climb up the ranks and provided support to allies in need.  Now that everything went down the drain, will it help you again?",
     "points": 9,
-    "traits": [ "MARTIAL_CRT" ],
+    "traits": [ "MARTIAL_CRT", "PROF_MILITARY" ],
     "skills": [
       { "level": 2, "name": "gun" },
       { "level": 2, "name": "pistol" },
@@ -352,7 +352,7 @@
     "id": "crt_juggernaught",
     "name": "C.R.I.T. Lone Wolf",
     "description": "STR 10 recommended.  You are fully armored badass granted the full authority of a U.S Marshal.  Sent in as the one man army capable of handling anything.  Dropped into warzones, you singlehandedly laid out entire battalions by yourself.  Time to hang them all.",
-    "traits": [ "MARTIAL_CRT", "PROF_FED" ],
+    "traits": [ "MARTIAL_CRT", "PROF_FED", "PROF_MILITARY" ],
     "CBMs": [
       "bio_weight",
       "bio_ups",
@@ -425,7 +425,7 @@
     "id": "crt",
     "name": "C.R.I.T. Spec Ops",
     "description": "STR 10 recommended.  You were an elite member of Catastrophe Response and Investigation Team, for a powerful military faction.  A looming spectre which responded to secular threats, with technology decades ahead of other world powers.  Your squad was the first to be deployed into the New England region, ground zero, to contain the impending outbreak and gain information to relay back to command.  Good luck soldier.",
-    "traits": [ "MARTIAL_CRT", "PROF_FED" ],
+    "traits": [ "MARTIAL_CRT", "PROF_FED", "PROF_MILITARY" ],
     "CBMs": [
       "bio_razors",
       "bio_sunglasses",
@@ -492,7 +492,7 @@
     "id": "crt_exile",
     "name": "C.R.I.T. Survivalist",
     "description": "You were an elite recon of the C.R.I.T.  You were hailed as a top survivalist after being stuck for weeks behind enemy lines and having to survive with nothing but some rocks, sticks and plants.  However, after a few too many drinks (20) at the local bar and getting into a fight (knocking them out) with one of your commanding officers during a drunken bout you were stripped of your rank and sent off into the forests with your current gear to run a trial by survival.  After an hour of scouting about in the forest for a good shelter, your radio rang and you were briefed over the fact that the world was suddenly ending.  Of course, no one has time to pick your sorry ass up, so cheers.  Staying away from drinks might be a good idea; at least you got some real tools this time!",
-    "traits": [ "MARTIAL_CRT", "LIGHTWEIGHT", "ADDICTIVE" ],
+    "traits": [ "MARTIAL_CRT", "PROF_MILITARY", "LIGHTWEIGHT", "ADDICTIVE" ],
     "points": 12,
     "skills": [
       { "level": 2, "name": "gun" },
@@ -548,7 +548,7 @@
     "id": "crt_normie",
     "name": "C.R.I.T. Recruit",
     "description": "You were scheduled for some survival training in New England when the Cataclysm broke out and your instructor never showed up for the next lesson.  Now stuck in the quarantine zone with your standard issue training equipment, you wish you had a better gun.  Looks like you'll definitely learn a thing or two about survival though!",
-    "traits": [ "MARTIAL_CRT" ],
+    "traits": [ "MARTIAL_CRT", "PROF_MILITARY" ],
     "points": 6,
     "skills": [
       { "level": 1, "name": "stabbing" },
@@ -595,7 +595,7 @@
     "id": "crt_employee",
     "name": "C.R.I.T. Employee",
     "description": "Like many others, you had requested to join the C.R.I.T organization's admin-offices to escape from bitter memories and past traumas after valiantly protecting your comrades for years.  After you completed the readjustment program, your skills may have rusted considerably since your last deployment to battle, but the drilled muscle memories have not worn away.  As your comrades' screams once again ring in your ears and repressed memories of abhorrent nature resurface, can you find it within yourself to overcome the looming terror which paralyzes you?",
-    "traits": [ "MARTIAL_CRT", "SPIRITUAL", "SCHIZOPHRENIC", "JITTERY" ],
+    "traits": [ "MARTIAL_CRT", "PROF_MILITARY", "SPIRITUAL", "SCHIZOPHRENIC", "JITTERY" ],
     "points": 6,
     "skills": [
       { "level": 2, "name": "computer" },

--- a/data/mods/Fuji_Mil_Prof/prof/army.json
+++ b/data/mods/Fuji_Mil_Prof/prof/army.json
@@ -5,6 +5,7 @@
     "name": "Military Rifleman",
     "description": "Frontline infantry, frontline infantry, frontline infantry, frontline infantry.",
     "points": 2,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [ { "level": 1, "name": "survival" }, { "level": 1, "name": "gun" }, { "level": 1, "name": "rifle" } ],
     "items": {
       "both": {
@@ -40,6 +41,7 @@
     "name": "Military Marksman",
     "description": "You like to think you're a real sniper, but really you're just infantry with a bigger gun.",
     "points": 4,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [ { "level": 1, "name": "survival" }, { "level": 2, "name": "gun" }, { "level": 2, "name": "rifle" } ],
     "items": {
       "both": {
@@ -73,6 +75,7 @@
     "name": "Military Automatic Rifleman",
     "description": "S stands for suppressing fire!",
     "points": 3,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [ { "level": 1, "name": "survival" }, { "level": 1, "name": "gun" }, { "level": 1, "name": "rifle" } ],
     "items": {
       "both": {
@@ -104,6 +107,7 @@
     "name": "Military Grenadier",
     "description": "There's no kill like overkill.",
     "points": 3,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 1, "name": "survival" },
       { "level": 1, "name": "gun" },
@@ -144,6 +148,7 @@
     "name": "Military Breacher",
     "description": "Doors and windows everywhere dare not speak your name.",
     "points": 3,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 1, "name": "survival" },
       { "level": 1, "name": "gun" },

--- a/data/mods/Fuji_Mil_Prof/prof/spc.json
+++ b/data/mods/Fuji_Mil_Prof/prof/spc.json
@@ -5,6 +5,7 @@
     "name": "Operator Recon",
     "description": "The only easy day was yesterday.",
     "points": 4,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 2, "name": "survival" },
       { "level": 2, "name": "gun" },
@@ -51,6 +52,7 @@
     "name": "Operator Sniper",
     "description": "You spent days dueling an enemy sniper, then he just… died.  And then un-died.",
     "points": 5,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [ { "level": 2, "name": "survival" }, { "level": 4, "name": "gun" }, { "level": 4, "name": "rifle" } ],
     "items": {
       "both": {
@@ -86,6 +88,7 @@
     "name": "Operator Hacker",
     "description": "You insist you're not a hacker, you're an 'Electronic Warfare Specialist'",
     "points": 5,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 1, "name": "survival" },
       { "level": 1, "name": "gun" },
@@ -135,6 +138,7 @@
     "name": "Operator Undercover",
     "description": "You've been tailing your target for months and now he's a zombie.  So much for that lead.",
     "points": 3,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 1, "name": "survival" },
       { "level": 2, "name": "gun" },
@@ -173,6 +177,7 @@
     "name": "Operator CBRN",
     "description": "Chemical weapons?  Check.  Biological outbreak?  Check.  Nuclear war?  Check.  Sounds like the perfect job for you!",
     "points": 5,
+    "traits": [ "PROF_MILITARY" ],
     "skills": [
       { "level": 1, "name": "survival" },
       { "level": 1, "name": "gun" },

--- a/data/mods/more_classes_scenarios/cs_classes.json
+++ b/data/mods/more_classes_scenarios/cs_classes.json
@@ -14,6 +14,7 @@
     "name": "Bionic Special Operator",
     "description": "Once bionic augmentation proved safe, you were chosen for a top secret soldier augmentation program.  As if being a top-tier special forces operator before the procedure wasn't enough, your new enhancements allow you to handle any combat scenario be it human or not.",
     "points": 8,
+    "traits": [ "PROF_MILITARY" ],
     "CBMs": [
       "bio_targeting",
       "bio_purifier",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Content "Allow alternative ways to access necropolis quest chain"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

One of the ideas on my todo list concerned making the necropolis actually factor into the existing questlines, and open additional ways to actually get the missions from them. This PR will set things up to allow that connection and make any other ways we want to open the mission chains up easier to implement too.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

- [X] Add profession trait: Military Remnant. Presently used primarily for some specific dialogue as a way to bypass needing to become a marshal, but could be given other uses too. If we ever get JSONized mutation adjustments of monster hostility, this could be used to make turrets ignore military personnel in the future (like how the eyebot special attack has hardcoded behavior that bails out early if the player is wearing certain police badges).
- [X] Added profession trait to relevant professions in both vanilla and mods.
- [X] Updated the captain at the necropolis so that military professions can readily talk them into giving permission to do their missions. Likewise, players who ended up a Marshal but forgot their badge can skip the nonsense just as any random schmuck with the badge can, with different dialogue depending on if they see you wearing the badge. This leads to setting a player variable that access to the missions now hinges on, so in addition to enabling other ways to gain access to the questline, it also has the benefit of the NPCs not forgetting who you are if you lose your badge somehow.
- [X] Update the other necropolis NPCs accordingly, to make their dialogue check primarily for having the okay from the captain instead of just seeing you wear the marshal badge. The comms NPC in particular mainly checks if you've been given the frequency list for the captain, as that's the easiest confirmation that you're cleared to be there, and the need to sent runners implies they don't yet have things set up such that the captain can directly inform them that the PC has clearance to be there.
- [x] Reworks the dialogue for the Old Guard rep's fourth mission to make it leading into a new mission make sense. Defined a report item for a mission where the Old Guard repo sends you to make contact with the necropolis team.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Actually making military identification a specific item the player has to have that all military professions start with. Seems pointless to me, and too easy to potentially confuse with military ID access cards.

#### Testing

1. Checked affected files for syntax and lint errors.
2. Load-tested changes in test build.
3. Speedran the Old Guard rep mission chain, confirmed I got referred to a necropolis at the end of it.
4. Warped over there and confirmed I can correctly start up their missions, both with and without the badge on.
5. Redid test with a military recruit warping straight to a necropolis, confirmed it also works.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
