### PR TITLE
ci: use ISO timestamp for automated translation pull

### DIFF
--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -15,10 +15,11 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v3
       - name: "Get current date"
-        uses: 1466587594/get-current-time@v2
+        uses: nanzm/get-time-action@v1.1
         id: current-date
         with:
-          format: "DD MMMM YYYY"
+          timeZone: 0
+          format: "YYYY-MM-DD"
       - name: "Pull translations"
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}


### PR DESCRIPTION
#### Summary

SUMMARY: I18N "Use ISO timestamp for automated translation pull"

#### Purpose of change

Improve readability by using the YYYY-MM-DD format. 
It is more natural to read time in YYYY-MM-DD HH:MM:SS than in DD-MM-YYYY HH:MM:SS because the former aligns from big to small.

#### Describe the solution

use `nanzm/get-time-action` from `release.yml`.