### PR TITLE
feat(balance): buff speed and power usage of `Joint Servo` CBM

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1104,7 +1104,7 @@
     "id": "bio_jointservo",
     "type": "bionic",
     "name": { "str": "Joint Servo" },
-    "description": "Your leg joints have been equipped with servomotors that provide power-assisted movement.  They are optimized for running, but walking also requires less effort when this bionic is online.  However, when it's offline it will hamper your movement, as you struggle against its moving parts.",
+    "description": "Your leg joints have been equipped with servomotors that provide power-assisted movement.  They are optimized for running, but walking also requires less effort when this bionic is online.  Even when they're offline, the servos balances your gait.",
     "occupied_bodyparts": [ [ "leg_l", 12 ], [ "leg_r", 12 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
     "trigger_cost": "35 J"

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10017,13 +10017,9 @@ int Character::run_cost( int base_cost, bool diag ) const
             movecost *= .9f;
         }
         if( has_active_bionic( bio_jointservo ) ) {
-            if( move_mode == CMM_RUN ) {
-                movecost *= 0.85f;
-            } else {
-                movecost *= 0.95f;
-            }
+            movecost *= ( move_mode == CMM_RUN ? 0.75f : 0.9f );
         } else if( has_bionic( bio_jointservo ) ) {
-            movecost *= 1.1f;
+            movecost *= 0.95f;
         }
 
         if( worn_with_flag( "SLOWS_MOVEMENT" ) ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4626,7 +4626,7 @@ void vehicle::consume_fuel( int load, const int t_seconds, bool skip_electric )
         }
         // decreased stamina burn scalable with load
         if( g->u.has_active_bionic( bio_jointservo ) ) {
-            g->u.mod_power_level( units::from_kilojoule( -std::max( eff_load / 20, 1 ) ) );
+            g->u.mod_power_level( -bio_jointservo->power_trigger * std::max( eff_load / 20, 1 ) );
             mod -= std::max( eff_load / 5, 5 );
         }
         if( one_in( 1000 / load ) && one_in( 10 ) ) {


### PR DESCRIPTION
#### Summary

SUMMARY: Balance "buff speed and power usage of Joint Servo CBM"

#### Purpose of change

got bug report & idea from https://gall.dcinside.com/board/view/?id=rlike&no=438546

some excerpts:
> When riding a bike, the joint servo CBM uses power in kilojoules, whereas running uses power in joules.

> The joint servo only increases speed by 8 to 10, yet its disadvantages outweigh the advantages. 

> To make it at least usable, the offline penalty should be removed and the online speed bonus should be doubled.

#### Describe the solution

1. buffed joint servo.

|         | Before | After |
| ------- | ------ | ----- |
| Running | 15%    | 25%   |
| Walking | 5%     | 10%   |
| Offline | -10%   | 5%    |

2. reduced power consumption while pedaling the vehicle.

#### Describe alternatives you've considered

port https://github.com/CleverRaven/Cataclysm-DDA/pull/47274

#### Testing
![Cataclysm: Bright Nights - 0 9-74078-g6f7ce443ef10-dirty_01](https://user-images.githubusercontent.com/54838975/234155756-9efd6ddc-8ad9-4323-bd4d-73d024037a8e.png)
default walking speed
![Cataclysm: Bright Nights - 0 9-74078-g6f7ce443ef10-dirty_05](https://user-images.githubusercontent.com/54838975/234155768-9b7fcd37-68e0-4149-9a4d-bc44b88bf490.png)
default running speed
![Cataclysm: Bright Nights - 0 9-74078-g6f7ce443ef10-dirty_02](https://user-images.githubusercontent.com/54838975/234155762-64360445-70a7-4cd8-bd36-d0802da09b4a.png)
joint servo(offline)
![Cataclysm: Bright Nights - 0 9-74078-g6f7ce443ef10-dirty_03](https://user-images.githubusercontent.com/54838975/234155763-60007841-c9ad-40cc-8382-8aa35e45ebf2.png)
joint servo, walking (online)
![Cataclysm: Bright Nights - 0 9-74078-g6f7ce443ef10-dirty_04](https://user-images.githubusercontent.com/54838975/234155766-9a5a66e6-e13a-40fb-8895-c740d7f2f405.png)
joint servo, running (online)

Driving 10 map tiles with autodrive (19km/h, 90 seconds) consumed 40 watts. This is on par with real-life usage of 54 watts, as the 40 watts does not take into account the manual leg power used.

#### Additional context

<details><summary>chat with GPT4</summary>

# Cyclist Power Calculation

### You
asuuming cyclist (average person) is 60kg, bicycle is 20kg (=total 80kg), calculate step by step how many watt is typically used @ 20km/h?

### ChatGPT
To calculate the power (in watts) used by a cyclist riding at 20 km/h, we need to consider three main factors: rolling resistance, air resistance, and mechanical efficiency of the bicycle.

1. Rolling resistance:

Rolling resistance is the force that resists the motion of a bicycle tire rolling over a surface. This force depends on the weight of the cyclist and bike, as well as the coefficient of rolling resistance (Crr) of the tire on the surface. The Crr of a typical road bike tire on asphalt is approximately 0.004.

First, we need to convert the weight of the cyclist and bicycle to Newtons (N) using the formula:

Weight (N) = Mass (kg) × Gravity (m/s²)

Assuming gravity is 9.81 m/s²:

Weight (N) = 80 kg × 9.81 m/s² = 784.8 N

Now, we can calculate the rolling resistance force (Frr):

Frr = Crr × Weight (N)
Frr = 0.004 × 784.8 N = 3.1392 N

1. Air resistance:

Air resistance is the force that opposes the motion of the cyclist through the air. This force depends on the air density (ρ), the drag coefficient (Cd), the frontal area of the cyclist (A), and the velocity of the cyclist (v).

Assuming an average drag coefficient for a cyclist on a road bike of 0.9 and a frontal area of 0.4 m², we can calculate the air resistance force (Fair) using the following formula:

Fair = 0.5 × ρ × Cd × A × v²

First, we need to convert the speed from km/h to m/s:

20 km/h × (1000 m/km) / (3600 s/h) = 5.56 m/s

Assuming air density (ρ) at sea level and at 20°C is 1.204 kg/m³:

Fair = 0.5 × 1.204 kg/m³ × 0.9 × 0.4 m² × (5.56 m/s)² = 6.1762 N

1. Total resistance force:

The total resistance force (Ftotal) is the sum of the rolling resistance and air resistance forces:

Ftotal = Frr + Fair = 3.1392 N + 6.1762 N = 9.3154 N

1. Power required to overcome resistance forces:

Now that we have the total resistance force, we can calculate the power (P) needed to overcome this force at a constant speed of 20 km/h. We use the following formula:

P (W) = Ftotal × v (m/s)

P (W) = 9.3154 N × 5.56 m/s = 51.7951 W

However, this value assumes 100% mechanical efficiency, which is not realistic. A typical mechanical efficiency for a road bike is around 95%. So, we need to adjust for this:

P_actual (W) = P (W) / Efficiency

P_actual (W) = 51.7951 W / 0.95 = 54.5201 W

Thus, a typical cyclist with a total weight of 80 kg (including the bike) would require about 54.5 watts of power to maintain a constant speed of 20 km/h.


</details> 
