### PR TITLE
fix(performance): temporarily allow explosion delay shorter than 5ms

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -358,7 +358,7 @@ class ExplosionProcess
             emitter( responsible ),
             player_flung( std::nullopt ),
             // We want to ensure the delay is at least some small value at least to make sure propagation occurs correctly
-            radius_step_delay( std::max( get_option<int>( "ANIMATION_DELAY" ), 5 ) ),
+            radius_step_delay( get_option<int>( "ANIMATION_DELAY" ) ),
             cur_time( 0 ),
             request_redraw( false ) {}
     private:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1810,7 +1810,8 @@ void options_manager::add_options_graphics()
     get_option( "ANIMATION_SCT_USE_FONT" ).setPrerequisite( "ANIMATION_SCT" );
 
     add( "ANIMATION_DELAY", "graphics", translate_marker( "Animation delay" ),
-         translate_marker( "The amount of time to pause between animation frames in ms." ),
+         translate_marker( "The amount of time to pause between animation frames in ms."
+                           "  Values lower than 5ms may cause issues with new explosion behavior." ),
          0, 100, 10
        );
 


### PR DESCRIPTION
#### Summary

SUMMARY: Performance "Temporarily allow explosion delay shorter than 5ms"

#### Purpose of change

despite known issues, player may prefer to choose shorter animation delay for certain situations.
issue is tracked in #2698 

#### Describe the solution

- removed the std::max sanity check that kepth animation delay at least 5ms for explosion.
- added warning on animation delay option.

#### Describe alternatives you've considered

wait until issue is resolved.

#### Testing

![image](https://user-images.githubusercontent.com/54838975/234295522-4b2b6f68-27b4-4bea-b0da-425f514b320b.png)

warning text.

https://user-images.githubusercontent.com/54838975/234291628-edef7f3a-a1e8-465b-8870-91e63a5ad30b.mp4

animation delay 0, with around 20 chain-reactioned explosion. would've taken 3~5 IRL minutes if delay was set to 5. also the issue with shorter framerate is visible: flame fields does not go away.

#### Additional Context

review requested: @DeltaEpsilon7787 
