### PR TITLE
fix(interface): remove color tags in game report

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1524,7 +1524,7 @@ std::string game_info::mods_loaded()
     std::transform( mod_ids.begin(), mod_ids.end(),
     std::back_inserter( mod_names ), []( const mod_id mod ) -> std::string {
         // e.g. "Dark Days Ahead [dda]".
-        return string_format( "%s [%s]", mod->name(), mod->ident.str() );
+        return string_format( "%s [%s]", remove_color_tags( mod->name() ), mod->ident.str() );
     } );
 
     return join( mod_names, ",\n    " ); // note: 4 spaces for a slight offset.


### PR DESCRIPTION
#### Summary

SUMMARY: Interface: "Remove color tags in game report"

#### Purpose of change

color tags does not work outside games and acts as a visual clutter. removing these tags makes reading colorful loaded mods in bug report easier.

#### Describe the solution

applied `remove_color_tags` when creating report of mods loaded.

#### Testing

![world with CRIT expansion loaded](https://user-images.githubusercontent.com/54838975/234298291-ea5551c7-9031-4e0a-b6dc-ad15cefefe19.png)
world with CRIT expansion (`<color_red>C.R.I.T. Expansion</color>`) loaded

![image](https://user-images.githubusercontent.com/54838975/234298266-aa56b90d-3a43-49f3-b649-f81f7485e9f9.png)
generated bug report have its color tags stripped.
