### PR TITLE
feat(content): allow rocks for (staff) sling, add {big,small} lead sling bullets

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1097,7 +1097,7 @@
     "symbol": "*",
     "color": "light_gray",
     "name": { "str": "small sling bullet" },
-    "description": "A small ball of lead traditionally thrown from a sling. It hits a lot harder than any old pebble.",
+    "description": "A small ball of lead traditionally thrown from a sling.  It hits a lot harder than any old pebble.",
     "material": "lead",
     "ammo_type": "pebble",
     "weight": "12 g",

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1093,7 +1093,7 @@
   },
   {
     "type": "AMMO",
-    "id": "sling_pebble",
+    "id": "sling_bullet_small",
     "symbol": "*",
     "color": "light_gray",
     "name": { "str": "small sling bullet" },

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1081,8 +1081,8 @@
     "description": "A ball of lead roughly the size of a baseball.  Traditionally thrown from a sling, and hits a lot harder than any old rock.",
     "material": "lead",
     "ammo_type": "rock",
-    "weight": "28 g",
-    "volume": "250 ml",
+    "weight": "150 g",
+    "volume": "50 ml",
     "bashing": 14,
     "damage": { "damage_type": "bash", "amount": 16 },
     "range": 14,
@@ -1100,13 +1100,13 @@
     "description": "A small ball of lead traditionally thrown from a sling.  It hits a lot harder than any old pebble.",
     "material": "lead",
     "ammo_type": "pebble",
-    "weight": "12 g",
+    "weight": "25 g",
     "volume": "250 ml",
     "damage": { "damage_type": "bash", "amount": 8 },
     "range": 20,
     "dispersion": 10,
     "loudness": 0,
-    "count": 50,
+    "count": 30,
     "effects": [ "NEVER_MISFIRES", "NON-FOULING", "RECOVER_100" ]
   }
 ]

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1071,5 +1071,42 @@
     "symbol": ",",
     "color": "yellow",
     "ammo_type": "components"
+  },
+  {
+    "type": "AMMO",
+    "id": "sling_bullet",
+    "symbol": "*",
+    "color": "light_gray",
+    "name": { "str": "sling bullet" },
+    "description": "A ball of lead roughly the size of a baseball. Traditionally thrown from a sling, and hits a lot harder than any old rock.",
+    "material": "lead",
+    "ammo_type": "rock",
+    "weight": "28 g",
+    "volume": "250 ml",
+    "bashing": 14,
+    "damage": { "damage_type": "bash", "amount": 16 },
+    "range": 14,
+    "dispersion": 10,
+    "loudness": 0,
+    "to_hit": -1,
+    "effects": [ "NEVER_MISFIRES", "NON-FOULING", "RECOVER_100" ]
+  },
+  {
+    "type": "AMMO",
+    "id": "sling_pebble",
+    "symbol": "*",
+    "color": "light_gray",
+    "name": { "str": "small sling bullet" },
+    "description": "A small ball of lead traditionally thrown from a sling. It hits a lot harder than any old pebble.",
+    "material": "lead",
+    "ammo_type": "pebble",
+    "weight": "12 g",
+    "volume": "250 ml",
+    "damage": { "damage_type": "bash", "amount": 8 },
+    "range": 20,
+    "dispersion": 10,
+    "loudness": 0,
+    "count": 50,
+    "effects": [ "NEVER_MISFIRES", "NON-FOULING", "RECOVER_100" ]
   }
 ]

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1078,7 +1078,7 @@
     "symbol": "*",
     "color": "light_gray",
     "name": { "str": "sling bullet" },
-    "description": "A ball of lead roughly the size of a baseball. Traditionally thrown from a sling, and hits a lot harder than any old rock.",
+    "description": "A ball of lead roughly the size of a baseball.  Traditionally thrown from a sling, and hits a lot harder than any old rock.",
     "material": "lead",
     "ammo_type": "rock",
     "weight": "28 g",

--- a/data/json/items/ranged/slings.json
+++ b/data/json/items/ranged/slings.json
@@ -11,7 +11,7 @@
     "//": "It's little more than a piece of slightly shaped leather",
     "material": "leather",
     "extend": { "flags": [ "BELT_CLIP" ] },
-    "ammo": "pebble",
+    "ammo": [ "pebble", "rock" ]
     "weight": "96 g",
     "volume": "250 ml",
     "price_postapoc": 250,
@@ -35,7 +35,7 @@
     "weapon_category": [ "QUARTERSTAVES" ],
     "extend": { "flags": [ "BELTED", "DURABLE_MELEE", "NONCONDUCTIVE", "SHEATH_SPEAR", "ALWAYS_TWOHAND" ] },
     "techniques": [ "WBLOCK_2", "RAPID", "SWEEP" ],
-    "ammo": "rock",
+    "ammo": [ "pebble", "rock" ]
     "weight": "2000 g",
     "volume": "3 L",
     "price_postapoc": 250,

--- a/data/json/items/ranged/slings.json
+++ b/data/json/items/ranged/slings.json
@@ -11,7 +11,7 @@
     "//": "It's little more than a piece of slightly shaped leather",
     "material": "leather",
     "extend": { "flags": [ "BELT_CLIP" ] },
-    "ammo": [ "pebble", "rock" ]
+    "ammo": [ "pebble", "rock" ],
     "weight": "96 g",
     "volume": "250 ml",
     "price_postapoc": 250,
@@ -35,7 +35,7 @@
     "weapon_category": [ "QUARTERSTAVES" ],
     "extend": { "flags": [ "BELTED", "DURABLE_MELEE", "NONCONDUCTIVE", "SHEATH_SPEAR", "ALWAYS_TWOHAND" ] },
     "techniques": [ "WBLOCK_2", "RAPID", "SWEEP" ],
-    "ammo": [ "pebble", "rock" ]
+    "ammo": [ "pebble", "rock" ],
     "weight": "2000 g",
     "volume": "3 L",
     "price_postapoc": 250,

--- a/data/json/recipes/ammo/other.json
+++ b/data/json/recipes/ammo/other.json
@@ -292,15 +292,15 @@
     "subcategory": "CSC_AMMO_OTHER",
     "skill_used": "fabrication",
     "difficulty": 3,
-    "time": "1 h",
-    "batch_time_factors": [ 50, 1 ],
+    "time": "6 m",
+    "batch_time_factors": [ 70, 1 ],
     "autolearn": true,
-    "charges": 10,
+    "charges": 1,
     "tools": [
       [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ],
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
     ],
-    "components": [ [ [ "lead", 500 ] ] ]
+    "components": [ [ [ "lead", 50 ] ] ]
   },
   {
     "result": "sling_pebble",
@@ -310,13 +310,13 @@
     "skill_used": "fabrication",
     "difficulty": 3,
     "time": "1 h",
-    "batch_time_factors": [ 50, 1 ],
+    "batch_time_factors": [ 70, 1 ],
     "autolearn": true,
-    "charges": 50,
+    "charges": 6,
     "tools": [
       [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ],
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
     ],
-    "components": [ [ [ "lead", 500 ] ] ]
+    "components": [ [ [ "lead", 50 ] ] ]
   }
 ]

--- a/data/json/recipes/ammo/other.json
+++ b/data/json/recipes/ammo/other.json
@@ -303,7 +303,7 @@
     "components": [ [ [ "lead", 50 ] ] ]
   },
   {
-    "result": "sling_pebble",
+    "result": "sling_bullet_small",
     "type": "recipe",
     "category": "CC_AMMO",
     "subcategory": "CSC_AMMO_OTHER",

--- a/data/json/recipes/ammo/other.json
+++ b/data/json/recipes/ammo/other.json
@@ -296,7 +296,10 @@
     "batch_time_factors": [ 50, 1 ],
     "autolearn": true,
     "charges": 10,
-    "tools": [ [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "tools": [
+      [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
+    ],
     "components": [ [ [ "lead", 500 ] ] ]
   },
   {
@@ -310,7 +313,10 @@
     "batch_time_factors": [ 50, 1 ],
     "autolearn": true,
     "charges": 50,
-    "tools": [ [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "tools": [
+      [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
+    ],
     "components": [ [ [ "lead", 500 ] ] ]
   }
 ]

--- a/data/json/recipes/ammo/other.json
+++ b/data/json/recipes/ammo/other.json
@@ -284,5 +284,33 @@
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "splinter", 1 ] ] ]
+  },
+  {
+    "result": "sling_bullet",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "1 h",
+    "batch_time_factors": [ 50, 1 ],
+    "autolearn": true,
+    "charges": 10,
+    "tools": [ [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "components": [ [ [ "lead", 500 ] ] ]
+  },
+  {
+    "result": "sling_pebble",
+    "type": "recipe",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "1 h",
+    "batch_time_factors": [ 50, 1 ],
+    "autolearn": true,
+    "charges": 50,
+    "tools": [ [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "components": [ [ [ "lead", 500 ] ] ]
   }
 ]


### PR DESCRIPTION
#### Summary

SUMMARY: Content "Changed sling and staff sling to be capable of using both rocks and pebbles as ammo, as well as added in new 'sling bullet' and 'small sling bullet' ammo as a higher-end lead ammo for slings and staff slings."

#### Purpose of change

Slings have been used to huck larger rocks historically, and staff slings are just a sling on the end of a staff. Furthermore, lead sling bullets are historically accurate and would serve as a nice alternative to ball bearings.

#### Describe the solution

It's a minor change to two items, two new items, and two new recipes.

#### Describe alternatives you've considered

You could keep the staff sling and sling as using rocks and pebbles respectively, but it's kind of a strange distinction to begin with.

#### Testing

I've made sure there are no json errors and it seems fairly balanced in terms of stats and crafting.
