### PR TITLE
Fixed impassable furniture stopping the player from climbing

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2060,7 +2060,7 @@ int map::climb_difficulty( const tripoint &p ) const
     }
 
     // TODO: Make this more sensible - check opposite sides, not just movement blocker count
-    return best_difficulty - blocks_movement;
+    return std::max(0, best_difficulty - blocks_movement);
 }
 
 bool map::has_floor( const tripoint &p ) const

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2060,7 +2060,7 @@ int map::climb_difficulty( const tripoint &p ) const
     }
 
     // TODO: Make this more sensible - check opposite sides, not just movement blocker count
-    return std::max(0, best_difficulty - blocks_movement);
+    return std::max( 0, best_difficulty - blocks_movement );
 }
 
 bool map::has_floor( const tripoint &p ) const


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed impassable furniture stopping the player from climbing"

#### Purpose of change
During gameplay I have noticed that having too many furniture around a downspout will cause it to no longer be climbable, as far I know this is unintended behaviour. This issue should also affect everything that is climbable, with a few exceptions.

Fixes #2704

#### Describe the solution
Made the return unable to return anything lower than 0, makes it so that the move cost won't go negative and thus stop the player from climbing.

#### Describe alternatives you've considered
Do nothing, it might be intended.
Cry because I accidentally removed everything I wrote.

#### Testing
1. Try to climb with 5 impassable furniture around, can climb
2. Try to climb with 6 impassable furniture around, can now climb unlike before.