### PR TITLE
Aftershock atomic butter churn uncraft

### DIFF
--- a/data/mods/Aftershock/recipes/uncraft.json
+++ b/data/mods/Aftershock/recipes/uncraft.json
@@ -75,7 +75,7 @@
     "result": "atomic_butterchurn",
     "type": "uncraft",
     "skill_used": "electronics",
-    "time": 30 s,
+    "time": "30 s",
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "plastic_chunk", 5 ] ],

--- a/data/mods/Aftershock/recipes/uncraft.json
+++ b/data/mods/Aftershock/recipes/uncraft.json
@@ -70,5 +70,19 @@
     "using": [ [ "welding_standard", 3 ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "afs_scrap_titanium", 2 ] ] ]
+  },
+  {
+    "result": "atomic_butterchurn",
+    "type": "uncraft",
+    "skill_used": "electronics",
+    "time": 30 s,
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "plastic_chunk", 5 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "element", 1 ] ],
+      [ [ "scrap", 2 ] ],
+      [ [ "plut_cell", 1 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
SUMMARY: [Balance] "Adds an uncraft to the atomic butter churn"

#### Purpose of change

There's no uncraft for the atomic butter churn, this adds one.

#### Describe the solution

This requires some context to fully explain. All of the Aftershock atomic appliances have bad uncrafts which do not respect their mass, rather than rebalance all of them I currently chose to go with the existing balance by making the atomic butter churn have the same uncraft as the atomic coffee maker. Their weight is only off by 1 pound, so it's very close.

#### Describe alternatives you've considered

Rebalance every single atomic item to have their uncraft respect their mass.

#### Testing

Loaded game, did the uncraft. It worked, no crashes.

#### Additional context

I'll rebalance the uncrafts for all atomic items later, even DDA Aftershock seems to lack an uncraft for the atomic butter churn.
