### PR TITLE
Add Kevlar Vest's Recipe

### DIFF
--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -417,7 +417,7 @@
     "reversible": true,
     "decomp_learn": 6,
     "autolearn": true,
-    "using": [ [ "sewing_standard", 54 ] ],
+    "using": [ [ "sewing_standard", 30 ] ],
     "components": [ [ [ "kevlar_plate", 24 ] ] ]
   },
   {

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -407,6 +407,20 @@
     "components": [ [ [ "jacket_leather", 1 ], [ "jacket_leather_red", 1 ] ], [ [ "scrap", 9 ] ] ]
   },
   {
+    "result": "kevlar",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 6,
+    "time": "40 m",
+    "reversible": true,
+    "decomp_learn": 6,
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 54 ] ],
+    "components": [ [ [ "kevlar_plate", 24 ] ] ]
+  },
+  {
     "result": "leotard",
     "type": "recipe",
     "category": "CC_ARMOR",


### PR DESCRIPTION
#### Summary

Allows Survivors to craft Kevlar Vests at tailoring level 6 by adding recipe.

#### Purpose of change

The Kevlar Vest is the 'basic' lightweight bullet armor that is worn as the innermost part. However, Kevlar vests can only be farmed in police-related elements, and even this is rare. And as long as there are XL Kevlar vests, I am uploading this PR because I decided that it would be nice if it was possible to produce a normal size Kevlar vest.

#### Describe the solution

By adding a Kevlar vest, I think it will be the answer to survivors who are wondering what to wear underneath.

#### Describe alternatives you've considered

It is to increase the supply of Kevlar vests not only to the police, but also to the military and gunsmiths.

#### Testing

No problem, works fine.

#### Additional context

![kevlarman](https://user-images.githubusercontent.com/108422062/235307727-8a75d850-7634-426c-a636-c4680c17b676.png)

