### PR TITLE
avgas can be used in gasoline engines

### DIFF
--- a/data/json/vehicleparts/combustion.json
+++ b/data/json/vehicleparts/combustion.json
@@ -32,6 +32,7 @@
     "type": "vehicle_part",
     "fuel_type": "gasoline",
     "fuel_options": [ "gasoline", "avgas" ],
+    "//2": "TODO: remove when injectors are implemented",
     "m2c": 60,
     "//": "30% energy efficiency",
     "description": "A combustion engine.  Burns gasoline fuel from a tank in the vehicle."

--- a/data/json/vehicleparts/combustion.json
+++ b/data/json/vehicleparts/combustion.json
@@ -31,6 +31,7 @@
     "copy-from": "engine_combustion",
     "type": "vehicle_part",
     "fuel_type": "gasoline",
+    "fuel_options": [ "gasoline", "avgas" ],
     "m2c": 60,
     "//": "30% energy efficiency",
     "description": "A combustion engine.  Burns gasoline fuel from a tank in the vehicle."


### PR DESCRIPTION
SUMMARY: [Balance] "Avgas can be used in gasoline engines"

#### Purpose of change

From a balance perspective, I see no issue with using avgas as gasoline since you're using a harder to find and more valuable fuel (you know for helicopters) to power weaker engines than a gas turbine engine. From a realism perspective, see this thread over at DDA for tons of research. https://github.com/CleverRaven/Cataclysm-DDA/pull/58181 I see no compelling reason on the realism side that this CANT be done, even if it's not a great idea. If you go through each of the links and arrive at a different conclusion, mention that in the pull.

We do not model vehicle wear and tear, and we also don't model engine modifications so both of these can be done as future solutions if desired.

#### Describe the solution

I added the fuel options field to gasoline engines, and added avgas and gasoline as the two options. it works.

#### Describe alternatives you've considered

Not doing this, requiring engine modification and removal of catalytic converters in the exhaust system.

#### Testing

I loaded my JSON change into the game and it worked. no errors

![image](https://user-images.githubusercontent.com/112293514/235340338-6bf43bb4-8460-4795-acda-1131fc7a8364.png)

![image](https://user-images.githubusercontent.com/112293514/235340331-49cb1b38-f100-475e-8687-6908297a49c5.png)


#### Additional context

Maybe later I'll touch alcohol since mods have issues with copyfroms. Have to run that one by a few people to make sure the balance works, the modifications for alcohol engines are within $100 or less so this would again come down to we don't actually model modifying an engine
