### PR TITLE
Add seatbelts and 5-point harness items

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -1315,6 +1315,8 @@
       [ "horn_bicycle", 8 ],
       [ "seat", 8 ],
       [ "seat_leather", 1 ],
+      [ "seatbelt", 8 ],
+      [ "five-point_harness", 2 ],
       [ "saddle", 8 ],
       [ "wheel", 10 ],
       [ "wheel_wide", 10 ],

--- a/data/json/itemgroups/collections_trades.json
+++ b/data/json/itemgroups/collections_trades.json
@@ -72,6 +72,8 @@
       [ "jerrycan", 10 ],
       [ "jerrycan_big", 10 ],
       [ "metal_tank", 8 ],
+      { "item": "seatbelt", "prob": 8, "count": [ 1, 4 ] },
+      { "item": "five-point_harness", "prob": 2, "count": [ 1, 2 ] },
       [ "metal_tank_little", 8 ],
       [ "cu_pipe", 5 ],
       [ "eyedrops", 4 ],

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -381,6 +381,8 @@
       [ "wheel_bicycle_or", 5 ],
       [ "wheel_motorbike_or", 5 ],
       [ "wheel_slick", 5 ],
+      { "item": "seatbelt", "prob": 10, "count": [ 3, 10 ] },
+      { "item": "five-point_harness", "prob": 3, "count": [ 2, 4 ] },
       [ "1cyl_combustion", 10 ],
       [ "v2_combustion", 10 ],
       [ "i4_combustion", 10 ],

--- a/data/json/items/generic/spares.json
+++ b/data/json/items/generic/spares.json
@@ -33,6 +33,18 @@
     "price_postapoc": 50
   },
   {
+    "id": "five-point_harness",
+    "copy-from": "spare_part",
+    "type": "GENERIC",
+    "name": { "str": "5-point harness", "str_pl": "5-point harnesses" },
+    "description": "A harness made of three belts meant to be mounted on vehicle to fasten a passenger securely to their seat.",
+    "material": "nylon",
+    "weight": "2204 g",
+    "volume": "750 ml",
+    "price": 10000,
+    "price_postapoc": 5000
+  },
+  {
     "id": "filter_air",
     "copy-from": "spare_part",
     "type": "GENERIC",

--- a/data/json/items/generic/spares.json
+++ b/data/json/items/generic/spares.json
@@ -39,7 +39,7 @@
     "name": { "str": "5-point harness", "str_pl": "5-point harnesses" },
     "description": "A harness made of three belts meant to be mounted on vehicle to fasten a passenger securely to their seat.",
     "material": "nylon",
-    "weight": "2204 g",
+    "weight": "2 kg",
     "volume": "750 ml",
     "price": 10000,
     "price_postapoc": 5000

--- a/data/json/items/generic/string.json
+++ b/data/json/items/generic/string.json
@@ -103,7 +103,7 @@
     "description": "A length of synthetic fiber weaved into a flat band, usually used to securely fasten a passenger inside a vehicle.",
     "material": "nylon",
     "weight": "800 g",
-    "volume": "696 ml"
+    "volume": "500 ml"
   },
   {
     "id": "stick_fiber",

--- a/data/json/items/generic/string.json
+++ b/data/json/items/generic/string.json
@@ -96,6 +96,16 @@
     "proportional": { "price": 0.5 }
   },
   {
+    "id": "seatbelt",
+    "copy-from": "rope_6",
+    "type": "GENERIC",
+    "name": { "str": "seat belt" },
+    "description": "A length of synthetic fiber weaved into a flat band, usually used to securely fasten a passenger inside a vehicle.",
+    "material": "nylon",
+    "weight": "800 g",
+    "volume": "696 ml"
+  },
+  {
     "id": "stick_fiber",
     "type": "COMESTIBLE",
     "category": "spare_parts",

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -122,6 +122,18 @@
     "components": [ [ [ "leather", 6 ], [ "fur", 6 ] ], [ [ "wood_structural", 4, "LIST" ] ], [ [ "rope_natural_short", 4, "LIST" ] ] ]
   },
   {
+    "result": "five-point_harness",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_VEHICLE",
+    "skill_used": "fabrication",
+    "difficulty": 2,
+    "time": "15 m",
+    "autolearn": true,
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "seatbelt", 3 ] ] ]
+  },
+  {
     "result": "hd_tow_cable",
     "type": "recipe",
     "category": "CC_OTHER",

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -117,7 +117,7 @@
     "id": "rope_natural_short",
     "type": "requirement",
     "//": "Materials used for lashing, when choice of makeshift rope is sensible, per 216 g/180 cm of rope.",
-    "components": [ [ [ "rope_6", 1 ], [ "vine_6", 1 ], [ "rope_makeshift_6", 1 ] ] ]
+    "components": [ [ [ "rope_6", 1 ], [ "vine_6", 1 ], [ "rope_makeshift_6", 1 ], [ "seatbelt", 1 ] ] ]
   },
   {
     "id": "rope_superior",
@@ -129,7 +129,7 @@
     "id": "rope_superior_short",
     "type": "requirement",
     "//": "Materials used for lashing, when extra durability and/or flexibilty is needed, per 216 g/180 cm of rope.",
-    "components": [ [ [ "rope_6", 1 ], [ "vine_6", 1 ] ] ]
+    "components": [ [ [ "rope_6", 1 ], [ "vine_6", 1 ], [ "seatbelt", 1 ] ] ]
   },
   {
     "id": "steel_standard",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -4376,5 +4376,13 @@
       [ [ "receiver", 1 ] ],
       [ [ "plastic_chunk", 5 ] ]
     ]
+  },
+  {
+    "type": "uncraft",
+    "result": "seatbelt",
+    "time": "30 s",
+    "components": [ [ [ "nylon", 3 ] ] ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "flags": [ "BLIND_HARD" ]
   }
 ]

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1444,7 +1444,7 @@
     "description": "A belt, attached to a seat.",
     "folded_volume": 2,
     "bonus": 25,
-    "item": "rope_6",
+    "item": "seatbelt",
     "location": "on_seat",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
@@ -1452,7 +1452,7 @@
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
     },
     "flags": [ "SEATBELT", "FOLDABLE" ],
-    "breaks_into": [ { "item": "string_36", "count": [ 0, 3 ] } ]
+    "breaks_into": [ { "item": "nylon", "count": [ 0, 3 ] } ]
   },
   {
     "type": "vehicle_part",
@@ -1498,7 +1498,7 @@
     "description": "A series of straps attached to the seat, intended to fasten together after going over your shoulders and hips and between your legs.",
     "folded_volume": 4,
     "bonus": 25,
-    "item": "rope_30",
+    "item": "five-point_harness",
     "location": "on_seat",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "vehicle_screw", 1 ] ] },
@@ -1506,7 +1506,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
     },
     "flags": [ "SEATBELT", "FOLDABLE" ],
-    "breaks_into": [ { "item": "string_36", "count": [ 0, 3 ] } ]
+    "breaks_into": [ { "item": "seatbelt", "count": [ 0, 3 ] } ]
   },
   {
     "type": "vehicle_part",

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -261,6 +261,7 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
     const float fuel_percentage_used = fuel_level * ( starting_fuel_per - fuel_left );
     int adjusted_tiles_travelled = tiles_travelled / fuel_percentage_used;
     if( target_distance >= 0 ) {
+        INFO( veh.name );
         CHECK( adjusted_tiles_travelled >= min_dist );
         CHECK( adjusted_tiles_travelled <= max_dist );
     }
@@ -436,8 +437,8 @@ TEST_CASE( "vehicle_efficiency", "[vehicle] [engine]" )
     test_vehicle( "beetle", 816837, 431300, 338700, 95610, 68060 );
     test_vehicle( "car", 1122954, 617500, 386100, 52730, 25170 );
     test_vehicle( "car_sports", 1155382, 352600, 267600, 36790, 22350 );
-    test_vehicle( "electric_car", 1128423, 132700, 72290, 8240, 3390 );
-    test_vehicle( "suv", 1322622, 1163000, 630000, 85540, 30920 );
+    test_vehicle( "electric_car", 1128423, 132700, 71290, 8240, 3300 );
+    test_vehicle( "suv", 1322622, 1163000, 629000, 85540, 32000 );
     test_vehicle( "motorcycle", 163085, 120300, 99930, 63320, 50810 );
     test_vehicle( "quad_bike", 265345, 116100, 116100, 46770, 46770 );
     test_vehicle( "scooter", 57587, 233500, 233500, 167900, 167900 );

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -448,7 +448,7 @@ TEST_CASE( "vehicle_efficiency", "[vehicle] [engine]" )
     test_vehicle( "fire_truck", 6317523, 410700, 83850, 19080, 4063 );
     test_vehicle( "truck_swat", 5964006, 682900, 131700, 29610, 7604 );
     test_vehicle( "tractor_plow", 723658, 681200, 681200, 132400, 132400 );
-    test_vehicle( "apc", 5803867, 1626000, 1119000, 130800, 85590 );
+    test_vehicle( "apc", 5803459, 1626000, 1119000, 130800, 85590 );
     test_vehicle( "humvee", 5504381, 767900, 306900, 25620, 9171 );
     test_vehicle( "road_roller", 8829804, 602500, 147100, 22760, 6925 );
     test_vehicle( "golf_cart", 444630, 37180, 27560, 14100, 5681 );

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -433,42 +433,42 @@ TEST_CASE( "make_vehicle_efficiency_case", "[.]" )
 TEST_CASE( "vehicle_efficiency", "[vehicle] [engine]" )
 {
     clear_all_state();
-    test_vehicle( "beetle", 815669, 431300, 338700, 95610, 68060 );
-    test_vehicle( "car", 1120618, 617500, 386100, 52730, 25170 );
-    test_vehicle( "car_sports", 1154214, 352600, 267600, 36790, 22350 );
-    test_vehicle( "electric_car", 1126087, 132700, 72290, 8240, 3390 );
-    test_vehicle( "suv", 1320286, 1163000, 630000, 85540, 30920 );
+    test_vehicle( "beetle", 816837, 431300, 338700, 95610, 68060 );
+    test_vehicle( "car", 1122954, 617500, 386100, 52730, 25170 );
+    test_vehicle( "car_sports", 1155382, 352600, 267600, 36790, 22350 );
+    test_vehicle( "electric_car", 1128423, 132700, 72290, 8240, 3390 );
+    test_vehicle( "suv", 1322622, 1163000, 630000, 85540, 30920 );
     test_vehicle( "motorcycle", 163085, 120300, 99930, 63320, 50810 );
     test_vehicle( "quad_bike", 265345, 116100, 116100, 46770, 46770 );
     test_vehicle( "scooter", 57587, 233500, 233500, 167900, 167900 );
     test_vehicle( "superbike", 242085, 109800, 65300, 41780, 24070 );
-    test_vehicle( "ambulance", 1839299, 613400, 504700, 77700, 58290 );
-    test_vehicle( "fire_engine", 2628611, 1885000, 1558000, 334700, 257000 );
-    test_vehicle( "fire_truck", 6314603, 410700, 83850, 19080, 4063 );
-    test_vehicle( "truck_swat", 5959334, 682900, 131700, 29610, 7604 );
+    test_vehicle( "ambulance", 1840467, 613400, 504700, 77700, 58290 );
+    test_vehicle( "fire_engine", 2632115, 1885000, 1558000, 334700, 257000 );
+    test_vehicle( "fire_truck", 6317523, 410700, 83850, 19080, 4063 );
+    test_vehicle( "truck_swat", 5964006, 682900, 131700, 29610, 7604 );
     test_vehicle( "tractor_plow", 723658, 681200, 681200, 132400, 132400 );
-    test_vehicle( "apc", 5801619, 1626000, 1119000, 130800, 85590 );
-    test_vehicle( "humvee", 5502045, 767900, 306900, 25620, 9171 );
-    test_vehicle( "road_roller", 8829220, 602500, 147100, 22760, 6925 );
+    test_vehicle( "apc", 5803867, 1626000, 1119000, 130800, 85590 );
+    test_vehicle( "humvee", 5504381, 767900, 306900, 25620, 9171 );
+    test_vehicle( "road_roller", 8829804, 602500, 147100, 22760, 6925 );
     test_vehicle( "golf_cart", 444630, 37180, 27560, 14100, 5681 );
 
     // in reverse
-    test_vehicle( "beetle", 815669, 58970, 58870, 44560, 43060, 0, 0, true );
-    test_vehicle( "car", 1120618, 76060, 76060, 44230, 24870, 0, 0, true );
-    test_vehicle( "car_sports", 1154214, 353200, 268000, 35200, 19540, 0, 0, true );
-    test_vehicle( "electric_car", 1126087, 133100, 72520, 8140, 3390, 0, 0, true );
-    test_vehicle( "suv", 1320286, 112000, 111800, 66880, 31670, 0, 0, true );
+    test_vehicle( "beetle", 816837, 58970, 58870, 44560, 43060, 0, 0, true );
+    test_vehicle( "car", 1122954, 76060, 76060, 44230, 24870, 0, 0, true );
+    test_vehicle( "car_sports", 1155382, 353200, 268000, 35200, 19540, 0, 0, true );
+    test_vehicle( "electric_car", 1128423, 133100, 72520, 8140, 3390, 0, 0, true );
+    test_vehicle( "suv", 1322622, 112000, 111800, 66880, 31670, 0, 0, true );
     test_vehicle( "motorcycle", 163085, 19980, 19030, 15490, 14890, 0, 0, true );
     test_vehicle( "quad_bike", 265345, 19650, 19650, 15440, 15440, 0, 0, true );
     test_vehicle( "scooter", 57587, 62440, 62440, 47990, 47990, 0, 0, true );
     test_vehicle( "superbike", 242085, 18320, 10570, 13070, 8497, 0, 0, true );
-    test_vehicle( "ambulance", 1839299, 58460, 57780, 42480, 39130, 0, 0, true );
-    test_vehicle( "fire_engine", 2628611, 258000, 257800, 179800, 173300, 0, 0, true );
-    test_vehicle( "fire_truck", 6314603, 58480, 58640, 18600, 4471, 0, 0, true );
-    test_vehicle( "truck_swat", 5959334, 129300, 130100, 29350, 7668, 0, 0, true );
+    test_vehicle( "ambulance", 1840467, 58460, 57780, 42480, 39130, 0, 0, true );
+    test_vehicle( "fire_engine", 2632115, 258000, 257800, 179800, 173300, 0, 0, true );
+    test_vehicle( "fire_truck", 6317523, 58480, 58640, 18600, 4471, 0, 0, true );
+    test_vehicle( "truck_swat", 5964006, 129300, 130100, 29350, 7668, 0, 0, true );
     test_vehicle( "tractor_plow", 723658, 72240, 72240, 53610, 53610, 0, 0, true );
-    test_vehicle( "apc", 5801619, 381500, 382100, 123600, 82000, 0, 0, true );
-    test_vehicle( "humvee", 5502045, 89940, 89940, 25780, 9086, 0, 0, true );
-    test_vehicle( "road_roller", 8829220, 97490, 97690, 22880, 6606, 0, 0, true );
+    test_vehicle( "apc", 5803867, 381500, 382100, 123600, 82000, 0, 0, true );
+    test_vehicle( "humvee", 5504381, 89940, 89940, 25780, 9086, 0, 0, true );
+    test_vehicle( "road_roller", 8829804, 97490, 97690, 22880, 6606, 0, 0, true );
     test_vehicle( "golf_cart", 444630, 37140, 11510, 14110, 4450, 0, 0, true );
 }


### PR DESCRIPTION
SUMMARY: [Content] "[Briefly describe the change in these quotation marks]"

#### Purpose of change

I recently saw this pull https://github.com/CleverRaven/Cataclysm-DDA/pull/64834 and decided it was a good way of also adding a source of synthetic fabric. Now the seatbelts have an item AND we have a source of synthetic fabric. Thanks to @Fris0uman for the concept and much of the PR. 
#### Describe the solution

Adds seatbelts and 5-point harnesses, which are used for their vehicle parts. Adds a recipe to make a 5-point harness from 3 seatbelts plus hammering and cutting (My guess here is messing with the belt buckles, I figure you'd handle more on the installation side anyway), also adds an uncraft of seatbelt into synthetic fabric. In a separate PR I am merging lycra into nylon to remove this redundant material. Scarf suggested 3 nylon per seatbelt, so I went with that. Seatbelts are also used as a short rope for tying animals so you won't lose out on ropes

#### Describe alternatives you've considered

Make the seatbelts out of lycra because why not, don't add seatbelts, don't remove lycra but add a use for nylon.

#### Testing

Loaded changes into the game. Everything worked as expected. As Kheir suggested, I tested if tying a cow with a seatbelt would turn it magically into a short rope, but thankfully it didn't.

#### Additional context

Co-authored-by: @Fris0uman 
https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2735

