### PR TITLE
Fix gunmod checks

### DIFF
--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -373,7 +373,7 @@ void gunmod_add( avatar &you, item &gun, item &mod )
     if( no_magazines && !modded.magazine_integral() ) {
         query_msg += "\n";
         query_msg += colorize(
-                         _( "Warning: after installing this mod, a magazine adapter mod will be required to load it!" ),
+                         _( "Warning: This mod changes ammunition used by this gun, a magazine adapter may be required to load it." ),
                          c_red );
     }
 

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -365,12 +365,12 @@ void gunmod_add( avatar &you, item &gun, item &mod )
 
     item modded = gun;
     modded.put_in( mod );
-    bool no_magazines = modded.common_ammo_default().is_null();
+    bool no_magazines = !mod.type->mod->ammo_modifier.empty() && modded.common_ammo_default().is_null();
 
     std::string query_msg = mod.is_irremovable()
                             ? _( "<color_yellow>Permanently</color> install your %1$s in your %2$s?" )
                             : _( "Attach your %1$s to your %2$s?" );
-    if( no_magazines ) {
+    if( no_magazines && !modded.magazine_integral() ) {
         query_msg += "\n";
         query_msg += colorize(
                          _( "Warning: after installing this mod, a magazine adapter mod will be required to load it!" ),

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6858,6 +6858,11 @@ bool item::can_unload_liquid() const
     return is_bucket() || !cts_is_frozen_liquid;
 }
 
+bool item::can_reload_with( const ammotype &ammo ) const
+{
+    return is_reloadable_helper( ammo->default_ammotype(), false );
+}
+
 bool item::can_reload_with( const itype_id &ammo ) const
 {
     return is_reloadable_helper( ammo, false );

--- a/src/item.h
+++ b/src/item.h
@@ -1211,6 +1211,11 @@ class item : public visitable<item>
          * Returns true if this item can be reloaded with specified ammo type,
          * ignoring currently loaded ammo.
          */
+        bool can_reload_with( const ammotype &ammo ) const;
+        /**
+         * Returns true if this item can be reloaded with specified ammo item,
+         * ignoring currently loaded ammo.
+         */
         bool can_reload_with( const itype_id &ammo ) const;
         /** Returns true if this item can be reloaded with specified ammo type at this moment. */
         bool is_reloadable_with( const itype_id &ammo ) const;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix gunmod installation checks for integral magazines."

#### Purpose of change

- fixes #649

When gunmods are installed, warning for magazine adaptor appears in inappropriate situations. As the check does nothing within the same universe as what the warning is meant to indicate. It checks whether the gun's loaded magazine has a default ammo type. Meaning that if you could install a conversion kit while the gun was loaded (which is impossible), the check would pass.

Furthermore, it fails due to guns with integral magazines not returning a default ammo type, as they count as "not loaded" with a magazine. It also fails when unloaded guns are modified, even when the modification doesn't change the ammo type used by the gun.

#### Describe the solution

Rewrite the entire check so it provides appropriate warning.

#### Describe alternatives you've considered

- Make the code only check if ammo type is changed, stating that a magazine adaptor _may_ be required.
  - Would be a hell of a lot simpler, but I have standards.

#### Testing
- [x] Spawn M4A1, remove magazine, install any compatible gunmod that is not a conversion kit: waterproofing, shoulderstrap, suppressor, etc. Check that no warning fires.
  - [x] With magazine in, install any compatible gunmod, check that no warning fires.
- Via Json, add Bore mod location to Remington 1100.
  - [x] Spawn Remington 1100 shotgun, install any compatible gunmod that is not a conversion kit. Check that no warning fires.
- [x] Spawn 7.62x51mm caliber conversion kit, install into M4A1 and Remington, check that warning only fires for M4A1.
- [x] Spawn .300 AAC Blackout AR-15 conversion kit. Install into M4A1, check that no warning fires.

#### Additional context