### PR TITLE
Fixed basic power armor (No Hope)

### DIFF
--- a/data/mods/No_Hope/Items/armor.json
+++ b/data/mods/No_Hope/Items/armor.json
@@ -101,7 +101,7 @@
       "flag": "POWERARMOR_EXTERNAL",
       "menu_text": "Turn off",
       "msg": "The %s disengages.",
-      "target": "power_armor_light"
+      "target": "power_armor_basic"
     },
     "covers": [ "torso", "arms", "hands", "legs", "feet" ],
     "encumbrance": 10


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed basic power armor turning into the wrong item (No Hope)"

#### Purpose of change
Basic power armor turned into light power armor when turned off.
Fixes #2711

#### Describe the solution
When turned off it will now become a basic power armor.

#### Describe alternatives you've considered
Watch as the issue list grows.

#### Testing
Before fix: Turned into light power armor.
After fix: Turned into basic power armor.