### PR TITLE
Clean up and rebalance microlab palette item spawns

### DIFF
--- a/data/json/mapgen_palettes/microlab.json
+++ b/data/json/mapgen_palettes/microlab.json
@@ -55,25 +55,13 @@
       "d": { "item": "office", "chance": 70, "repeat": [ 1, 3 ] },
       "B": [ { "item": "textbooks", "chance": 50 }, { "item": "manuals", "chance": 50 } ],
       "F": [
-        { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 2, 5 ] },
-        { "item": "supplies_samples_lab", "chance": 40, "repeat": [ 1, 3 ] }
+        { "item": "supplies_reagents_lab", "chance": 75, "repeat": 4 },
+        { "item": "supplies_samples_lab", "chance": 50, "repeat": 2 }
       ],
-      "U": [
-        { "item": "tools_science", "chance": 30, "repeat": [ 1, 3 ] },
-        { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 1, 3 ] },
-        { "item": "supplies_samples_lab", "chance": 10, "repeat": [ 1, 2 ] }
-      ],
-      "c": [
-        { "item": "tools_science", "chance": 30, "repeat": [ 1, 3 ] },
-        { "item": "supplies_reagents_lab", "chance": 70, "repeat": [ 1, 3 ] },
-        { "item": "supplies_samples_lab", "chance": 10, "repeat": [ 1, 2 ] }
-      ],
-      "R": [
-        { "item": "tools_robotics", "chance": 20, "repeat": [ 1, 3 ] },
-        { "item": "robots", "chance": 40, "repeat": [ 1, 3 ] },
-        { "item": "supplies_electronics", "chance": 40, "repeat": [ 1, 3 ] }
-      ],
-      "O": [ { "item": "tools_robotics", "chance": 40, "repeat": [ 1, 3 ] }, { "item": "schematics", "chance": 2 } ],
+      "U": [ { "item": "softdrugs", "chance": 50, "repeat": 2 }, { "item": "surgery", "chance": 25, "repeat": 3 } ],
+      "c": [ { "item": "tools_science", "chance": 50, "repeat": 3 }, { "item": "supplies_reagents_lab", "chance": 10 } ],
+      "R": [ { "item": "robots", "chance": 50, "repeat": 2 }, { "item": "supplies_electronics", "chance": 50, "repeat": 3 } ],
+      "O": [ { "item": "tools_robotics", "chance": 50, "repeat": 3 }, { "item": "schematics", "chance": 5 } ],
       "i": { "item": "cleaning", "chance": 20 }
     },
     "vendingmachines": { "V": {  } }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Microlab mapgen palette spawns generic science stuff in specific furniture instead of being all over all of them, other adjustments"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This starts some of the basic work pertaining to that idea I had of making the content of microlabs a bit less bland, starting with some easy updates to the palette. The main flaw with it is how a solid half of the spawns in the mapgen palette call the exact same itengroups, making it a bland mess.

Related issue, which this is a start on: https://github.com/cataclysmbnteam/Cataclysm-BN/issues/971

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Made the `repeat` numbers for the glass fridge spawns on `F` more consistent, phasing out variable-repeat for these. These will be the main place where `supplies_reagents_lab` and `supplies_samples_lab` spawn, in storage where they belong.
2. Repurposed the utility shelf spawns on `U`, removing the redundant generic science stuff with a focus on itemgroups `surgery` and `softdrugs`. `U` is less common than the ubiquitous `F` and `c` in microlabs, so medical supplies (in particular with a group that can spawn autoclave pouches and anesthesia, fitting my planned idea of microlabs being a support location for the contents of normal labs) will show up in certain rooms here and there, making them marginally less forgettable.
3. Refocused the counter spawns on `c` to spawn `tools_science` at a much more consistent rate, making the counters the main spawn of laboratory tools. They've retained a much smaller chance of calling a single spawn of `supplies_reagents_lab` to represent the occasional chemical item left on the table in the ensuing chaos, but otherwise their primary focus is on tool storage.
4. Made the spawns of items for the utility shelves on `O` and the tables on `R` more consistent, along with shuffling them around so the shelves are exclusively supplies (`robots` and `supplies_electronics`), while the tables are exclusively `tools_robotics` and `schematics`, the latter having its chance bumped up a bit. `O` and `R` are paired together in certain specific rooms within microlabs, making them a general electronics area where they show up, with `O` being the less commonly-used spawn.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Defining some sort of surgical supplies itemgroup that's specifically for autoclave pouches, anesthesia, concentrated hydrogen peroxide, and other stuff that counts as medical supplies for stuff that `tools_medical` and the various drug itemgroups aren't ideal for, specifically to use in places where `surgery` would be the closest fit.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and lint errors.

#### Additional context

Here's a rough summary of my planned followups. First, the easy stuff I could tack onto this or as a sister PR:
1. Sift through `tools_science` and obsolete any items that're completely useless fluff.
2. Find any other locations that currrently lack any way to spawn `tools_science` but could warrant having spawns of them.
3. Sanity-check how common monster spawns are in microlabs relative to normal labs. Ideally this will likely average them out a bit, make microlabs less of a slog but make regular labs less empty.

These combined (better weight and more places to spawn them) would help make the uncraftable flavor tools only needed for advanced chemical recipes a more consistent obstacle to tackle by raiding locations you'd expect to have such things, and not merely a source of "literally the only reason I've been in this microlab for several hours and I still haven't found the one item I need" situations.

The more complex bit, and more directly related to microlabs, would be the ideas in the above issue/discussion where certain areas have a chance of spawning special rooms dedicated to storing other resources, likely with hardened security and a focus on some specific sort of supply that's much more directly useful in standard labs.

The plan I've come up with finally would be to look at all the cases where the mapgen places a single complete room inside that area, categorize all existing examples (isolated science workstation rooms, offices, overgrown storage closets, whatever may be there) by their overall size, then convert them into a pool of mapgen chunk spawns that can then enable me to inject a random chance of the desired extra rooms to show up.

The following special rooms are planned to be fitted into this:
1. Electronics room. Additional area for electronics supplies, focusing on `tools_electronic` first and foremost, with secondary calls to `ammo_any_batteries_full` and a smaller chance of `ammo_atomic_batteries_full`. Chance of spawning a recharging cart.
2. Engineering: Broken generators and industrial machines, use of `supplies_plumbing` and `tools_construction`. Small workshop/storage space dedicated to `acetylene_production` itemgroup. Technician zombies
3. Sterilization room. Sealed access to make it a clean room in a way, maybe lockers with cleansuits and other PPE on the way in. Main focus is a fixed spawn of a furniture autoclave.
4. CVD supply: Rare. Stores hydrogen tanks, plasma cells, and coal. Secure storage isolating each rack in a small closet, make it seem like a blastproof vault.
5. Plutonium storage: Rare. Locked up and well-secured with secubot console, hazmat airlock like the sterilization room. Stores plutonium cells, smaller chance of plutonium batteries. Even odds of a minireactor, a mech power cell, or one of the new microreactor CBMs as a bonus. Should definitely be irradiated.
6. Nanomaterial vault: Rare. Design like a bank vault with secubot-guarded console. Stores nanomaterial canisters and some chance of an STC.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
