### PR TITLE
Weapon Value Caches properly update

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1210,6 +1210,7 @@ bool avatar::wield( item &target )
         return false;
     }
     clear_npc_ai_info_cache( npc_ai_info::weapon_value );
+    clear_npc_ai_info_cache( npc_ai_info::ideal_weapon_value );
     if( target.is_null() ) {
         return true;
     }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -576,7 +576,7 @@ static float rate_critter( const Creature &c )
 {
     const npc *np = dynamic_cast<const npc *>( &c );
     if( np != nullptr ) {
-        return npc_ai::weapon_value( *np, np->weapon );
+        return npc_ai::wielded_value( *np, true );
     }
 
     const monster *m = dynamic_cast<const monster *>( &c );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -134,7 +134,6 @@ static const itype_id itype_anesthetic( "anesthetic" );
 static const itype_id itype_burnt_out_bionic( "burnt_out_bionic" );
 static const itype_id itype_radiocontrol( "radiocontrol" );
 static const itype_id itype_remotevehcontrol( "remotevehcontrol" );
-static const itype_id itype_UPS( "UPS" );
 static const itype_id itype_UPS_off( "UPS_off" );
 static const itype_id itype_water_clean( "water_clean" );
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -471,6 +471,7 @@ void deactivate_weapon_cbm( npc &who )
         }
     }
     who.clear_npc_ai_info_cache( npc_ai_info::weapon_value );
+    who.clear_npc_ai_info_cache( npc_ai_info::ideal_weapon_value );
 }
 
 std::vector<std::pair<bionic_id, item>> find_reloadable_cbms( npc &who )
@@ -529,42 +530,40 @@ void npc::check_or_use_weapon_cbm()
         item best_cbm_weap = null_item_reference();
         for( int i : avail_toggle_cbms ) {
             bionic &bio = ( *my_bionics )[ i ];
-            if( free_power > bio.info().power_activate ) {
-                item cbm_fake = item( bio.info().fake_item );
-                if( bio.ammo_count > 0 ) {
-                    cbm_fake.ammo_set( bio.ammo_loaded, bio.ammo_count );
-                }
-                const int fake_shots = item_funcs::shots_remaining( *this, cbm_fake );
+            if( free_power < bio.info().power_activate ) {
+                continue;
+            }
+            item cbm_fake = item( bio.info().fake_item );
+            if( bio.ammo_count > 0 ) {
+                cbm_fake.ammo_set( bio.ammo_loaded, bio.ammo_count );
+            }
+            const int fake_shots = item_funcs::shots_remaining( *this, cbm_fake );
 
-                bool not_allowed = ( !rules.has_flag( ally_rule::use_guns ) && cbm_fake.is_gun() ) ||
-                                   ( rules.has_flag( ally_rule::use_silent ) && !cbm_fake.is_silent() );
-                if( not_allowed ) {
-                    continue;
-                }
+            bool not_allowed = ( !rules.has_flag( ally_rule::use_guns ) && cbm_fake.is_gun() ) ||
+                               ( rules.has_flag( ally_rule::use_silent ) && !cbm_fake.is_silent() );
+            if( not_allowed ) {
+                continue;
+            }
 
-                const item to_compare = toggle_index >= 0 ? best_cbm_weap : weapon;
-                const int to_compare_shots = item_funcs::shots_remaining( *this, to_compare );
+            double to_compare_value = 0.0;
+            if( toggle_index >= 0 ) {
+                // Previous iteration chose a CBM, compare them.
+                const int to_compare_shots = item_funcs::shots_remaining( *this, best_cbm_weap );
+                to_compare_value = npc_ai::weapon_value( *this, best_cbm_weap, to_compare_shots );
+            } else {
+                // Compare against weapon.
+                to_compare_value = npc_ai::wielded_value( *this, false );
+            }
 
-                if( npc_ai::weapon_value( *this, to_compare, to_compare_shots ) <
-                    npc_ai::weapon_value( *this, cbm_fake, fake_shots ) ) {
-                    toggle_index = i;
-                    best_cbm_weap = cbm_fake;
-                }
+            if( to_compare_value < npc_ai::weapon_value( *this, cbm_fake, fake_shots ) ) {
+                toggle_index = i;
+                best_cbm_weap = cbm_fake;
             }
         }
 
         if( toggle_index >= 0 ) {
-            // Decided on a bionic, swap to it.
-            if( is_armed() ) {
-                stow_item( weapon );
-            }
-            activate_bionic_by_id( ( *my_bionics )[ toggle_index ].id );
-            if( get_player_character().sees( pos() ) ) {
-                add_msg( m_info, _( "%s activates their %s." ), disp_name(),
-                         ( *my_bionics )[ toggle_index ].info().name );
-            }
-            clear_npc_ai_info_cache( npc_ai_info::weapon_value );
-            cbm_toggled = ( *my_bionics )[ toggle_index ].id;
+            cbm_toggled = ( *my_bionics )[toggle_index].id;
+            cbm_fake_toggled = best_cbm_weap;
         }
     }
 
@@ -586,37 +585,32 @@ void npc::check_or_use_weapon_cbm()
             // Have fun changing this in the future.
             int cbm_ammo = free_power / bio.info().power_activate;
 
-            if( active_index >= 0 ) {
-                // Previous iteration chose a CBM, compare them.
-                int b_cbm_ammo = free_power / ( *my_bionics )[active_index].info().power_activate;
-
-                if( npc_ai::weapon_value( *this, best_cbm_active, b_cbm_ammo ) < npc_ai::weapon_value( *this,
-                        cbm_weapon, cbm_ammo ) ) {
-                    // New one is better, update.
-                    active_index = i;
-                    best_cbm_active = cbm_weapon;
-                }
-
-            } else if( wield_gun ) {
-                // For melee we keep it in reserve anyway, but ranged we're using either it or this one.
-                // Right now no BIONIC_GUNS are melee weapons, unlike BIONIC_WEAPONS and the bionic shotgun.
-                const int weapon_shots = item_funcs::shots_remaining( *this, weapon );
-
-                if( npc_ai::weapon_value( *this, weapon, weapon_shots ) <
-                    npc_ai::weapon_value( *this, cbm_weapon, cbm_ammo ) ) {
-                    active_index = i;
-                    best_cbm_active = cbm_weapon;
-                }
-
-            } else {
+            double to_compare_value = 0.0;
+            if( !wield_gun && active_index < 0 ) {
                 // If it's not a gun, then we only need to compare the CBMs as
                 // You can fire an activated CBM without the need to equip/unequip anything.
                 active_index = i;
                 best_cbm_active = cbm_weapon;
+                continue;
+            }
+            if( active_index >= 0 ) {
+                // Previous iteration chose a CBM, compare them.
+                int b_cbm_ammo = free_power / ( *my_bionics )[active_index].info().power_activate;
+                to_compare_value = npc_ai::weapon_value( *this, best_cbm_active, b_cbm_ammo );
+            } else if( wield_gun ) {
+                // For melee we keep it in reserve anyway, but ranged we're using either it or this one.
+                // Right now no BIONIC_GUNS are melee weapons, unlike BIONIC_WEAPONS and the bionic shotgun.
+                to_compare_value = npc_ai::wielded_value( *this, false );
+            }
+
+            if( to_compare_value < npc_ai::weapon_value( *this, cbm_weapon, cbm_ammo ) ) {
+                active_index = i;
+                best_cbm_active = cbm_weapon;
             }
         }
-        cbm_active = ( *my_bionics )[ active_index ].id;
-        if( !cbm_active.is_null() ) {
+
+        if( active_index > 0 ) {
+            cbm_active = ( *my_bionics )[active_index].id;
             cbm_fake_active = best_cbm_active;
         }
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2502,6 +2502,7 @@ item Character::remove_weapon()
     item tmp = weapon;
     weapon = item();
     clear_npc_ai_info_cache( npc_ai_info::weapon_value );
+    clear_npc_ai_info_cache( npc_ai_info::ideal_weapon_value );
     return tmp;
 }
 

--- a/src/character.h
+++ b/src/character.h
@@ -99,6 +99,7 @@ enum vision_modes {
 
 enum npc_ai_info : size_t {
     weapon_value = 0,
+    ideal_weapon_value,
     reloadables,
     reloadable_cbms,
     num_npc_ai_info,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4460,7 +4460,7 @@ void item::on_wield( player &p, int mv )
         msg = _( "You wield your %s." );
     }
     // if game is loaded - don't want ownership assigned during char creation
-    if( get_avatar().getID().is_valid() ) {
+    if( p.getID().is_valid() ) {
         handle_pickup_ownership( p );
     }
     p.add_msg_if_player( m_neutral, msg, tname() );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2273,7 +2273,11 @@ double npc_ai::wielded_value( const Character &who, bool ideal )
     }
     int ammo_count = ideal ? who.weapon.ammo_capacity() :
                      character_funcs::ammo_count_for( who, who.weapon );
-    double weap_val = weapon_value( who, who.weapon, ammo_count );
+    item ideal_weapon = who.weapon;
+    if( !ideal_weapon.ammo_default().is_null() ) {
+        ideal_weapon.ammo_set( ideal_weapon.ammo_default(), -1 );
+    }
+    double weap_val = weapon_value( who, ideal ? ideal_weapon : who.weapon, ammo_count );
     if( ideal ) {
         who.set_npc_ai_info_cache( npc_ai_info::ideal_weapon_value, weap_val );
     } else {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -23,6 +23,7 @@
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character.h"
+#include "character_functions.h"
 #include "character_martial_arts.h"
 #include "creature.h"
 #include "damage.h"
@@ -2258,15 +2259,31 @@ int Character::attack_cost( const item &weap ) const
     return move_cost;
 }
 
+double npc_ai::wielded_value( const Character &who, bool ideal )
+{
+    const double cached = ideal ? *who.get_npc_ai_info_cache( npc_ai_info::ideal_weapon_value ) :
+                          *who.get_npc_ai_info_cache( npc_ai_info::weapon_value );
+    if( cached >= 0.0 ) {
+        if( ideal ) {
+            add_msg( m_debug, "%s ideal sum value: %.1f", who.weapon.type->get_id().str(), cached );
+        } else {
+            add_msg( m_debug, "%s cached sum value: %.1f", who.weapon.type->get_id().str(), cached );
+        }
+        return cached;
+    }
+    int ammo_count = ideal ? who.weapon.ammo_capacity() :
+                     character_funcs::ammo_count_for( who, who.weapon );
+    double weap_val = weapon_value( who, who.weapon, ammo_count );
+    if( ideal ) {
+        who.set_npc_ai_info_cache( npc_ai_info::ideal_weapon_value, weap_val );
+    } else {
+        who.set_npc_ai_info_cache( npc_ai_info::weapon_value, weap_val );
+    }
+    return weap_val;
+}
+
 double npc_ai::weapon_value( const Character &who, const item &weap, int ammo )
 {
-    if( who.is_wielding( weap ) ) {
-        auto cached = who.get_npc_ai_info_cache( npc_ai_info::weapon_value );
-        if( cached >= 0.0 ) {
-            add_msg( m_debug, "%s (%ld ammo) sum value: %.1f", weap.type->get_id().str(), ammo, *cached );
-            return *cached;
-        }
-    }
     const double val_gun = gun_value( who, weap, ammo );
     const double val_melee = melee_value( who, weap );
     const double more = std::max( val_gun, val_melee );
@@ -2281,9 +2298,6 @@ double npc_ai::weapon_value( const Character &who, const item &weap, int ammo )
     // A small bonus for guns you can also use to hit stuff with (bayonets etc.)
     const double my_val = ( more + ( less / 2.0 ) ) * armor_penalty;
     add_msg( m_debug, "%s (%ld ammo) sum value: %.1f", weap.type->get_id().str(), ammo, my_val );
-    if( who.is_wielding( weap ) ) {
-        who.set_npc_ai_info_cache( npc_ai_info::weapon_value, my_val );
-    }
     return my_val;
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1158,6 +1158,7 @@ void npc::stow_item( item &it )
 bool npc::wield( item &it )
 {
     clear_npc_ai_info_cache( npc_ai_info::weapon_value );
+    clear_npc_ai_info_cache( npc_ai_info::ideal_weapon_value );
     if( is_armed() ) {
         stow_item( weapon );
     }
@@ -1228,7 +1229,7 @@ void npc::form_opinion( const player &u )
         } else {
             op_of_u.fear += 6;
         }
-    } else if( npc_ai::weapon_value( u, u.weapon ) > 20 ) {
+    } else if( npc_ai::wielded_value( u, true ) > 20 ) {
         op_of_u.fear += 2;
     } else if( !u.is_armed() ) {
         // Unarmed, but actually unarmed ("unarmed weapons" are not unarmed)
@@ -1514,7 +1515,7 @@ void npc::decide_needs()
         needrank[need_safety] = 1;
     }
 
-    needrank[need_weapon] = npc_ai::weapon_value( *this, weapon );
+    needrank[need_weapon] = npc_ai::wielded_value( *this, true );
     needrank[need_food] = 15.0f - ( max_stored_kcal() - get_stored_kcal() ) / 10.0f;
     needrank[need_drink] = 15 - get_thirst();
     invslice slice = inv.slice();
@@ -1765,7 +1766,7 @@ int npc::value( const item &it, int market_price ) const
 
     int ret = 0;
     // TODO: Cache own weapon value (it can be a bit expensive to compute 50 times/turn)
-    double weapon_val = npc_ai::weapon_value( *this, it ) - npc_ai::weapon_value( *this, weapon );
+    double weapon_val = npc_ai::weapon_value( *this, it ) - npc_ai::wielded_value( *this, true );
     if( weapon_val > 0 ) {
         ret += weapon_val;
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1765,7 +1765,6 @@ int npc::value( const item &it, int market_price ) const
     }
 
     int ret = 0;
-    // TODO: Cache own weapon value (it can be a bit expensive to compute 50 times/turn)
     double weapon_val = npc_ai::weapon_value( *this, it,
                         it.ammo_capacity() ) - npc_ai::wielded_value( *this, true );
     if( weapon_val > 0 ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1766,7 +1766,8 @@ int npc::value( const item &it, int market_price ) const
 
     int ret = 0;
     // TODO: Cache own weapon value (it can be a bit expensive to compute 50 times/turn)
-    double weapon_val = npc_ai::weapon_value( *this, it ) - npc_ai::wielded_value( *this, true );
+    double weapon_val = npc_ai::weapon_value( *this, it,
+                        it.ammo_capacity() ) - npc_ai::wielded_value( *this, true );
     if( weapon_val > 0 ) {
         ret += weapon_val;
     }

--- a/src/npc.h
+++ b/src/npc.h
@@ -1341,6 +1341,8 @@ class npc : public player
         item cbm_fake_active = null_item_reference();
         // index for chosen toggled cbm weapon;
         bionic_id cbm_toggled = bionic_id::NULL_ID();
+        // Copy of toggled CBM weapon for comparisons;
+        item cbm_fake_toggled = null_item_reference();
 
         bool dead = false;  // If true, we need to be cleaned up
 
@@ -1390,6 +1392,8 @@ npc *pick_follower();
 
 namespace npc_ai
 {
+/** Evaluate wielded weapon */
+double wielded_value( const Character &who, bool ideal );
 /** Evaluate item as weapon (melee or gun) */
 double weapon_value( const Character &who, const item &weap, int ammo = item::INFINITE_CHARGES );
 /** Evaluates item as a gun */

--- a/src/npc.h
+++ b/src/npc.h
@@ -1395,9 +1395,9 @@ namespace npc_ai
 /** Evaluate wielded weapon */
 double wielded_value( const Character &who, bool ideal );
 /** Evaluate item as weapon (melee or gun) */
-double weapon_value( const Character &who, const item &weap, int ammo = item::INFINITE_CHARGES );
+double weapon_value( const Character &who, const item &weap, int ammo );
 /** Evaluates item as a gun */
-double gun_value( const Character &who, const item &weap, int ammo = item::INFINITE_CHARGES );
+double gun_value( const Character &who, const item &weap, int ammo );
 /** Evaluate item as a melee weapon */
 double melee_value( const Character &who, const item &weap );
 /** Evaluate unarmed melee value */

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3491,7 +3491,7 @@ bool npc::wield_better_weapon()
             cbm_active = bionic_id::NULL_ID();
         }
         return true;
-    } else if( best != &cbm_fake_toggled && weapon.typeId() == cbm_fake_toggled.typeId() ) {
+    } else if( weapon.typeId() == cbm_fake_toggled.typeId() ) {
         deactivate_bionic_by_id( cbm_toggled );
         cbm_toggled = bionic_id::NULL_ID();
         cbm_fake_toggled = null_item_reference();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -628,7 +628,7 @@ float npc::character_danger( const Character &u ) const
     float ret = 0.0;
     bool u_gun = u.weapon.is_gun();
     bool my_gun = weapon.is_gun();
-    double u_weap_val = npc_ai::weapon_value( u, u.weapon );
+    double u_weap_val = npc_ai::wielded_value( u, true );
     const double &my_weap_val = ai_cache.my_weapon_value;
     if( u_gun && !my_gun ) {
         u_weap_val *= 1.5f;
@@ -666,7 +666,7 @@ void npc::regen_ai_cache()
     ai_cache.can_heal.clear_all();
     ai_cache.danger = 0.0f;
     ai_cache.total_danger = 0.0f;
-    ai_cache.my_weapon_value = npc_ai::weapon_value( *this, weapon );
+    ai_cache.my_weapon_value = npc_ai::wielded_value( *this, true );
     ai_cache.dangerous_explosives = find_dangerous_explosives();
 
     assess_danger();
@@ -1425,15 +1425,15 @@ npc_action npc::method_of_attack()
         return npc_melee;
     }
 
+    if( !weapon.ammo_sufficient() && can_reload_current() ) {
+        add_msg( m_debug, "%s is reloading", disp_name() );
+        return npc_reload;
+    }
+
     // TODO: Add a time check now that wielding takes a lot of time
     if( wield_better_weapon() ) {
         add_msg( m_debug, "%s is changing weapons", disp_name() );
         return npc_noop;
-    }
-
-    if( !weapon.ammo_sufficient() && can_reload_current() ) {
-        add_msg( m_debug, "%s is reloading", disp_name() );
-        return npc_reload;
     }
 
     // TODO: Needs a check for transparent but non-passable tiles on the way
@@ -1601,6 +1601,7 @@ void npc::deactivate_combat_cbms()
     cbm_active = bionic_id::NULL_ID();
     cbm_fake_active = null_item_reference();
     cbm_toggled = bionic_id::NULL_ID();
+    cbm_fake_toggled = null_item_reference();
 }
 
 bool npc::activate_bionic_by_id( const bionic_id &cbm_id, bool eff_only )
@@ -3398,7 +3399,8 @@ bool npc::do_player_activity()
 
 bool npc::wield_better_weapon()
 {
-    if( weapon.has_flag( flag_NO_UNWIELD ) && cbm_toggled.is_null() ) {
+    // Check against typeId() because the NPC doesn't actually wield the fake item.
+    if( weapon.has_flag( flag_NO_UNWIELD ) && weapon.typeId() != cbm_fake_toggled.typeId() ) {
         add_msg( m_debug, "Cannot unwield %s, not switching.", weapon.type->get_id().str() );
         return false;
     }
@@ -3419,7 +3421,13 @@ bool npc::wield_better_weapon()
         if( !allowed ) {
             val = npc_ai::weapon_value( *this, it, 0 );
         } else {
-            val = npc_ai::weapon_value( *this, it, item_funcs::shots_remaining( *this, it ) );
+            if( this->is_wielding( it ) ) {
+                // Accounts for ammo in inventory.
+                val = npc_ai::wielded_value( *this, false );
+            } else {
+                // Saves on processing by only checking loaded ammo instead of npc inventory.
+                val = npc_ai::weapon_value( *this, it, item_funcs::shots_remaining( *this, it ) );
+            }
         }
 
         if( val > best_value ) {
@@ -3431,6 +3439,12 @@ bool npc::wield_better_weapon()
     compare_weapon( weapon );
     // To prevent changing to barely better stuff
     best_value *= std::max<float>( 1.0f, ai_cache.danger_assessment / 10.0f );
+
+    // Compare Toggled CBM selected earlier in check_or_use_weapon_cbm()
+    // But only if it's not already wielded
+    if( weapon.typeId() != cbm_fake_toggled.typeId() ) {
+        compare_weapon( cbm_fake_toggled );
+    }
 
     // Fists aren't checked below
     compare_weapon( null_item_reference() );
@@ -3457,17 +3471,30 @@ bool npc::wield_better_weapon()
         add_msg( m_debug, "Wielded %s is best at %.1f, not switching", best->type->get_id().str(),
                  best_value );
         return false;
-    } else {
-        if( !cbm_toggled.is_null() ) {
-            deactivate_bionic_by_id( cbm_toggled );
-            cbm_toggled = bionic_id::NULL_ID();
+    }
+
+    if( best == &cbm_fake_toggled ) {
+        if( is_armed() ) {
+            stow_item( weapon );
         }
+        activate_bionic_by_id( cbm_toggled );
+        if( get_player_character().sees( pos() ) ) {
+            add_msg( m_info, _( "%s activates their %s." ), disp_name(),
+                     cbm_toggled->name );
+        }
+        clear_npc_ai_info_cache( npc_ai_info::weapon_value );
+        clear_npc_ai_info_cache( npc_ai_info::ideal_weapon_value );
 
         if( !cbm_fake_active.is_null() && best->is_gun() ) {
             // They'll need time to swap weapons anyway, consolidates the comparisons into check_or_use_bionics.
             cbm_fake_active = null_item_reference();
             cbm_active = bionic_id::NULL_ID();
         }
+        return true;
+    } else if( best != &cbm_fake_toggled && weapon.typeId() == cbm_fake_toggled.typeId() ) {
+        deactivate_bionic_by_id( cbm_toggled );
+        cbm_toggled = bionic_id::NULL_ID();
+        cbm_fake_toggled = null_item_reference();
     }
 
     add_msg( m_debug, "Wielding %s at value %.1f", best->type->get_id().str(), best_value );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2015,7 +2015,7 @@ double npc_ai::gun_value( const Character &who, const item &weap, int ammo )
     }
 
     // Gives an approximation of DPS disregarding modes.
-    float move_cost_factor = move_cost / 100;
+    float move_cost_factor = move_cost / 100.0f;
 
     // "Medium range" below means 9 tiles, "short range" means 4
     // Those are guarantees (assuming maximum time spent aiming)

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1978,7 +1978,6 @@ double npc_ai::gun_value( const Character &who, const item &weap, int ammo )
         return 0.0;
     }
 
-    const islot_gun &gun = *weap.type->gun;
     itype_id ammo_type;
     if( !weap.ammo_current().is_null() ) {
         ammo_type = weap.ammo_current();
@@ -1990,6 +1989,8 @@ double npc_ai::gun_value( const Character &who, const item &weap, int ammo )
     const itype *def_ammo_i = ammo_type.is_null() ? nullptr : &*ammo_type;
 
     damage_instance gun_damage = weap.gun_damage();
+    const int ammo_cap = weap.ammo_capacity();
+    bool empty = weap.ammo_remaining() == 0;
     item tmp = weap;
     tmp.ammo_set( ammo_type );
     int total_dispersion = ranged::get_weapon_dispersion( who, tmp ).max() +
@@ -2008,16 +2009,18 @@ double npc_ai::gun_value( const Character &who, const item &weap, int ammo )
     }
 
     int move_cost = time_to_attack( who, weap, item_location() );
-    if( gun.clip != 0 && gun.clip < 10 ) {
-        // TODO: RELOAD_ONE should get a penalty here
-        int reload_cost = gun.reload_time + who.encumb( bp_hand_l ) + who.encumb( bp_hand_r );
-        reload_cost /= gun.clip;
+    if( empty && ammo >= 1 ) {
+        int reload_cost = weap.get_reload_time() + who.encumb( bp_hand_l ) + who.encumb( bp_hand_r );
         move_cost += reload_cost;
     }
 
+    // Gives an approximation of DPS disregarding modes.
+    float move_cost_factor = move_cost / 100;
+
     // "Medium range" below means 9 tiles, "short range" means 4
     // Those are guarantees (assuming maximum time spent aiming)
-    static const std::vector<std::pair<float, float>> dispersion_thresholds = {{
+    static const std::vector<std::pair<float, float>> dispersion_thresholds = {
+        {
             // Headshots all the time
             { 0.0f, 5.0f },
             // Critical at medium range
@@ -2037,30 +2040,13 @@ double npc_ai::gun_value( const Character &who, const item &weap, int ammo )
         }
     };
 
-    static const std::vector<std::pair<float, float>> move_cost_thresholds = {{
-            { 10.0f, 4.0f },
-            { 25.0f, 3.0f },
-            { 100.0f, 1.0f },
-            { 500.0f, 5.0f },
-        }
-    };
-
-    float move_cost_factor = multi_lerp( move_cost_thresholds, move_cost );
-
-    // Penalty for dodging in melee makes the gun unusable in melee
-    // Until NPCs get proper kiting, at least
-    int melee_penalty = who.weapon.volume() / 250_ml - who.get_skill_level( skill_dodge );
-    if( melee_penalty <= 0 ) {
-        // Dispersion matters less if you can just use the gun in melee
-        total_dispersion = std::min<int>( total_dispersion / move_cost_factor, total_dispersion );
-    }
-
     float dispersion_factor = multi_lerp( dispersion_thresholds, total_dispersion );
 
     float damage_and_accuracy = damage_factor * dispersion_factor;
 
     // TODO: Some better approximation of the ability to keep on shooting
-    static const std::vector<std::pair<float, float>> capacity_thresholds = {{
+    static const std::vector<std::pair<float, float>> capacity_thresholds = {
+        {
             { 1.0f, 0.5f },
             { 5.0f, 1.0f },
             { 10.0f, 1.5f },
@@ -2069,17 +2055,16 @@ double npc_ai::gun_value( const Character &who, const item &weap, int ammo )
         }
     };
 
-    // How much until reload
-    float capacity = gun.clip > 0 ? std::min<float>( gun.clip, ammo ) : ammo;
-    // How much until dry and a new weapon is needed
-    capacity += std::min<float>( 1.0, ammo / 20.0 );
+    // Ammo capacity. Reduced to ammo available if that's lower.
+    float capacity = ammo_cap > 0 ? std::min( ammo_cap, ammo ) : ammo;
+
     double capacity_factor = multi_lerp( capacity_thresholds, capacity );
 
-    double gun_value = damage_and_accuracy * capacity_factor;
+    double gun_value = damage_and_accuracy * capacity_factor * move_cost_factor;
 
-    add_msg( m_debug, "%s as gun: %.1f total, %.1f dispersion, %.1f damage, %.1f capacity",
+    add_msg( m_debug, "%s as gun: %.1f total, %.1f dispersion, %.1f damage, %.1f capacity, %.1f move",
              weap.type->get_id().str(), gun_value, dispersion_factor, damage_factor,
-             capacity_factor );
+             capacity_factor, move_cost_factor );
     return std::max( 0.0, gun_value );
 }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1618,11 +1618,17 @@ void npc::load( const JsonObject &data )
     }
     cbm_toggled = bionic_id::NULL_ID();
     data.read( "cbm_toggled", cbm_toggled );
+    cbm_fake_toggled = null_item_reference();
+    data.read( "cbm_fake_toggled", cbm_fake_toggled );
+    if( !cbm_toggled.is_null() && cbm_fake_toggled.is_null() ) {
+        cbm_fake_toggled = item( cbm_toggled->fake_item );
+    }
     if( data.has_member( "cbm_weapon_index" ) ) {
         int index = 0;
         data.read( "cbm_weapon_index", index );
         if( index >= 0 ) {
             cbm_toggled = ( *my_bionics )[ index ].id;
+            cbm_fake_toggled = item( cbm_toggled->fake_item );
         }
     }
     cbm_active = bionic_id::NULL_ID();
@@ -1691,6 +1697,9 @@ void npc::store( JsonOut &json ) const
     json.member( "rules", rules );
 
     json.member( "cbm_toggled", cbm_toggled );
+    if( !cbm_fake_toggled.is_null() ) {
+        json.member( "cbm_fake_toggled", cbm_fake_toggled );
+    }
     json.member( "cbm_active", cbm_active );
     if( !cbm_fake_active.is_null() ) {
         json.member( "cbm_fake_active", cbm_fake_active );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Weapon Value Caches properly update"

#### Purpose of change

#1705 revealed issues with weapon value cache for NPCs, where they try to store and read ideal and current values, leading to mismatch and incorrect evaluations.

#### Describe the solution

Adds new `wielded_value()` function dedicated to updating value of currently wielded weapon. Accepts Character and bool as arguments, where the bool decides whether the value to be retrieved is the ideal value if the NPC had access to "infinite" ammo (set to magazine size otherwise values can get absurd).

Refactors `wield_better_weapon()` to solve secondary issue @scarf005 noticed in #1705 where NPC would swap to bionic weapon only to swap back due to how weapon swapping occurs in both `check_or_use_weapon_cbms()` and `wield_better_weapon()`. Now weapon swapping can _only_ occur in `wield_better_weapon()`, `check_or_use_weapon_cbms()` instead queues the cbm weapon for checking.

#### Describe alternatives you've considered

Can't think of any.

#### Testing

Spawn NPC, give them a katana, an M4A1, a filled STANAG 20 round magazine, 50 5.56 NATO rounds, 6 00 shotshells, and then install the bionic shotgun into them.

- [x] Spawn menacing debug monster within range. Check that the NPC wields their M4A1.
- [x] Check that NPC empties first magazine, then swaps magazines and continues to fire
  - [x] Check that NPC does not try to reload empty magazines during combat.
- [x] Check that NPC then swaps to bionic shotgun once ammo sufficiently depleted and shoots until they run out of ammo
  - [x] Check that NPC, having emptied the bionic shotgun's magazine, loads ammo one at a time and shoots the monster after each load.
- [x] Check that once bionic shotgun is emptied (and NPC swaps back to M4A1 and _fully_ empties that.) NPC swaps to katana.

#### Additional context

Note, NPC will not _empty_ the M4A1 on their last mag but leave it on 1 bullet remaining, fixing this is somewhat out of scope, as it requires adding consideration for reload cost, weapon swap cost, and firing cost.