### PR TITLE
Adjust monster density of labs vs microlabs

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_lab.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_lab.json
@@ -5,7 +5,7 @@
     "name": "science lab",
     "sym": "L",
     "color": "light_blue",
-    "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
+    "spawns": { "group": "GROUP_LAB", "population": [ 1, 10 ], "chance": 50 },
     "see_cost": 5,
     "flags": [ "NO_ROTATE", "RISK_HIGH" ]
   },
@@ -16,7 +16,7 @@
     "sym": "L",
     "color": "blue",
     "see_cost": 5,
-    "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
+    "spawns": { "group": "GROUP_LAB", "population": [ 1, 10 ], "chance": 50 },
     "flags": [ "KNOWN_DOWN", "NO_ROTATE", "RISK_HIGH" ]
   },
   {
@@ -25,7 +25,7 @@
     "name": "science lab",
     "sym": "L",
     "color": "light_blue",
-    "spawns": { "group": "GROUP_LAB", "population": [ 0, 8 ], "chance": 30 },
+    "spawns": { "group": "GROUP_LAB", "population": [ 1, 10 ], "chance": 50 },
     "see_cost": 5,
     "flags": [ "NO_ROTATE", "RISK_HIGH" ]
   },
@@ -44,7 +44,7 @@
     "name": "science lab",
     "sym": "L",
     "color": "light_blue",
-    "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
+    "spawns": { "group": "GROUP_LAB", "population": [ 1, 10 ], "chance": 50 },
     "see_cost": 5,
     "flags": [ "NO_ROTATE" ]
   },
@@ -54,7 +54,7 @@
     "name": "science lab",
     "sym": "L",
     "color": "light_blue",
-    "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
+    "spawns": { "group": "GROUP_LAB", "population": [ 1, 10 ], "chance": 50 },
     "see_cost": 5,
     "flags": [ "NO_ROTATE", "RISK_HIGH" ]
   },
@@ -65,7 +65,7 @@
     "sym": "L",
     "color": "blue",
     "see_cost": 5,
-    "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
+    "spawns": { "group": "GROUP_LAB", "population": [ 1, 10 ], "chance": 50 },
     "flags": [ "KNOWN_DOWN", "NO_ROTATE" ]
   },
   {
@@ -84,7 +84,7 @@
     "name": "science lab",
     "sym": "L",
     "color": "light_blue",
-    "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
+    "spawns": { "group": "GROUP_LAB", "population": [ 1, 10 ], "chance": 50 },
     "see_cost": 5,
     "flags": [ "NO_ROTATE", "RISK_HIGH" ]
   },
@@ -95,7 +95,7 @@
     "sym": "L",
     "color": "blue",
     "see_cost": 5,
-    "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
+    "spawns": { "group": "GROUP_LAB", "population": [ 1, 10 ], "chance": 50 },
     "flags": [ "KNOWN_DOWN", "NO_ROTATE" ]
   },
   {
@@ -104,7 +104,7 @@
     "name": "science lab",
     "sym": "L",
     "color": "light_blue",
-    "spawns": { "group": "GROUP_LAB", "population": [ 0, 8 ], "chance": 30 },
+    "spawns": { "group": "GROUP_LAB", "population": [ 1, 10 ], "chance": 50 },
     "see_cost": 5,
     "flags": [ "NO_ROTATE" ]
   },
@@ -125,7 +125,7 @@
     "sym": "L",
     "color": "light_blue",
     "see_cost": 5,
-    "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
+    "spawns": { "group": "GROUP_LAB", "population": [ 1, 10 ], "chance": 50 },
     "flags": [ "NO_ROTATE", "RISK_HIGH" ]
   },
   {
@@ -135,7 +135,7 @@
     "sym": "L",
     "color": "blue",
     "see_cost": 5,
-    "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
+    "spawns": { "group": "GROUP_LAB", "population": [ 1, 10 ], "chance": 50 },
     "flags": [ "NO_ROTATE" ]
   },
   {
@@ -155,7 +155,7 @@
     "color": "light_blue",
     "see_cost": 5,
     "extras": "subway",
-    "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
+    "spawns": { "group": "GROUP_LAB", "population": [ 1, 10 ], "chance": 50 },
     "flags": [ "NO_ROTATE", "RISK_HIGH" ]
   },
   {
@@ -163,7 +163,7 @@
     "id": "central_lab_train_depot",
     "name": "central train depot",
     "copy-from": "lab_train_depot",
-    "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 0, 5 ], "chance": 20 }
+    "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 1, 10 ], "chance": 50 }
   },
   {
     "type": "overmap_terrain",
@@ -191,7 +191,7 @@
     "color": "cyan",
     "see_cost": 5,
     "flags": [ "RISK_HIGH" ],
-    "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 0, 5 ], "chance": 20 }
+    "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 1, 10 ], "chance": 50 }
   },
   {
     "type": "overmap_terrain",
@@ -216,7 +216,7 @@
     "color": "light_blue",
     "see_cost": 5,
     "flags": [ "NO_ROTATE" ],
-    "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 0, 7 ], "chance": 40 }
+    "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 1, 10 ], "chance": 50 }
   },
   {
     "type": "overmap_terrain",
@@ -226,7 +226,7 @@
     "color": "blue",
     "see_cost": 5,
     "flags": [ "NO_ROTATE" ],
-    "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 0, 7 ], "chance": 40 }
+    "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 1, 10 ], "chance": 50 }
   },
   {
     "type": "overmap_terrain",
@@ -236,7 +236,7 @@
     "color": "light_blue",
     "see_cost": 5,
     "flags": [ "NO_ROTATE" ],
-    "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 0, 7 ], "chance": 40 }
+    "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 1, 10 ], "chance": 50 }
   },
   {
     "type": "overmap_terrain",
@@ -246,7 +246,7 @@
     "color": "cyan",
     "see_cost": 5,
     "flags": [ "NO_ROTATE" ],
-    "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 0, 5 ], "chance": 20 }
+    "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 1, 10 ], "chance": 50 }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_microlab.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_microlab.json
@@ -5,7 +5,7 @@
     "name": "science lab",
     "sym": "L",
     "color": "light_blue",
-    "spawns": { "group": "GROUP_MICROLAB", "population": [ 40, 45 ], "chance": 80 },
+    "spawns": { "group": "GROUP_MICROLAB", "population": [ 20, 40 ], "chance": 50 },
     "see_cost": 5,
     "flags": [ "NO_ROTATE", "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Pull spawn totals in labs and microlabs a bit closer together, spawning a more a bit monsters in labs and a bit less in microlabs"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

As noted in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2740, another flaw with microlabs I wanted to address was how they're infamous for being a slog through a massive hoard of zombies for so little gain. Conversely, regular labs are extremely barren and underpopulated, so adjusting the two a bit makes a degree of sense.

On the one hand, on average a regular lab will likely contain maybe 5 times as many tiles as a microlab (hard to tell for sure) so an individual microlab tile will need to have a higher population count for the two locations to have similar total spawns, but these values can in many ways be nudged a bit closer together.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Main changes:
1. Adjusted standard lab monster spawns from 20% for 0-5 monsters to 50% for 1-10. This makes it so if it does spawn something a monster of some sort is always certain, while making it more variable.
2. Adjusted standard microlab monster spawns from 80% for 40-45 to 50% for 20-40. This combines with the first one to literally average their spawn chances, and increases variation in how many monsters spawn.

Secondary changes:
1. Set spawns in lab core sections from a 30% of 0-8 spawns to the same 50% and 1-10 as normal lab areas.
2. Set central lab tiles to also use the same rates as standard lab areas.

I left lab surface spawns and finale spawns unchanged for now as they're generally elevated above the norm, and left microlab subway stations unchanged since it seems a reduced monster count is intended for those already.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Playing around with the actual contents of `GROUP_LAB` and `GROUP_MICROLAB` to see if any adjustments need to be made to monster variety.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

Poked around in a regular science lab and found that before, it was rare to exceed a dozen spawns in view with clairvoyance, while a giant lab that generated didn't exceed 20. Meanwhile microlabs easily broke triple digits.

After the change, the first basic-sized lab I tested leaned towards 20-30 monsters per floor, while the microlabs seemed to hover around 75ish critters in view. The weird giant lab had monster counts into the 40s in some of the larger blobs of lab sector.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
