### PR TITLE
fix(content): enable laser gunmods for v29 laser pistol

### DIFF
--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -135,7 +135,7 @@
   },
   {
     "id": "v29",
-    "copy-from": "pistol_base",
+    "copy-from": "pistol_energy",
     "type": "GUN",
     "name": { "str": "V29 laser pistol" },
     "description": "This V29 laser pistol was one of the first handheld laser weapons.  It is larger than most traditional handguns, but displays no recoil whatsoever.",


### PR DESCRIPTION

#### Summary

SUMMARY: Content "Fix v29 laser pistol being unable to install laser gunmods"

#### Purpose of change

v29 laser pistol was based on `pistol_base`, preventing installation of laser gunmods like lens.

#### Describe the solution
change `copy-from` to `pistol_base` -> `pistol_energy`

#### Testing
![_01](https://user-images.githubusercontent.com/54838975/235546348-ffc66d08-c237-4599-873a-8ff9acef80e2.png)
![_02](https://user-images.githubusercontent.com/54838975/235546357-8cf795ce-769c-4c3f-ad05-0dd8256b66f5.png)
spawnwed v29 laser pistol and lens gunmod. confirmed it could be installed to v29.
