### PR TITLE
Allow debug menu to directly spawn irremovable item mods

### DIFF
--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -463,7 +463,9 @@ bool gunmod_remove( avatar &you, item &gun, item &mod )
 
     const itype *modtype = mod.type;
 
-    you.i_add_or_drop( mod );
+    if( !mod.is_irremovable() ) {
+        you.i_add_or_drop( mod );
+    }
     gun.remove_item( mod );
 
     //If the removed gunmod added mod locations, check to see if any mods are in invalid locations

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2392,14 +2392,13 @@ bool Character::i_add_or_drop( item &it, int qty )
 {
     bool retval = true;
     bool drop = it.made_of( LIQUID );
-    bool add = it.is_gun() || !it.is_irremovable();
     inv.assign_empty_invlet( it, *this );
     map &here = get_map();
     for( int i = 0; i < qty; ++i ) {
         drop |= !can_pick_weight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) || !can_pick_volume( it );
         if( drop ) {
             retval &= !here.add_item_or_charges( pos(), it ).is_null();
-        } else if( add ) {
+        } else {
             i_add( it );
         }
     }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1740,7 +1740,9 @@ int iuse::remove_all_mods( player *p, item *, bool, const tripoint & )
             return e.is_toolmod() && !e.is_irremovable();
         } );
         add_msg( m_info, _( "You remove the %s from the tool." ), mod->tname() );
-        p->i_add_or_drop( *mod );
+        if( !mod->is_irremovable() ) {
+            p->i_add_or_drop( *mod );
+        }
         loc->remove_item( *mod );
 
         remove_radio_mod( *loc, *p );

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -745,9 +745,7 @@ void debug_menu::wishitem( player *p, const tripoint &pos )
                             p->i_add_or_drop( granted );
                         }
                     } else {
-                        for( int i = 0; i < amount; i++ ) {
-                            p->i_add_or_drop( granted );
-                        }
+                        p->i_add_or_drop( granted, amount );
                     }
                     p->invalidate_crafting_inventory();
                 } else if( pos.x >= 0 && pos.y >= 0 ) {


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Allow debug menu to directly spawn irremovable item mods"

#### Purpose of change

Requiring people to debug spawn irremovable item/gun mods like conversion kits via map editor is unintuitive and annoying.

#### Describe the solution

Removes that consideration in `i_add_or_drop()`. Instead the check is done directly on mod removal. Also updates the wish function for non-count_by_charges items to be slightly more efficient.

#### Describe alternatives you've considered

#### Testing

Spawn conversion mods without issue. Still can't uninstall irremovable mods.

#### Additional context

Game doesn't even allow you to try to uninstall irremovable mods, so this seems somewhat extraneous.