### PR TITLE
Merge helicopter scenarios into a single one

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1188,6 +1188,16 @@
   },
   {
     "type": "profession",
+    "id": "heli_pilot_scenario",
+    "name": "Helicopter Pilot",
+    "description": "You earned a living ferrying businessmen and tourists from helipad to helipad, now your flying skills are all you have to rely on.",
+    "vehicle": "2seater2",
+    "points": 4,
+    "copy-from": "heli_pilot",
+    "flags": [ "SCEN_ONLY" ]
+  },
+  {
+    "type": "profession",
     "id": "k9_cop",
     "name": "K9 Officer",
     "description": "You spent your career busting drug smugglers with your faithful canine companion.  Now the world has ended and none of that matters anymore.  But at least you have a loyal friend.",
@@ -4463,7 +4473,7 @@
     "type": "profession",
     "id": "mili_pilot_blackhawk",
     "name": "UH-60 Blackhawk pilot",
-    "description": "You managed to get to your UH-60.  Your co-pilot didn't.",
+    "description": "You managed to get to your UH-60.  Your co-pilot didn't.  You got to see things fall apart from the sky, transporting soldiers and survivors from one holdout to the next, but now it's just you and your bird.",
     "vehicle": "helicopter_blackhawk_3a",
     "points": 7,
     "copy-from": "mili_pilot"

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1190,7 +1190,7 @@
     "type": "profession",
     "id": "heli_pilot_scenario",
     "name": "Helicopter Pilot",
-    "description": "You earned a living ferrying businessmen and tourists from helipad to helipad, now your flying skills are all you have to rely on.",
+    "description": "You earned a living ferrying businesspeople and tourists from helipad to helipad, now your flying skills are all you have to rely on.",
     "vehicle": "2seater2",
     "points": 4,
     "copy-from": "heli_pilot",

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -540,7 +540,7 @@
     "start_name": "Emergency Landing Site",
     "allowed_locs": [ "sloc_field", "sloc_forest" ],
     "missions": [ "MISSION_HELICOPTER_REFUEL" ],
-    "professions": [ "heli_pilot", "mili_pilot_blackhawk" ],
+    "professions": [ "heli_pilot_scenario", "mili_pilot_blackhawk" ],
     "flags": [ "LONE_START" ]
   },
   {

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -536,12 +536,11 @@
     "id": "last_flight",
     "name": "Last Flight",
     "points": 2,
-    "description": "Once it became clear that the world was ending you took to the skies, hoping that your flying skills could lead you to safety.  You found no standing safe zones, and when your fuel ran out, were forced to land in an empty field.",
+    "description": "Once it became clear that the world was ending you took to the skies, hoping that your flying skills could lead you to safety.  With no safe landing zones, knowing fuel will soon be a concern, you made a quick landing to plan your next move.",
     "start_name": "Emergency Landing Site",
-    "allowed_locs": [ "sloc_field" ],
-    "vehicle": "2seater2_scenario",
+    "allowed_locs": [ "sloc_field", "sloc_forest" ],
     "missions": [ "MISSION_HELICOPTER_REFUEL" ],
-    "professions": [ "heli_pilot" ],
+    "professions": [ "heli_pilot", "mili_pilot_blackhawk" ],
     "flags": [ "LONE_START" ]
   },
   {
@@ -603,16 +602,5 @@
       "bio_gangster"
     ],
     "flags": [ "CHALLENGE", "LONE_START" ]
-  },
-  {
-    "type": "scenario",
-    "id": "helicopter",
-    "name": "Ride of the Valkyries",
-    "points": 1,
-    "description": "You managed to get to the chopper just in time.  But are there safe places to land left in this world now?",
-    "start_name": "Wilderness",
-    "allowed_locs": [ "sloc_field", "sloc_forest" ],
-    "professions": [ "mili_pilot_blackhawk" ],
-    "flags": [ "LONE_START" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Merge Last Flight and Ride of The Valkyries scenario"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This merges together two fairly bare-bones scenarios that're basically the same general concept, both involving a pilot being forced to land.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Merged the Last Flight and Ride of The Valkyries scenarios together. Used the name, description (altered a bit to account for spawning with fuel), point cost, and starting mission of Last Flight, while using the start location options from Ride of The Valkyries, and removed the scenario-level vehicle spawn since we'll have profession-level ones.
2. Defined a scenario-only version of the standard helicopter pliot profession, using copy-from like how the blackhawk profession works. 2 points higher than the general version that lacks a vehicle. In exchange however, allowed them to use the fueled version of the 2-seater.
3. Misc: Reworked the profession description for the scenario-only version of the blackhawk pilot to be based off the other version.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding a vehicle that's literally just the standard blackhawk but with no fuel to keep Last Flight's original flavor.
2. Just saying "fuck it" and rigging it so the scenario makes perfect sense whether your starter vehicle spawns fueled or not.
3. Going full "fuck it" and letting the 2-point-cost heli pilot start with a helicopter instead of defining a scenario-only on, in exchange for using the version that lacks fuel.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Ported over a save made in a test build using the now-removed scenario.

It shows the following message on doing this: `Tried to use non-existent scenario 'helicopter'. Setting to generic 'evacuee'.` but this can be skipped through without issue, and this cleans up the problem entirely afterward.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
