### PR TITLE
content: Add the Kickboxing Martial Art style

### DIFF
--- a/data/json/itemgroups/books.json
+++ b/data/json/itemgroups/books.json
@@ -555,6 +555,7 @@
     "subtype": "distribution",
     "entries": [
       { "item": "manual_karate", "prob": 12 },
+      { "item": "manual_kickboxing", "prob": 12 },
       { "item": "manual_judo", "prob": 12 },
       { "item": "manual_aikido", "prob": 12 },
       { "item": "manual_taekwondo", "prob": 12 },

--- a/data/json/items/book/martial.json
+++ b/data/json/items/book/martial.json
@@ -104,7 +104,7 @@
     "description": "A complete guide to Shotokan Karate.",
     "book_data": { "martial_art": "style_karate" }
   },
-   {
+  {
     "id": "manual_kickboxing",
     "copy-from": "book_martial",
     "type": "BOOK",

--- a/data/json/items/book/martial.json
+++ b/data/json/items/book/martial.json
@@ -104,6 +104,15 @@
     "description": "A complete guide to Shotokan Karate.",
     "book_data": { "martial_art": "style_karate" }
   },
+   {
+    "id": "manual_kickboxing",
+    "copy-from": "book_martial",
+    "type": "BOOK",
+    "name": { "str": "The Ultimate Guide to Kickboxing", "str_pl": "copies of Ultimate Guide to Kickboxing" },
+    "price_postapoc": 2000,
+    "description": "The ultimate guide to learning and mastering kickboxing, from beginner to black belt.",
+    "martial_art": "style_kickboxing"
+  },
   {
     "id": "manual_krav_maga",
     "copy-from": "book_martial",

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -536,6 +536,33 @@
   },
   {
     "type": "martial_art",
+    "id": "style_kickboxing",
+    "name": { "str": "Kickboxing" },
+    "description": "A martial art that combines western boxing with elements of Karate, Taekwondo, Muay Thai and Savate, particularly in the use of kicks.",
+    "initiate": [ "You assume a kickboxing stance and focus power into your limbs.", "%s assumes a kickboxing stance." ],
+    "learn_difficulty": 4,
+    "arm_block": 2,
+    "leg_block": 4,
+    "static_buffs": [
+      {
+        "id": "buff_kickboxing_stance_static",
+        "name": "Kick stance",
+        "description": "You have adopted a stance which allows for greater mobility and stability.  Your hands are in a guard position with elbows forward to protect yourself.\n\nBlocked damage reduced by 25% of Strength.\n+1.0 Dodging skill",
+        "unarmed_allowed": true,
+        "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.5 }, { "stat": "dodge", "scale": 1.0 } ]
+      }
+    ],
+    "techniques": [
+      "tec_kickboxing_rapid",
+      "tec_kickboxing_straight_cross",
+      "tec_kickboxing_upper",
+      "tec_kickboxing_roundhouse",
+      "tec_kickboxing_sidekick",
+      "tec_kickboxing_straight_kick"
+    ]
+  },
+  {
+    "type": "martial_art",
     "id": "style_krav_maga",
     "name": { "str": "Krav Maga" },
     "description": "Originating in Israel, Krav Maga is based on taking down an enemy quickly and effectively.  It focuses on applicable attacks rather than showy or complex moves.  Popular among police and armed forces everywhere.",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -581,11 +581,11 @@
     "id": "MARTIAL_ARTS",
     "name": { "str": "Martial Arts Training" },
     "points": 2,
-    "description": "You have received some martial arts training at a local dojo.  You start with your choice of Karate, Judo, Aikido, Tai Chi, Taekwondo, or Pankration.",
+    "description": "You have received some martial arts training at a local dojo.  You start with your choice of Karate, Judo, Aikido, Tai Chi, Taekwondo, Kickboxing, or Pankration.",
     "starting_trait": true,
-    "initial_ma_styles": [ "style_karate", "style_judo", "style_aikido", "style_tai_chi", "style_taekwondo", "style_pankration" ],
+    "initial_ma_styles": [ "style_karate", "style_judo", "style_aikido", "style_tai_chi", "style_taekwondo", "style_pankration", "style_kickboxing" ],
     "valid": false
-  },
+  }
   {
     "type": "mutation",
     "id": "MARTIAL_ARTS2",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -583,7 +583,15 @@
     "points": 2,
     "description": "You have received some martial arts training at a local dojo.  You start with your choice of Karate, Judo, Aikido, Tai Chi, Taekwondo, Kickboxing, or Pankration.",
     "starting_trait": true,
-    "initial_ma_styles": [ "style_karate", "style_judo", "style_aikido", "style_tai_chi", "style_taekwondo", "style_pankration", "style_kickboxing" ],
+    "initial_ma_styles": [
+      "style_karate",
+      "style_judo",
+      "style_aikido",
+      "style_tai_chi",
+      "style_taekwondo",
+      "style_pankration",
+      "style_kickboxing"
+    ],
     "valid": false
   },
   {

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -585,7 +585,7 @@
     "starting_trait": true,
     "initial_ma_styles": [ "style_karate", "style_judo", "style_aikido", "style_tai_chi", "style_taekwondo", "style_pankration", "style_kickboxing" ],
     "valid": false
-  }
+  },
   {
     "type": "mutation",
     "id": "MARTIAL_ARTS2",

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -974,7 +974,7 @@
     "messages": [ "You roundhouse kick %s", "<npcname> roundhouse kicks %s" ],
     "unarmed_allowed": true,
     "melee_allowed": true,
-    "crit_ok" : true,
+    "crit_ok": true,
     "weighting": -2,
     "mult_bonuses": [
       { "stat": "damage", "type": "bash", "scale": 1.2 },

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -933,7 +933,7 @@
     "unarmed_allowed": true,
     "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.2 } ]
   },
-   {
+  {
     "type": "technique",
     "id": "tec_kickboxing_rapid",
     "name": "Jab",

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -974,6 +974,8 @@
     "messages": [ "You roundhouse kick %s", "<npcname> roundhouse kicks %s" ],
     "unarmed_allowed": true,
     "melee_allowed": true,
+    "crit_ok" : true,
+    "weighting": -2,
     "mult_bonuses": [
       { "stat": "damage", "type": "bash", "scale": 1.2 },
       { "stat": "damage", "type": "cut", "scale": 1.2 },
@@ -988,6 +990,7 @@
     "skill_requirements": [ { "name": "unarmed", "level": 2 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
+    "dodge_counter": true,
     "mult_bonuses": [
       { "stat": "damage", "type": "bash", "scale": 1.2 },
       { "stat": "damage", "type": "cut", "scale": 1.2 },

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -945,8 +945,7 @@
       { "stat": "damage", "type": "bash", "scale": 0.66 },
       { "stat": "damage", "type": "cut", "scale": 0.66 },
       { "stat": "damage", "type": "stab", "scale": 0.66 }
-    ],
-    "attack_vectors": [ "HAND" ]
+    ]
   },
   {
     "type": "technique",
@@ -955,8 +954,7 @@
     "messages": [ "You deliver a cross punch to %s", "<npcname> delivers a cross punch to %s" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
-    "crit_tec": true,
-    "attack_vectors": [ "HAND" ]
+    "crit_tec": true
   },
   {
     "type": "technique",
@@ -967,8 +965,7 @@
     "unarmed_allowed": true,
     "crit_tec": true,
     "stun_dur": 1,
-    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.4 } ],
-    "attack_vectors": [ "HAND" ]
+    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.4 } ]
   },
   {
     "type": "technique",
@@ -981,8 +978,7 @@
       { "stat": "damage", "type": "bash", "scale": 1.2 },
       { "stat": "damage", "type": "cut", "scale": 1.2 },
       { "stat": "damage", "type": "stab", "scale": 1.2 }
-    ],
-    "attack_vectors": [ "FOOT" ]
+    ]
   },
   {
     "type": "technique",
@@ -996,8 +992,7 @@
       { "stat": "damage", "type": "bash", "scale": 1.2 },
       { "stat": "damage", "type": "cut", "scale": 1.2 },
       { "stat": "damage", "type": "stab", "scale": 1.2 }
-    ],
-    "attack_vectors": [ "FOOT" ]
+    ]
   },
   {
     "type": "technique",
@@ -1012,8 +1007,7 @@
     "crit_tec": true,
     "knockback_dist": 1,
     "stun_dur": 1,
-    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.3 } ],
-    "attack_vectors_random": [ "LOWER_LEG", "FOOT" ]
+    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.3 } ]
   },
   {
     "type": "technique",

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -933,6 +933,88 @@
     "unarmed_allowed": true,
     "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.2 } ]
   },
+   {
+    "type": "technique",
+    "id": "tec_kickboxing_rapid",
+    "name": "Jab",
+    "messages": [ "You quickly jab %s", "<npcname> quickly jabs at %s" ],
+    "skill_requirements": [ { "name": "unarmed", "level": 2 } ],
+    "unarmed_allowed": true,
+    "mult_bonuses": [
+      { "stat": "movecost", "scale": 0.5 },
+      { "stat": "damage", "type": "bash", "scale": 0.66 },
+      { "stat": "damage", "type": "cut", "scale": 0.66 },
+      { "stat": "damage", "type": "stab", "scale": 0.66 }
+    ],
+    "attack_vectors": [ "HAND" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_kickboxing_straight_cross",
+    "name": "Straight Cross",
+    "messages": [ "You deliver a cross punch to %s", "<npcname> delivers a cross punch to %s" ],
+    "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
+    "unarmed_allowed": true,
+    "crit_tec": true,
+    "attack_vectors": [ "HAND" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_kickboxing_upper",
+    "name": "Uppercut",
+    "messages": [ "You uppercut %s", "<npcname> uppercuts %s" ],
+    "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
+    "unarmed_allowed": true,
+    "crit_tec": true,
+    "stun_dur": 1,
+    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.4 } ],
+    "attack_vectors": [ "HAND" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_kickboxing_roundhouse",
+    "name": "Roundhouse Kick",
+    "messages": [ "You roundhouse kick %s", "<npcname> roundhouse kicks %s" ],
+    "unarmed_allowed": true,
+    "melee_allowed": true,
+    "mult_bonuses": [
+      { "stat": "damage", "type": "bash", "scale": 1.2 },
+      { "stat": "damage", "type": "cut", "scale": 1.2 },
+      { "stat": "damage", "type": "stab", "scale": 1.2 }
+    ],
+    "attack_vectors": [ "FOOT" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_kickboxing_sidekick",
+    "name": "Side Kick",
+    "messages": [ "You side kick %s", "<npcname> side kicks %s" ],
+    "skill_requirements": [ { "name": "unarmed", "level": 2 } ],
+    "unarmed_allowed": true,
+    "melee_allowed": true,
+    "mult_bonuses": [
+      { "stat": "damage", "type": "bash", "scale": 1.2 },
+      { "stat": "damage", "type": "cut", "scale": 1.2 },
+      { "stat": "damage", "type": "stab", "scale": 1.2 }
+    ],
+    "attack_vectors": [ "FOOT" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_kickboxing_straight_kick",
+    "name": "Straight Kick",
+    "messages": [
+      "You deliver a straight kick to %s, knocking them back",
+      "<npcname> delivers a straight kick to %s, knocking them back"
+    ],
+    "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
+    "unarmed_allowed": true,
+    "crit_tec": true,
+    "knockback_dist": 1,
+    "stun_dur": 1,
+    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.3 } ],
+    "attack_vectors_random": [ "LOWER_LEG", "FOOT" ]
+  },
   {
     "type": "technique",
     "id": "tec_krav_maga_rapid",


### PR DESCRIPTION
#### Summary

SUMMARY: Content: "Add the Kickboxing Martial Art style"

Purpose of change

There was a new MA style added in the following pull on DDA [https://github.com/CleverRaven/Cataclysm-DDA/pull/59732](https://github.com/CleverRaven/Cataclysm-DDA/pull/59732), original creator [https://github.com/DamienRoyan](https://github.com/DamienRoyan) referenced for attribution if necessary, and there was an update to said MA under [https://github.com/CleverRaven/Cataclysm-DDA/pull/60649](https://github.com/CleverRaven/Cataclysm-DDA/pull/60649). This PR includes the changes from the latter.

#### Describe the solution

Bring it over/recreate it in BN.

#### Describe alternatives you've considered

Not doing it was the big one. It can also just be made into a mod, and I could easily see how some folks would consider it 'clutter' on the grounds that it doesn't necessarily do something Karate/TKD/Krav don't already do.

#### Testing

Spawned in a character, gave them Kickboxing, the moves and such seemed to work fine.

#### Additional context

For anyone not familiar, this is Western/American Kickboxing - it blends Karate/TKD/Savate kicks in with Boxing hand strikes. Usually taught as a sport/competition form but has actual practical combat use if you get a good instructor, and looks damn flashy to boot. Perfect fit for some kinds of characters.
One change I made was to add it to the Martial Arts Training mutation as a selectable style. Seemed appropriate - Boxing got added to Self-Defense, and the other styles under MA Training were of a similar nature (having sport AND combat application).