### PR TITLE
Fixed electric chainsaw lajatang not working with UPS

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3115,7 +3115,7 @@ int iuse::ecs_lajatang_off( player *p, item *it, bool, const tripoint & )
 {
     return toolweapon_off( *p, *it,
                            false,
-                           it->ammo_remaining() > 1 && !p->is_underwater(),
+                           !p->is_underwater(),
                            40, _( "With a buzz, the chainsaws leap to life!" ),
                            _( "You pull the trigger, but nothing happens." ) );
 }


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fixed electric chainsaw lajatang not working with UPS"

#### Purpose of change
The item could not be turned on when an UPS was attached to it. (I want stable release 3)
Fixes #2104 

#### Describe the solution
Removed `it->ammo_remaining() > 1` from the code, making it nearly identical to the electric chainsaw. Now it works with UPS.

#### Describe alternatives you've considered
Understand exactly why `ammo_remaining()` is not working.

#### Testing
1. Combined UPS conversion mod with chainsaw lajatang
2. Successfully turned it on.
3. Confirmed that all actions still work
4. Confirmed that both versions shut down when power is drained

#### Additional context
Electric chainsaw lajatang now
![image](https://user-images.githubusercontent.com/60388907/236457337-b8101dbb-1955-4da0-aa5f-494665e452a7.png)

Electric chainsaw
![image](https://user-images.githubusercontent.com/60388907/236457381-99587262-622c-4659-a744-3acf23998879.png)

