### PR TITLE
Sling bullet/ball bearing recovery

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -360,7 +360,8 @@
     "dispersion": 14,
     "loudness": 0,
     "count": 50,
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING", "RECOVER_1000" ]
+    "dont_recover_one_in": 1000,
+    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
   },
   {
     "type": "AMMO",

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -360,8 +360,7 @@
     "dispersion": 14,
     "loudness": 0,
     "count": 50,
-    "drop": "bearing",
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
+    "effects": [ "NEVER_MISFIRES", "NON-FOULING", "RECOVER_1000" ]
   },
   {
     "type": "AMMO",
@@ -1077,8 +1076,7 @@
     "dispersion": 10,
     "loudness": 0,
     "to_hit": -1,
-    "drop": "sling_bullet",
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
+    "effects": [ "NEVER_MISFIRES", "NON-FOULING", "RECOVER_1000" ]
   },
   {
     "type": "AMMO",
@@ -1097,7 +1095,6 @@
     "dispersion": 10,
     "loudness": 0,
     "count": 30,
-    "drop": "sling_bullet_small",
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
+    "effects": [ "NEVER_MISFIRES", "NON-FOULING", "RECOVER_1000" ]
   }
 ]

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1097,6 +1097,7 @@
     "dispersion": 10,
     "loudness": 0,
     "count": 30,
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING", "RECOVER_1000" ]
+    "dont_recover_one_in": 1000,
+    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
   }
 ]

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1077,7 +1077,8 @@
     "dispersion": 10,
     "loudness": 0,
     "to_hit": -1,
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING", "RECOVER_1000" ]
+    "dont_recover_one_in": 1000,
+    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
   },
   {
     "type": "AMMO",

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -360,6 +360,7 @@
     "dispersion": 14,
     "loudness": 0,
     "count": 50,
+    "drop": "bearing",
     "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
   },
   {
@@ -1076,7 +1077,8 @@
     "dispersion": 10,
     "loudness": 0,
     "to_hit": -1,
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING", "RECOVER_100" ]
+    "drop": "sling_bullet",
+    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
   },
   {
     "type": "AMMO",
@@ -1095,6 +1097,7 @@
     "dispersion": 10,
     "loudness": 0,
     "count": 30,
-    "effects": [ "NEVER_MISFIRES", "NON-FOULING", "RECOVER_100" ]
+    "drop": "sling_bullet_small",
+    "effects": [ "NEVER_MISFIRES", "NON-FOULING" ]
   }
 ]


### PR DESCRIPTION
#### Summary

SUMMARY: [Balance] "Sling bullets, small sling bullets, and ball bearings now drop themselves upon hit."

#### Purpose of change

Sling bullets already had "RECOVERY_100" in the flags, which made you recover them almost all of the time, but ball bearings did not. Scarf suggested I do this.

#### Describe the solution

I modified the "RECOVERY_100" flag on sling bullets and small sling bullets to "RECOVERY_1000", and added it to ball bearings as well.

#### Describe alternatives you've considered

I attempted to use the 'drop' field, but it caused issues.

#### Testing

It doesn't give json errors and ball bearings now are recoverable.
