### PR TITLE
build: fix MSVC complaints

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -599,8 +599,8 @@ bool can_examine_at( const tripoint &p )
     if( here.has_items( p ) ) {
         return true;
     }
-    const furn_t &xfurn_t = here.furn( p ).obj();
-    const ter_t &xter_t = here.ter( p ).obj();
+    const furn_t xfurn_t = here.furn( p ).obj();
+    const ter_t xter_t = here.ter( p ).obj();
 
     if( here.has_furn( p ) && xfurn_t.examine != &iexamine::none ) {
         return true;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -793,8 +793,8 @@ static hack_type get_hack_type( tripoint examp )
 {
     hack_type type = HACK_NULL;
     const map &here = get_map();
-    const furn_t &xfurn_t = here.furn( examp ).obj();
-    const ter_t &xter_t = here.ter( examp ).obj();
+    const furn_t xfurn_t = here.furn( examp ).obj();
+    const ter_t xter_t = here.ter( examp ).obj();
     if( xter_t.examine == &iexamine::pay_gas || xfurn_t.examine == &iexamine::pay_gas ) {
         type = HACK_GAS;
     } else if( xter_t.examine == &iexamine::cardreader || xfurn_t.examine == &iexamine::cardreader ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5520,8 +5520,8 @@ void game::examine( const tripoint &examp )
     } else if( m.has_flag( "CONSOLE", examp ) && u.is_mounted() ) {
         add_msg( m_warning, _( "You cannot use a console while mounted." ) );
     }
-    const furn_t &xfurn_t = m.furn( examp ).obj();
-    const ter_t &xter_t = m.ter( examp ).obj();
+    const furn_t xfurn_t = m.furn( examp ).obj();
+    const ter_t xter_t = m.ter( examp ).obj();
 
     const tripoint player_pos = u.pos();
 

--- a/src/hash_utils.h
+++ b/src/hash_utils.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_HASH_UTILS_H
 #define CATA_SRC_HASH_UTILS_H
 
+#include <cstdint>
 #include <functional>
 
 // Support for hashing standard types.

--- a/src/om_direction.h
+++ b/src/om_direction.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_OM_DIRECTION_H
 
 #include <climits>
+#include <cstdint>
 #include <array>
 #include <string>
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1501,7 +1501,7 @@ void sfx::do_footstep()
             return;
         }
         if( veh_displayed_part ) {
-            const std::string &part_id = veh_displayed_part->part().info().get_id().str();
+            const std::string part_id = veh_displayed_part->part().info().get_id().str();
             if( has_variant_sound( "plmove", part_id ) ) {
                 play_plmove_sound_variant( part_id );
             } else if( veh_displayed_part->has_feature( VPFLAG_AISLE ) ) {

--- a/src/units_mass.h
+++ b/src/units_mass.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_UNITS_MASS_H
 #define CATA_SRC_UNITS_MASS_H
 
+#include <cstdint>
 #include <algorithm>
 
 #include "units_def.h"


### PR DESCRIPTION
#### Summary

SUMMARY: Build "Explicitly include <cstdint>, fix dangling reference error"

#### Purpose of change

fix funni error messages

<details><summary>Details</summary>

```
 src/sounds.cpp: In function 'void sfx::do_footstep()':
src/sounds.cpp:1504:32: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
 1504 |             const std::string &part_id = veh_displayed_part->part().info().get_id().str();
      |                                ^~~~~~~
src/sounds.cpp:1504:88: note: the temporary was destroyed at the end of the full expression '(&(& veh_displayed_part.std::optional<vpart_reference>::operator->()->vpart_reference::part())->vehicle_part::info())->vpart_info::get_id().string_id<vpart_info>::str()'
 1504 |             const std::string &part_id = veh_displayed_part->part().info().get_id().str();
      |                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
start_location.o
```

</details> 

<details><summary>Details</summary>

```
[3/324] Building CXX object src/CMakeFiles/cataclysm-tiles-common.dir/achievement.cpp.o
FAILED: src/CMakeFiles/cataclysm-tiles-common.dir/achievement.cpp.o 
ccache /usr/lib/ccache/clang++ -DBACKTRACE -DCMAKE -DGIT_VERSION -DRELEASE -DSDL_SOUND -DTILES -I/usr/include/SDL2 -fuse-ld=mold -Wno-unused-command-line-argument -Werror -Wall -Wextra -Wformat-signedness -Wlogical-op -Wmissing-declarations -Wmissing-noreturn -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Wpedantic -Wsuggest-override -Wunused-macros -Wzero-as-null-pointer-constant -Wno-unknown-warning-option -Wno-range-loop-analysis -Wredundant-decls  -fsigned-char -O2 -g -DNDEBUG -pthread -std=gnu++17 -MD -MT src/CMakeFiles/cataclysm-tiles-common.dir/achievement.cpp.o -MF src/CMakeFiles/cataclysm-tiles-common.dir/achievement.cpp.o.d -o src/CMakeFiles/cataclysm-tiles-common.dir/achievement.cpp.o -c /home/scarf/repo/cata/Cataclysm/src/achievement.cpp
In file included from /home/scarf/repo/cata/Cataclysm/src/achievement.cpp:1:
In file included from /home/scarf/repo/cata/Cataclysm/src/achievement.h:14:
In file included from /home/scarf/repo/cata/Cataclysm/src/cata_variant.h:15:
/home/scarf/repo/cata/Cataclysm/src/hash_utils.h:93:57: error: no type named 'uint64_t' in namespace 'std'; did you mean simply 'uint64_t'?
std::enable_if_t < sizeof( T ) < 8, T > maybe_mix_bits( std::uint64_t val )
                                                        ^~~~~~~~~~~~~
                                                        uint64_t
/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h:27:20: note: 'uint64_t' declared here
typedef __uint64_t uint64_t;
                   ^
In file included from /home/scarf/repo/cata/Cataclysm/src/achievement.cpp:1:
In file included from /home/scarf/repo/cata/Cataclysm/src/achievement.h:14:
In file included from /home/scarf/repo/cata/Cataclysm/src/cata_variant.h:15:
/home/scarf/repo/cata/Cataclysm/src/hash_utils.h:95:5: error: no type named 'uint32_t' in namespace 'std'; did you mean simply 'uint32_t'?
    std::uint32_t hi = val >> 32;
    ^~~~~~~~~~~~~
    uint32_t
/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h:26:20: note: 'uint32_t' declared here
typedef __uint32_t uint32_t;
                   ^
In file included from /home/scarf/repo/cata/Cataclysm/src/achievement.cpp:1:
In file included from /home/scarf/repo/cata/Cataclysm/src/achievement.h:14:
In file included from /home/scarf/repo/cata/Cataclysm/src/cata_variant.h:15:
/home/scarf/repo/cata/Cataclysm/src/hash_utils.h:96:5: error: no type named 'uint32_t' in namespace 'std'; did you mean simply 'uint32_t'?
    std::uint32_t lo = val;
    ^~~~~~~~~~~~~
    uint32_t
/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h:26:20: note: 'uint32_t' declared here
typedef __uint32_t uint32_t;
                   ^
In file included from /home/scarf/repo/cata/Cataclysm/src/achievement.cpp:1:
In file included from /home/scarf/repo/cata/Cataclysm/src/achievement.h:14:
In file included from /home/scarf/repo/cata/Cataclysm/src/cata_variant.h:15:
/home/scarf/repo/cata/Cataclysm/src/hash_utils.h:103:58: error: no type named 'uint64_t' in namespace 'std'; did you mean simply 'uint64_t'?
std::enable_if_t < sizeof( T ) >= 8, T > maybe_mix_bits( std::uint64_t val )
                                                         ^~~~~~~~~~~~~
                                                         uint64_t
/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h:27:20: note: 'uint64_t' declared here
typedef __uint64_t uint64_t;
                   ^
In file included from /home/scarf/repo/cata/Cataclysm/src/achievement.cpp:1:
In file included from /home/scarf/repo/cata/Cataclysm/src/achievement.h:14:
In file included from /home/scarf/repo/cata/Cataclysm/src/cata_variant.h:15:
/home/scarf/repo/cata/Cataclysm/src/hash_utils.h:112:28: error: no type named 'uint64_t' in namespace 'std'; did you mean simply 'uint64_t'?
inline std::size_t hash64( std::uint64_t val )
                           ^~~~~~~~~~~~~
                           uint64_t
/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h:27:20: note: 'uint64_t' declared here
typedef __uint64_t uint64_t;
                   ^
5 errors generated.
[6/324] Building CXX object src/CMakeFiles/cataclysm-tiles-common.dir/active_tile_data.cpp.o^C
ninja: build stopped: interrupted by user.
```

</details> 

#### Describe the solution

include `<stdint>` for each errors

#### Describe alternatives you've considered

scream
