### PR TITLE
build: explicitly add `<cstdint>` header

### DIFF
--- a/src/hash_utils.h
+++ b/src/hash_utils.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_HASH_UTILS_H
 #define CATA_SRC_HASH_UTILS_H
 
+#include <cstdint>
 #include <functional>
 
 // Support for hashing standard types.

--- a/src/om_direction.h
+++ b/src/om_direction.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_OM_DIRECTION_H
 #define CATA_SRC_OM_DIRECTION_H
 
+#include <cstdint>
 #include <climits>
 #include <array>
 #include <string>

--- a/src/units_mass.h
+++ b/src/units_mass.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_UNITS_MASS_H
 #define CATA_SRC_UNITS_MASS_H
 
+#include <cstdint>
 #include <algorithm>
 
 #include "units_def.h"


### PR DESCRIPTION
#### Summary

SUMMARY: Build "Explicitly add <cstdint> headers"

#### Purpose of change

fixes some complaints when using clang-16

#### Describe the solution

added `<cstdint>` where fixed-width intergers like `uint32_t` are used.

#### Testing

it built on my machine!