### PR TITLE
Fixes to Isherwood weapons and clothing

### DIFF
--- a/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
@@ -20,9 +20,9 @@
     "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
-    "carry_override": "NC_ISHERWOOD_rifle",
-    "weapon_override": "NC_ISHERWOOD_archery",
+    "worn_override": "NC_Isherwood_male_worn",
+    "carry_override": "NC_ISHERWOOD_carry",
+    "weapon_override": "EMPTY_GROUP",
     "skills": [
       {
         "skill": "ALL",

--- a/data/json/npcs/isherwood_farm/NPC_Chris_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Chris_Isherwood.json
@@ -20,9 +20,9 @@
     "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
-    "carry_override": "NC_ISHERWOOD_rifle",
-    "weapon_override": "NC_ISHERWOOD_archery",
+    "worn_override": "NC_Isherwood_male_worn",
+    "carry_override": "NC_ISHERWOOD_carry",
+    "weapon_override": "EMPTY_GROUP",
     "skills": [
       {
         "skill": "ALL",

--- a/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
@@ -20,8 +20,9 @@
     "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "carry_override": "NC_ISHERWOOD_rifle",
-    "weapon_override": "NC_ISHERWOOD_archery",
+    "worn_override": "NC_Isherwood_female_worn",
+    "carry_override": "NC_ISHERWOOD_carry",
+    "weapon_override": "EMPTY_GROUP",
     "shopkeeper_item_group": "NC_ISHERWOOD_CLAIRE_misc",
     "skills": [
       {

--- a/data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json
@@ -20,9 +20,9 @@
     "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
-    "carry_override": "NC_ISHERWOOD_rifle",
-    "weapon_override": "NC_ISHERWOOD_archery",
+    "worn_override": "NC_Isherwood_male_worn",
+    "carry_override": "NC_ISHERWOOD_carry",
+    "weapon_override": "EMPTY_GROUP",
     "shopkeeper_item_group": "NC_ISHERWOOD_EDDIE_misc",
     "skills": [
       {

--- a/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
@@ -20,9 +20,9 @@
     "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
-    "carry_override": "NC_ISHERWOOD_rifle",
-    "weapon_override": "NC_ISHERWOOD_archery",
+    "worn_override": "NC_Isherwood_male_worn",
+    "carry_override": "NC_ISHERWOOD_carry",
+    "weapon_override": "EMPTY_GROUP",
     "shopkeeper_item_group": "NC_ISHERWOOD_JACK_misc",
     "skills": [
       {
@@ -39,53 +39,139 @@
   },
   {
     "type": "item_group",
-    "id": "NC_Isherwood_worn",
+    "id": "NC_Isherwood_male_worn",
     "subtype": "collection",
     "entries": [
-      { "item": "backpack_leather" },
+      { "item": "boxer_shorts" },
       { "item": "jeans" },
-      { "item": "tshirt" },
-      { "item": "gloves_fingerless" },
-      { "item": "panties" },
+      {
+        "distribution": [ { "item": "tshirt", "prob": 50 }, { "item": "longshirt", "prob": 25 }, { "item": "dress_shirt", "prob": 25 } ]
+      },
+      {
+        "distribution": [
+          { "item": "jacket_light", "prob": 20 },
+          { "item": "jacket_leather", "prob": 20 },
+          { "item": "trenchcoat", "prob": 20 },
+          { "item": "jacket_jean", "prob": 20 },
+          { "item": "jacket_flannel", "prob": 20 }
+        ]
+      },
+      {
+        "distribution": [
+          { "item": "gloves_work", "prob": 50 },
+          { "item": "gloves_leather", "prob": 25 },
+          { "item": "gloves_fingerless", "prob": 25 }
+        ]
+      },
       { "item": "socks" },
-      { "item": "cowboy_hat" },
-      { "item": "boots" }
-    ],
-    "items": [
-      [ "jacket_light", 20 ],
-      [ "jacket_leather", 20 ],
-      [ "trenchcoat", 20 ],
-      [ "jacket_jean", 20 ],
-      [ "jacket_flannel", 20 ]
+      { "item": "boots" },
+      { "distribution": [ { "item": "cowboy_hat", "prob": 75 }, { "item": "straw_hat", "prob": 25 } ] },
+      { "distribution": [ { "item": "backpack_leather", "prob": 75 }, { "item": "backpack", "prob": 25 } ] }
     ]
   },
   {
     "type": "item_group",
-    "id": "NC_ISHERWOOD_archery",
-    "subtype": "distribution",
+    "id": "NC_Isherwood_female_worn",
+    "subtype": "collection",
     "entries": [
-      { "item": "crossbow", "prob": 20 },
-      { "item": "shortbow", "prob": 5 },
-      { "item": "compbow", "prob": 15 },
-      { "item": "compositebow", "prob": 15 },
-      { "item": "longbow", "prob": 10 },
-      { "item": "hand_crossbow", "prob": 15 },
-      { "item": "selfbow", "prob": 5 }
+      { "item": "panties" },
+      { "item": "jeans" },
+      { "item": "bra" },
+      {
+        "distribution": [ { "item": "tshirt", "prob": 50 }, { "item": "longshirt", "prob": 25 }, { "item": "dress_shirt", "prob": 25 } ]
+      },
+      {
+        "distribution": [
+          { "item": "jacket_light", "prob": 20 },
+          { "item": "jacket_leather", "prob": 20 },
+          { "item": "trenchcoat", "prob": 20 },
+          { "item": "jacket_jean", "prob": 20 },
+          { "item": "jacket_flannel", "prob": 20 }
+        ]
+      },
+      {
+        "distribution": [
+          { "item": "gloves_work", "prob": 50 },
+          { "item": "gloves_leather", "prob": 25 },
+          { "item": "gloves_fingerless", "prob": 25 }
+        ]
+      },
+      { "item": "socks" },
+      { "item": "boots" },
+      { "distribution": [ { "item": "cowboy_hat", "prob": 75 }, { "item": "straw_hat", "prob": 25 } ] },
+      { "distribution": [ { "item": "backpack_leather", "prob": 75 }, { "item": "backpack", "prob": 25 } ] }
     ]
   },
   {
     "type": "item_group",
-    "id": "NC_ISHERWOOD_rifle",
+    "id": "NC_ISHERWOOD_carry",
     "subtype": "distribution",
     "entries": [
-      { "item": "rifle_22", "prob": 5 },
-      { "item": "rifle_9mm", "prob": 5 },
-      { "item": "ruger_1022", "prob": 10 },
-      { "item": "browning_blr", "prob": 10 },
-      { "item": "remington_700", "prob": 10 },
-      { "item": "savage_111f", "prob": 5 },
-      { "item": "marlin_9a", "prob": 25 },
-      { "item": "m1903", "prob": 5 }
+      {
+        "collection": [ { "item": "crossbow", "ammo-item": "bolt_steel", "charges": 1 }, { "item": "bolt_steel", "charges": [ 15, 30 ] } ],
+        "prob": 20
+      },
+      {
+        "collection": [ { "item": "shortbow", "ammo-item": "arrow_metal" }, { "item": "arrow_metal", "charges": [ 15, 30 ] } ],
+        "prob": 5
+      },
+      {
+        "collection": [ { "item": "compbow", "ammo-item": "arrow_metal" }, { "item": "arrow_metal", "charges": [ 15, 30 ] } ],
+        "prob": 15
+      },
+      {
+        "collection": [ { "item": "compositebow", "ammo-item": "arrow_metal" }, { "item": "arrow_metal", "charges": [ 15, 30 ] } ],
+        "prob": 15
+      },
+      {
+        "collection": [ { "item": "longbow", "ammo-item": "arrow_metal" }, { "item": "arrow_metal", "charges": [ 15, 30 ] } ],
+        "prob": 10
+      },
+      {
+        "collection": [
+          { "item": "hand_crossbow", "ammo-item": "bolt_steel", "charges": 1 },
+          { "item": "bolt_steel", "charges": [ 15, 30 ] }
+        ],
+        "prob": 15
+      },
+      {
+        "collection": [ { "item": "selfbow", "ammo-item": "arrow_metal" }, { "item": "arrow_metal", "charges": [ 15, 30 ] } ],
+        "prob": 5
+      },
+      {
+        "collection": [ { "item": "rifle_22", "ammo-item": "22_cphp", "charges": 1 }, { "item": "22_cphp", "charges": [ 20, 40 ] } ],
+        "prob": 5
+      },
+      { "collection": [ { "item": "rifle_9mm", "charges": 1 }, { "item": "9mm", "charges": [ 20, 40 ] } ], "prob": 5 },
+      {
+        "collection": [
+          { "item": "ruger_1022", "ammo-item": "22_cphp", "charges": 10 },
+          { "item": "ruger1022mag", "ammo-item": "22_cphp", "charges": 10 },
+          { "item": "22_cphp", "charges": [ 10, 20 ] }
+        ],
+        "prob": 10
+      },
+      {
+        "collection": [
+          { "item": "browning_blr", "charges": 4 },
+          { "item": "blrmag", "charges": 4 },
+          { "item": "3006", "charges": [ 10, 20 ] }
+        ],
+        "prob": 10
+      },
+      {
+        "collection": [ { "item": "remington_700", "charges": 4 }, { "item": "3006", "charges": [ 10, 20 ] } ],
+        "prob": 10
+      },
+      {
+        "collection": [ { "item": "savage_111f", "ammo-item": "308", "charges": 3 }, { "item": "308", "charges": [ 10, 20 ] } ],
+        "prob": 5
+      },
+      {
+        "collection": [ { "item": "rifle_22", "ammo-item": "22_cphp", "charges": 19 }, { "item": "22_cphp", "charges": [ 10, 20 ] } ],
+        "prob": 25
+      },
+      { "collection": [ { "item": "m1903", "charges": 5 }, { "item": "3006", "charges": [ 10, 20 ] } ], "prob": 5 }
     ]
   },
   {

--- a/data/json/npcs/isherwood_farm/NPC_Jesse_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Jesse_Isherwood.json
@@ -20,9 +20,9 @@
     "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
-    "carry_override": "NC_ISHERWOOD_rifle",
-    "weapon_override": "NC_ISHERWOOD_archery",
+    "worn_override": "NC_Isherwood_female_worn",
+    "carry_override": "NC_ISHERWOOD_carry",
+    "weapon_override": "EMPTY_GROUP",
     "skills": [
       {
         "skill": "ALL",

--- a/data/json/npcs/isherwood_farm/NPC_Lisa_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Lisa_Isherwood.json
@@ -19,9 +19,9 @@
     "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
-    "carry_override": "NC_ISHERWOOD_rifle",
-    "weapon_override": "NC_ISHERWOOD_archery",
+    "worn_override": "NC_Isherwood_female_worn",
+    "carry_override": "NC_ISHERWOOD_carry",
+    "weapon_override": "EMPTY_GROUP",
     "skills": [
       {
         "skill": "ALL",

--- a/data/json/npcs/isherwood_farm/NPC_Luke_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Luke_Isherwood.json
@@ -20,9 +20,9 @@
     "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
     "common": false,
     "bonus_per": { "one_in": 4 },
-    "worn_override": "NC_Isherwood_worn",
-    "carry_override": "NC_ISHERWOOD_rifle",
-    "weapon_override": "NC_ISHERWOOD_archery",
+    "worn_override": "NC_Isherwood_male_worn",
+    "carry_override": "NC_ISHERWOOD_carry",
+    "weapon_override": "EMPTY_GROUP",
     "skills": [
       {
         "skill": "ALL",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fixes for Isherwood NPC weapons and outfits"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

While rampaging around at the Isherwood farm again in my most recent playthrough, I noticed a mysterious lack of getting shot in the face by them and soon found out their weapons all spawn without ammo, along with some other problems encountered while digging deeper.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Split the worn item collection off between male and female variants for the Isherwoods, along with increasing the variety of clothing a bit.
2. Phased out the weird system of wielding an empty bow/crossbow and having an (also empty) rifle spawn loose in inventory. Instead their carry override has them pick between a bow, crossbow, or rifle which will always spawn with some spare ammo, a spare mag where relevant. Uses the same combined weights as the original two itemgroups used.
3. Fixed Claire using standard vanilla survivor clothes instead of the Isherwood outfit.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Giving the ones that use `shopkeeper_item_group` a melee weapon instead, see below.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Spawned in the farm and paid them a visit, confirmed they were wielding assorted loaded guns.
3. Debug killed them, confirmed they had ammo and/or mags on hand too.

One thing I noticed: the ones that use `shopkeeper_item_group` like Eddie spawn unarmed, because they aren't actually using `carry_override`. Could replace those with a melee-centric itemgroup for wielding maybe?

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
