### PR TITLE
fix: rename id of `sai` to `sai_weapon`

### DIFF
--- a/data/json/items/melee/unarmed_weapons.json
+++ b/data/json/items/melee/unarmed_weapons.json
@@ -153,7 +153,7 @@
     "flags": [ "DURABLE_MELEE", "UNARMED_WEAPON", "BELT_CLIP", "NONCONDUCTIVE", "STAB" ]
   },
   {
-    "id": "sai",
+    "id": "sai_weapon",
     "type": "GENERIC",
     "name": "sai",
     "description": "A pointed metal baton with two curved prongs projecting from the handle.  It's primarily used for disarming opponents, but can also make your punches puncture your foes.",

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -794,7 +794,7 @@
     ]
   },
   {
-    "result": "sai",
+    "result": "sai_weapon",
     "type": "recipe",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_PIERCING",


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "[Briefly describe the change in these quotation marks]"


#### Purpose of change

i've overlooked [chaosvolt's review](https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2715#issuecomment-1535657338) in #2715 that the graphic glitch was due to overmap terrain and weapon sharing same id `sai`.

#### Describe the solution

renamed id of `sai` to `sai_weapon`, which changes the two uses of sai:
- weapon sai
- crafting recipe sai

#### Describe alternatives you've considered

add a migration to change `sai` to `sai_weapon` but hopefully nobody downloaded today's experimental releases as i've deleted one with the PR #2715 

#### Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/9728a00a-1b88-4876-ad90-316ea053bc40)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/ba935366-9a93-4703-a7bd-8da65bb504ca)
