### PR TITLE
Craftable gyrocopter rotors

### DIFF
--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -551,7 +551,7 @@
     "id": "civilian_helicopter_parts",
     "type": "item_group",
     "//": "Parts for civilian helicopter",
-    "items": [ [ "small_turbine_engine", 50 ], [ "small_helicopter_rotor", 50 ] ]
+    "items": [ [ "small_turbine_engine", 50 ], [ "small_helicopter_rotor", 40 ], [ "homebuilt_gyrocopter_rotor", 10 ] ]
   },
   {
     "id": "military_helicopter_parts",

--- a/data/json/items/vehicle/rotor.json
+++ b/data/json/items/vehicle/rotor.json
@@ -28,5 +28,20 @@
     "material": "steel",
     "symbol": "X",
     "color": "blue"
+  },
+  {
+    "id": "homebuilt_gyrocopter_rotor",
+    "type": "GENERIC",
+    "category": "veh_parts",
+    "name": { "str": "homebuilt gyrocopter rotors", "str_pl": "sets of homebuilt gyrocopter rotors" },
+    "description": "A two-bladed wooden rotor and propeller, for lightweight vehicles put together by hobbyists.",
+    "price": "10 USD",
+    "price_postapoc": "2 USD",
+    "weight": "120 kg",
+    "volume": "120 L",
+    "looks_like": "wind_turbine",
+    "material": [ "steel", "wood" ],
+    "symbol": "X",
+    "color": "brown"
   }
 ]

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -1311,5 +1311,37 @@
     "using": [ [ "welding_standard", 5 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "solar_panel_v2", 1 ] ], [ [ "reinforced_glass_pane", 1 ] ], [ [ "scrap", 2 ] ], [ [ "wire", 2 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "homebuilt_gyrocopter_rotor",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_PARTS",
+    "skill_used": "fabrication",
+    "skills_required": [ "mechanics", 5 ],
+    "difficulty": 7,
+    "time": "1 h",
+    "book_learn": [
+      [ "textbook_fabrication", 6 ],
+      [ "welding_book", 6 ],
+      [ "textbook_carpentry", 6 ],
+      [ "book_icef", 4 ],
+      [ "textbook_mechanics", 4 ],
+      [ "manual_mechanics", 4 ]
+    ],
+    "using": [ [ "welding_standard", 10 ], [ "adhesive", 4 ] ],
+    "qualities": [
+      { "id": "SCREW", "level": 1 },
+      { "id": "HAMMER", "level": 2 },
+      { "id": "SAW_M", "level": 2 },
+      { "id": "SAW_W", "level": 2 }
+    ],
+    "components": [
+      [ [ "2x4", 20 ], [ "frame_wood", 4 ], [ "wood_panel", 4 ] ],
+      [ [ "sheet_metal_small", 10 ] ],
+      [ [ "nail", 20 ] ],
+      [ [ "pipe", 5 ] ],
+      [ [ "chain", 1 ] ]
+    ]
   }
 ]

--- a/data/json/vehicleparts/rotor.json
+++ b/data/json/vehicleparts/rotor.json
@@ -49,6 +49,29 @@
     "damage_reduction": { "all": 22 }
   },
   {
+    "id": "gyrocopter_rotors",
+    "copy-from": "helicopter_rotors",
+    "type": "vehicle_part",
+    "name": "gyrocopter rotors",
+    "item": "homebuilt_gyrocopter_rotor",
+    "looks_like": "small_helicopter_rotor",
+    "rotor_diameter": 6,
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 5 ] ], "time": "60 m", "using": [ [ "vehicle_bolt", 1 ] ] },
+      "removal": { "skills": [ [ "mechanics", 5 ] ], "time": "30 m", "using": [ [ "vehicle_bolt", 1 ] ] },
+      "repair": { "skills": [ [ "mechanics", 6 ] ], "time": "60 m", "using": [ [ "welding_standard", 10 ] ] }
+    },
+    "durability": 50,
+    "description": "A pair of rotor blades powered by a propeller, for light vehicles.",
+    "damage_modifier": 80,
+    "breaks_into": [
+      { "item": "scrap", "count": [ 4, 8 ] },
+      { "item": "steel_chunk", "count": [ 1, 4 ] },
+      { "item": "splinter", "count": [ 15, 30 ] }
+    ],
+    "damage_reduction": { "all": 10 }
+  },
+  {
     "id": "heavy_duty_military_blackhawk_rotors",
     "copy-from": "heavy_duty_military_rotor",
     "type": "vehicle_part",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Content "Add a form of lightweight rotors the player can potentially craft"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

On looking into some assorted things I was reminded that a form of craftable rotor may potentially be desirable. Regular helicopter rotors would be a bit beyond what might feel reasonable for the player to make, but gyrocopter rotors are something hobbyists put together.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added item for homebuilt gyrocopter rotors. Uses steel and wood, hence lighter weight along with overall smaller size than helicopter rotors.
2. Added vehiclepart definition for gyro rotors. I went with a rotor diameter of 6, basing it off the 20-foot diameter of the Bensen autogyros that seem to be the most common sort of thing hobbyists tinker with.
3. Added recipe for gyro rotors. Based the recipe's overall requirements on wind turbines but beefed up to be a bit closer match in terms of component weight, with the overall crafting level being 2 levels higher than the larger turbine and 7 level higher than the makeshift steam engine. Unlike the turbines I decided not to have it be reversible since you're likely doing a fair bit of alterations to the wood and metal, and also went with it being booklearn-only but with a decent selection of potential books. Also has a few fitting flavor components like adhesive and a chain.
4. Added them to `civilian_helicopter_parts` itemgroup.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. If we wanted to be more realistic, technically autogyros tend to be unable to outright hover. Supporting that would require some sort of basic "disallow ascending/descending unless you're got some speed" code presumably tied to a vehicle flag, it'd be more complicated for no immediate gain but might make it easier to also implement airplanes in the future.
2. Adding an actual pre-built gyrocopter for testing purposes and/or novelty spawns somewhere. Where would we even spawn it besides airports though.
3. Saying "fuck it" and reworking quad copter rotors from drones into a valid vehiclepart too, as utterly unlikely as it is the player will have a vehicle light enough to lift it without being unusable.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors, then added file changes to test build.
2. Put together a lightweight heli by modifying a bicycle, confirmed it had plenty enough lift to handle the player with a fairly basic I-4 engine (based off the Bensen B-8, quick wikipedia search says it uses an engine that has the exact same watt output as said engine).

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

It is about 7 AM or so as of the time this PR was opened, I should be trying to get some sleep but ideas keep hitting me.

This came to me after I'd already spent a while hashing out JSON for a future implementation of steam turbines as a top-tier option for coal-fueled deathmobiles, which I put aside because spawning it will likely require adding small local power plants and I don't want to mess with writing mapgen this late/early.