### PR TITLE
Thick smoke can get through vehicles like other gases

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -291,8 +291,7 @@
             "body_part": "mouth",
             "intensity": 4,
             "min_duration": "15 seconds",
-            "max_duration": "15 seconds",
-            "immune_inside_vehicle": true
+            "max_duration": "15 seconds"
           }
         ],
         "scent_neutralization": 5


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Allow thick smoke to affect player through vehicles, like most other gases"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

As discussed recently, smoke should perhaps be able to seep into vehicles if heavy enough. I did test and found out that the immunity effect does actually consider if you're properly enclosed in a vehicle in some manner, so it'd be feasible to make the most intense fields get you through a vehicle like most gas fields can.

Closes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/2734

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Removed `immune_inside_vehicle` from intensity 3 of smoke. This makes it consistent with several other gas fields. One thing to note is that vehicle exhaust can rarely produce thick smoke, so I'd be leery of going too overboard with this lest players start wondering why they're coughing after driving through their own exhaust (sharing in the suffering of motorcycle mains).

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Nerfing it even harder so tier-2 fields seep through cars too. I'd probably advise against that as noted above.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and lint errors.
2. Loaded into compiled build, spawned in an intact car, got in and closed the doors.
3. Having previously tested and confirmed heavy smoke did nothing when spawned in my tile earlier, spawned some thick smoke on my position.
4. Confirmed I get the coof.
5. Also tested tier 1 and 2 smoke to confirm those still don't trigger coughing.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
