### PR TITLE
Expand room variation of microlabs

### DIFF
--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -496,5 +496,32 @@
       [ "test_tube", 10 ],
       [ "bionic_scanner", 5 ]
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "microlab_storage_cvd_carbon",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "charcoal", "prob": 75, "charges": [ 25, 50 ] },
+      { "item": "coal_lump", "prob": 25, "charges": [ 25, 50 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "microlab_storage_cvd_hydrogen",
+    "subtype": "distribution",
+    "entries": [ { "item": "hydrogen_tank", "prob": 25 }, { "item": "plasma", "prob": 75, "charges": [ 10, 20 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "microlab_storage_plutonium_special",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "minireactor", "prob": 50 },
+      { "item": "bio_reactor", "prob": 10 },
+      { "item": "bio_advreactor", "prob": 10 },
+      { "item": "bio_reactor_upgrade", "prob": 5 },
+      { "item": "huge_atomic_battery_cell", "prob": 25 }
+    ]
   }
 ]

--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -499,6 +499,20 @@
   },
   {
     "type": "item_group",
+    "id": "microlab_storage_electric",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "alloy_plate", "prob": 20 },
+      { "item": "recharge_station", "prob": 20 },
+      { "item": "solar_panel", "prob": 10 },
+      { "item": "solar_panel_v2", "prob": 20 },
+      { "item": "motor_large", "prob": 5 },
+      { "item": "motor_enhanced", "prob": 15 },
+      { "item": "motor_super", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
     "id": "microlab_storage_cvd_carbon",
     "subtype": "distribution",
     "entries": [

--- a/data/json/mapgen/lab/lab_floorplans.json
+++ b/data/json/mapgen/lab/lab_floorplans.json
@@ -337,7 +337,7 @@
     "type": "mapgen",
     "method": "json",
     "om_terrain": [ "lab_4side" ],
-    "weight": 100,
+    "weight": 50,
     "object": {
       "rotation": [ 3, 4 ],
       "fill_ter": "t_thconc_floor",

--- a/data/json/mapgen/microlab/microlab_generic_edge.json
+++ b/data/json/mapgen/microlab/microlab_generic_edge.json
@@ -560,7 +560,7 @@
       },
       "furniture": { "S": "f_utility_shelf" },
       "mapping": {
-        "S": { "items": { "item": "microlab_storage_electric" }, "items": { "item": "gas_charging_rack", "chance": 50 } },
+        "S": { "items": [ { "item": "microlab_storage_electric" }, { "item": "gas_charging_rack", "chance": 50 } ] },
         "t": {
           "items": [
             { "item": "tools_lighting_industrial", "chance": 25, "repeat": 2 },

--- a/data/json/mapgen/microlab/microlab_generic_edge.json
+++ b/data/json/mapgen/microlab/microlab_generic_edge.json
@@ -508,5 +508,167 @@
       ],
       "palettes": [ "microlab" ]
     }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": [ [ "microlab_generic_edge" ] ],
+    "method": "json",
+    "object": {
+      "fill_ter": "t_strconc_floor",
+      "rows": [
+        "     |    |  |    |     ",
+        " ch  2    2  2    2  cc ",
+        " ch  ||||||22||||||  cc ",
+        "     |F                 ",
+        "  ccc|F                 ",
+        "||||||||||((((|||22|||||",
+        " cc |               |FF ",
+        "    2      YY       (   ",
+        " U6 2      YY       (   ",
+        "    |               |   ",
+        "|22||  -----------  ||2|",
+        "   B|  - 54 331 P-  2   ",
+        "   B|  - 5  33  P-  2   ",
+        "|22||  -        P-  ||||",
+        "    |22|(((((|   -    | ",
+        " 66    |S 666|   -    2 ",
+        " 66h   |     2   -    2 ",
+        "       |tttt |   -    | ",
+        "|((|2|||||||||GGG-  |2||",
+        " cc  |       |      (   ",
+        "     2       2      (   ",
+        " FF  ||||||22||22||||   ",
+        "     2  ci|  2   B|6h   ",
+        "     |    |  |    |     "
+      ],
+      "place_nested": [
+        { "chunks": [ [ "null", 4 ], "sub_fd_shock_vent" ], "x": 17, "y": 12 },
+        { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 0, "neighbors": { "north": "microlab_rock_border" } },
+        { "chunks": [ "concrete_wall_ns" ], "x": 23, "y": 0, "neighbors": { "east": "microlab_rock_border" } },
+        { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 23, "neighbors": { "south": "microlab_rock_border" } },
+        { "chunks": [ "concrete_wall_ns" ], "x": 0, "y": 0, "neighbors": { "west": "microlab_rock_border" } }
+      ],
+      "palettes": [ "microlab" ],
+      "terrain": {
+        "-": "t_chainfence",
+        "1": "t_switchgear_l",
+        "3": "t_current_trans",
+        "5": "t_potential_trans",
+        "4": "t_oil_circ_brkr_l",
+        "G": "t_chaingate_l",
+        "P": "t_generator_broken"
+      },
+      "furniture": { "S": "f_utility_shelf" },
+      "mapping": {
+        "S": {
+          "item": { "item": "recharge_station", "chance": 75 },
+          "items": { "item": "gas_charging_rack", "chance": 50, "repeat": 2 }
+        },
+        "t": {
+          "items": [
+            { "item": "tools_lighting_industrial", "chance": 25, "repeat": 2 },
+            { "item": "supplies_electronics", "chance": 50, "repeat": 3 },
+            { "item": "ammo_atomic_batteries", "chance": 10 }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": [ [ "microlab_generic_edge" ] ],
+    "method": "json",
+    "object": {
+      "fill_ter": "t_strconc_floor",
+      "rows": [
+        "     |h   |  |    |     ",
+        " F  c|dd  2  |    |6  c ",
+        " F  c||||||  ||22||6  c ",
+        "      2     c|          ",
+        "      2    cc|ccU       ",
+        "|((|22||||||||||||||22||",
+        "6666  |SSSS    ee|B     ",
+        "  h   |        ee|B Y   ",
+        "      |         W|  Y   ",
+        "      |         W|^     ",
+        "|((|22||44||||||||||22||",
+        "2     -    11 33 -      ",
+        "2     -          -      ",
+        "||||  G    PP  CC-  ||2|",
+        "   |  G    PP   C-  |c  ",
+        " Y 2  G          -  (c  ",
+        " Y |  -        CC-  (U  ",
+        "   |  -CCC     CC-  |U  ",
+        "|2||  ------------  ||2|",
+        "   |       YY       |   ",
+        " i |       YY       |6  ",
+        " c ||||((||  ||||||||c  ",
+        " 6   2 66 2  2 cc 2     ",
+        "     |    |  |    |     "
+      ],
+      "place_nested": [
+        { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 0, "neighbors": { "north": "microlab_rock_border" } },
+        { "chunks": [ "concrete_wall_ns" ], "x": 23, "y": 0, "neighbors": { "east": "microlab_rock_border" } },
+        { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 23, "neighbors": { "south": "microlab_rock_border" } },
+        { "chunks": [ "concrete_wall_ns" ], "x": 0, "y": 0, "neighbors": { "west": "microlab_rock_border" } }
+      ],
+      "palettes": [ "microlab" ],
+      "terrain": {
+        "-": "t_chainfence",
+        "1": "t_machinery_heavy",
+        "3": "t_machinery_old",
+        "G": "t_chaingate_l",
+        "P": "t_generator_broken"
+      },
+      "furniture": { "C": "f_crate_c", "S": "f_utility_shelf" },
+      "mapping": {
+        "C": { "items": [ { "item": "supplies_plumbing", "chance": 50, "repeat": 2 }, { "item": "supplies_metal", "chance": 50 } ] },
+        "S": { "items": { "item": "tools_construction", "chance": 50, "repeat": 2 } },
+        "e": { "items": { "item": "acetylene_production", "chance": 40, "repeat": 2 } }
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": [ [ "microlab_generic_edge" ] ],
+    "method": "json",
+    "object": {
+      "fill_ter": "t_strconc_floor",
+      "rows": [
+        "     |    |  ||||||     ",
+        " B d |    |  | UUU|     ",
+        " Bhd 2   6(  2    ||22||",
+        " B d |   6(  2          ",
+        "     |    |  | cccF     ",
+        "||22|||22||||||||((((22|",
+        "          |666         |",
+        "         F| h  YY cci  |",
+        "         F|    YY cci  |",
+        " ccccc   F|FFF         |",
+        "|(((((|||||||||||((((22|",
+        "    FF|r   |    |       ",
+        "      |r   4    2       ",
+        "||||  |    4    2  |||||",
+        "   |  |c   |    |  | 66 ",
+        " Y 2  |c   ||22||  2    ",
+        " Y 2  |c  A|    |  2    ",
+        "   |  ||||||b  l|  |    ",
+        "|(2|      B|b  l|||||22|",
+        "   |b     B|b  l|FF|    ",
+        "   ||||22||||||||  |    ",
+        "     (       2     2    ",
+        "     (cci6   2     |    ",
+        "     ||((||22|     |    "
+      ],
+      "place_nested": [
+        { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 0, "neighbors": { "north": "microlab_rock_border" } },
+        { "chunks": [ "concrete_wall_ns" ], "x": 23, "y": 0, "neighbors": { "east": "microlab_rock_border" } },
+        { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 23, "neighbors": { "south": "microlab_rock_border" } },
+        { "chunks": [ "concrete_wall_ns" ], "x": 0, "y": 0, "neighbors": { "west": "microlab_rock_border" } }
+      ],
+      "palettes": [ "microlab" ],
+      "furniture": { "A": "f_autoclave" },
+      "mapping": { "r": { "item": { "item": "pouch_autoclave", "chance": 50 } } }
+    }
   }
 ]

--- a/data/json/mapgen/microlab/microlab_generic_edge.json
+++ b/data/json/mapgen/microlab/microlab_generic_edge.json
@@ -560,10 +560,7 @@
       },
       "furniture": { "S": "f_utility_shelf" },
       "mapping": {
-        "S": {
-          "items": { "item": "microlab_storage_electric" },
-          "items": { "item": "gas_charging_rack", "chance": 50 }
-        },
+        "S": { "items": { "item": "microlab_storage_electric" }, "items": { "item": "gas_charging_rack", "chance": 50 } },
         "t": {
           "items": [
             { "item": "tools_lighting_industrial", "chance": 25, "repeat": 2 },

--- a/data/json/mapgen/microlab/microlab_generic_edge.json
+++ b/data/json/mapgen/microlab/microlab_generic_edge.json
@@ -561,8 +561,8 @@
       "furniture": { "S": "f_utility_shelf" },
       "mapping": {
         "S": {
-          "item": { "item": "recharge_station", "chance": 75 },
-          "items": { "item": "gas_charging_rack", "chance": 50, "repeat": 2 }
+          "items": { "item": "microlab_storage_electric" },
+          "items": { "item": "gas_charging_rack", "chance": 50 }
         },
         "t": {
           "items": [
@@ -620,7 +620,7 @@
         "G": "t_chaingate_l",
         "P": "t_generator_broken"
       },
-      "furniture": { "C": "f_crate_c", "S": "f_utility_shelf" },
+      "furniture": { "C": "f_crate_c", "S": "f_utility_shelf", "W": "f_workbench" },
       "mapping": {
         "C": { "items": [ { "item": "supplies_plumbing", "chance": 50, "repeat": 2 }, { "item": "supplies_metal", "chance": 50 } ] },
         "S": { "items": { "item": "tools_construction", "chance": 50, "repeat": 2 } },

--- a/data/json/mapgen/microlab/microlab_special_tiles.json
+++ b/data/json/mapgen/microlab/microlab_special_tiles.json
@@ -221,5 +221,156 @@
         }
       }
     }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": [ [ "microlab_generic" ] ],
+    "method": "json",
+    "object": {
+      "fill_ter": "t_strconc_floor",
+      "rows": [
+        "     |    |  |((((|     ",
+        "     ||22||  | 66 |     ",
+        " ccc      2  2    2     ",
+        "          2  2 cc 2     ",
+        " UUU      |  |    | ??V^",
+        "|((((2|||||||||22|||||||",
+        "       |  |   |         ",
+        " hhh   |  5   2   666   ",
+        " ttt   |  5   2   666   ",
+        "       |  |7  |         ",
+        "|((|||||44|||||22|||||||",
+        "   |----  ----|         ",
+        "   |-r +  - S-| ????    ",
+        "|22|----  - S-||((((|22|",
+        "   |-r +  + S-|UUcc    |",
+        "  d|----  - S-|       6|",
+        " hd|-r +  - S-|       6|",
+        "   |----------|        |",
+        "|22|||||||||||||22||||||",
+        "    B|             2  cF",
+        "    B|ccii         2  c ",
+        " F   |((((|22|||||||  c ",
+        " i   2 66 2  2  Y  2    ",
+        "     |    |  |     |    "
+      ],
+      "palettes": [ "microlab" ],
+      "terrain": { "+": "t_door_metal_c", "7": "t_console" },
+      "furniture": { "S": "f_utility_shelf" },
+      "mapping": {
+        "S": { "items": { "item": "microlab_storage_cvd_carbon", "chance": 50, "repeat": 2 } },
+        "r": { "items": { "item": "microlab_storage_cvd_hydrogen", "chance": 50, "repeat": 4 } }
+      },
+      "computers": {
+        "7": {
+          "name": "Hydrocarbon Materials Storage Control",
+          "security": 5,
+          "options": [ { "name": "UNLOCK STORAGE", "action": "unlock" } ],
+          "failures": [ { "action": "alarm" }, { "action": "damage" } ]
+        }
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": [ [ "microlab_generic" ] ],
+    "method": "json",
+    "object": {
+      "fill_ter": "t_strconc_floor",
+      "rows": [
+        "    h|||||||||    |     ",
+        " 6 dd|B  h  ^(    (cc   ",
+        " 6 dd|B ddd  (    (cc   ",
+        "    h|       (    (     ",
+        "     2       2    2     ",
+        "    n|||||||||||||||||||",
+        "     2       Y      2   ",
+        "     2       Y      2   ",
+        "   hd||22||||||||||||   ",
+        "    d|    |---------|   ",
+        "||2((|    55      r-|22|",
+        "     |    55      r-|   ",
+        "     |   7|-      r-|   ",
+        "|    ||22||-       -|22|",
+        "|t   |    |-     ---|   ",
+        "|^   |l  b|-     4 -|   ",
+        "|?   |l  b|-rrr  -S-|   ",
+        "|?   |l  b|---------|   ",
+        "|||2|||||||||||||||||22|",
+        "     | cFF|B   ??? |    ",
+        " FF  |    |B       2    ",
+        " cc  2 66 ||||     (6   ",
+        "     | 66 2  2     (6h  ",
+        "     |    |  |     |    "
+      ],
+      "palettes": [ "microlab" ],
+      "furniture": { "S": "f_utility_shelf" },
+      "set": [ { "square": "radiation", "amount": [ 10, 30 ], "x": 12, "y": 10, "x2": 18, "y2": 16 } ],
+      "mapping": {
+        "S": { "items": { "item": "microlab_storage_plutonium_special" } },
+        "l": { "items": { "item": "rad_gear", "chance": 50, "repeat": 2 } },
+        "r": {
+          "item": { "item": "plut_cell", "chance": 40, "repeat": 2 },
+          "items": { "item": "ammo_atomic_batteries_full", "chance": 25 }
+        }
+      },
+      "computers": {
+        "7": {
+          "name": "Nuclear Materials Storage Control",
+          "access_denied": "ERROR!  Access denied!  Unauthorized access will be met with lethal force!",
+          "security": 5,
+          "options": [ { "name": "UNLOCK STORAGE - CAUTION: RADIATION LEAK DETECTED", "action": "unlock" } ],
+          "failures": [ { "action": "alarm" }, { "action": "damage" }, { "action": "secubots" } ]
+        }
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": [ [ "microlab_generic" ] ],
+    "method": "json",
+    "object": {
+      "fill_ter": "t_strconc_floor",
+      "rows": [
+        "     |    |  ||||||     ",
+        " FF c|    |  |?  V(th   ",
+        " FF i||22||  |?  n(th   ",
+        " 66  2       |    (th   ",
+        "     2       2    2     ",
+        "||2||||||||||||||||||2||",
+        "      FF|------|  |     ",
+        "  66    |-r  x-|  2  d  ",
+        "  66  h |-r   -|  2  h  ",
+        "      cc|-r   -|  | BBB ",
+        "22|||||||-    -|  ||||||",
+        "  |FF|cc|--55--|YY      ",
+        "  |     |||55|||YY      ",
+        "22|     |    7 |  |||2||",
+        "    U O |      |  (6    ",
+        "    U O | 6    2  (6    ",
+        "    U O |hd    |  (dh   ",
+        "        | d BBB|  (d    ",
+        "||||||22||||||||22|||22|",
+        " 666n|    2  2    |6    ",
+        " h   2    2  2    |   c ",
+        "    c( YY |  | BB 2   c ",
+        "    c( YY |  | BB |  FF ",
+        "     |    |  |    |     "
+      ],
+      "palettes": [ "microlab" ],
+      "mapping": {
+        "r": { "item": { "item": "nanomaterial", "chance": 50, "repeat": 2 } },
+        "x": { "item": { "item": "standard_template_construct", "repeat": [ 1, 2 ] } }
+      },
+      "computers": {
+        "7": {
+          "name": "Nanomaterial Storage Control",
+          "access_denied": "ERROR!  Access denied!  Unauthorized access will be met with lethal force!",
+          "security": 5,
+          "options": [ { "name": "UNLOCK STORAGE", "action": "unlock" } ],
+          "failures": [ { "action": "alarm" }, { "action": "damage" }, { "action": "secubots" } ]
+        }
+      }
+    }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Content "Add new storage room variations to microlabs"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This works towards implementing the other half of https://github.com/cataclysmbnteam/Cataclysm-BN/issues/971 via adding more rooms that store different items. The goal is injecting some variations that provide materials that become useful later on as you explore regular labs, making microlabs better at serving as a supplement to labs and thus encouraging you to visit both.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added three new variations to the `microlab_generic_edge` mapgen pool, containing mildly useful equipment and supplies (but less exciting than what the center tiles can yield). One's a simple electrical workstation with potential to find assorted goodies (including a suggestion by Lostman to find uncommon vehicleparts), another's a utility area in the same vein as the industrial locations in regular labs (with some chance of welding gas related supplies), and the third is a secured cleanroom with an autoclave and related materials. As all other edge tiles have nothing of note in them, this grants a 20% chance of any given edge tile having something mildly interesting inside.
2. Added three new variations to the `microlab_generic` mapgen pool, containing secured vaults for storing specific materials that come into play when you find the right locations elsewhere. One has storage for hydrogen and carbon (for use with a CVD machine), one focuses on plutonium cells and/or batteries (with a bonus chance of spawning a special item related to the theme such as one of the newly-reworked CBMs, a minireactor, or a mech power cell), and finally there's a nanomaterial vault with the potential for further-locked-up STCs. Combined with the 3 existing microlabs that I'd rate as having a noteworthy resource, this makes the chance of finding some interesting resource in any given center tile go from 15% to ~26%.
3. Defined itemgroups used by a couple of said storage rooms.
. Misc: Reduced the mapgen weight of one of the generic lab 4-side floorplans in order to elevate the second autodoc variation from 50 to 100 (keeping the same weight total of 1500), thus elevating the overall odds of finding an autodoc from 10% to 15%. Paired with the above since the odds of finding an autodoc in microlab centers goes down a bit due to increased mapgen pool (from 5% to ~4.4%).

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Completely removing the mutagen, bionic storage, and autodoc rooms from microlabs in favor of increasing the mapgen weights for comparable rooms in regular labs, to further reinforce the idea of microlabs being a supplement to normal labs.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Load-tested on compiled build.
3. Visted various microlabs to confirm nothing looked weird whenever I ran into one of the variants I added.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
