### PR TITLE
Separate starting battery from mechs

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -717,5 +717,10 @@
       { "item": "medium_atomic_battery_cell", "prob": 2, "charges": 5000 },
       { "item": "heavy_atomic_battery_cell", "prob": 1, "charges": 10000 }
     ]
+  },
+  {
+    "id": "mech_power_cell_spawn",
+    "type": "item_group",
+    "items": [ { "item": "huge_atomic_battery_cell", "prob": 10, "charges": [ 0, 100000 ] } ]
   }
 ]

--- a/data/json/mapgen/bunker.json
+++ b/data/json/mapgen/bunker.json
@@ -102,11 +102,18 @@
       },
       "furniture": { "r": "f_rack" },
       "items": { "r": { "item": "bunker_basement_loot", "chance": 15, "repeat": [ 2, 8 ] } },
-      "place_monster": [
-        { "monster": "mon_mech_combat", "x": 5, "y": 5, "chance": 2 },
-        { "monster": "mon_mech_lifter", "x": 6, "y": 6, "chance": 5 },
-        { "monster": "mon_mech_recon", "x": 7, "y": 6, "chance": 3 }
-      ]
+      "place_nested": [ { "chunks": [ [ "null", 9 ], "bunker_mech_spawn" ], "x": 5, "y": 5 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "bunker_mech_spawn",
+    "weight": 25,
+    "object": {
+      "mapgensize": [ 3, 3 ],
+      "place_loot": [ { "group": "mech_power_cell_spawn", "x": [ 0, 2 ], "y": 2 } ],
+      "place_monster": [ { "monster": [ "mon_mech_combat", "mon_mech_lifter", "mon_mech_recon" ], "x": [ 0, 1 ], "y": [ 0, 1 ] } ]
     }
   },
   {

--- a/data/json/mapgen/lab/lab_floorplans_finale1level.json
+++ b/data/json/mapgen/lab/lab_floorplans_finale1level.json
@@ -38,6 +38,7 @@
       "terrain": { "?": "t_nanofab", "r": "t_metal_floor", "/": "t_nanofab_body" },
       "mapping": { "r": { "item": { "item": "standard_template_construct" } }, "R": { "item": { "item": "nanomaterial" } } },
       "place_nested": [ { "chunks": [ "lab_finale_loot" ], "x": 6, "y": 11 } ],
+      "place_loot": [ { "group": "mech_power_cell_spawn", "x": [ 4, 5 ], "y": [ 3, 5 ] } ],
       "place_monster": [
         { "monster": "mon_secubot", "x": [ 1, 4 ], "y": [ 20, 22 ], "chance": 90 },
         { "monster": "mon_secubot", "x": [ 19, 20 ], "y": [ 20, 22 ], "chance": 90 },

--- a/data/mods/DinoMod/mapgen/DinoLabFinale.json
+++ b/data/mods/DinoMod/mapgen/DinoLabFinale.json
@@ -144,6 +144,7 @@
           ]
         }
       },
+      "place_loot": [ { "group": "mech_power_cell_spawn", "x": 1, "y": [ 1, 4 ] } ],
       "place_monster": [
         { "monster": "mon_deinonychus", "x": [ 7, 8 ], "y": [ 17, 18 ], "chance": 90, "repeat": [ 1, 5 ] },
         { "monster": "mon_deinonychus", "x": [ 16, 17 ], "y": [ 17, 18 ], "chance": 90, "repeat": [ 1, 5 ] },

--- a/data/mods/No_Hope/Mapgen/bunker.json
+++ b/data/mods/No_Hope/Mapgen/bunker.json
@@ -102,11 +102,7 @@
       },
       "furniture": { "r": "f_rack" },
       "items": { "r": { "item": "bunker_basement_loot", "chance": 15, "repeat": [ 2, 8 ] } },
-      "place_monster": [
-        { "monster": "mon_mech_combat", "x": 5, "y": 5, "chance": 2 },
-        { "monster": "mon_mech_lifter", "x": 6, "y": 6, "chance": 5 },
-        { "monster": "mon_mech_recon", "x": 7, "y": 6, "chance": 3 }
-      ]
+      "place_nested": [ { "chunks": [ [ "null", 9 ], "bunker_mech_spawn" ], "x": 5, "y": 5 } ]
     }
   },
   {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -214,13 +214,6 @@ monster::monster( const mtype_id &id ) : monster()
     if( monster::has_flag( MF_AQUATIC ) ) {
         fish_population = dice( 1, 20 );
     }
-    if( monster::has_flag( MF_RIDEABLE_MECH ) ) {
-        itype_id mech_bat = itype_id( type->mech_battery );
-        int max_charge = mech_bat->magazine->capacity;
-        item mech_bat_item = item( mech_bat, calendar::start_of_cataclysm );
-        mech_bat_item.ammo_consume( rng( 0, max_charge ), tripoint_zero );
-        battery_item = cata::make_value<item>( mech_bat_item );
-    }
 }
 
 monster::monster( const mtype_id &id, const tripoint &p ) : monster( id )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Spawn mech battery separate from the mech, allowing for mechs to be placed without a power cell when needed"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Set this change aside separate from https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2829 so it doesn't bog the other stuff down or vice-versa.

This is aimed specifically at making it less of a pain in the ass to add support for mechs that can be spawned via a `place_monster` item. Presently not useful in vanilla but it could be in the future, out of repo it's useful for Arcana.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In monster.cpp, change `monster::monster` so that mechs don't spawn with a battery pre-loaded.

The reason for this is, if you have a source of the monster from an item, there's the possbility that it may have been crafted or otherwise loaded, such that the player is well aware how charged the battery that went into it is. As such, having it spawn with a random amount of battery power in this instance is a mere annoyance, and it'd be better to have the player provide the power cell separately after getting the mech up and running.

I would've wanted to have this only take effect if the mech spawns with the pet flag, to cover the above issues, but pet flag application from `place_monster` items presumably takes effect after the monster generates its starting battery, so this doesn't work. As such, because this removes the starter battery from all mechs...

2. Reworked the mech spawn in bunkers to use a nested chunk that has a 10% chance of spawning, instead of three separate super-low spawn chances. Said chunk picks one of the mechs at random to spawn along with placing the power cell on the nearby rack.
3. Updated the lab finale variant that spawns a mech to also place the power cell on the nearby counter.
4. Updated Dinomod and No Hope accordingly.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Spawning mech cells in these spawns with set amounts of charge, or even just grant full ones outright.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Temporarily added Arcana to mods folder.
3. Spawned in and used a rebuilt anomaly recon mech.
4. Examined it and confirmed it spawned without a power cell loaded.
5. Tested that loading an essence fuel cell into it still works, and that it drains power with use.
6. Spawned in a vanilla recon mech, confirmed it spawns with no battery loaded but can have one loaded.
7. Checked affected C++ file for astyle.
8. Temporarily elevated the mech variant of bunkers to have a much higher spawn weight.
9. Spawned in said location multiple times, confirmed that mechs sometime spawn, and when they do it's always with a power cell.
10. Checked affected JSON files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
