### PR TITLE
feat: buff all water purification methods by 8x (250ml -> 2L)

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -975,7 +975,7 @@
     "container": "bottle_plastic_small",
     "comestible_type": "MED",
     "symbol": "!",
-    "description": "Intended for the clarification and disinfection of unsafe drinking water, these halazone-based purification tablets remove dangerous contaminants using powerful chemicals.  The label says to use one tablet per unit of water.",
+    "description": "Intended for the clarification and disinfection of unsafe drinking water, these halazone-based purification tablets remove dangerous contaminants using powerful chemicals.  The label says one tablet purifies up to 2L of water.",
     "price": 900,
     "price_postapoc": 2000,
     "volume": "250 ml",

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2098,6 +2098,8 @@ int iuse::pack_item( player *p, item *it, bool t, const tripoint & )
 
 int iuse::water_purifier( player *p, item *it, bool, const tripoint & )
 {
+    constexpr auto purification_efficiency = 8; // one tablet purifies 250ml x 8 = 2L
+
     if( p->is_mounted() ) {
         p->add_msg_if_player( m_info, _( "You cannot do that while mounted." ) );
         return 0;
@@ -2112,15 +2114,16 @@ int iuse::water_purifier( player *p, item *it, bool, const tripoint & )
     }
 
     item &liquid = obj->contents.front();
-    if( !it->units_sufficient( *p, liquid.charges ) ) {
+    const auto used_charges = std::max( liquid.charges / purification_efficiency, 1 );
+    if( !it->units_sufficient( *p, used_charges ) ) {
         p->add_msg_if_player( m_info, _( "That volume of water is too large to purify." ) );
         return 0;
     }
 
     p->moves -= to_moves<int>( 2_seconds );
-
     liquid.convert( itype_water_clean ).poison = 0;
-    return liquid.charges;
+
+    return used_charges;
 }
 
 int iuse::radio_off( player *p, item *it, bool, const tripoint & )


### PR DESCRIPTION
#### Summary

SUMMARY: Balance "Buff all water purification methods by 8x (250ml -> 2L)"

#### Purpose of change

rationale:
1. water purification tablets are too inefficient
2. google says a single tablet can purify up to 1~2L of water

> Each tablet treats up to 2 quarts of clean water or 0.8 quart of dirty water
[ew, US measurements but that's not the point](https://www.rei.com/product/109906/aquatabs-water-purification-tablets-package-of-30)

#### Describe the solution

modified charges used in `iuse::water_purifier` by 1/8

#### Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/ae758574-6ea8-4adb-ad71-0839c292cdf7

<details><summary>using single tablet</summary>

1. spawn a 3L bottle, a bottle (0.5L), and 2 water purification tablet
2. fill the bottles with water
3. use tablets to each bottles
4. check that both are purified

</details> 

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/3ea56051-085e-4c13-b737-aa1f6b8bfdee

<details><summary>using multiple tablets</summary>

1. spawn a 10L jerrycan, and 5 water purification tablet
2. fill the jerrycan with water
3. use tablet
4. check that the jerrycan is purified, and all tablets are used