### PR TITLE
Fix PARROT_AT_DANGER attack, proper quotes for new feral lines

### DIFF
--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -227,7 +227,7 @@
     "path_settings": { "max_dist": 10 },
     "diff": 5,
     "starting_ammo": { "9mm": 5 },
-    "special_attacks": [ [ "PARROT_AT_DANGER", 5 ], [ "SEARCHLIGHT", 1 ], [ "TAZER", 10 ] ],
+    "special_attacks": [ [ "PARROT_AT_DANGER", 5 ], [ "TAZER", 10 ] ],
     "death_drops": "feral_security_death_drops_flashlight",
     "death_function": [ "NORMAL" ],
     "zombify_into": "mon_zombie_labsecurity",

--- a/data/json/speech.json
+++ b/data/json/speech.json
@@ -2610,259 +2610,259 @@
   {
     "type": "speech",
     "speaker": [ "mon_feral_scientist_scalpel" ],
-    "sound": "I'll show them.  I'll prove I was right all along!",
+    "sound": "\"I'll show them.  I'll prove I was right all along!\"",
     "volume": 20
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_scientist_scalpel" ],
-    "sound": "The vectors, the vectors are all wrong…",
+    "sound": "\"The vectors, the vectors are all wrong…\"",
     "volume": 15
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_scientist_scalpel" ],
-    "sound": "There's nothing there.  This is all just a simulation, a bad dream…",
+    "sound": "\"There's nothing there.  This is all just a simulation, a bad dream…\"",
     "volume": 15
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_scientist_scalpel" ],
-    "sound": "There's.  Nothing.  There.",
+    "sound": "\"There's.  Nothing.  There.\"",
     "volume": 20
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_scientist_scalpel" ],
-    "sound": "They called me a fool.  Now who's the fool!?",
+    "sound": "\"They called me a fool.  Now who's the fool!?\"",
     "volume": 40
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_labsecurity_9mm", "mon_feral_labsecurity_flashlight" ],
-    "sound": "Get back in your cage!",
+    "sound": "\"Get back in your cage!\"",
     "volume": 40
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_labsecurity_9mm", "mon_feral_labsecurity_flashlight", "mon_feral_soldier" ],
-    "sound": "X-ray breaching perimeter!",
+    "sound": "\"X-ray breaching perimeter!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_labsecurity_9mm", "mon_feral_labsecurity_flashlight" ],
-    "sound": "Lock this sector down, damnit!",
+    "sound": "\"Lock this sector down, damnit!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_labsecurity_9mm", "mon_feral_labsecurity_flashlight" ],
-    "sound": "Unknown entity escaping containment!",
+    "sound": "\"Unknown entity escaping containment!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_jackboot" ],
-    "sound": "I am the night rider!",
+    "sound": "\"I am the night rider!\"",
     "volume": 20
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_jackboot" ],
-    "sound": "I'm here to swim in gasoline, baby!",
+    "sound": "\"I'm here to swim in gasoline, baby!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_jackboot" ],
-    "sound": "Give me unleaded, or you'll get lead!",
+    "sound": "\"Give me unleaded, or you'll get lead!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_jackboot" ],
-    "sound": "I'm a fuel-injected suicide machine!",
+    "sound": "\"I'm a fuel-injected suicide machine!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_jackboot" ],
-    "sound": "I'm gonna tan your god damn hide!",
+    "sound": "\"I'm gonna tan your god damn hide!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_jackboot" ],
-    "sound": "Which one of you fuckers touched my bike!?",
+    "sound": "\"Which one of you fuckers touched my bike!?\"",
     "volume": 40
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_militia", "mon_feral_prepper", "mon_feral_survivalist" ],
-    "sound": "Reach for the sky!",
+    "sound": "\"Reach for the sky!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_labsecurity_9mm", "mon_feral_militia", "mon_feral_prepper" ],
-    "sound": "Clear my line of fire!",
+    "sound": "\"Clear my line of fire!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_militia", "mon_feral_prepper", "mon_feral_survivalist" ],
-    "sound": "Reach for the sky!",
+    "sound": "\"Reach for the sky!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_militia", "mon_feral_prepper" ],
-    "sound": "Weapons hot!",
+    "sound": "\"Weapons hot!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_militia", "mon_feral_prepper" ],
-    "sound": "Lock and load!",
+    "sound": "\"Lock and load!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_survivalist" ],
-    "sound": "I don't have to be faster than them, just faster than you!",
+    "sound": "\"I don't have to be faster than them, just faster than you!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_survivalist" ],
-    "sound": "My feet failed me!  Arms, don't fail me!",
+    "sound": "\"My feet failed me!  Arms, don't fail me!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_militia", "mon_feral_prepper", "mon_feral_survivalist" ],
-    "sound": "Look at me.  I am the captain now.",
+    "sound": "\"Look at me.  I am the captain now.\"",
     "volume": 20
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_militia", "mon_feral_prepper", "mon_feral_survivalist" ],
-    "sound": "I don't have to take this abuse from you, there are plenty of people to abuse me!",
+    "sound": "\"I don't have to take this abuse from you, there are plenty of people to abuse me!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_militia", "mon_feral_prepper", "mon_feral_survivalist" ],
-    "sound": "You're a monster!",
+    "sound": "\"You're a monster!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_militia", "mon_feral_prepper", "mon_feral_survivalist" ],
-    "sound": "I've had enough of your bullshit!",
+    "sound": "\"I've had enough of your bullshit!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_militia", "mon_feral_prepper", "mon_feral_survivalist" ],
-    "sound": "Adios, motherfucker!",
+    "sound": "\"Adios, motherfucker!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_militia", "mon_feral_prepper", "mon_feral_survivalist" ],
-    "sound": "Get out of here or I'll kill you!",
+    "sound": "\"Get out of here or I'll kill you!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_militia", "mon_feral_prepper", "mon_feral_survivalist" ],
-    "sound": "Keep your distance!",
+    "sound": "\"Keep your distance!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_jackboot", "mon_feral_militia", "mon_feral_prepper", "mon_feral_survivalist" ],
-    "sound": "This is my territory, asshole!",
+    "sound": "\"This is my territory, asshole!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_jackboot", "mon_feral_militia", "mon_feral_prepper", "mon_feral_survivalist" ],
-    "sound": "Fuck off, I saw this place first!",
+    "sound": "\"Fuck off, I saw this place first!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_jackboot", "mon_feral_militia", "mon_feral_prepper", "mon_feral_survivalist" ],
-    "sound": "Get out of here, I own this town now!",
+    "sound": "\"Get out of here, I own this town now!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_soldier" ],
-    "sound": "We've got incoming!",
+    "sound": "\"We've got incoming!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_soldier" ],
-    "sound": "Hostiles inbound.",
+    "sound": "\"Hostiles inbound.\"",
     "volume": 20
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_labsecurity_9mm", "mon_feral_labsecurity_flashlight", "mon_feral_soldier" ],
-    "sound": "I've got movement!",
+    "sound": "\"I've got movement!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_soldier" ],
-    "sound": "Danger close!",
+    "sound": "\"Danger close!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_soldier" ],
-    "sound": "Last one alive, lock the door!",
+    "sound": "\"Last one alive, lock the door!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_soldier" ],
-    "sound": "We have you surrounded, at least from this side!",
+    "sound": "\"We have you surrounded, at least from this side!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_soldier" ],
-    "sound": "Charge!",
+    "sound": "\"Charge!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_soldier" ],
-    "sound": "Contact!",
+    "sound": "\"Contact!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_soldier" ],
-    "sound": "Contact, enemy in sight!",
+    "sound": "\"Contact, enemy in sight!\"",
     "volume": 30
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_soldier" ],
-    "sound": "Target in sight!",
+    "sound": "\"Target in sight!\"",
     "volume": 25
   },
   {
     "type": "speech",
     "speaker": [ "mon_feral_soldier" ],
-    "sound": "We've got hostiles!",
+    "sound": "\"We've got hostiles!\"",
     "volume": 25
   }
 ]

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4556,14 +4556,11 @@ bool mattack::parrot( monster *z )
 
 bool mattack::parrot_at_danger( monster *parrot )
 {
-    for( monster &monster : g->all_monsters() ) {
-        if( one_in( 20 ) && ( monster.faction->attitude( parrot->faction ) == mf_attitude::MFA_HATE ||
-                              ( monster.anger > 0 &&
-                                monster.faction->attitude( parrot->faction ) == mf_attitude::MFA_BY_MOOD ) ) &&
-            parrot->sees( monster ) ) {
-            parrot_common( parrot );
-            return true;
-        }
+
+    Creature *target = parrot->attack_target();
+    if( one_in( 20 ) && target != nullptr && parrot->sees( *target ) ) {
+        parrot_common( parrot );
+        return true;
     }
 
     return false;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "PARROT_AT_DANGER monster attack can now be triggered when targeting the player, added quotation marks to new feral speech lines."

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Dumb thing I forgot in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2809 hecc

In addition, a side effect of this is Scarf discovered that PARROT_AT_DANGER doesn't work if the monster is after the player, they can only see monsters it seems.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Fixed new feral lines not having the second layer of quotes so that they'll properly be depicted saying the lines in-game.
2. Updated `mattack::parrot_at_danger` to actually check for if target of the monster has a target they're after (and not a hacky-as-fuck-looking check of all monsters), then if it has a valid target it can see proceeding with the parrot attack.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Screaming "I am the night rider!" at the code until it fixes itself for me.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected JSON file for syntax and lint errors.
2. Load-tested in compiled test build.
3. Debugged in a feral biker for a nice, well-lit basement conversation.
4. Correctly got screamed at by the Night Rider (also shot).
5. Tested from stealth that a feral with scream powers stayed silent when left alone, but would yell at monsters spawned for them to get shouty at too.
6. The new lines were also in quotes as expected,.
7. Checked affected C++ file for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
