### PR TITLE
Update `last_world_pos` considerations

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2745,6 +2745,9 @@ bool game::save()
         }, _( "uistate data" ) ) ) {
             return false;
         } else {
+            world_generator->last_world_name = world_generator->active_world->world_name;
+            world_generator->last_character_name = u.name;
+            world_generator->save_last_world_info();
             world_generator->active_world->add_save( save_t::from_save_id( u.get_save_id() ) );
             return true;
         }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -613,18 +613,11 @@ bool main_menu::opening_screen()
     player_character = avatar();
 
     int sel_line = 0;
-    size_t last_world_pos = 0;
 
     // Make [Load Game] the default cursor position if there's game save available
     if( !world_generator->all_worldnames().empty() ) {
-        std::vector<std::string> worlds = world_generator->all_worldnames();
-        last_world_pos = std::find( worlds.begin(), worlds.end(),
-                                    world_generator->last_world_name ) - worlds.begin();
-        if( last_world_pos >= worlds.size() ) {
-            last_world_pos = 0;
-        }
         sel1 = getopt( main_menu_opts::LOADCHAR );
-        sel2 = last_world_pos;
+        sel2 = world_generator->get_world_index( world_generator->last_world_name );
     }
 
     background_pane background;
@@ -642,6 +635,7 @@ bool main_menu::opening_screen()
     bool start_new = false;
     while( !start ) {
         ui_manager::redraw();
+        size_t last_world_pos = world_generator->get_world_index( world_generator->last_world_name );
         std::string action = ctxt.handle_input();
         input_event sInput = ctxt.get_raw_input();
 

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -635,7 +635,9 @@ bool main_menu::opening_screen()
     bool start_new = false;
     while( !start ) {
         ui_manager::redraw();
-        size_t last_world_pos = world_generator->get_world_index( world_generator->last_world_name );
+        // Refresh in case player created new world or deleted old world
+        // Since this is an index for a mutable array, it should always be regenerated instead of modified.
+        const size_t last_world_pos = world_generator->get_world_index( world_generator->last_world_name );
         std::string action = ctxt.handle_input();
         input_event sInput = ctxt.get_raw_input();
 

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1673,6 +1673,17 @@ WORLDPTR worldfactory::get_world( const std::string &name )
     return iter->second.get();
 }
 
+size_t worldfactory::get_world_index( const std::string &name )
+{
+    std::vector<std::string> worlds = all_worldnames();
+    size_t world_pos = std::find( worlds.begin(), worlds.end(),
+                                  name ) - worlds.begin();
+    if( world_pos >= worlds.size() ) {
+        world_pos = 0;
+    }
+    return world_pos;
+}
+
 // Helper predicate to exclude files from deletion when resetting a world directory.
 static bool isForbidden( const std::string &candidate )
 {

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -96,8 +96,10 @@ class worldfactory
         WORLDPTR make_new_world( special_game_type special_type );
         // Used for unit tests - does NOT verify if the mods can be loaded
         WORLDPTR make_new_world( const std::vector<mod_id> &mods );
-        /// Returns the *existing* world of given name.
+        // Returns the *existing* world of given name.
         WORLDPTR get_world( const std::string &name );
+        // Returns index for world name, 0 if world cannot be found.
+        size_t get_world_index( const std::string &name );
         bool has_world( const std::string &name ) const;
 
         void set_active_world( WORLDPTR world );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Update `last_world_pos` considerations"

#### Purpose of change

Several issues noted with current version, namely
- Saving the game and returning to the main menu does not update last_world_name properly
- last_world_pos returns wrong offset on deleting/creating a world.

First issue has been solved on DDA but I was unable to git blame the commit, though I was able to find the solution code. If someone is willing to step forward with the commit I will add them as co-author.

Second issue was solved on DDA as well, but produced more issues and in my opinion was inefficient.
- CleverRaven/Cataclysm-DDA#64795 and subsequently  CleverRaven/Cataclysm-DDA#65124 solved it via making `last_world_pos` a class variable and incrementing/decrementing it on world create/delete

In general, I believe that derived indexes should only be regenerated instead of modified, as this prevents any risk of segfaults and keeps the code easy to follow.

In a similar vein, I don't believe that such indexes should be saved as class variables, as you will need to remember to update them every single time you code for dependent value changes instead of letting it be regenerated.

#### Describe the solution

Added code to update `last_world_name` and `last_character_name` on saving the game.

Added `get_world_index()` function using existing `std::find` code. Now `last_world_pos` is updated every redraw. The effect of this on performance should be negligible on any half decent phone/computer.

#### Describe alternatives you've considered

- Regenerate last_world_pos only when world is created/destroyed.
  - Would be more performant, but as I consider the boost to be generally negligible, I've elected against it.

#### Testing

- [x] Create 5 worlds, and make a character in the third world. Save and return to the main menu.
- [x]  Check that pointer when in load menu defaults to the third world. Move to world tab and delete either world 1/2
- [x] Check that it still defaults to the correct world when in load menu. Move to world tab and delete one of the last 2 worlds
- [x] Check that it still defaults to the correct world when in load menu.
- [x] Add worlds above and below the correct world (order is alphabetical). Check that it still defaults to correct world in load menu.

#### Additional context