### PR TITLE
Fix UB in deferred loading.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -174,7 +174,6 @@ void DynamicDataLoader::load_deferred( deferred_json &data )
                     debugmsg( "(json-error)\n%s", err.what() );
                 }
             }
-            ++it;
             inp_mngr.pump_events();
         }
         auto it = data.begin();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -159,8 +159,9 @@ void DynamicDataLoader::load_deferred( deferred_json &data )
 {
     while( !data.empty() ) {
         const size_t n = data.size();
-        auto it = data.begin();
         for( size_t idx = 0; idx != n; ++idx ) {
+            auto it = data.begin();
+            std::advance(it, idx);
             if( !it->first.path ) {
                 debugmsg( "JSON source location has null path, data may load incorrectly" );
             } else {
@@ -176,6 +177,8 @@ void DynamicDataLoader::load_deferred( deferred_json &data )
             ++it;
             inp_mngr.pump_events();
         }
+        auto it = data.begin();
+        std::advance(it, n);
         data.erase( data.begin(), it );
         if( data.size() == n ) {
             for( const auto &elem : data ) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -161,7 +161,7 @@ void DynamicDataLoader::load_deferred( deferred_json &data )
         const size_t n = data.size();
         for( size_t idx = 0; idx != n; ++idx ) {
             auto it = data.begin();
-            std::advance(it, idx);
+            std::advance( it, idx );
             if( !it->first.path ) {
                 debugmsg( "JSON source location has null path, data may load incorrectly" );
             } else {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -178,7 +178,7 @@ void DynamicDataLoader::load_deferred( deferred_json &data )
             inp_mngr.pump_events();
         }
         auto it = data.begin();
-        std::advance(it, n);
+        std::advance( it, n );
         data.erase( data.begin(), it );
         if( data.size() == n ) {
             for( const auto &elem : data ) {


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix rare crash with too many mods"

#### Purpose of change

Prevent UB when the list is resized during iteration.

#### Describe the solution

Just std::advance using the index instead.

#### Describe alternatives you've considered

Rewriting it to just copy and clear the list first which would be preferable tbh.

#### Testing

No more UB with all the mods on my branch.