### PR TITLE
feat: drag heavier vehicles

### DIFF
--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -77,19 +77,13 @@ bool game::grabbed_veh_move( const tripoint &dp )
     // Make sure the mass and pivot point are correct
     grabbed_vehicle->invalidate_mass();
 
-    //vehicle movement: strength check
+    //vehicle movement: strength check. very strong humans can move about 2,000 kg in a wheelbarrow.
     int mc = 0;
-    int str_req = grabbed_vehicle->total_mass() / 25_kilogram; //strength required to move vehicle.
+    int str_req = grabbed_vehicle->total_mass() / 100_kilogram; //strength required to move vehicle.
+    // ARM_STR governs dragging heavy things
+    int str = u.get_str();
 
     //if vehicle is rollable we modify str_req based on a function of movecost per wheel.
-
-    // Vehicle just too big to grab & move; 41-45 lets folks have a bit of a window
-    // (Roughly 1.1K kg = danger zone; cube vans are about the max)
-    if( str_req > 45 ) {
-        add_msg( m_info, _( "The %s is too bulky for you to move by hand." ),
-                 grabbed_vehicle->name );
-        return true; // No shoving around an RV.
-    }
 
     const auto &wheel_indices = grabbed_vehicle->wheelcache;
     if( grabbed_vehicle->valid_wheel_config() ) {
@@ -107,10 +101,12 @@ bool game::grabbed_veh_move( const tripoint &dp )
         } else {
             str_req = mc / wheel_indices.size() + 1;
         }
+        //finally, adjust by the off-road coefficient (always 1.0 on a road, as low as 0.1 off road.)
+        str_req /= grabbed_vehicle->k_traction( get_map().vehicle_wheel_traction( *grabbed_vehicle ) );
     } else {
-        str_req++;
-        //if vehicle has no wheels str_req make a noise.
-        if( str_req <= u.get_str() ) {
+        str_req *= 10;
+        //if vehicle has no wheels str_req make a noise. since it has no wheels assume it has the worst off roading possible (0.1)
+        if( str_req <= str ) {
             sounds::sound( grabbed_vehicle->global_pos3(), str_req * 2, sounds::sound_t::movement,
                            _( "a scraping noise." ), true, "misc", "scraping" );
         }
@@ -121,9 +117,11 @@ bool game::grabbed_veh_move( const tripoint &dp )
     if( str_req <= u.get_str() ) {
         //calculate exertion factor and movement penalty
         ///\EFFECT_STR increases speed of dragging vehicles
-        u.moves -= 100 * str_req / std::max( 1, u.get_str() );
-        const int ex = dice( 1, 3 ) - 1 + str_req;
-        if( ex > u.get_str() + 1 ) {
+        u.moves -= 400 * str_req / std::max( 1, str );
+        ///\EFFECT_STR decreases stamina cost of dragging vehicles
+        u.mod_stamina( -200 * str_req / std::max( 1, str ) );
+        const int ex = dice( 1, 6 ) - 1 + str_req;
+        if( ex > str + 1 ) {
             // Pain and movement penalty if exertion exceeds character strength
             add_msg( m_bad, _( "You strain yourself to move the %s!" ), grabbed_vehicle->name );
             u.moves -= 200;

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -2,11 +2,13 @@
 
 #include <cstdlib>
 #include <algorithm>
+#include <numeric>
 
 #include "avatar.h"
 #include "map.h"
 #include "messages.h"
 #include "monster.h"
+#include "point.h"
 #include "sounds.h"
 #include "vehicle.h"
 #include "vpart_position.h"
@@ -17,6 +19,16 @@
 #include "units.h"
 
 static const efftype_id effect_harnessed( "harnessed" );
+
+namespace
+{
+auto make_scraping_noise( const tripoint &pos, const int volume ) -> void
+{
+    sounds::sound( pos, volume, sounds::sound_t::movement,
+                   _( "a scraping noise." ), true, "misc", "scraping" );
+}
+} // namespace
+
 
 bool game::grabbed_veh_move( const tripoint &dp )
 {
@@ -108,8 +120,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
         str_req *= 10;
         //if vehicle has no wheels str_req make a noise. since it has no wheels assume it has the worst off roading possible (0.1)
         if( str_req <= str ) {
-            sounds::sound( grabbed_vehicle->global_pos3(), str_req * 2, sounds::sound_t::movement,
-                           _( "a scraping noise." ), true, "misc", "scraping" );
+            make_scraping_noise( grabbed_vehicle->global_pos3(), str_req * 2 );
         }
     }
 

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -78,15 +78,16 @@ bool game::grabbed_veh_move( const tripoint &dp )
     grabbed_vehicle->invalidate_mass();
 
     //vehicle movement: strength check. very strong humans can move about 2,000 kg in a wheelbarrow.
-    int mc = 0;
     int str_req = grabbed_vehicle->total_mass() / 100_kilogram; //strength required to move vehicle.
     // ARM_STR governs dragging heavy things
-    int str = u.get_str();
+    const int str = u.get_str();
 
     //if vehicle is rollable we modify str_req based on a function of movecost per wheel.
 
     const auto &wheel_indices = grabbed_vehicle->wheelcache;
     if( grabbed_vehicle->valid_wheel_config() ) {
+        int mc = 0;
+
         //determine movecost for terrain touching wheels
         const tripoint vehpos = grabbed_vehicle->global_pos3();
         for( int p : wheel_indices ) {
@@ -114,7 +115,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
 
     //final strength check and outcomes
     ///\EFFECT_STR determines ability to drag vehicles
-    if( str_req <= u.get_str() ) {
+    if( str_req <= str ) {
         //calculate exertion factor and movement penalty
         ///\EFFECT_STR increases speed of dragging vehicles
         u.moves -= 400 * str_req / std::max( 1, str );
@@ -126,7 +127,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
             add_msg( m_bad, _( "You strain yourself to move the %s!" ), grabbed_vehicle->name );
             u.moves -= 200;
             u.mod_pain( 1 );
-        } else if( ex >= u.get_str() ) {
+        } else if( ex >= str ) {
             // Movement is slow if exertion nearly equals character strength
             add_msg( _( "It takes some time to move the %s." ), grabbed_vehicle->name );
             u.moves -= 200;


### PR DESCRIPTION
#### Summary

Balance "player can drag heavier vehicles"

#### Purpose of change

port https://github.com/CleverRaven/Cataclysm-DDA/pull/64867 by @anoobindisguise

#### Describe the solution

1. ported line changes.
2. extracted calculation functions from `grabbed_veh_move`.

#### Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/55ae56d4-0223-48f5-8a61-5c7ee7881931

