### PR TITLE
Explosions leave craters in the ground, update mapgen/MX craters accordingly

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -19,7 +19,14 @@
     "color": "yellow",
     "move_cost": 3,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_pit_shallow",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "items": [ { "item": "material_sand", "charges": [ 250, 500 ] } ]
+    }
   },
   {
     "type": "terrain",
@@ -31,14 +38,7 @@
     "looks_like": "t_dirt",
     "move_cost": 3,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": {
-      "sound": "thump",
-      "ter_set": "t_pit_shallow",
-      "str_min": 50,
-      "str_max": 100,
-      "str_min_supported": 100,
-      "items": [ { "item": "material_sand", "charges": [ 250, 500 ] } ]
-    }
+    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -225,7 +225,7 @@
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE" ],
     "bash": {
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -382,7 +382,7 @@
     "move_cost": 2,
     "looks_like": "t_dirtfloor",
     "flags": [ "TRANSPARENT", "FLAT", "DIGGABLE" ],
-    "bash": { "sound": "SMASH!", "ter_set": "t_null", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "SMASH!", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 400, "str_min_supported": 100 }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -8,7 +8,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -175,7 +175,7 @@
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE" ],
     "bash": {
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -193,7 +193,7 @@
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE" ],
     "bash": {
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -31,7 +31,14 @@
     "looks_like": "t_dirt",
     "move_cost": 3,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100, "items": [ { "item": "material_sand", "charges": [ 250, 500 ] } ] }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_pit_shallow",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "items": [ { "item": "material_sand", "charges": [ 250, 500 ] } ]
+    }
   },
   {
     "type": "terrain",
@@ -42,7 +49,14 @@
     "color": "light_red",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100, "items": [ { "item": "clay_lump", "count": [ 5, 10 ] } ] }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_pit_shallow",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "items": [ { "item": "clay_lump", "count": [ 5, 10 ] } ]
+    }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -19,7 +19,7 @@
     "color": "yellow",
     "move_cost": 3,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -31,7 +31,7 @@
     "looks_like": "t_dirt",
     "move_cost": 3,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100, "items": [ { "item": "material_sand", "charges": [ 250, 500 ] } ] }
   },
   {
     "type": "terrain",
@@ -42,7 +42,7 @@
     "color": "light_red",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100, "items": [ { "item": "clay_lump", "count": [ 5, 10 ] } ] }
   },
   {
     "type": "terrain",
@@ -91,7 +91,7 @@
     "color": "brown",
     "move_cost": 3,
     "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE", "PLANTABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100 },
+    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 50, "str_max": 100, "str_min_supported": 100 },
     "examine_action": "dirtmound"
   },
   {
@@ -107,7 +107,7 @@
     "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS" ],
     "bash": {
       "sound": "thump",
-      "ter_set": "t_null",
+      "ter_set": "t_dirtfloor",
       "str_min": 50,
       "str_max": 100,
       "str_min_supported": 100,

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -1986,7 +1986,7 @@
     "color": "green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 40, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -2010,7 +2010,7 @@
     "color": "green",
     "move_cost": 3,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -2023,7 +2023,7 @@
     "move_cost": 5,
     "coverage": 50,
     "flags": [ "TRANSPARENT", "DIGGABLE", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -2035,7 +2035,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "ter_set": "t_null", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -1963,7 +1963,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 40, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -1975,7 +1975,7 @@
     "color": "light_green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -1986,7 +1986,7 @@
     "color": "green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 40, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -1998,7 +1998,7 @@
     "color": "white",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -2047,7 +2047,7 @@
     "color": "light_green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "ter_set": "t_null", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 400, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -2059,7 +2059,7 @@
     "color": "white",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "ter_set": "t_null", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 400, "str_min_supported": 100 }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -1963,7 +1963,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 40, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-fungal.json
+++ b/data/json/furniture_and_terrain/terrain-fungal.json
@@ -24,7 +24,7 @@
     "bash": {
       "sound": "smash",
       "//": "muffled because fungus",
-      "ter_set": "t_null",
+      "ter_set": "t_pit_shallow",
       "str_min": 20,
       "str_max": 400,
       "str_min_supported": 50

--- a/data/json/furniture_and_terrain/terrain-traps.json
+++ b/data/json/furniture_and_terrain/terrain-traps.json
@@ -8,7 +8,7 @@
     "color": "yellow",
     "move_cost": 8,
     "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_pit", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -20,7 +20,7 @@
     "move_cost": 10,
     "trap": "tr_pit",
     "flags": [ "TRANSPARENT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true },
+    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true },
     "examine_action": "pit"
   },
   {

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -1089,7 +1089,7 @@
     "color": "brown",
     "move_cost": 0,
     "coverage": 100,
-    "roof": "t_dirt",
+    "roof": "t_thatch_roof",
     "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT" ],
     "bash": {
       "str_min": 12,

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -118,7 +118,7 @@
       "sound_volume": 0,
       "sound_msg": "Tick.",
       "no_deactivate_msg": "You've already set the %s's timer, you might want to get away from it.",
-      "explosion": { "damage": 200, "radius": 8 }
+      "explosion": { "damage": 200, "radius": 6 }
     },
     "flags": [ "TRADER_AVOID" ]
   },

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1616,6 +1616,10 @@ static bool mx_crater( map &m, const tripoint &abs_sub )
             //Pythagoras to the rescue, x^2 + y^2 = hypotenuse^2
             if( !trigdist || ( i - p.x ) * ( i - p.x ) + ( j - p.y ) * ( j - p.y ) <= size_squared ) {
                 m.destroy( tripoint( i,  j, abs_sub.z ), true );
+                // Make the resulting crater a bit more shallow if needed.
+                if( m.ter( tripoint( i, j, abs_sub.z ) ) == t_pit ) {
+                    m.ter_set( tripoint( i,  j, abs_sub.z ), t_pit_shallow );
+                }
                 m.adjust_radiation( point( i, j ), rng( 20, 40 ) );
             }
         }

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -214,7 +214,7 @@ void mapgen_crater( mapgendata &dat )
         for( int j = 0; j < SEEY * 2; j++ ) {
             if( rng( 0, dat.w_fac ) <= i && rng( 0, dat.e_fac ) <= SEEX * 2 - 1 - i &&
                 rng( 0, dat.n_fac ) <= j && rng( 0, dat.s_fac ) <= SEEX * 2 - 1 - j ) {
-                m->ter_set( point( i, j ), t_dirt );
+                m->ter_set( point( i, j ), t_pit_shallow );
                 m->make_rubble( tripoint( i,  j, m->get_abs_sub().z ), f_rubble_rock );
                 m->set_radiation( point( i, j ), rng( 0, 4 ) * rng( 0, 2 ) );
             } else {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Features "Explosions blast terrain down to shallow and deep pits to form craters, before finally punching through z-levels"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So for quite a while I've wanted to make it so that explosions can leave craters on the ground instead of always punching big, janky holes in the floor. I recall running into problems last time I tried this, but I think I found what I did wrong.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

JSON changes:
- [X] Set it so that dirt and grass terrain consistently turn into shallow pits when bashed, and no longer call `bash_below`.
- [X] Related: fixed grass, dirt, and especially dead grass all having different bash strengths.
- [X] Shallow pits in turn convert into deep pits when bashed, and don't call `bash_below`.
- [X] Deep pits meanwhile gain the bash stats of rock floors, on the basis that at this point blasting through it would entail effectively cracking through into the stone underneath.
- [X] Converted other relevant misc terrain that should turn into dirt and/shallow pits to not use `t_null`. I left a good bunch of it still set to turn into the underlying terrain's roof because there's no certainly if something like a door frame or interior floor will be on the surface level, underground, or above-ground.
- [X] Per feedback, reduced radius of C-4 to match that of other comparable handheld demo explosives, from a radius of 8 to 6. This also seems to make them less eager to knock holes in the dirt under the new explosions system.
- [x] Fixing a skippable load error: root walls don't like the fact that dirt no longer counts as bashing below.

C++ changes:
- [X] Set mapgen craters to build the rubble piles on shallow pits instead of bare dirt for consistency.
- [X] Likewise, set it so map extra craters place shallow pits if it blasted the terrain down enough.

A note on that while I'm at it: Having `bash_below` turned on has some weird, janky behavior if you try to implement decent-looking craters. It will let the explosion propagate down and then fill the "crater" with patches of rock floor.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding shallow and deep craters to rock floors, that can't normally be dug (unless we added that as a thing for pickaxes/jackhammers) but can be used to add crater support for underground layers.
2. Splitting up the assorted spaghetti that `bash_below` controls so that we can still turn some behaviors back on for regular dirt while leaving others disabled.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected JSON files for syntax and lint errors.
2. Compiled and load-tested.
3. Set off C-4 on open ground and observed the results.
4. Also checked that mapgen and map extra craters looked decent.
5. Checked affected C++ files for astyle.

C-4 Before, RoC Explosions:
![Before, RoC Explosions](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/0e44f9c3-0830-43fc-abff-86fc74ccfa82)

C-4 Before, Legacy Explosions:
![Before, Legacy Explosions](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/3124f1bf-432e-4405-8c9d-f6150ceaa264)

C-4 After, RoC Explosions:
![After, RoC Explosions](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/6ee10764-ff68-4bf0-8641-9de6bc04432e)

C-4 After, Legacy Explosions:
![After, Legacy Explosions](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/832d938d-a430-4edc-9c7e-092a6fc0bc88)

**Bonus:**

Mapgen crater, after shoveling out a few tiles:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/de77058b-866f-4dda-9567-1c3180174675)

Map extra crater, open ground:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/43159e7a-f6c3-4569-8bc0-d4a1353be1d8)

Map extra crater, building:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/9d76961d-dbd8-492b-8327-9f4785d4c2fb)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
