### PR TITLE
Expand recipe options for chili con carne

### DIFF
--- a/data/json/recipes/food/meat.json
+++ b/data/json/recipes/food/meat.json
@@ -801,7 +801,7 @@
     "time": "20 m",
     "charges": 2,
     "batch_time_factors": [ 80, 5 ],
-    "book_learn": [ [ "cookbook_italian", 2 ] ],
+    "book_learn": [ [ "cookbook_italian", 2 ], [ "cookbook", 2 ], [ "family_cookbook", 2 ] ],
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 8, "LIST" ] ] ],
     "components": [
@@ -814,11 +814,22 @@
         [ "dry_mushroom", 2 ],
         [ "morel_cooked", 2 ],
         [ "mushroom_cooked", 2 ],
-        [ "dry_veggy", 2 ]
+        [ "dry_veggy", 2 ],
+        [ "can_beans", 1 ],
+        [ "raw_beans", 1 ],
+        [ "dry_beans", 1 ],
+        [ "dry_lentils", 1 ],
+        [ "raw_lentils", 1 ]
       ],
-      [ [ "tomato", 1 ], [ "irradiated_tomato", 1 ], [ "can_tomato", 1 ] ],
+      [
+        [ "tomato", 1 ],
+        [ "irradiated_tomato", 1 ],
+        [ "can_tomato", 1 ],
+        [ "irradiated_onion", 1 ],
+        [ "onion", 1 ],
+        [ "garlic_clove", 1 ]
+      ],
       [ [ "meat_red", 1, "LIST" ], [ "dry_meat", 1 ], [ "can_chicken", 1 ] ],
-      [ [ "can_beans", 1 ], [ "raw_beans", 1 ], [ "dry_beans", 1 ] ],
       [ [ "chilly-p", 2 ], [ "chili_pepper", 1 ] ]
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Adjust chili recipe to make more feasible to craft and satisfy chili nerds"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Chili. It's always an interesting food item, but also one that is an endless source of arguments about what goes in it. Down in my part of the US it generally doesn't include beans or tomatoes (maybe, honestly for every 2-3 people online I've seen insist Texas-style chili doesn't have beans, I've seen 1 dissenting opinion insisting it should have it), but those ingredients are standard in other parts of the US.

The easiest way to allow both styles both would be to adjust the recipe a lil, so that the ingredients list reasonably allows the player to construct a version suiting either preference. This also improves availability of the recipe by making some of the recipe's component slots easier to fill in other gameplay contexts like innawoods.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Merged the extra veggies ingredient together with the beans, so the player can pick those as alternatives to beans if desired. Also helps make it more feasible to make innawoods since wild veggies and mushrooms are potential forage results. Also added lentils as an alternative, as the curry meat recipe directly above it does.
2. Added onions and garlic as alternatives to the tomatos. Picked that since the beans and veggies are more fitting for a filler role, while tomatoes are more likely to be added for their taste, for the same reason some recipes include onion and/or garlic. Also further reduces blockers to making this innawoods since garlic can be foraged, making chili peppers the main thing you'll need to find (plus the relevant book if you didn't start with cooking skill for that delicious QoL like I always do).
3. Added it Cooking on a Budget and Family Cookbook to its booklearn options. Having it be only in Cucina Italica is kinda weird, and I assume someone figured that Italian-style chili exists ergo it's a good-enough hack since no one's added a dedicated cookbook for Mexican cuisine yet.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Flour and cornflour is sometimes used as a thickener and filler, this could potentially be thrown into the recipe in the beans slot instead, and possibly in return moving the veggies and shrooms into the tomato/onion/garlic slot.
2. Allowing it to autolearn at any particular level?
3. Adding canning recipes at some point, possibly as a follow-up PR once the ingredients have been settled.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected file for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

One variation of Texas-style chili that uses meat, fat (notably absent from above discussion, I suspect adding it to the filler slot would be good but much more likely to fuck up the comestible test), salt, onion, garlic, and chili powder: https://www.youtube.com/watch?v=vM6nkG4vP0Q