### PR TITLE
Temperature for food that can rot is displayed in tagtext

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9065,7 +9065,7 @@ bool item::process_rot( const bool seals, const tripoint &pos,
     // If we're still here, mark how cold it is so we can apply tagtext to items
     // FIXME: this might cause issues with performance, move the comparision
     // directly to item::tname once #2250 lands
-    if( temp <= 0_c ) {
+    if( temp <= temperatures::freezing ) {
         unset_flag( flag_COLD );
         set_flag( flag_VERY_COLD );
     } else if( temp <= temperatures::root_cellar ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4699,6 +4699,11 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         } else if( is_fresh() ) {
             tagtext += _( " (fresh)" );
         }
+        if( has_flag( "COLD" ) ) {
+            tagtext += _( " (cold)" );
+        } else if( has_flag( "VERY_COLD" ) ) {
+            tagtext += _( " (very cold)" );
+        }
     }
 
     const sizing sizing_level = get_sizing( you, get_encumber( you ) != 0 );
@@ -9053,6 +9058,17 @@ bool item::process_rot( const bool seals, const tripoint &pos,
         last_rot_check = now;
 
         return has_rotten_away() && carrier == nullptr && !seals;
+    }
+    // If we're still here, mark how cold it is so we can apply tagtext to items
+    if ( temp <= 32_f ) {
+        unset_flag( "COLD" );
+        set_flag( "VERY_COLD" );
+    } else if ( temp <= 43_f ) {
+        set_flag( "COLD" );
+        unset_flag( "VERY_COLD" );
+    } else {
+        unset_flag( "COLD" );
+        unset_flag( "VERY_COLD" );
     }
 
     return false;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -282,6 +282,9 @@ static const activity_id ACT_PICKUP( "ACT_PICKUP" );
 
 static const matec_id rapid_strike( "RAPID" );
 
+static const std::string flag_COLD( "COLD" );
+static const std::string flag_VERY_COLD( "VERY_COLD" );
+
 class npc_class;
 
 using npc_class_id = string_id<npc_class>;
@@ -4699,9 +4702,9 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         } else if( is_fresh() ) {
             tagtext += _( " (fresh)" );
         }
-        if( has_flag( "COLD" ) ) {
+        if( has_flag( flag_COLD ) ) {
             tagtext += _( " (cold)" );
-        } else if( has_flag( "VERY_COLD" ) ) {
+        } else if( has_flag( flag_VERY_COLD ) ) {
             tagtext += _( " (very cold)" );
         }
     }
@@ -9060,15 +9063,17 @@ bool item::process_rot( const bool seals, const tripoint &pos,
         return has_rotten_away() && carrier == nullptr && !seals;
     }
     // If we're still here, mark how cold it is so we can apply tagtext to items
-    if ( temp <= 32_f ) {
-        unset_flag( "COLD" );
-        set_flag( "VERY_COLD" );
-    } else if ( temp <= 43_f ) {
-        set_flag( "COLD" );
-        unset_flag( "VERY_COLD" );
+    // FIXME: this might cause issues with performance, move the comparision
+    // directly to item::tname once #2250 lands
+    if( temp <= 0_c ) {
+        unset_flag( flag_COLD );
+        set_flag( flag_VERY_COLD );
+    } else if( temp <= temperatures::root_cellar ) {
+        set_flag( flag_COLD );
+        unset_flag( flag_VERY_COLD );
     } else {
-        unset_flag( "COLD" );
-        unset_flag( "VERY_COLD" );
+        unset_flag( flag_COLD );
+        unset_flag( flag_VERY_COLD );
     }
 
     return false;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Features "Show (cold) or (very cold) for perishable food to indicate when fridges, freezers, root cellars etc are working at a glance"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

One of the classic things I've been hoping to bring back was to make it so that storing food in a working fridge or freezer, or other conditions where the food is technically considered cold, would display a tagtext to make it easier for the player to see their fridge is actually working. Basically one of the main advantage of DDA's freezing system that was lost when the mechanic got purged for performance reasons.

Bringing it back wholesale seems like it'd be a pain in the ass to do and might still have performance worries, so adapting the current food preservation mechanics to at least accomplish that goal works too.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In `item::process_rot`, took advantage of the fact that item temp is looked at here as a place to mark the item when relevant with a flag that gets used in another function.
2. In `item::tname`, set it so the item gets if one of the above flags is set, applying the tagtext `(cold)` for items in a working fridge or root cellar, and `(very cold)` (not frozen to avoid confusion with DDA's mechanics) when in freezer conditions.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Figuring out how to get `item::tname` to look up item temperature flag, problem was I couldn't figure out how to grab the item location from in there.
2. Saying "fuck it" and struggling to bring back freshly-frozen hot meat all over again just so we can then lobotomize it by removing the annoying inedibility mechanics.
3. Using Celsius in the bit of code added to rot processing, in a function that otherwise uses Fahrenheit currently, so that Scarf will be slightly less sad.
4. Pestering Coolthulhu to do it for me and actually going to bed instead of staying up until almost 4 AM. :<

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Tested that clean water, protein rations, and cooked meat all did not display any extra tagtext when spawned in, picked up, after waiting a little bit, etc while just standing around since starting temp was just over 40.
3. Spawned in a root celler and tested it in mid-summer, appropriate food left in there for a bit shows as cold.
3. Spawned in a fridge and minifreezer after getting some power generated, confirmed that they respectively mark cooked meat as cold and very cold after waiting a bit after activating them.
5. Did the same test with a food truck, confirmed while it was on food able to show status would update accordingly.
6. Tested that after taking cold and very cold food out, it would soon update status.
7. Set time to midnight in mid-winter, confirmed that relevant food was showing as very cold even on the floor or in character inventory.
8. Checked affected file for astyle.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/57a7dcd6-29f5-47d0-81cc-e86111210eeb)

Two consideration here:
1. Current placement of the relevant tagtext means only food that can rot will show temperature status. Since this doesn't yet bring back the morale effects of cold drinks, it's probably for the best that it only show the status for items that are actually affected by it in any way.
2. I based the threshold for "cold" off what game_constants.h says will be applied by underground and the root cellar, so 43 F instead of what the same file says counts as the proper threshold for calling it cold (40 F). This was so that the player will also get a hint that underground conditions and root cellars help with food storage too.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
