### PR TITLE
Make unloading faction owned items be considered stealing

### DIFF
--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -3,6 +3,7 @@
 #include "activity_handlers.h"
 #include "avatar.h"
 #include "character_functions.h"
+#include "consumption.h"
 #include "fault.h"
 #include "field_type.h"
 #include "game.h"
@@ -646,32 +647,11 @@ static bool add_or_drop_with_msg( avatar &you, item &it, bool unloading )
     return true;
 }
 
-//Taken from consumption.cpp with the value reset here to keep asking as this is not a public function in consumption.cpp
-static bool query_interaction_ownership( item &target, avatar &you )
-{
-
-    if( you.get_value( "THIEF_MODE_KEEP" ) != "YES" ) {
-        you.set_value( "THIEF_MODE", "THIEF_ASK" );
-    }
-    if( !target.is_owned_by( you, true ) ) {
-        bool choice = true;
-        if( you.get_value( "THIEF_MODE" ) == "THIEF_ASK" ) {
-            choice = pickup::query_thief();
-        }
-        if( you.get_value( "THIEF_MODE" ) == "THIEF_HONEST" || !choice ) {
-            return false;
-        }
-        //Makes them warn you in the same way as when you eat food - possibly need to change to confront.
-        handle_theft_witnesses( you, target.get_owner() );
-    }
-    return true;
-}
-
 bool unload_item( avatar &you, item_location loc )
 {
     item &it = *loc.get_item();
     //Give the player the same options as when attempting to eat food that doesn't belong to them, bomb out if they say no.
-    if( !query_interaction_ownership( it, you ) ) {
+    if( !query_consume_ownership( it, you ) ) {
         return false;
     }
     // Unload a container consuming moves per item successfully removed

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -16,7 +16,6 @@
 #include "npc.h"
 #include "options.h"
 #include "output.h"
-#include "pickup.h"
 #include "skill.h"
 #include "trap.h"
 #include "veh_type.h"

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -15,6 +15,7 @@
 #include "npc.h"
 #include "options.h"
 #include "output.h"
+#include "pickup.h"
 #include "skill.h"
 #include "trap.h"
 #include "veh_type.h"
@@ -645,9 +646,34 @@ static bool add_or_drop_with_msg( avatar &you, item &it, bool unloading )
     return true;
 }
 
+//Taken from consumption.cpp with the value reset here to keep asking as this is not a public function in consumption.cpp
+static bool query_interaction_ownership( item &target, avatar &you )
+{
+	
+	if( you.get_value( "THIEF_MODE_KEEP" ) != "YES" ) {
+        you.set_value( "THIEF_MODE", "THIEF_ASK" );
+    }
+    if( !target.is_owned_by( you, true ) ) {
+        bool choice = true;
+        if( you.get_value( "THIEF_MODE" ) == "THIEF_ASK" ) {
+            choice = pickup::query_thief();
+        }
+        if( you.get_value( "THIEF_MODE" ) == "THIEF_HONEST" || !choice ) {
+            return false;
+        }
+		//Makes them warn you in the same way as when you eat food - possibly need to change to confront.
+        handle_theft_witnesses( you, target.get_owner() );
+    }
+    return true;
+}
+
 bool unload_item( avatar &you, item_location loc )
 {
     item &it = *loc.get_item();
+	//Give the player the same options as when attempting to eat food that doesn't belong to them, bomb out if they say no.
+	if(!query_interaction_ownership( it, you ) ) {
+        return false;
+    }
     // Unload a container consuming moves per item successfully removed
     if( it.is_container() || it.is_bandolier() ) {
         if( it.contents.empty() ) {

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -670,8 +670,8 @@ static bool query_interaction_ownership( item &target, avatar &you )
 bool unload_item( avatar &you, item_location loc )
 {
     item &it = *loc.get_item();
-	//Give the player the same options as when attempting to eat food that doesn't belong to them, bomb out if they say no.
-	if(!query_interaction_ownership( it, you ) ) {
+    //Give the player the same options as when attempting to eat food that doesn't belong to them, bomb out if they say no.
+    if( !query_interaction_ownership( it, you ) ) {
         return false;
     }
     // Unload a container consuming moves per item successfully removed

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -661,7 +661,7 @@ static bool query_interaction_ownership( item &target, avatar &you )
         if( you.get_value( "THIEF_MODE" ) == "THIEF_HONEST" || !choice ) {
             return false;
         }
-		//Makes them warn you in the same way as when you eat food - possibly need to change to confront.
+        //Makes them warn you in the same way as when you eat food - possibly need to change to confront.
         handle_theft_witnesses( you, target.get_owner() );
     }
     return true;

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -649,8 +649,8 @@ static bool add_or_drop_with_msg( avatar &you, item &it, bool unloading )
 //Taken from consumption.cpp with the value reset here to keep asking as this is not a public function in consumption.cpp
 static bool query_interaction_ownership( item &target, avatar &you )
 {
-	
-	if( you.get_value( "THIEF_MODE_KEEP" ) != "YES" ) {
+
+    if( you.get_value( "THIEF_MODE_KEEP" ) != "YES" ) {
         you.set_value( "THIEF_MODE", "THIEF_ASK" );
     }
     if( !target.is_owned_by( you, true ) ) {

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1471,8 +1471,12 @@ item &Character::get_consumable_from( item &it ) const
     return null_comestible;
 }
 
-static bool query_consume_ownership( item &target, avatar &you )
+bool query_consume_ownership( item &target, avatar &you )
 {
+	//Add in a reset here to make sure user keeps getting asked if not set to keep thief setting
+	if( you.get_value( "THIEF_MODE_KEEP" ) != "YES" ) {
+        you.set_value( "THIEF_MODE", "THIEF_ASK" );
+    }
     if( !target.is_owned_by( you, true ) ) {
         bool choice = true;
         if( you.get_value( "THIEF_MODE" ) == "THIEF_ASK" ) {

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1473,8 +1473,8 @@ item &Character::get_consumable_from( item &it ) const
 
 bool query_consume_ownership( item &target, avatar &you )
 {
-	//Add in a reset here to make sure user keeps getting asked if not set to keep thief setting
-	if( you.get_value( "THIEF_MODE_KEEP" ) != "YES" ) {
+    //Add in a reset here to make sure user keeps getting asked if not set to keep thief setting
+    if( you.get_value( "THIEF_MODE_KEEP" ) != "YES" ) {
         you.set_value( "THIEF_MODE", "THIEF_ASK" );
     }
     if( !target.is_owned_by( you, true ) ) {

--- a/src/consumption.h
+++ b/src/consumption.h
@@ -28,7 +28,6 @@ struct consumption_history_t {
     void serialize( JsonOut &json ) const;
     void deserialize( JsonIn &jsin );
 };
-	
 bool query_consume_ownership( item &target, avatar &you );
 
 #endif // CATA_SRC_CONSUMPTION_H

--- a/src/consumption.h
+++ b/src/consumption.h
@@ -28,5 +28,7 @@ struct consumption_history_t {
     void serialize( JsonOut &json ) const;
     void deserialize( JsonIn &jsin );
 };
+	
+bool query_consume_ownership( item &target, avatar &you );
 
 #endif // CATA_SRC_CONSUMPTION_H


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Make unloading faction owned items be considered stealing"

#### Purpose of change

Fixes #2491 - makes it so that unloading an owned item is seen as stealing by the owned faction in the same way as eating owned food is

#### Describe the solution

Borrowing from the system already in place for dealing with eating stolen food, I added the following:

- add and inherit for "pickup.h" to "avatar_functions.cpp" to leverage the same thief selection menu as when picking up a stolen item (Yes, No, Always, Never)
- Create function query_interaction_ownership copying from query_consume_ownership, using the same functions (query_thief, handle_theft witnesses) but with a reset for THIEF_MODE if THIEF_MODE_KEEP is not set to YES
-  Add a check using query_interaction_ownership - if the function returns false the player has chosen not to steal the item and the unload also stops at that moment before continuing

#### Describe alternatives you've considered

This possibly needs expanding to match the pickup theft code i.e. NPC's confronting the player directly and stopping the theft as with pickup, however this will need some more code to accomplish

#### Testing

Loaded into debug and release build

- Teleported to refugee center
- Went to arsonist (independent faction) and unloaded fuses and fertilizer, checked that got stealing messages
- Went into back room, unloaded salt water onto ground and checked that still counted as stealing
- Stole 3 more items via unload and made sure that the faction warning system is working - NPC's get angry

#### Additional context
Unloading items from the arsonists sofa
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/dee277ba-4ef3-4635-97b8-14d16fc6969a)
Options menu when trying to do so
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/79d17967-dfda-41f5-8a6a-d1bc7581f06a)
Saying no cancels the action
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/8568141c-0213-4063-9ce9-2d5cb0a37400)
Saying yes unloads the item into your inventory and causes thief shout from nearby faction NPC's just like eating owned food
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/5710fc41-9998-48e3-957f-1b5387c17e93)
Steal enough things and people get pissed off
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/b184ce39-becc-4cca-8f86-ad99420a0351)

