### PR TITLE
Added in new shields

### DIFF
--- a/data/json/itemgroups/art_antiques_crafts.json
+++ b/data/json/itemgroups/art_antiques_crafts.json
@@ -135,7 +135,7 @@
       { "item": "canteen_wood", "prob": 5 },
       { "item": "shield_wooden", "prob": 3 },
       { "item": "shield_wooden_large", "prob": 3 },
-      [ "item": "shield_banded", "prob": 3 ],
+      { "item": "shield_banded", "prob": 3 },
       { "item": "shield_banded_large", "prob": 3 },
       { "item": "apron_leather", "prob": 1 },
       { "item": "pot_copper", "prob": 3 },

--- a/data/json/itemgroups/art_antiques_crafts.json
+++ b/data/json/itemgroups/art_antiques_crafts.json
@@ -135,6 +135,7 @@
       { "item": "canteen_wood", "prob": 5 },
       { "item": "shield_wooden", "prob": 3 },
       { "item": "shield_wooden_large", "prob": 3 },
+      [ "item": "shield_banded", "prob": 3 ],
       { "item": "apron_leather", "prob": 1 },
       { "item": "pot_copper", "prob": 3 },
       { "group": "tinware", "prob": 10 }

--- a/data/json/itemgroups/art_antiques_crafts.json
+++ b/data/json/itemgroups/art_antiques_crafts.json
@@ -136,6 +136,7 @@
       { "item": "shield_wooden", "prob": 3 },
       { "item": "shield_wooden_large", "prob": 3 },
       [ "item": "shield_banded", "prob": 3 ],
+      { "item": "shield_banded_large", "prob": 3 },
       { "item": "apron_leather", "prob": 1 },
       { "item": "pot_copper", "prob": 3 },
       { "group": "tinware", "prob": 10 }

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -120,7 +120,7 @@
     "bashing": 8,
     "material": [ "wood", "steel" ],
     "looks_like": "shield_wooden",
-    "symbol": "x",
+    "symbol": "[",
     "color": "blue",
     "covers": [ "arm_either", "hand_either" ],
     "coverage": 90,

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -130,6 +130,7 @@
   {
     "id": "shield_leather_large",
     "copy-from": "shield_leather",
+    "looks_like": "shield_wooden_large",
     "type": "ARMOR",
     "name": { "str": "large leather shield" },
     "description": "A large shield made of wood with leather reinforcement.  Sturdier and stronger than a basic wooden shield, and less encumbering than a metal one.",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -88,7 +88,7 @@
   {
     "id": "shield_leather",
     "type": "ARMOR",
-    "name": { "str": "leather reinforced shield" },
+    "name": { "str": "leather-reinforced shield" },
     "description": "A simple round shield made of wood with leather reinforcement.  Sturdier and stronger than a simple wooden shield, and less encumbering than a metal one.",
     "weight": "3200 g",
     "volume": "3 L",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -98,7 +98,7 @@
     "bashing": 8,
     "material": [ "wood", "leather" ],
     "looks_like": "shield_wooden",
-    "symbol": "x",
+    "symbol": "[",
     "color": "blue",
     "covers": [ "arm_either", "hand_either" ],
     "coverage": 90,

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -96,6 +96,7 @@
     "price_postapoc": "8 USD",
     "to_hit": -1,
     "bashing": 8,
+    "//": "Wood-only to prevent repairing it via sewing.",
     "material": [ "wood" ],
     "looks_like": "shield_wooden",
     "symbol": "[",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -158,6 +158,6 @@
     "price_postapoc": "14 USD",
     "encumbrance": 30,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
+    "extend": { "flags": [ "STURDY" ] }
   }
 ]

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -95,7 +95,7 @@
     "price": "80 USD",
     "price_postapoc": "8 USD",
     "bashing": 8,
-    "material": ["wood", "leather"],
+    "material": [ "wood", "leather" ],
     "looks_like": "shield_wooden",
     "symbol": "x",
     "color": "blue",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -130,6 +130,7 @@
   {
    "id": "shield_leather_large",
    "copy-from": "shield_leather",
+   "type": "ARMOR",
    "name": { "str": "large leather shield" },
    "description": "A large shield made of wood with leather reinforcement.  Sturdier and stronger than a basic wooden shield, and less encumbering than a metal one.",
    "volume": "5 L",
@@ -143,6 +144,7 @@
   {
    "id": "shield_banded_large",
    "copy-from": "shield_banded",
+   "type": "ARMOR",
    "name": { "str": "large banded shield" },
    "description": "A large shield made of wood with steel bands reinforcing it.",
    "volume": "5 L",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -111,7 +111,7 @@
     "id": "shield_banded",
     "type": "ARMOR",
     "name": { "str": "banded shield" },
-    "description": "A simple round shield made of wood with bands of steel reinforcing it.",
+    "description": "A simple round shield made of wood with bands of steel reinforcing it.  Stronger than a simple wooden shield, but also more encumbering.",
     "weight": "3400 g",
     "volume": "3 L",
     "price": "100 USD",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -143,7 +143,7 @@
     "price_postapoc": "10 USD",
     "encumbrance": 26,
     "techniques": [ "WBLOCK_3" ],
-    "extend": { "flags": [ "STURDY" ] },
+    "extend": { "flags": [ "STURDY" ] }
   },
   {
     "id": "shield_banded_large",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -142,17 +142,17 @@
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   },
   {
-   "id": "shield_banded_large",
-   "copy-from": "shield_banded",
-   "type": "ARMOR",
-   "name": { "str": "large banded shield" },
-   "description": "A large shield made of wood with steel bands reinforcing it.",
-   "volume": "5 L",
-   "weight": "5200 g",
-   "price": "120 USD",
-   "price_postapoc": "14 USD",
-   "encumbrance": 26,
-   "material_thickness": 4,
-   "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
+    "id": "shield_banded_large",
+    "copy-from": "shield_banded",
+    "type": "ARMOR",
+    "name": { "str": "large banded shield" },
+    "description": "A large shield made of wood with steel bands reinforcing it.",
+    "volume": "5 L",
+    "weight": "5200 g",
+    "price": "120 USD",
+    "price_postapoc": "14 USD",
+    "encumbrance": 26,
+    "material_thickness": 4,
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   }
 ]

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -152,7 +152,7 @@
     "name": { "str": "large banded shield" },
     "description": "A large shield made of wood with steel bands reinforcing it.",
     "volume": "5 L",
-    "weight": "5200 g",
+    "weight": "5400 g",
     "price": "120 USD",
     "price_postapoc": "14 USD",
     "encumbrance": 26,

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -116,6 +116,7 @@
     "volume": "3 L",
     "price": "100 USD",
     "price_postapoc": "10 USD",
+    "to_hit": -1,
     "bashing": 8,
     "material": [ "wood", "steel" ],
     "looks_like": "shield_wooden",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -145,6 +145,7 @@
   {
     "id": "shield_banded_large",
     "copy-from": "shield_banded",
+    "looks_like": "shield_wooden_large",
     "type": "ARMOR",
     "name": { "str": "large banded shield" },
     "description": "A large shield made of wood with steel bands reinforcing it.",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -84,5 +84,59 @@
     "environmental_protection": 2,
     "techniques": [ "WBLOCK_2" ],
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+  },
+  {
+    "id": "shield_leather",
+    "type": "ARMOR",
+    "name": { "str": "leather reinforced shield" },
+    "description": "A simple round shield made of wood with leather reinforcement.  Sturdier and stronger than a simple wooden shield, and less encumbering than a metal one.",
+    "weight": "3200 g",
+    "volume": "3 L",
+    "price": 110000,
+    "bashing": 8,
+    "material": ["wood", "leather"],
+    "looks_like": "shield_wooden",
+    "symbol": "x",
+    "color": "blue",
+    "covers": ["arm_either", "hand_either"],
+    "coverage": 90,
+    "encumbrance": 16,
+    "material_thickness": 4,
+    "techniques": ["WBLOCK_2"],
+    "flags": [
+      "OVERSIZE",
+      "BELTED",
+      "RESTRICT_HANDS",
+      "BLOCK_WHILE_WORN",
+      "NONCONDUCTIVE",
+      "STURDY"
+    ]
+  },
+  {
+    "id": "shield_banded",
+    "type": "ARMOR",
+    "name": { "str": "banded shield" },
+    "description": "A simple round shield made of wood with bands of steel reinforcing it.",
+    "weight": "3400 g",
+    "volume": "3 L",
+    "price": 110000,
+    "bashing": 8,
+    "material": ["wood", "steel"],
+    "looks_like": "shield_wooden",
+    "symbol": "x",
+    "color": "blue",
+    "covers": ["arm_either", "hand_either"],
+    "coverage": 90,
+    "encumbrance": 20,
+    "material_thickness": 4,
+    "techniques": ["WBLOCK_2"],
+    "flags": [
+      "OVERSIZE",
+      "BELTED",
+      "RESTRICT_HANDS",
+      "BLOCK_WHILE_WORN",
+      "NONCONDUCTIVE",
+      "STURDY"
+    ]
   }
 ]

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -124,7 +124,7 @@
     "coverage": 90,
     "encumbrance": 20,
     "material_thickness": 4,
-    "techniques": ["WBLOCK_2"],
+    "techniques": [ "WBLOCK_2" ],
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "NONCONDUCTIVE", "STURDY" ]
   },
   {

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -96,7 +96,7 @@
     "price_postapoc": "8 USD",
     "to_hit": -1,
     "bashing": 8,
-    "material": [ "wood", "leather" ],
+    "material": [ "wood" ],
     "looks_like": "shield_wooden",
     "symbol": "[",
     "color": "blue",
@@ -141,6 +141,7 @@
     "price": "80 USD",
     "price_postapoc": "10 USD",
     "encumbrance": 26,
+    "techniques": [ "WBLOCK_3" ],
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   },
   {
@@ -155,6 +156,7 @@
     "price": "120 USD",
     "price_postapoc": "14 USD",
     "encumbrance": 26,
+    "techniques": [ "WBLOCK_3" ],
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   }
 ]

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -155,7 +155,7 @@
     "weight": "5400 g",
     "price": "120 USD",
     "price_postapoc": "14 USD",
-    "encumbrance": 26,
+    "encumbrance": 30,
     "techniques": [ "WBLOCK_3" ],
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   }

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -150,7 +150,7 @@
     "looks_like": "shield_wooden_large",
     "type": "ARMOR",
     "name": { "str": "large banded shield" },
-    "description": "A large shield made of wood with steel bands reinforcing it.",
+    "description": "A large shield made of wood with steel bands reinforcing it.  Stronger than a simple wooden shield, but also more encumbering.",
     "volume": "5 L",
     "weight": "5400 g",
     "price": "120 USD",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -142,6 +142,7 @@
     "price_postapoc": "10 USD",
     "encumbrance": 26,
     "material_thickness": 4,
+    "techniques": [ "WBLOCK_3" ],
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   },
   {
@@ -157,6 +158,7 @@
     "price_postapoc": "14 USD",
     "encumbrance": 26,
     "material_thickness": 4,
+    "techniques": [ "WBLOCK_3" ],
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   }
 ]

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -103,7 +103,7 @@
     "coverage": 90,
     "encumbrance": 16,
     "material_thickness": 4,
-    "techniques": ["WBLOCK_2"],
+    "techniques": [ "WBLOCK_2" ],
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   },
   {

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -143,7 +143,7 @@
     "price_postapoc": "10 USD",
     "encumbrance": 26,
     "techniques": [ "WBLOCK_3" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
+    "extend": { "flags": [ "STURDY" ] },
   },
   {
     "id": "shield_banded_large",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -92,7 +92,8 @@
     "description": "A simple round shield made of wood with leather reinforcement.  Sturdier and stronger than a simple wooden shield, and less encumbering than a metal one.",
     "weight": "3200 g",
     "volume": "3 L",
-    "price": 110000,
+    "price": "80 USD",
+    "price_postapoc": "8 USD",
     "bashing": 8,
     "material": ["wood", "leather"],
     "looks_like": "shield_wooden",
@@ -103,14 +104,7 @@
     "encumbrance": 16,
     "material_thickness": 4,
     "techniques": ["WBLOCK_2"],
-    "flags": [
-      "OVERSIZE",
-      "BELTED",
-      "RESTRICT_HANDS",
-      "BLOCK_WHILE_WORN",
-      "NONCONDUCTIVE",
-      "STURDY"
-    ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   },
   {
     "id": "shield_banded",
@@ -119,7 +113,8 @@
     "description": "A simple round shield made of wood with bands of steel reinforcing it.",
     "weight": "3400 g",
     "volume": "3 L",
-    "price": 110000,
+    "price": "100 USD",
+    "price_postapoc": "10 USD",
     "bashing": 8,
     "material": ["wood", "steel"],
     "looks_like": "shield_wooden",
@@ -130,13 +125,32 @@
     "encumbrance": 20,
     "material_thickness": 4,
     "techniques": ["WBLOCK_2"],
-    "flags": [
-      "OVERSIZE",
-      "BELTED",
-      "RESTRICT_HANDS",
-      "BLOCK_WHILE_WORN",
-      "NONCONDUCTIVE",
-      "STURDY"
-    ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "NONCONDUCTIVE", "STURDY" ]
+  },
+  {
+   "id": "shield_leather_large",
+   "copy-from": "shield_leather",
+   "name": { "str": "large leather shield" },
+   "description": "A large shield made of wood with leather reinforcement.  Sturdier and stronger than a basic wooden shield, and less encumbering than a metal one.",
+   "volume": "5 L",
+   "weight": "5200 g",
+   "price": "80 USD",
+   "price_postapoc": "10 USD",
+   "encumbrance": 26,
+   "material_thickness": 4,
+   "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
+  },
+  {
+   "id": "shield_banded_large",
+   "copy-from": "shield_banded",
+   "name": { "str": "large banded shield" },
+   "description": "A large shield made of wood with steel bands reinforcing it.",
+   "volume": "5 L",
+   "weight": "5200 g",
+   "price": "120 USD",
+   "price_postapoc": "14 USD",
+   "encumbrance": 26,
+   "material_thickness": 4,
+   "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   }
 ]

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -99,7 +99,7 @@
     "looks_like": "shield_wooden",
     "symbol": "x",
     "color": "blue",
-    "covers": ["arm_either", "hand_either"],
+    "covers": [ "arm_either", "hand_either" ],
     "coverage": 90,
     "encumbrance": 16,
     "material_thickness": 4,

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -103,7 +103,7 @@
     "covers": [ "arm_either", "hand_either" ],
     "coverage": 90,
     "encumbrance": 16,
-    "material_thickness": 4,
+    "material_thickness": 3,
     "techniques": [ "WBLOCK_2" ],
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   },
@@ -125,7 +125,7 @@
     "covers": [ "arm_either", "hand_either" ],
     "coverage": 90,
     "encumbrance": 20,
-    "material_thickness": 4,
+    "material_thickness": 3,
     "techniques": [ "WBLOCK_2" ],
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "NONCONDUCTIVE", "STURDY" ]
   },

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -120,7 +120,7 @@
     "looks_like": "shield_wooden",
     "symbol": "x",
     "color": "blue",
-    "covers": ["arm_either", "hand_either"],
+    "covers": [ "arm_either", "hand_either" ],
     "coverage": 90,
     "encumbrance": 20,
     "material_thickness": 4,

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -94,6 +94,7 @@
     "volume": "3 L",
     "price": "80 USD",
     "price_postapoc": "8 USD",
+    "to_hit": -1,
     "bashing": 8,
     "material": [ "wood", "leather" ],
     "looks_like": "shield_wooden",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -135,7 +135,7 @@
     "copy-from": "shield_leather",
     "looks_like": "shield_wooden_large",
     "type": "ARMOR",
-    "name": { "str": "large leather shield" },
+    "name": { "str": "large leather-reinforced shield" },
     "description": "A large shield made of wood with leather reinforcement.  Sturdier and stronger than a basic wooden shield, and less encumbering than a metal one.",
     "volume": "5 L",
     "weight": "5200 g",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -116,7 +116,7 @@
     "price": "100 USD",
     "price_postapoc": "10 USD",
     "bashing": 8,
-    "material": ["wood", "steel"],
+    "material": [ "wood", "steel" ],
     "looks_like": "shield_wooden",
     "symbol": "x",
     "color": "blue",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -103,7 +103,7 @@
     "covers": [ "arm_either", "hand_either" ],
     "coverage": 90,
     "encumbrance": 16,
-    "material_thickness": 3,
+    "material_thickness": 4,
     "techniques": [ "WBLOCK_2" ],
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   },

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -128,18 +128,18 @@
     "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "NONCONDUCTIVE", "STURDY" ]
   },
   {
-   "id": "shield_leather_large",
-   "copy-from": "shield_leather",
-   "type": "ARMOR",
-   "name": { "str": "large leather shield" },
-   "description": "A large shield made of wood with leather reinforcement.  Sturdier and stronger than a basic wooden shield, and less encumbering than a metal one.",
-   "volume": "5 L",
-   "weight": "5200 g",
-   "price": "80 USD",
-   "price_postapoc": "10 USD",
-   "encumbrance": 26,
-   "material_thickness": 4,
-   "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
+    "id": "shield_leather_large",
+    "copy-from": "shield_leather",
+    "type": "ARMOR",
+    "name": { "str": "large leather shield" },
+    "description": "A large shield made of wood with leather reinforcement.  Sturdier and stronger than a basic wooden shield, and less encumbering than a metal one.",
+    "volume": "5 L",
+    "weight": "5200 g",
+    "price": "80 USD",
+    "price_postapoc": "10 USD",
+    "encumbrance": 26,
+    "material_thickness": 4,
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY" ]
   },
   {
    "id": "shield_banded_large",

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -450,6 +450,22 @@
     ]
   },
   {
+    "result": "shield_leather_large",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "time": "1 h",
+    "autolearn": true,
+    "reversible": true,
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
+    "components": [
+      [ [ "shield_wooden_large", 1 ] ],
+      [ [ "fur", 8 ], [ "leather", 8 ] ]
+    ]
+  },
+  {
     "result": "shield_banded",
     "type": "recipe",
     "category": "CC_ARMOR",
@@ -460,8 +476,19 @@
     "autolearn": true,
     "using": [ [ "blacksmithing_standard", 2 ], [ "steel_standard", 2 ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [
-      [ [ "shield_wooden", 1 ] ]
-    ]
+    "components": [ [ [ "shield_wooden", 1 ] ] ]
+  },
+  {
+    "result": "shield_banded_large",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "time": "1 h",
+    "autolearn": true,
+    "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 4 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "shield_wooden_large", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -457,10 +457,7 @@
     "autolearn": true,
     "reversible": true,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
-    "components": [
-      [ [ "shield_wooden_large", 1 ] ],
-      [ [ "fur", 8 ], [ "leather", 8 ] ]
-    ]
+    "components": [ [ [ "shield_wooden_large", 1 ] ], [ [ "fur", 8 ], [ "leather", 8 ] ] ]
   },
   {
     "result": "shield_banded",

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -432,5 +432,35 @@
       [ [ "2x4", 8 ], [ "wood_panel", 2 ] ],
       [ [ "rag", 2 ], [ "felt_patch", 2 ], [ "fur", 2 ], [ "leather", 2 ] ]
     ]
+  },
+  {
+    "result": "shield_leather",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": "1 h",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
+    "components": [
+      [ [ "shield_wooden", 1 ] ],
+      [ [ "fur", 4 ], [ "leather", 4 ] ]
+    ]
+  },
+  {
+    "result": "shield_banded",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "time": "1 h",
+    "autolearn": true,
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_standard", 2 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [
+      [ [ "shield_wooden", 1 ] ]
+    ]
   }
 ]

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -444,10 +444,7 @@
     "autolearn": true,
     "reversible": true,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
-    "components": [
-      [ [ "shield_wooden", 1 ] ],
-      [ [ "fur", 4 ], [ "leather", 4 ] ]
-    ]
+    "components": [ [ [ "shield_wooden", 1 ] ], [ [ "fur", 4 ], [ "leather", 4 ] ] ]
   },
   {
     "result": "shield_leather_large",

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -442,6 +442,7 @@
     "difficulty": 4,
     "time": "1 h",
     "autolearn": true,
+    "reversible": true,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
     "components": [
       [ [ "shield_wooden", 1 ] ],


### PR DESCRIPTION
#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Content] "Two new shields, one reinforced with leather and one reinforced with steel, plus recipes adding the steel one to the medieval itemgroup."

#### Purpose of change

The wooden shields are a good start, but there needed to be shields in-between crude wood and modern riot shields. These serve that purpose.

#### Describe the solution

There are two new shields, made using a basic wooden shield and either leather or steel and forging equipment. Each one has the sturdy flag and more armor than the basic wooden one.

#### Describe alternatives you've considered

We could add in pure metal and leather shields, but I feel like reinforcing an existing wooden shield would work best.

#### Testing

I tested out the json myself to make sure it functions.
