### PR TITLE
Made forges have metal sawing properties

### DIFF
--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -69,6 +69,7 @@
     "symbol": ";",
     "color": "dark_gray",
     "ammo": "charcoal",
+    "qualities": [ [ "SAW_M", 2 ], [ "SAW_M_FINE", 1 ] ],
     "sub": "forge",
     "max_charges": 500,
     "charges_per_use": 8,
@@ -184,6 +185,7 @@
     "material": [ "steel", "plastic" ],
     "symbol": ";",
     "color": "light_gray",
+    "qualities": [ [ "SAW_M", 2 ], [ "SAW_M_FINE", 1 ] ],
     "ammo": "battery",
     "charges_per_use": 4,
     "use_action": [


### PR DESCRIPTION
#### Summary

SUMMARY: Content "Gave forge and char_forge the SAW_M and SAW_M_FINE tool properties to simulate the ability to melt metal items down into their base components."

#### Purpose of change

Realistically, if you have access to a forge, you should be able to use it to melt down metal items into ingots or other metal items. This was simply a basic implementation of that.

#### Describe the solution

I added one line to each of the two items under json/items/tool/metalworking.json, giving them the metal sawing and fine metal sawing tool properties.

#### Describe alternatives you've considered

We could implement a secondary disassembly requirement and give forges the ability to melt down steel items, but I am not good enough at coding to do that myself.

#### Testing

The json checks out, since it's just two lines added.