### PR TITLE
Fixed shield flags

### DIFF
--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -106,7 +106,7 @@
     "encumbrance": 16,
     "material_thickness": 4,
     "techniques": [ "WBLOCK_2" ],
-    "extend": { "flags": [ "STURDY" ] }
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
   },
   {
     "id": "shield_banded",
@@ -128,7 +128,7 @@
     "encumbrance": 20,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_2" ],
-    "extend": { "flags": [ "STURDY" ] }
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "NONCONDUCTIVE" ]
   },
   {
     "id": "shield_leather_large",

--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -106,7 +106,7 @@
     "encumbrance": 16,
     "material_thickness": 4,
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "STURDY", "BLOCK_WHILE_WORN" ]
   },
   {
     "id": "shield_banded",
@@ -128,7 +128,7 @@
     "encumbrance": 20,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "NONCONDUCTIVE" ]
+    "flags": [ "OVERSIZE", "BELTED", "RESTRICT_HANDS", "BLOCK_WHILE_WORN", "STURDY", "NONCONDUCTIVE" ]
   },
   {
     "id": "shield_leather_large",


### PR DESCRIPTION
#### Summary

SUMMARY: [Bugfixes] "Fix flags on leather and banded shields."

#### Purpose of change

Chaosvolt accidentally gave them an extend function, believing they were copying from the wooden shield; this merely returns their flags to them.

#### Describe the solution

It's two lines in the json, mostly copying from the basic wooden shield.

#### Describe alternatives you've considered

We could make the leather and banded shields use the copy-from line instead. I don't particularly care either way.

#### Testing

It works fine. It's just two lines.