### PR TITLE
Nonconductive swords with wooden handles

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -30,7 +30,7 @@
     "cutting": 28,
     "to_hit": 1,
     "price_postapoc": 2500,
-    "flags": [ "SHEATH_SWORD" ],
+    "flags": [ "SHEATH_SWORD", "NONCONDUCTIVE" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 7 ] ],
     "techniques": [ "WBLOCK_2" ]
   },
@@ -300,7 +300,7 @@
     "color": "dark_gray",
     "techniques": "WBLOCK_2",
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 15 ] ],
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ]
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "NONCONDUCTIVE" ]
   },
   {
     "id": "makeshift_machete",
@@ -358,7 +358,7 @@
     "color": "dark_gray",
     "techniques": [ "WBLOCK_2", "RAPID" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ]
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "NONCONDUCTIVE" ]
   },
   {
     "id": "cavalry_sabre_fake",
@@ -442,7 +442,7 @@
     "price": 100000,
     "price_postapoc": 4000,
     "material": "steel",
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "NONCONDUCTIVE" ],
     "techniques": [ "WBLOCK_2" ],
     "weight": "800 g",
     "volume": "2 L",
@@ -490,7 +490,7 @@
     "price_postapoc": 3500,
     "material": "iron",
     "techniques": [ "WBLOCK_2" ],
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "NONCONDUCTIVE" ],
     "weight": "1133 g",
     "volume": "2 L",
     "bashing": 6,
@@ -538,7 +538,7 @@
     "price_postapoc": 5000,
     "material": "steel",
     "techniques": [ "WBLOCK_2", "PRECISE" ],
-    "flags": [ "STAB", "DURABLE_MELEE", "SHEATH_SWORD" ],
+    "flags": [ "STAB", "DURABLE_MELEE", "SHEATH_SWORD", "NONCONDUCTIVE" ],
     "weight": "1814 g",
     "volume": "2750 ml",
     "bashing": 9,
@@ -584,7 +584,7 @@
     "price": 130000,
     "price_postapoc": 6000,
     "material": "steel",
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "NONCONDUCTIVE" ],
     "techniques": [ "WBLOCK_2" ],
     "weight": "1814 g",
     "volume": "2750 ml",
@@ -633,7 +633,7 @@
     "price": 100000,
     "price_postapoc": 4500,
     "material": "steel",
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "NONCONDUCTIVE" ],
     "techniques": [ "WBLOCK_2" ],
     "weight": "1360 g",
     "volume": "2 L",
@@ -809,7 +809,7 @@
     "color": "dark_gray",
     "techniques": "RAPID",
     "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 18 ] ],
-    "flags": [ "STAB", "DURABLE_MELEE", "SHEATH_KNIFE" ]
+    "flags": [ "STAB", "DURABLE_MELEE", "SHEATH_KNIFE", "NONCONDUCTIVE" ]
   },
   {
     "id": "tanto_inferior",
@@ -860,7 +860,7 @@
     "color": "light_gray",
     "techniques": [ "RAPID", "WBLOCK_2" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 13 ] ],
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ]
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "NONCONDUCTIVE" ]
   },
   {
     "id": "wakizashi_inferior",
@@ -909,7 +909,7 @@
     "color": "light_gray",
     "techniques": [ "WBLOCK_1", "WIDE", "BRUTAL", "SWEEP" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 4 ] ],
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "ALWAYS_TWOHAND" ]
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "ALWAYS_TWOHAND", "NONCONDUCTIVE" ]
   },
   {
     "id": "zweihander_inferior",
@@ -992,7 +992,7 @@
     "color": "light_gray",
     "techniques": [ "WBLOCK_1", "RAPID", "WIDE", "BRUTAL" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 10 ] ],
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "ALWAYS_TWOHAND" ]
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "ALWAYS_TWOHAND", "NONCONDUCTIVE" ]
   },
   {
     "id": "nodachi_inferior",
@@ -1171,7 +1171,7 @@
     "cutting": 25,
     "looks_like": "rapier",
     "techniques": [ "PRECISE", "RAPID", "WBLOCK_2" ],
-    "flags": [ "STAB", "SHEATH_SWORD" ]
+    "flags": [ "STAB", "SHEATH_SWORD", "NONCONDUCTIVE" ]
   },
   {
     "id": "broadsword",
@@ -1192,7 +1192,7 @@
     "color": "light_gray",
     "techniques": [ "WBLOCK_2" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 9 ] ],
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ]
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "NONCONDUCTIVE" ]
   },
   {
     "id": "broadsword_inferior",
@@ -1240,7 +1240,7 @@
     "color": "light_gray",
     "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 9 ] ],
-    "flags": [ "STAB", "DURABLE_MELEE", "SHEATH_SWORD" ]
+    "flags": [ "STAB", "DURABLE_MELEE", "SHEATH_SWORD", "NONCONDUCTIVE" ]
   },
   {
     "id": "rapier_fake",
@@ -1276,7 +1276,7 @@
     "color": "light_gray",
     "techniques": [ "RAPID", "WBLOCK_2" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 9 ] ],
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ]
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "NONCONDUCTIVE" ]
   },
   {
     "id": "katana_inferior",
@@ -1320,7 +1320,7 @@
     "price": 50000,
     "price_postapoc": 6000,
     "material": "steel",
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "ALWAYS_TWOHAND" ],
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "ALWAYS_TWOHAND", "NONCONDUCTIVE" ],
     "techniques": [ "WBLOCK_2" ],
     "weight": "1766 g",
     "volume": "1500 ml",
@@ -1432,7 +1432,7 @@
     "color": "dark_gray",
     "techniques": "WBLOCK_2",
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 9 ] ],
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ]
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "NONCONDUCTIVE" ]
   },
   {
     "id": "cutlass_inferior",
@@ -1585,5 +1585,26 @@
     "use_action": "E_COMBATSAW_ON",
     "flags": [ "MESSY", "DURABLE_MELEE", "TRADER_AVOID", "ALWAYS_TWOHAND" ],
     "magazine_well": "500 ml"
+  },
+  {
+    "id": "dagger_medieval",
+    "type": "GENERIC",
+    "category": "weapons",
+    "weapon_category": [ "KNIVES" ],
+    "name": { "str": "dagger" },
+    "description": "A medieval dagger, more finely crafted than a baselard.",
+    "weight": "420 g",
+    "volume": "250 ml",
+    "price": 19590,
+    "to_hit": 2,
+    "bashing": 5,
+    "cutting": 22,
+    "material": [ "iron" ],
+    "looks_like": "knife_baselard",
+    "symbol": ";",
+    "color": "dark_gray",
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 20 ] ],
+    "techniques": "RAPID",
+    "flags": [ "STAB", "SHEATH_KNIFE", "NONCONDUCTIVE", "DURABLE_MELEE" ]
   }
 ]

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -1604,7 +1604,6 @@
     "symbol": ";",
     "color": "dark_gray",
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 20 ] ],
-    "techniques": "RAPID",
     "flags": [ "STAB", "SHEATH_KNIFE", "NONCONDUCTIVE", "DURABLE_MELEE" ]
   }
 ]

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -806,5 +806,19 @@
     "qualities": [ { "id": "HAMMER", "level": 3 } ],
     "using": [ [ "blacksmithing_standard", 12 ], [ "steel_standard", 2 ] ],
     "components": [ [ [ "fur", 2 ], [ "leather", 2 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "dagger_medieval",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_PIERCING",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "time": "2 h 30 m",
+    "book_learn": [ [ "textbook_weapwest", 7 ] ],
+    "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ] ],
+    "qualities": [ { "id": "CHISEL", "level": 3 } ],
+    "tools": [ [ [ "swage", -1 ] ] ],
+    "components": [ [ [ "2x4", 1 ], [ "stick", 1 ] ], [ [ "fur", 2 ], [ "leather", 2 ] ] ]
   }
 ]

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -815,7 +815,7 @@
     "skill_used": "fabrication",
     "difficulty": 5,
     "time": "2 h 30 m",
-    "book_learn": [ [ "textbook_weapwest", 7 ] ],
+    "book_learn": [ [ "textbook_weapwest", 3 ] ],
     "autolearn": true,
     "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ] ],
     "qualities": [ { "id": "CHISEL", "level": 3 } ],

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -816,6 +816,7 @@
     "difficulty": 5,
     "time": "2 h 30 m",
     "book_learn": [ [ "textbook_weapwest", 7 ] ],
+    "autolearn": true,
     "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ] ],
     "qualities": [ { "id": "CHISEL", "level": 3 } ],
     "tools": [ [ [ "swage", -1 ] ] ],


### PR DESCRIPTION
#### Summary

SUMMARY: [Content] "Swords with wooden handles are now nonconductive, plus a dagger weapon."

#### Purpose of change

Melee is hampered by weapons which conduct electricity, since shocker and zapper zombies can quickly injure you using conductive equipment and weapons. If a sword has wood in its crafting recipe, that means it has a wooden handle, and that means it wouldn't conduct electricity to you when wielded. Furthermore, you can make a baselard, but you can't craft a genuine combat dagger that's better than the baselard, which is a shame.

#### Describe the solution

I gave the nonconductive flag to every ingame sword that uses wood in its crafting recipe, plus a new item and corresponding recipe for a good player-made dagger.

#### Describe alternatives you've considered

We could keep swords as they are, but that hampers their usefulness when facing electrical zombies. As for the dagger, we could... not implement it? I don't see why not, it's literally just a baselard but slightly better due to more skilled forging.

#### Testing

I've tested it out, there are no json errors on my end.