### PR TITLE
Add command to pet menu for removing individual items from storage

### DIFF
--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -741,7 +741,6 @@ void monexamine::take_items_from( monster &z )
 {
     std::string pet_name = z.get_name();
     avatar &you = get_avatar();
-    map &here = get_map();
 
     std::vector<item> monster_inv = z.inv;
     if( monster_inv.empty() ) {

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -739,7 +739,7 @@ bool monexamine::give_items_to( monster &z )
 
 void monexamine::take_items_from( monster &z )
 {
-    std::string pet_name = z.get_name();
+    const std::string pet_name = z.get_name();
     avatar &you = get_avatar();
 
     std::vector<item> monster_inv = z.inv;
@@ -756,8 +756,7 @@ void monexamine::take_items_from( monster &z )
     }
     selection_menu.selected = 1;
     selection_menu.query();
-    int index = selection_menu.ret;
-
+    const int index = selection_menu.ret;
     if( index == 0 || index == UILIST_CANCEL || index < 0 ||
         index > static_cast<int>( monster_inv.size() ) ) {
         return;

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -742,7 +742,7 @@ void monexamine::take_items_from( monster &z )
     const std::string pet_name = z.get_name();
     avatar &you = get_avatar();
 
-    std::vector<item> monster_inv = z.inv;
+    std::vector<item> &monster_inv = z.inv;
     if( monster_inv.empty() ) {
         return;
     }

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -740,8 +740,6 @@ bool monexamine::give_items_to( monster &z )
 void monexamine::take_items_from( monster &z )
 {
     const std::string pet_name = z.get_name();
-    avatar &you = get_avatar();
-
     std::vector<item> &monster_inv = z.inv;
     if( monster_inv.empty() ) {
         return;
@@ -762,11 +760,15 @@ void monexamine::take_items_from( monster &z )
         return;
     }
 
-    item retrieved_item = monster_inv[index - 1];
+    // because the first entry is the cancel option
+    const int selection = index - 1;
+    item retrieved_item = monster_inv[selection];
+    monster_inv.erase( monster_inv.begin() + selection );
 
-    you.i_add( retrieved_item );
     add_msg( _( "You remove the %1$s from the %2$s's bag." ), retrieved_item.tname(), pet_name );
-    z.inv.erase( z.inv.begin() + index - 1 );
+
+    avatar &you = get_avatar();
+    you.i_add( retrieved_item );
 }
 
 bool monexamine::add_armor( monster &z )

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -76,6 +76,7 @@ bool monexamine::pet_menu( monster &z )
         remove_bag,
         drop_all,
         give_items,
+        take_items,
         mon_armor_add,
         mon_harness_remove,
         mon_armor_remove,
@@ -124,6 +125,7 @@ bool monexamine::pet_menu( monster &z )
         amenu.addentry( give_items, true, 'g', _( "Place items into bag" ) );
         amenu.addentry( remove_bag, true, 'b', _( "Remove bag from %s" ), pet_name );
         if( !z.inv.empty() ) {
+            amenu.addentry( take_items, true, 'G', _( "Take items from bag" ) );
             amenu.addentry( drop_all, true, 'd', _( "Remove all items from bag" ) );
         }
     } else if( !z.has_flag( MF_RIDEABLE_MECH ) ) {
@@ -276,6 +278,9 @@ bool monexamine::pet_menu( monster &z )
             break;
         case give_items:
             return give_items_to( z );
+        case take_items:
+            take_items_from( z );
+            break;
         case mon_armor_add:
             return add_armor( z );
         case mon_harness_remove:
@@ -730,6 +735,40 @@ bool monexamine::give_items_to( monster &z )
     you.drop( to_move, z.pos(), true );
 
     return false;
+}
+
+void monexamine::take_items_from( monster &z )
+{
+    std::string pet_name = z.get_name();
+    avatar &you = get_avatar();
+    map &here = get_map();
+
+    std::vector<item> monster_inv = z.inv;
+    if( monster_inv.empty() ) {
+        return;
+    }
+
+    int i = 0;
+    uilist selection_menu;
+    selection_menu.text = string_format( _( "Select an item to remove from the %s." ), z.get_name() );
+    selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Cancel" ) );
+    for( auto iter : monster_inv ) {
+        selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Retrieve %s" ), iter.tname() );
+    }
+    selection_menu.selected = 1;
+    selection_menu.query();
+    int index = selection_menu.ret;
+
+    if( index == 0 || index == UILIST_CANCEL || index < 0 ||
+        index > static_cast<int>( monster_inv.size() ) ) {
+        return;
+    }
+
+    item retrieved_item = monster_inv[index - 1];
+
+    you.i_add( retrieved_item );
+    add_msg( _( "You remove the %1$s from the %2$s's bag." ), retrieved_item.tname(), pet_name );
+    z.inv.erase( z.inv.begin() + index - 1 );
 }
 
 bool monexamine::add_armor( monster &z )

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -749,7 +749,7 @@ void monexamine::take_items_from( monster &z )
 
     int i = 0;
     uilist selection_menu;
-    selection_menu.text = string_format( _( "Select an item to remove from the %s." ), z.get_name() );
+    selection_menu.text = string_format( _( "Select an item to remove from the %s." ), pet_name );
     selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Cancel" ) );
     for( auto iter : monster_inv ) {
         selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Retrieve %s" ), iter.tname() );

--- a/src/monexamine.h
+++ b/src/monexamine.h
@@ -19,6 +19,7 @@ void attach_bag_to( monster &z );
 void remove_bag_from( monster &z );
 void dump_items( monster &z );
 bool give_items_to( monster &z );
+void take_items_from( monster &z );
 bool add_armor( monster &z );
 void remove_armor( monster &z );
 void remove_harness( monster &z );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Interface "Allow retrieving individual items from a mount's stored items"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This adds a QoL feature I'd been pondering about for a while. Having "dump everything that you stored in your mount's saddlebags" obviously is not ideal when you just want to grab a single item. Making menus is...clunky and weird but figured the rough basics out.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Added `monexamine::take_items_from` function to monexamine.cpp, cannibalized from random bits and bobs of `monexamine::dump_items`, `monexamine::add_leash`, and `monexamine::remove_leash` as references, plus @joveeater's help with the `erase` function at the end that actually removes the chosen item from the monster's inventory.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Removing the "dump all items" command, I'd say keep it for now because this menu makes you pick one item to retrieve at a time currently.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Spawned in and tamed a horse, attached a backpack to it.
3. Started to test storing and retrieving items from it.

Handing them items and retrieving it correctly removes the offending item from the list, and the order of remaining items on the list stays intact. It also removes the correct item when called for, and can handle stuff like stacks of comesestibles, ammo, comestibles in containers, tools with charges, etc.

One thing it does do a bit weirdly though:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/c00eea7f-b29c-488f-ac4c-861a783c53e0)

This was from deliberately splitting a stack of ammo up by handing half of it to the horse in one instance of give-item, then the other half in the second instance. Both instances are thus handled as separate entries on the list, presumably because the monster inventory probably stores them as such internally?

Being able to implement it in a way that works similar to multidrop, letting you select multiple items to retrieve at once, would be an improvement but UI is not something I'm experienced with yet.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
