### PR TITLE
Fix pickup key spoiling presence of loot in crates

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -47,6 +47,7 @@ static const std::string flag_FLOTATION( "FLOTATION" );
 static const std::string flag_GOES_DOWN( "GOES_DOWN" );
 static const std::string flag_GOES_UP( "GOES_UP" );
 static const std::string flag_REACH_ATTACK( "REACH_ATTACK" );
+static const std::string flag_SEALED( "SEALED" );
 static const std::string flag_SWIMMABLE( "SWIMMABLE" );
 
 class inventory;
@@ -625,7 +626,7 @@ static bool can_pickup_at( const tripoint &p )
         const int cargo_part = vp->vehicle().part_with_feature( vp->part_index(), "CARGO", false );
         veh_has_items = cargo_part >= 0 && !vp->vehicle().get_items( cargo_part ).empty();
     }
-    return here.has_items( p ) || veh_has_items;
+    return ( here.has_items( p ) && !here.has_flag( flag_SEALED, p ) ) || veh_has_items;
 }
 
 bool can_interact_at( action_id action, const tripoint &p )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Hitting g will no longer highlight sealed crates/coffins/etc that have loot in them, spoiling which ones to open"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes a problem with the code for checking whether to show the "valid direction" highlight, in which it didn't screen for whether you shouldn't be able to see the presence of valid items on that tile:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/cd46a1ef-c5d7-40f8-b891-3d79069894a8)

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

In action.cpp, changed `can_pickup_at` to make the "tile has items here" part of its return also verify that the tile in question lacks the `SEALED` flag, which would normally preclude being able to get items from them. This means you can't use `g` to sniff out whether a crate is worth prying or not anymore.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Letting you still use this exploit anyway just because.
2. If we want to go peak realism, let you do see the highlight if you have like 20+ strength on the basis that you're just picking the whole-ass crate up and shaking it like a kid checking their christmas presents.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->


1. Compiled and load-tested.
2. Verified that items just loose on the ground are still selectable.
3. Verified that items in a vehicle tile are also still selectable.
4. Spawned in some crates, one covering an item on the ground.
5. Confirmed none of the crates showed the selection prompt, so I couldn't reveal which was which anymore.
6. Tested a vehicle with cargo sitting on top of a crate that also had stuff in it. It still offers the choice between picking up an item in the vehicle vs on the ground, closing out of the menu as normal if you try to pick up items in the crate. This is at least significantly less exploitable since vehicles and crates object quite strongly to being merged together in-game, so you'd only be able to use this for any crates a map-maker might've accidentally spawned a vehicle on, and even then only if the overlapping tile has a cargo storage part.
7. Checked affected file for syntax and lint errors.

One of these crates has stuff in it. Which one? You'll have to find out with a crowbar:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/b92807ae-e08d-4e42-9753-17f3644035a0)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
