### PR TITLE
Added in recipe for rockwheel

### DIFF
--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -1353,12 +1353,7 @@
     "skills_required": [ "mechanics", 3 ],
     "difficulty": 6,
     "autolearn": true,
-    "book_learn": [
-      [ "textbook_fabrication", 4 ],
-      [ "welding_book", 4 ],
-      [ "textbook_mechanics", 2 ],
-      [ "manual_mechanics", 2 ]
-    ],
+    "book_learn": [ [ "textbook_fabrication", 4 ], [ "welding_book", 4 ], [ "textbook_mechanics", 2 ], [ "manual_mechanics", 2 ] ],
     "time": "8 h",
     "using": [ [ "welding_standard", 25 ], [ "steel_standard", 20 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "WRENCH", "level": 1 } ],

--- a/data/json/recipes/other/vehicles.json
+++ b/data/json/recipes/other/vehicles.json
@@ -1343,5 +1343,25 @@
       [ [ "pipe", 5 ] ],
       [ [ "chain", 1 ] ]
     ]
+  },
+  {
+    "result": "v_rockwheel_item",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_VEHICLE",
+    "skill_used": "fabrication",
+    "skills_required": [ "mechanics", 3 ],
+    "difficulty": 6,
+    "autolearn": true,
+    "book_learn": [
+      [ "textbook_fabrication", 4 ],
+      [ "welding_book", 4 ],
+      [ "textbook_mechanics", 2 ],
+      [ "manual_mechanics", 2 ]
+    ],
+    "time": "8 h",
+    "using": [ [ "welding_standard", 25 ], [ "steel_standard", 20 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
+    "components": [ [ [ "frame", 2 ] ] ]
   }
 ]


### PR DESCRIPTION
#### Summary

SUMMARY: [Balance] "[Add in rockwheel recipe]"

#### Purpose of change

The rockwheel is a very useful ingame item for fortifying a base, but it's fairly rare and there are no other simple ways to dig large trenches, such as a construction recipe. Adding in a recipe for the rockwheel, requiring a lot of time and steel to make, simply makes it easier to get one.

#### Describe the solution

I added in a recipe for the rockwheel.

#### Describe alternatives you've considered

We could make rockwheel-bearing vehicles more common, as they're pretty normal to find in construction sites.

#### Testing

It's just a recipe, so it's not difficult to test. The json works fine, though I'm not 100% on the recipe requirements.