### PR TITLE
feat: do not prompt when it's safe to climb down

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10026,9 +10026,10 @@ void game::vertical_move( int movez, bool force, bool peeking )
             }
         }
 
-        const int cost = map_funcs::climbing_cost( m, u.pos(), stairs );
 
-        if( cost == 0 ) {
+        const auto cost = map_funcs::climbing_cost( m, u.pos(), stairs );
+
+        if( !cost.has_value() ) {
             if( u.has_trait( trait_WEB_ROPE ) )  {
                 if( pts.empty() ) {
                     add_msg( m_info, _( "There is nothing above you that you can attach a web to." ) );
@@ -10056,14 +10057,14 @@ void game::vertical_move( int movez, bool force, bool peeking )
 
         }
 
-        if( cost <= 0 || pts.empty() ) {
+        if( pts.empty() ) {
             add_msg( m_info,
                      _( "You can't climb here - there is no terrain above you that would support your weight." ) );
             return;
         } else {
             // TODO: Make it an extended action
             climbing = true;
-            move_cost = cost;
+            move_cost = cost.value();
 
             const std::optional<tripoint> pnt = point_selection_menu( pts );
             if( !pnt ) {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -195,7 +195,7 @@ static const trait_id trait_PARKOUR( "PARKOUR" );
 static const trait_id trait_PROBOSCIS( "PROBOSCIS" );
 static const trait_id trait_THRESH_MARLOSS( "THRESH_MARLOSS" );
 static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
-static const trait_id trait_WEB_BRDIGE( "WEB_BRIDGE" );
+static const trait_id trait_WEB_BRIDGE( "WEB_BRIDGE" );
 
 static const quality_id qual_ANESTHESIA( "ANESTHESIA" );
 static const quality_id qual_DIG( "DIG" );
@@ -4614,7 +4614,7 @@ void iexamine::ledge( player &p, const tripoint &examp )
     cmenu.text = _( "There is a ledge here.  What do you want to do?" );
     cmenu.addentry( ledge_action::jump_over, true, 'j', _( "Jump over." ) );
     cmenu.addentry( ledge_action::climb_down, true, 'c', _( "Climb down." ) );
-    if( p.has_trait( trait_WEB_BRDIGE ) ) {
+    if( p.has_trait( trait_WEB_BRIDGE ) ) {
         cmenu.addentry( ledge_action::spin_web_bridge, true, 'w', _( "Spin Web Bridge." ) );
     }
 
@@ -4717,7 +4717,7 @@ void iexamine::ledge( player &p, const tripoint &examp )
         }
         case ledge_action::spin_web_bridge: {
 
-            if( !can_use_mutation_warn( trait_WEB_BRDIGE, p ) ) {
+            if( !can_use_mutation_warn( trait_WEB_BRIDGE, p ) ) {
                 break;
             }
             const int range = 6; //this means we could web across a gap of 5.
@@ -4741,7 +4741,7 @@ void iexamine::ledge( player &p, const tripoint &examp )
 
                     g->m.ter_set( dest, t_web_bridge );
                 }
-                p.mutation_spend_resources( trait_WEB_BRDIGE );
+                p.mutation_spend_resources( trait_WEB_BRIDGE );
             }
             break;
         }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4608,20 +4608,21 @@ void iexamine::pay_gas( player &p, const tripoint &examp )
 
 void iexamine::ledge( player &p, const tripoint &examp )
 {
+    enum ledge_action : int { jump_over, climb_down, spin_web_bridge };
 
     uilist cmenu;
     cmenu.text = _( "There is a ledge here.  What do you want to do?" );
-    cmenu.addentry( 1, true, 'j', _( "Jump over." ) );
-    cmenu.addentry( 2, true, 'c', _( "Climb down." ) );
+    cmenu.addentry( ledge_action::jump_over, true, 'j', _( "Jump over." ) );
+    cmenu.addentry( ledge_action::climb_down, true, 'c', _( "Climb down." ) );
     if( p.has_trait( trait_WEB_BRDIGE ) ) {
-        cmenu.addentry( 3, true, 'w', _( "Spin Web Bridge." ) );
+        cmenu.addentry( ledge_action::spin_web_bridge, true, 'w', _( "Spin Web Bridge." ) );
     }
 
     cmenu.query();
 
     map &here = get_map();
     switch( cmenu.ret ) {
-        case 1: {
+        case ledge_action::jump_over: {
             tripoint dest( p.posx() + 2 * sgn( examp.x - p.posx() ), p.posy() + 2 * sgn( examp.y - p.posy() ),
                            p.posz() );
             if( p.get_str() < 4 ) {
@@ -4641,7 +4642,7 @@ void iexamine::ledge( player &p, const tripoint &examp )
             }
             break;
         }
-        case 2: {
+        case ledge_action::climb_down: {
             tripoint where = examp;
             tripoint below = examp;
             below.z--;
@@ -4701,7 +4702,7 @@ void iexamine::ledge( player &p, const tripoint &examp )
             here.creature_on_trap( p );
             break;
         }
-        case 3: {
+        case ledge_action::spin_web_bridge: {
 
             if( !can_use_mutation_warn( trait_WEB_BRDIGE, p ) ) {
                 break;

--- a/src/map_functions.cpp
+++ b/src/map_functions.cpp
@@ -13,15 +13,15 @@ static const mtype_id mon_mi_go_myrmidon( "mon_mi_go_myrmidon" );
 namespace map_funcs
 {
 
-int climbing_cost( const map &m, const tripoint &from, const tripoint &to )
+auto climbing_cost( const map &m, const tripoint &from, const tripoint &to ) -> std::optional<int>
 {
     // TODO: All sorts of mutations, equipment weight etc. for characters
     if( !m.valid_move( from, to, false, true ) ) {
-        return 0;
+        return {};
     }
     const int diff = m.climb_difficulty( from );
     if( diff > 5 ) {
-        return 0;
+        return {};
     }
     return 50 + diff * 100;
 }

--- a/src/map_functions.h
+++ b/src/map_functions.h
@@ -2,6 +2,8 @@
 #ifndef CATA_SRC_MAP_FUNCTIONS_H
 #define CATA_SRC_MAP_FUNCTIONS_H
 
+#include <optional>
+
 struct tripoint;
 class map;
 
@@ -11,10 +13,9 @@ namespace map_funcs
 /**
  * Checks both the neighborhoods of from and to for climbable surfaces,
  * returns move cost of climbing from `from` to `to`.
- * 0 means climbing is not possible.
  * Return value can depend on the orientation of the terrain.
  */
-int climbing_cost( const map &m, const tripoint &from, const tripoint &to );
+auto climbing_cost( const map &m, const tripoint &from, const tripoint &to ) -> std::optional<int>;
 
 void migo_nerve_cage_removal( map &m, const tripoint &p, bool spawn_damaged );
 


### PR DESCRIPTION

#### Summary

SUMMARY: Features "Do not prompt whether to climb down when it's safe to do so"

#### Purpose of change

Even it's perfectly safe to climb down a level (able to climb up), prompts are shown. 

#### Describe the solution

1. made ledge actions UI entry use enums to make it easier to read
2. defined either monad, `climb_result` modeled after possible outcomes of climbing down:

| only one-way  | both-way |
| ------------- | -------- |
| dangerous     | easy     |
| unclimbable   | grapnel  |
| hard_to_climb |          |

3. used switch and `std::visitor` to exhaustively visit all possibilities

#### Describe alternatives you've considered

use the 'simple' way, use single enum, ret_val<T>, nested ternaries, etc.

#### Testing

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/b19ed372-af59-4aba-b6c6-3cc915ae7807

#### Additional context

it may be overly complex, but i'm just too anxious to use mutables and non-exhausted conditional.

cc @DeltaEpsilon7787 @joveeater 