### PR TITLE
Holsters/sheathes can now be unloaded

### DIFF
--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -649,7 +649,7 @@ bool unload_item( avatar &you, item_location loc )
 {
     item &it = *loc.get_item();
     // Unload a container consuming moves per item successfully removed
-    if( it.is_container() || it.is_bandolier() ) {
+    if( it.is_container() || it.is_bandolier() || it.type->can_use( "holster" ) ) {
         if( it.contents.empty() ) {
             add_msg( m_info, _( "The %s is already empty!" ), it.tname() );
             return false;

--- a/src/item_functions.cpp
+++ b/src/item_functions.cpp
@@ -2,6 +2,7 @@
 
 #include "character.h"
 #include "item.h"
+#include "itype.h"
 #include "units.h"
 
 static flag_str_id flag_NO_UNLOAD( "NO_UNLOAD" );
@@ -13,7 +14,8 @@ namespace item_funcs
 
 bool can_be_unloaded( const item &itm )
 {
-    if( ( itm.is_container() || itm.is_bandolier() ) && !itm.contents.empty() &&
+    if( ( itm.is_container() || itm.is_bandolier() || itm.type->can_use( "holster" ) ) &&
+        !itm.contents.empty() &&
         itm.can_unload_liquid() ) {
         return true;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Features "Allow items with holster use action to be unloaded if they have contents"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes the issue where holsters could not be unloaded, forcing the player to always activate them, wield the resulting weapon, then finally do whatever they planned to do with it.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In avatar_functions.cpp, changed `unload_item` to also look for items with the `holster` use action.
2. In item_functions.cpp, changed `can_be_unloaded` to allow count items with the `holster` use action as valid if they have something in them, just as `avatar_action::reload` checks for holsters for the sake of trying to reload their contents.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Screaming.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Spawned in and killed some zombie soldiers.
3. Stood next to ones that dropped a holstered pistol and a sheathed combat knife.
4. Hit `U`, holsters and sheathes showed up on the menu.
5. Selected the nearby holstered pistol, confirmed I got a still-loaded pistol put in my inventory, and the holster left on the ground was empty.
6. Also selected a nearby sheathed combat knife, same results as expected.
7. Also tested filling up an MBR vest with magazines, then unloading it, correctly still unloads. It already had some special-casing for loaded ammo pouches somewhere in here can can now probably be removed, but I can't find it in these functions. @joveeater suspects it to just be an unexpected benefit of the code that lets it look for magazines loaded into guns, if so no need to remove any special-casing in it.
8. Stashed a quartet of tools in a toolbelt and unloaded, it correctly gave me back all four items.
9. Checked affected files for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/f1f0d09a-1714-4c50-9e78-e2e07387645f)

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/15555527-2f42-41b6-a4e6-230c9a8d68df)

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/f50a2992-9f9e-43c0-9714-ed27f2fd1ef1)

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/a0aaaca2-ae49-4b49-a013-95d724d5a21f)