### PR TITLE
Adjustments to collapsed shed map extra

### DIFF
--- a/data/json/mapgen/map_extras/wilderness.json
+++ b/data/json/mapgen/map_extras/wilderness.json
@@ -208,10 +208,10 @@
       "mapgensize": [ 11, 11 ],
       "rows": [
         "--++++--||-",
-        "-_______RR|",
-        "w_______RRw",
-        "w________Rw",
-        "|_________|",
+        "-______?RR|",
+        "w______?RRw",
+        "w_______?Rw",
+        "|________?|",
         "||-_____|||",
         "|_________|",
         "w_________w",
@@ -220,10 +220,11 @@
         "--||||||-||"
       ],
       "palettes": [ "desolatebarn_palette" ],
-      "terrain": { "_": "t_dirt" },
-      "furniture": { "_": [ [ "f_null", 30 ], "f_rubble", "f_rubble_rock" ] },
+      "terrain": { "?": [ "t_dirtfloor", "t_dirt" ], "R": "t_dirt" },
+      "furniture": { "_": [ [ "f_null", 30 ], "f_rubble", "f_rubble_rock" ], "?": [ [ "f_null", 3 ], "f_rubble", "f_rubble_rock" ] },
       "items": {
         "_": { "item": "wood_workshop", "chance": 1 },
+        "?": [ { "item": "wood_workshop", "chance": 2 }, { "item": "mischw", "chance": 2 } ],
         "R": [ { "item": "wood_workshop", "chance": 3 }, { "item": "mischw", "chance": 2 } ]
       }
     }
@@ -237,18 +238,19 @@
       "rows": [
         "--w_-||-",
         "-______|",
-        "|______+",
-        "|R_____+",
-        "|RR____|",
-        "|_RRR__w",
-        "-__RRR_w",
+        "|?_____+",
+        "|R?____+",
+        "|RR??__|",
+        "|?RRR?_w",
+        "-_?RRR?w",
         "--w||-||"
       ],
       "palettes": [ "desolatebarn_palette" ],
-      "terrain": { "_": "t_dirt" },
-      "furniture": { "_": [ [ "f_null", 30 ], "f_rubble", "f_rubble_rock" ] },
+      "terrain": { "?": [ "t_dirtfloor", "t_dirt" ], "R": "t_dirt" },
+      "furniture": { "_": [ [ "f_null", 30 ], "f_rubble", "f_rubble_rock" ], "?": [ [ "f_null", 3 ], "f_rubble", "f_rubble_rock" ] },
       "items": {
         "_": { "item": "wood_workshop", "chance": 1 },
+        "?": [ { "item": "wood_workshop", "chance": 2 }, { "item": "mischw", "chance": 2 } ],
         "R": [ { "item": "wood_workshop", "chance": 3 }, { "item": "mischw", "chance": 2 } ]
       }
     }

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -256,6 +256,7 @@
     "name": "Derelict shed",
     "description": "A collapsed shed.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_fallen_shed_map" },
+    "sym": "N",
     "color": "brown",
     "autonote": true
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Collapsed sheds have roofs over normal tiles and no roof over the actual collapse, fix appearance on minimap"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fixes some assorted oddities observed with the collapsed shed map extra.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Set it so the basic tiles use the default tile of the palette and thus still have a roof.
2. Conversely, set the fixed piles of rubble, the presumed collapse of said collapsed sheds, to have outdoor dirt instead of dirt floor (which made them the only part of the interior to have a roof).
3. Added a bit around the edges of the rubble that add a bit of random chance of being intact or not, along with varying chance of also having rubble.
4. Fixed shed's auto-note being visible on the main map but becoming a solid black sqaure on the minimap, this was due to it lacking a symbol in its map_extra definition.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Picking a symbol other than the default `N`.
2. Setting chipped walls to autogenerate a roof overhead, since it does look a bit odd.
3. Toning down their mapgen weight a bit, given they do seem reasonably common, far more so than the desolate barn overmap special they're somewhat similar to.
4. Adding a chance to spawn something actually interesting in these.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Tested in compiled build.
3. Wandered around until I found a shed, confirmed it didn't show up as a black block on the minimap.
4. Confirmed the interior was mostly roofed aside from the holes in the ceiling from the main rubble pile, and from the chipped walls not generating walls overhead.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/26105565-aa90-4005-a282-47b430b312a8)

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/439c569a-546c-4476-9398-8093ec419a8b)

I'm not sure why the lighting looks like that, given the only spots lacking a roof are in the NE corner and where the chipped walls are.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/0589734c-68a6-4919-ab9c-3cd682fa0502)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
