### PR TITLE
Fix Killer Drive trait not liking murder, not prompting on cannibalism

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -560,7 +560,7 @@
     "valid": false,
     "social_modifiers": { "intimidate": 5 },
     "cancels": [ "KILLER", "PACIFIST" ],
-    "flags": [ "CANNIBAL" ]
+    "flags": [ "PSYCHOPATH", "CANNIBAL" ]
   },
   {
     "type": "mutation",
@@ -574,7 +574,7 @@
     "prereqs": [ "PSYCHOPATH" ],
     "category": [ "LUPINE" ],
     "cancels": [ "PACIFIST" ],
-    "flags": [ "CANNIBAL" ]
+    "flags": [ "PSYCHOPATH" ]
   },
   {
     "type": "mutation",

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -114,6 +114,7 @@ static const trait_id trait_DEBUG_MIND_CONTROL( "DEBUG_MIND_CONTROL" );
 static const trait_id trait_HALLUCINATION( "HALLUCINATION" );
 static const trait_id trait_HYPEROPIC( "HYPEROPIC" );
 static const trait_id trait_ILLITERATE( "ILLITERATE" );
+static const trait_id trait_KILLER( "KILLER" );
 static const trait_id trait_MUTE( "MUTE" );
 static const trait_id trait_PROF_DICEMASTER( "PROF_DICEMASTER" );
 static const trait_id trait_PSYCHOPATH( "PSYCHOPATH" );
@@ -2520,14 +2521,21 @@ void npc::die( Creature *nkiller )
 
     if( killer == &g->u && ( !guaranteed_hostile() || hit_by_player ) ) {
         bool cannibal = g->u.has_trait( trait_CANNIBAL );
-        bool psycho = g->u.has_trait( trait_PSYCHOPATH );
+        bool psycho = g->u.has_trait( trait_PSYCHOPATH ) || g->u.has_trait( trait_KILLER );
         if( g->u.has_trait( trait_SAPIOVORE ) || psycho ) {
-            // No morale effect
+            // No morale penalty
         } else if( cannibal ) {
             g->u.add_morale( MORALE_KILLED_INNOCENT, -5, 0, 2_days, 3_hours );
         } else {
             g->u.add_morale( MORALE_KILLED_INNOCENT, -100, 0, 2_days, 3_hours );
         }
+    }
+
+    if( killer == &g->u && g->u.has_trait( trait_KILLER ) ) {
+        const translation snip = SNIPPET.random_from_category( "killer_on_kill" ).value_or( translation() );
+        g->u.add_msg_if_player( m_good, "%s", snip );
+        g->u.add_morale( MORALE_KILLER_HAS_KILLED, 5, 10, 6_hours, 4_hours );
+        g->u.rem_morale( MORALE_KILLER_NEED_TO_KILL );
     }
 
     place_corpse();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Killer Drive now rewards for killing innocent NPCs, prompts before committing cannibalism"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

One annoyance I found was that Killer Drive clashed with the Psychopath trait, motivating you to kill but still prompting guilt when you kill an innocent NPC. It also had the flaw where the `CANNIBAL` trait flag would mark human flesh as safe to eat and fail to prompt you, but because the morale effect only looks for the Cannibal trait itself, you'd end up getting sad about it.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

C++ changes:
1. In npc.cpp, set it so the check for inflicting morale from murdering an innoect NPC also excludes characters with the Killer Drive trait.
2. Additionally, set it so killing NPCs counts as a kill for the sake of the Killer Drive morale effects. This is separate from the other morale effects because the if statement for guilt over murdering the innocent only checks if the NPC was considered innocent, when it logically should trigger on killing NPCs in general. Since NPC kills a a bit more special than regular kills, I set it to always print the kill enjoyment message, but kept the morale impact the same.

JSON changes:
1. Switched Killer Drive to use the `PSYCHOPATH` trait flag. Its effects are buried in the code largely unused, but the key thing is it counts as identical to Cannibal and Sapiovore for the purpose of butchering human corpses, without flagging human flesh as being safe to eat (when it secretly isn't in the case of Killer Drive).

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Letting it count as Psychopath for the purpose of eating human flesh. I think it's probably good enough like this, allowing you to murder innocents and butcher them is plenty enough. It's Killer Drive after all, not Killer and Eater Drive. If the player wants to put their victims to good use afterward, the trait goes quite well with Cannibal.
2. Conversely, making it so Killer Drive still penalizes you for butchering human corpses, so your focus is entirely on murder, and warranting the purchase of the Cannibal trait if you want to do anything fun with victims after the main event is finished.
3. Allowing Killer Drive to dig up graves without penalty. Also probably out of focus for it I figure, and far more niche than other applications of Psychopath. Besides, gravedigging isn't killing, the victims have already been used up and tossed aside by the cataclysm at large.
4. Making NPCs more fun to kill than monsters.

If we increased the overlap between Psychopath and Killer Drive, since it comes with morale for doing what the average Cata player will be doing by the dozen anyway, we're likely want to bump the point cost of Killer Drive up a bit. In its current form as of this PR, you get all of the murder-related benefits of Psychopath and have the option to spend an extra point to get a morale-increasing equivalent to the people-eating benefits, leaving only gravedigging absent.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->


1. Checked affected JSON file for syntax and lint errors.
2. Compiled and load-tested.
3. Started up a world with Killer Drive.
4. Spawned in an M2 Browning and debugged my skills to max.
5. Tenderized the meat in my starting shelter.
6. Enjoyed tenderizing the meat instead of hating it.
7. Butchered the corpses without any sadness, observed the meat was nonetheless not good eatin's since didn't add the Cannibal trait.
8. Tenderized a few more delicious friends, observed they always printed the happy message.
9. Checked affected C++ file for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

The discovery of the `PSYCHOPATH` flag also gives me something I can use for Arcana, to allow sanguinist professions to always be okay with butchering corpses.