### PR TITLE
Fixes for vehicles over grass

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -18,7 +18,7 @@
     "symbol": ".",
     "color": "yellow",
     "move_cost": 3,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "NOCOLLIDE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_pit_shallow",
@@ -37,7 +37,7 @@
     "color": "brown",
     "looks_like": "t_dirt",
     "move_cost": 3,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "NOCOLLIDE" ],
     "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
@@ -118,7 +118,7 @@
     "color": "brown",
     "move_cost": 3,
     "coverage": 40,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "NOCOLLIDE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_dirtfloor",

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -2009,7 +2009,7 @@
     "symbol": ",",
     "color": "green",
     "move_cost": 3,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "NOCOLLIDE" ],
     "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
@@ -2022,7 +2022,7 @@
     "color": "green",
     "move_cost": 5,
     "coverage": 50,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "PLOWABLE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "PLOWABLE", "NOCOLLIDE" ],
     "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-traps.json
+++ b/data/json/furniture_and_terrain/terrain-traps.json
@@ -7,7 +7,7 @@
     "symbol": "0",
     "color": "yellow",
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN", "NOCOLLIDE" ],
     "bash": { "sound": "thump", "ter_set": "t_pit", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Use NOCOLLIDE to make vehicles not crash into grass"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Found out I fucked something up and didn't realize that vehicles don't like stuff that can be bashed into non-null stuff if it also has a slow movement cost. Turns out it's an easy fix at least but oof.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/2891

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Added `NOCOLLIDE` flag to all terrain affected by https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2842 to have a `move_cost` of 3 or higher.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Lowering move cost penalties or otherwise figuring out what will help reduce the problems this can still cause.
2. Reverting the PR that caused this because fuuuuck I didn't think it'd cause this much trouble.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Tested that running a car across woodchips, moss, clay, and regular grass didn't trigger a collosion since move cost is below 3.
3. Tested running over long grass, tall grass, and sand to confirm none of them triggered and impact either due to the flag being added.

Also dragged a shopping cart across my test strip. It's still slow to drag across plain fucking grass and gets fully stuck in tall grass, despite the cart being empty.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
