### PR TITLE
Add Animal Spawn Rate scaling factor option to Worldgen

### DIFF
--- a/data/json/game_balance.json
+++ b/data/json/game_balance.json
@@ -127,13 +127,6 @@
   },
   {
     "type": "EXTERNAL_OPTION",
-    "name": "SPAWN_ANIMAL_DENSITY",
-    "info": "A scaling factor that determines density of wild, formerly domesticated and mutated animal spawns.",
-    "stype": "float",
-    "value": 1.0
-  },
-  {
-    "type": "EXTERNAL_OPTION",
     "name": "DISABLE_ANIMAL_CLASH",
     "info": "Disable additional spawn of large groups of monsters fighting each other on swamps.",
     "stype": "bool",

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2237,7 +2237,6 @@ void options_manager::add_options_world_default()
          translate_marker( "A scaling factor that determines density of monster spawns." ),
          0.0, 50.0, 1.0, 0.1
        );
-	   
     add( "SPAWN_ANIMAL_DENSITY", world_default, translate_marker( "Animal spawn rate scaling factor" ),
          translate_marker( "A scaling factor that determines density of animal spawns." ),
          0.0, 50.0, 1.0, 0.1

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2237,6 +2237,11 @@ void options_manager::add_options_world_default()
          translate_marker( "A scaling factor that determines density of monster spawns." ),
          0.0, 50.0, 1.0, 0.1
        );
+	   
+    add( "SPAWN_ANIMAL_DENSITY", world_default, translate_marker( "Animal spawn rate scaling factor" ),
+         translate_marker( "A scaling factor that determines density of animal spawns." ),
+         0.0, 50.0, 1.0, 0.1
+       );
 
     add( "CARRION_SPAWNRATE", world_default, translate_marker( "Carrion spawn rate scaling factor" ),
          translate_marker( "A scaling factor that determines how often creatures spawn from rotting material." ),


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Add Animal Spawn Rate scaling factor option to Worldgen"

#### Purpose of change

Fixes #2795 - adds animal spawn rate to worldgen options in both initial setup and in-game menu

#### Describe the solution

- Add option for SPAWN_ANIMAL_DENSITY within options.cpp, set min, max and default the same as Spawn Density
- Remove external option from game_balance.json in core data

#### Describe alternatives you've considered

Leaving this as an external and not internal option

#### Testing

- Built game in debug and release mode with the option change
- Created world, noted option was available in the world gen
- Loaded world, noted that settings had transferred to option screen after removing external option
- Upped scaling to 50.00, noted vastly increased animal spawns 
- Loaded older world created before change, animal spawn rate set as 1.00 due to external option setting
- Modified speedydex to add SPAWN_ANIMAL_DENSITY as an external option, noted this overrode the world settings, reverted change

#### Additional context

World Gen Screen
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/3798c56c-8c02-4bb7-9254-7ab492254319)

In World Options Screen
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/7e7395b6-a231-4077-a111-95a9a1f2af50)

Field with 50.00 scaling factor turned on
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/2bcdbd8c-0cca-4720-a865-325c44b6fc15)



