### PR TITLE
Allow scrapping engine blocks for steel

### DIFF
--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -4384,5 +4384,50 @@
     "components": [ [ [ "nylon", 3 ] ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "type": "uncraft",
+    "result": "engine_block_tiny",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "10 m",
+    "qualities": [ { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "steel_lump", 8 ] ] ]
+  },
+  {
+    "type": "uncraft",
+    "result": "engine_block_small",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "15 m",
+    "qualities": [ { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "steel_lump", 40 ] ] ]
+  },
+  {
+    "type": "uncraft",
+    "result": "engine_block_medium",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "20 m",
+    "qualities": [ { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "steel_lump", 90 ] ] ]
+  },
+  {
+    "type": "uncraft",
+    "result": "engine_block_large",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "25 m",
+    "qualities": [ { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "steel_lump", 190 ] ] ]
+  },
+  {
+    "type": "uncraft",
+    "result": "engine_block_massive",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "30 m",
+    "qualities": [ { "id": "SAW_M", "level": 1 } ],
+    "components": [ [ [ "steel_lump", 280 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Engine blocks can be sawn down for steel lumps"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This adds the option to saw down engine blocks for scrap metal based on their weight, since as they are currently they aren't that useful once you've taken the entire engine apart.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Added uncrafts for tiny, small, medium, large, and massive engine blocks. Has the same basic requirements as most "turn this uncraftable metal thing into steel lumps" uncrafts, with escalating time as you go up in size. Steel lump yield matches the weight of the engine block exactly, due to each item weighing an exact amount of kg and steel lumps being 1 kg in weight each.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Also letting you craft your own engines if you find the parts for them, possibly allowing makeshift parts where relevant like with drive belts.

If we also made it so a destroyed vehicle engine has a high chance of dropping the engine block, and replaced a good chunk of "whose fuckin' engine randomly fell out of their car" spawns in the road itemgroup with engine blocks, this could be a good way to extend their utility and allow players more ways to potentially get a low-mid tier engine. Without those changes craftable engines wouldn't really add much, since you currently have to sacrifice an engine block for it.


#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Tested affected file for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
