### PR TITLE
Convert water dispenser into furniture holding a limited amount

### DIFF
--- a/data/json/furniture_and_terrain/furniture-plumbing.json
+++ b/data/json/furniture_and_terrain/furniture-plumbing.json
@@ -142,6 +142,43 @@
   },
   {
     "type": "furniture",
+    "id": "f_water_dispenser",
+    "copy-from": "f_water_heater",
+    "name": "water dispenser",
+    "looks_like": "t_water_dispenser",
+    "description": "A machine with several taps that dispenses clean water.  Also known as a water cooler, it's still useful so long as the tank is full.",
+    "symbol": "W",
+    "color": "light_blue",
+    "keg_capacity": 75,
+    "bash": {
+      "str_min": 15,
+      "str_max": 80,
+      "sound": "whack!",
+      "sound_fail": "thunk.",
+      "items": [
+        { "item": "sheet_metal", "count": 1 },
+        { "item": "sheet_metal_small", "count": [ 0, 10 ] },
+        { "item": "steel_chunk", "count": [ 0, 2 ] },
+        { "item": "scrap", "count": [ 3, 6 ] },
+        { "item": "pipe", "count": [ 0, 2 ] },
+        { "item": "hose", "count": 1 },
+        { "item": "water_faucet", "count": 1 }
+      ]
+    },
+    "deconstruct": {
+      "items": [
+        { "item": "sheet_metal", "count": 2 },
+        { "item": "steel_chunk", "count": 2 },
+        { "item": "scrap", "count": 6 },
+        { "item": "pipe", "count": 2 },
+        { "item": "cable", "charges": 10 },
+        { "item": "hose", "count": 1 },
+        { "item": "water_faucet", "count": 1 }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_water_purifier",
     "looks_like": "f_water_heater",
     "name": "water purifier",

--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -646,31 +646,6 @@
   },
   {
     "type": "terrain",
-    "id": "t_water_dispenser",
-    "name": "water dispenser",
-    "looks_like": "f_sink",
-    "description": "A machine with several taps that dispenses clean water.",
-    "symbol": "W",
-    "color": "light_blue",
-    "move_cost": 0,
-    "coverage": 40,
-    "flags": [ "TRANSPARENT" ],
-    "bash": {
-      "str_min": 15,
-      "str_max": 80,
-      "sound": "whack!",
-      "sound_fail": "thunk.",
-      "ter_set": "t_concrete",
-      "items": [
-        { "item": "steel_chunk", "count": [ 0, 2 ] },
-        { "item": "scrap", "count": [ 3, 6 ] },
-        { "item": "pipe", "count": [ 0, 2 ] }
-      ]
-    },
-    "examine_action": "clean_water_source"
-  },
-  {
-    "type": "terrain",
     "id": "t_plut_generator",
     "name": "plutonium generator",
     "description": "This imposing apparatus harnesses the power of the atom.  Refined nuclear fuel is 'burned' to provide nearly limitless electrical power.  It's not doing much good here though.  Perhaps it could be salvaged for other purposes.",

--- a/data/json/mapgen/hazardous_waste_sarcophagus.json
+++ b/data/json/mapgen/hazardous_waste_sarcophagus.json
@@ -107,8 +107,8 @@
         "s": "t_floor",
         "v": "t_dirt",
         "V": "t_vat",
+        "W": "t_floor",
         "L": "t_door_metal_locked",
-        "W": "t_water_dispenser",
         "~": "t_thconc_floor",
         "`": "t_wall_glass"
       },
@@ -131,9 +131,11 @@
         "l": "f_locker",
         "p": [ "f_indoor_plant", "f_indoor_plant_y" ],
         "s": "f_sink",
+        "W": "f_water_dispenser",
         "v": "f_vent_pipe"
       },
       "toilets": { "&": {  } },
+      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 75 ] } },
       "items": {
         "2": { "item": "coat_rack", "chance": 60, "repeat": 2 },
         "4": { "item": "toxic_dump_equipment", "chance": 85, "repeat": [ 1, 2 ] },
@@ -267,7 +269,7 @@
         "E": "t_elevator",
         "e": "t_elevator_control_off",
         "5": "t_console",
-        "W": "t_water_dispenser",
+        "W": "t_metal_floor",
         "~": [ [ "t_sewage", 55 ], [ "t_dirtfloor", 25 ], [ "t_dirtmound", 20 ] ]
       },
       "furniture": {
@@ -281,9 +283,11 @@
         "9": "f_utility_shelf",
         "a": "f_air_conditioner",
         "F": "f_filing_cabinet",
+        "W": "f_water_dispenser",
         "~": [ [ "f_null", 50 ], [ "f_wreckage", 50 ] ]
       },
       "toilets": { "&": {  } },
+      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 75 ] } },
       "items": {
         "8": { "item": "mechanics", "chance": 60, "repeat": [ 1, 2 ] },
         "9": { "item": "sewage_plant", "chance": 60, "repeat": [ 1, 2 ] },

--- a/data/json/mapgen/mine/mine_entrance.json
+++ b/data/json/mapgen/mine/mine_entrance.json
@@ -66,7 +66,6 @@
         "s": "t_linoleum_white",
         "v": "t_dirt",
         "w": "t_window_alarm",
-        "W": "t_water_dispenser",
         "Й": "t_linoleum_white",
         "Ф": "t_chaingate_l"
       },
@@ -102,11 +101,13 @@
         "T": "f_counter",
         "t": "f_table",
         "v": "f_vent_pipe",
+        "W": "f_water_dispenser",
         "Д": "f_desk",
         "д": "f_desk",
         "Й": "f_rack_coat"
       },
       "toilets": { "&": {  } },
+      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 75 ] } },
       "items": {
         "2": { "item": "coat_rack", "chance": 60, "repeat": 2 },
         "8": { "item": "mine_materials", "chance": 50, "repeat": 4 },

--- a/data/json/mapgen/missile_silo.json
+++ b/data/json/mapgen/missile_silo.json
@@ -117,7 +117,6 @@
         "S": "t_floor",
         "t": "t_floor",
         "T": "t_floor",
-        "W": "t_water_dispenser",
         "C": "t_floor",
         "6": "t_floor",
         "=": "t_door_locked",
@@ -144,10 +143,12 @@
         "l": "f_locker",
         "s": "f_sofa",
         "S": "f_sink",
+        "W": "f_water_dispenser",
         "6": "f_shower",
         "b": "f_bookcase",
         "1": "f_speaker_cabinet"
       },
+      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 75 ] } },
       "items": {
         "r": { "item": "trash_cart", "chance": 50, "repeat": 2 },
         "l": { "item": "lab_dorm", "chance": 70, "repeat": 2 },
@@ -222,7 +223,6 @@
         "S": "t_floor",
         "t": "t_floor",
         "T": "t_floor",
-        "W": "t_water_dispenser",
         "C": "t_floor",
         "0": "t_reinforced_glass_shutter",
         "^": "t_elevator_control_off",
@@ -414,8 +414,7 @@
         "<": "t_stairs_up",
         "Y": "t_card_military",
         "^": "t_elevator_control_off",
-        "$": "t_elevator",
-        "W": "t_water_dispenser"
+        "$": "t_elevator"
       },
       "furniture": {
         "4": "f_speaker_cabinet",
@@ -429,9 +428,11 @@
         "r": "f_rack",
         "s": "f_shower",
         "S": "f_sink",
-        "t": "f_trashcan"
+        "t": "f_trashcan",
+        "W": "f_water_dispenser"
       },
       "toilets": { "@": {  } },
+      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 75 ] } },
       "items": {
         "b": { "item": "army_bed", "chance": 60 },
         "t": { "item": "trash_cart", "chance": 60 },

--- a/data/json/mapgen_palettes/basement.json
+++ b/data/json/mapgen_palettes/basement.json
@@ -140,9 +140,10 @@
       "<": "t_stairs_up",
       "M": "t_wall_metal",
       "|": "t_reinforced_glass",
-      "/": "t_door_curtain_c",
-      "W": "t_water_dispenser"
+      "/": "t_door_curtain_c"
     },
+    "furniture": { "W": "f_water_dispenser" },
+    "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 75 ] } },
     "toilets": { "&": {  } }
   },
   {

--- a/data/json/obsoletion/uncategorized.json
+++ b/data/json/obsoletion/uncategorized.json
@@ -411,5 +411,31 @@
       { "fuel": 1, "smoke": 3, "burn": 3 },
       { "fuel": 1, "smoke": 5, "burn": 5 }
     ]
+  },
+  {
+    "type": "terrain",
+    "//": "Obsoleted in favor of a furniture version.",
+    "id": "t_water_dispenser",
+    "name": "water dispenser",
+    "looks_like": "f_sink",
+    "description": "A machine with several taps that dispenses clean water.",
+    "symbol": "W",
+    "color": "light_blue",
+    "move_cost": 0,
+    "coverage": 40,
+    "flags": [ "TRANSPARENT" ],
+    "bash": {
+      "str_min": 15,
+      "str_max": 80,
+      "sound": "whack!",
+      "sound_fail": "thunk.",
+      "ter_set": "t_concrete",
+      "items": [
+        { "item": "steel_chunk", "count": [ 0, 2 ] },
+        { "item": "scrap", "count": [ 3, 6 ] },
+        { "item": "pipe", "count": [ 0, 2 ] }
+      ]
+    },
+    "examine_action": "clean_water_source"
   }
 ]

--- a/data/mods/Aftershock/maps/mapgen/millyficent_lab.json
+++ b/data/mods/Aftershock/maps/mapgen/millyficent_lab.json
@@ -152,10 +152,9 @@
         "H": "t_linoleum_white",
         "T": "t_linoleum_white",
         "8": "t_console_broken",
-        "W": "t_water_dispenser",
         "*": "t_thconc_floor_olight"
       },
-      "liquids": { "E": { "liquid": "water", "amount": [ 0, 100 ] } },
+      "liquids": { "E": { "liquid": "water", "amount": [ 0, 100 ] }, "W": { "liquid": "water_clean", "amount": [ 0, 75 ] } },
       "furniture": {
         "T": "f_workbench",
         "G": "f_glass_cabinet",
@@ -174,7 +173,8 @@
         "f": "f_filing_cabinet",
         "5": "f_server",
         "b": "f_lab_bench",
-        "D": "f_fume_hood"
+        "D": "f_fume_hood",
+        "W": "f_water_dispenser"
       },
       "items": {
         "U": [

--- a/data/mods/No_Hope/Mapgen/missile_silo.json
+++ b/data/mods/No_Hope/Mapgen/missile_silo.json
@@ -103,7 +103,6 @@
         "|": "t_metal_railing",
         "-": "t_metal_railing",
         "~": "t_metal_floor",
-        "W": "t_water_dispenser",
         "=": "t_door_locked",
         "+": "t_door_metal_locked",
         "?": "t_door_metal_c_peep",
@@ -130,7 +129,8 @@
         "S": "f_sink",
         "6": "f_shower",
         "b": "f_bookcase",
-        "1": "f_speaker_cabinet"
+        "1": "f_speaker_cabinet",
+        "W": "f_water_dispenser"
       },
       "items": {
         "r": { "item": "trash_cart", "chance": 50, "repeat": 2 },
@@ -143,6 +143,7 @@
       },
       "item": { "e": { "item": "microwave", "chance": 70 }, "T": { "item": "militarymap", "chance": 30 } },
       "toilets": { "&": {  } },
+      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 75 ] } },
       "monster": { ".": { "monster": "mon_zombie_soldier", "chance": 10 } }
     }
   },
@@ -206,7 +207,6 @@
         "S": "t_floor",
         "t": "t_floor",
         "T": "t_floor",
-        "W": "t_water_dispenser",
         "C": "t_floor",
         "0": "t_reinforced_glass_shutter",
         "^": "t_elevator_control_off",
@@ -398,8 +398,7 @@
         "<": "t_stairs_up",
         "Y": "t_card_military",
         "^": "t_elevator_control_off",
-        "$": "t_elevator",
-        "W": "t_water_dispenser"
+        "$": "t_elevator"
       },
       "furniture": {
         "4": "f_speaker_cabinet",
@@ -413,9 +412,11 @@
         "r": "f_rack",
         "s": "f_shower",
         "S": "f_sink",
-        "t": "f_trashcan"
+        "t": "f_trashcan",
+        "W": "f_water_dispenser"
       },
       "toilets": { "@": {  } },
+      "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 75 ] } },
       "items": {
         "b": { "item": "army_bed", "chance": 60 },
         "t": { "item": "trash_cart", "chance": 60 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Water dispensers converted from infinite clear water terrain to keg-style furniture holding a limited amount of clean water"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

The BN discord once again reminded me that infinite clean water from a water dispenser may be a lil bit odd, and it wouldn't be too wacky to nerf it into behaving like a simple water container instead.

Of course, I figured it'd be simple but turns out that terrain doesn't play nice with the `keg` use action, so I guess we're getting a migration to furniture.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added a furniture version of the water dispenser in the appropriate file. Made it a water container like water heaters instead of infinite clean water. Set a keg capacity of 75, so about 5 gallons (a common size for water cooler tanks).
2. Obsoleted the old terrain version.
2. Set the basement_bunker palette to use the new furniture version, and also place 0-75 clean water in the dispenser it's set to place (5 gallons being a standard size for water coolers). Only case where dispensers are set by mapgen palette instead of mapgen itself, oddly enough.
3. Did the same with dispensers in the HWS, mine entrance, and missile silo.
4. Also removed water dispensers from the `terrain` def for the silo mapgen floor that didn't actually place a dispenser in it. I guess someday that will need to be converted to a mapgen palette, weh.
5. Also converted examples in mods folder.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

It was also brought up that we oughta have some sorta constructable "pump with integrated water purification" thing so that we still have an in-repo application of the `clean_water_source` examine action. Question would be do we just want it to entail slapping enough stuff on it to stand in for a whole-house water filter and let it still be infinite-use, or do we want to hack together some way to make it require power and/or charges of filter material...

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled build.
3. Started in bottom of a mine scenario and warped up to the entrance.
4. Water dispenser correctly had clean water inside it, and could be drank from it or poured out as normal.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
