### PR TITLE
Sanity-check effect of rough terrain on dragging light vehicles

### DIFF
--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -36,6 +36,12 @@ auto base_str_req( vehicle *veh )-> int
     return veh->total_mass() / 100_kilogram;
 }
 
+// alternative strength check, for saner results with weights less than 100 kg
+auto offroad_str_req_cap( vehicle *veh )-> int
+{
+    return veh->total_mass() / 10_kilogram;
+}
+
 // determine movecost for terrain touching wheels
 auto get_grabbed_vehicle_movecost( vehicle *veh ) -> int
 {
@@ -145,7 +151,9 @@ bool game::grabbed_veh_move( const tripoint &dp )
 
     //vehicle movement: strength check. very strong humans can move about 2,000 kg in a wheelbarrow.
     // int str_req = grabbed_vehicle->total_mass() / 100_kilogram; //strength required to move vehicle.
-    const int str_req = get_vehicle_str_requirement( grabbed_vehicle );
+    // for smaller vehicles, offroad_str_req_cap sanity-checks our results.
+    int str_req = std::min( get_vehicle_str_requirement( grabbed_vehicle ),
+                            offroad_str_req_cap( grabbed_vehicle ) );
     const int str = u.get_str();
     add_msg( m_debug, "str_req: %d", str_req );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Implement a cap on dragging strength requirement based on vehicle weight, fixing shopping carts getting stuck while empty"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This changes how difficulty for dragging a vehicle is determined, specifically so that lightweight vehicles don't get punished to a wacky extent such that a little bit of grass makes a shopping cart immobile while empty.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/2897

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In grab.cpp, defined `offroad_str_req_cap` that equals vehicle weight divided by 10 kg, or one tenth the effectiveness of `base_str_req`
2. In `game::grabbed_veh_move`, set it so it sanity-checks modified strength result by comparing the results of `get_vehicle_str_requirement` against `offroad_str_req_cap`. If they don't match up, as it generally does when you're dragging vehicles with weights below 200 or so kg, it picks the lower of the 2. This ensures that effective weight multiplier caps out at 10 times the vehicle weight, not something wacky like 30 times.

The idea here is that we take the same logic of "worst case scenario multiplies the requirement by 10" except the cap applies it to the vehicle weight directly, whereas `get_vehicle_str_requirement` applies its modifiers after vehicle weight has already been crunched down into a smaller, less granular value. As you can probably guess, this breaks down HARD when the weights involved are small enough, so using a touch std::min here will keep those cases from returning wacky multipliers that make the vehicle effectively count as 30 or more times heavier than it actually is.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Restructuring both `get_grabbed_vehicle_movecost` and `get_vehicle_str_requirement` so that we're always dealing with the vehicle's weight until the last moment would make std::min'ing it where it counts unnecessary, but that seems like it'd be a fair bit more complex than just injecting a specific sanity-check into the most critical function.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->


1. Compiled and load-tested, also testing in 2023-05-26-1006 for comparison.
2. Spawned in a shopping cart (12 kg) and took it out for a spin in both versions
3. Strength requirement on pavement was 1 in both the 5/26 build and compiled build.
4. Injected some tall grass into the mix, with temporary modification to make it passable again (see https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2894).
5. Requirement was 10 in the 5/26 build, 1 in the compiled test build. `12 kg / 10` is 1.2 so presumably rounding down, contrast `12 / 100` being presumably rounded up to 1, then multiplied by 10, you can probably figure where the 5/26 build got that value.
6. Also took them out onto some plain grass in both versions. Requirement was 4 in 5/26 build, 1 in compiled build. As it should be for a completely empty cart.
7. Loaded out cart friend up to the brim with lumps of steel, increasing weight to 162 kg.
8. Strength required in both the 5/26 build and the compiled build was 1 on pavement, 10 on grass, and 20 on tall grass.
9. Strength required for this in compiled build was 1 on pavement, 10 on grass, and 16 on tall grass. So in this example only the tall grass situation was bad enough that it hit the cap.
10. Spawned in a car (1123 kg) in both versions to test.
11. Strength requirement on pavement was 5 in both the 5/26 build and in the compiled test build.
12. Swapped out the pavement for tall grass, requirement was 70 in both versions. This indicates that the net impact is returning a value where either both `get_vehicle_str_requirement` and `offroad_str_req_cap` are returning results that round to the same value, or else `get_vehicle_str_requirement` is less than the cap in this case. Quick math tells us obviously `1123 / 10 = 112.3` so it's the latter.
13. Checked affected file for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
