### PR TITLE
Standardize use of lye and lye powder, smaller batch recipe

### DIFF
--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -278,7 +278,7 @@
       [ [ "water", 4 ], [ "water_clean", 4 ] ],
       [ [ "meal_bone", 2 ] ],
       [ [ "meal_chitin_piece", 1 ] ],
-      [ [ "ammonia", 1 ], [ [ "chem_lye", 3, "LIST" ] ], [ "chem_saltpetre", 50 ] ]
+      [ [ "ammonia", 1 ], [ "chem_lye", 3, "LIST" ], [ "chem_saltpetre", 50 ] ]
     ]
   },
   {

--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -116,7 +116,7 @@
         [ "tobacco_raw", 50 ],
         [ "nicotine_liquid", 50 ]
       ],
-      [ [ "lye", 2 ], [ "lye_powder", 50 ] ]
+      [ [ "chem_lye", 2, "LIST" ] ]
     ]
   },
   {
@@ -205,12 +205,13 @@
     "subcategory": "CSC_CHEM_CHEMICALS",
     "skill_used": "cooking",
     "difficulty": 3,
-    "time": "1 h 30 m",
+    "time": "15 m",
     "autolearn": true,
     "batch_time_factors": [ 80, 4 ],
+    "charges": 30,
     "qualities": [ { "id": "BOIL", "level": 1 } ],
-    "tools": [ [ [ "water_boiling_heat", 120, "LIST" ] ] ],
-    "components": [ [ [ "lye", 6 ] ] ]
+    "tools": [ [ [ "water_boiling_heat", 25, "LIST" ] ] ],
+    "components": [ [ [ "lye", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -277,7 +278,7 @@
       [ [ "water", 4 ], [ "water_clean", 4 ] ],
       [ [ "meal_bone", 2 ] ],
       [ [ "meal_chitin_piece", 1 ] ],
-      [ [ "ammonia", 1 ], [ "lye_powder", 100 ], [ "chem_saltpetre", 50 ] ]
+      [ [ "ammonia", 1 ], [ [ "chem_lye", 3, "LIST" ] ], [ "chem_saltpetre", 50 ] ]
     ]
   },
   {
@@ -308,7 +309,7 @@
     "tools": [ [ [ "surface_heat", 18, "LIST" ] ] ],
     "components": [
       [ [ "edible_tallow_lard", 2, "LIST" ], [ "cooking_oil", 16 ], [ "cooking_oil2", 16 ] ],
-      [ [ "lye", 2 ], [ "lye_powder", 75 ] ],
+      [ [ "chem_lye", 2, "LIST" ] ],
       [ [ "water", 2 ], [ "water_clean", 2 ] ]
     ],
     "flags": [ "ALLOW_ROTTEN" ]

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -12,6 +12,12 @@
     "components": [ [ [ "lead", 1 ] ] ]
   },
   {
+    "id": "chem_lye",
+    "type": "requirement",
+    "//": "Comparable ratios of liquid lye and lye powder.",
+    "components": [ [ [ "lye", 1 ], [ "lye_powder", 30 ] ] ]
+  },
+  {
     "id": "copper_scrap_equivalent",
     "type": "requirement",
     "//": "Material used for equivalence between one unit of scrap copper and corresponding amount of elemental copper.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Make lye powder 1 lye at a time, add crafting requirement for consistent recipe uses"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

It was brought up in the BN discord that making lye powder 6 lye at a time was a bit bothersome.

Along the way it became clear that the ratio between lye powder and lye in recipes was wildly inconsistent.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->


1. Standardized the ratio of lye to lye powder at 1:30 (very close to the ratio for the recipe making lye poiwder from lye) via implementing a crafting requirement to use for it.
2. Changed the `from_lye` recipe for lye powder to only take 1 lye, output 30 lye powder, as per above. Updated time and heating requirements accordingly.
3. Updated other recipes in the chem folder to use the new crafting quality. Ammonia recipe was left untouched though since it uses a small amount of lye powder or charcoal, at a ratio consistent with the old-school lye-powder-from-charcoal recipe. Saltpetre recipe also left untouched since it looks like lye powder is being used for generic reasons here.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Screaming.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
