### PR TITLE
Fix Jenny Forcette Greeting

### DIFF
--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -112,7 +112,10 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_JENNY_1",
     "dynamic_line": {
-      "u_has_effect": "u_met_Jenny_Forcette",
+      "u_has_var": "u_met_Jenny_Forcette", 
+	  "type": "general", 
+	  "context": "meeting", 
+	  "value": "yes",
       "yes": [ "Hello again.", "Nice to see you again.", "What's up?" ],
       "no": "Hi there.  Haven't see you around here before.  I'm Jenny, Jenny Forcette."
     },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -112,10 +112,10 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_JENNY_1",
     "dynamic_line": {
-      "u_has_var": "u_met_Jenny_Forcette", 
-	  "type": "general", 
-	  "context": "meeting", 
-	  "value": "yes",
+      "u_has_var": "u_met_Jenny_Forcette",
+      "type": "general",
+      "context": "meeting",
+      "value": "yes",
       "yes": [ "Hello again.", "Nice to see you again.", "What's up?" ],
       "no": "Hi there.  Haven't see you around here before.  I'm Jenny, Jenny Forcette."
     },


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix Jenny Forcette to acknowledge previous meeting"


#### Purpose of change

To fix Jenny Forcette so she acknowledges meeting player before

#### Describe the solution

Noticed during prep work on my mod after searching u_has_effect in core data that this should be u_has_var in Jennys dynamic line greeting to acknowledge previously meeting player, changed this in JSON file

#### Describe alternatives you've considered

Leaving it as is

#### Testing

Loaded into base game and tested, Jenny now greets properly second and subsequent times

#### Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/2b4923b2-05dc-45da-9ef9-9abbcca601a4)

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/e39629ee-139e-4a79-bdc9-99e0f2927435)
