### PR TITLE
Obsolete extra gallon jug recipe

### DIFF
--- a/data/json/obsoletion/recipes.json
+++ b/data/json/obsoletion/recipes.json
@@ -3167,5 +3167,11 @@
     "result": "chem_zinc_powder",
     "type": "recipe",
     "obsolete": true
+  },
+  {
+    "type": "recipe",
+    "result": "jug_plastic",
+    "id_suffix": "plastic-mod",
+    "obsolete": true
   }
 ]

--- a/data/json/recipes/other/containers.json
+++ b/data/json/recipes/other/containers.json
@@ -390,19 +390,6 @@
   },
   {
     "type": "recipe",
-    "result": "jug_plastic",
-    "id_suffix": "plastic-mod",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_CONTAINERS",
-    "skill_used": "fabrication",
-    "difficulty": 2,
-    "time": "45 m",
-    "autolearn": true,
-    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "surface_heat", 15, "LIST" ] ] ],
-    "components": [ [ [ "plastic_chunk", 15 ] ] ]
-  },
-  {
-    "type": "recipe",
     "result": "canteen",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_CONTAINERS",


### PR DESCRIPTION
#### Summary

SUMMARY: Balance "Obsolete extra gallon jug recipe "

#### Purpose of change

There were two recipes for gallon jugs. Both required the same ingredients and tools but one took 15 less fuel charges, 5 more minutes and 1 more difficulty in fabrication.

#### Describe the solution

I obsoleted the extra one which took longer with less fuel charges, as using a campfire or a base setup with tons of power generation means consuming more charges for less time is always optimal.

#### Describe alternatives you've considered

This second recipe could lose the plastic mold requirement and take considerably longer, but almost every other plastic recipe requires a plastic mold AND there is few examples where not making a plastic mold is in your best interest as justifying this would mean it taking quite a bit longer, not to mention we'd want to add a mold-less version of every other recipe to keep consistency.

#### Testing

It loads and no errors are found.
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/9b7cc34e-c58b-4c03-8074-8af3a146e929)


#### Additional context

Maybe with specialized tools we could add recipes that are even quicker but more difficult and take more heat charges. I do not know what tools would allow this.
