### PR TITLE
Magiclysm: Plastic Golems no longer regenerate

### DIFF
--- a/data/mods/Magiclysm/monsters/golems.json
+++ b/data/mods/Magiclysm/monsters/golems.json
@@ -57,7 +57,6 @@
     "vision_day": 30,
     "vision_night": 30,
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
-    "regenerates": 10,
     "death_function": [ "BROKEN" ],
     "flags": [ "SEES", "HEARS", "NO_BREATHE", "LOUDMOVES" ]
   },


### PR DESCRIPTION
#### Summary

SUMMARY: [Mods] "Removed regeneration from Magiclysm plastic golems"

#### Purpose of change

It is well known to Magiclysm users that plastic golems from Wizard Towers can clear an entire city for you because they have good combat stats, insatiable bloodlust, and can regenerate health. Removing their regeneration fixes this, in my mind there's no reason the golems are enchanted to regenerate, or that it wore off due to a lack of maintenance.

#### Describe the solution

Removed the regeneration field from their JSON.

#### Describe alternatives you've considered

Nerfing any other aspect of plastic golems instead.

#### Testing

Loaded up the change, spawned them in, watched the carnage.
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/7b39cae6-b3fe-4967-953f-beb6bd6cae32)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/7a32dfb1-c787-4a0b-9032-a802f2aec65c)


#### Additional context

Soon owlbears will lose their insatiable bloodlust.
