### PR TITLE
Improvements to feral survivor and Mycus experience

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -260,8 +260,11 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
 
     if( monster *const mon_ptr = g->critter_at<monster>( dest_loc, true ) ) {
         monster &critter = *mon_ptr;
+        // Additional checking to make sure we won't take a swing at friendly monsters.
+        Character &u = get_player_character();
+        monster_attitude att = critter.attitude( const_cast<Character *>( &u ) );
         if( critter.friendly == 0 &&
-            !critter.has_effect( effect_pet ) ) {
+            !critter.has_effect( effect_pet ) && att != MATT_FRIEND ) {
             if( you.is_auto_moving() ) {
                 add_msg( m_warning, _( "Monster in the way.  Auto-move canceled." ) );
                 add_msg( m_info, _( "Move into the monster to attack." ) );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2967,6 +2967,15 @@ void monster::hear_sound( const tripoint &source, const int vol, const int dist 
         return;
     }
 
+    static const string_id<monfaction> faction_zombie( "zombie" );
+    const bool feral_friend = ( faction == faction_zombie || !type->in_species( ZOMBIE ) ) &&
+                              g->u.has_trait( trait_PROF_FERAL ) && !g->u.has_effect( effect_feral_infighting_punishment );
+
+    // Hackery: If player is currently a feral and you're a zombie, ignore any sounds close to their position.
+    if( feral_friend && rl_dist( g->u.pos(), source ) <= 10 ) {
+        return;
+    }
+
     const bool goodhearing = has_flag( MF_GOODHEARING );
     const int volume = goodhearing ? 2 * vol - dist : vol - dist;
     // Error is based on volume, louder sound = less error


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Feral survivors and Mycus properly displace friendly monsters instead of attacking, zombies ignore sounds near feral players"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some related improvements to playable ferals to make some of the quirks I found previously less annoying, fixing two things I ran into while testing the Lost and Damned PR.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In monster.cpp, `monster::hear_sound` so that sounds made near a feral player are ignored by zombies/ferals, so they'll stop crowding around you, smashing up all your shit, and following your footsteps.
2. In avatar_action.cpp, added a bit to `avatar_action::move` to make certain the player won't take a swing a monster that's considered a friend when trying to move into their space. This not only fixes feral players taking a swing at their fellow zeds, it also fixes Mycus players attacking friendly fungaloids.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Screaming.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Spawned in as a normal character, confirmed that ferals and zombies would make their way to my position if I made noise.
3. Became a feral survivor, zombies ignore my when I make a racket now.
4. Tested that a jabberwock still happily reacted to my noises by kool-aid-man'ing its way after me.
5. Tested that a normal survivor will still happily slap a cow, but displace one that's been tamed by cattle fodder.
6. Tested I still slap the shit out of a non-tamed cow as a feral survivor, and now correctly displace zombies and ferals when I walk into them.
7. Mycus players likewise now displace fungaloids instead of slapping them.
8. Checked affected files for syntax and lint errors.

They sometimes still sit around you after you've walked about a bit if they have nothing better to do, but they're a lot better about it now, aren't directly triggered by sound, and they're way better about losing interest in you.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
