### PR TITLE
Prevent vehicle part installation on mountable terrain and furniture

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -143,7 +143,6 @@ static const bionic_id bio_ups( "bio_ups" );
 static const std::string flag_CONSUMABLE( "CONSUMABLE" );
 static const std::string flag_DISABLE_SIGHTS( "DISABLE_SIGHTS" );
 static const std::string flag_FIRE_TWOHAND( "FIRE_TWOHAND" );
-static const std::string flag_MOUNTABLE( "MOUNTABLE" );
 static const std::string flag_MOUNTED_GUN( "MOUNTED_GUN" );
 static const std::string flag_NEVER_JAMS( "NEVER_JAMS" );
 static const std::string flag_NON_FOULING( "NON-FOULING" );

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -62,6 +62,7 @@ trajectory mode_shaped( avatar &you, shape_factory &shape_fac, aim_activity_acto
 } // namespace target_handler
 
 int range_with_even_chance_of_good_hit( int dispersion );
+static const std::string flag_MOUNTABLE( "MOUNTABLE" ); //Moved here to be checked by the vehicle interaction menu
 
 namespace ranged
 {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -48,6 +48,7 @@
 #include "pimpl.h"
 #include "player.h"
 #include "point.h"
+#include "ranged.h"
 #include "requirements.h"
 #include "skill.h"
 #include "string_formatter.h"
@@ -2148,6 +2149,10 @@ void veh_interact::move_cursor( point d, int dstart_at )
     if( ovp && &ovp->vehicle() != veh ) {
         obstruct = true;
     }
+	//Set obstruction if object is mountable to stop vehicles being built in windows, on tables etc.
+	if ( g->m.has_flag( flag_MOUNTABLE, vehp ) ) {
+		obstruct = true;
+	}
 
     can_mount.clear();
     if( !obstruct ) {
@@ -2321,6 +2326,10 @@ void veh_interact::display_veh()
     if( ovp && &ovp->vehicle() != veh ) {
         obstruct = true;
     }
+	//Set obstruction if object is mountable to stop vehicles being built in windows, on tables etc.
+	if ( g->m.has_flag( flag_MOUNTABLE, vehp ) ) {
+		obstruct = true;
+	}
     nc_color col = cpart >= 0 ? veh->part_color( cpart ) : c_black;
     int sym = cpart >= 0 ? veh->part_sym( cpart ) : ' ';
     mvwputch( w_disp, point( hw, hh ), obstruct ? red_background( col ) : hilite( col ),


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Prevent vehicle part installation on mountable terrain and furniture"

#### Purpose of change

Fixes #124 by not allowing installation of vehicle parts if the terrain or furniture in the square are moutable

#### Describe the solution

- Move the Flag_MOUNTABLE definition from ranged.cpp to ranged.h to avoid duplicating
- Add "ranged.h" to veh_interact.cpp
- Add check for both the installation and the cursor color to mark mountable terrain and furniture (which is otherwise allowed due to it not being impassable) as obstructing installation   

#### Describe alternatives you've considered

I originally leveraged construct::check_empty from construction.cpp which worked however it would not let a part be installed if anything was on the square, including the player and furniture ignored by vehicles such as flowers so not ideal 

#### Testing

- Built the game in both debug an release mode
- Turned on all debug mutations for player
- Started vehicle construction next to various mountable terrain to confirm these block - fences, open windows, mounds of dirt etc.
- Started vehicle construction next to various mountable furniture to confirm these block - tables, beds, ovens etc,

#### Additional context
Before changes - able to build vehicle parts on anything that was not impassable terrain, trying to then move the vehicle shows errors
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/8d142017-d39e-4bab-94af-2d9b442625e2)

After changes, new vehicle construction - mountable to the top (open window) and bottom (fence)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/e127ec14-7318-4561-a217-bf0d4b2499c9)

As expected, cannot install anything in window frame to the north
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/594b7ed5-bd19-422a-9266-5fb33be8b905)

Also cannot install anything due to the fence in the south
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/1fc2bbde-5274-41dd-91cc-2396881dd5d4)

Smashing the fence removes the mountable flag
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/978b7552-42ab-426e-93c5-1056b85decf3)

Can now install to the south
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/91185016/3cb21d8c-d1e8-43a8-9442-e598960a2da1)



