### PR TITLE
Fix vehicles turning bushes into pits

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -7,7 +7,7 @@
     "symbol": ".",
     "color": "brown",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "VEH_TREAT_AS_BASH_BELOW" ],
     "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
@@ -18,7 +18,7 @@
     "symbol": ".",
     "color": "yellow",
     "move_cost": 3,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "NOCOLLIDE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "VEH_TREAT_AS_BASH_BELOW" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_pit_shallow",
@@ -37,7 +37,7 @@
     "color": "brown",
     "looks_like": "t_dirt",
     "move_cost": 3,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "NOCOLLIDE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "VEH_TREAT_AS_BASH_BELOW" ],
     "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
@@ -104,7 +104,7 @@
     "symbol": "#",
     "color": "brown",
     "move_cost": 3,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE", "PLANTABLE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "VEH_TREAT_AS_BASH_BELOW", "PLANTABLE" ],
     "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 50, "str_max": 100, "str_min_supported": 100 },
     "examine_action": "dirtmound"
   },
@@ -118,7 +118,7 @@
     "color": "brown",
     "move_cost": 3,
     "coverage": 40,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "NOCOLLIDE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "VEH_TREAT_AS_BASH_BELOW" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_dirtfloor",
@@ -151,7 +151,7 @@
     "symbol": "#",
     "color": "green",
     "move_cost": 3,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "VEH_TREAT_AS_BASH_BELOW" ],
     "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
@@ -163,7 +163,7 @@
     "symbol": "#",
     "color": "brown",
     "move_cost": 3,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE", "CONTAINER", "SEALED" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "VEH_TREAT_AS_BASH_BELOW", "CONTAINER", "SEALED" ],
     "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -2009,7 +2009,7 @@
     "symbol": ",",
     "color": "green",
     "move_cost": 3,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "NOCOLLIDE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "VEH_TREAT_AS_BASH_BELOW" ],
     "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
@@ -2022,7 +2022,7 @@
     "color": "green",
     "move_cost": 5,
     "coverage": 50,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "PLOWABLE", "NOCOLLIDE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "PLOWABLE", "VEH_TREAT_AS_BASH_BELOW" ],
     "bash": { "sound": "thump", "ter_set": "t_pit_shallow", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-traps.json
+++ b/data/json/furniture_and_terrain/terrain-traps.json
@@ -7,7 +7,7 @@
     "symbol": "0",
     "color": "yellow",
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN", "NOCOLLIDE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN", "VEH_TREAT_AS_BASH_BELOW" ],
     "bash": { "sound": "thump", "ter_set": "t_pit", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -601,6 +601,7 @@ List of known flags, used in both `terrain.json` and `furniture.json`.
 - ```TRANSPARENT``` Players and monsters can see through/past it. Also sets ter_t.transparent.
 - ```UNSTABLE``` Walking here cause the bouldering effect on the character.
 - ```USABLE_FIRE``` This terrain or furniture counts as a nearby fire for crafting.
+- ```VEH_TREAT_AS_BASH_BELOW``` Vehicles will not collide with this even if it counts as rough terrain, like floor with bash_below does.  Used for terrain meant to be turned into other terrain when smashed instead of destroying the tile beneath it.
 - ```WALL``` This terrain is an upright obstacle. Used for fungal conversion, and also implies `CONNECT_TO_WALL`.
 
 ### Examine Actions

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2525,7 +2525,8 @@ bool map::is_bashable( const tripoint &p, const bool allow_floor ) const
 bool map::is_bashable_ter( const tripoint &p, const bool allow_floor ) const
 {
     const auto &ter_bash = ter( p ).obj().bash;
-    return ter_bash.str_max != -1 && ( !ter_bash.bash_below || allow_floor );
+    return ter_bash.str_max != -1 && ( ( !ter_bash.bash_below &&
+                                         !ter( p ).obj().has_flag( "VEH_TREAT_AS_BASH_BELOW" ) ) || allow_floor );
 }
 
 bool map::is_bashable_furn( const tripoint &p ) const

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -717,7 +717,8 @@ bool vehicle::autodrive_controller::check_drivable( tripoint pt ) const
         // terrain with neutral move cost or tagged with NOCOLLIDE will never cause
         // collisions
         return true;
-    } else if( terrain_type.bash.str_max >= 0 && !terrain_type.bash.bash_below ) {
+    } else if( terrain_type.bash.str_max >= 0 && !terrain_type.bash.bash_below &&
+               !terrain_type.has_flag( "VEH_TREAT_AS_BASH_BELOW" ) ) {
         // bashable terrain (but not bashable floors) will cause collisions
         return false;
     } else if( terrain_type.has_flag( TFLAG_LIQUID ) ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -693,6 +693,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
             //       Floor values are still used to set damage dealt to vehicle
             smashed = here.is_bashable_ter_furn( p, false ) &&
                       here.bash_resistance( p, bash_floor ) <= obj_dmg &&
+                      !here.has_flag_ter_or_furn( "NOCOLLIDE", p ) &&
                       here.bash( p, obj_dmg, false, false, false, this ).success;
             if( smashed ) {
                 if( here.is_bashable_ter_furn( p, bash_floor ) ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -693,7 +693,6 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
             //       Floor values are still used to set damage dealt to vehicle
             smashed = here.is_bashable_ter_furn( p, false ) &&
                       here.bash_resistance( p, bash_floor ) <= obj_dmg &&
-                      !here.has_flag_ter_or_furn( "NOCOLLIDE", p ) &&
                       here.bash( p, obj_dmg, false, false, false, this ).success;
             if( smashed ) {
                 if( here.is_bashable_ter_furn( p, bash_floor ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Vehicle collision stops when result is no longer a valid obstacle, also fix autodrive "

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Yet another bug with craterization to resolve, this time fixing shrubs getting rammed directly into deep pits and usuully fucking up your wheels in the process.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/2923

After a false start, I figured out a better method that makes more sense for fixing this, as well as being a less wacky alternative fix to https://github.com/cataclysmbnteam/Cataclysm-BN/issues/2891 that doesn't cause medium boulders to ignore collision if they're in a shallow pit, and additionally fixes autodrive not treating long grass as valid terrain.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

C++ changes:
1. In map.cpp, updated `map::is_bashable` to treat the presence of the new `VEH_TREAT_AS_BASH_BELOW` flag to count as equivalent to it being `bash_below`.
2. In vehicle_autodrive.cpp, likewise updated `vehicle::autodrive_controller::check_drivable` so that the `VEH_TREAT_AS_BASH_BELOW` flag is treated as equivalent to `bash_below` being true for the sake of checking for terrain it can't drive through.

JSON changes:
1. Replaced the use of `NOCOLLIDE` in terrain-floors-outdoors.json, terrain-flora.json, and terrain-traps.json with `VEH_TREAT_AS_BASH_BELOW`.
2. Added it to dirt as well so that terrain that gets bashed into dirt by a vehicle collision won't try to turn into a shallow pit afterward too.

Documentation changes:
1. Documented `VEH_TREAT_AS_BASH_BELOW` flag.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Reverting https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2842 because the problems keep coming and they don't stop coming and they don't stop coming and they don't stop coming...
2. Finally removing vorpal shrubs outside by making them not collide with regular vehicle parts. This would still trigger on wheel collisions probably though.
3. This current method still lets you manually smash dirt into pits, we could opt to turn this into some sort of `BASH_BELOW_ONLY_FOR_EXPLOSIONS` flag and add it to more relevant checks until only explosion handling and z-level-follow-through treats it as different from it being bash below.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected JSON files for syntax and lint errors.
1. Compiled and load-tested.
2. Tested that ramming vehicles into shrubs would only convert it into dirt instead of pits or shallow pits.
3. Tested that vehicles could still be dragged through tall grass like with the other fix.
4. Tested that a shallow pit no longer makes medium boulders ignore vehicle collision.
5. Tested a car trapped in a ~~salt circle~~ ring of tall grass can once more autodrive out of it.
6. Checked affected C++ for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
