### PR TITLE
Fix mutant scenarios adding an obsoleted trait

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -250,7 +250,7 @@
     "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale" ],
     "traits": [
       "ELFAEYES",
-      "URSINE_EYE",
+      "NIGHTVISION2",
       "FANGS",
       "GILLS",
       "SPINES",
@@ -489,7 +489,7 @@
     ],
     "traits": [
       "ELFAEYES",
-      "URSINE_EYE",
+      "NIGHTVISION2",
       "FANGS",
       "GILLS",
       "SPINES",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Swap obsoleted Ursine Eyes trait in mutant scenarios for High Night Vision"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

While working on an unrelated thing I discovered that the ursine eye mutation had been obsoleted but was still used in mutant scenarios, since I didn't notice last time I touched the trait list that they were obsolete.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Swapped the obsolete `URSINE_EYE` mutation for High Night Vision in Lab Patient and Experiment scenarios, fitting since this is another interesting mutation to play with that's pre-threshold and doesn't have any weird prereq behavior.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Adding Infravision instead since it changes things up more. Only problem is it's post-thresh and has requirements it doesn't supersede.
2. Added Reptilian IR instead, it's not pre-thresh but also intended to be picked up alongside Reptilian Eyes so.
3. Bringing ursine vision back if we really want I guess.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and lint errors.
2. Used my own non-mutated eyes to confirm the mutation was replace with one that's in the mutations folder and not the obsolete folder.
3. Started up in compiled test build, confirmed I can't try to pick both Night Vision and High Night Vision no matter which I pick first.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
