### PR TITLE
Rework `wield_better_weapon` considerations

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2311,14 +2311,8 @@ double npc_ai::weapon_value( const Character &who, const item &weap, int ammo )
     const double more = std::max( val_gun, val_melee );
     const double less = std::min( val_gun, val_melee );
 
-    // discourage wielding helmets, but not worn firearms
-    int armor_penalty = 1;
-    if( weap.is_armor() && !weap.is_gun() ) {
-        armor_penalty = 0;
-    }
-
     // A small bonus for guns you can also use to hit stuff with (bayonets etc.)
-    const double my_val = ( more + ( less / 2.0 ) ) * armor_penalty;
+    const double my_val = ( more + ( less / 2.0 ) );
     add_msg( m_debug, "%s (%ld ammo) sum value: %.1f", weap.type->get_id().str(), ammo, my_val );
     return my_val;
 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3497,7 +3497,11 @@ bool npc::wield_better_weapon()
     // to have NPCs wield weapons with shorter ranges than dist in preparation
     // if they don't have a weapon with appropriate range/ammo.
     visit_items( [&compare_weapon, this ]( item * node ) {
-        // Only compare melee weapons, guns, or holstered items
+        // For worn items, only compare if they have a weapon category defined.
+        if( is_worn( *node ) && node->type->weapon_category.empty() ) {
+            return VisitResponse::SKIP;
+        }
+        // Otherwise, compare any melee usable item, guns or holstered items
         if( node->is_melee() || node->is_gun() ) {
             compare_weapon( *node );
         } else if( node->get_use( "holster" ) && !node->contents.empty() && node != &primary_weapon() ) {


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Rework `wield_better_weapon` considerations"

#### Purpose of change

- #1029 fixed NPCs wielding armor by making them never wield them at all. This new solution aims to allow them to do so if that's the best thing they've got, but without them literally taking off their armour to beat people to death with it.

#### Describe the solution

Originally I was having trouble since anything worn is considered valid for `is_armor()` and `is_melee` only checks if a single hit deals 5 points of any type of damage. But then I remembered that weapon categories exist.

So now, it will only compare items when worn if they have a weapon category defined, which due to how #1709 was done means basically all items that can be used as proper ranged or melee weapons.

#### Describe alternatives you've considered

- Keeping the old solution.
  - It's not actually a bad solution. I just feel that NPCs could be allowed to wield helmets if it's in their inventory, since currently non-armour improvised weapons are allowed for NPCs, this just removes the blanket ban and makes them more discerning.

#### Testing

- Give battleaxes `"IS_ARMOR"`, `"BELTED"` and `"OVERSIZE"`.
- Spawn an NPC and mind control them.
- Spawn an M4A1 and shoulder strap and install the shoulder strap into the M4A1.
- Spawn an army helmet

- [x] Have the NPC wear the army helmet, check that when engaging debug monster they will not wield the helmet and leave their fleshy, crushable head exposed.
- [x] Give the NPC the battleaxe and have them wear it. check when engaging debug monster they will wield the battleaxe.
- [x] Give the NPC the M4A1+1 and have them wear it, check when engaging debug monster they will wield and shoot the M4A1.
- [x] Give the NPC the army helmet but _do not_ make them wear it, check that when engaging the debug monster they will wield the helmet.

#### Additional context
