### PR TITLE
Shuffle overmap specials

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4580,6 +4580,8 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
         return;
     }
 
+    std::shuffle( enabled_specials.begin(), enabled_specials.end(), rng_get_engine() );
+
     // First, place the mandatory specials to ensure that all minimum instance
     // counts are met.
     place_specials_pass( enabled_specials, sectors, false, false );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fixes too many mods preventing some locations from spawning"

#### Purpose of change

When too many mods are enabled it becomes common for overmap specials to crowd each other out. This results in only the first to be placed actually being able to fit.

#### Describe the solution

Shuffle the order in which they're placed for every overmap tile.

#### Testing

I got a lab to spawn with a bunch of mods turned on after failing on 4-5 overmaps with the same set before the patch. It's hard to be sure what's rng though.

#### Additional context

This isn't an ideal solution but it does do a lot to alleviate the problem and restore variety when too many mods are turned on. 