### PR TITLE
Fix RAS weapon range in `target_ui`

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3098,7 +3098,13 @@ void target_ui::update_ammo_range_from_gun_mode()
     } else {
         ammo = activity->reload_loc ? activity->reload_loc.get_item()->type :
                relevant->gun_current_mode().target->ammo_data();
-        range = relevant->gun_current_mode().target->gun_range( you );
+        if( activity->reload_loc ) {
+            item temp_weapon = *relevant;
+            temp_weapon.ammo_set( ammo->get_id() );
+            range = temp_weapon.gun_current_mode().target->gun_range( you );
+        } else {
+            range = relevant->gun_current_mode().target->gun_range( you );
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix RAS weapon range in `target_ui`"

#### Purpose of change

- #2468 created issue #2915 due to ammo not being loaded until being fired.

#### Describe the solution

Spawn temp item for use in range calculation.

#### Describe alternatives you've considered

- Load weapon before starting `target_ui`
  - Considering the sheer amount of work I did to prevent that. No.

#### Testing

- Spawn sling, unload rock from it and spawn a marble. Set all attributes to 8 and skill to 0.
- [x] Wield the sling and enter aim menu, with rock selected, check that sling can aim to, fire and hit a target at max range 18
- [x] Check that with marble selected sling can aim to, fire and hit target at max range 26

#### Additional context

- #2468 really is the gift that keeps on giving.