### PR TITLE
Add warning for smashing with glass item

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -688,6 +688,10 @@ static void smash()
         }
     }
     item &weapon = u.primary_weapon();
+    if( weapon.made_of( material_id( "glass" ) ) &&
+        !query_yn( _( "Are you sure you want to smash with an item made of glass?" ) ) ) {
+        return;
+    }
     const int move_cost = !u.is_armed() ? 80 : weapon.attack_cost() * 0.8;
     bool didit = false;
     bool mech_smash = false;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Add warning for smashing with glass item"

#### Purpose of change

- Partially deal with #2925 by adding a warning.

#### Describe the solution

Add warning so when you try to do something like this the game queries if you're _sure_ you want to hurt yourself.

#### Describe alternatives you've considered

- Code for items to be more or less of a material and be more discerning about how much damage and what items are eligible for hurting yourself.
  - Would be nice but I don't wanna, it's a lot of work.

#### Testing

Wield a glass fridge, press s and be queried about my self-harm tendencies.

#### Additional context

I don't see a good way to make it shatter the fridge, it currently already uses the `handle_melee_wear()` function on the refrigerator so it's clear that the steel is protecting the fridge. I can't set the code to fire for items made purely of glass as flasks and test tubes have rubber as a material too.