### PR TITLE
Set safe speed for wagons to hidden animal speed limit

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3747,6 +3747,26 @@ int vehicle::max_reverse_velocity( const bool fueled ) const
 // the same physics as max_ground_velocity, but with a smaller engine power
 int vehicle::safe_ground_velocity( const bool fueled ) const
 {
+    for( size_t e = 0; e < parts.size(); e++ ) {
+        const vehicle_part &vp = parts[ e ];
+        int animal_vel = 0;
+        if( vp.info().fuel_type == fuel_type_animal && engines.size() != 1 ) {
+            monster *mon = get_pet( e );
+            if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
+                int animal_vel_cur = mon->get_speed() * 12;
+                if( animal_vel > 0 ) {
+                    animal_vel = std::min( animal_vel, animal_vel_cur );
+                } else {
+                    animal_vel = animal_vel_cur;
+                }
+            }
+        }
+        // Cap safe speed at the point where the slowest animal found would start to damage their yoke
+        // If damage or weight has pulled max speed lower than this, cap at that instead.
+        if( animal_vel > 0 ) {
+            return std::min( animal_vel, max_ground_velocity( fueled ) );
+        }
+    }
     int effective_engine_w = total_power_w( fueled, true );
     double c_rolling_drag = coeff_rolling_drag();
     double safe_in_mps = simple_cubic_solution( coeff_air_drag(), c_rolling_drag,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Interface "Displayed safe speed for animal-powered vehicles now matches the previously-hidden speed limit at which the slowest animal starts damaging its yoke"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This was a thing I'd wanted to do for a while now, fix an annoyance where the listed safe speed for an animal-pulled vehicle doesn't actually match up with the hidden code effect that prevents animals from exceeding a certain speed.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

In vehicle.cpp, added a section to `vehicle::safe_ground_velocity` that checks for animal-powered vehicle parts, and if any valid animals are present on them, sifts through to track whoever is the slowest of them. If any are found then it returns that as the safe speed instead of whatever the engine power calcs claim it to be.

Additionally, it gives one final check to floor this resulting safe speed to max speed if something has pushed max speed lower than this resulting safe speed. From earlier tests I found it works just fine even if you don't do this, but this makes it look less weird.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. From what I can tell, this speed limit doesn't really match up sanely with the monster's walk OR run speed as a mount. Thing is, I think what I'd like to do long-term is implement some form of basic stamina mechanic that makes the animal force you to slow down if you exceed the speed limit, instead of its current janky shit mechanic of damaging the yoke. Then we could mess with the slowdown speed in either direction, whether it be lowering it to walk speed or raising it to run speed.
2. Speaking of, obviously it really shouldn't be damaging the yoke because that just seems real damn weird to me, but the only obvious idea for what it should do instead would tie in with the "mount stamina" idea and thus not really be ideal currently. Or we could make it damage the mount but that'd be an even dumber idea because the player has no real way to fix damaged mounts in vanilla, at least a damaged yoke can be fixed.
3. Or we could just axe the above mechanic now because it's kind of a bad hack, and re-implement a better alternative when animal stamina is implemented.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

First, tested strapping a pair of horses to a wagon in a compiled test build. Listed safe speed was 38 MPH, listed max speed was 39 MPH. Actual safe speed before yokes suffered damage was 36 MPH.

Next, replaced the horses with 2 cow, max speeds changed to 28 and 28 MPH. Actual safe speed before yokes suffered damage was 12 MPH.

Rough math estimates actual safe speed is probably 15 MPH, as the next step up in vehicle cruise is 16 MPH, cow's monster speed is 130, horse is 300 speed, 130/300 is ~0.433, and this multiplied by 36 returns 15.6.

1. Compiled and load-tested.
2. Loaded up the save with the horse wagon.
3. Listed safe speed was 36 MPH, matching the above actual speed limit.
4. Listed max speed was still 39 tiles per turn.
5. Confirmed that ramping it up to 36 MPH remained safe.
6. Let them fuck up the yokes a bit, this caused max speed to go down, and dragged safe speed with it once it was low enough.
7. Reloaded and swapped the horses with cows, safe speed changed to 15 MPH as expected. Max speed stayed at 29 MPH.
8. Set it to auto-travel along the road, the wagon stayed comfortably under the safe speed and didn't do anything weird.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

I plan to eventually implement some other changes that'll relate to this, I mentioned the idea of stamina but the full idea is basically:
1. Add an effect that tracks exertion for mounted and wagon-pulling animals.
2. Change the function for moving with a running mount to check if the duration of this effect is above a certain amount. If so, kick it back down to walking speed. If not, add 2 seconds worth of duration.
3. Add a check to the move mode menu that prevents you from setting an animal to run if the above effect's duration is over a set 
4. Threshold will probably be 50 seconds of duration times size class, so for example a horse would have a threshold of 250 duration.
5. Replace the yoke damage mechanic with a mechanic that instead racks up the above exertion effect if you exceed safe speed.
6. Change vehicle max speed to in some way scale down towards vehicle safe speed when the duration exceeds the threshold that prevents running.
7. Lower the wagon safe speed limit to consistently match what the animal's actual movement speed is at a walking pace, in exchange for having made it so you have the ability to exceed safe speed with no consequences other than it gradually being throttled back down to their walking speed.
8. Probably also cap an animal's vehicle max speed with no stamina penalty to double the safe speed.