### PR TITLE
Convert buckler to not inherit hand coverage from banded shield

### DIFF
--- a/data/json/items/armor/shields.json
+++ b/data/json/items/armor/shields.json
@@ -185,8 +185,6 @@
   },
   {
     "id": "shield_buckler",
-    "copy-from": "shield_banded",
-    "looks_like": "shield_banded",
     "type": "ARMOR",
     "name": { "str": "buckler" },
     "description": "A small metal shield historically used for dueling rather than protection from arrows.  It's small and light enough to not hinder the use of your hands.",
@@ -194,11 +192,16 @@
     "weight": "1400 g",
     "price": "120 USD",
     "price_postapoc": "10 USD",
+    "bashing": 8,
     "material": [ "steel" ],
-    "to_hit": 0,
+    "looks_like": "shield_banded",
+    "symbol": "[",
+    "color": "blue",
     "covers": [ "arm_either" ],
     "coverage": 50,
     "encumbrance": 10,
+    "material_thickness": 3,
+    "techniques": [ "WBLOCK_2" ],
     "flags": [ "OVERSIZE", "BELTED", "ONLY_ONE", "BLOCK_WHILE_WORN", "STURDY" ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Buckler no longer inherits from banded shield, fixing unintended hand coverage"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Fixes bucklers so they don't suffer from the inheritance problems as reported in https://github.com/cataclysmbnteam/Cataclysm-BN/issues/2939. Does not fix the underlying code problem since I have no idea what causes that.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Converted bucklers to not inherit from the banded shield, so they correctly don't end up mysteriously inheriting hand coverage from it.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Screaming at the src folder until I find what ancient code spaghetti causes the underlying problem.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and lint errors.
2. Load-tested in compiled test build, buckler showed it only covered one arm, no other stat differences evident.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/07127628-d2d3-4427-9771-bbd7ed116ec5)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
