### PR TITLE
Cots can be crafted & uncrafted

### DIFF
--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -475,5 +475,23 @@
       [ [ "black_box", -1 ] ]
     ],
     "components": [ [ [ "paper", 1 ] ] ]
+  },
+  {
+    "result": "cot",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": "30 m",
+    "autolearn": true,
+    "reversible": true,
+    "using": [ [ "welding_standard", 6 ], [ "sewing_standard", 12 ] ],
+    "qualities": [
+      { "id": "HAMMER_FINE", "level": 1 },
+      { "id": "SAW_M_FINE", "level": 1 },
+      { "id": "DRILL", "level": 2 }
+    ],
+    "components": [ [ [ "material_aluminium_ingot", 8 ] ], [ [ "sheet", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -487,11 +487,7 @@
     "autolearn": true,
     "reversible": true,
     "using": [ [ "welding_standard", 6 ], [ "sewing_standard", 12 ] ],
-    "qualities": [
-      { "id": "HAMMER_FINE", "level": 1 },
-      { "id": "SAW_M_FINE", "level": 1 },
-      { "id": "DRILL", "level": 2 }
-    ],
+    "qualities": [ { "id": "HAMMER_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 }, { "id": "DRILL", "level": 2 } ],
     "components": [ [ [ "material_aluminium_ingot", 8 ] ], [ [ "sheet", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
#### Summary

SUMMARY: Balance "Cots can be crafted and uncrafted"

#### Purpose of change

Cots had no crafting recipe nor uncraft, making them a portable bed that is fairly useless since generally you'd sleep in your car anyway. This lets you make them should you want one, and uncraft it for valuable aluminum in case you found one in the wild.

#### Describe the solution

The cot is based on welding together aluminum ingots just like an extra-light frame, but I also included fine hammering, drilling, and fine metal sawing. While a frame needs to be one concise piece of metal, a cot is designed to be assembled and disassembled quickly. You can assemble one within 60 seconds IRL according to training videos on Youtube that U.S. Army veterans have made. Thus, the pieces have to correctly fit together, so drilling holes and sawing pieces to what they need to be.

You also need sewing and one sheet, since you can make a pillow at 0 tailoring I don't see why a 0 tailor can't sew a sheet together. You're sewing holes in this sheet that the metal bars will fit into, and given a window curtain drops two sheets one should be big enough for a cot. House curtains are pretty big, a single panel should fit well here.

#### Describe alternatives you've considered

Adding screwdriving, other misc tool qualities. Also, optionally making it a forge recipe but that would make it a lot more useless to actually craft. Using an entire blanket for the cot instead of a sheet but they seem thin, need a Veteran to give advice on this one or to go out and buy one.

#### Testing

Loaded in game, the recipe and uncraft correctly works and no errors are reported.

#### Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/823b8984-8bf5-4b48-ab84-091ae55ae7fb)
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/aa5f2be9-ae48-4474-bd82-e2819298fde3)


