### PR TITLE
Fix open safe spawning on indoor shrub in house variant

### DIFF
--- a/data/json/mapgen/house/house25.json
+++ b/data/json/mapgen/house/house25.json
@@ -34,9 +34,6 @@
       ],
       "palettes": [ "standard_domestic_palette" ],
       "terrain": {
-        "%": [ "t_region_shrub", "t_region_shrub_fruit", "t_region_shrub_decorative" ],
-        "[": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ],
-        "!": "t_region_groundcover_urban",
         "`": "t_concrete",
         "~": "t_carpet_yellow",
         "_": "t_window_boarded",
@@ -45,7 +42,7 @@
         ",": "t_thconc_floor",
         "#": "t_wall_log"
       },
-      "furniture": { "%": "f_safe_o", "!": "f_region_flower" },
+      "furniture": { "%": "f_safe_l" },
       "place_items": [
         { "chance": 10, "item": "ammo_rifle_common", "x": 9, "y": 17 },
         { "chance": 20, "item": "camping", "x": 13, "y": 19 },
@@ -96,8 +93,6 @@
       ],
       "palettes": [ "standard_domestic_palette" ],
       "terrain": {
-        "[": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ],
-        "!": "t_region_groundcover_urban",
         "`": "t_concrete",
         "~": "t_carpet_yellow",
         "_": "t_window_domestic_taped",
@@ -106,7 +101,6 @@
         ",": "t_thconc_floor",
         "#": "t_wall_log"
       },
-      "furniture": { "!": "f_region_flower" },
       "place_items": [
         { "chance": 20, "item": "stash_wood", "x": 5, "y": 8 },
         { "chance": 20, "item": "camping", "x": 13, "y": 19 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Belatedly port over fix to house variant with safe spawning on shrubs"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Every so often I'd see the one house variant that spawns an open safe over some shrubs indoors, go "that's weird, is that a Cata++ thing I didn't fix for Noct?" before finding out it was vanilla, resolving to fix it, and forgetting about it.

After I fixed it I went to check if it was still broken in DDA and found a PR fixed it but also removed some unused terrain and furniture from it. Ended up just deciding to make it a port PR via also doing those changes too I guess.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Set that one weird `house_25` variant with the safe to not place shrubs where the safe goes, and set it to spawn a locked safe instead of open.
2. Also as per DDA's implementation, removed some terrain and furniture defs that aren't actually used for anything in the mapgen file.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Keeping the open safe since it doesn't spawn much of value in it. DDA's version kept the safe open but I opted to close it.
2. Adding some more useful spawns to it.
3. Reworking the bedroom it's in into a sort of open-air fancy outdoor bedroom to justify this.
4. At some point we need a big sifting through of unused terrain and furniture definitions in mapgen files but weh.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and lint errors.
2. Ported JSON change to a release for testing, confirmed the safe is not on inexplicable indoor flora now, and no errors from load-testing the removed bits.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR, by @Night-Pyranik: https://github.com/CleverRaven/Cataclysm-DDA/pull/50353