### PR TITLE
Update 10mm auto to use large pistol primers

### DIFF
--- a/data/json/requirements/ammo.json
+++ b/data/json/requirements/ammo.json
@@ -44,7 +44,7 @@
     "id": "ammo_10mm",
     "type": "requirement",
     "//": "Components required for 10mm Auto ammo",
-    "components": [ [ [ "10mm_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ] ]
+    "components": [ [ [ "10mm_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ] ]
   },
   {
     "id": "ammo_45colt",

--- a/data/json/uncraft/ammo/10mm.json
+++ b/data/json/uncraft/ammo/10mm.json
@@ -4,7 +4,7 @@
     "type": "uncraft",
     "time": "5 s",
     "qualities": [ { "id": "PULL", "level": 1 } ],
-    "components": [ [ [ "lead", 2 ] ], [ [ "10mm_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
+    "components": [ [ [ "lead", 2 ] ], [ [ "10mm_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder", 5 ] ] ],
     "charges": 1
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Set 10mm auto to use large pistol primers instead of small"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So I was looking at some things and, reminded that large pistol primers seem relatively underused among ammotypes, decided to look up what type some common ones use and only really found one case where an ammo uses the wrong primer type. In this case it does at least mean one more ammotype using large primers instead of the more commonly-used small ones.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Updated `ammo_10mm` crafting requirement and to use large primers instead of small. Quick search indicates that .40 S&W using small primers and 10mm auto using large primers is indeed a thing.
2. Likewise updated the uncraft for 10mm ammo.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making other ammo use large primers anyway, realism be damned.
2. Migrating large pistol and rifle primers so we only have pistol, rifle, and shotgun primers.
3. Screaming.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
