### PR TITLE
style: typo in `Lost To The Cataclysm` profession

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6461,7 +6461,7 @@
     "id": "PROF_FERAL",
     "name": { "str": "Lost To The Cataclysm" },
     "points": 0,
-    "description": "Something inside you snapped.  Whether though wallowing in decay or by otherworldly influence, the living shun you while the undead mostly ignore you.  Your mind and body will deteriorate if you don't keep killing the living and sane.  Your fellow lost and damned will suffice too, but that might cause the others to mistake you for the living.",
+    "description": "Something inside you snapped.  Whether through wallowing in decay or by otherworldly influence, the living shun you while the undead mostly ignore you.  Your mind and body will deteriorate if you don't keep killing the living and sane.  Your fellow lost and damned will suffice too, but that might cause the others to mistake you for the living.",
     "valid": false,
     "purifiable": false,
     "profession": true,


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "From 'though' to 'through'"

#### Purpose of change

Fixes a very minor spelling error.

#### Describe the solution

Adding a single letter.

#### Describe alternatives you've considered

Leaving it be.

#### Testing

A single letter change is all that is.

#### Additional context

Good day to everyone.
