### PR TITLE
Fix how NPCs handle loose sheath/holsters

### DIFF
--- a/data/json/monsters/misc.json
+++ b/data/json/monsters/misc.json
@@ -29,7 +29,7 @@
     "copy-from": "debug_mon",
     "name": { "str": "menacing debug monster" },
     "description": "This monster exists only for testing purposes.  It's threatening enough to warrant bullets from NPCs",
-    "diff": 20
+    "diff": 1
   },
   {
     "id": "mon_dragon_dummy",

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -530,7 +530,7 @@ bool try_wield_contents( Character &who, item &container, item *internal_item, b
         return false;
     }
 
-    const ret_val<bool> ret = who.as_player()->can_wield( *internal_item );
+    const ret_val<bool> ret = who.can_wield( *internal_item );
     if( !ret.success() ) {
         who.add_msg_if_player( m_info, "%s", ret.c_str() );
         return false;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2776,7 +2776,7 @@ int holster_actor::use( player &p, item &it, bool, const tripoint & ) const
             penalties = true;
             cost = INVENTORY_HANDLING_PENALTY;
         }
-        character_funcs::try_wield_contents( *p.as_avatar(), it, internal_item, penalties, cost );
+        character_funcs::try_wield_contents( p, it, internal_item, penalties, cost );
 
     } else {
         item_location loc = game_menus::inv::holster( p, it );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1171,24 +1171,6 @@ bool npc::wield( item &it )
         return true;
     }
 
-    // check if the item is in a holster
-    int position = inv.position_by_item( &it );
-    if( position != INT_MIN ) {
-        item &maybe_holster = inv.find_item( position );
-        assert( !maybe_holster.is_null() );
-        if( &maybe_holster != &it && maybe_holster.is_holster() ) {
-            assert( !maybe_holster.contents.empty() );
-            const size_t old_size = maybe_holster.contents.num_item_stacks();
-            invoke_item( &maybe_holster );
-            // TODO: change invoke_item to somehow report this change
-            // HACK: test whether wielding the item from the holster has been done.
-            // (Wielding may be prevented by various reasons: see player::wield_contained)
-            if( old_size != maybe_holster.contents.num_item_stacks() ) {
-                return true;
-            }
-        }
-    }
-
     moves -= 15;
     if( has_item( it ) ) {
         primary_weapon() = remove_item( it );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix how NPCs handle loose sheath/holsters"

#### Purpose of change

- Fix #2947  

Caused by NPCs attempting to invoke the holster which causes a crash as it's not appropriately handled.

#### Describe the solution

Route through the same code that allows them to wield an item from worn holsters/sheaths.

This PR also adjusts the `diff` value for debug monsters so they're still threatening enough to shoot at 100 but not so threatening most NPCs will run away in terror (2000+).

#### Describe alternatives you've considered

- ~~Fix holster iuse so NPCs can properly invoke it.~~
  - ~~Maybe for the future, right now this works and is fairly clean.~~
  - Done, but NPCs will still not use it in this iteration because the code is cleaner with fewer checks and branches, and if an NPC fails to wield an item from the holster, only one function need be checked. 

#### Testing

- Give NPC a sheathed combat knife and prevent them from wearing it, set them loose onto a debug monster.
- [x] Confirm that they wield the combat knife instead of crashing the game.

#### Additional context

Note that NPCs will not replace weapons into sheaths/scabbards/holsters in their inventory, like they would with worn holsters/sheaths. The player can't do this either without directly invoking the holster/sheath so it's not really a huge issue.
