### PR TITLE
Make `covers` field be overwritten properly.

### DIFF
--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -242,6 +242,9 @@ class body_part_set
         void set( const body_part &bp ) {
             parts.set( bp );
         }
+        void reset() {
+            parts.reset();
+        }
         void reset( const body_part &bp ) {
             parts.reset( bp );
         }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -148,12 +148,14 @@ static bool assign_coverage_from_json( const JsonObject &jo, const std::string &
     };
 
     if( jo.has_array( key ) ) {
+        parts.reset();
         for( const std::string line : jo.get_array( key ) ) {
             parse( line );
         }
         return true;
 
     } else if( jo.has_string( key ) ) {
+        parts.reset();
         parse( jo.get_string( key ) );
         return true;
 


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Make `covers` field be overwritten properly."

#### Purpose of change

When "overwritten", the `covers` field inherits the old and only adds newly set entries.

#### Describe the solution

Add reset function that only triggers if `covers` is defined so that during `copy-from` it is properly overwritten

#### Describe alternatives you've considered

- Change away from bitset
  - Not now, it's useful this way, though if we add json definable body plans in the future this will have to change somehow.

#### Testing

- Revert #2940 
- [x] Confirm that it only covers the arms and not the hands.

#### Additional context
