### PR TITLE
Use bismuth in recipes, related ammo fixes

### DIFF
--- a/data/json/items/ammo/4570.json
+++ b/data/json/items/ammo/4570.json
@@ -46,5 +46,15 @@
     "price_postapoc": 400,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "relative": { "range": -8, "damage": { "damage_type": "bullet", "amount": -14, "armor_penetration": -25 }, "recoil": -900 }
+  },
+  {
+    "id": "reloaded_4570_bp",
+    "copy-from": "4570_low",
+    "type": "AMMO",
+    "name": { "str": ".45-70, black powder" },
+    "description": ".45-70 Government ammunition loaded with a 405 grain lead flat nose bullet using black powder to original specifications.  Quite a bit less powerful and a lot dirtier than modern ammo, but still packs a punch.  This one has been hand-loaded.",
+    "proportional": { "price": 0.6, "damage": { "damage_type": "bullet", "amount": 0.8 }, "dispersion": 1.2 },
+    "extend": { "effects": [ "RECYCLED", "MUZZLE_SMOKE", "BLACKPOWDER" ] },
+    "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
   }
 ]

--- a/data/json/recipes/ammo/other.json
+++ b/data/json/recipes/ammo/other.json
@@ -300,7 +300,7 @@
       [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ],
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
     ],
-    "components": [ [ [ "lead", 50 ] ] ]
+    "components": [ [ [ "lead", 50 ], [ "bismuth", 125 ] ] ]
   },
   {
     "result": "sling_bullet_small",
@@ -317,6 +317,6 @@
       [ [ "brick_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ],
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ]
     ],
-    "components": [ [ [ "lead", 50 ] ] ]
+    "components": [ [ [ "lead", 50 ], [ "bismuth", 125 ] ] ]
   }
 ]

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -393,7 +393,7 @@
     "charges": 1,
     "reversible": true,
     "using": [ [ "bullet_forming", 15 ], [ "ammo_bullet", 8 ] ],
-    "components": [ [ [ "4570_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "chem_black_powder", 12 ] ], [ [ "lead", 9 ] ] ]
+    "components": [ [ [ "4570_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "chem_black_powder", 12 ] ] ]
   },
   {
     "result": "5x50dart",

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -9,7 +9,7 @@
     "id": "ammo_bullet",
     "type": "requirement",
     "//": "Materials used when forming bullets",
-    "components": [ [ [ "lead", 1 ] ] ]
+    "components": [ [ [ "lead", 1 ], [ "bismuth", 3 ] ] ]
   },
   {
     "id": "chem_lye",
@@ -178,7 +178,7 @@
     "id": "weights",
     "type": "requirement",
     "//": "Materials used for adding weight to weapons and to other items. The materials should be malleable, ductile and dense.",
-    "components": [ [ [ "lead", 5 ], [ "silver_small", 5 ], [ "gold_small", 3 ], [ "platinum_small", 3 ] ] ]
+    "components": [ [ [ "lead", 5 ], [ "bismuth", 8 ], [ "silver_small", 5 ], [ "gold_small", 3 ], [ "platinum_small", 3 ] ] ]
   },
   {
     "id": "plastics",

--- a/data/json/uncraft/ammo/4570.json
+++ b/data/json/uncraft/ammo/4570.json
@@ -34,15 +34,5 @@
     "qualities": [ { "id": "PULL", "level": 2 } ],
     "components": [ [ [ "lead", 8 ] ], [ [ "4570_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder", 12 ] ] ],
     "charges": 1
-  },
-  {
-    "id": "reloaded_4570_bp",
-    "copy-from": "4570_low",
-    "type": "AMMO",
-    "name": { "str": ".45-70, black powder" },
-    "description": ".45-70 Government ammunition loaded with a 405 grain lead flat nose bullet using black powder to original specifications.  Quite a bit less powerful and a lot dirtier than modern ammo, but still packs a punch.  This one has been hand-loaded.",
-    "proportional": { "price": 0.6, "damage": { "damage_type": "bullet", "amount": 0.8 }, "dispersion": 1.2 },
-    "extend": { "effects": [ "RECYCLED", "MUZZLE_SMOKE", "BLACKPOWDER" ] },
-    "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Allow using bismuth in some recipes, related ammo fixes"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

I noticed that bismuth was fairly lacking in recipe use, when its use as a lead substitute for bullets is fairly common.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Added bismuth to `ammo_bullet` crafting requirement, requiring 3 units (total 6 weight) per 1 unit (5 weight) of lead.
2. Added bismuth to `weights` crafting requirement, requiring 8 units (total 16 weight) per 5 units (15 weight) of lead.
3. Added bismuth to sling bullet recipes, requiring 125 units per 50 units of lead (actually matching in weight for once).
4. Fixed recipe for blackpowder .45-70 requiring some extra lead on top of calling for `ammo_bullet` already, despite being basically the cowboy load but with blackpowder.
5. Misc: Fixed some weirdness where for some reason the item entry for blackpowder .45-70 was in the uncraft file instead of where it belongs.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Not doing this for bullets because most of the items still rely on uncrafts instead of reversible recipes, meaning this can technically transmute bismuth into lead (at some loss of mass) if you intentionally craft handloads then take them apart for whatever reason.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected files for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
