### PR TITLE
Fix fire weapon messages failing to print

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2193,6 +2193,7 @@ int fireweapon_off_actor::use( player &p, item &it, bool t, const tripoint & ) c
     if( rng( 0, 10 ) - it.damage_level( 4 ) > success_chance && !p.is_underwater() ) {
         if( noise > 0 ) {
             sounds::sound( p.pos(), noise, sounds::sound_t::combat, _( success_message ) );
+            p.add_msg_if_player( _( success_message ) );
         } else {
             p.add_msg_if_player( _( success_message ) );
         }
@@ -2260,6 +2261,7 @@ int fireweapon_on_actor::use( player &p, item &it, bool t, const tripoint & ) co
     } else if( one_in( noise_chance ) ) {
         if( noise > 0 ) {
             sounds::sound( p.pos(), noise, sounds::sound_t::combat, _( noise_message ) );
+            p.add_msg_if_player( _( noise_message ) );
         } else {
             p.add_msg_if_player( _( noise_message ) );
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2193,10 +2193,8 @@ int fireweapon_off_actor::use( player &p, item &it, bool t, const tripoint & ) c
     if( rng( 0, 10 ) - it.damage_level( 4 ) > success_chance && !p.is_underwater() ) {
         if( noise > 0 ) {
             sounds::sound( p.pos(), noise, sounds::sound_t::combat, _( success_message ) );
-            p.add_msg_if_player( _( success_message ) );
-        } else {
-            p.add_msg_if_player( _( success_message ) );
         }
+        p.add_msg_if_player( _( success_message ) );
 
         it.convert( target_id );
         it.active = true;
@@ -2261,10 +2259,8 @@ int fireweapon_on_actor::use( player &p, item &it, bool t, const tripoint & ) co
     } else if( one_in( noise_chance ) ) {
         if( noise > 0 ) {
             sounds::sound( p.pos(), noise, sounds::sound_t::combat, _( noise_message ) );
-            p.add_msg_if_player( _( noise_message ) );
-        } else {
-            p.add_msg_if_player( _( noise_message ) );
         }
+        p.add_msg_if_player( _( noise_message ) );
     }
 
     return it.type->charges_to_use();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Fix invisible activation and idle messages for fire weapons"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

While testing some stuff related to use actions, I noticed a familiar flaw with the fire weapon use actions. One of these days we might have use for these outside of No Hope, so.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. In iuse_actor.cpp, set `fireweapon_off_actor::use` to also print the success message even if it also creates sound, because it doesn't actually print the results of `sounds::sound` in the message log in this case.
2. Likewise set `fireweapon_on_actor::use` to print the idle message so it actually shows on the player's message log.

Basically the same message concepts as used in https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1487 to fix activation and noise messages not actually showing on message log.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Figuring out what the makes important sound messages like that fail to print in the message log when the player is the source, and turning that off where relevant.
2. Either that or splitting up the messages and the noise into entirely different strings since even without this change there's the risk that if an item is left on the drop they'll see "you hear The Sun Shines" or whatever proc every so often which would be vastly more janky than what the messages seem meant to do.
3. Un-obsoleting fire weapons, or possibly re-implementing and rebalancing them to avoid whatever flaws stand in the way of them being worth using.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Debugged in a no. 9.
3. Lit it up, observed it actually prints message on successful activation now.
4. Idle a bit, idling message is shown too.
5. Checked affected file for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
