### PR TITLE
Add use action for bringing up gun cleaning mend menu

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -96,6 +96,11 @@
   },
   {
     "type": "item_action",
+    "id": "GUN_CLEAN",
+    "name": { "str": "Repair/mend a gun" }
+  },
+  {
+    "type": "item_action",
     "id": "GUN_REPAIR",
     "name": { "str": "Repair a gun" }
   },

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -1698,7 +1698,8 @@
     "price_postapoc": 50,
     "material": [ "steel", "cotton" ],
     "symbol": ";",
-    "color": "light_gray"
+    "color": "light_gray",
+    "use_action": "GUN_CLEAN"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -492,7 +492,7 @@
       [ "SCREW", 1 ],
       [ "CHISEL", 3 ]
     ],
-    "use_action": [ "GUN_REPAIR", "CROWBAR", "HAMMER" ],
+    "use_action": [ "GUN_CLEAN", "GUN_REPAIR", "CROWBAR", "HAMMER" ],
     "magazines": [
       [
         "battery",
@@ -839,7 +839,7 @@
       [ "SCREW", 1 ],
       [ "CHISEL", 3 ]
     ],
-    "use_action": [ "GUN_REPAIR", "CROWBAR", "HAMMER" ],
+    "use_action": [ "GUN_CLEAN", "GUN_REPAIR", "CROWBAR", "HAMMER" ],
     "magazines": [
       [
         "battery",

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -940,6 +940,7 @@ void Item_factory::init()
     add_iuse( "GRANADE", &iuse::granade );
     add_iuse( "GRANADE_ACT", &iuse::granade_act );
     add_iuse( "GRENADE_INC_ACT", &iuse::grenade_inc_act );
+    add_iuse( "GUN_CLEAN", &iuse::gun_clean );
     add_iuse( "GUN_REPAIR", &iuse::gun_repair );
     add_iuse( "GUNMOD_ATTACH", &iuse::gunmod_attach );
     add_iuse( "TOOLMOD_ATTACH", &iuse::toolmod_attach );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5842,7 +5842,7 @@ int iuse::talking_doll( player *p, item *it, bool, const tripoint & )
     return it->type->charges_to_use();
 }
 
-int iuse::gun_clean( player *p, item *, bool, const tripoint &pos )
+int iuse::gun_clean( player *p, item *, bool, const tripoint & )
 {
     item_location loc = game_menus::inv::titled_menu( g->u, ( "Select the firearm to clean or mend" ) );
     if( !loc ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5842,6 +5842,26 @@ int iuse::talking_doll( player *p, item *it, bool, const tripoint & )
     return it->type->charges_to_use();
 }
 
+int iuse::gun_clean( player *p, item *, bool, const tripoint &pos )
+{
+    item_location loc = game_menus::inv::titled_menu( g->u, ( "Select the firearm to clean or mend" ) );
+    if( !loc ) {
+        p->add_msg_if_player( m_info, _( "You do not have that item!" ) );
+        return 0;
+    }
+    item &fix = *loc;
+    if( !fix.is_firearm() ) {
+        p->add_msg_if_player( m_info, _( "That isn't a firearm!" ) );
+        return 0;
+    }
+    if( fix.faults.empty() ) {
+        p->add_msg_if_player( m_info, _( "There's nothing you can clean or mend with this." ) );
+        return 0;
+    }
+    avatar_funcs::mend_item( *p->as_avatar(), std::move( loc ) );
+    return 0;
+}
+
 int iuse::gun_repair( player *p, item *it, bool, const tripoint & )
 {
     if( !it->units_sufficient( *p ) ) {

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -166,6 +166,7 @@ int radio_mod( player *, item *, bool, const tripoint & );
 int remove_all_mods( player *, item *, bool, const tripoint & );
 int fishing_rod( player *, item *, bool, const tripoint & );
 int fish_trap( player *, item *, bool, const tripoint & );
+int gun_clean( player *, item *, bool, const tripoint & );
 int gun_repair( player *, item *, bool, const tripoint & );
 int gunmod_attach( player *, item *, bool, const tripoint & );
 int toolmod_attach( player *, item *, bool, const tripoint & );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Feature "Add use action for pipe cleaners and repair kits to make gun fault mending more intuitive"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

So a while back during https://github.com/cataclysmbnteam/Cataclysm-BN/pull/1665 one thing that came up was adding a use/examine action to autoclaves to add an additional way to access the mend menu, since it being buried in the item summary menu is not newbie-friendly.

Logically, it might be good to extend that to gun cleaning since it's the other notable example of item mending at present.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

C++ changes:
1. In item_factory.cpp, added `GUN_CLEAN` to the big iuse list in `Item_factory::init`.
2. In iuse.cpp and iuse.h, defined `iuse::gun_clean` function based off `iuse::gun_repair`, which brings up the mend menu when you select a valid faulty gun.

JSON changes:
1. Added `item_action` definition for gun cleaning.
2. Added `GUN_CLEAN` action to pipe cleaner, firearm repair kit, and gunsmith repair kit.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Merging the two use actions into some isue_actor stuff that selects different types of items depending on 
2. Saying "fuck it" and removing gun cleaning and fouling because pointless realism. It does eventually start to impact gun reliability and recoil however, so if anything it might be desirable to keep but sanity-check whether guns perhaps need any faster or slower fouling rates.
3. Adding some way to clean a batch of guns at once. @EkarusRynden once jokingly suggested just throwing them in the washing machine.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->


1. Checked affected JSON for syntax and load errors.
2. Compiled and load-tested.
3. Tested activating a pipe cleaner, it brings up a menu much like gun repair.
4. Confirmed that it brings up the mend menu if you select a gun with faults, and appropriate menus show up with invalid
5. Checked affected C++ files for astyle.

This is a bit wacky as it doesn't actually filter out non-guns, but the gun repair menu has the same weirdness:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/29ae2a60-89b9-4d45-a00c-fd802a377df4)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
