### PR TITLE
Magiclysm harvest fixes

### DIFF
--- a/data/mods/Magiclysm/harvest.json
+++ b/data/mods/Magiclysm/harvest.json
@@ -227,9 +227,8 @@
     "id": "dragon_black",
     "type": "harvest",
     "entries": [
-      { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "dragon_blood", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "meat_dragon", "type": "flesh", "mass_ratio": 0.18 },
+      { "drop": "meat_dragon", "type": "flesh", "mass_ratio": 0.19 },
       { "drop": "dragon_black_scale", "type": "skin", "mass_ratio": 0.05 },
       { "drop": "black_dragon_hide_raw", "type": "skin", "mass_ratio": 0.1 },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.1 }
@@ -292,10 +291,10 @@
       { "drop": "blood", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "human_flesh", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "human_fat", "type": "flesh", "mass_ratio": 0.1 },
       { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
-      { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.01 }
+      { "drop": "raw_hleather", "type": "skin", "mass_ratio": 0.01 }
     ]
   },
   {
@@ -328,7 +327,7 @@
     "type": "harvest",
     "entries": [
       { "drop": "tainted_blood", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.4 }
+      { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.4 }
     ]
   },
   {


### PR DESCRIPTION
#### Summary

SUMMARY: [Mods] "Fix Harvest products in Magiclysm"

#### Purpose of change

With the recent feral humans update I noticed they were dropping normal chunks of fat. I went over the file and found several harvests that could use updating.

#### Describe the solution

First, their human override now gives human fat and human skin correctly. Dragons were giving two types of meat and were switched solely to dragon meat. Lemures gave tainted blood but normal meat and a note said they were meant to be tainted, so I switched them to tainted meat.

#### Describe alternatives you've considered

Not fixing this because eating people is half the game and cannibals unfairly get all the fun.

#### Testing

Changes loaded in and tested without issue, correct products below.

#### Additional context

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/a9bb3518-1742-4810-918e-224961fb0b1b)

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/112293514/55a2d9ab-59c1-4508-b82f-87fb243a3af3)
