### PR TITLE
Additional follow-up code tweaks for feral survivors

### DIFF
--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -110,7 +110,7 @@
     "fear_triggers": [ "PLAYER_CLOSE" ],
     "placate_triggers": [ "PLAYER_WEAK" ],
     "death_function": [ "NORMAL" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "BADVENOM", "HARDTOSHOOT", "SWIMS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "BADVENOM", "HARDTOSHOOT", "SWIMS", "ANIMAL" ]
   },
   {
     "id": "mon_rattlesnake_giant",

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -316,6 +316,7 @@ static const trait_id trait_MARLOSS_YELLOW( "MARLOSS_YELLOW" );
 static const trait_id trait_MYOPIC( "MYOPIC" );
 static const trait_id trait_NOPAIN( "NOPAIN" );
 static const trait_id trait_POISRESIST( "POISRESIST" );
+static const trait_id trait_PROF_FERAL( "PROF_FERAL" );
 static const trait_id trait_PSYCHOPATH( "PSYCHOPATH" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
 static const trait_id trait_SPIRITUAL( "SPIRITUAL" );
@@ -1323,7 +1324,7 @@ static void marloss_common( player &p, item &it, const trait_id &current_color )
     } else if( effect == 8 ) {
         p.add_msg_if_player( m_bad, _( "You take one bite, and immediately vomit!" ) );
         p.vomit();
-    } else if( p.crossed_threshold() ) {
+    } else if( p.crossed_threshold() || p.has_trait( trait_PROF_FERAL ) ) {
         // Mycus Rejection.  Goo already present fights off the fungus.
         p.add_msg_if_player( m_bad,
                              _( "You feel a familiar warmth, but suddenly it surges into an excruciating burn as you convulse, vomiting, and black out…" ) );
@@ -1593,6 +1594,15 @@ static int petfood( player &p, item &it, Petfood animal_food_type )
             p.add_msg_if_player( _( "You try to feed the %s some %s, but it vanishes!" ),
                                  mon.type->nname(), it.tname() );
             mon.die( nullptr );
+            return 0;
+        }
+
+        // Feral survivors don't get to tame normal critters.
+        if( p.has_trait( trait_PROF_FERAL ) ) {
+            // TODO: Allow player ferals to tame zombie animals, but make sure non-feral players
+            // can't tame them, and for flavor possibly only allow taming with meat-based items.
+            p.add_msg_if_player( _( "You reach for the %s, but it recoils away from you!" ),
+                                 mon.type->nname() );
             return 0;
         }
 

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -581,6 +581,10 @@ bool gun_actor::call( monster &z ) const
         }
     }
 
+    // One last check to make sure we're not firing on a friendly
+    if( z.attitude_to( *target ) == Creature::A_FRIENDLY ) {
+        return false;
+    }
     int dist = rl_dist( z.pos(), aim_at );
     for( const auto &e : ranges ) {
         if( dist >= e.first.first && dist <= e.first.second ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Feral survivors can no longer tame animals or become marloss vectors, some improvements to monster behavior with feral survivors"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Some more misc. code ideas related to feral survivors.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

C++ changes:
1. In iuse.cpp, set `marloss_common` so that having Lost to The Cataclysm prevents gaining the marloss mutations and instead triggers a negative reaction, like with having a competing mutation threshold. Gameplay-wise, it prevents stacking up on permanent immunities to major monster factions. Lore-wise it'd be reasonable to assume that a feral survivor has been altered in some way given zombies see them as one of their own and the zombie-like physical symptoms referenced in monster descriptions. It also makes it possible that the Mycus might view them as unsuitable as a local guide given they have no value left for subverting and influencing others, just as zombies are only useful to them as a vector for fungal infection.
2. Also in iuse.cpp, set the `petfood` function to cancel out if the player has Lost to The Cataclysm, preventing them from trying to tame animals. In the future we could possibly put together some more complex checks that would allow feral surivoors to tame zombie animals, but I figured this will be adequate for now for preventing the player from just cornering an animal and forcing it tame.
3. In monster.cpp, simplified the way `monster::attitude` makes wildlife react to feral survivors, forcing them to either return as hostile or fleeing instead of adjusting their anger and morale. This ensures that whatever their aggression stats, are no mundane animal will put up with a feral survivor and just be chill with them.
4. Also in monster.cpp, fixed `monster::hear_sound` defining `feral_friend` to check for the absence of the zombie species by mistake.
5. And additionally in monster.cpp, set `monster::attitude_to` to add an additional check between zombies and ferals when the player is a feral, so that you can have things like pet zombies without them infighting with the rest of the horde. This is needed because while feral survivors have zombies marked as friendly due to setting them as `MATT_FRIEND`, this isn't the exact same outcome code-wise as actually flipping `friendly` to 1, so pet monsters will still pick fights with zombies and ferals even if they're both flagged as friendly to a feral survivor. Dunno if I'll implement that though.
6. In mattack_actors.cpp, added a check in `gun_actor::call` that fixes properly-friendly feral humans from chucking rocks at not-quite-friendly zombies that're currently ignoring a feral survivor.

JSON changes:
1. Gave rattlesnakes the `ANIMAL` flag, since they're the only mundane critter in reptile_amphibian.json that's chill with survivors by default. This fixes them being ignoring feral survivors.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Setting marloss berries to instead have a separate failure result where they just give you fungus, maybe with a flavor message like "you feel unworthy" or some other "the Mycus is judging you" sort of response, instead of the much naster pile-up of effects from trying to go marloss as a post-thresh mutant.
2. Alternatively, allowing feral survivors to become Mycus anyway, but just having the threshold mutation cancel Lost to The Cataclysm to make it effectively an "escape condition" (like becoming Paragon of The Veil does in Arcana).
3. Giving giant rattlesnakes the `ANIMAL` flag too. This won't affect feral survivors, but will make them put up with animal empathy users a bit better. Otherwise it'd be a consistency change with little real impact.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected JSON file for syntax and lint errors.
2. Compiled and load-tested in Lost and Damned scenario.
3. Spawned in two feral humans, one flagged as friendly. Confirmed they neither fought each other nor threw rocks at each other.
4. Spawned in dog food, confirmed trying to use it on a dog fails, same with cattle fodder on a cow.
5. Spawned in marloss berries after removing my carnivore mutation, ended up rejecting it. 
6. Spawned in a normal scenario, confirmed zombies still infight if one is friendly when you're not a feral, that taming items still work, and that you can get marloss'd.
7. Checked affected C++ files for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
