### PR TITLE
Solar panel CBM no longer provides power at all times

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1281,11 +1281,13 @@ bool Character::burn_fuel( bionic &bio, bool start )
                         mod_stored_kcal( -kcal_consumed );
                         mod_power_level( power_gain );
                     } else if( is_perpetual_fuel ) {
-                        if( fuel == fuel_type_sun_light && g->is_in_sunlight( pos() ) ) {
-                            const weather_type_id &wtype = current_weather( pos() );
-                            const float tick_sunlight = incident_sunlight( wtype, calendar::turn );
-                            const double intensity = tick_sunlight / default_daylight_level();
-                            mod_power_level( units::from_kilojoule( fuel_energy ) * intensity * effective_efficiency );
+                        if( fuel == fuel_type_sun_light ) {
+                            if( g->is_in_sunlight( pos() ) ) {
+                                const weather_type_id &wtype = current_weather( pos() );
+                                const float tick_sunlight = incident_sunlight( wtype, calendar::turn );
+                                const double intensity = tick_sunlight / default_daylight_level();
+                                mod_power_level( units::from_kilojoule( fuel_energy ) * intensity * effective_efficiency );
+                            }
                         } else if( fuel == fuel_type_wind ) {
                             int vehwindspeed = 0;
                             const optional_vpart_position vp = here.veh_at( pos() );


### PR DESCRIPTION

#### Summary

SUMMARY: Bugfixes "Solar panel CBM now only provides power when outside in sunlight."

#### Purpose of change

After installing the solar generator CBM and turning it on, I noticed that it produced power regardless of location or time. Obviously solar panels recharging bionics while at the bottom of a mine at night isn't working as intended.

#### Describe the solution

The if/else chain for perpetual fuel types was continuing to the bottom "make power anyway" section if the fuel type was sunlight but you weren't in sunlight. That no longer happens, and if you aren't in sunlight it makes no power.

#### Describe alternatives you've considered

Accepting free power from the bionic wizards.

#### Testing

Debug installed the solar CBM and some power, turned it on.

1. No power when inside the evac center under a roof
2. No power when in the basement.
3. Power when walking outside.
4. No power after setting time to midnight.

#### Additional context

Even when working correctly this CBM seems hilariously overtuned, generating over a kilowatt when in the normal clear-weather 8 AM starting conditions. That's over twenty times what a vehicle mounted solar panel produces, and fiddling with the fuel_efficiency in the json would probably be a good idea. I'm not touching balance though.