### PR TITLE
Broken cyborg bionics return as burnt-out bionics when extracted

### DIFF
--- a/data/json/itemgroups/Monsters_Animals_Lairs/monster_drops_advtech.json
+++ b/data/json/itemgroups/Monsters_Animals_Lairs/monster_drops_advtech.json
@@ -113,21 +113,7 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "item": "bio_dis_acid", "prob": 1 },
-      { "item": "bio_drain", "prob": 1 },
-      { "item": "bio_noise", "prob": 1 },
-      { "item": "bio_power_weakness", "prob": 1 },
-      { "item": "bio_nostril", "prob": 1 },
-      { "item": "bio_thumbs", "prob": 1 },
-      { "item": "bio_shakes", "prob": 1 },
-      { "item": "bio_leaky", "prob": 1 },
-      { "item": "bio_sleepy", "prob": 1 },
-      { "item": "bio_deformity", "prob": 1 },
-      { "item": "bio_voice", "prob": 1 },
-      { "item": "bio_pokedeye", "prob": 1 },
-      { "item": "bio_ankles", "prob": 1 },
-      { "item": "bio_trip", "prob": 1 },
-      { "item": "bio_stiff", "prob": 1 },
+      { "group": "bionic_salvage_junk", "prob": 15 },
       { "item": "bio_armor_head", "prob": 2 },
       { "item": "bio_armor_torso", "prob": 2 },
       { "item": "bio_armor_arms", "prob": 2 },
@@ -135,6 +121,23 @@
       { "item": "bio_armor_eyes", "prob": 2 },
       { "item": "bio_razors", "prob": 2 },
       { "item": "bio_torsionratchet", "prob": 1 }
+    ]
+  },
+  {
+    "id": "bionic_salvage_junk",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "burnt_out_bionic", "prob": 25 },
+      { "item": "scrap", "prob": 15, "charges": [ 1, 5 ] },
+      { "item": "alloy_sheet", "prob": 10 },
+      { "item": "cable", "prob": 15, "charges": [ 5, 10 ] },
+      { "item": "e_scrap", "prob": 10, "charges": [ 1, 5 ] },
+      { "item": "processor", "prob": 5 },
+      { "item": "RAM", "prob": 5 },
+      { "item": "amplifier", "prob": 5 },
+      { "item": "receiver", "prob": 5 },
+      { "item": "circuit", "prob": 5 }
     ]
   }
 ]

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -31,7 +31,9 @@
     "price": 0,
     "price_postapoc": 0,
     "weight": "500 g",
-    "description": "This CBM is broken beyond repair, you can't do anything with it."
+    "description": "This CBM is broken beyond repair, you can't do anything with it.",
+    "//": "Needed for dissection of faulty CBMs from dead PCs and NPCs to convert the harvest result into a burnt-out bionic automatically.",
+    "extend": { "flags": [ "BIONIC_FAULTY" ] }
   },
   {
     "id": "bio_adrenaline",
@@ -1096,7 +1098,7 @@
     "id": "bio_deformity",
     "copy-from": "bionic_general_faulty",
     "type": "BIONIC_ITEM",
-    "name": { "str": "Pieces Of Junk", "str_pl": "Pieces of Junk" },
+    "name": { "str": "Bionic-Induced Deformity", "str_pl": "Bionic-Induced Deformities" },
     "description": "A jumble of broken metal pieces that were removed during reconstructive surgery.",
     "difficulty": 5
   },
@@ -1104,7 +1106,7 @@
     "id": "bio_dis_acid",
     "copy-from": "bionic_general_faulty",
     "type": "BIONIC_ITEM",
-    "name": { "str": "Acidic Leaking CBM" },
+    "name": { "str": "Acidic Discharge" },
     "description": "This CBM has been breached in several places and some acid is leaking from it.",
     "weight": "700 g",
     "difficulty": 11
@@ -1113,7 +1115,7 @@
     "id": "bio_dis_shock",
     "copy-from": "bionic_general_faulty",
     "type": "BIONIC_ITEM",
-    "name": { "str": "Faulty Electric System" },
+    "name": { "str": "Electrical Discharge" },
     "description": "This CBM is a mess of naked wire and burnt resistors.",
     "weight": "700 g",
     "difficulty": 5

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -202,6 +202,8 @@ static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_tied( "tied" );
 static const efftype_id effect_under_op( "under_operation" );
 
+static const fault_id fault_bionic_nonsterile( "fault_bionic_nonsterile" );
+
 static const itype_id itype_2x4( "2x4" );
 static const itype_id itype_animal( "animal" );
 static const itype_id itype_battery( "battery" );
@@ -485,10 +487,19 @@ static void extract_or_wreck_cbms( const std::list<item> &cbms, int roll,
         // This complicates things
         if( it.is_bionic() ) {
             if( check_butcher_cbm( roll ) || it.typeId() == itype_burnt_out_bionic ) {
-                add_msg( m_good, _( "You discover a %s!" ), it.tname() );
+                if( it.has_flag( "BIONIC_FAULTY" ) ) {
+                    it.convert( itype_burnt_out_bionic );
+                    // We don't need the non-sterile fault on a piece of burnt-out bionic
+                    if( it.has_fault( fault_bionic_nonsterile ) ) {
+                        it.faults.erase( fault_bionic_nonsterile );
+                    }
+                }
+                add_msg( m_good, _( "You discover: %s!" ), it.tname() );
             } else {
-                // We convert instead of recreating so that it keeps flags and faults
                 it.convert( itype_burnt_out_bionic );
+                if( it.has_fault( fault_bionic_nonsterile ) ) {
+                    it.faults.erase( fault_bionic_nonsterile );
+                }
                 add_msg( m_bad, _( "Your imprecise surgery damaged a bionic, producing a %s." ), it.tname() );
             }
         } else {
@@ -496,7 +507,11 @@ static void extract_or_wreck_cbms( const std::list<item> &cbms, int roll,
                 add_msg( m_bad, _( "Your imprecise surgery destroyed some organs." ) );
                 continue;
             } else {
-                add_msg( m_good, _( "You discover a %s!" ), it.tname() );
+                // If we have non-bionic loot in a harvest's bionic_group it doesn't need to be marked non-sterile either.
+                if( it.has_fault( fault_bionic_nonsterile ) ) {
+                    it.faults.erase( fault_bionic_nonsterile );
+                }
+                add_msg( m_good, _( "You discover: %s!" ), it.tname() );
             }
         }
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -203,6 +203,7 @@ static const std::string flag_SEALED( "SEALED" );
 static const std::string flag_SEMITANGIBLE( "SEMITANGIBLE" );
 static const std::string flag_SPLINT( "SPLINT" );
 
+static const flag_str_id flag_BIONIC_FAULTY( "BIONIC_FAULTY" );
 static const flag_str_id flag_BIONIC_GUN( "BIONIC_GUN" );
 static const flag_str_id flag_BIONIC_WEAPON( "BIONIC_WEAPON" );
 static const flag_str_id flag_BIONIC_TOGGLED( "BIONIC_TOGGLED" );
@@ -2136,10 +2137,10 @@ void Character::perform_uninstall( bionic_id bid, int difficulty, int success,
         mod_max_power_level( -power_lvl );
 
         item cbm( itype_burnt_out_bionic );
-        if( bid->itype().is_valid() ) {
+        if( bid->itype().is_valid() && !bid.obj().has_flag( flag_BIONIC_FAULTY ) ) {
             cbm = item( bid.c_str() );
+            cbm.faults.emplace( fault_bionic_nonsterile );
         }
-        cbm.faults.emplace( fault_bionic_nonsterile );
         here.add_item( pos(), cbm );
     } else {
         g->events().send<event_type::fails_to_remove_cbm>( getID(), bid );
@@ -2209,9 +2210,12 @@ bool Character::uninstall_bionic( const bionic &target_cbm, monster &installer, 
         // remove power bank provided by bionic
         patient.mod_max_power_level( -target_cbm.info().capacity );
         patient.remove_bionic( target_cbm.id );
-        const itype_id iid = itemtype.is_valid() ? itemtype : itype_burnt_out_bionic;
+        const itype_id iid = itemtype.is_valid() &&
+                             !target_cbm.info().has_flag( flag_BIONIC_FAULTY ) ? itemtype : itype_burnt_out_bionic;
         item cbm( iid, calendar::start_of_cataclysm );
-        cbm.faults.emplace( fault_bionic_nonsterile );
+        if( itemtype.is_valid() ) {
+            cbm.faults.emplace( fault_bionic_nonsterile );
+        }
         get_map().add_item( patient.pos(), cbm );
     } else {
         bionics_uninstall_failure( installer, patient, difficulty, success, adjusted_skill );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Features "Uninstalling bionic complications yields burnt-out bionics instead of CBMs, replace spawns of useless bionic fault CBMs in cyborg harvest with bionic components"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This sets it so that faulty bionics no longer return a CBM item when extracted, as it's a bit weird to return it as a perfectly working faulty bionic you can then clean up and try to install in yourself.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

C++ changes:
1. In activity_handlers.cpp, set `extract_or_wreck_cbms` so that CBMs with the `BIONIC_FAULTY` flag always convert into burnt-out bionics when harvested. Used mainly for dead players and NPCs, since below I'm changing harvest entries to do something a bit more interesting. Additionally fixed it so that it will remove the non-sterile fault from non-bionics obtained by this harvest. This fixes junk you can't install showing as needing sterilization, PLUS allows for the possibility of a bionic_group having non-bionic items injected into it. Reworded the "you discover a X" message to be less clunky when it returns unexpected things like copper wire.
2. In bionics.cpp, set `Character::perform_uninstall` to only set the item to be returned on an uninstall if the item is valid but also not a faulty bionic, and likewise only emplacing the non-sterile fault if both apply.
3. Also in bionics.cpp, changed `Character::uninstall_bionic` to implement similar checks.

JSON changes:
1. Set the `bionic_general_faulty` item abstract to have the `BIONIC_FAULTY` flag. This is needed because `extract_or_wreck_cbms` checks the item itself, not the bionic it links to.
2. Set the `cyborg_harvest` itemgroup to no longer have any of the individual faulty CBMs in it, instead replacing it with an equal weight of a newly-defined itemgroup, `bionic_salvage_junk`. This is used to give them a wider variety of non-bionic items to obtain beyond simply automatically converting the relevant bionics to just burnt-out bionics, and I plan to make more use of this group in the future eventually as part of that "make the bionic scanner matter more" idea.
3. Defined the `bionic_salvage_junk` with a decent variety of electronics scrap in addition to of course burnt-out bionics.
4. Renamed the faulty bionic item names where needed so they all match what the bionic menu says it is, so that it's easier to find a specific faulty bionic you want to remove in the uninstall menu.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. If I could figure out some sane way to make it show the bionic name in the uninstall UI and not the bionic ITEM name that'd be great, it'd avoid needing to change the item form names and make it so they don't show as "sterile" in the uninstall menu.
2. Moving the copper wire in the broken cyborg harvest entry purely the dissection results. I feel like it's reasonably that you should find some bits and bobs mixed in general tissues so this is maybe still fine.
3. Making the hardcoded "turn into faulty bionics" results instead pick an item from the new itemgroup?

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected JSON for syntax and lint errors.
2. Compiled and load-tested.
3. Spawned in as a defective cyborg, set up an autodoc and stuff to test uninstalling CBMs.
4. Uninstalled some faulty CBMs, confirmed they return as burnt-out bionics.
5. Uninstalled a normal CBM, confirmed it returns as the expected item.
6. Had that character die after having a new one saved in the same shelter.
7. Dissected their corpse, all their faulty bionics returned as burnt-out bionics, and they were not marked as non-sterile.
8. Spawned in and dissected broken cyborg monsters, sometimes they return extra components instead of CBMs.
9. Checked affected C++ files for astyle.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/5ad03541-e22e-4f2f-b587-466b285ace76)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
