### PR TITLE
Allow creation of cabbage seeds from cabbages

### DIFF
--- a/data/json/recipes/food/seeds.json
+++ b/data/json/recipes/food/seeds.json
@@ -526,5 +526,17 @@
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "sugar_beet", 1 ] ] ],
     "flags": [ "ALLOW_ROTTEN" ]
+  },
+  {
+    "result": "seed_cabbage",
+    "type": "recipe",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_SEEDS",
+    "skill_used": "survival",
+    "difficulty": 2,
+    "time": "5 m",
+    "autolearn": true,
+    "components": [ [ [ "cabbage", 1 ] ] ],
+    "flags": [ "ALLOW_ROTTEN" ]
   }
 ]


### PR DESCRIPTION
**SUMMARY: [Bugfixes] "Allow creation of cabbage seeds from cabbages"**

**Purpose of change**

Adds cabbage seeds to recipes, following other vegetable seed recipes. Surprised this wasn't there when I tried to continue farming with them.

**Describe the solution**

Copied text from chamomile in the seeds.json

**Testing**

Fired up in existing game, no problems with recipe.
