### PR TITLE
Tone down reduction in wetness morale a bit

### DIFF
--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1926,9 +1926,9 @@ void Character::apply_wetness_morale( int temperature )
         }
 
         // For an unmutated human swimming in deep water, this will add up to:
-        // +12 when hot in 100% water friendly clothing
-        // -26 when cold/hot in 100% unfriendly clothing
-        total_morale += static_cast<int>( bp_morale * ( 1.0 + scaled_temperature ) / 8.0 );
+        // +26 when hot in 100% water friendly clothing
+        // -52 when cold/hot in 100% unfriendly clothing
+        total_morale += static_cast<int>( bp_morale * ( 1.0 + scaled_temperature ) / 4.0 );
     }
 
     if( total_morale == 0 ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Reduce morale divisor from 8 to 4 for wetness morale"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2962 got merged a lil early since I was still testing, and my findings as posted there suggest that cutting the peak morale in half (as @KheirFerrum suggested in the BN discord when this was first proposed) rather than quartering it would be a more reasonable nerf to it.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

In suffer.cpp, adjusted `Character::apply_wetness_morale` to use a divisor of 4.0, in between its original value and the one introduced by the previous PR.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Keeping the super reduced values since it's honestly probably fine either way, but in any case you have to be both sopping wet AND miserably hot/cold to hit peak morale so should be aight. Even in my test I didn't hit peak morale just yet, I'll likely need to test with a fursuit or something to see how close to peak I can get during the drying-off stage

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Compiled and load-tested.
2. Took a good soak in a river as a basic survivor with gills for 3 hours, observed morale bottomed out at -19 while underwater (was comfy).
3. Got back out and started waiting, morale didn't go below -20.
4. Repeated test in mid-summer. Oddly, you end up very cold while soaking underwater where in mid-spring I stayed comfy during the soak, bumping morale down to -29.
5. Drying out in the summer heat had me at only about -22 or so.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
