### PR TITLE
Some updates to obsolete mods just in case anybody uses them (like yours truly)

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -191,7 +191,7 @@
     "id": "player_feral",
     "name": "Challenge - The Lost And Damned",
     "points": -5,
-    "description": "You spent the first few weeks of the cataclysm in a dull haze.  The riots have died down and the summer sun has drawn out the stench of decay.  You stagger out of your hiding place with a gnawing hunger, unsure if you're the only one left alive, or if this is what living death is like.",
+    "description": "You spent the first few weeks of the Cataclysm in a dull haze.  The riots have died down and the summer sun has drawn out the stench of decay.  You stagger out of your hiding place with a gnawing hunger, unsure if you're the only one left alive, or if this is what living death is like.",
     "start_name": "In Town?",
     "allowed_locs": [
       "sloc_shelter_vandalized",

--- a/data/mods/Hydroponics/construction.json
+++ b/data/mods/Hydroponics/construction.json
@@ -21,7 +21,7 @@
       [ [ "water", 100 ] ]
     ],
     "pre_special": "check_empty",
-    "post_terrain": "f_hydroponics"
+    "post_furniture": "f_hydroponics"
   },
   {
     "type": "construction",
@@ -40,6 +40,6 @@
       [ [ "power_supply", 1 ] ]
     ],
     "pre_special": "check_empty",
-    "post_terrain": "f_hydro_heater"
+    "post_furniture": "f_hydro_heater"
   }
 ]

--- a/data/mods/More_Locations/terrain.json
+++ b/data/mods/More_Locations/terrain.json
@@ -9,7 +9,7 @@
     "color": "white",
     "move_cost": 0,
     "flags": [ "NOITEM", "SUPPORTS_ROOF" ],
-    "roof": "t_rock_floor",
+    "roof": "t_rock_roof",
     "bash": {
       "str_min": 100,
       "str_max": 400,


### PR DESCRIPTION
#### Summary

SUMMARY: Mods "Some updates to obsolete mods just in case anybody uses them"

#### Purpose of change

While fiddling around with mods, I came across some bugs. More Locations and Hydroponics were throwing simple errors, so I took the liberty of quickly fixing them up.

Edit: Also changed the spelling "cataclysm" into "Cataclysm" for the Lost and Damned scenario.

#### Describe the solution

Hydroponics used "post_terrain" for furniture which apparently got depreciated for "post_furniture" while More Locations had "t_rock_floor" as a roof when "t_rock_roof" existed. Kenan's Modpack appears to have altered it to a concrete roof, but I went through the game files and found out that indeed, rock floor had a matching rock roof palette. :)

#### Describe alternatives you've considered

Leaving them be.

#### Testing

Basic changes, so no errors or bugs.

#### Additional context

Hope everyone is doing great 💯 
