### PR TITLE
Sanity-checking construction components yet again

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -3304,12 +3304,12 @@
     "group": "build_rammed_earth_wall",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 2 ] ],
-    "time": "360 m",
-    "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "tools": [ [ "frame_wood_light" ], [ "log" ] ],
+    "time": "240 m",
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SMOOTH", "level": 1 } ],
+    "tools": [ [ "log" ] ],
     "components": [
-      [ [ "material_soil", 240 ] ],
-      [ [ "water", 100 ], [ "water_clean", 100 ] ],
+      [ [ "material_soil", 100 ] ],
+      [ [ "water", 50 ], [ "water_clean", 50 ] ],
       [ [ "material_sand", 20 ], [ "material_quicklime", 20 ], [ "concrete", 1 ] ]
     ],
     "pre_terrain": "t_fence_post",

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -81,7 +81,7 @@
     "required_skills": [ [ "survival", 2 ] ],
     "time": "60 m",
     "qualities": [ [ { "id": "CUT", "level": 1 } ], [ { "id": "HAMMER", "level": 1 } ] ],
-    "components": [ [ [ "stick", 12 ], [ "2x4", 6 ], [ "wood_panel", 1 ] ], [ [ "pine_bough", 24 ], [ "willowbark", 24 ] ] ],
+    "components": [ [ [ "wood_structural", 3, "LIST" ], [ "wood_panel", 1 ] ], [ [ "pine_bough", 24 ], [ "willowbark", 24 ] ] ],
     "pre_terrain": "t_pit_shallow",
     "dark_craftable": true,
     "post_terrain": "t_improvised_shelter"
@@ -126,7 +126,7 @@
     "required_skills": [ [ "fabrication", 2 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "CUT", "level": 1 } ] ],
-    "components": [ [ [ "2x4", 6 ], [ "stick", 6 ], [ "wood_panel", 1 ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ] ],
+    "components": [ [ [ "wood_structural", 3, "LIST" ], [ "wood_panel", 1 ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_terrain": "t_door_frame",
     "post_terrain": "t_door_makeshift_c"

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1374,7 +1374,11 @@
     "required_skills": [ [ "fabrication", 4 ] ],
     "time": "120 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "components": [ [ [ "log", 2 ] ], [ [ "wood_structural_small", 3, "LIST" ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_30", 1 ] ] ],
+    "components": [
+      [ [ "log", 2 ] ],
+      [ [ "wood_structural_small", 3, "LIST" ] ],
+      [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_30", 1 ] ]
+    ],
     "pre_note": "Must be between palisade walls to function, and at least one wall must have an adjacent rope & pulley system.",
     "pre_terrain": "t_pit",
     "post_terrain": "t_palisade_gate"
@@ -2572,7 +2576,10 @@
       [ { "id": "DIG", "level": 2 } ]
     ],
     "tools": [ [ [ "pickaxe", -1 ], [ "jackhammer", 140 ], [ "elec_jackhammer", 7000 ] ] ],
-    "components": [ [ [ "2x4", 8 ], [ "log", 8 ] ], [ [ "rope_makeshift_30", 1 ], [ "rope_30", 1 ], [ "vine_30", 1 ] ] ],
+    "components": [
+      [ [ "wood_structural", 4, "LIST" ], [ "log", 1 ] ],
+      [ [ "rope_makeshift_30", 1 ], [ "rope_30", 1 ], [ "vine_30", 1 ] ]
+    ],
     "pre_flags": "DIGGABLE",
     "pre_special": "check_down_OK",
     "post_special": "done_dig_stair"
@@ -2590,7 +2597,10 @@
       [ { "id": "DIG", "level": 2 } ]
     ],
     "tools": [ [ [ "pickaxe", -1 ], [ "jackhammer", 160 ], [ "elec_jackhammer", 7000 ] ] ],
-    "components": [ [ [ "2x4", 12 ], [ "log", 12 ] ], [ [ "rope_makeshift_30", 1 ], [ "rope_30", 1 ], [ "vine_30", 1 ] ] ],
+    "components": [
+      [ [ "wood_structural", 6, "LIST" ], [ "log", 2 ] ],
+      [ [ "rope_makeshift_30", 1 ], [ "rope_30", 1 ], [ "vine_30", 1 ] ]
+    ],
     "pre_special": "check_down_OK",
     "pre_terrain": "t_rock_floor",
     "post_special": "done_mine_downstair"
@@ -2669,7 +2679,10 @@
       ]
     ],
     "//": "Helmets are essential because you're digging up and things may fall on you.",
-    "components": [ [ [ "2x4", 12 ], [ "log", 12 ] ], [ [ "rope_makeshift_30", 1 ], [ "rope_30", 1 ], [ "vine_30", 1 ] ] ],
+    "components": [
+      [ [ "wood_structural", 6, "LIST" ], [ "log", 2 ] ],
+      [ [ "rope_makeshift_30", 1 ], [ "rope_30", 1 ], [ "vine_30", 1 ] ]
+    ],
     "pre_special": "check_up_OK",
     "pre_terrain": "t_rock",
     "post_special": "done_mine_upstair"
@@ -3083,7 +3096,11 @@
     "required_skills": [ [ "fabrication", 4 ] ],
     "time": "130 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
-    "components": [ [ [ "rock", 40 ], [ "brick", 40 ] ], [ [ "wood_structural", 3, "LIST" ] ], [ [ "withered", 12 ], [ "straw_pile", 12 ] ] ],
+    "components": [
+      [ [ "rock", 40 ], [ "brick", 40 ] ],
+      [ [ "wood_structural", 3, "LIST" ] ],
+      [ [ "withered", 12 ], [ "straw_pile", 12 ] ]
+    ],
     "pre_note": "You need a deep pit to construct a root cellar.",
     "pre_terrain": "t_pit",
     "post_terrain": "t_rootcellar"

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -646,10 +646,17 @@
     "time": "50 m",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
     "components": [
-      [ [ "2x4", 5 ], [ "stick", 10 ] ],
-      [ [ "material_quicklime", 4 ], [ "material_limestone", 4 ], [ "clay_lump", 4 ] ],
-      [ [ "pebble", 10 ], [ "material_sand", 10 ] ],
-      [ [ "straw_pile", 4 ], [ "cattail_stalk", 4 ], [ "dogbane", 4 ], [ "pine_bough", 4 ] ],
+      [ [ "wood_structural_small", 5, "LIST" ] ],
+      [ [ "material_quicklime", 4 ], [ "material_limestone", 4 ], [ "clay_lump", 4 ], [ "material_soil", 20 ] ],
+      [
+        [ "withered", 4 ],
+        [ "straw_pile", 4 ],
+        [ "cattail_stalk", 4 ],
+        [ "dogbane", 4 ],
+        [ "pine_bough", 4 ],
+        [ "pebble", 10 ],
+        [ "material_sand", 10 ]
+      ],
       [ [ "water", 5 ], [ "water_clean", 5 ] ]
     ],
     "pre_special": "check_empty",
@@ -665,10 +672,17 @@
     "time": "50 m",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
     "components": [
-      [ [ "2x4", 5 ], [ "stick", 10 ] ],
-      [ [ "material_quicklime", 4 ], [ "material_limestone", 4 ], [ "clay_lump", 4 ] ],
-      [ [ "pebble", 10 ], [ "material_sand", 10 ] ],
-      [ [ "straw_pile", 4 ], [ "cattail_stalk", 4 ], [ "dogbane", 4 ], [ "pine_bough", 4 ] ],
+      [ [ "wood_structural_small", 5, "LIST" ] ],
+      [ [ "material_quicklime", 4 ], [ "material_limestone", 4 ], [ "clay_lump", 4 ], [ "material_soil", 20 ] ],
+      [
+        [ "withered", 4 ],
+        [ "straw_pile", 4 ],
+        [ "cattail_stalk", 4 ],
+        [ "dogbane", 4 ],
+        [ "pine_bough", 4 ],
+        [ "pebble", 10 ],
+        [ "material_sand", 10 ]
+      ],
       [ [ "water", 5 ], [ "water_clean", 5 ] ]
     ],
     "pre_terrain": "t_wall_wattle_half",

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -697,7 +697,7 @@
     "time": "30 m",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
     "components": [
-      [ [ "2x4", 2 ], [ "stick", 4 ] ],
+      [ [ "wood_structural_small", 2, "LIST" ] ],
       [ [ "material_quicklime", 2 ], [ "material_limestone", 2 ], [ "clay_lump", 2 ] ],
       [ [ "pebble", 4 ], [ "material_sand", 4 ] ],
       [ [ "straw_pile", 2 ], [ "cattail_stalk", 2 ], [ "dogbane", 2 ], [ "pine_bough", 2 ] ],
@@ -780,7 +780,7 @@
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "60 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "components": [ [ [ "log", 2 ] ], [ [ "stick", 3 ], [ "2x4", 6 ] ] ],
+    "components": [ [ [ "log", 2 ] ], [ [ "wood_structural_small", 3, "LIST" ] ] ],
     "pre_terrain": "t_pit_shallow",
     "post_terrain": "t_wall_log_half"
   },
@@ -1319,7 +1319,7 @@
     "required_skills": [ [ "fabrication", 5 ], [ "survival", 3 ] ],
     "time": "120 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "2x4", 8 ], [ "stick", 8 ] ], [ [ "straw_pile", 24 ], [ "withered", 24 ] ], [ [ "cordage", 2, "LIST" ] ] ],
+    "components": [ [ [ "wood_structural", 4, "LIST" ] ], [ [ "straw_pile", 24 ], [ "withered", 24 ] ], [ [ "cordage", 2, "LIST" ] ] ],
     "pre_special": "check_support",
     "post_terrain": "t_dirtfloor_thatchroof"
   },
@@ -1333,7 +1333,7 @@
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [
       [ [ "log", 2 ] ],
-      [ [ "stick", 4 ], [ "2x4", 4 ] ],
+      [ [ "wood_structural", 2, "LIST" ] ],
       [ [ "material_soil", 40 ] ],
       [ [ "birchbark", 12 ], [ "pine_bough", 12 ] ]
     ],
@@ -1361,7 +1361,7 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 5 ], [ "mechanics", 2 ] ],
     "time": "60 m",
-    "components": [ [ [ "rope_makeshift_30", 1 ], [ "rope_30", 1 ], [ "vine_30", 1 ] ], [ [ "stick", 8 ], [ "2x4", 8 ] ] ],
+    "components": [ [ [ "rope_makeshift_30", 1 ], [ "rope_30", 1 ], [ "vine_30", 1 ] ], [ [ "wood_structural", 4, "LIST" ] ] ],
     "pre_note": "Can be deconstructed without tools.  Must be adjacent to a palisade wall that is itself adjacent to a palisade gate in order to open said gate.",
     "pre_special": "check_empty",
     "post_terrain": "t_palisade_pulley"
@@ -1374,7 +1374,7 @@
     "required_skills": [ [ "fabrication", 4 ] ],
     "time": "120 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
-    "components": [ [ [ "log", 2 ] ], [ [ "2x4", 3 ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_30", 1 ] ] ],
+    "components": [ [ [ "log", 2 ] ], [ [ "wood_structural_small", 3, "LIST" ] ], [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ], [ "vine_30", 1 ] ] ],
     "pre_note": "Must be between palisade walls to function, and at least one wall must have an adjacent rope & pulley system.",
     "pre_terrain": "t_pit",
     "post_terrain": "t_palisade_gate"
@@ -1870,7 +1870,7 @@
     "category": "FURN",
     "required_skills": [ [ "fabrication", 1 ] ],
     "time": "30 m",
-    "components": [ [ [ "2x4", 4 ], [ "stick", 4 ] ], [ [ "straw_pile", 8 ], [ "withered", 8 ], [ "pine_bough", 8 ] ] ],
+    "components": [ [ [ "wood_structural", 2, "LIST" ] ], [ [ "straw_pile", 8 ], [ "withered", 8 ], [ "pine_bough", 8 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_special": "check_empty",
     "dark_craftable": true,
@@ -3002,7 +3002,7 @@
     "required_skills": [ [ "fabrication", 3 ], [ "cooking", 2 ] ],
     "time": "90 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "CUT", "level": 1 } ], [ { "id": "SAW_W", "level": 1 } ] ],
-    "components": [ [ [ "stick", 16 ], [ "2x4", 16 ] ], [ [ "rock", 8 ] ] ],
+    "components": [ [ [ "wood_structural", 8, "LIST" ] ], [ [ "rock", 8 ] ] ],
     "pre_note": "Can be deconstructed without tools.",
     "pre_special": "check_empty",
     "post_furniture": "f_smoking_rack"
@@ -3083,7 +3083,7 @@
     "required_skills": [ [ "fabrication", 4 ] ],
     "time": "130 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
-    "components": [ [ [ "rock", 40 ], [ "brick", 40 ] ], [ [ "2x4", 6 ], [ "stick", 6 ] ], [ [ "withered", 12 ], [ "straw_pile", 12 ] ] ],
+    "components": [ [ [ "rock", 40 ], [ "brick", 40 ] ], [ [ "wood_structural", 3, "LIST" ] ], [ [ "withered", 12 ], [ "straw_pile", 12 ] ] ],
     "pre_note": "You need a deep pit to construct a root cellar.",
     "pre_terrain": "t_pit",
     "post_terrain": "t_rootcellar"
@@ -3469,7 +3469,7 @@
     "required_skills": [ [ "fabrication", 2 ] ],
     "time": "90m",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "stick", 6 ], [ "2x4", 3 ] ] ],
+    "components": [ [ [ "wood_structural_small", 3, "LIST" ] ] ],
     "pre_terrain": "t_tree_pine",
     "post_terrain": "t_leanto"
   },

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1242,7 +1242,7 @@
     "required_skills": [ [ "fabrication", 6 ] ],
     "time": "180 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "DIG", "level": 2 } ] ],
-    "components": [ [ [ "rock", 12 ] ], [ [ "pebble", 50 ] ], [ [ "mortar_build", 1 ] ] ],
+    "components": [ [ [ "rock", 12 ] ], [ [ "pebble", 50 ] ], [ [ "mortar_build", 1 ], [ "mortar_adobe", 1 ] ] ],
     "pre_special": "check_empty",
     "post_terrain": "t_rock_wall_half"
   },
@@ -1255,7 +1255,7 @@
     "required_skills": [ [ "fabrication", 6 ] ],
     "time": "180 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "DIG", "level": 2 } ] ],
-    "components": [ [ [ "rock", 12 ] ], [ [ "mortar_build", 1 ] ] ],
+    "components": [ [ [ "rock", 12 ] ], [ [ "mortar_build", 1 ], [ "mortar_adobe", 1 ] ] ],
     "pre_terrain": "t_rock_wall_half",
     "post_terrain": "t_rock_wall"
   },
@@ -1319,7 +1319,11 @@
     "required_skills": [ [ "fabrication", 5 ], [ "survival", 3 ] ],
     "time": "120 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "wood_structural", 4, "LIST" ] ], [ [ "straw_pile", 24 ], [ "withered", 24 ] ], [ [ "cordage", 2, "LIST" ] ] ],
+    "components": [
+      [ [ "wood_structural", 4, "LIST" ] ],
+      [ [ "straw_pile", 24 ], [ "withered", 24 ], [ "pine_bough", 24 ] ],
+      [ [ "cordage", 2, "LIST" ] ]
+    ],
     "pre_special": "check_support",
     "post_terrain": "t_dirtfloor_thatchroof"
   },
@@ -3042,7 +3046,7 @@
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [
       [ [ "rock", 40 ] ],
-      [ [ "material_cement", 50 ], [ "mortar_build", 1 ], [ "clay_lump", 12 ] ],
+      [ [ "material_cement", 50 ], [ "mortar_build", 1 ], [ "mortar_adobe", 1 ], [ "clay_lump", 12 ] ],
       [ [ "water", 2 ], [ "water_clean", 2 ] ]
     ],
     "pre_note": "Can be deconstructed without tools.",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -1965,7 +1965,7 @@
     "symbol": ",",
     "color": "brown",
     "name": { "str": "soft adobe brick" },
-    "description": "A compacted mass of soil and natural fibers, still too wet to build with.  Load it onto a pallet and leave it to dry.",
+    "description": "A compacted mass of soil and natural fibers, still too wet to build with.  You could load it onto a pallet and leave it to dry to process them in bulk.",
     "price": 0,
     "price_postapoc": 0,
     "material": "soil",
@@ -1973,14 +1973,14 @@
     "volume": "750 ml",
     "bashing": 2,
     "to_hit": -3,
+    "flags": [ "ALLOWS_REMOTE_USE" ],
     "use_action": {
       "target": "adobe_brick",
       "msg": "You test the brick, and it seems solid enough to use.",
       "moves": 50,
       "type": "delayed_transform",
       "transform_age": 100800,
-      "not_ready_msg": "The brick is still too damp to bear weight.",
-      "//": "Should be about a week. Irl it's ten days, so make big batches."
+      "not_ready_msg": "The brick is still too damp to bear weight."
     }
   },
   {

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -21,8 +21,7 @@
       "moves": 50,
       "type": "delayed_transform",
       "transform_age": 100800,
-      "not_ready_msg": "The bricks are still too damp to bear weight.",
-      "//": "Should be about a week. Irl it's ten days, so make big batches."
+      "not_ready_msg": "The bricks are still too damp to bear weight."
     }
   },
   {
@@ -30,7 +29,7 @@
     "type": "GENERIC",
     "category": "tools",
     "name": { "str": "pallet of dry adobe bricks", "str_pl": "pallets of dry adobe bricks" },
-    "description": "A pallet of humble mud bricks that have dried for a week, while you were out risking your life.  Disassemble it to retrieve your frame and building supplies.",
+    "description": "A pallet of humble mud bricks that have dried out while you were out risking your life.  Disassemble it to retrieve your frame and building supplies.",
     "weight": "30000 g",
     "volume": "12500 ml",
     "price": 40000,

--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_common.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_common.json
@@ -146,11 +146,11 @@
     "blueprint_resources": [ "fake_char_smoker", "fake_char_smoker", "fake_char_smoker", "fake_char_kiln" ],
     "blueprint_needs": {
       "time": "6 h 30 m",
-      "skills": [ [ "cooking", 2 ], [ "fabrication", 3 ] ],
+      "skills": [ [ "fabrication", 3 ], [ "cooking", 2 ] ],
       "inline": {
         "tools": [  ],
-        "qualities": [ [ { "id": "SAW_W" } ], [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 48 ], [ "stick", 48 ] ], [ [ "material_soil", 2 ] ], [ [ "rock", 64 ] ] ]
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W" } ] ],
+        "components": [ [ [ "2x4", 48 ], [ "stick", 48 ], [ "stick_long", 24 ] ], [ [ "material_soil", 2 ] ], [ [ "rock", 64 ] ] ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_log.json
@@ -19,7 +19,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 131 ] ],
+          [ [ "2x4", 95 ] ],
           [ [ "glass_sheet", 3 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "log", 24 ] ],
@@ -49,7 +49,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 151 ] ],
+          [ [ "2x4", 97 ] ],
           [ [ "glass_sheet", 1 ] ],
           [ [ "hinge", 4 ] ],
           [ [ "log", 36 ] ],
@@ -78,7 +78,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 252 ] ], [ [ "log", 24 ] ], [ [ "nail", 448 ] ], [ [ "wood_panel", 22 ] ] ]
+        "components": [ [ [ "2x4", 216 ] ], [ [ "log", 24 ] ], [ [ "nail", 448 ] ], [ [ "wood_panel", 22 ] ] ]
       }
     }
   },
@@ -101,7 +101,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
-        "components": [ [ [ "log", 64 ] ], [ [ "2x4", 180 ], [ "stick", 90 ] ], [ [ "glass_sheet", 2 ] ], [ [ "nail", 60 ] ] ]
+        "components": [ [ [ "log", 64 ] ], [ [ "2x4", 90 ], [ "stick", 90 ] ], [ [ "glass_sheet", 2 ] ], [ [ "nail", 60 ] ] ]
       }
     }
   },
@@ -125,7 +125,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 128 ] ],
+          [ [ "2x4", 92 ] ],
           [ [ "glass_sheet", 2 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "log", 24 ] ],
@@ -154,7 +154,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 141 ] ], [ [ "glass_sheet", 3 ] ], [ [ "log", 28 ] ], [ [ "nail", 120 ] ] ]
+        "components": [ [ [ "2x4", 99 ] ], [ [ "glass_sheet", 3 ] ], [ [ "log", 28 ] ], [ [ "nail", 120 ] ] ]
       }
     }
   },
@@ -178,7 +178,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 53 ] ],
+          [ [ "2x4", 41 ] ],
           [ [ "glass_sheet", 1 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "log", 8 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_rammed_earth.json
@@ -13,24 +13,25 @@
     "blueprint_provides": [ { "id": "fbmk_center" } ],
     "blueprint_excludes": [ { "id": "fbmk_center" } ],
     "blueprint_needs": {
-      "time": "2 d 5 h 45 m",
+      "time": "1 d 17 h 45 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
         "qualities": [
           [ { "id": "CUT" } ],
           [ { "id": "DIG", "level": 2 } ],
           [ { "id": "HAMMER", "level": 2 } ],
-          [ { "id": "SAW_W", "level": 2 } ]
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
         ],
         "components": [
           [ [ "2x4", 151 ] ],
+          [ [ "concrete", 6 ], [ "material_quicklime", 120 ], [ "material_sand", 120 ] ],
+          [ [ "material_soil", 600 ] ],
           [ [ "nail", 334 ] ],
           [ [ "pointy_stick", 12 ], [ "spear_wood", 12 ] ],
-          [ [ "material_soil", 1440 ] ],
-          [ [ "water", 600 ], [ "water_clean", 600 ] ],
-          [ [ "material_sand", 120 ], [ "material_quicklime", 120 ], [ "concrete", 6 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 300 ], [ "water_clean", 300 ] ],
           [ [ "wood_panel", 11 ] ]
         ]
       }
@@ -50,24 +51,25 @@
     "blueprint_provides": [ { "id": "fbmk_center2" } ],
     "blueprint_excludes": [ { "id": "fbmk_center2" } ],
     "blueprint_needs": {
-      "time": "3 d 4 h 30 m",
+      "time": "2 d 10 h 30 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
         "qualities": [
           [ { "id": "CUT" } ],
           [ { "id": "DIG", "level": 2 } ],
           [ { "id": "HAMMER", "level": 2 } ],
-          [ { "id": "SAW_W", "level": 2 } ]
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
         ],
         "components": [
           [ [ "2x4", 179 ] ],
+          [ [ "concrete", 9 ], [ "material_quicklime", 180 ], [ "material_sand", 180 ] ],
+          [ [ "material_soil", 900 ] ],
           [ [ "nail", 398 ] ],
           [ [ "pointy_stick", 18 ], [ "spear_wood", 18 ] ],
-          [ [ "material_soil", 2160 ] ],
-          [ [ "water", 900 ], [ "water_clean", 900 ] ],
-          [ [ "material_sand", 180 ], [ "material_quicklime", 180 ], [ "concrete", 9 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 450 ], [ "water_clean", 450 ] ],
           [ [ "wood_panel", 16 ] ]
         ]
       }
@@ -87,18 +89,23 @@
     "blueprint_provides": [ { "id": "fbmk_smoking_area" } ],
     "blueprint_excludes": [ { "id": "fbmk_smoking_area" } ],
     "blueprint_needs": {
-      "time": "2 d 11 h 55 m",
+      "time": "1 d 23 h 55 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [
+          [ { "id": "DIG", "level": 2 } ],
+          [ { "id": "HAMMER", "level": 2 } ],
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
+        ],
         "components": [
-          [ [ "pointy_stick", 12 ], [ "spear_wood", 12 ] ],
           [ [ "2x4", 180 ] ],
+          [ [ "concrete", 6 ], [ "material_quicklime", 120 ], [ "material_sand", 120 ] ],
+          [ [ "material_soil", 600 ] ],
           [ [ "nail", 448 ] ],
-          [ [ "material_soil", 1440 ] ],
-          [ [ "water", 600 ], [ "water_clean", 600 ] ],
-          [ [ "material_sand", 120 ], [ "material_quicklime", 120 ], [ "concrete", 6 ] ],
+          [ [ "pointy_stick", 12 ], [ "spear_wood", 12 ] ],
+          [ [ "water", 300 ], [ "water_clean", 300 ] ],
           [ [ "wood_panel", 22 ] ]
         ]
       }
@@ -118,18 +125,23 @@
     "blueprint_provides": [ { "id": "fbmk_pantry_room" } ],
     "blueprint_excludes": [ { "id": "fbmk_pantry_room" } ],
     "blueprint_needs": {
-      "time": "5 d 1 h 15 m",
+      "time": "3 d 19 h 15 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [
+          [ { "id": "DIG", "level": 2 } ],
+          [ { "id": "HAMMER", "level": 2 } ],
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
+        ],
         "components": [
           [ [ "2x4", 230 ] ],
           [ [ "concrete", 15 ], [ "material_quicklime", 300 ], [ "material_sand", 300 ] ],
-          [ [ "material_soil", 3600 ] ],
+          [ [ "material_soil", 1500 ] ],
           [ [ "nail", 560 ] ],
           [ [ "pointy_stick", 30 ], [ "spear_wood", 30 ] ],
-          [ [ "water", 1500 ], [ "water_clean", 1500 ] ],
+          [ [ "water", 750 ], [ "water_clean", 750 ] ],
           [ [ "wood_panel", 25 ] ]
         ]
       }
@@ -149,24 +161,25 @@
     "blueprint_provides": [ { "id": "fbmk_canteen_dining_west" } ],
     "blueprint_excludes": [ { "id": "fbmk_canteen_dining_west" } ],
     "blueprint_needs": {
-      "time": "2 d 6 h",
+      "time": "1 d 18 h",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
         "qualities": [
           [ { "id": "CUT" } ],
           [ { "id": "DIG", "level": 2 } ],
           [ { "id": "HAMMER", "level": 2 } ],
-          [ { "id": "SAW_W", "level": 2 } ]
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
         ],
         "components": [
           [ [ "2x4", 148 ] ],
           [ [ "concrete", 6 ], [ "material_quicklime", 120 ], [ "material_sand", 120 ] ],
-          [ [ "material_soil", 1440 ] ],
+          [ [ "material_soil", 600 ] ],
           [ [ "nail", 334 ] ],
           [ [ "pointy_stick", 12 ], [ "spear_wood", 12 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
-          [ [ "water", 600 ], [ "water_clean", 600 ] ],
+          [ [ "water", 300 ], [ "water_clean", 300 ] ],
           [ [ "wood_panel", 11 ] ]
         ]
       }
@@ -186,18 +199,23 @@
     "blueprint_provides": [ { "id": "fbmk_canteen_dining_east" } ],
     "blueprint_excludes": [ { "id": "fbmk_canteen_dining_east" } ],
     "blueprint_needs": {
-      "time": "2 d 18 h",
+      "time": "2 d 4 h",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [
+          [ { "id": "DIG", "level": 2 } ],
+          [ { "id": "HAMMER", "level": 2 } ],
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
+        ],
         "components": [
-          [ [ "pointy_stick", 14 ], [ "spear_wood", 14 ] ],
           [ [ "2x4", 193 ] ],
+          [ [ "concrete", 7 ], [ "material_quicklime", 140 ], [ "material_sand", 140 ] ],
+          [ [ "material_soil", 700 ] ],
           [ [ "nail", 460 ] ],
-          [ [ "material_soil", 1680 ] ],
-          [ [ "water", 700 ], [ "water_clean", 700 ] ],
-          [ [ "material_sand", 140 ], [ "material_quicklime", 140 ], [ "concrete", 7 ] ],
+          [ [ "pointy_stick", 14 ], [ "spear_wood", 14 ] ],
+          [ [ "water", 350 ], [ "water_clean", 350 ] ],
           [ [ "wood_panel", 17 ] ]
         ]
       }
@@ -217,24 +235,25 @@
     "blueprint_provides": [ { "id": "fbmk_canteen_dining_center" } ],
     "blueprint_excludes": [ { "id": "fbmk_canteen_dining_center" } ],
     "blueprint_needs": {
-      "time": "1 d 15 h 15 m",
+      "time": "1 d 11 h 15 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
         "qualities": [
           [ { "id": "CUT" } ],
           [ { "id": "DIG", "level": 2 } ],
           [ { "id": "HAMMER", "level": 2 } ],
-          [ { "id": "SAW_W", "level": 2 } ]
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
         ],
         "components": [
           [ [ "2x4", 225 ] ],
+          [ [ "concrete", 2 ], [ "material_quicklime", 40 ], [ "material_sand", 40 ] ],
+          [ [ "material_soil", 200 ] ],
           [ [ "nail", 534 ] ],
           [ [ "pointy_stick", 4 ], [ "spear_wood", 4 ] ],
-          [ [ "material_soil", 480 ] ],
-          [ [ "water", 200 ], [ "water_clean", 200 ] ],
-          [ [ "material_sand", 40 ], [ "material_quicklime", 40 ], [ "concrete", 2 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 100 ], [ "water_clean", 100 ] ],
           [ [ "wood_panel", 24 ] ]
         ]
       }

--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_rock.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_rock.json
@@ -22,7 +22,7 @@
           [ [ "2x4", 59 ] ],
           [ [ "glass_sheet", 3 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "mortar_build", 12 ] ],
+          [ [ "mortar_adobe", 12 ], [ "mortar_build", 12 ] ],
           [ [ "nail", 126 ] ],
           [ [ "pebble", 300 ] ],
           [ [ "rock", 144 ] ],
@@ -54,7 +54,7 @@
           [ [ "2x4", 43 ] ],
           [ [ "glass_sheet", 1 ] ],
           [ [ "hinge", 4 ] ],
-          [ [ "mortar_build", 18 ] ],
+          [ [ "mortar_adobe", 18 ], [ "mortar_build", 18 ] ],
           [ [ "nail", 102 ] ],
           [ [ "pebble", 450 ] ],
           [ [ "rock", 216 ] ],
@@ -84,10 +84,10 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 180 ] ],
+          [ [ "mortar_adobe", 12 ], [ "mortar_build", 12 ] ],
           [ [ "nail", 448 ] ],
-          [ [ "rock", 144 ] ],
           [ [ "pebble", 300 ] ],
-          [ [ "mortar_build", 12 ] ],
+          [ [ "rock", 144 ] ],
           [ [ "wood_panel", 22 ] ]
         ]
       }
@@ -115,7 +115,7 @@
         "components": [
           [ [ "2x4", 30 ], [ "log", 4 ] ],
           [ [ "glass_sheet", 2 ] ],
-          [ [ "mortar_build", 30 ] ],
+          [ [ "mortar_adobe", 30 ], [ "mortar_build", 30 ] ],
           [ [ "nail", 60 ] ],
           [ [ "pebble", 750 ] ],
           [ [ "rock", 360 ] ]
@@ -146,7 +146,7 @@
           [ [ "2x4", 56 ] ],
           [ [ "glass_sheet", 2 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "mortar_build", 12 ] ],
+          [ [ "mortar_adobe", 12 ], [ "mortar_build", 12 ] ],
           [ [ "nail", 126 ] ],
           [ [ "pebble", 300 ] ],
           [ [ "rock", 144 ] ],
@@ -177,7 +177,7 @@
         "components": [
           [ [ "2x4", 57 ] ],
           [ [ "glass_sheet", 3 ] ],
-          [ [ "mortar_build", 14 ] ],
+          [ [ "mortar_adobe", 14 ], [ "mortar_build", 14 ] ],
           [ [ "nail", 120 ] ],
           [ [ "pebble", 350 ] ],
           [ [ "rock", 168 ] ]
@@ -208,7 +208,7 @@
           [ [ "2x4", 29 ] ],
           [ [ "glass_sheet", 1 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "mortar_build", 4 ] ],
+          [ [ "mortar_adobe", 4 ], [ "mortar_build", 4 ] ],
           [ [ "nail", 66 ] ],
           [ [ "pebble", 100 ] ],
           [ [ "rock", 48 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_canteen/recipe_modular_canteen_wad.json
@@ -14,18 +14,30 @@
     "blueprint_excludes": [ { "id": "fbmk_center" } ],
     "blueprint_needs": {
       "time": "1 d 1 h",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 181 ] ],
+          [
+            [ "cattail_stalk", 60 ],
+            [ "dogbane", 60 ],
+            [ "material_sand", 150 ],
+            [ "pebble", 150 ],
+            [ "pine_bough", 60 ],
+            [ "straw_pile", 60 ],
+            [ "withered", 60 ]
+          ],
+          [
+            [ "clay_lump", 60 ],
+            [ "material_limestone", 60 ],
+            [ "material_quicklime", 60 ],
+            [ "material_soil", 300 ]
+          ],
           [ [ "nail", 244 ] ],
-          [ [ "material_quicklime", 60 ], [ "material_limestone", 60 ], [ "clay_lump", 60 ] ],
-          [ [ "pebble", 150 ], [ "material_sand", 150 ] ],
-          [ [ "straw_pile", 60 ], [ "cattail_stalk", 60 ], [ "dogbane", 60 ], [ "pine_bough", 60 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 75 ], [ "water_clean", 75 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
           [ [ "wood_panel", 11 ] ]
         ]
       }
@@ -46,18 +58,30 @@
     "blueprint_excludes": [ { "id": "fbmk_center2" } ],
     "blueprint_needs": {
       "time": "1 d 10 h 50 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 259 ] ],
+          [
+            [ "cattail_stalk", 76 ],
+            [ "dogbane", 76 ],
+            [ "material_sand", 190 ],
+            [ "pebble", 190 ],
+            [ "pine_bough", 76 ],
+            [ "straw_pile", 76 ],
+            [ "withered", 76 ]
+          ],
+          [
+            [ "clay_lump", 76 ],
+            [ "material_limestone", 76 ],
+            [ "material_quicklime", 76 ],
+            [ "material_soil", 380 ]
+          ],
           [ [ "nail", 368 ] ],
-          [ [ "material_quicklime", 76 ], [ "material_limestone", 76 ], [ "clay_lump", 76 ] ],
-          [ [ "pebble", 190 ], [ "material_sand", 190 ] ],
-          [ [ "straw_pile", 76 ], [ "cattail_stalk", 76 ], [ "dogbane", 76 ], [ "pine_bough", 76 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
           [ [ "water", 95 ], [ "water_clean", 95 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
           [ [ "wood_panel", 16 ] ]
         ]
       }
@@ -78,16 +102,28 @@
     "blueprint_excludes": [ { "id": "fbmk_smoking_area" } ],
     "blueprint_needs": {
       "time": "1 d 8 h 25 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 240 ] ],
+          [
+            [ "cattail_stalk", 48 ],
+            [ "dogbane", 48 ],
+            [ "material_sand", 120 ],
+            [ "pebble", 120 ],
+            [ "pine_bough", 48 ],
+            [ "straw_pile", 48 ],
+            [ "withered", 48 ]
+          ],
+          [
+            [ "clay_lump", 48 ],
+            [ "material_limestone", 48 ],
+            [ "material_quicklime", 48 ],
+            [ "material_soil", 240 ]
+          ],
           [ [ "nail", 448 ] ],
-          [ [ "material_quicklime", 48 ], [ "material_limestone", 48 ], [ "clay_lump", 48 ] ],
-          [ [ "pebble", 120 ], [ "material_sand", 120 ] ],
-          [ [ "straw_pile", 48 ], [ "cattail_stalk", 48 ], [ "dogbane", 48 ], [ "pine_bough", 48 ] ],
           [ [ "water", 60 ], [ "water_clean", 60 ] ],
           [ [ "wood_panel", 22 ] ]
         ]
@@ -109,15 +145,27 @@
     "blueprint_excludes": [ { "id": "fbmk_pantry_room" } ],
     "blueprint_needs": {
       "time": "2 d 3 h 40 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 360 ] ],
-          [ [ "cattail_stalk", 128 ], [ "dogbane", 128 ], [ "pine_bough", 128 ], [ "straw_pile", 128 ] ],
-          [ [ "clay_lump", 128 ], [ "material_limestone", 128 ], [ "material_quicklime", 128 ] ],
-          [ [ "material_sand", 320 ], [ "pebble", 320 ] ],
+          [
+            [ "cattail_stalk", 128 ],
+            [ "dogbane", 128 ],
+            [ "material_sand", 320 ],
+            [ "pebble", 320 ],
+            [ "pine_bough", 128 ],
+            [ "straw_pile", 128 ],
+            [ "withered", 128 ]
+          ],
+          [
+            [ "clay_lump", 128 ],
+            [ "material_limestone", 128 ],
+            [ "material_quicklime", 128 ],
+            [ "material_soil", 640 ]
+          ],
           [ [ "nail", 500 ] ],
           [ [ "water", 160 ], [ "water_clean", 160 ] ],
           [ [ "wood_panel", 25 ] ]
@@ -146,9 +194,21 @@
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 188 ] ],
-          [ [ "cattail_stalk", 56 ], [ "dogbane", 56 ], [ "pine_bough", 56 ], [ "straw_pile", 56 ] ],
-          [ [ "clay_lump", 56 ], [ "material_limestone", 56 ], [ "material_quicklime", 56 ] ],
-          [ [ "material_sand", 140 ], [ "pebble", 140 ] ],
+          [
+            [ "cattail_stalk", 56 ],
+            [ "dogbane", 56 ],
+            [ "material_sand", 140 ],
+            [ "pebble", 140 ],
+            [ "pine_bough", 56 ],
+            [ "straw_pile", 56 ],
+            [ "withered", 56 ]
+          ],
+          [
+            [ "clay_lump", 56 ],
+            [ "material_limestone", 56 ],
+            [ "material_quicklime", 56 ],
+            [ "material_soil", 280 ]
+          ],
           [ [ "nail", 274 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 70 ], [ "water_clean", 70 ] ],
@@ -172,16 +232,28 @@
     "blueprint_excludes": [ { "id": "fbmk_canteen_dining_east" } ],
     "blueprint_needs": {
       "time": "1 d 8 h 40 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 233 ] ],
+          [
+            [ "cattail_stalk", 68 ],
+            [ "dogbane", 68 ],
+            [ "material_sand", 170 ],
+            [ "pebble", 170 ],
+            [ "pine_bough", 68 ],
+            [ "straw_pile", 68 ],
+            [ "withered", 68 ]
+          ],
+          [
+            [ "clay_lump", 68 ],
+            [ "material_limestone", 68 ],
+            [ "material_quicklime", 68 ],
+            [ "material_soil", 340 ]
+          ],
           [ [ "nail", 370 ] ],
-          [ [ "material_quicklime", 68 ], [ "material_limestone", 68 ], [ "clay_lump", 68 ] ],
-          [ [ "pebble", 170 ], [ "material_sand", 170 ] ],
-          [ [ "straw_pile", 68 ], [ "cattail_stalk", 68 ], [ "dogbane", 68 ], [ "pine_bough", 68 ] ],
           [ [ "water", 85 ], [ "water_clean", 85 ] ],
           [ [ "wood_panel", 17 ] ]
         ]
@@ -203,18 +275,30 @@
     "blueprint_excludes": [ { "id": "fbmk_canteen_dining_center" } ],
     "blueprint_needs": {
       "time": "1 d 5 h 40 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 235 ] ],
+          [
+            [ "cattail_stalk", 20 ],
+            [ "dogbane", 20 ],
+            [ "material_sand", 50 ],
+            [ "pebble", 50 ],
+            [ "pine_bough", 20 ],
+            [ "straw_pile", 20 ],
+            [ "withered", 20 ]
+          ],
+          [
+            [ "clay_lump", 20 ],
+            [ "material_limestone", 20 ],
+            [ "material_quicklime", 20 ],
+            [ "material_soil", 100 ]
+          ],
           [ [ "nail", 504 ] ],
-          [ [ "material_quicklime", 20 ], [ "material_limestone", 20 ], [ "clay_lump", 20 ] ],
-          [ [ "pebble", 50 ], [ "material_sand", 50 ] ],
-          [ [ "straw_pile", 20 ], [ "cattail_stalk", 20 ], [ "dogbane", 20 ], [ "pine_bough", 20 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 25 ], [ "water_clean", 25 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
           [ [ "wood_panel", 24 ] ]
         ]
       }

--- a/data/json/recipes/basecamps/recipe_modular_field_common.json
+++ b/data/json/recipes/basecamps/recipe_modular_field_common.json
@@ -127,7 +127,10 @@
       "inline": {
         "tools": [  ],
         "qualities": [  ],
-        "components": [ [ [ "2x4", 8 ], [ "stick", 8 ] ], [ [ "straw_pile", 16 ], [ "withered", 16 ], [ "pine_bough", 16 ] ] ]
+        "components": [
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
+          [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ]
+        ]
       }
     }
   },
@@ -178,7 +181,10 @@
       "inline": {
         "tools": [  ],
         "qualities": [  ],
-        "components": [ [ [ "2x4", 8 ], [ "stick", 8 ] ], [ [ "straw_pile", 16 ], [ "withered", 16 ], [ "pine_bough", 16 ] ] ]
+        "components": [
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
+          [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ]
+        ]
       }
     }
   },
@@ -229,7 +235,10 @@
       "inline": {
         "tools": [  ],
         "qualities": [  ],
-        "components": [ [ [ "2x4", 16 ], [ "stick", 16 ] ], [ [ "straw_pile", 32 ], [ "withered", 32 ], [ "pine_bough", 32 ] ] ]
+        "components": [
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
+          [ [ "pine_bough", 32 ], [ "straw_pile", 32 ], [ "withered", 32 ] ]
+        ]
       }
     }
   },
@@ -280,7 +289,10 @@
       "inline": {
         "tools": [  ],
         "qualities": [  ],
-        "components": [ [ [ "2x4", 16 ], [ "stick", 16 ] ], [ [ "straw_pile", 32 ], [ "withered", 32 ], [ "pine_bough", 32 ] ] ]
+        "components": [
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
+          [ [ "pine_bough", 32 ], [ "straw_pile", 32 ], [ "withered", 32 ] ]
+        ]
       }
     }
   },
@@ -331,7 +343,10 @@
       "inline": {
         "tools": [  ],
         "qualities": [  ],
-        "components": [ [ [ "2x4", 16 ], [ "stick", 16 ] ], [ [ "straw_pile", 32 ], [ "withered", 32 ], [ "pine_bough", 32 ] ] ]
+        "components": [
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
+          [ [ "pine_bough", 32 ], [ "straw_pile", 32 ], [ "withered", 32 ] ]
+        ]
       }
     }
   },
@@ -382,7 +397,10 @@
       "inline": {
         "tools": [  ],
         "qualities": [  ],
-        "components": [ [ [ "2x4", 16 ], [ "stick", 16 ] ], [ [ "straw_pile", 32 ], [ "withered", 32 ], [ "pine_bough", 32 ] ] ]
+        "components": [
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
+          [ [ "pine_bough", 32 ], [ "straw_pile", 32 ], [ "withered", 32 ] ]
+        ]
       }
     }
   },
@@ -433,7 +451,10 @@
       "inline": {
         "tools": [  ],
         "qualities": [  ],
-        "components": [ [ [ "2x4", 16 ], [ "stick", 16 ] ], [ [ "straw_pile", 32 ], [ "withered", 32 ], [ "pine_bough", 32 ] ] ]
+        "components": [
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
+          [ [ "pine_bough", 32 ], [ "straw_pile", 32 ], [ "withered", 32 ] ]
+        ]
       }
     }
   },
@@ -484,7 +505,10 @@
       "inline": {
         "tools": [  ],
         "qualities": [  ],
-        "components": [ [ [ "2x4", 16 ], [ "stick", 16 ] ], [ [ "straw_pile", 32 ], [ "withered", 32 ], [ "pine_bough", 32 ] ] ]
+        "components": [
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
+          [ [ "pine_bough", 32 ], [ "straw_pile", 32 ], [ "withered", 32 ] ]
+        ]
       }
     }
   },
@@ -535,7 +559,10 @@
       "inline": {
         "tools": [  ],
         "qualities": [  ],
-        "components": [ [ [ "2x4", 16 ], [ "stick", 16 ] ], [ [ "straw_pile", 32 ], [ "withered", 32 ], [ "pine_bough", 32 ] ] ]
+        "components": [
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
+          [ [ "pine_bough", 32 ], [ "straw_pile", 32 ], [ "withered", 32 ] ]
+        ]
       }
     }
   },
@@ -586,7 +613,10 @@
       "inline": {
         "tools": [  ],
         "qualities": [  ],
-        "components": [ [ [ "2x4", 16 ], [ "stick", 16 ] ], [ [ "straw_pile", 32 ], [ "withered", 32 ], [ "pine_bough", 32 ] ] ]
+        "components": [
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
+          [ [ "pine_bough", 32 ], [ "straw_pile", 32 ], [ "withered", 32 ] ]
+        ]
       }
     }
   },
@@ -637,7 +667,10 @@
       "inline": {
         "tools": [  ],
         "qualities": [  ],
-        "components": [ [ [ "2x4", 16 ], [ "stick", 16 ] ], [ [ "straw_pile", 32 ], [ "withered", 32 ], [ "pine_bough", 32 ] ] ]
+        "components": [
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
+          [ [ "pine_bough", 32 ], [ "straw_pile", 32 ], [ "withered", 32 ] ]
+        ]
       }
     }
   },
@@ -854,7 +887,11 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 6 ], [ "stick", 6 ] ], [ [ "brick", 40 ], [ "rock", 40 ] ], [ [ "straw_pile", 12 ], [ "withered", 12 ] ] ]
+        "components": [
+          [ [ "2x4", 6 ], [ "stick", 6 ], [ "stick_long", 3 ] ],
+          [ [ "brick", 40 ], [ "rock", 40 ] ],
+          [ [ "straw_pile", 12 ], [ "withered", 12 ] ]
+        ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_field_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_field_rammed_earth.json
@@ -13,19 +13,19 @@
     "blueprint_provides": [ { "id": "fbmh_northeast" } ],
     "blueprint_excludes": [ { "id": "fbmh_northeast" } ],
     "blueprint_needs": {
-      "time": "1 d 9 h",
+      "time": "1 d 1 h",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
           [ [ "log", 8 ] ],
-          [ [ "material_soil", 1120 ] ],
+          [ [ "material_soil", 560 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
-          [ [ "water", 400 ], [ "water_clean", 400 ] ]
+          [ [ "water", 200 ], [ "water_clean", 200 ] ]
         ]
       }
     }
@@ -44,20 +44,20 @@
     "blueprint_provides": [ { "id": "fbmh_northeast" } ],
     "blueprint_excludes": [ { "id": "fbmh_northeast", "amount": 2 }, { "id": "fbmh_tent_northeast" } ],
     "blueprint_needs": {
-      "time": "1 d 6 h",
+      "time": "1 d",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "log", 12 ] ],
           [ [ "2x4", 20 ], [ "stick", 20 ], [ "stick_long", 10 ] ],
           [ [ "birchbark", 60 ], [ "pine_bough", 60 ] ],
           [ [ "concrete", 3 ], [ "material_quicklime", 60 ], [ "material_sand", 60 ] ],
-          [ [ "material_soil", 920 ] ],
+          [ [ "material_soil", 500 ] ],
           [ [ "nail", 30 ] ],
           [ [ "pointy_stick", 6 ], [ "spear_wood", 6 ] ],
-          [ [ "water", 300 ], [ "water_clean", 300 ] ]
+          [ [ "water", 150 ], [ "water_clean", 150 ] ]
         ]
       }
     }
@@ -77,19 +77,19 @@
     "blueprint_provides": [ { "id": "fbmh_northeast", "amount": 2 } ],
     "blueprint_excludes": [ { "id": "fbmh_northeast", "amount": 4 }, { "id": "fbmh_tent_northeast" } ],
     "blueprint_needs": {
-      "time": "1 d 21 h 15 m",
+      "time": "1 d 7 h 15 m",
       "skills": [ [ "fabrication", 2 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 18 ] ],
+          [ [ "concrete", 7 ], [ "material_quicklime", 140 ], [ "material_sand", 140 ] ],
+          [ [ "material_soil", 700 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 14 ], [ "spear_wood", 14 ] ],
-          [ [ "material_soil", 1680 ] ],
-          [ [ "water", 700 ], [ "water_clean", 700 ] ],
-          [ [ "material_sand", 140 ], [ "material_quicklime", 140 ], [ "concrete", 7 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 350 ], [ "water_clean", 350 ] ]
         ]
       }
     }
@@ -108,21 +108,21 @@
     "blueprint_provides": [ { "id": "fbmh_east", "amount": 4 } ],
     "blueprint_excludes": [ { "id": "fbmh_east" } ],
     "blueprint_needs": {
-      "time": "5 d 22 h 30 m",
+      "time": "4 d 12 h 30 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 115 ] ],
+          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ],
+          [ [ "concrete", 17 ], [ "material_quicklime", 340 ], [ "material_sand", 340 ] ],
+          [ [ "log", 32 ] ],
+          [ [ "material_soil", 2340 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 34 ], [ "spear_wood", 34 ] ],
-          [ [ "material_soil", 4720 ] ],
-          [ [ "water", 1700 ], [ "water_clean", 1700 ] ],
-          [ [ "material_sand", 340 ], [ "material_quicklime", 340 ], [ "concrete", 17 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
-          [ [ "log", 32 ] ],
-          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 850 ], [ "water_clean", 850 ] ]
         ]
       }
     }
@@ -142,21 +142,21 @@
     "blueprint_provides": [ { "id": "fbmh_east", "amount": 4 } ],
     "blueprint_excludes": [ { "id": "fbmh_east" }, { "id": "fbmh_tent_northeast" } ],
     "blueprint_needs": {
-      "time": "5 d 11 h 45 m",
+      "time": "4 d 7 h 45 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 131 ] ],
+          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ],
+          [ [ "concrete", 14 ], [ "material_quicklime", 280 ], [ "material_sand", 280 ] ],
+          [ [ "log", 40 ] ],
+          [ [ "material_soil", 2200 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 28 ], [ "spear_wood", 28 ] ],
-          [ [ "material_soil", 4160 ] ],
-          [ [ "water", 1400 ], [ "water_clean", 1400 ] ],
-          [ [ "material_sand", 280 ], [ "material_quicklime", 280 ], [ "concrete", 14 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
-          [ [ "log", 40 ] ],
-          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 700 ], [ "water_clean", 700 ] ]
         ]
       }
     }
@@ -175,21 +175,21 @@
     "blueprint_provides": [ { "id": "fbmh_southeast", "amount": 4 } ],
     "blueprint_excludes": [ { "id": "fbmh_southeast" } ],
     "blueprint_needs": {
-      "time": "5 d 22 h 30 m",
+      "time": "4 d 12 h 30 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 115 ] ],
+          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ],
+          [ [ "concrete", 17 ], [ "material_quicklime", 340 ], [ "material_sand", 340 ] ],
+          [ [ "log", 32 ] ],
+          [ [ "material_soil", 2340 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 34 ], [ "spear_wood", 34 ] ],
-          [ [ "material_soil", 4720 ] ],
-          [ [ "water", 1700 ], [ "water_clean", 1700 ] ],
-          [ [ "material_sand", 340 ], [ "material_quicklime", 340 ], [ "concrete", 17 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
-          [ [ "log", 32 ] ],
-          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 850 ], [ "water_clean", 850 ] ]
         ]
       }
     }
@@ -209,21 +209,21 @@
     "blueprint_provides": [ { "id": "fbmh_southeast", "amount": 4 } ],
     "blueprint_excludes": [ { "id": "fbmh_southeast" }, { "id": "fbmh_tent_east" } ],
     "blueprint_needs": {
-      "time": "5 d 5 h 30 m",
+      "time": "4 d 3 h 30 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 131 ] ],
+          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ],
+          [ [ "concrete", 13 ], [ "material_quicklime", 260 ], [ "material_sand", 260 ] ],
+          [ [ "log", 40 ] ],
+          [ [ "material_soil", 2100 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 26 ], [ "spear_wood", 26 ] ],
-          [ [ "material_soil", 3920 ] ],
-          [ [ "water", 1300 ], [ "water_clean", 1300 ] ],
-          [ [ "material_sand", 260 ], [ "material_quicklime", 260 ], [ "concrete", 13 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
-          [ [ "log", 40 ] ],
-          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 650 ], [ "water_clean", 650 ] ]
         ]
       }
     }
@@ -242,21 +242,21 @@
     "blueprint_provides": [ { "id": "fbmh_northwest", "amount": 4 } ],
     "blueprint_excludes": [ { "id": "fbmh_northwest" } ],
     "blueprint_needs": {
-      "time": "4 d 12 h 15 m",
+      "time": "3 d 8 h 15 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 69 ] ],
+          [ [ "birchbark", 108 ], [ "pine_bough", 108 ] ],
+          [ [ "concrete", 14 ], [ "material_quicklime", 280 ], [ "material_sand", 280 ] ],
+          [ [ "log", 18 ] ],
+          [ [ "material_soil", 1760 ] ],
           [ [ "nail", 54 ] ],
           [ [ "pointy_stick", 28 ], [ "spear_wood", 28 ] ],
-          [ [ "material_soil", 3720 ] ],
-          [ [ "water", 1400 ], [ "water_clean", 1400 ] ],
-          [ [ "material_sand", 280 ], [ "material_quicklime", 280 ], [ "concrete", 14 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
-          [ [ "log", 18 ] ],
-          [ [ "birchbark", 108 ], [ "pine_bough", 108 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 700 ], [ "water_clean", 700 ] ]
         ]
       }
     }
@@ -275,21 +275,21 @@
     "blueprint_provides": [ { "id": "fbmh_west", "amount": 4 } ],
     "blueprint_excludes": [ { "id": "fbmh_west" } ],
     "blueprint_needs": {
-      "time": "5 d 22 h 30 m",
+      "time": "4 d 12 h 30 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 115 ] ],
+          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ],
+          [ [ "concrete", 17 ], [ "material_quicklime", 340 ], [ "material_sand", 340 ] ],
+          [ [ "log", 32 ] ],
+          [ [ "material_soil", 2340 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 34 ], [ "spear_wood", 34 ] ],
-          [ [ "material_soil", 4720 ] ],
-          [ [ "water", 1700 ], [ "water_clean", 1700 ] ],
-          [ [ "material_sand", 340 ], [ "material_quicklime", 340 ], [ "concrete", 17 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
-          [ [ "log", 32 ] ],
-          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 850 ], [ "water_clean", 850 ] ]
         ]
       }
     }
@@ -308,21 +308,21 @@
     "blueprint_provides": [ { "id": "fbmh_west", "amount": 4 } ],
     "blueprint_excludes": [ { "id": "fbmh_west" }, { "id": "fbmh_tent_northwest" } ],
     "blueprint_needs": {
-      "time": "5 d 11 h 45 m",
+      "time": "4 d 7 h 45 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 131 ] ],
+          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ],
+          [ [ "concrete", 14 ], [ "material_quicklime", 280 ], [ "material_sand", 280 ] ],
+          [ [ "log", 40 ] ],
+          [ [ "material_soil", 2200 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 28 ], [ "spear_wood", 28 ] ],
-          [ [ "material_soil", 4160 ] ],
-          [ [ "water", 1400 ], [ "water_clean", 1400 ] ],
-          [ [ "material_sand", 280 ], [ "material_quicklime", 280 ], [ "concrete", 14 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
-          [ [ "log", 40 ] ],
-          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 700 ], [ "water_clean", 700 ] ]
         ]
       }
     }
@@ -341,21 +341,21 @@
     "blueprint_provides": [ { "id": "fbmh_southwest", "amount": 4 } ],
     "blueprint_excludes": [ { "id": "fbmh_southwest" } ],
     "blueprint_needs": {
-      "time": "5 d 22 h 30 m",
+      "time": "4 d 12 h 30 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 115 ] ],
+          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ],
+          [ [ "concrete", 17 ], [ "material_quicklime", 340 ], [ "material_sand", 340 ] ],
+          [ [ "log", 32 ] ],
+          [ [ "material_soil", 2340 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 34 ], [ "spear_wood", 34 ] ],
-          [ [ "material_soil", 4720 ] ],
-          [ [ "water", 1700 ], [ "water_clean", 1700 ] ],
-          [ [ "material_sand", 340 ], [ "material_quicklime", 340 ], [ "concrete", 17 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
-          [ [ "log", 32 ] ],
-          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 850 ], [ "water_clean", 850 ] ]
         ]
       }
     }
@@ -374,21 +374,21 @@
     "blueprint_provides": [ { "id": "fbmh_southwest", "amount": 4 } ],
     "blueprint_excludes": [ { "id": "fbmh_southwest" }, { "id": "fbmh_tent_west" } ],
     "blueprint_needs": {
-      "time": "5 d 5 h 30 m",
+      "time": "4 d 3 h 30 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 131 ] ],
+          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ],
+          [ [ "concrete", 13 ], [ "material_quicklime", 260 ], [ "material_sand", 260 ] ],
+          [ [ "log", 40 ] ],
+          [ [ "material_soil", 2100 ] ],
           [ [ "nail", 78 ] ],
           [ [ "pointy_stick", 26 ], [ "spear_wood", 26 ] ],
-          [ [ "material_soil", 3920 ] ],
-          [ [ "water", 1300 ], [ "water_clean", 1300 ] ],
-          [ [ "material_sand", 260 ], [ "material_quicklime", 260 ], [ "concrete", 13 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
-          [ [ "log", 40 ] ],
-          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 650 ], [ "water_clean", 650 ] ]
         ]
       }
     }
@@ -407,21 +407,21 @@
     "blueprint_provides": [ { "id": "fbmh_center", "amount": 2 }, { "id": "fbmh_ne_center" } ],
     "blueprint_excludes": [ { "id": "fbmh_ne_center" } ],
     "blueprint_needs": {
-      "time": "2 d 17 h 15 m",
+      "time": "2 d 3 h 15 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 58 ] ],
+          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ],
+          [ [ "concrete", 7 ], [ "material_quicklime", 140 ], [ "material_sand", 140 ] ],
+          [ [ "log", 20 ] ],
+          [ [ "material_soil", 1100 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 14 ], [ "spear_wood", 14 ] ],
-          [ [ "material_soil", 2080 ] ],
-          [ [ "water", 700 ], [ "water_clean", 700 ] ],
-          [ [ "material_sand", 140 ], [ "material_quicklime", 140 ], [ "concrete", 7 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
-          [ [ "log", 20 ] ],
-          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 350 ], [ "water_clean", 350 ] ]
         ]
       }
     }
@@ -440,19 +440,19 @@
     "blueprint_provides": [ { "id": "fbmh_center", "amount": 2 }, { "id": "fbmh_ne_center" } ],
     "blueprint_excludes": [ { "id": "fbmh_ne_center" }, { "id": "fbmh_tent_east" } ],
     "blueprint_needs": {
-      "time": "2 d 45 m",
+      "time": "1 d 18 h 45 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 60 ], [ "stick", 60 ], [ "stick_long", 30 ] ],
           [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ],
           [ [ "concrete", 3 ], [ "material_quicklime", 60 ], [ "material_sand", 60 ] ],
           [ [ "log", 30 ] ],
-          [ [ "material_soil", 1320 ] ],
+          [ [ "material_soil", 900 ] ],
           [ [ "pointy_stick", 6 ], [ "spear_wood", 6 ] ],
-          [ [ "water", 300 ], [ "water_clean", 300 ] ]
+          [ [ "water", 150 ], [ "water_clean", 150 ] ]
         ]
       }
     }
@@ -471,21 +471,21 @@
     "blueprint_provides": [ { "id": "fbmh_center", "amount": 2 }, { "id": "fbmh_nw_center" } ],
     "blueprint_excludes": [ { "id": "fbmh_nw_center" } ],
     "blueprint_needs": {
-      "time": "2 d 12 h 30 m",
+      "time": "2 d 30 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 76 ] ],
+          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ],
+          [ [ "concrete", 6 ], [ "material_quicklime", 120 ], [ "material_sand", 120 ] ],
+          [ [ "log", 20 ] ],
+          [ [ "material_soil", 1000 ] ],
           [ [ "nail", 48 ] ],
           [ [ "pointy_stick", 12 ], [ "spear_wood", 12 ] ],
-          [ [ "material_soil", 1840 ] ],
-          [ [ "water", 600 ], [ "water_clean", 600 ] ],
-          [ [ "material_sand", 120 ], [ "material_quicklime", 120 ], [ "concrete", 6 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
-          [ [ "log", 20 ] ],
-          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 300 ], [ "water_clean", 300 ] ]
         ]
       }
     }
@@ -504,21 +504,21 @@
     "blueprint_provides": [ { "id": "fbmh_center", "amount": 2 }, { "id": "fbmh_nw_center" } ],
     "blueprint_excludes": [ { "id": "fbmh_nw_center" }, { "id": "fbmh_tent_west" } ],
     "blueprint_needs": {
-      "time": "1 d 20 h",
+      "time": "1 d 16 h",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 78 ] ],
+          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ],
+          [ [ "concrete", 2 ], [ "material_quicklime", 40 ], [ "material_sand", 40 ] ],
+          [ [ "log", 30 ] ],
+          [ [ "material_soil", 800 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 4 ], [ "spear_wood", 4 ] ],
-          [ [ "material_soil", 1080 ] ],
-          [ [ "water", 200 ], [ "water_clean", 200 ] ],
-          [ [ "material_sand", 40 ], [ "material_quicklime", 40 ], [ "concrete", 2 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
-          [ [ "log", 30 ] ],
-          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 100 ], [ "water_clean", 100 ] ]
         ]
       }
     }
@@ -537,21 +537,21 @@
     "blueprint_provides": [ { "id": "fbmh_center", "amount": 4 }, { "id": "fbmh_ne_center" }, { "id": "fbmh_nw_center" } ],
     "blueprint_excludes": [ { "id": "fbmh_ne_center" }, { "id": "fbmh_nw_center" }, { "id": "fbmh_tent_east" }, { "id": "fbmh_tent_west" } ],
     "blueprint_needs": {
-      "time": "3 d 20 h 45 m",
+      "time": "3 d 10 h 45 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 138 ] ],
+          [ [ "birchbark", 360 ], [ "pine_bough", 360 ] ],
+          [ [ "concrete", 5 ], [ "material_quicklime", 100 ], [ "material_sand", 100 ] ],
+          [ [ "log", 60 ] ],
+          [ [ "material_soil", 1700 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 10 ], [ "spear_wood", 10 ] ],
-          [ [ "material_soil", 2400 ] ],
-          [ [ "water", 500 ], [ "water_clean", 500 ] ],
-          [ [ "material_sand", 100 ], [ "material_quicklime", 100 ], [ "concrete", 5 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
-          [ [ "log", 60 ] ],
-          [ [ "birchbark", 360 ], [ "pine_bough", 360 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 250 ], [ "water_clean", 250 ] ]
         ]
       }
     }
@@ -570,21 +570,21 @@
     "blueprint_provides": [ { "id": "fbmh_south", "amount": 2 }, { "id": "fbmh_se_south" } ],
     "blueprint_excludes": [ { "id": "fbmh_se_south" } ],
     "blueprint_needs": {
-      "time": "2 d 12 h 30 m",
+      "time": "2 d 30 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 76 ] ],
+          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ],
+          [ [ "concrete", 6 ], [ "material_quicklime", 120 ], [ "material_sand", 120 ] ],
+          [ [ "log", 20 ] ],
+          [ [ "material_soil", 1000 ] ],
           [ [ "nail", 48 ] ],
           [ [ "pointy_stick", 12 ], [ "spear_wood", 12 ] ],
-          [ [ "material_soil", 1840 ] ],
-          [ [ "water", 600 ], [ "water_clean", 600 ] ],
-          [ [ "material_sand", 120 ], [ "material_quicklime", 120 ], [ "concrete", 6 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
-          [ [ "log", 20 ] ],
-          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 300 ], [ "water_clean", 300 ] ]
         ]
       }
     }
@@ -604,21 +604,21 @@
     "blueprint_provides": [ { "id": "fbmh_south", "amount": 2 }, { "id": "fbmh_se_south" } ],
     "blueprint_excludes": [ { "id": "fbmh_se_south" }, { "id": "fbmh_tent_southeast" } ],
     "blueprint_needs": {
-      "time": "1 d 20 h",
+      "time": "1 d 16 h",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 78 ] ],
+          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ],
+          [ [ "concrete", 2 ], [ "material_quicklime", 40 ], [ "material_sand", 40 ] ],
+          [ [ "log", 30 ] ],
+          [ [ "material_soil", 800 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 4 ], [ "spear_wood", 4 ] ],
-          [ [ "material_soil", 1080 ] ],
-          [ [ "water", 200 ], [ "water_clean", 200 ] ],
-          [ [ "material_sand", 40 ], [ "material_quicklime", 40 ], [ "concrete", 2 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
-          [ [ "log", 30 ] ],
-          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 100 ], [ "water_clean", 100 ] ]
         ]
       }
     }
@@ -637,21 +637,21 @@
     "blueprint_provides": [ { "id": "fbmh_south", "amount": 2 }, { "id": "fbmh_sw_south" } ],
     "blueprint_excludes": [ { "id": "fbmh_sw_south" } ],
     "blueprint_needs": {
-      "time": "2 d 17 h 15 m",
+      "time": "2 d 3 h 15 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 58 ] ],
+          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ],
+          [ [ "concrete", 7 ], [ "material_quicklime", 140 ], [ "material_sand", 140 ] ],
+          [ [ "log", 20 ] ],
+          [ [ "material_soil", 1100 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 14 ], [ "spear_wood", 14 ] ],
-          [ [ "material_soil", 2080 ] ],
-          [ [ "water", 700 ], [ "water_clean", 700 ] ],
-          [ [ "material_sand", 140 ], [ "material_quicklime", 140 ], [ "concrete", 7 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
-          [ [ "log", 20 ] ],
-          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 350 ], [ "water_clean", 350 ] ]
         ]
       }
     }
@@ -670,19 +670,19 @@
     "blueprint_provides": [ { "id": "fbmh_south", "amount": 2 }, { "id": "fbmh_sw_south" } ],
     "blueprint_excludes": [ { "id": "fbmh_sw_south" }, { "id": "fbmh_tent_southwest" } ],
     "blueprint_needs": {
-      "time": "2 d 45 m",
+      "time": "1 d 18 h 45 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 60 ], [ "stick", 60 ], [ "stick_long", 30 ] ],
           [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ],
           [ [ "concrete", 3 ], [ "material_quicklime", 60 ], [ "material_sand", 60 ] ],
           [ [ "log", 30 ] ],
-          [ [ "material_soil", 1320 ] ],
+          [ [ "material_soil", 900 ] ],
           [ [ "pointy_stick", 6 ], [ "spear_wood", 6 ] ],
-          [ [ "water", 300 ], [ "water_clean", 300 ] ]
+          [ [ "water", 150 ], [ "water_clean", 150 ] ]
         ]
       }
     }
@@ -706,21 +706,21 @@
       { "id": "fbmh_tent_southwest" }
     ],
     "blueprint_needs": {
-      "time": "3 d 20 h 45 m",
+      "time": "3 d 10 h 45 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 138 ] ],
+          [ [ "birchbark", 360 ], [ "pine_bough", 360 ] ],
+          [ [ "concrete", 5 ], [ "material_quicklime", 100 ], [ "material_sand", 100 ] ],
+          [ [ "log", 60 ] ],
+          [ [ "material_soil", 1700 ] ],
           [ [ "nail", 24 ] ],
           [ [ "pointy_stick", 10 ], [ "spear_wood", 10 ] ],
-          [ [ "material_soil", 2400 ] ],
-          [ [ "water", 500 ], [ "water_clean", 500 ] ],
-          [ [ "material_sand", 100 ], [ "material_quicklime", 100 ], [ "concrete", 5 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
-          [ [ "log", 60 ] ],
-          [ [ "birchbark", 360 ], [ "pine_bough", 360 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 250 ], [ "water_clean", 250 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_field_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_field_rammed_earth.json
@@ -19,13 +19,13 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
-          [ [ "material_soil", 1120 ] ],
-          [ [ "water", 400 ], [ "water_clean", 400 ] ],
-          [ [ "material_sand", 80 ], [ "material_quicklime", 80 ], [ "concrete", 4 ] ],
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
+          [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
+          [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
           [ [ "log", 8 ] ],
-          [ [ "stick", 16 ], [ "2x4", 16 ] ],
-          [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ]
+          [ [ "material_soil", 1120 ] ],
+          [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
+          [ [ "water", 400 ], [ "water_clean", 400 ] ]
         ]
       }
     }
@@ -51,7 +51,7 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "log", 12 ] ],
-          [ [ "2x4", 20 ], [ "stick", 20 ] ],
+          [ [ "2x4", 20 ], [ "stick", 20 ], [ "stick_long", 10 ] ],
           [ [ "birchbark", 60 ], [ "pine_bough", 60 ] ],
           [ [ "concrete", 3 ], [ "material_quicklime", 60 ], [ "material_sand", 60 ] ],
           [ [ "material_soil", 920 ] ],
@@ -446,13 +446,13 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "pointy_stick", 6 ], [ "spear_wood", 6 ] ],
-          [ [ "material_soil", 1320 ] ],
-          [ [ "water", 300 ], [ "water_clean", 300 ] ],
-          [ [ "material_sand", 60 ], [ "material_quicklime", 60 ], [ "concrete", 3 ] ],
+          [ [ "2x4", 60 ], [ "stick", 60 ], [ "stick_long", 30 ] ],
+          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ],
+          [ [ "concrete", 3 ], [ "material_quicklime", 60 ], [ "material_sand", 60 ] ],
           [ [ "log", 30 ] ],
-          [ [ "stick", 60 ], [ "2x4", 60 ] ],
-          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ]
+          [ [ "material_soil", 1320 ] ],
+          [ [ "pointy_stick", 6 ], [ "spear_wood", 6 ] ],
+          [ [ "water", 300 ], [ "water_clean", 300 ] ]
         ]
       }
     }
@@ -676,13 +676,13 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "pointy_stick", 6 ], [ "spear_wood", 6 ] ],
-          [ [ "material_soil", 1320 ] ],
-          [ [ "water", 300 ], [ "water_clean", 300 ] ],
-          [ [ "material_sand", 60 ], [ "material_quicklime", 60 ], [ "concrete", 3 ] ],
+          [ [ "2x4", 60 ], [ "stick", 60 ], [ "stick_long", 30 ] ],
+          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ],
+          [ [ "concrete", 3 ], [ "material_quicklime", 60 ], [ "material_sand", 60 ] ],
           [ [ "log", 30 ] ],
-          [ [ "stick", 60 ], [ "2x4", 60 ] ],
-          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ]
+          [ [ "material_soil", 1320 ] ],
+          [ [ "pointy_stick", 6 ], [ "spear_wood", 6 ] ],
+          [ [ "water", 300 ], [ "water_clean", 300 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_field_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_field_wad.json
@@ -14,19 +14,25 @@
     "blueprint_excludes": [ { "id": "fbmh_northeast" } ],
     "blueprint_needs": {
       "time": "14 h 40 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 56 ], [ "stick", 96 ] ],
-          [ [ "material_quicklime", 32 ], [ "material_limestone", 32 ], [ "clay_lump", 32 ] ],
-          [ [ "pebble", 80 ], [ "material_sand", 80 ] ],
-          [ [ "straw_pile", 32 ], [ "cattail_stalk", 32 ], [ "dogbane", 32 ], [ "pine_bough", 32 ] ],
-          [ [ "water", 40 ], [ "water_clean", 40 ] ],
+          [ [ "2x4", 56 ], [ "stick", 56 ] ],
+          [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
+          [
+            [ "cattail_stalk", 32 ],
+            [ "dogbane", 32 ],
+            [ "material_sand", 80 ],
+            [ "pebble", 80 ],
+            [ "pine_bough", 32 ],
+            [ "straw_pile", 32 ],
+            [ "withered", 32 ]
+          ],
+          [ [ "material_soil", 320 ] ],
           [ [ "log", 8 ] ],
-          [ [ "material_soil", 160 ] ],
-          [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ]
+          [ [ "water", 40 ], [ "water_clean", 40 ] ]
         ]
       }
     }
@@ -46,19 +52,25 @@
     "blueprint_excludes": [ { "id": "fbmh_northeast", "amount": 2 }, { "id": "fbmh_tent_northeast" } ],
     "blueprint_needs": {
       "time": "15 h 50 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 55 ], [ "stick", 90 ] ],
-          [ [ "material_quicklime", 28 ], [ "material_limestone", 28 ], [ "clay_lump", 28 ] ],
-          [ [ "pebble", 70 ], [ "material_sand", 70 ] ],
-          [ [ "straw_pile", 28 ], [ "cattail_stalk", 28 ], [ "dogbane", 28 ], [ "pine_bough", 28 ] ],
-          [ [ "water", 35 ], [ "water_clean", 35 ] ],
+          [ [ "2x4", 55 ], [ "stick", 55 ] ],
+          [ [ "birchbark", 60 ], [ "pine_bough", 60 ] ],
+          [
+            [ "cattail_stalk", 28 ],
+            [ "dogbane", 28 ],
+            [ "material_sand", 70 ],
+            [ "pebble", 70 ],
+            [ "pine_bough", 28 ],
+            [ "straw_pile", 28 ],
+            [ "withered", 28 ]
+          ],
+          [ [ "material_soil", 340 ] ],
           [ [ "log", 10 ] ],
-          [ [ "material_soil", 200 ] ],
-          [ [ "birchbark", 60 ], [ "pine_bough", 60 ] ]
+          [ [ "water", 35 ], [ "water_clean", 35 ] ]
         ]
       }
     }
@@ -79,18 +91,30 @@
     "blueprint_excludes": [ { "id": "fbmh_northeast", "amount": 4 }, { "id": "fbmh_tent_northeast" } ],
     "blueprint_needs": {
       "time": "13 h 10 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 88 ] ],
+          [
+            [ "cattail_stalk", 56 ],
+            [ "dogbane", 56 ],
+            [ "material_sand", 140 ],
+            [ "pebble", 140 ],
+            [ "pine_bough", 56 ],
+            [ "straw_pile", 56 ],
+            [ "withered", 56 ]
+          ],
+          [
+            [ "clay_lump", 56 ],
+            [ "material_limestone", 56 ],
+            [ "material_quicklime", 56 ],
+            [ "material_soil", 280 ]
+          ],
           [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 56 ], [ "material_limestone", 56 ], [ "clay_lump", 56 ] ],
-          [ [ "pebble", 140 ], [ "material_sand", 140 ] ],
-          [ [ "straw_pile", 56 ], [ "cattail_stalk", 56 ], [ "dogbane", 56 ], [ "pine_bough", 56 ] ],
-          [ [ "water", 70 ], [ "water_clean", 70 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 70 ], [ "water_clean", 70 ] ]
         ]
       }
     }
@@ -110,21 +134,27 @@
     "blueprint_excludes": [ { "id": "fbmh_east" } ],
     "blueprint_needs": {
       "time": "2 d 16 h 10 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 275 ] ],
-          [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 140 ], [ "material_limestone", 140 ], [ "clay_lump", 140 ] ],
-          [ [ "pebble", 350 ], [ "material_sand", 350 ] ],
-          [ [ "straw_pile", 140 ], [ "cattail_stalk", 140 ], [ "dogbane", 140 ], [ "pine_bough", 140 ] ],
-          [ [ "water", 175 ], [ "water_clean", 175 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ],
+          [
+            [ "cattail_stalk", 140 ],
+            [ "dogbane", 140 ],
+            [ "material_sand", 350 ],
+            [ "pebble", 350 ],
+            [ "pine_bough", 140 ],
+            [ "straw_pile", 140 ],
+            [ "withered", 140 ]
+          ],
+          [ [ "material_soil", 1340 ] ],
           [ [ "log", 32 ] ],
-          [ [ "material_soil", 640 ] ],
-          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ]
+          [ [ "nail", 48 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 175 ], [ "water_clean", 175 ] ]
         ]
       }
     }
@@ -145,21 +175,27 @@
     "blueprint_excludes": [ { "id": "fbmh_east" }, { "id": "fbmh_tent_northeast" } ],
     "blueprint_needs": {
       "time": "2 d 19 h 10 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 261 ] ],
-          [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 116 ], [ "material_limestone", 116 ], [ "clay_lump", 116 ] ],
-          [ [ "pebble", 290 ], [ "material_sand", 290 ] ],
-          [ [ "straw_pile", 116 ], [ "cattail_stalk", 116 ], [ "dogbane", 116 ], [ "pine_bough", 116 ] ],
-          [ [ "water", 145 ], [ "water_clean", 145 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ],
+          [
+            [ "cattail_stalk", 116 ],
+            [ "dogbane", 116 ],
+            [ "material_sand", 290 ],
+            [ "pebble", 290 ],
+            [ "pine_bough", 116 ],
+            [ "straw_pile", 116 ],
+            [ "withered", 116 ]
+          ],
+          [ [ "material_soil", 1380 ] ],
           [ [ "log", 40 ] ],
-          [ [ "material_soil", 800 ] ],
-          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ]
+          [ [ "nail", 48 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 145 ], [ "water_clean", 145 ] ]
         ]
       }
     }
@@ -179,21 +215,27 @@
     "blueprint_excludes": [ { "id": "fbmh_southeast" } ],
     "blueprint_needs": {
       "time": "2 d 16 h 10 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 275 ] ],
-          [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 140 ], [ "material_limestone", 140 ], [ "clay_lump", 140 ] ],
-          [ [ "pebble", 350 ], [ "material_sand", 350 ] ],
-          [ [ "straw_pile", 140 ], [ "cattail_stalk", 140 ], [ "dogbane", 140 ], [ "pine_bough", 140 ] ],
-          [ [ "water", 175 ], [ "water_clean", 175 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ],
+          [
+            [ "cattail_stalk", 140 ],
+            [ "dogbane", 140 ],
+            [ "material_sand", 350 ],
+            [ "pebble", 350 ],
+            [ "pine_bough", 140 ],
+            [ "straw_pile", 140 ],
+            [ "withered", 140 ]
+          ],
+          [ [ "material_soil", 1340 ] ],
           [ [ "log", 32 ] ],
-          [ [ "material_soil", 640 ] ],
-          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ]
+          [ [ "nail", 48 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 175 ], [ "water_clean", 175 ] ]
         ]
       }
     }
@@ -214,21 +256,27 @@
     "blueprint_excludes": [ { "id": "fbmh_southeast" }, { "id": "fbmh_tent_east" } ],
     "blueprint_needs": {
       "time": "2 d 17 h 30 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 251 ] ],
-          [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 108 ], [ "material_limestone", 108 ], [ "clay_lump", 108 ] ],
-          [ [ "pebble", 270 ], [ "material_sand", 270 ] ],
-          [ [ "straw_pile", 108 ], [ "cattail_stalk", 108 ], [ "dogbane", 108 ], [ "pine_bough", 108 ] ],
-          [ [ "water", 135 ], [ "water_clean", 135 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ],
+          [
+            [ "cattail_stalk", 108 ],
+            [ "dogbane", 108 ],
+            [ "material_sand", 270 ],
+            [ "pebble", 270 ],
+            [ "pine_bough", 108 ],
+            [ "straw_pile", 108 ],
+            [ "withered", 108 ]
+          ],
+          [ [ "material_soil", 1340 ] ],
           [ [ "log", 40 ] ],
-          [ [ "material_soil", 800 ] ],
-          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ]
+          [ [ "nail", 48 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 135 ], [ "water_clean", 135 ] ]
         ]
       }
     }
@@ -248,21 +296,27 @@
     "blueprint_excludes": [ { "id": "fbmh_northwest" } ],
     "blueprint_needs": {
       "time": "1 d 19 h 40 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 199 ] ],
-          [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 116 ], [ "material_limestone", 116 ], [ "clay_lump", 116 ] ],
-          [ [ "pebble", 290 ], [ "material_sand", 290 ] ],
-          [ [ "straw_pile", 116 ], [ "cattail_stalk", 116 ], [ "dogbane", 116 ], [ "pine_bough", 116 ] ],
-          [ [ "water", 145 ], [ "water_clean", 145 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
+          [ [ "birchbark", 108 ], [ "pine_bough", 108 ] ],
+          [
+            [ "cattail_stalk", 116 ],
+            [ "dogbane", 116 ],
+            [ "material_sand", 290 ],
+            [ "pebble", 290 ],
+            [ "pine_bough", 116 ],
+            [ "straw_pile", 116 ],
+            [ "withered", 116 ]
+          ],
+          [ [ "material_soil", 940 ] ],
           [ [ "log", 18 ] ],
-          [ [ "material_soil", 360 ] ],
-          [ [ "birchbark", 108 ], [ "pine_bough", 108 ] ]
+          [ [ "nail", 24 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 145 ], [ "water_clean", 145 ] ]
         ]
       }
     }
@@ -282,21 +336,27 @@
     "blueprint_excludes": [ { "id": "fbmh_west" } ],
     "blueprint_needs": {
       "time": "2 d 16 h 10 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 275 ] ],
-          [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 140 ], [ "material_limestone", 140 ], [ "clay_lump", 140 ] ],
-          [ [ "pebble", 350 ], [ "material_sand", 350 ] ],
-          [ [ "straw_pile", 140 ], [ "cattail_stalk", 140 ], [ "dogbane", 140 ], [ "pine_bough", 140 ] ],
-          [ [ "water", 175 ], [ "water_clean", 175 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ],
+          [
+            [ "cattail_stalk", 140 ],
+            [ "dogbane", 140 ],
+            [ "material_sand", 350 ],
+            [ "pebble", 350 ],
+            [ "pine_bough", 140 ],
+            [ "straw_pile", 140 ],
+            [ "withered", 140 ]
+          ],
+          [ [ "material_soil", 1340 ] ],
           [ [ "log", 32 ] ],
-          [ [ "material_soil", 640 ] ],
-          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ]
+          [ [ "nail", 48 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 175 ], [ "water_clean", 175 ] ]
         ]
       }
     }
@@ -316,21 +376,27 @@
     "blueprint_excludes": [ { "id": "fbmh_west" }, { "id": "fbmh_tent_northwest" } ],
     "blueprint_needs": {
       "time": "2 d 19 h 10 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 261 ] ],
-          [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 116 ], [ "material_limestone", 116 ], [ "clay_lump", 116 ] ],
-          [ [ "pebble", 290 ], [ "material_sand", 290 ] ],
-          [ [ "straw_pile", 116 ], [ "cattail_stalk", 116 ], [ "dogbane", 116 ], [ "pine_bough", 116 ] ],
-          [ [ "water", 145 ], [ "water_clean", 145 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ],
+          [
+            [ "cattail_stalk", 116 ],
+            [ "dogbane", 116 ],
+            [ "material_sand", 290 ],
+            [ "pebble", 290 ],
+            [ "pine_bough", 116 ],
+            [ "straw_pile", 116 ],
+            [ "withered", 116 ]
+          ],
+          [ [ "material_soil", 1380 ] ],
           [ [ "log", 40 ] ],
-          [ [ "material_soil", 800 ] ],
-          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ]
+          [ [ "nail", 48 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 145 ], [ "water_clean", 145 ] ]
         ]
       }
     }
@@ -350,21 +416,27 @@
     "blueprint_excludes": [ { "id": "fbmh_southwest" } ],
     "blueprint_needs": {
       "time": "2 d 16 h 10 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 275 ] ],
-          [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 140 ], [ "material_limestone", 140 ], [ "clay_lump", 140 ] ],
-          [ [ "pebble", 350 ], [ "material_sand", 350 ] ],
-          [ [ "straw_pile", 140 ], [ "cattail_stalk", 140 ], [ "dogbane", 140 ], [ "pine_bough", 140 ] ],
-          [ [ "water", 175 ], [ "water_clean", 175 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ],
+          [
+            [ "cattail_stalk", 140 ],
+            [ "dogbane", 140 ],
+            [ "material_sand", 350 ],
+            [ "pebble", 350 ],
+            [ "pine_bough", 140 ],
+            [ "straw_pile", 140 ],
+            [ "withered", 140 ]
+          ],
+          [ [ "material_soil", 1340 ] ],
           [ [ "log", 32 ] ],
-          [ [ "material_soil", 640 ] ],
-          [ [ "birchbark", 192 ], [ "pine_bough", 192 ] ]
+          [ [ "nail", 48 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 175 ], [ "water_clean", 175 ] ]
         ]
       }
     }
@@ -384,21 +456,27 @@
     "blueprint_excludes": [ { "id": "fbmh_southwest" }, { "id": "fbmh_tent_west" } ],
     "blueprint_needs": {
       "time": "2 d 17 h 30 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 251 ] ],
-          [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 108 ], [ "material_limestone", 108 ], [ "clay_lump", 108 ] ],
-          [ [ "pebble", 270 ], [ "material_sand", 270 ] ],
-          [ [ "straw_pile", 108 ], [ "cattail_stalk", 108 ], [ "dogbane", 108 ], [ "pine_bough", 108 ] ],
-          [ [ "water", 135 ], [ "water_clean", 135 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ],
+          [
+            [ "cattail_stalk", 108 ],
+            [ "dogbane", 108 ],
+            [ "material_sand", 270 ],
+            [ "pebble", 270 ],
+            [ "pine_bough", 108 ],
+            [ "straw_pile", 108 ],
+            [ "withered", 108 ]
+          ],
+          [ [ "material_soil", 1340 ] ],
           [ [ "log", 40 ] ],
-          [ [ "material_soil", 800 ] ],
-          [ [ "birchbark", 240 ], [ "pine_bough", 240 ] ]
+          [ [ "nail", 48 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 135 ], [ "water_clean", 135 ] ]
         ]
       }
     }
@@ -418,21 +496,27 @@
     "blueprint_excludes": [ { "id": "fbmh_ne_center" } ],
     "blueprint_needs": {
       "time": "1 d 9 h 10 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 128 ] ],
-          [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 56 ], [ "material_limestone", 56 ], [ "clay_lump", 56 ] ],
-          [ [ "pebble", 140 ], [ "material_sand", 140 ] ],
-          [ [ "straw_pile", 56 ], [ "cattail_stalk", 56 ], [ "dogbane", 56 ], [ "pine_bough", 56 ] ],
-          [ [ "water", 70 ], [ "water_clean", 70 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
+          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ],
+          [
+            [ "cattail_stalk", 56 ],
+            [ "dogbane", 56 ],
+            [ "material_sand", 140 ],
+            [ "pebble", 140 ],
+            [ "pine_bough", 56 ],
+            [ "straw_pile", 56 ],
+            [ "withered", 56 ]
+          ],
+          [ [ "material_soil", 680 ] ],
           [ [ "log", 20 ] ],
-          [ [ "material_soil", 400 ] ],
-          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ]
+          [ [ "nail", 24 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 70 ], [ "water_clean", 70 ] ]
         ]
       }
     }
@@ -452,19 +536,25 @@
     "blueprint_excludes": [ { "id": "fbmh_ne_center" }, { "id": "fbmh_tent_east" } ],
     "blueprint_needs": {
       "time": "1 d 11 h",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 90 ], [ "stick", 120 ] ],
-          [ [ "material_quicklime", 24 ], [ "material_limestone", 24 ], [ "clay_lump", 24 ] ],
-          [ [ "pebble", 60 ], [ "material_sand", 60 ] ],
-          [ [ "straw_pile", 24 ], [ "cattail_stalk", 24 ], [ "dogbane", 24 ], [ "pine_bough", 24 ] ],
-          [ [ "water", 30 ], [ "water_clean", 30 ] ],
+          [ [ "2x4", 90 ], [ "stick", 90 ] ],
+          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ],
+          [
+            [ "cattail_stalk", 24 ],
+            [ "dogbane", 24 ],
+            [ "material_sand", 60 ],
+            [ "pebble", 60 ],
+            [ "pine_bough", 24 ],
+            [ "straw_pile", 24 ],
+            [ "withered", 24 ]
+          ],
+          [ [ "material_soil", 720 ] ],
           [ [ "log", 30 ] ],
-          [ [ "material_soil", 600 ] ],
-          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ]
+          [ [ "water", 30 ], [ "water_clean", 30 ] ]
         ]
       }
     }
@@ -484,21 +574,27 @@
     "blueprint_excludes": [ { "id": "fbmh_nw_center" } ],
     "blueprint_needs": {
       "time": "1 d 9 h",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 136 ] ],
-          [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 48 ], [ "material_limestone", 48 ], [ "clay_lump", 48 ] ],
-          [ [ "pebble", 120 ], [ "material_sand", 120 ] ],
-          [ [ "straw_pile", 48 ], [ "cattail_stalk", 48 ], [ "dogbane", 48 ], [ "pine_bough", 48 ] ],
-          [ [ "water", 60 ], [ "water_clean", 60 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ],
+          [
+            [ "cattail_stalk", 48 ],
+            [ "dogbane", 48 ],
+            [ "material_sand", 120 ],
+            [ "pebble", 120 ],
+            [ "pine_bough", 48 ],
+            [ "straw_pile", 48 ],
+            [ "withered", 48 ]
+          ],
+          [ [ "material_soil", 640 ] ],
           [ [ "log", 20 ] ],
-          [ [ "material_soil", 400 ] ],
-          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ]
+          [ [ "nail", 48 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 60 ], [ "water_clean", 60 ] ]
         ]
       }
     }
@@ -518,21 +614,27 @@
     "blueprint_excludes": [ { "id": "fbmh_nw_center" }, { "id": "fbmh_tent_west" } ],
     "blueprint_needs": {
       "time": "1 d 10 h 50 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 98 ] ],
-          [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 16 ], [ "material_limestone", 16 ], [ "clay_lump", 16 ] ],
-          [ [ "pebble", 40 ], [ "material_sand", 40 ] ],
-          [ [ "straw_pile", 16 ], [ "cattail_stalk", 16 ], [ "dogbane", 16 ], [ "pine_bough", 16 ] ],
-          [ [ "water", 20 ], [ "water_clean", 20 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
+          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ],
+          [
+            [ "cattail_stalk", 16 ],
+            [ "dogbane", 16 ],
+            [ "material_sand", 40 ],
+            [ "pebble", 40 ],
+            [ "pine_bough", 16 ],
+            [ "straw_pile", 16 ],
+            [ "withered", 16 ]
+          ],
+          [ [ "material_soil", 680 ] ],
           [ [ "log", 30 ] ],
-          [ [ "material_soil", 600 ] ],
-          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ]
+          [ [ "nail", 24 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 20 ], [ "water_clean", 20 ] ]
         ]
       }
     }
@@ -552,21 +654,27 @@
     "blueprint_excludes": [ { "id": "fbmh_ne_center" }, { "id": "fbmh_nw_center" }, { "id": "fbmh_tent_east" }, { "id": "fbmh_tent_west" } ],
     "blueprint_needs": {
       "time": "2 d 21 h 50 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 188 ] ],
-          [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 40 ], [ "material_limestone", 40 ], [ "clay_lump", 40 ] ],
-          [ [ "pebble", 100 ], [ "material_sand", 100 ] ],
-          [ [ "straw_pile", 40 ], [ "cattail_stalk", 40 ], [ "dogbane", 40 ], [ "pine_bough", 40 ] ],
-          [ [ "water", 50 ], [ "water_clean", 50 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
+          [ [ "birchbark", 360 ], [ "pine_bough", 360 ] ],
+          [
+            [ "cattail_stalk", 40 ],
+            [ "dogbane", 40 ],
+            [ "material_sand", 100 ],
+            [ "pebble", 100 ],
+            [ "pine_bough", 40 ],
+            [ "straw_pile", 40 ],
+            [ "withered", 40 ]
+          ],
+          [ [ "material_soil", 1400 ] ],
           [ [ "log", 60 ] ],
-          [ [ "material_soil", 1200 ] ],
-          [ [ "birchbark", 360 ], [ "pine_bough", 360 ] ]
+          [ [ "nail", 24 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 50 ], [ "water_clean", 50 ] ]
         ]
       }
     }
@@ -586,21 +694,27 @@
     "blueprint_excludes": [ { "id": "fbmh_se_south" } ],
     "blueprint_needs": {
       "time": "1 d 9 h",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 136 ] ],
-          [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 48 ], [ "material_limestone", 48 ], [ "clay_lump", 48 ] ],
-          [ [ "pebble", 120 ], [ "material_sand", 120 ] ],
-          [ [ "straw_pile", 48 ], [ "cattail_stalk", 48 ], [ "dogbane", 48 ], [ "pine_bough", 48 ] ],
-          [ [ "water", 60 ], [ "water_clean", 60 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ],
+          [
+            [ "cattail_stalk", 48 ],
+            [ "dogbane", 48 ],
+            [ "material_sand", 120 ],
+            [ "pebble", 120 ],
+            [ "pine_bough", 48 ],
+            [ "straw_pile", 48 ],
+            [ "withered", 48 ]
+          ],
+          [ [ "material_soil", 640 ] ],
           [ [ "log", 20 ] ],
-          [ [ "material_soil", 400 ] ],
-          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ]
+          [ [ "nail", 48 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 60 ], [ "water_clean", 60 ] ]
         ]
       }
     }
@@ -621,21 +735,27 @@
     "blueprint_excludes": [ { "id": "fbmh_se_south" }, { "id": "fbmh_tent_southeast" } ],
     "blueprint_needs": {
       "time": "1 d 10 h 50 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 98 ] ],
-          [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 16 ], [ "material_limestone", 16 ], [ "clay_lump", 16 ] ],
-          [ [ "pebble", 40 ], [ "material_sand", 40 ] ],
-          [ [ "straw_pile", 16 ], [ "cattail_stalk", 16 ], [ "dogbane", 16 ], [ "pine_bough", 16 ] ],
-          [ [ "water", 20 ], [ "water_clean", 20 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
+          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ],
+          [
+            [ "cattail_stalk", 16 ],
+            [ "dogbane", 16 ],
+            [ "material_sand", 40 ],
+            [ "pebble", 40 ],
+            [ "pine_bough", 16 ],
+            [ "straw_pile", 16 ],
+            [ "withered", 16 ]
+          ],
+          [ [ "material_soil", 680 ] ],
           [ [ "log", 30 ] ],
-          [ [ "material_soil", 600 ] ],
-          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ]
+          [ [ "nail", 24 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 20 ], [ "water_clean", 20 ] ]
         ]
       }
     }
@@ -655,21 +775,27 @@
     "blueprint_excludes": [ { "id": "fbmh_sw_south" } ],
     "blueprint_needs": {
       "time": "1 d 9 h 10 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 128 ] ],
-          [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 56 ], [ "material_limestone", 56 ], [ "clay_lump", 56 ] ],
-          [ [ "pebble", 140 ], [ "material_sand", 140 ] ],
-          [ [ "straw_pile", 56 ], [ "cattail_stalk", 56 ], [ "dogbane", 56 ], [ "pine_bough", 56 ] ],
-          [ [ "water", 70 ], [ "water_clean", 70 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
+          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ],
+          [
+            [ "cattail_stalk", 56 ],
+            [ "dogbane", 56 ],
+            [ "material_sand", 140 ],
+            [ "pebble", 140 ],
+            [ "pine_bough", 56 ],
+            [ "straw_pile", 56 ],
+            [ "withered", 56 ]
+          ],
+          [ [ "material_soil", 680 ] ],
           [ [ "log", 20 ] ],
-          [ [ "material_soil", 400 ] ],
-          [ [ "birchbark", 120 ], [ "pine_bough", 120 ] ]
+          [ [ "nail", 24 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 70 ], [ "water_clean", 70 ] ]
         ]
       }
     }
@@ -689,19 +815,25 @@
     "blueprint_excludes": [ { "id": "fbmh_sw_south" }, { "id": "fbmh_tent_southwest" } ],
     "blueprint_needs": {
       "time": "1 d 11 h",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 90 ], [ "stick", 120 ] ],
-          [ [ "material_quicklime", 24 ], [ "material_limestone", 24 ], [ "clay_lump", 24 ] ],
-          [ [ "pebble", 60 ], [ "material_sand", 60 ] ],
-          [ [ "straw_pile", 24 ], [ "cattail_stalk", 24 ], [ "dogbane", 24 ], [ "pine_bough", 24 ] ],
-          [ [ "water", 30 ], [ "water_clean", 30 ] ],
+          [ [ "2x4", 90 ], [ "stick", 90 ] ],
+          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ],
+          [
+            [ "cattail_stalk", 24 ],
+            [ "dogbane", 24 ],
+            [ "material_sand", 60 ],
+            [ "pebble", 60 ],
+            [ "pine_bough", 24 ],
+            [ "straw_pile", 24 ],
+            [ "withered", 24 ]
+          ],
+          [ [ "material_soil", 720 ] ],
           [ [ "log", 30 ] ],
-          [ [ "material_soil", 600 ] ],
-          [ [ "birchbark", 180 ], [ "pine_bough", 180 ] ]
+          [ [ "water", 30 ], [ "water_clean", 30 ] ]
         ]
       }
     }
@@ -726,21 +858,27 @@
     ],
     "blueprint_needs": {
       "time": "2 d 21 h 50 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 188 ] ],
-          [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 40 ], [ "material_limestone", 40 ], [ "clay_lump", 40 ] ],
-          [ [ "pebble", 100 ], [ "material_sand", 100 ] ],
-          [ [ "straw_pile", 40 ], [ "cattail_stalk", 40 ], [ "dogbane", 40 ], [ "pine_bough", 40 ] ],
-          [ [ "water", 50 ], [ "water_clean", 50 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
+          [ [ "birchbark", 360 ], [ "pine_bough", 360 ] ],
+          [
+            [ "cattail_stalk", 40 ],
+            [ "dogbane", 40 ],
+            [ "material_sand", 100 ],
+            [ "pebble", 100 ],
+            [ "pine_bough", 40 ],
+            [ "straw_pile", 40 ],
+            [ "withered", 40 ]
+          ],
+          [ [ "material_soil", 1400 ] ],
           [ [ "log", 60 ] ],
-          [ [ "material_soil", 1200 ] ],
-          [ [ "birchbark", 360 ], [ "pine_bough", 360 ] ]
+          [ [ "nail", 24 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 50 ], [ "water_clean", 50 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_firestation1.json
+++ b/data/json/recipes/basecamps/recipe_modular_firestation1.json
@@ -615,8 +615,8 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
+          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_adobe", 1 ], [ "mortar_build", 1 ] ],
           [ [ "rock", 40 ] ],
-          [ [ "material_cement", 50 ], [ "mortar_build", 1 ], [ "clay_lump", 12 ] ],
           [ [ "water", 2 ], [ "water_clean", 2 ] ]
         ]
       }

--- a/data/json/recipes/basecamps/recipe_modular_firestation1.json
+++ b/data/json/recipes/basecamps/recipe_modular_firestation1.json
@@ -269,8 +269,8 @@
       "skills": [ [ "fabrication", 3 ], [ "cooking", 2 ] ],
       "inline": {
         "tools": [  ],
-        "qualities": [ [ { "id": "SAW_W" } ], [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 32 ], [ "stick", 32 ] ], [ [ "material_soil", 2 ] ], [ [ "rock", 56 ] ] ]
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W" } ] ],
+        "components": [ [ [ "2x4", 32 ], [ "stick", 32 ], [ "stick_long", 16 ] ], [ [ "material_soil", 2 ] ], [ [ "rock", 56 ] ] ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_livestock/recipe_modular_livestock_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_livestock/recipe_modular_livestock_log.json
@@ -19,7 +19,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 354 ] ],
+          [ [ "2x4", 246 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "log", 72 ] ],
           [ [ "nail", 360 ] ],
@@ -54,7 +54,7 @@
           [ { "id": "WRENCH" } ]
         ],
         "components": [
-          [ [ "2x4", 274 ] ],
+          [ [ "2x4", 208 ] ],
           [ [ "glass_sheet", 4 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "log", 44 ] ],
@@ -86,7 +86,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 341 ] ],
+          [ [ "2x4", 251 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "log", 60 ] ],
           [ [ "nail", 432 ] ],
@@ -116,7 +116,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 334 ] ],
+          [ [ "2x4", 256 ] ],
           [ [ "hinge", 4 ] ],
           [ [ "log", 52 ] ],
           [ [ "nail", 464 ] ],
@@ -146,7 +146,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 338 ] ],
+          [ [ "2x4", 254 ] ],
           [ [ "hinge", 4 ] ],
           [ [ "log", 56 ] ],
           [ [ "nail", 444 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_livestock/recipe_modular_livestock_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_livestock/recipe_modular_livestock_rammed_earth.json
@@ -13,20 +13,25 @@
     "blueprint_provides": [ { "id": "fbml_northeast" }, { "id": "chicken_coop" } ],
     "blueprint_excludes": [ { "id": "fbml_northeast" } ],
     "blueprint_needs": {
-      "time": "5 d 10 h 15 m",
+      "time": "3 d 22 h 15 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [
+          [ { "id": "DIG", "level": 2 } ],
+          [ { "id": "HAMMER", "level": 2 } ],
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
+        ],
         "components": [
-          [ [ "pointy_stick", 36 ], [ "spear_wood", 36 ] ],
           [ [ "2x4", 138 ] ],
-          [ [ "nail", 360 ] ],
-          [ [ "wire", 20 ] ],
+          [ [ "concrete", 18 ], [ "material_quicklime", 360 ], [ "material_sand", 360 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "material_soil", 4320 ] ],
-          [ [ "water", 1800 ], [ "water_clean", 1800 ] ],
-          [ [ "material_sand", 360 ], [ "material_quicklime", 360 ], [ "concrete", 18 ] ],
+          [ [ "material_soil", 1800 ] ],
+          [ [ "nail", 360 ] ],
+          [ [ "pointy_stick", 36 ], [ "spear_wood", 36 ] ],
+          [ [ "water", 900 ], [ "water_clean", 900 ] ],
+          [ [ "wire", 20 ] ],
           [ [ "wood_panel", 16 ] ]
         ]
       }
@@ -46,24 +51,25 @@
     "blueprint_provides": [ { "id": "fbml_southeast" } ],
     "blueprint_excludes": [ { "id": "fbml_southeast" } ],
     "blueprint_needs": {
-      "time": "3 d 18 h 25 m",
+      "time": "2 d 20 h 25 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
         "qualities": [
           [ { "id": "CUT" } ],
           [ { "id": "DIG", "level": 2 } ],
           [ { "id": "HAMMER", "level": 2 } ],
-          [ { "id": "SAW_W", "level": 2 } ]
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
         ],
         "components": [
           [ [ "2x4", 176 ] ],
           [ [ "concrete", 11 ], [ "material_quicklime", 220 ], [ "material_sand", 220 ] ],
-          [ [ "material_soil", 2640 ] ],
+          [ [ "material_soil", 1100 ] ],
           [ [ "nail", 512 ] ],
           [ [ "pointy_stick", 22 ], [ "spear_wood", 22 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
-          [ [ "water", 1100 ], [ "water_clean", 1100 ] ],
+          [ [ "water", 550 ], [ "water_clean", 550 ] ],
           [ [ "wood_panel", 29 ] ]
         ]
       }
@@ -83,19 +89,24 @@
     "blueprint_provides": [ { "id": "fbml_southwest" }, { "id": "stables" } ],
     "blueprint_excludes": [ { "id": "fbml_southwest" } ],
     "blueprint_needs": {
-      "time": "4 d 17 h 45 m",
+      "time": "3 d 11 h 45 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [
+          [ { "id": "DIG", "level": 2 } ],
+          [ { "id": "HAMMER", "level": 2 } ],
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
+        ],
         "components": [
-          [ [ "pointy_stick", 38 ], [ "spear_wood", 38 ] ],
           [ [ "2x4", 161 ] ],
-          [ [ "nail", 432 ] ],
-          [ [ "material_soil", 3600 ] ],
-          [ [ "water", 1500 ], [ "water_clean", 1500 ] ],
-          [ [ "material_sand", 300 ], [ "material_quicklime", 300 ], [ "concrete", 15 ] ],
+          [ [ "concrete", 15 ], [ "material_quicklime", 300 ], [ "material_sand", 300 ] ],
           [ [ "hinge", 2 ] ],
+          [ [ "material_soil", 1500 ] ],
+          [ [ "nail", 432 ] ],
+          [ [ "pointy_stick", 38 ], [ "spear_wood", 38 ] ],
+          [ [ "water", 750 ], [ "water_clean", 750 ] ],
           [ [ "wood_panel", 17 ] ]
         ]
       }
@@ -115,19 +126,24 @@
     "blueprint_provides": [ { "id": "fbml_west" } ],
     "blueprint_excludes": [ { "id": "fbml_west" } ],
     "blueprint_needs": {
-      "time": "4 d 7 h 15 m",
+      "time": "3 d 5 h 15 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [
+          [ { "id": "DIG", "level": 2 } ],
+          [ { "id": "HAMMER", "level": 2 } ],
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
+        ],
         "components": [
-          [ [ "pointy_stick", 34 ], [ "spear_wood", 34 ] ],
           [ [ "2x4", 178 ] ],
-          [ [ "nail", 464 ] ],
-          [ [ "material_soil", 3120 ] ],
-          [ [ "water", 1300 ], [ "water_clean", 1300 ] ],
-          [ [ "material_sand", 260 ], [ "material_quicklime", 260 ], [ "concrete", 13 ] ],
+          [ [ "concrete", 13 ], [ "material_quicklime", 260 ], [ "material_sand", 260 ] ],
           [ [ "hinge", 4 ] ],
+          [ [ "material_soil", 1300 ] ],
+          [ [ "nail", 464 ] ],
+          [ [ "pointy_stick", 34 ], [ "spear_wood", 34 ] ],
+          [ [ "water", 650 ], [ "water_clean", 650 ] ],
           [ [ "wood_panel", 19 ] ]
         ]
       }
@@ -147,19 +163,24 @@
     "blueprint_provides": [ { "id": "fbml_northwest" } ],
     "blueprint_excludes": [ { "id": "fbml_northwest" } ],
     "blueprint_needs": {
-      "time": "4 d 12 h 30 m",
+      "time": "3 d 8 h 30 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [
+          [ { "id": "DIG", "level": 2 } ],
+          [ { "id": "HAMMER", "level": 2 } ],
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
+        ],
         "components": [
-          [ [ "pointy_stick", 36 ], [ "spear_wood", 36 ] ],
           [ [ "2x4", 170 ] ],
-          [ [ "nail", 444 ] ],
-          [ [ "material_soil", 3360 ] ],
-          [ [ "water", 1400 ], [ "water_clean", 1400 ] ],
-          [ [ "material_sand", 280 ], [ "material_quicklime", 280 ], [ "concrete", 14 ] ],
+          [ [ "concrete", 14 ], [ "material_quicklime", 280 ], [ "material_sand", 280 ] ],
           [ [ "hinge", 4 ] ],
+          [ [ "material_soil", 1400 ] ],
+          [ [ "nail", 444 ] ],
+          [ [ "pointy_stick", 36 ], [ "spear_wood", 36 ] ],
+          [ [ "water", 700 ], [ "water_clean", 700 ] ],
           [ [ "wood_panel", 18 ] ]
         ]
       }

--- a/data/json/recipes/basecamps/recipe_modular_livestock/recipe_modular_livestock_rock.json
+++ b/data/json/recipes/basecamps/recipe_modular_livestock/recipe_modular_livestock_rock.json
@@ -20,12 +20,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 138 ] ],
-          [ [ "nail", 360 ] ],
-          [ [ "wire", 20 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "rock", 432 ] ],
+          [ [ "mortar_adobe", 36 ], [ "mortar_build", 36 ] ],
+          [ [ "nail", 360 ] ],
           [ [ "pebble", 900 ] ],
-          [ [ "mortar_build", 36 ] ],
+          [ [ "rock", 432 ] ],
+          [ [ "wire", 20 ] ],
           [ [ "wood_panel", 16 ] ]
         ]
       }
@@ -57,15 +57,15 @@
         ],
         "components": [
           [ [ "2x4", 142 ] ],
-          [ [ "nail", 324 ] ],
-          [ [ "wood_panel", 10 ] ],
-          [ [ "hinge", 2 ] ],
-          [ [ "pipe", 60 ] ],
-          [ [ "sheet_metal", 10 ] ],
           [ [ "glass_sheet", 4 ] ],
-          [ [ "rock", 264 ] ],
+          [ [ "hinge", 2 ] ],
+          [ [ "mortar_adobe", 22 ], [ "mortar_build", 22 ] ],
+          [ [ "nail", 324 ] ],
           [ [ "pebble", 550 ] ],
-          [ [ "mortar_build", 22 ] ]
+          [ [ "pipe", 60 ] ],
+          [ [ "rock", 264 ] ],
+          [ [ "sheet_metal", 10 ] ],
+          [ [ "wood_panel", 10 ] ]
         ]
       }
     }
@@ -91,12 +91,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 161 ] ],
-          [ [ "nail", 432 ] ],
-          [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "rock", 360 ] ],
+          [ [ "mortar_adobe", 30 ], [ "mortar_build", 30 ] ],
+          [ [ "nail", 432 ] ],
           [ [ "pebble", 750 ] ],
-          [ [ "mortar_build", 30 ] ],
+          [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
+          [ [ "rock", 360 ] ],
           [ [ "wood_panel", 17 ] ]
         ]
       }
@@ -123,12 +123,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 178 ] ],
-          [ [ "nail", 464 ] ],
-          [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
           [ [ "hinge", 4 ] ],
-          [ [ "rock", 312 ] ],
+          [ [ "mortar_adobe", 26 ], [ "mortar_build", 26 ] ],
+          [ [ "nail", 464 ] ],
           [ [ "pebble", 650 ] ],
-          [ [ "mortar_build", 26 ] ],
+          [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
+          [ [ "rock", 312 ] ],
           [ [ "wood_panel", 19 ] ]
         ]
       }
@@ -155,12 +155,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 170 ] ],
-          [ [ "nail", 444 ] ],
-          [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
           [ [ "hinge", 4 ] ],
-          [ [ "rock", 336 ] ],
+          [ [ "mortar_adobe", 28 ], [ "mortar_build", 28 ] ],
+          [ [ "nail", 444 ] ],
           [ [ "pebble", 700 ] ],
-          [ [ "mortar_build", 28 ] ],
+          [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
+          [ [ "rock", 336 ] ],
           [ [ "wood_panel", 18 ] ]
         ]
       }

--- a/data/json/recipes/basecamps/recipe_modular_livestock/recipe_modular_livestock_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_livestock/recipe_modular_livestock_wad.json
@@ -14,19 +14,31 @@
     "blueprint_excludes": [ { "id": "fbml_northeast" } ],
     "blueprint_needs": {
       "time": "1 d 23 h 45 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 318 ] ],
-          [ [ "nail", 360 ] ],
-          [ [ "wire", 20 ] ],
+          [
+            [ "cattail_stalk", 144 ],
+            [ "dogbane", 144 ],
+            [ "material_sand", 360 ],
+            [ "pebble", 360 ],
+            [ "pine_bough", 144 ],
+            [ "straw_pile", 144 ],
+            [ "withered", 144 ]
+          ],
+          [
+            [ "clay_lump", 144 ],
+            [ "material_limestone", 144 ],
+            [ "material_quicklime", 144 ],
+            [ "material_soil", 720 ]
+          ],
           [ [ "hinge", 2 ] ],
-          [ [ "material_quicklime", 144 ], [ "material_limestone", 144 ], [ "clay_lump", 144 ] ],
-          [ [ "pebble", 360 ], [ "material_sand", 360 ] ],
-          [ [ "straw_pile", 144 ], [ "cattail_stalk", 144 ], [ "dogbane", 144 ], [ "pine_bough", 144 ] ],
+          [ [ "nail", 360 ] ],
           [ [ "water", 180 ], [ "water_clean", 180 ] ],
+          [ [ "wire", 20 ] ],
           [ [ "wood_panel", 16 ] ]
         ]
       }
@@ -47,15 +59,27 @@
     "blueprint_excludes": [ { "id": "fbml_southeast" } ],
     "blueprint_needs": {
       "time": "1 d 14 h 20 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 246 ] ],
-          [ [ "cattail_stalk", 104 ], [ "dogbane", 104 ], [ "pine_bough", 104 ], [ "straw_pile", 104 ] ],
-          [ [ "clay_lump", 104 ], [ "material_limestone", 104 ], [ "material_quicklime", 104 ] ],
-          [ [ "material_sand", 260 ], [ "pebble", 260 ] ],
+          [
+            [ "cattail_stalk", 104 ],
+            [ "dogbane", 104 ],
+            [ "material_sand", 260 ],
+            [ "pebble", 260 ],
+            [ "pine_bough", 104 ],
+            [ "straw_pile", 104 ],
+            [ "withered", 104 ]
+          ],
+          [
+            [ "clay_lump", 104 ],
+            [ "material_limestone", 104 ],
+            [ "material_quicklime", 104 ],
+            [ "material_soil", 520 ]
+          ],
           [ [ "nail", 392 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 130 ], [ "water_clean", 130 ] ],
@@ -79,7 +103,7 @@
     "blueprint_excludes": [ { "id": "fbml_southwest" } ],
     "blueprint_needs": {
       "time": "1 d 21 h",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [
@@ -90,12 +114,24 @@
         ],
         "components": [
           [ [ "2x4", 311 ] ],
+          [
+            [ "cattail_stalk", 120 ],
+            [ "dogbane", 120 ],
+            [ "material_sand", 300 ],
+            [ "pebble", 300 ],
+            [ "pine_bough", 120 ],
+            [ "straw_pile", 120 ],
+            [ "withered", 120 ]
+          ],
+          [
+            [ "clay_lump", 120 ],
+            [ "material_limestone", 120 ],
+            [ "material_quicklime", 120 ],
+            [ "material_soil", 600 ]
+          ],
+          [ [ "hinge", 2 ] ],
           [ [ "nail", 432 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
-          [ [ "hinge", 2 ] ],
-          [ [ "material_quicklime", 120 ], [ "material_limestone", 120 ], [ "clay_lump", 120 ] ],
-          [ [ "pebble", 300 ], [ "material_sand", 300 ] ],
-          [ [ "straw_pile", 120 ], [ "cattail_stalk", 120 ], [ "dogbane", 120 ], [ "pine_bough", 120 ] ],
           [ [ "water", 150 ], [ "water_clean", 150 ] ],
           [ [ "wood_panel", 17 ] ]
         ]
@@ -117,7 +153,7 @@
     "blueprint_excludes": [ { "id": "fbml_west" } ],
     "blueprint_needs": {
       "time": "1 d 19 h 40 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [
@@ -128,12 +164,24 @@
         ],
         "components": [
           [ [ "2x4", 308 ] ],
+          [
+            [ "cattail_stalk", 104 ],
+            [ "dogbane", 104 ],
+            [ "material_sand", 260 ],
+            [ "pebble", 260 ],
+            [ "pine_bough", 104 ],
+            [ "straw_pile", 104 ],
+            [ "withered", 104 ]
+          ],
+          [
+            [ "clay_lump", 104 ],
+            [ "material_limestone", 104 ],
+            [ "material_quicklime", 104 ],
+            [ "material_soil", 520 ]
+          ],
+          [ [ "hinge", 4 ] ],
           [ [ "nail", 464 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
-          [ [ "hinge", 4 ] ],
-          [ [ "material_quicklime", 104 ], [ "material_limestone", 104 ], [ "clay_lump", 104 ] ],
-          [ [ "pebble", 260 ], [ "material_sand", 260 ] ],
-          [ [ "straw_pile", 104 ], [ "cattail_stalk", 104 ], [ "dogbane", 104 ], [ "pine_bough", 104 ] ],
           [ [ "water", 130 ], [ "water_clean", 130 ] ],
           [ [ "wood_panel", 19 ] ]
         ]
@@ -155,7 +203,7 @@
     "blueprint_excludes": [ { "id": "fbml_northwest" } ],
     "blueprint_needs": {
       "time": "1 d 20 h 20 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [
@@ -166,12 +214,24 @@
         ],
         "components": [
           [ [ "2x4", 310 ] ],
+          [
+            [ "cattail_stalk", 112 ],
+            [ "dogbane", 112 ],
+            [ "material_sand", 280 ],
+            [ "pebble", 280 ],
+            [ "pine_bough", 112 ],
+            [ "straw_pile", 112 ],
+            [ "withered", 112 ]
+          ],
+          [
+            [ "clay_lump", 112 ],
+            [ "material_limestone", 112 ],
+            [ "material_quicklime", 112 ],
+            [ "material_soil", 560 ]
+          ],
+          [ [ "hinge", 4 ] ],
           [ [ "nail", 444 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
-          [ [ "hinge", 4 ] ],
-          [ [ "material_quicklime", 112 ], [ "material_limestone", 112 ], [ "clay_lump", 112 ] ],
-          [ [ "pebble", 280 ], [ "material_sand", 280 ] ],
-          [ [ "straw_pile", 112 ], [ "cattail_stalk", 112 ], [ "dogbane", 112 ], [ "pine_bough", 112 ] ],
           [ [ "water", 140 ], [ "water_clean", 140 ] ],
           [ [ "wood_panel", 18 ] ]
         ]

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_log.json
@@ -19,7 +19,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 387 ] ],
+          [ [ "2x4", 267 ] ],
           [ [ "birchbark", 228 ], [ "pine_bough", 228 ] ],
           [ [ "glass_sheet", 3 ] ],
           [ [ "hinge", 2 ] ],
@@ -56,7 +56,7 @@
           [ { "id": "WRENCH" } ]
         ],
         "components": [
-          [ [ "2x4", 242 ] ],
+          [ [ "2x4", 176 ] ],
           [ [ "birchbark", 96 ], [ "pine_bough", 96 ] ],
           [ [ "glass_sheet", 4 ] ],
           [ [ "hinge", 2 ] ],
@@ -85,7 +85,7 @@
     "blueprint_excludes": [ { "id": "fbmsw_southwest" } ],
     "blueprint_needs": {
       "time": "4 d 16 h",
-      "skills": [ [ "cooking", 3 ], [ "fabrication", 4 ] ],
+      "skills": [ [ "fabrication", 4 ], [ "cooking", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [
@@ -96,7 +96,7 @@
           [ { "id": "WRENCH" } ]
         ],
         "components": [
-          [ [ "2x4", 424 ] ],
+          [ [ "2x4", 298 ] ],
           [ [ "birchbark", 288 ], [ "pine_bough", 288 ] ],
           [ [ "glass_sheet", 2 ] ],
           [ [ "hinge", 2 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_rammed_earth.json
@@ -13,24 +13,25 @@
     "blueprint_provides": [ { "id": "fbmsw_northeast" }, { "id": "Salt_Pan" } ],
     "blueprint_excludes": [ { "id": "fbmsw_northeast" } ],
     "blueprint_needs": {
-      "time": "6 d 5 h 10 m",
+      "time": "4 d 13 h 10 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
         "qualities": [
           [ { "id": "CUT" } ],
           [ { "id": "DIG", "level": 2 } ],
           [ { "id": "HAMMER", "level": 2 } ],
-          [ { "id": "SAW_W", "level": 2 } ]
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
         ],
         "components": [
           [ [ "2x4", 211 ] ],
           [ [ "concrete", 20 ], [ "material_quicklime", 400 ], [ "material_sand", 400 ] ],
-          [ [ "material_soil", 4800 ] ],
+          [ [ "material_soil", 2000 ] ],
           [ [ "nail", 486 ] ],
           [ [ "pointy_stick", 40 ], [ "spear_wood", 40 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
-          [ [ "water", 2000 ], [ "water_clean", 2000 ] ],
+          [ [ "water", 1000 ], [ "water_clean", 1000 ] ],
           [ [ "wood_panel", 22 ] ]
         ]
       }
@@ -50,27 +51,28 @@
     "blueprint_provides": [ { "id": "fbmsw_southeast" } ],
     "blueprint_excludes": [ { "id": "fbmsw_southeast" } ],
     "blueprint_needs": {
-      "time": "3 d 10 h 45 m",
+      "time": "2 d 12 h 45 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
         "qualities": [
           [ { "id": "CUT" } ],
           [ { "id": "DIG", "level": 2 } ],
           [ { "id": "HAMMER", "level": 2 } ],
           [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ],
           [ { "id": "WRENCH" } ]
         ],
         "components": [
           [ [ "2x4", 98 ] ],
           [ [ "concrete", 11 ], [ "material_quicklime", 220 ], [ "material_sand", 220 ] ],
-          [ [ "material_soil", 2640 ] ],
+          [ [ "material_soil", 1100 ] ],
           [ [ "nail", 192 ] ],
           [ [ "pipe", 60 ] ],
           [ [ "pointy_stick", 22 ], [ "spear_wood", 22 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "sheet_metal", 10 ] ],
-          [ [ "water", 1100 ], [ "water_clean", 1100 ] ],
+          [ [ "water", 550 ], [ "water_clean", 550 ] ],
           [ [ "wood_panel", 3 ] ]
         ]
       }
@@ -90,30 +92,31 @@
     "blueprint_provides": [ { "id": "fbmsw_southwest" }, { "id": "brewery" } ],
     "blueprint_excludes": [ { "id": "fbmsw_southwest" } ],
     "blueprint_needs": {
-      "time": "6 d 17 h 45 m",
-      "skills": [ [ "cooking", 3 ], [ "fabrication", 3 ] ],
+      "time": "4 d 23 h 45 m",
+      "skills": [ [ "fabrication", 3 ], [ "cooking", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
         "qualities": [
           [ { "id": "CUT" } ],
           [ { "id": "DIG", "level": 2 } ],
           [ { "id": "HAMMER", "level": 2 } ],
           [ { "id": "SAW_M", "level": 2 } ],
           [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ],
           [ { "id": "WRENCH" } ]
         ],
         "components": [
           [ [ "2x4", 240 ] ],
+          [ [ "concrete", 21 ], [ "material_quicklime", 420 ], [ "material_sand", 420 ] ],
+          [ [ "material_soil", 2100 ] ],
           [ [ "nail", 510 ] ],
-          [ [ "pointy_stick", 42 ], [ "spear_wood", 42 ] ],
           [ [ "pipe", 36 ] ],
+          [ [ "pointy_stick", 42 ], [ "spear_wood", 42 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "sheet_metal", 7 ] ],
           [ [ "sheet_metal_small", 12 ] ],
+          [ [ "water", 1050 ], [ "water_clean", 1050 ] ],
           [ [ "water_faucet", 2 ] ],
-          [ [ "material_soil", 5040 ] ],
-          [ [ "water", 2100 ], [ "water_clean", 2100 ] ],
-          [ [ "material_sand", 420 ], [ "material_quicklime", 420 ], [ "concrete", 21 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
           [ [ "wood_panel", 20 ] ]
         ]
       }

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_stone.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_stone.json
@@ -20,13 +20,13 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 71 ] ],
-          [ [ "nail", 158 ] ],
-          [ [ "wood_panel", 6 ] ],
-          [ [ "hinge", 2 ] ],
           [ [ "glass_sheet", 3 ] ],
-          [ [ "rock", 480 ] ],
+          [ [ "hinge", 2 ] ],
+          [ [ "mortar_adobe", 40 ], [ "mortar_build", 40 ] ],
+          [ [ "nail", 158 ] ],
           [ [ "pebble", 1000 ] ],
-          [ [ "mortar_build", 40 ] ]
+          [ [ "rock", 480 ] ],
+          [ [ "wood_panel", 6 ] ]
         ]
       }
     }
@@ -57,15 +57,15 @@
         ],
         "components": [
           [ [ "2x4", 78 ] ],
-          [ [ "nail", 164 ] ],
-          [ [ "wood_panel", 2 ] ],
-          [ [ "hinge", 2 ] ],
-          [ [ "pipe", 60 ] ],
-          [ [ "sheet_metal", 10 ] ],
           [ [ "glass_sheet", 4 ] ],
-          [ [ "rock", 264 ] ],
+          [ [ "hinge", 2 ] ],
+          [ [ "mortar_adobe", 22 ], [ "mortar_build", 22 ] ],
+          [ [ "nail", 164 ] ],
           [ [ "pebble", 550 ] ],
-          [ [ "mortar_build", 22 ] ]
+          [ [ "pipe", 60 ] ],
+          [ [ "rock", 264 ] ],
+          [ [ "sheet_metal", 10 ] ],
+          [ [ "wood_panel", 2 ] ]
         ]
       }
     }
@@ -85,7 +85,7 @@
     "blueprint_excludes": [ { "id": "fbmsw_southwest" } ],
     "blueprint_needs": {
       "time": "5 d 17 h 30 m",
-      "skills": [ [ "cooking", 3 ], [ "fabrication", 6 ] ],
+      "skills": [ [ "fabrication", 6 ], [ "cooking", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [
@@ -97,17 +97,17 @@
         ],
         "components": [
           [ [ "2x4", 76 ] ],
-          [ [ "nail", 122 ] ],
-          [ [ "wood_panel", 1 ] ],
+          [ [ "glass_sheet", 2 ] ],
           [ [ "hinge", 2 ] ],
+          [ [ "mortar_adobe", 42 ], [ "mortar_build", 42 ] ],
+          [ [ "nail", 122 ] ],
+          [ [ "pebble", 1050 ] ],
           [ [ "pipe", 36 ] ],
+          [ [ "rock", 504 ] ],
           [ [ "sheet_metal", 7 ] ],
           [ [ "sheet_metal_small", 12 ] ],
           [ [ "water_faucet", 2 ] ],
-          [ [ "glass_sheet", 2 ] ],
-          [ [ "rock", 504 ] ],
-          [ [ "pebble", 1050 ] ],
-          [ [ "mortar_build", 42 ] ]
+          [ [ "wood_panel", 1 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_saltworks/recipe_modular_saltworks_wad.json
@@ -14,15 +14,27 @@
     "blueprint_excludes": [ { "id": "fbmsw_northeast" } ],
     "blueprint_needs": {
       "time": "2 d 8 h 15 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 381 ] ],
-          [ [ "cattail_stalk", 172 ], [ "dogbane", 172 ], [ "pine_bough", 172 ], [ "straw_pile", 172 ] ],
-          [ [ "clay_lump", 172 ], [ "material_limestone", 172 ], [ "material_quicklime", 172 ] ],
-          [ [ "material_sand", 430 ], [ "pebble", 430 ] ],
+          [
+            [ "cattail_stalk", 172 ],
+            [ "dogbane", 172 ],
+            [ "material_sand", 430 ],
+            [ "pebble", 430 ],
+            [ "pine_bough", 172 ],
+            [ "straw_pile", 172 ],
+            [ "withered", 172 ]
+          ],
+          [
+            [ "clay_lump", 172 ],
+            [ "material_limestone", 172 ],
+            [ "material_quicklime", 172 ],
+            [ "material_soil", 860 ]
+          ],
           [ [ "nail", 396 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 215 ], [ "water_clean", 215 ] ],
@@ -46,15 +58,27 @@
     "blueprint_excludes": [ { "id": "fbmsw_southeast" } ],
     "blueprint_needs": {
       "time": "1 d 6 h 40 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
           [ [ "2x4", 168 ] ],
-          [ [ "cattail_stalk", 104 ], [ "dogbane", 104 ], [ "pine_bough", 104 ], [ "straw_pile", 104 ] ],
-          [ [ "clay_lump", 104 ], [ "material_limestone", 104 ], [ "material_quicklime", 104 ] ],
-          [ [ "material_sand", 260 ], [ "pebble", 260 ] ],
+          [
+            [ "cattail_stalk", 104 ],
+            [ "dogbane", 104 ],
+            [ "material_sand", 260 ],
+            [ "pebble", 260 ],
+            [ "pine_bough", 104 ],
+            [ "straw_pile", 104 ],
+            [ "withered", 104 ]
+          ],
+          [
+            [ "clay_lump", 104 ],
+            [ "material_limestone", 104 ],
+            [ "material_quicklime", 104 ],
+            [ "material_soil", 520 ]
+          ],
           [ [ "nail", 72 ] ],
           [ [ "pipe", 60 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
@@ -80,7 +104,7 @@
     "blueprint_excludes": [ { "id": "fbmsw_southwest" } ],
     "blueprint_needs": {
       "time": "2 d 16 h 40 m",
-      "skills": [ [ "cooking", 3 ], [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ], [ "cooking", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [
@@ -92,16 +116,28 @@
         ],
         "components": [
           [ [ "2x4", 430 ] ],
+          [
+            [ "cattail_stalk", 176 ],
+            [ "dogbane", 176 ],
+            [ "material_sand", 440 ],
+            [ "pebble", 440 ],
+            [ "pine_bough", 176 ],
+            [ "straw_pile", 176 ],
+            [ "withered", 176 ]
+          ],
+          [
+            [ "clay_lump", 176 ],
+            [ "material_limestone", 176 ],
+            [ "material_quicklime", 176 ],
+            [ "material_soil", 880 ]
+          ],
           [ [ "nail", 450 ] ],
           [ [ "pipe", 36 ] ],
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "sheet_metal", 7 ] ],
           [ [ "sheet_metal_small", 12 ] ],
-          [ [ "water_faucet", 2 ] ],
-          [ [ "material_quicklime", 176 ], [ "material_limestone", 176 ], [ "clay_lump", 176 ] ],
-          [ [ "pebble", 440 ], [ "material_sand", 440 ] ],
-          [ [ "straw_pile", 176 ], [ "cattail_stalk", 176 ], [ "dogbane", 176 ], [ "pine_bough", 176 ] ],
           [ [ "water", 220 ], [ "water_clean", 220 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ],
+          [ [ "water_faucet", 2 ] ],
           [ [ "wood_panel", 20 ] ]
         ]
       }

--- a/data/json/recipes/basecamps/recipe_modular_shelter/recipe_modular_shelter_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter/recipe_modular_shelter_log.json
@@ -18,7 +18,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 86 ] ], [ [ "hinge", 2 ] ], [ [ "log", 24 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 50 ] ], [ [ "hinge", 2 ] ], [ [ "log", 24 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -41,7 +41,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 86 ] ], [ [ "hinge", 2 ] ], [ [ "log", 24 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 50 ] ], [ [ "hinge", 2 ] ], [ [ "log", 24 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -64,7 +64,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 122 ] ], [ [ "hinge", 2 ] ], [ [ "log", 36 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 68 ] ], [ [ "hinge", 2 ] ], [ [ "log", 36 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -87,7 +87,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 86 ] ], [ [ "hinge", 2 ] ], [ [ "log", 24 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 50 ] ], [ [ "hinge", 2 ] ], [ [ "log", 24 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -110,7 +110,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 38 ] ], [ [ "hinge", 2 ] ], [ [ "log", 8 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 26 ] ], [ [ "hinge", 2 ] ], [ [ "log", 8 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   }

--- a/data/json/recipes/basecamps/recipe_modular_shelter/recipe_modular_shelter_rock.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter/recipe_modular_shelter_rock.json
@@ -20,12 +20,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 14 ] ],
-          [ [ "nail", 36 ] ],
-          [ [ "wood_panel", 1 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "rock", 144 ] ],
+          [ [ "mortar_adobe", 12 ], [ "mortar_build", 12 ] ],
+          [ [ "nail", 36 ] ],
           [ [ "pebble", 300 ] ],
-          [ [ "mortar_build", 12 ] ]
+          [ [ "rock", 144 ] ],
+          [ [ "wood_panel", 1 ] ]
         ]
       }
     }
@@ -51,12 +51,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 14 ] ],
-          [ [ "nail", 36 ] ],
-          [ [ "wood_panel", 1 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "rock", 144 ] ],
+          [ [ "mortar_adobe", 12 ], [ "mortar_build", 12 ] ],
+          [ [ "nail", 36 ] ],
           [ [ "pebble", 300 ] ],
-          [ [ "mortar_build", 12 ] ]
+          [ [ "rock", 144 ] ],
+          [ [ "wood_panel", 1 ] ]
         ]
       }
     }
@@ -82,12 +82,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 14 ] ],
-          [ [ "nail", 36 ] ],
-          [ [ "wood_panel", 1 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "rock", 216 ] ],
+          [ [ "mortar_adobe", 18 ], [ "mortar_build", 18 ] ],
+          [ [ "nail", 36 ] ],
           [ [ "pebble", 450 ] ],
-          [ [ "mortar_build", 18 ] ]
+          [ [ "rock", 216 ] ],
+          [ [ "wood_panel", 1 ] ]
         ]
       }
     }
@@ -113,12 +113,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 14 ] ],
-          [ [ "nail", 36 ] ],
-          [ [ "wood_panel", 1 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "rock", 144 ] ],
+          [ [ "mortar_adobe", 12 ], [ "mortar_build", 12 ] ],
+          [ [ "nail", 36 ] ],
           [ [ "pebble", 300 ] ],
-          [ [ "mortar_build", 12 ] ]
+          [ [ "rock", 144 ] ],
+          [ [ "wood_panel", 1 ] ]
         ]
       }
     }
@@ -144,12 +144,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 14 ] ],
-          [ [ "nail", 36 ] ],
-          [ [ "wood_panel", 1 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "rock", 48 ] ],
+          [ [ "mortar_adobe", 4 ], [ "mortar_build", 4 ] ],
+          [ [ "nail", 36 ] ],
           [ [ "pebble", 100 ] ],
-          [ [ "mortar_build", 4 ] ]
+          [ [ "rock", 48 ] ],
+          [ [ "wood_panel", 1 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_shelter/recipe_modular_shelter_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter/recipe_modular_shelter_wad.json
@@ -14,18 +14,30 @@
     "blueprint_excludes": [ { "id": "fbmc_shelter_bedroom1" } ],
     "blueprint_needs": {
       "time": "11 h 30 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 78 ] ],
+          [
+            [ "cattail_stalk", 48 ],
+            [ "dogbane", 48 ],
+            [ "material_sand", 120 ],
+            [ "pebble", 120 ],
+            [ "pine_bough", 48 ],
+            [ "straw_pile", 48 ],
+            [ "withered", 48 ]
+          ],
+          [
+            [ "clay_lump", 48 ],
+            [ "material_limestone", 48 ],
+            [ "material_quicklime", 48 ],
+            [ "material_soil", 240 ]
+          ],
           [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 48 ], [ "material_limestone", 48 ], [ "clay_lump", 48 ] ],
-          [ [ "pebble", 120 ], [ "material_sand", 120 ] ],
-          [ [ "straw_pile", 48 ], [ "cattail_stalk", 48 ], [ "dogbane", 48 ], [ "pine_bough", 48 ] ],
-          [ [ "water", 60 ], [ "water_clean", 60 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 60 ], [ "water_clean", 60 ] ]
         ]
       }
     }
@@ -45,18 +57,30 @@
     "blueprint_excludes": [ { "id": "fbmc_shelter_bedroom2" } ],
     "blueprint_needs": {
       "time": "11 h 30 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 78 ] ],
+          [
+            [ "cattail_stalk", 48 ],
+            [ "dogbane", 48 ],
+            [ "material_sand", 120 ],
+            [ "pebble", 120 ],
+            [ "pine_bough", 48 ],
+            [ "straw_pile", 48 ],
+            [ "withered", 48 ]
+          ],
+          [
+            [ "clay_lump", 48 ],
+            [ "material_limestone", 48 ],
+            [ "material_quicklime", 48 ],
+            [ "material_soil", 240 ]
+          ],
           [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 48 ], [ "material_limestone", 48 ], [ "clay_lump", 48 ] ],
-          [ [ "pebble", 120 ], [ "material_sand", 120 ] ],
-          [ [ "straw_pile", 48 ], [ "cattail_stalk", 48 ], [ "dogbane", 48 ], [ "pine_bough", 48 ] ],
-          [ [ "water", 60 ], [ "water_clean", 60 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 60 ], [ "water_clean", 60 ] ]
         ]
       }
     }
@@ -76,18 +100,30 @@
     "blueprint_excludes": [ { "id": "fbmc_shelter_bedroom3" } ],
     "blueprint_needs": {
       "time": "16 h 30 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 108 ] ],
+          [
+            [ "cattail_stalk", 72 ],
+            [ "dogbane", 72 ],
+            [ "material_sand", 180 ],
+            [ "pebble", 180 ],
+            [ "pine_bough", 72 ],
+            [ "straw_pile", 72 ],
+            [ "withered", 72 ]
+          ],
+          [
+            [ "clay_lump", 72 ],
+            [ "material_limestone", 72 ],
+            [ "material_quicklime", 72 ],
+            [ "material_soil", 360 ]
+          ],
           [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 72 ], [ "material_limestone", 72 ], [ "clay_lump", 72 ] ],
-          [ [ "pebble", 180 ], [ "material_sand", 180 ] ],
-          [ [ "straw_pile", 72 ], [ "cattail_stalk", 72 ], [ "dogbane", 72 ], [ "pine_bough", 72 ] ],
-          [ [ "water", 90 ], [ "water_clean", 90 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 90 ], [ "water_clean", 90 ] ]
         ]
       }
     }
@@ -107,18 +143,30 @@
     "blueprint_excludes": [ { "id": "fbmc_shelter_bedroom4" } ],
     "blueprint_needs": {
       "time": "11 h 30 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 78 ] ],
+          [
+            [ "cattail_stalk", 48 ],
+            [ "dogbane", 48 ],
+            [ "material_sand", 120 ],
+            [ "pebble", 120 ],
+            [ "pine_bough", 48 ],
+            [ "straw_pile", 48 ],
+            [ "withered", 48 ]
+          ],
+          [
+            [ "clay_lump", 48 ],
+            [ "material_limestone", 48 ],
+            [ "material_quicklime", 48 ],
+            [ "material_soil", 240 ]
+          ],
           [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 48 ], [ "material_limestone", 48 ], [ "clay_lump", 48 ] ],
-          [ [ "pebble", 120 ], [ "material_sand", 120 ] ],
-          [ [ "straw_pile", 48 ], [ "cattail_stalk", 48 ], [ "dogbane", 48 ], [ "pine_bough", 48 ] ],
-          [ [ "water", 60 ], [ "water_clean", 60 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 60 ], [ "water_clean", 60 ] ]
         ]
       }
     }
@@ -138,18 +186,25 @@
     "blueprint_excludes": [ { "id": "fbmc_shelter_bedroom5" } ],
     "blueprint_needs": {
       "time": "4 h 50 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 38 ] ],
+          [
+            [ "cattail_stalk", 16 ],
+            [ "dogbane", 16 ],
+            [ "material_sand", 40 ],
+            [ "pebble", 40 ],
+            [ "pine_bough", 16 ],
+            [ "straw_pile", 16 ],
+            [ "withered", 16 ]
+          ],
+          [ [ "clay_lump", 16 ], [ "material_limestone", 16 ], [ "material_quicklime", 16 ], [ "material_soil", 80 ] ],
           [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 16 ], [ "material_limestone", 16 ], [ "clay_lump", 16 ] ],
-          [ [ "pebble", 40 ], [ "material_sand", 40 ] ],
-          [ [ "straw_pile", 16 ], [ "cattail_stalk", 16 ], [ "dogbane", 16 ], [ "pine_bough", 16 ] ],
-          [ [ "water", 20 ], [ "water_clean", 20 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 20 ], [ "water_clean", 20 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_common.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_common.json
@@ -288,11 +288,11 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "sheet_metal", 2 ] ],
-          [ [ "pipe", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
-          [ [ "straw_pile", 16 ], [ "withered", 16 ], [ "pine_bough", 16 ] ]
+          [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
+          [ [ "pipe", 8 ] ],
+          [ [ "sheet_metal", 2 ] ]
         ]
       }
     }
@@ -317,11 +317,11 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "sheet_metal", 2 ] ],
-          [ [ "pipe", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
-          [ [ "straw_pile", 16 ], [ "withered", 16 ], [ "pine_bough", 16 ] ]
+          [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
+          [ [ "pipe", 8 ] ],
+          [ [ "sheet_metal", 2 ] ]
         ]
       }
     }
@@ -346,11 +346,11 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "sheet_metal", 2 ] ],
-          [ [ "pipe", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
-          [ [ "straw_pile", 16 ], [ "withered", 16 ], [ "pine_bough", 16 ] ]
+          [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
+          [ [ "pipe", 8 ] ],
+          [ [ "sheet_metal", 2 ] ]
         ]
       }
     }
@@ -375,11 +375,11 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "sheet_metal", 2 ] ],
-          [ [ "pipe", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
-          [ [ "straw_pile", 16 ], [ "withered", 16 ], [ "pine_bough", 16 ] ]
+          [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
+          [ [ "pipe", 8 ] ],
+          [ [ "sheet_metal", 2 ] ]
         ]
       }
     }
@@ -740,11 +740,11 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "sheet_metal", 4 ] ],
-          [ [ "pipe", 16 ] ],
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
           [ [ "lock", 2 ] ],
-          [ [ "2x4", 16 ], [ "stick", 16 ] ],
-          [ [ "straw_pile", 32 ], [ "withered", 32 ], [ "pine_bough", 32 ] ]
+          [ [ "pine_bough", 32 ], [ "straw_pile", 32 ], [ "withered", 32 ] ],
+          [ [ "pipe", 16 ] ],
+          [ [ "sheet_metal", 4 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_log.json
@@ -18,7 +18,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 62 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 38 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -41,7 +41,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 62 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 38 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -64,7 +64,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 62 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 38 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -87,7 +87,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 86 ] ], [ [ "hinge", 2 ] ], [ [ "log", 24 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 50 ] ], [ [ "hinge", 2 ] ], [ [ "log", 24 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -110,7 +110,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 100 ] ], [ [ "hinge", 4 ] ], [ [ "log", 24 ] ], [ [ "nail", 72 ] ], [ [ "wood_panel", 2 ] ] ]
+        "components": [ [ [ "2x4", 64 ] ], [ [ "hinge", 4 ] ], [ [ "log", 24 ] ], [ [ "nail", 72 ] ], [ [ "wood_panel", 2 ] ] ]
       }
     }
   }

--- a/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_rock.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_rock.json
@@ -20,12 +20,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 14 ] ],
-          [ [ "nail", 36 ] ],
-          [ [ "wood_panel", 1 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "rock", 96 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
+          [ [ "nail", 36 ] ],
           [ [ "pebble", 200 ] ],
-          [ [ "mortar_build", 8 ] ]
+          [ [ "rock", 96 ] ],
+          [ [ "wood_panel", 1 ] ]
         ]
       }
     }
@@ -51,12 +51,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 14 ] ],
-          [ [ "nail", 36 ] ],
-          [ [ "wood_panel", 1 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "rock", 96 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
+          [ [ "nail", 36 ] ],
           [ [ "pebble", 200 ] ],
-          [ [ "mortar_build", 8 ] ]
+          [ [ "rock", 96 ] ],
+          [ [ "wood_panel", 1 ] ]
         ]
       }
     }
@@ -106,7 +106,7 @@
         "components": [
           [ [ "2x4", 14 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "mortar_build", 12 ] ],
+          [ [ "mortar_adobe", 12 ], [ "mortar_build", 12 ] ],
           [ [ "nail", 36 ] ],
           [ [ "pebble", 300 ] ],
           [ [ "rock", 144 ] ],
@@ -136,12 +136,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 28 ] ],
-          [ [ "nail", 72 ] ],
-          [ [ "wood_panel", 2 ] ],
           [ [ "hinge", 4 ] ],
-          [ [ "rock", 144 ] ],
+          [ [ "mortar_adobe", 12 ], [ "mortar_build", 12 ] ],
+          [ [ "nail", 72 ] ],
           [ [ "pebble", 300 ] ],
-          [ [ "mortar_build", 12 ] ]
+          [ [ "rock", 144 ] ],
+          [ [ "wood_panel", 2 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_rock.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_rock.json
@@ -80,7 +80,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 62 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 38 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_standard.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_standard.json
@@ -64,7 +64,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 62 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 38 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_wad.json
@@ -14,18 +14,30 @@
     "blueprint_excludes": [ { "id": "fbmc_shelter_1_bedroom1" } ],
     "blueprint_needs": {
       "time": "8 h 10 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 58 ] ],
+          [
+            [ "cattail_stalk", 32 ],
+            [ "dogbane", 32 ],
+            [ "material_sand", 80 ],
+            [ "pebble", 80 ],
+            [ "pine_bough", 32 ],
+            [ "straw_pile", 32 ],
+            [ "withered", 32 ]
+          ],
+          [
+            [ "clay_lump", 32 ],
+            [ "material_limestone", 32 ],
+            [ "material_quicklime", 32 ],
+            [ "material_soil", 160 ]
+          ],
           [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 32 ], [ "material_limestone", 32 ], [ "clay_lump", 32 ] ],
-          [ [ "pebble", 80 ], [ "material_sand", 80 ] ],
-          [ [ "straw_pile", 32 ], [ "cattail_stalk", 32 ], [ "dogbane", 32 ], [ "pine_bough", 32 ] ],
-          [ [ "water", 40 ], [ "water_clean", 40 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 40 ], [ "water_clean", 40 ] ]
         ]
       }
     }
@@ -45,18 +57,30 @@
     "blueprint_excludes": [ { "id": "fbmc_shelter_1_bedroom2" } ],
     "blueprint_needs": {
       "time": "8 h 10 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 58 ] ],
+          [
+            [ "cattail_stalk", 32 ],
+            [ "dogbane", 32 ],
+            [ "material_sand", 80 ],
+            [ "pebble", 80 ],
+            [ "pine_bough", 32 ],
+            [ "straw_pile", 32 ],
+            [ "withered", 32 ]
+          ],
+          [
+            [ "clay_lump", 32 ],
+            [ "material_limestone", 32 ],
+            [ "material_quicklime", 32 ],
+            [ "material_soil", 160 ]
+          ],
           [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 32 ], [ "material_limestone", 32 ], [ "clay_lump", 32 ] ],
-          [ [ "pebble", 80 ], [ "material_sand", 80 ] ],
-          [ [ "straw_pile", 32 ], [ "cattail_stalk", 32 ], [ "dogbane", 32 ], [ "pine_bough", 32 ] ],
-          [ [ "water", 40 ], [ "water_clean", 40 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 40 ], [ "water_clean", 40 ] ]
         ]
       }
     }
@@ -105,9 +129,21 @@
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 78 ] ],
-          [ [ "cattail_stalk", 48 ], [ "dogbane", 48 ], [ "pine_bough", 48 ], [ "straw_pile", 48 ] ],
-          [ [ "clay_lump", 48 ], [ "material_limestone", 48 ], [ "material_quicklime", 48 ] ],
-          [ [ "material_sand", 120 ], [ "pebble", 120 ] ],
+          [
+            [ "cattail_stalk", 48 ],
+            [ "dogbane", 48 ],
+            [ "material_sand", 120 ],
+            [ "pebble", 120 ],
+            [ "pine_bough", 48 ],
+            [ "straw_pile", 48 ],
+            [ "withered", 48 ]
+          ],
+          [
+            [ "clay_lump", 48 ],
+            [ "material_limestone", 48 ],
+            [ "material_quicklime", 48 ],
+            [ "material_soil", 240 ]
+          ],
           [ [ "nail", 24 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 60 ], [ "water_clean", 60 ] ]
@@ -130,18 +166,30 @@
     "blueprint_excludes": [ { "id": "fbmc_shelter_1_bedroom6" } ],
     "blueprint_needs": {
       "time": "13 h",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 96 ] ],
+          [
+            [ "cattail_stalk", 48 ],
+            [ "dogbane", 48 ],
+            [ "material_sand", 120 ],
+            [ "pebble", 120 ],
+            [ "pine_bough", 48 ],
+            [ "straw_pile", 48 ],
+            [ "withered", 48 ]
+          ],
+          [
+            [ "clay_lump", 48 ],
+            [ "material_limestone", 48 ],
+            [ "material_quicklime", 48 ],
+            [ "material_soil", 240 ]
+          ],
           [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 48 ], [ "material_limestone", 48 ], [ "clay_lump", 48 ] ],
-          [ [ "pebble", 120 ], [ "material_sand", 120 ] ],
-          [ [ "straw_pile", 48 ], [ "cattail_stalk", 48 ], [ "dogbane", 48 ], [ "pine_bough", 48 ] ],
-          [ [ "water", 60 ], [ "water_clean", 60 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 60 ], [ "water_clean", 60 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_wad.json
@@ -104,7 +104,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 62 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 38 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_wood.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_1/recipe_modular_shelter_1_wood.json
@@ -64,7 +64,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 62 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 38 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },

--- a/data/json/recipes/basecamps/recipe_modular_shelter_2/recipe_modular_shelter_2_common.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_2/recipe_modular_shelter_2_common.json
@@ -288,11 +288,11 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "sheet_metal", 2 ] ],
-          [ [ "pipe", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
-          [ [ "straw_pile", 16 ], [ "withered", 16 ], [ "pine_bough", 16 ] ]
+          [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
+          [ [ "pipe", 8 ] ],
+          [ [ "sheet_metal", 2 ] ]
         ]
       }
     }
@@ -317,11 +317,11 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "sheet_metal", 2 ] ],
-          [ [ "pipe", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
-          [ [ "straw_pile", 16 ], [ "withered", 16 ], [ "pine_bough", 16 ] ]
+          [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
+          [ [ "pipe", 8 ] ],
+          [ [ "sheet_metal", 2 ] ]
         ]
       }
     }
@@ -346,11 +346,11 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "sheet_metal", 2 ] ],
-          [ [ "pipe", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
-          [ [ "straw_pile", 16 ], [ "withered", 16 ], [ "pine_bough", 16 ] ]
+          [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
+          [ [ "pipe", 8 ] ],
+          [ [ "sheet_metal", 2 ] ]
         ]
       }
     }
@@ -375,11 +375,11 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "sheet_metal", 2 ] ],
-          [ [ "pipe", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
-          [ [ "straw_pile", 16 ], [ "withered", 16 ], [ "pine_bough", 16 ] ]
+          [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
+          [ [ "pipe", 8 ] ],
+          [ [ "sheet_metal", 2 ] ]
         ]
       }
     }
@@ -554,7 +554,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
           [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
           [ [ "pipe", 8 ] ],
@@ -643,7 +643,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
           [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
           [ [ "pipe", 8 ] ],
@@ -732,7 +732,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
           [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
           [ [ "pipe", 8 ] ],
@@ -821,7 +821,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
           [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
           [ [ "pipe", 8 ] ],
@@ -910,7 +910,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
           [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
           [ [ "pipe", 8 ] ],
@@ -999,7 +999,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
           [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
           [ [ "pipe", 8 ] ],
@@ -1088,7 +1088,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "WRENCH" } ] ],
         "components": [
-          [ [ "2x4", 8 ], [ "stick", 8 ] ],
+          [ [ "2x4", 8 ], [ "stick", 8 ], [ "stick_long", 4 ] ],
           [ [ "lock", 1 ] ],
           [ [ "pine_bough", 16 ], [ "straw_pile", 16 ], [ "withered", 16 ] ],
           [ [ "pipe", 8 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_shelter_2/recipe_modular_shelter_2_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_2/recipe_modular_shelter_2_log.json
@@ -18,7 +18,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 62 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 38 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -41,7 +41,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 62 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 38 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -64,7 +64,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 50 ] ], [ [ "hinge", 2 ] ], [ [ "log", 12 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 32 ] ], [ [ "hinge", 2 ] ], [ [ "log", 12 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -87,7 +87,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 122 ] ], [ [ "hinge", 2 ] ], [ [ "log", 36 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 68 ] ], [ [ "hinge", 2 ] ], [ [ "log", 36 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -110,7 +110,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 74 ] ], [ [ "hinge", 2 ] ], [ [ "log", 20 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 44 ] ], [ [ "hinge", 2 ] ], [ [ "log", 20 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -133,7 +133,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 124 ] ], [ [ "hinge", 4 ] ], [ [ "log", 32 ] ], [ [ "nail", 72 ] ], [ [ "wood_panel", 2 ] ] ]
+        "components": [ [ [ "2x4", 76 ] ], [ [ "hinge", 4 ] ], [ [ "log", 32 ] ], [ [ "nail", 72 ] ], [ [ "wood_panel", 2 ] ] ]
       }
     }
   },
@@ -156,7 +156,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 150 ] ], [ [ "hinge", 6 ] ], [ [ "log", 36 ] ], [ [ "nail", 108 ] ], [ [ "wood_panel", 3 ] ] ]
+        "components": [ [ [ "2x4", 96 ] ], [ [ "hinge", 6 ] ], [ [ "log", 36 ] ], [ [ "nail", 108 ] ], [ [ "wood_panel", 3 ] ] ]
       }
     }
   },
@@ -179,7 +179,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 74 ] ], [ [ "hinge", 2 ] ], [ [ "log", 20 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 44 ] ], [ [ "hinge", 2 ] ], [ [ "log", 20 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -202,7 +202,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 62 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 38 ] ], [ [ "hinge", 2 ] ], [ [ "log", 16 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   },
@@ -225,7 +225,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 50 ] ], [ [ "hinge", 2 ] ], [ [ "log", 12 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
+        "components": [ [ [ "2x4", 32 ] ], [ [ "hinge", 2 ] ], [ [ "log", 12 ] ], [ [ "nail", 36 ] ], [ [ "wood_panel", 1 ] ] ]
       }
     }
   }

--- a/data/json/recipes/basecamps/recipe_modular_shelter_2/recipe_modular_shelter_2_rock.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_2/recipe_modular_shelter_2_rock.json
@@ -20,12 +20,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 14 ] ],
-          [ [ "nail", 36 ] ],
-          [ [ "wood_panel", 1 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "rock", 96 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
+          [ [ "nail", 36 ] ],
           [ [ "pebble", 200 ] ],
-          [ [ "mortar_build", 8 ] ]
+          [ [ "rock", 96 ] ],
+          [ [ "wood_panel", 1 ] ]
         ]
       }
     }
@@ -51,12 +51,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 14 ] ],
-          [ [ "nail", 36 ] ],
-          [ [ "wood_panel", 1 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "rock", 96 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
+          [ [ "nail", 36 ] ],
           [ [ "pebble", 200 ] ],
-          [ [ "mortar_build", 8 ] ]
+          [ [ "rock", 96 ] ],
+          [ [ "wood_panel", 1 ] ]
         ]
       }
     }
@@ -83,7 +83,7 @@
         "components": [
           [ [ "2x4", 14 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "mortar_build", 6 ] ],
+          [ [ "mortar_adobe", 6 ], [ "mortar_build", 6 ] ],
           [ [ "nail", 36 ] ],
           [ [ "pebble", 150 ] ],
           [ [ "rock", 72 ] ],
@@ -114,7 +114,7 @@
         "components": [
           [ [ "2x4", 14 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "mortar_build", 18 ] ],
+          [ [ "mortar_adobe", 18 ], [ "mortar_build", 18 ] ],
           [ [ "nail", 36 ] ],
           [ [ "pebble", 450 ] ],
           [ [ "rock", 216 ] ],
@@ -145,7 +145,7 @@
         "components": [
           [ [ "2x4", 14 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "mortar_build", 10 ] ],
+          [ [ "mortar_adobe", 10 ], [ "mortar_build", 10 ] ],
           [ [ "nail", 36 ] ],
           [ [ "pebble", 250 ] ],
           [ [ "rock", 120 ] ],
@@ -176,7 +176,7 @@
         "components": [
           [ [ "2x4", 28 ] ],
           [ [ "hinge", 4 ] ],
-          [ [ "mortar_build", 16 ] ],
+          [ [ "mortar_adobe", 16 ], [ "mortar_build", 16 ] ],
           [ [ "nail", 72 ] ],
           [ [ "pebble", 400 ] ],
           [ [ "rock", 192 ] ],
@@ -207,7 +207,7 @@
         "components": [
           [ [ "2x4", 42 ] ],
           [ [ "hinge", 6 ] ],
-          [ [ "mortar_build", 18 ] ],
+          [ [ "mortar_adobe", 18 ], [ "mortar_build", 18 ] ],
           [ [ "nail", 108 ] ],
           [ [ "pebble", 450 ] ],
           [ [ "rock", 216 ] ],
@@ -238,7 +238,7 @@
         "components": [
           [ [ "2x4", 14 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "mortar_build", 10 ] ],
+          [ [ "mortar_adobe", 10 ], [ "mortar_build", 10 ] ],
           [ [ "nail", 36 ] ],
           [ [ "pebble", 250 ] ],
           [ [ "rock", 120 ] ],
@@ -268,12 +268,12 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 14 ] ],
-          [ [ "nail", 36 ] ],
-          [ [ "wood_panel", 1 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "rock", 96 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
+          [ [ "nail", 36 ] ],
           [ [ "pebble", 200 ] ],
-          [ [ "mortar_build", 8 ] ]
+          [ [ "rock", 96 ] ],
+          [ [ "wood_panel", 1 ] ]
         ]
       }
     }
@@ -300,7 +300,7 @@
         "components": [
           [ [ "2x4", 14 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "mortar_build", 6 ] ],
+          [ [ "mortar_adobe", 6 ], [ "mortar_build", 6 ] ],
           [ [ "nail", 36 ] ],
           [ [ "pebble", 150 ] ],
           [ [ "rock", 72 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_shelter_2/recipe_modular_shelter_2_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_shelter_2/recipe_modular_shelter_2_wad.json
@@ -14,18 +14,30 @@
     "blueprint_excludes": [ { "id": "fbmc_shelter_2_bedroom1" } ],
     "blueprint_needs": {
       "time": "8 h 10 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 58 ] ],
+          [
+            [ "cattail_stalk", 32 ],
+            [ "dogbane", 32 ],
+            [ "material_sand", 80 ],
+            [ "pebble", 80 ],
+            [ "pine_bough", 32 ],
+            [ "straw_pile", 32 ],
+            [ "withered", 32 ]
+          ],
+          [
+            [ "clay_lump", 32 ],
+            [ "material_limestone", 32 ],
+            [ "material_quicklime", 32 ],
+            [ "material_soil", 160 ]
+          ],
           [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 32 ], [ "material_limestone", 32 ], [ "clay_lump", 32 ] ],
-          [ [ "pebble", 80 ], [ "material_sand", 80 ] ],
-          [ [ "straw_pile", 32 ], [ "cattail_stalk", 32 ], [ "dogbane", 32 ], [ "pine_bough", 32 ] ],
-          [ [ "water", 40 ], [ "water_clean", 40 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 40 ], [ "water_clean", 40 ] ]
         ]
       }
     }
@@ -45,18 +57,30 @@
     "blueprint_excludes": [ { "id": "fbmc_shelter_2_bedroom2" } ],
     "blueprint_needs": {
       "time": "8 h 10 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 58 ] ],
+          [
+            [ "cattail_stalk", 32 ],
+            [ "dogbane", 32 ],
+            [ "material_sand", 80 ],
+            [ "pebble", 80 ],
+            [ "pine_bough", 32 ],
+            [ "straw_pile", 32 ],
+            [ "withered", 32 ]
+          ],
+          [
+            [ "clay_lump", 32 ],
+            [ "material_limestone", 32 ],
+            [ "material_quicklime", 32 ],
+            [ "material_soil", 160 ]
+          ],
           [ [ "nail", 24 ] ],
-          [ [ "material_quicklime", 32 ], [ "material_limestone", 32 ], [ "clay_lump", 32 ] ],
-          [ [ "pebble", 80 ], [ "material_sand", 80 ] ],
-          [ [ "straw_pile", 32 ], [ "cattail_stalk", 32 ], [ "dogbane", 32 ], [ "pine_bough", 32 ] ],
-          [ [ "water", 40 ], [ "water_clean", 40 ] ],
-          [ [ "rope_makeshift_6", 2 ], [ "rope_6", 2 ] ]
+          [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
+          [ [ "water", 40 ], [ "water_clean", 40 ] ]
         ]
       }
     }
@@ -82,9 +106,21 @@
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 48 ] ],
-          [ [ "cattail_stalk", 24 ], [ "dogbane", 24 ], [ "pine_bough", 24 ], [ "straw_pile", 24 ] ],
-          [ [ "clay_lump", 24 ], [ "material_limestone", 24 ], [ "material_quicklime", 24 ] ],
-          [ [ "material_sand", 60 ], [ "pebble", 60 ] ],
+          [
+            [ "cattail_stalk", 24 ],
+            [ "dogbane", 24 ],
+            [ "material_sand", 60 ],
+            [ "pebble", 60 ],
+            [ "pine_bough", 24 ],
+            [ "straw_pile", 24 ],
+            [ "withered", 24 ]
+          ],
+          [
+            [ "clay_lump", 24 ],
+            [ "material_limestone", 24 ],
+            [ "material_quicklime", 24 ],
+            [ "material_soil", 120 ]
+          ],
           [ [ "nail", 24 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 30 ], [ "water_clean", 30 ] ]
@@ -113,9 +149,21 @@
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 108 ] ],
-          [ [ "cattail_stalk", 72 ], [ "dogbane", 72 ], [ "pine_bough", 72 ], [ "straw_pile", 72 ] ],
-          [ [ "clay_lump", 72 ], [ "material_limestone", 72 ], [ "material_quicklime", 72 ] ],
-          [ [ "material_sand", 180 ], [ "pebble", 180 ] ],
+          [
+            [ "cattail_stalk", 72 ],
+            [ "dogbane", 72 ],
+            [ "material_sand", 180 ],
+            [ "pebble", 180 ],
+            [ "pine_bough", 72 ],
+            [ "straw_pile", 72 ],
+            [ "withered", 72 ]
+          ],
+          [
+            [ "clay_lump", 72 ],
+            [ "material_limestone", 72 ],
+            [ "material_quicklime", 72 ],
+            [ "material_soil", 360 ]
+          ],
           [ [ "nail", 24 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 90 ], [ "water_clean", 90 ] ]
@@ -144,9 +192,21 @@
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 68 ] ],
-          [ [ "cattail_stalk", 40 ], [ "dogbane", 40 ], [ "pine_bough", 40 ], [ "straw_pile", 40 ] ],
-          [ [ "clay_lump", 40 ], [ "material_limestone", 40 ], [ "material_quicklime", 40 ] ],
-          [ [ "material_sand", 100 ], [ "pebble", 100 ] ],
+          [
+            [ "cattail_stalk", 40 ],
+            [ "dogbane", 40 ],
+            [ "material_sand", 100 ],
+            [ "pebble", 100 ],
+            [ "pine_bough", 40 ],
+            [ "straw_pile", 40 ],
+            [ "withered", 40 ]
+          ],
+          [
+            [ "clay_lump", 40 ],
+            [ "material_limestone", 40 ],
+            [ "material_quicklime", 40 ],
+            [ "material_soil", 200 ]
+          ],
           [ [ "nail", 24 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 50 ], [ "water_clean", 50 ] ]
@@ -175,9 +235,21 @@
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 116 ] ],
-          [ [ "cattail_stalk", 64 ], [ "dogbane", 64 ], [ "pine_bough", 64 ], [ "straw_pile", 64 ] ],
-          [ [ "clay_lump", 64 ], [ "material_limestone", 64 ], [ "material_quicklime", 64 ] ],
-          [ [ "material_sand", 160 ], [ "pebble", 160 ] ],
+          [
+            [ "cattail_stalk", 64 ],
+            [ "dogbane", 64 ],
+            [ "material_sand", 160 ],
+            [ "pebble", 160 ],
+            [ "pine_bough", 64 ],
+            [ "straw_pile", 64 ],
+            [ "withered", 64 ]
+          ],
+          [
+            [ "clay_lump", 64 ],
+            [ "material_limestone", 64 ],
+            [ "material_quicklime", 64 ],
+            [ "material_soil", 320 ]
+          ],
           [ [ "nail", 48 ] ],
           [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
           [ [ "water", 80 ], [ "water_clean", 80 ] ]
@@ -206,10 +278,22 @@
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 136 ] ],
-          [ [ "cattail_stalk", 72 ], [ "dogbane", 72 ], [ "pine_bough", 72 ], [ "straw_pile", 72 ] ],
-          [ [ "clay_lump", 72 ], [ "material_limestone", 72 ], [ "material_quicklime", 72 ] ],
+          [
+            [ "cattail_stalk", 72 ],
+            [ "dogbane", 72 ],
+            [ "material_sand", 180 ],
+            [ "pebble", 180 ],
+            [ "pine_bough", 72 ],
+            [ "straw_pile", 72 ],
+            [ "withered", 72 ]
+          ],
+          [
+            [ "clay_lump", 72 ],
+            [ "material_limestone", 72 ],
+            [ "material_quicklime", 72 ],
+            [ "material_soil", 360 ]
+          ],
           [ [ "hinge", 4 ] ],
-          [ [ "material_sand", 180 ], [ "pebble", 180 ] ],
           [ [ "nail", 96 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 90 ], [ "water_clean", 90 ] ],
@@ -239,9 +323,21 @@
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 68 ] ],
-          [ [ "cattail_stalk", 40 ], [ "dogbane", 40 ], [ "pine_bough", 40 ], [ "straw_pile", 40 ] ],
-          [ [ "clay_lump", 40 ], [ "material_limestone", 40 ], [ "material_quicklime", 40 ] ],
-          [ [ "material_sand", 100 ], [ "pebble", 100 ] ],
+          [
+            [ "cattail_stalk", 40 ],
+            [ "dogbane", 40 ],
+            [ "material_sand", 100 ],
+            [ "pebble", 100 ],
+            [ "pine_bough", 40 ],
+            [ "straw_pile", 40 ],
+            [ "withered", 40 ]
+          ],
+          [
+            [ "clay_lump", 40 ],
+            [ "material_limestone", 40 ],
+            [ "material_quicklime", 40 ],
+            [ "material_soil", 200 ]
+          ],
           [ [ "nail", 24 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 50 ], [ "water_clean", 50 ] ]
@@ -270,9 +366,21 @@
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 58 ] ],
-          [ [ "cattail_stalk", 32 ], [ "dogbane", 32 ], [ "pine_bough", 32 ], [ "straw_pile", 32 ] ],
-          [ [ "clay_lump", 32 ], [ "material_limestone", 32 ], [ "material_quicklime", 32 ] ],
-          [ [ "material_sand", 80 ], [ "pebble", 80 ] ],
+          [
+            [ "cattail_stalk", 32 ],
+            [ "dogbane", 32 ],
+            [ "material_sand", 80 ],
+            [ "pebble", 80 ],
+            [ "pine_bough", 32 ],
+            [ "straw_pile", 32 ],
+            [ "withered", 32 ]
+          ],
+          [
+            [ "clay_lump", 32 ],
+            [ "material_limestone", 32 ],
+            [ "material_quicklime", 32 ],
+            [ "material_soil", 160 ]
+          ],
           [ [ "nail", 24 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 40 ], [ "water_clean", 40 ] ]
@@ -301,9 +409,21 @@
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 48 ] ],
-          [ [ "cattail_stalk", 24 ], [ "dogbane", 24 ], [ "pine_bough", 24 ], [ "straw_pile", 24 ] ],
-          [ [ "clay_lump", 24 ], [ "material_limestone", 24 ], [ "material_quicklime", 24 ] ],
-          [ [ "material_sand", 60 ], [ "pebble", 60 ] ],
+          [
+            [ "cattail_stalk", 24 ],
+            [ "dogbane", 24 ],
+            [ "material_sand", 60 ],
+            [ "pebble", 60 ],
+            [ "pine_bough", 24 ],
+            [ "straw_pile", 24 ],
+            [ "withered", 24 ]
+          ],
+          [
+            [ "clay_lump", 24 ],
+            [ "material_limestone", 24 ],
+            [ "material_quicklime", 24 ],
+            [ "material_soil", 120 ]
+          ],
           [ [ "nail", 24 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 30 ], [ "water_clean", 30 ] ]

--- a/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_log.json
@@ -18,7 +18,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER" } ] ],
-        "components": [ [ [ "2x4", 144 ], [ "stick", 72 ] ], [ [ "log", 48 ] ] ]
+        "components": [ [ [ "2x4", 72 ], [ "stick", 72 ] ], [ [ "log", 48 ] ] ]
       }
     }
   },
@@ -41,7 +41,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER" } ] ],
-        "components": [ [ [ "2x4", 144 ], [ "stick", 72 ] ], [ [ "log", 48 ] ] ]
+        "components": [ [ [ "2x4", 72 ], [ "stick", 72 ] ], [ [ "log", 48 ] ] ]
       }
     }
   },
@@ -64,7 +64,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
-        "components": [ [ [ "log", 18 ] ], [ [ "2x4", 48 ], [ "stick", 24 ] ], [ [ "glass_sheet", 1 ] ], [ [ "nail", 30 ] ] ]
+        "components": [ [ [ "log", 18 ] ], [ [ "2x4", 24 ], [ "stick", 24 ] ], [ [ "glass_sheet", 1 ] ], [ [ "nail", 30 ] ] ]
       }
     }
   },
@@ -87,7 +87,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
-        "components": [ [ [ "log", 18 ] ], [ [ "2x4", 48 ], [ "stick", 24 ] ], [ [ "glass_sheet", 1 ] ], [ [ "nail", 30 ] ] ]
+        "components": [ [ [ "log", 18 ] ], [ [ "2x4", 24 ], [ "stick", 24 ] ], [ [ "glass_sheet", 1 ] ], [ [ "nail", 30 ] ] ]
       }
     }
   },
@@ -110,7 +110,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
-        "components": [ [ [ "log", 18 ] ], [ [ "2x4", 48 ], [ "stick", 24 ] ], [ [ "glass_sheet", 1 ] ], [ [ "nail", 30 ] ] ]
+        "components": [ [ [ "log", 18 ] ], [ [ "2x4", 24 ], [ "stick", 24 ] ], [ [ "glass_sheet", 1 ] ], [ [ "nail", 30 ] ] ]
       }
     }
   },
@@ -133,7 +133,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
-        "components": [ [ [ "log", 18 ] ], [ [ "2x4", 48 ], [ "stick", 24 ] ], [ [ "glass_sheet", 1 ] ], [ [ "nail", 30 ] ] ]
+        "components": [ [ [ "log", 18 ] ], [ [ "2x4", 24 ], [ "stick", 24 ] ], [ [ "glass_sheet", 1 ] ], [ [ "nail", 30 ] ] ]
       }
     }
   },
@@ -157,7 +157,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 106 ] ],
+          [ [ "2x4", 82 ] ],
           [ [ "glass_sheet", 2 ] ],
           [ [ "hinge", 4 ] ],
           [ [ "log", 16 ] ],
@@ -187,7 +187,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 106 ] ],
+          [ [ "2x4", 82 ] ],
           [ [ "glass_sheet", 2 ] ],
           [ [ "hinge", 4 ] ],
           [ [ "log", 16 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_rammed_earth.json
@@ -13,19 +13,19 @@
     "blueprint_provides": [ { "id": "fbms_east" } ],
     "blueprint_excludes": [ { "id": "fbms_east" } ],
     "blueprint_needs": {
-      "time": "4 d 3 h",
+      "time": "3 d 3 h",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 48 ], [ "stick", 48 ], [ "stick_long", 24 ] ],
           [ [ "birchbark", 144 ], [ "pine_bough", 144 ] ],
           [ [ "concrete", 12 ], [ "material_quicklime", 240 ], [ "material_sand", 240 ] ],
           [ [ "log", 24 ] ],
-          [ [ "material_soil", 3360 ] ],
+          [ [ "material_soil", 1680 ] ],
           [ [ "pointy_stick", 24 ], [ "spear_wood", 24 ] ],
-          [ [ "water", 1200 ], [ "water_clean", 1200 ] ]
+          [ [ "water", 600 ], [ "water_clean", 600 ] ]
         ]
       }
     }
@@ -44,19 +44,19 @@
     "blueprint_provides": [ { "id": "fbms_west" } ],
     "blueprint_excludes": [ { "id": "fbms_west" } ],
     "blueprint_needs": {
-      "time": "4 d 3 h",
+      "time": "3 d 3 h",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 48 ], [ "stick", 48 ], [ "stick_long", 24 ] ],
           [ [ "birchbark", 144 ], [ "pine_bough", 144 ] ],
           [ [ "concrete", 12 ], [ "material_quicklime", 240 ], [ "material_sand", 240 ] ],
           [ [ "log", 24 ] ],
-          [ [ "material_soil", 3360 ] ],
+          [ [ "material_soil", 1680 ] ],
           [ [ "pointy_stick", 24 ], [ "spear_wood", 24 ] ],
-          [ [ "water", 1200 ], [ "water_clean", 1200 ] ]
+          [ [ "water", 600 ], [ "water_clean", 600 ] ]
         ]
       }
     }
@@ -75,20 +75,20 @@
     "blueprint_provides": [ { "id": "fbms_northwest" } ],
     "blueprint_excludes": [ { "id": "fbms_northwest" } ],
     "blueprint_needs": {
-      "time": "1 d 10 h 15 m",
+      "time": "1 d 2 h 15 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "log", 10 ] ],
           [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
-          [ [ "material_soil", 1120 ] ],
+          [ [ "material_soil", 560 ] ],
           [ [ "nail", 30 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
-          [ [ "water", 400 ], [ "water_clean", 400 ] ]
+          [ [ "water", 200 ], [ "water_clean", 200 ] ]
         ]
       }
     }
@@ -107,20 +107,20 @@
     "blueprint_provides": [ { "id": "fbms_southwest" } ],
     "blueprint_excludes": [ { "id": "fbms_southwest" } ],
     "blueprint_needs": {
-      "time": "1 d 10 h 15 m",
+      "time": "1 d 2 h 15 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "log", 10 ] ],
           [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
-          [ [ "material_soil", 1120 ] ],
+          [ [ "material_soil", 560 ] ],
           [ [ "nail", 30 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
-          [ [ "water", 400 ], [ "water_clean", 400 ] ]
+          [ [ "water", 200 ], [ "water_clean", 200 ] ]
         ]
       }
     }
@@ -139,20 +139,20 @@
     "blueprint_provides": [ { "id": "fbms_northeast" } ],
     "blueprint_excludes": [ { "id": "fbms_northeast" } ],
     "blueprint_needs": {
-      "time": "1 d 10 h 15 m",
+      "time": "1 d 2 h 15 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "log", 10 ] ],
           [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
-          [ [ "material_soil", 1120 ] ],
+          [ [ "material_soil", 560 ] ],
           [ [ "nail", 30 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
-          [ [ "water", 400 ], [ "water_clean", 400 ] ]
+          [ [ "water", 200 ], [ "water_clean", 200 ] ]
         ]
       }
     }
@@ -171,20 +171,20 @@
     "blueprint_provides": [ { "id": "fbms_southeast" } ],
     "blueprint_excludes": [ { "id": "fbms_southeast" } ],
     "blueprint_needs": {
-      "time": "1 d 10 h 15 m",
+      "time": "1 d 2 h 15 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "log", 10 ] ],
           [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
-          [ [ "material_soil", 1120 ] ],
+          [ [ "material_soil", 560 ] ],
           [ [ "nail", 30 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
-          [ [ "water", 400 ], [ "water_clean", 400 ] ]
+          [ [ "water", 200 ], [ "water_clean", 200 ] ]
         ]
       }
     }
@@ -203,21 +203,21 @@
     "blueprint_provides": [ { "id": "fbms_south" } ],
     "blueprint_excludes": [ { "id": "fbms_south" } ],
     "blueprint_needs": {
-      "time": "3 d 6 h 30 m",
+      "time": "2 d 22 h 30 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 162 ] ],
+          [ [ "birchbark", 288 ], [ "pine_bough", 288 ] ],
+          [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
+          [ [ "log", 48 ] ],
+          [ [ "material_soil", 1360 ] ],
           [ [ "nail", 108 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
-          [ [ "material_soil", 1920 ] ],
-          [ [ "water", 400 ], [ "water_clean", 400 ] ],
-          [ [ "material_sand", 80 ], [ "material_quicklime", 80 ], [ "concrete", 4 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
-          [ [ "log", 48 ] ],
-          [ [ "birchbark", 288 ], [ "pine_bough", 288 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 200 ], [ "water_clean", 200 ] ]
         ]
       }
     }
@@ -236,21 +236,21 @@
     "blueprint_provides": [ { "id": "fbms_north" } ],
     "blueprint_excludes": [ { "id": "fbms_north" } ],
     "blueprint_needs": {
-      "time": "3 d 6 h 30 m",
+      "time": "2 d 22 h 30 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 162 ] ],
+          [ [ "birchbark", 288 ], [ "pine_bough", 288 ] ],
+          [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
+          [ [ "log", 48 ] ],
+          [ [ "material_soil", 1360 ] ],
           [ [ "nail", 108 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
-          [ [ "material_soil", 1920 ] ],
-          [ [ "water", 400 ], [ "water_clean", 400 ] ],
-          [ [ "material_sand", 80 ], [ "material_quicklime", 80 ], [ "concrete", 4 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
-          [ [ "log", 48 ] ],
-          [ [ "birchbark", 288 ], [ "pine_bough", 288 ] ]
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 200 ], [ "water_clean", 200 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_rammed_earth.json
@@ -19,13 +19,13 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "pointy_stick", 24 ], [ "spear_wood", 24 ] ],
-          [ [ "material_soil", 3360 ] ],
-          [ [ "water", 1200 ], [ "water_clean", 1200 ] ],
-          [ [ "material_sand", 240 ], [ "material_quicklime", 240 ], [ "concrete", 12 ] ],
+          [ [ "2x4", 48 ], [ "stick", 48 ], [ "stick_long", 24 ] ],
+          [ [ "birchbark", 144 ], [ "pine_bough", 144 ] ],
+          [ [ "concrete", 12 ], [ "material_quicklime", 240 ], [ "material_sand", 240 ] ],
           [ [ "log", 24 ] ],
-          [ [ "stick", 48 ], [ "2x4", 48 ] ],
-          [ [ "birchbark", 144 ], [ "pine_bough", 144 ] ]
+          [ [ "material_soil", 3360 ] ],
+          [ [ "pointy_stick", 24 ], [ "spear_wood", 24 ] ],
+          [ [ "water", 1200 ], [ "water_clean", 1200 ] ]
         ]
       }
     }
@@ -50,13 +50,13 @@
         "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "pointy_stick", 24 ], [ "spear_wood", 24 ] ],
-          [ [ "material_soil", 3360 ] ],
-          [ [ "water", 1200 ], [ "water_clean", 1200 ] ],
-          [ [ "material_sand", 240 ], [ "material_quicklime", 240 ], [ "concrete", 12 ] ],
+          [ [ "2x4", 48 ], [ "stick", 48 ], [ "stick_long", 24 ] ],
+          [ [ "birchbark", 144 ], [ "pine_bough", 144 ] ],
+          [ [ "concrete", 12 ], [ "material_quicklime", 240 ], [ "material_sand", 240 ] ],
           [ [ "log", 24 ] ],
-          [ [ "stick", 48 ], [ "2x4", 48 ] ],
-          [ [ "birchbark", 144 ], [ "pine_bough", 144 ] ]
+          [ [ "material_soil", 3360 ] ],
+          [ [ "pointy_stick", 24 ], [ "spear_wood", 24 ] ],
+          [ [ "water", 1200 ], [ "water_clean", 1200 ] ]
         ]
       }
     }
@@ -82,7 +82,7 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "log", 10 ] ],
-          [ [ "2x4", 16 ], [ "stick", 16 ] ],
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
           [ [ "material_soil", 1120 ] ],
@@ -114,7 +114,7 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "log", 10 ] ],
-          [ [ "2x4", 16 ], [ "stick", 16 ] ],
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
           [ [ "material_soil", 1120 ] ],
@@ -146,7 +146,7 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "log", 10 ] ],
-          [ [ "2x4", 16 ], [ "stick", 16 ] ],
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
           [ [ "material_soil", 1120 ] ],
@@ -178,7 +178,7 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "log", 10 ] ],
-          [ [ "2x4", 16 ], [ "stick", 16 ] ],
+          [ [ "2x4", 16 ], [ "stick", 16 ], [ "stick_long", 8 ] ],
           [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
           [ [ "material_soil", 1120 ] ],
@@ -275,10 +275,10 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
+          [ [ "2x4", 240 ], [ "stick", 240 ], [ "stick_long", 120 ] ],
+          [ [ "birchbark", 720 ], [ "pine_bough", 720 ] ],
           [ [ "log", 120 ] ],
-          [ [ "stick", 240 ], [ "2x4", 240 ] ],
-          [ [ "material_soil", 2400 ] ],
-          [ [ "birchbark", 720 ], [ "pine_bough", 720 ] ]
+          [ [ "material_soil", 2400 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_rock.json
+++ b/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_rock.json
@@ -18,7 +18,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
-        "components": [ [ [ "mortar_build", 24 ] ], [ [ "pebble", 600 ] ], [ [ "rock", 288 ] ] ]
+        "components": [ [ [ "mortar_adobe", 24 ], [ "mortar_build", 24 ] ], [ [ "pebble", 600 ] ], [ [ "rock", 288 ] ] ]
       }
     }
   },
@@ -41,7 +41,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
-        "components": [ [ [ "mortar_build", 24 ] ], [ [ "pebble", 600 ] ], [ [ "rock", 288 ] ] ]
+        "components": [ [ [ "mortar_adobe", 24 ], [ "mortar_build", 24 ] ], [ [ "pebble", 600 ] ], [ [ "rock", 288 ] ] ]
       }
     }
   },
@@ -67,7 +67,7 @@
         "components": [
           [ [ "2x4", 15 ], [ "log", 2 ] ],
           [ [ "glass_sheet", 1 ] ],
-          [ [ "mortar_build", 8 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
           [ [ "nail", 30 ] ],
           [ [ "pebble", 200 ] ],
           [ [ "rock", 96 ] ]
@@ -97,7 +97,7 @@
         "components": [
           [ [ "2x4", 15 ], [ "log", 2 ] ],
           [ [ "glass_sheet", 1 ] ],
-          [ [ "mortar_build", 8 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
           [ [ "nail", 30 ] ],
           [ [ "pebble", 200 ] ],
           [ [ "rock", 96 ] ]
@@ -127,7 +127,7 @@
         "components": [
           [ [ "2x4", 15 ], [ "log", 2 ] ],
           [ [ "glass_sheet", 1 ] ],
-          [ [ "mortar_build", 8 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
           [ [ "nail", 30 ] ],
           [ [ "pebble", 200 ] ],
           [ [ "rock", 96 ] ]
@@ -157,7 +157,7 @@
         "components": [
           [ [ "2x4", 15 ], [ "log", 2 ] ],
           [ [ "glass_sheet", 1 ] ],
-          [ [ "mortar_build", 8 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
           [ [ "nail", 30 ] ],
           [ [ "pebble", 200 ] ],
           [ [ "rock", 96 ] ]
@@ -188,7 +188,7 @@
           [ [ "2x4", 58 ] ],
           [ [ "glass_sheet", 2 ] ],
           [ [ "hinge", 4 ] ],
-          [ [ "mortar_build", 8 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
           [ [ "nail", 132 ] ],
           [ [ "pebble", 200 ] ],
           [ [ "rock", 96 ] ],
@@ -220,7 +220,7 @@
           [ [ "2x4", 58 ] ],
           [ [ "glass_sheet", 2 ] ],
           [ [ "hinge", 4 ] ],
-          [ [ "mortar_build", 8 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
           [ [ "nail", 132 ] ],
           [ [ "pebble", 200 ] ],
           [ [ "rock", 96 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_wad.json
@@ -14,19 +14,25 @@
     "blueprint_excludes": [ { "id": "fbms_east" } ],
     "blueprint_needs": {
       "time": "1 d 20 h",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 168 ], [ "stick", 288 ] ],
-          [ [ "material_quicklime", 96 ], [ "material_limestone", 96 ], [ "clay_lump", 96 ] ],
-          [ [ "pebble", 240 ], [ "material_sand", 240 ] ],
-          [ [ "straw_pile", 96 ], [ "cattail_stalk", 96 ], [ "dogbane", 96 ], [ "pine_bough", 96 ] ],
-          [ [ "water", 120 ], [ "water_clean", 120 ] ],
+          [ [ "2x4", 168 ], [ "stick", 168 ] ],
+          [ [ "birchbark", 144 ], [ "pine_bough", 144 ] ],
+          [
+            [ "cattail_stalk", 96 ],
+            [ "dogbane", 96 ],
+            [ "material_sand", 240 ],
+            [ "pebble", 240 ],
+            [ "pine_bough", 96 ],
+            [ "straw_pile", 96 ],
+            [ "withered", 96 ]
+          ],
+          [ [ "material_soil", 960 ] ],
           [ [ "log", 24 ] ],
-          [ [ "material_soil", 480 ] ],
-          [ [ "birchbark", 144 ], [ "pine_bough", 144 ] ]
+          [ [ "water", 120 ], [ "water_clean", 120 ] ]
         ]
       }
     }
@@ -46,19 +52,25 @@
     "blueprint_excludes": [ { "id": "fbms_west" } ],
     "blueprint_needs": {
       "time": "1 d 20 h",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 168 ], [ "stick", 288 ] ],
-          [ [ "material_quicklime", 96 ], [ "material_limestone", 96 ], [ "clay_lump", 96 ] ],
-          [ [ "pebble", 240 ], [ "material_sand", 240 ] ],
-          [ [ "straw_pile", 96 ], [ "cattail_stalk", 96 ], [ "dogbane", 96 ], [ "pine_bough", 96 ] ],
-          [ [ "water", 120 ], [ "water_clean", 120 ] ],
+          [ [ "2x4", 168 ], [ "stick", 168 ] ],
+          [ [ "birchbark", 144 ], [ "pine_bough", 144 ] ],
+          [
+            [ "cattail_stalk", 96 ],
+            [ "dogbane", 96 ],
+            [ "material_sand", 240 ],
+            [ "pebble", 240 ],
+            [ "pine_bough", 96 ],
+            [ "straw_pile", 96 ],
+            [ "withered", 96 ]
+          ],
+          [ [ "material_soil", 960 ] ],
           [ [ "log", 24 ] ],
-          [ [ "material_soil", 480 ] ],
-          [ [ "birchbark", 144 ], [ "pine_bough", 144 ] ]
+          [ [ "water", 120 ], [ "water_clean", 120 ] ]
         ]
       }
     }
@@ -78,19 +90,25 @@
     "blueprint_excludes": [ { "id": "fbms_northwest" } ],
     "blueprint_needs": {
       "time": "15 h 30 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 61 ], [ "stick", 106 ] ],
-          [ [ "material_quicklime", 36 ], [ "material_limestone", 36 ], [ "clay_lump", 36 ] ],
-          [ [ "pebble", 90 ], [ "material_sand", 90 ] ],
-          [ [ "straw_pile", 36 ], [ "cattail_stalk", 36 ], [ "dogbane", 36 ], [ "pine_bough", 36 ] ],
-          [ [ "water", 45 ], [ "water_clean", 45 ] ],
+          [ [ "2x4", 61 ], [ "stick", 61 ] ],
+          [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
+          [
+            [ "cattail_stalk", 36 ],
+            [ "dogbane", 36 ],
+            [ "material_sand", 90 ],
+            [ "pebble", 90 ],
+            [ "pine_bough", 36 ],
+            [ "straw_pile", 36 ],
+            [ "withered", 36 ]
+          ],
+          [ [ "material_soil", 340 ] ],
           [ [ "log", 8 ] ],
-          [ [ "material_soil", 160 ] ],
-          [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ]
+          [ [ "water", 45 ], [ "water_clean", 45 ] ]
         ]
       }
     }
@@ -110,19 +128,25 @@
     "blueprint_excludes": [ { "id": "fbms_southwest" } ],
     "blueprint_needs": {
       "time": "15 h 30 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 61 ], [ "stick", 106 ] ],
-          [ [ "material_quicklime", 36 ], [ "material_limestone", 36 ], [ "clay_lump", 36 ] ],
-          [ [ "pebble", 90 ], [ "material_sand", 90 ] ],
-          [ [ "straw_pile", 36 ], [ "cattail_stalk", 36 ], [ "dogbane", 36 ], [ "pine_bough", 36 ] ],
-          [ [ "water", 45 ], [ "water_clean", 45 ] ],
+          [ [ "2x4", 61 ], [ "stick", 61 ] ],
+          [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
+          [
+            [ "cattail_stalk", 36 ],
+            [ "dogbane", 36 ],
+            [ "material_sand", 90 ],
+            [ "pebble", 90 ],
+            [ "pine_bough", 36 ],
+            [ "straw_pile", 36 ],
+            [ "withered", 36 ]
+          ],
+          [ [ "material_soil", 340 ] ],
           [ [ "log", 8 ] ],
-          [ [ "material_soil", 160 ] ],
-          [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ]
+          [ [ "water", 45 ], [ "water_clean", 45 ] ]
         ]
       }
     }
@@ -142,19 +166,25 @@
     "blueprint_excludes": [ { "id": "fbms_northeast" } ],
     "blueprint_needs": {
       "time": "15 h 30 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 61 ], [ "stick", 106 ] ],
-          [ [ "material_quicklime", 36 ], [ "material_limestone", 36 ], [ "clay_lump", 36 ] ],
-          [ [ "pebble", 90 ], [ "material_sand", 90 ] ],
-          [ [ "straw_pile", 36 ], [ "cattail_stalk", 36 ], [ "dogbane", 36 ], [ "pine_bough", 36 ] ],
-          [ [ "water", 45 ], [ "water_clean", 45 ] ],
+          [ [ "2x4", 61 ], [ "stick", 61 ] ],
+          [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
+          [
+            [ "cattail_stalk", 36 ],
+            [ "dogbane", 36 ],
+            [ "material_sand", 90 ],
+            [ "pebble", 90 ],
+            [ "pine_bough", 36 ],
+            [ "straw_pile", 36 ],
+            [ "withered", 36 ]
+          ],
+          [ [ "material_soil", 340 ] ],
           [ [ "log", 8 ] ],
-          [ [ "material_soil", 160 ] ],
-          [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ]
+          [ [ "water", 45 ], [ "water_clean", 45 ] ]
         ]
       }
     }
@@ -174,19 +204,25 @@
     "blueprint_excludes": [ { "id": "fbms_southeast" } ],
     "blueprint_needs": {
       "time": "15 h 30 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 61 ], [ "stick", 106 ] ],
-          [ [ "material_quicklime", 36 ], [ "material_limestone", 36 ], [ "clay_lump", 36 ] ],
-          [ [ "pebble", 90 ], [ "material_sand", 90 ] ],
-          [ [ "straw_pile", 36 ], [ "cattail_stalk", 36 ], [ "dogbane", 36 ], [ "pine_bough", 36 ] ],
-          [ [ "water", 45 ], [ "water_clean", 45 ] ],
+          [ [ "2x4", 61 ], [ "stick", 61 ] ],
+          [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ],
+          [
+            [ "cattail_stalk", 36 ],
+            [ "dogbane", 36 ],
+            [ "material_sand", 90 ],
+            [ "pebble", 90 ],
+            [ "pine_bough", 36 ],
+            [ "straw_pile", 36 ],
+            [ "withered", 36 ]
+          ],
+          [ [ "material_soil", 340 ] ],
           [ [ "log", 8 ] ],
-          [ [ "material_soil", 160 ] ],
-          [ [ "birchbark", 48 ], [ "pine_bough", 48 ] ]
+          [ [ "water", 45 ], [ "water_clean", 45 ] ]
         ]
       }
     }
@@ -206,21 +242,27 @@
     "blueprint_excludes": [ { "id": "fbms_south" } ],
     "blueprint_needs": {
       "time": "2 d 11 h 20 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 182 ] ],
-          [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 40 ], [ "material_limestone", 40 ], [ "clay_lump", 40 ] ],
-          [ [ "pebble", 100 ], [ "material_sand", 100 ] ],
-          [ [ "straw_pile", 40 ], [ "cattail_stalk", 40 ], [ "dogbane", 40 ], [ "pine_bough", 40 ] ],
-          [ [ "water", 50 ], [ "water_clean", 50 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "birchbark", 288 ], [ "pine_bough", 288 ] ],
+          [
+            [ "cattail_stalk", 40 ],
+            [ "dogbane", 40 ],
+            [ "material_sand", 100 ],
+            [ "pebble", 100 ],
+            [ "pine_bough", 40 ],
+            [ "straw_pile", 40 ],
+            [ "withered", 40 ]
+          ],
+          [ [ "material_soil", 1160 ] ],
           [ [ "log", 48 ] ],
-          [ [ "material_soil", 960 ] ],
-          [ [ "birchbark", 288 ], [ "pine_bough", 288 ] ]
+          [ [ "nail", 48 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 50 ], [ "water_clean", 50 ] ]
         ]
       }
     }
@@ -240,21 +282,27 @@
     "blueprint_excludes": [ { "id": "fbms_north" } ],
     "blueprint_needs": {
       "time": "2 d 11 h 20 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 182 ] ],
-          [ [ "nail", 48 ] ],
-          [ [ "material_quicklime", 40 ], [ "material_limestone", 40 ], [ "clay_lump", 40 ] ],
-          [ [ "pebble", 100 ], [ "material_sand", 100 ] ],
-          [ [ "straw_pile", 40 ], [ "cattail_stalk", 40 ], [ "dogbane", 40 ], [ "pine_bough", 40 ] ],
-          [ [ "water", 50 ], [ "water_clean", 50 ] ],
-          [ [ "rope_makeshift_6", 4 ], [ "rope_6", 4 ] ],
+          [ [ "birchbark", 288 ], [ "pine_bough", 288 ] ],
+          [
+            [ "cattail_stalk", 40 ],
+            [ "dogbane", 40 ],
+            [ "material_sand", 100 ],
+            [ "pebble", 100 ],
+            [ "pine_bough", 40 ],
+            [ "straw_pile", 40 ],
+            [ "withered", 40 ]
+          ],
+          [ [ "material_soil", 1160 ] ],
           [ [ "log", 48 ] ],
-          [ [ "material_soil", 960 ] ],
-          [ [ "birchbark", 288 ], [ "pine_bough", 288 ] ]
+          [ [ "nail", 48 ] ],
+          [ [ "rope_6", 4 ], [ "rope_makeshift_6", 4 ] ],
+          [ [ "water", 50 ], [ "water_clean", 50 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_storehouse/recipe_modular_storehouse_wad.json
@@ -327,10 +327,10 @@
         "tools": [  ],
         "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
         "components": [
+          [ [ "2x4", 240 ], [ "stick", 240 ], [ "stick_long", 120 ] ],
+          [ [ "birchbark", 720 ], [ "pine_bough", 720 ] ],
           [ [ "log", 120 ] ],
-          [ [ "stick", 240 ], [ "2x4", 240 ] ],
-          [ [ "material_soil", 2400 ] ],
-          [ [ "birchbark", 720 ], [ "pine_bough", 720 ] ]
+          [ [ "material_soil", 2400 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop.rock.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop.rock.json
@@ -21,7 +21,7 @@
         "components": [
           [ [ "2x4", 230 ] ],
           [ [ "glass_sheet", 2 ] ],
-          [ [ "mortar_build", 18 ] ],
+          [ [ "mortar_adobe", 18 ], [ "mortar_build", 18 ] ],
           [ [ "nail", 560 ] ],
           [ [ "pebble", 450 ] ],
           [ [ "rock", 216 ] ],
@@ -51,13 +51,13 @@
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 131 ] ],
-          [ [ "nail", 394 ] ],
-          [ [ "wood_panel", 23 ] ],
-          [ [ "hinge", 2 ] ],
           [ [ "glass_sheet", 1 ] ],
-          [ [ "rock", 144 ] ],
+          [ [ "hinge", 2 ] ],
+          [ [ "mortar_adobe", 12 ], [ "mortar_build", 12 ] ],
+          [ [ "nail", 394 ] ],
           [ [ "pebble", 300 ] ],
-          [ [ "mortar_build", 12 ] ]
+          [ [ "rock", 144 ] ],
+          [ [ "wood_panel", 23 ] ]
         ]
       }
     }
@@ -80,13 +80,13 @@
       "skills": [ [ "fabrication", 6 ] ],
       "inline": {
         "tools": [  ],
-        "qualities": [ [ { "id": "SAW_W", "level": 2 } ], [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 281 ] ],
           [ [ "glass_sheet", 1 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "material_soil", 2 ] ],
-          [ [ "mortar_build", 8 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
           [ [ "nail", 746 ] ],
           [ [ "pebble", 200 ] ],
           [ [ "rock", 136 ] ],
@@ -118,7 +118,7 @@
           [ [ "2x4", 152 ] ],
           [ [ "blanket", 1 ], [ "down_blanket", 1 ], [ "fur_blanket", 1 ] ],
           [ [ "glass_sheet", 2 ] ],
-          [ [ "mortar_build", 8 ] ],
+          [ [ "mortar_adobe", 8 ], [ "mortar_build", 8 ] ],
           [ [ "nail", 372 ] ],
           [ [ "pebble", 200 ] ],
           [ [ "rock", 96 ] ],
@@ -146,7 +146,7 @@
       "time": "1 d 16 h 10 m",
       "skills": [ [ "fabrication", 6 ] ],
       "inline": {
-        "tools": [ [ [ "oxy_torch", 20 ], [ "toolset", 150 ], [ "welder", 100 ], [ "welder_crude", 150 ] ] ],
+        "tools": [ [ [ "fake_gridwelder", 100 ], [ "oxy_torch", 20 ], [ "toolset", 150 ], [ "welder", 100 ], [ "welder_crude", 150 ] ] ],
         "qualities": [
           [ { "id": "DIG", "level": 2 } ],
           [ { "id": "GLARE", "level": 2 } ],
@@ -155,7 +155,7 @@
         ],
         "components": [
           [ [ "2x4", 132 ] ],
-          [ [ "mortar_build", 7 ] ],
+          [ [ "mortar_adobe", 7 ], [ "mortar_build", 7 ] ],
           [ [ "nail", 380 ] ],
           [ [ "pebble", 150 ] ],
           [ [ "pipe", 16 ] ],
@@ -191,7 +191,7 @@
           [ [ "2x4", 166 ] ],
           [ [ "glass_sheet", 2 ] ],
           [ [ "hinge", 2 ] ],
-          [ [ "mortar_build", 22 ] ],
+          [ [ "mortar_adobe", 22 ], [ "mortar_build", 22 ] ],
           [ [ "nail", 526 ] ],
           [ [ "pebble", 550 ] ],
           [ [ "rock", 264 ] ],
@@ -222,17 +222,17 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "metal_tank", 2 ] ],
-          [ [ "water_faucet", 2 ] ],
+          [ [ "2x4", 352 ] ],
           [ [ "anvil", 1 ] ],
           [ [ "chain", 4 ] ],
+          [ [ "metal_tank", 2 ] ],
+          [ [ "mortar_adobe", 20 ], [ "mortar_build", 20 ] ],
+          [ [ "nail", 880 ] ],
+          [ [ "pebble", 500 ] ],
           [ [ "pipe", 3 ] ],
           [ [ "rock", 240 ] ],
-          [ [ "pebble", 500 ] ],
-          [ [ "mortar_build", 20 ] ],
-          [ [ "wood_panel", 44 ] ],
-          [ [ "2x4", 352 ] ],
-          [ [ "nail", 880 ] ]
+          [ [ "water_faucet", 2 ] ],
+          [ [ "wood_panel", 44 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_log.json
@@ -142,7 +142,7 @@
         ],
         "components": [
           [ [ "2x4", 150 ] ],
-          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_build", 1 ] ],
+          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_adobe", 1 ], [ "mortar_build", 1 ] ],
           [ [ "log", 12 ] ],
           [ [ "nail", 380 ] ],
           [ [ "pipe", 16 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_log.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_log.json
@@ -18,7 +18,7 @@
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
-        "components": [ [ [ "2x4", 338 ] ], [ [ "glass_sheet", 2 ] ], [ [ "log", 36 ] ], [ [ "nail", 560 ] ], [ [ "wood_panel", 25 ] ] ]
+        "components": [ [ [ "2x4", 284 ] ], [ [ "glass_sheet", 2 ] ], [ [ "log", 36 ] ], [ [ "nail", 560 ] ], [ [ "wood_panel", 25 ] ] ]
       }
     }
   },
@@ -42,7 +42,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 203 ] ],
+          [ [ "2x4", 167 ] ],
           [ [ "glass_sheet", 1 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "log", 24 ] ],
@@ -72,7 +72,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 329 ] ],
+          [ [ "2x4", 305 ] ],
           [ [ "glass_sheet", 1 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "log", 16 ] ],
@@ -104,7 +104,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 200 ] ],
+          [ [ "2x4", 176 ] ],
           [ [ "blanket", 1 ], [ "down_blanket", 1 ], [ "fur_blanket", 1 ] ],
           [ [ "glass_sheet", 2 ] ],
           [ [ "log", 16 ] ],
@@ -141,7 +141,7 @@
           [ { "id": "SAW_W", "level": 2 } ]
         ],
         "components": [
-          [ [ "2x4", 168 ] ],
+          [ [ "2x4", 150 ] ],
           [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_build", 1 ] ],
           [ [ "log", 12 ] ],
           [ [ "nail", 380 ] ],
@@ -175,7 +175,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 298 ] ],
+          [ [ "2x4", 232 ] ],
           [ [ "glass_sheet", 2 ] ],
           [ [ "hinge", 2 ] ],
           [ [ "log", 44 ] ],
@@ -207,7 +207,7 @@
         "tools": [  ],
         "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
-          [ [ "2x4", 472 ] ],
+          [ [ "2x4", 412 ] ],
           [ [ "anvil", 1 ] ],
           [ [ "chain", 4 ] ],
           [ [ "log", 40 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_metal.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_metal.json
@@ -180,7 +180,7 @@
         ],
         "components": [
           [ [ "2x4", 120 ] ],
-          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_build", 1 ] ],
+          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_adobe", 1 ], [ "mortar_build", 1 ] ],
           [ [ "nail", 300 ] ],
           [ [ "pipe", 40 ] ],
           [ [ "rock", 40 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_migo_resin.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_migo_resin.json
@@ -119,12 +119,12 @@
       "time": "1 d 7 h 10 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "oxy_torch", 20 ], [ "toolset", 150 ], [ "welder", 100 ], [ "welder_crude", 150 ] ] ],
+        "tools": [ [ [ "fake_gridwelder", 100 ], [ "oxy_torch", 20 ], [ "toolset", 150 ], [ "welder", 100 ], [ "welder_crude", 150 ] ] ],
         "qualities": [ [ { "id": "GLARE", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W" } ], [ { "id": "SMOOTH" } ] ],
         "components": [
           [ [ "2x4", 12 ] ],
           [ [ "alien_pod_resin", 36 ] ],
-          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_build", 1 ] ],
+          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_adobe", 1 ], [ "mortar_build", 1 ] ],
           [ [ "nail", 80 ] ],
           [ [ "pipe", 16 ] ],
           [ [ "rock", 40 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_rammed_earth.json
@@ -157,9 +157,9 @@
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
         "tools": [
+          [ [ "fake_gridwelder", 100 ], [ "oxy_torch", 20 ], [ "toolset", 150 ], [ "welder", 100 ], [ "welder_crude", 150 ] ],
           [ [ "frame_wood_light", -1 ] ],
-          [ [ "log", -1 ] ],
-          [ [ "oxy_torch", 20 ], [ "toolset", 150 ], [ "welder", 100 ], [ "welder_crude", 150 ] ]
+          [ [ "log", -1 ] ]
         ],
         "qualities": [
           [ { "id": "DIG", "level": 2 } ],
@@ -169,7 +169,7 @@
         ],
         "components": [
           [ [ "2x4", 132 ] ],
-          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_build", 1 ] ],
+          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_adobe", 1 ], [ "mortar_build", 1 ] ],
           [ [ "concrete", 3 ], [ "material_quicklime", 60 ], [ "material_sand", 60 ] ],
           [ [ "material_soil", 720 ] ],
           [ [ "nail", 380 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_rammed_earth.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_rammed_earth.json
@@ -13,18 +13,23 @@
     "blueprint_provides": [ { "id": "fbmw_northeast" } ],
     "blueprint_excludes": [ { "id": "fbmw_northeast" } ],
     "blueprint_needs": {
-      "time": "3 d 11 h 45 m",
+      "time": "2 d 17 h 45 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [
+          [ { "id": "DIG", "level": 2 } ],
+          [ { "id": "HAMMER", "level": 2 } ],
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
+        ],
         "components": [
           [ [ "2x4", 230 ] ],
           [ [ "concrete", 9 ], [ "material_quicklime", 180 ], [ "material_sand", 180 ] ],
-          [ [ "material_soil", 2160 ] ],
+          [ [ "material_soil", 900 ] ],
           [ [ "nail", 560 ] ],
           [ [ "pointy_stick", 18 ], [ "spear_wood", 18 ] ],
-          [ [ "water", 900 ], [ "water_clean", 900 ] ],
+          [ [ "water", 450 ], [ "water_clean", 450 ] ],
           [ [ "wood_panel", 25 ] ]
         ]
       }
@@ -44,24 +49,25 @@
     "blueprint_provides": [ { "id": "fbmw_north" } ],
     "blueprint_excludes": [ { "id": "fbmw_north" } ],
     "blueprint_needs": {
-      "time": "2 d 6 h 40 m",
+      "time": "1 d 18 h 40 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
         "qualities": [
           [ { "id": "CUT" } ],
           [ { "id": "DIG", "level": 2 } ],
           [ { "id": "HAMMER", "level": 2 } ],
-          [ { "id": "SAW_W", "level": 2 } ]
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
         ],
         "components": [
           [ [ "2x4", 135 ] ],
           [ [ "concrete", 6 ], [ "material_quicklime", 120 ], [ "material_sand", 120 ] ],
-          [ [ "material_soil", 1440 ] ],
+          [ [ "material_soil", 600 ] ],
           [ [ "nail", 382 ] ],
           [ [ "pointy_stick", 12 ], [ "spear_wood", 12 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
-          [ [ "water", 600 ], [ "water_clean", 600 ] ],
+          [ [ "water", 300 ], [ "water_clean", 300 ] ],
           [ [ "wood_panel", 22 ] ]
         ]
       }
@@ -81,25 +87,26 @@
     "blueprint_provides": [ { "id": "fbmw_east" }, { "id": "blacksmith_recipes_3" } ],
     "blueprint_excludes": [ { "id": "fbmw_east" } ],
     "blueprint_needs": {
-      "time": "2 d 14 h 25 m",
+      "time": "2 d 6 h 25 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
         "qualities": [
-          [ { "id": "SAW_W", "level": 2 } ],
-          [ { "id": "DIG", "level": 2 } ],
           [ { "id": "CUT" } ],
-          [ { "id": "HAMMER", "level": 2 } ]
+          [ { "id": "DIG", "level": 2 } ],
+          [ { "id": "HAMMER", "level": 2 } ],
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
         ],
         "components": [
           [ [ "2x4", 285 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
-          [ [ "material_soil", 962 ] ],
+          [ [ "material_soil", 402 ] ],
           [ [ "nail", 734 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
           [ [ "rock", 40 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
-          [ [ "water", 400 ], [ "water_clean", 400 ] ],
+          [ [ "water", 200 ], [ "water_clean", 200 ] ],
           [ [ "wood_panel", 38 ] ]
         ]
       }
@@ -119,19 +126,24 @@
     "blueprint_provides": [ { "id": "fbmw_center" } ],
     "blueprint_excludes": [ { "id": "fbmw_center" } ],
     "blueprint_needs": {
-      "time": "1 d 19 h 5 m",
+      "time": "1 d 11 h 5 m",
       "skills": [ [ "fabrication", 3 ], [ "tailor", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [
+          [ { "id": "DIG", "level": 2 } ],
+          [ { "id": "HAMMER", "level": 2 } ],
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
+        ],
         "components": [
           [ [ "2x4", 152 ] ],
           [ [ "blanket", 1 ], [ "down_blanket", 1 ], [ "fur_blanket", 1 ] ],
           [ [ "concrete", 4 ], [ "material_quicklime", 80 ], [ "material_sand", 80 ] ],
-          [ [ "material_soil", 960 ] ],
+          [ [ "material_soil", 400 ] ],
           [ [ "nail", 372 ] ],
           [ [ "pointy_stick", 8 ], [ "spear_wood", 8 ] ],
-          [ [ "water", 400 ], [ "water_clean", 400 ] ],
+          [ [ "water", 200 ], [ "water_clean", 200 ] ],
           [ [ "wood_panel", 19 ] ]
         ]
       }
@@ -153,32 +165,32 @@
     "blueprint_resources": [ "tongs", "chisel", "hammer", "swage" ],
     "components": [ [ [ "tongs", 1 ] ], [ [ "chisel", 1 ] ], [ [ "hammer", 1 ] ], [ [ "swage", 1 ] ] ],
     "blueprint_needs": {
-      "time": "1 d 16 h 55 m",
+      "time": "1 d 10 h 55 m",
       "skills": [ [ "fabrication", 4 ] ],
       "inline": {
         "tools": [
           [ [ "fake_gridwelder", 100 ], [ "oxy_torch", 20 ], [ "toolset", 150 ], [ "welder", 100 ], [ "welder_crude", 150 ] ],
-          [ [ "frame_wood_light", -1 ] ],
           [ [ "log", -1 ] ]
         ],
         "qualities": [
           [ { "id": "DIG", "level": 2 } ],
           [ { "id": "GLARE", "level": 2 } ],
           [ { "id": "HAMMER", "level": 2 } ],
-          [ { "id": "SAW_W", "level": 2 } ]
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
         ],
         "components": [
           [ [ "2x4", 132 ] ],
           [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_adobe", 1 ], [ "mortar_build", 1 ] ],
           [ [ "concrete", 3 ], [ "material_quicklime", 60 ], [ "material_sand", 60 ] ],
-          [ [ "material_soil", 720 ] ],
+          [ [ "material_soil", 300 ] ],
           [ [ "nail", 380 ] ],
           [ [ "pipe", 16 ] ],
           [ [ "pointy_stick", 6 ], [ "spear_wood", 6 ] ],
           [ [ "rock", 40 ] ],
           [ [ "sheet_metal", 4 ] ],
           [ [ "sheet_metal_small", 8 ] ],
-          [ [ "water", 302 ], [ "water_clean", 302 ] ],
+          [ [ "water", 152 ], [ "water_clean", 152 ] ],
           [ [ "wood_panel", 23 ] ]
         ]
       }
@@ -198,24 +210,25 @@
     "blueprint_provides": [ { "id": "fbmw_northwest" }, { "id": "blacksmith_recipes_5" } ],
     "blueprint_excludes": [ { "id": "fbmw_northwest" } ],
     "blueprint_needs": {
-      "time": "3 d 18 h 55 m",
+      "time": "2 d 20 h 55 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
         "qualities": [
           [ { "id": "CUT" } ],
           [ { "id": "DIG", "level": 2 } ],
           [ { "id": "HAMMER", "level": 2 } ],
-          [ { "id": "SAW_W", "level": 2 } ]
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
         ],
         "components": [
           [ [ "2x4", 170 ] ],
           [ [ "concrete", 11 ], [ "material_quicklime", 220 ], [ "material_sand", 220 ] ],
-          [ [ "material_soil", 2640 ] ],
+          [ [ "material_soil", 1100 ] ],
           [ [ "nail", 514 ] ],
           [ [ "pointy_stick", 22 ], [ "spear_wood", 22 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
-          [ [ "water", 1100 ], [ "water_clean", 1100 ] ],
+          [ [ "water", 550 ], [ "water_clean", 550 ] ],
           [ [ "wood_panel", 30 ] ]
         ]
       }
@@ -237,24 +250,29 @@
     "blueprint_resources": [ "wrench", "pliers", "fake_drop_hammer" ],
     "components": [ [ [ "wrench", 1 ] ], [ [ "pliers", 1 ] ] ],
     "blueprint_needs": {
-      "time": "4 d 12 h 30 m",
+      "time": "3 d 16 h 30 m",
       "skills": [ [ "fabrication", 3 ] ],
       "inline": {
-        "tools": [ [ [ "frame_wood_light", -1 ] ], [ [ "log", -1 ] ] ],
-        "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+        "tools": [ [ [ "log", -1 ] ] ],
+        "qualities": [
+          [ { "id": "DIG", "level": 2 } ],
+          [ { "id": "HAMMER", "level": 2 } ],
+          [ { "id": "SAW_W", "level": 2 } ],
+          [ { "id": "SMOOTH" } ]
+        ],
         "components": [
-          [ [ "pointy_stick", 20 ], [ "spear_wood", 20 ] ],
-          [ [ "material_soil", 2400 ] ],
-          [ [ "water", 1000 ], [ "water_clean", 1000 ] ],
-          [ [ "material_sand", 200 ], [ "material_quicklime", 200 ], [ "concrete", 10 ] ],
-          [ [ "metal_tank", 2 ] ],
-          [ [ "water_faucet", 2 ] ],
+          [ [ "2x4", 352 ] ],
           [ [ "anvil", 1 ] ],
           [ [ "chain", 4 ] ],
+          [ [ "concrete", 10 ], [ "material_quicklime", 200 ], [ "material_sand", 200 ] ],
+          [ [ "material_soil", 1000 ] ],
+          [ [ "metal_tank", 2 ] ],
+          [ [ "nail", 880 ] ],
           [ [ "pipe", 3 ] ],
-          [ [ "wood_panel", 44 ] ],
-          [ [ "2x4", 352 ] ],
-          [ [ "nail", 880 ] ]
+          [ [ "pointy_stick", 20 ], [ "spear_wood", 20 ] ],
+          [ [ "water", 500 ], [ "water_clean", 500 ] ],
+          [ [ "water_faucet", 2 ] ],
+          [ [ "wood_panel", 44 ] ]
         ]
       }
     }

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_wad.json
@@ -14,15 +14,27 @@
     "blueprint_excludes": [ { "id": "fbmw_northeast" } ],
     "blueprint_needs": {
       "time": "1 d 17 h 40 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 300 ] ],
-          [ [ "cattail_stalk", 80 ], [ "dogbane", 80 ], [ "pine_bough", 80 ], [ "straw_pile", 80 ] ],
-          [ [ "clay_lump", 80 ], [ "material_limestone", 80 ], [ "material_quicklime", 80 ] ],
-          [ [ "material_sand", 200 ], [ "pebble", 200 ] ],
+          [
+            [ "cattail_stalk", 80 ],
+            [ "dogbane", 80 ],
+            [ "material_sand", 200 ],
+            [ "pebble", 200 ],
+            [ "pine_bough", 80 ],
+            [ "straw_pile", 80 ],
+            [ "withered", 80 ]
+          ],
+          [
+            [ "clay_lump", 80 ],
+            [ "material_limestone", 80 ],
+            [ "material_quicklime", 80 ],
+            [ "material_soil", 400 ]
+          ],
           [ [ "nail", 500 ] ],
           [ [ "water", 100 ], [ "water_clean", 100 ] ],
           [ [ "wood_panel", 25 ] ]
@@ -45,15 +57,27 @@
     "blueprint_excludes": [ { "id": "fbmw_north" } ],
     "blueprint_needs": {
       "time": "1 d 2 h 45 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 185 ] ],
-          [ [ "cattail_stalk", 52 ], [ "dogbane", 52 ], [ "pine_bough", 52 ], [ "straw_pile", 52 ] ],
-          [ [ "clay_lump", 52 ], [ "material_limestone", 52 ], [ "material_quicklime", 52 ] ],
-          [ [ "material_sand", 130 ], [ "pebble", 130 ] ],
+          [
+            [ "cattail_stalk", 52 ],
+            [ "dogbane", 52 ],
+            [ "material_sand", 130 ],
+            [ "pebble", 130 ],
+            [ "pine_bough", 52 ],
+            [ "straw_pile", 52 ],
+            [ "withered", 52 ]
+          ],
+          [
+            [ "clay_lump", 52 ],
+            [ "material_limestone", 52 ],
+            [ "material_quicklime", 52 ],
+            [ "material_soil", 260 ]
+          ],
           [ [ "nail", 352 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 65 ], [ "water_clean", 65 ] ],
@@ -80,13 +104,19 @@
       "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
-        "qualities": [ [ { "id": "SAW_W", "level": 2 } ], [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ] ],
+        "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 315 ] ],
-          [ [ "cattail_stalk", 36 ], [ "dogbane", 36 ], [ "pine_bough", 36 ], [ "straw_pile", 36 ] ],
-          [ [ "clay_lump", 36 ], [ "material_limestone", 36 ], [ "material_quicklime", 36 ] ],
-          [ [ "material_sand", 90 ], [ "pebble", 90 ] ],
-          [ [ "material_soil", 2 ] ],
+          [
+            [ "cattail_stalk", 36 ],
+            [ "dogbane", 36 ],
+            [ "material_sand", 90 ],
+            [ "pebble", 90 ],
+            [ "pine_bough", 36 ],
+            [ "straw_pile", 36 ],
+            [ "withered", 36 ]
+          ],
+          [ [ "material_soil", 182 ] ],
           [ [ "nail", 704 ] ],
           [ [ "rock", 40 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
@@ -111,16 +141,28 @@
     "blueprint_excludes": [ { "id": "fbmw_center" } ],
     "blueprint_needs": {
       "time": "23 h 55 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ], [ "tailor", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ], [ "tailor", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 172 ] ],
           [ [ "blanket", 1 ], [ "down_blanket", 1 ], [ "fur_blanket", 1 ] ],
-          [ [ "cattail_stalk", 40 ], [ "dogbane", 40 ], [ "pine_bough", 40 ], [ "straw_pile", 40 ] ],
-          [ [ "clay_lump", 40 ], [ "material_limestone", 40 ], [ "material_quicklime", 40 ] ],
-          [ [ "material_sand", 100 ], [ "pebble", 100 ] ],
+          [
+            [ "cattail_stalk", 40 ],
+            [ "dogbane", 40 ],
+            [ "material_sand", 100 ],
+            [ "pebble", 100 ],
+            [ "pine_bough", 40 ],
+            [ "straw_pile", 40 ],
+            [ "withered", 40 ]
+          ],
+          [
+            [ "clay_lump", 40 ],
+            [ "material_limestone", 40 ],
+            [ "material_quicklime", 40 ],
+            [ "material_soil", 200 ]
+          ],
           [ [ "nail", 312 ] ],
           [ [ "water", 50 ], [ "water_clean", 50 ] ],
           [ [ "wood_panel", 19 ] ]
@@ -145,9 +187,9 @@
     "components": [ [ [ "tongs", 1 ] ], [ [ "chisel", 1 ] ], [ [ "hammer", 1 ] ], [ [ "swage", 1 ] ] ],
     "blueprint_needs": {
       "time": "1 d 3 h 10 m",
-      "skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 4 ] ],
       "inline": {
-        "tools": [ [ [ "oxy_torch", 20 ], [ "toolset", 150 ], [ "welder", 100 ], [ "welder_crude", 150 ] ] ],
+        "tools": [ [ [ "fake_gridwelder", 100 ], [ "oxy_torch", 20 ], [ "toolset", 150 ], [ "welder", 100 ], [ "welder_crude", 150 ] ] ],
         "qualities": [
           [ { "id": "CUT" } ],
           [ { "id": "GLARE", "level": 2 } ],
@@ -156,10 +198,22 @@
         ],
         "components": [
           [ [ "2x4", 162 ] ],
-          [ [ "cattail_stalk", 24 ], [ "dogbane", 24 ], [ "pine_bough", 24 ], [ "straw_pile", 24 ] ],
+          [
+            [ "cattail_stalk", 24 ],
+            [ "dogbane", 24 ],
+            [ "material_sand", 60 ],
+            [ "pebble", 60 ],
+            [ "pine_bough", 24 ],
+            [ "straw_pile", 24 ],
+            [ "withered", 24 ]
+          ],
           [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_build", 1 ] ],
-          [ [ "clay_lump", 24 ], [ "material_limestone", 24 ], [ "material_quicklime", 24 ] ],
-          [ [ "material_sand", 60 ], [ "pebble", 60 ] ],
+          [
+            [ "clay_lump", 24 ],
+            [ "material_limestone", 24 ],
+            [ "material_quicklime", 24 ],
+            [ "material_soil", 120 ]
+          ],
           [ [ "nail", 380 ] ],
           [ [ "pipe", 16 ] ],
           [ [ "rock", 40 ] ],
@@ -192,9 +246,21 @@
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 260 ] ],
-          [ [ "cattail_stalk", 96 ], [ "dogbane", 96 ], [ "pine_bough", 96 ], [ "straw_pile", 96 ] ],
-          [ [ "clay_lump", 96 ], [ "material_limestone", 96 ], [ "material_quicklime", 96 ] ],
-          [ [ "material_sand", 240 ], [ "pebble", 240 ] ],
+          [
+            [ "cattail_stalk", 96 ],
+            [ "dogbane", 96 ],
+            [ "material_sand", 240 ],
+            [ "pebble", 240 ],
+            [ "pine_bough", 96 ],
+            [ "straw_pile", 96 ],
+            [ "withered", 96 ]
+          ],
+          [
+            [ "clay_lump", 96 ],
+            [ "material_limestone", 96 ],
+            [ "material_quicklime", 96 ],
+            [ "material_soil", 480 ]
+          ],
           [ [ "nail", 454 ] ],
           [ [ "rope_6", 2 ], [ "rope_makeshift_6", 2 ] ],
           [ [ "water", 120 ], [ "water_clean", 120 ] ],
@@ -220,17 +286,29 @@
     "components": [ [ [ "wrench", 1 ] ], [ [ "pliers", 1 ] ] ],
     "blueprint_needs": {
       "time": "2 d 14 h 40 m",
-      "skills": [ [ "fabrication", 3 ], [ "survival", 3 ] ],
+      "skills": [ [ "survival", 3 ], [ "fabrication", 3 ] ],
       "inline": {
         "tools": [  ],
         "qualities": [ [ { "id": "CUT" } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 452 ] ],
           [ [ "anvil", 1 ] ],
-          [ [ "cattail_stalk", 80 ], [ "dogbane", 80 ], [ "pine_bough", 80 ], [ "straw_pile", 80 ] ],
+          [
+            [ "cattail_stalk", 80 ],
+            [ "dogbane", 80 ],
+            [ "material_sand", 200 ],
+            [ "pebble", 200 ],
+            [ "pine_bough", 80 ],
+            [ "straw_pile", 80 ],
+            [ "withered", 80 ]
+          ],
           [ [ "chain", 4 ] ],
-          [ [ "clay_lump", 80 ], [ "material_limestone", 80 ], [ "material_quicklime", 80 ] ],
-          [ [ "material_sand", 200 ], [ "pebble", 200 ] ],
+          [
+            [ "clay_lump", 80 ],
+            [ "material_limestone", 80 ],
+            [ "material_quicklime", 80 ],
+            [ "material_soil", 400 ]
+          ],
           [ [ "metal_tank", 2 ] ],
           [ [ "nail", 880 ] ],
           [ [ "pipe", 3 ] ],

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_wad.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_wad.json
@@ -207,7 +207,7 @@
             [ "straw_pile", 24 ],
             [ "withered", 24 ]
           ],
-          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_build", 1 ] ],
+          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_adobe", 1 ], [ "mortar_build", 1 ] ],
           [
             [ "clay_lump", 24 ],
             [ "material_limestone", 24 ],

--- a/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_wood.json
+++ b/data/json/recipes/basecamps/recipe_modular_workshop/recipe_modular_workshop_wood.json
@@ -143,7 +143,7 @@
         "qualities": [ [ { "id": "GLARE", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
         "components": [
           [ [ "2x4", 162 ] ],
-          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_build", 1 ] ],
+          [ [ "clay_lump", 12 ], [ "material_cement", 50 ], [ "mortar_adobe", 1 ], [ "mortar_build", 1 ] ],
           [ [ "nail", 500 ] ],
           [ [ "pipe", 16 ] ],
           [ [ "rock", 40 ] ],

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -855,10 +855,13 @@
     "difficulty": 2,
     "time": "10 m",
     "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "tools": [ [ [ "frame_wood", -1 ], [ "frame_wood_light", -1 ] ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "SMOOTH", "level": 1 } ],
     "batch_time_factors": [ 75, 4 ],
-    "components": [ [ [ "water", 1 ], [ "water_clean", 1 ] ], [ [ "material_soil", 2 ] ], [ [ "withered", 2 ], [ "straw_pile", 2 ] ] ]
+    "components": [
+      [ [ "water", 1 ], [ "water_clean", 1 ] ],
+      [ [ "material_soil", 2 ] ],
+      [ [ "withered", 2 ], [ "straw_pile", 2 ], [ "cattail_stalk", 2 ], [ "dogbane", 2 ], [ "pine_bough", 2 ] ]
+    ]
   },
   {
     "type": "recipe",
@@ -868,7 +871,7 @@
     "skill_used": "fabrication",
     "skills_required": [ "survival", 1 ],
     "difficulty": 2,
-    "time": "30 m",
+    "time": "15 m",
     "autolearn": true,
     "components": [ [ [ "soft_adobe_brick", 20 ] ], [ [ "frame_wood_light", 1 ] ] ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Make material usage in constructions more consistent, sanity-check some constructions"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This has been buried in my to-do list for a decent while, basically sanity-checking use of some materials in constructions.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

- [x] Standardized use of planks vs heavy sticks in recipes to no longer have it be a crapshoot whether using planks or sticks is more efficient, instead using the 1:1 by-weight ratio defined by the `wood_structural_small` crafting requirement, with some use of `wood_structural` where the amount was large enough to warrant it. (partially complete).
- [x] Standardize use of logs in recipes that allow choosing between logs and sticks/planks, Set it so you tend to use 1 log for every 10 sticks/planks called for, instead of equal numbers of logs and planks.
- [x] Allowed use of adobe mortar for stone walls and clay kilns.
- [x] Allow soil as an alternative to clay, withered plants/straw as an alternative to cattails, in wattle and daub recipe. Also maybe merge pebbles and sand into the straw component, as both are logically part of the filler role.
- [x] Added `ALLOW_REMOTE_USE` flag to wet bricks, converted the need for a wooden frame to instead use smoothing quality. Also add all the other permitted plant filler items from the wattle and daub recipe to the brick recipe as alternatives to straw and withered plants. Cut the time to load a pallet in half. Also removed references to incorrect time, transform delay is taking only about a day (time may be borked due to one-second turns?) and honestly I'd assumed that was intended because taking a day seems reasonable too.
- [x] Sanity-checked rammed earth wall construction, reducing material usage to be more consistent with adobe brick walls. Reduced soil used from 240 to 100 (adobe uses 46 soil per finished wall, by contrast). Reduced water used from 100 to 50 (adobe uses 24). Replace use of a wooden frame with smoothing quality. Reduced time to make down to 4, matching adobe brick walls taking 4 hours to make per tile.
- [x] Permitted use of pine boughs for thatch roofing.
- [x] Updated faction camp recipes, using the newly-awakened power of python.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Any other no-shit construction options that we perhaps could implement, especially for walls and roofs? MST Extra does have some potential idea fodder to grab but hmm.

Also, being able to just fire adobe bricks might be a reasonable option. I've tried to look up whether you can fire them and I get a different answer each time, often within the same thread.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Testing to continue as implementation ensues.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
