### PR TITLE
Add Weapon Category to makeshift hammer (same as stone hammer)

### DIFF
--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -506,6 +506,7 @@
     "id": "makeshift_hammer",
     "type": "GENERIC",
     "category": "tools",
+    "weapon_category": [ "1H_HAMMERS" ],
     "name": { "str": "makeshift hammer" },
     "description": "This is a crude hammer made from a piece of metal affixed to a stick.  It functions adequately as a hammer, but really can't compare to a proper one.",
     "weight": "1020 g",


### PR DESCRIPTION
#### Summary

SUMMARY: Balance "Give Weapon Category to makeshift hammer"

#### Purpose of change

I noticed while playing the game that stone hammers have a Weapon Category, while makeshift hammers did not. Both are nigh-identical, so I decided to give the makeshift hammer a Weapon Category befitting it.

#### Describe the solution

Copying and pasting one line.

#### Describe alternatives you've considered

Makeshift hammers are hammers too. They deserve justice.

#### Testing

No issues.

#### Additional context

Hope everyone is doing great!
