### PR TITLE
Port over anthill fixes

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
@@ -325,7 +325,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "ants_larvae",
+    "id": [ "ants_larvae", "ants_larvae_acid" ],
     "name": "ant larva chamber",
     "sym": "O",
     "color": "white",
@@ -334,7 +334,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "ants_queen",
+    "id": [ "ants_queen", "ants_queen_acid" ],
     "name": "ant queen chamber",
     "sym": "O",
     "color": "red",

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -40,7 +40,9 @@ static const itype_id itype_jackhammer( "jackhammer" );
 static const itype_id itype_mask_dust( "mask_dust" );
 
 static const mtype_id mon_ant_larva( "mon_ant_larva" );
+static const mtype_id mon_ant_acid_larva( "mon_ant_acid_larva" );
 static const mtype_id mon_ant_queen( "mon_ant_queen" );
+static const mtype_id mon_ant_acid_queen( "mon_ant_acid_queen" );
 static const mtype_id mon_bee( "mon_bee" );
 static const mtype_id mon_beekeeper( "mon_beekeeper" );
 static const mtype_id mon_zombie_jackson( "mon_zombie_jackson" );
@@ -145,7 +147,9 @@ building_gen_pointer get_mapgen_cfunction( const std::string &ident )
             { "ants_four_way",    &mapgen_ants_four_way },
             { "ants_food", &mapgen_ants_food },
             { "ants_larvae", &mapgen_ants_larvae },
+            { "ants_larvae_acid", &mapgen_ants_larvae_acid },
             { "ants_queen", &mapgen_ants_queen },
+            { "ants_queen_acid", &mapgen_ants_queen_acid },
             { "tutorial", &mapgen_tutorial },
             { "lake_shore", &mapgen_lake_shore },
         }
@@ -2324,19 +2328,6 @@ static void mapgen_ants_generic( mapgendata &dat )
             }
         }
     }
-    if( dat.terrain_type() == "ants_food" ) {
-        m->place_items( item_group_id( "ant_food" ), 92, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ),
-                        true, dat.when() );
-    } else {
-        m->place_items( item_group_id( "ant_egg" ),  98, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ),
-                        true, dat.when() );
-    }
-    if( dat.terrain_type() == "ants_queen" ) {
-        m->add_spawn( mon_ant_queen, 1, { SEEX, SEEY, m->get_abs_sub().z } );
-    } else if( dat.terrain_type() == "ants_larvae" ) {
-        m->add_spawn( mon_ant_larva, 10, { SEEX, SEEY, m->get_abs_sub().z } );
-    }
-
 }
 
 void mapgen_ants_food( mapgendata &dat )
@@ -2350,19 +2341,35 @@ void mapgen_ants_food( mapgendata &dat )
 void mapgen_ants_larvae( mapgendata &dat )
 {
     mapgen_ants_generic( dat );
-    dat.m.place_items( item_group_id( "ant_egg" ),  98, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ),
+    dat.m.place_items( item_group_id( "ant_egg" ), 98, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ),
                        true,
                        dat.when() );
     dat.m.add_spawn( mon_ant_larva, 10, { SEEX, SEEY, dat.m.get_abs_sub().z } );
 }
 
+void mapgen_ants_larvae_acid( mapgendata &dat )
+{
+    mapgen_ants_generic( dat );
+    dat.m.place_items( item_group_id( "ant_egg" ), 98, point_zero,
+                       point( SEEX * 2 - 1, SEEY * 2 - 1 ), true, dat.when() );
+    dat.m.add_spawn( mon_ant_acid_larva, 10, { SEEX, SEEY, dat.m.get_abs_sub().z } );
+}
+
 void mapgen_ants_queen( mapgendata &dat )
 {
     mapgen_ants_generic( dat );
-    dat.m.place_items( item_group_id( "ant_egg" ),  98, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ),
+    dat.m.place_items( item_group_id( "ant_egg" ), 98, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ),
                        true,
                        dat.when() );
     dat.m.add_spawn( mon_ant_queen, 1, { SEEX, SEEY, dat.m.get_abs_sub().z } );
+}
+
+void mapgen_ants_queen_acid( mapgendata &dat )
+{
+    mapgen_ants_generic( dat );
+    dat.m.place_items( item_group_id( "ant_egg" ), 98, point_zero,
+                       point( SEEX * 2 - 1, SEEY * 2 - 1 ), true, dat.when() );
+    dat.m.add_spawn( mon_ant_acid_queen, 1, { SEEX, SEEY, dat.m.get_abs_sub().z } );
 }
 
 void mapgen_tutorial( mapgendata &dat )

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -73,7 +73,9 @@ void mapgen_ants_straight( mapgendata &dat );
 void mapgen_ants_tee( mapgendata &dat );
 void mapgen_ants_food( mapgendata &dat );
 void mapgen_ants_larvae( mapgendata &dat );
+void mapgen_ants_larvae_acid( mapgendata &dat );
 void mapgen_ants_queen( mapgendata &dat );
+void mapgen_ants_queen_acid( mapgendata &dat );
 void mapgen_tutorial( mapgendata &dat );
 void mapgen_lake_shore( mapgendata &dat );
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1954,7 +1954,7 @@ bool overmap::generate_sub( const int z )
         add_mon_group(
             mongroup( ant_group, tripoint_om_sm( project_to<coords::sm>( i.pos ), z ),
                       ( i.size * 3 ) / 2, rng( 6000, 8000 ) ) );
-        build_anthill( p_loc, i.size );
+        build_anthill( p_loc, i.size, ter( p_loc + tripoint_above ) == "anthill" );
     }
 
     return requires_sub;
@@ -3552,10 +3552,10 @@ bool overmap::build_lab( const tripoint_om_omt &p, lab &l, int s,
     return numstairs > 0;
 }
 
-void overmap::build_anthill( const tripoint_om_omt &p, int s )
+void overmap::build_anthill( const tripoint_om_omt &p, int s, bool ordinary_ants )
 {
     for( om_direction::type dir : om_direction::all ) {
-        build_tunnel( p, s - rng( 0, 3 ), dir );
+        build_tunnel( p, s - rng( 0, 3 ), dir, ordinary_ants );
     }
 
     // TODO: This should follow the tunnel network,
@@ -3573,7 +3573,7 @@ void overmap::build_anthill( const tripoint_om_omt &p, int s )
         debugmsg( "No queenpoints when building anthill, anthill over %s", ter( p ).id().str() );
     }
     const tripoint_om_omt target = random_entry( queenpoints );
-    ter_set( target, oter_id( "ants_queen" ) );
+    ter_set( target, ordinary_ants ? oter_id( "ants_queen" ) : oter_id( "ants_queen_acid" ) );
 
     const oter_id root_id( "ants_isolated" );
 
@@ -3600,7 +3600,8 @@ void overmap::build_anthill( const tripoint_om_omt &p, int s )
     }
 }
 
-void overmap::build_tunnel( const tripoint_om_omt &p, int s, om_direction::type dir )
+void overmap::build_tunnel( const tripoint_om_omt &p, int s, om_direction::type dir,
+                            bool ordinary_ants )
 {
     if( s <= 0 ) {
         return;
@@ -3633,6 +3634,7 @@ void overmap::build_tunnel( const tripoint_om_omt &p, int s, om_direction::type 
 
     const oter_id ants_food( "ants_food" );
     const oter_id ants_larvae( "ants_larvae" );
+    const oter_id ants_larvae_acid( "ants_larvae_acid" );
     const tripoint_om_omt next =
         s != 1 ? p + om_direction::displace( dir ) : tripoint_om_omt( -1, -1, -1 );
 
@@ -3648,15 +3650,15 @@ void overmap::build_tunnel( const tripoint_om_omt &p, int s, om_direction::type 
                 if( one_in( 2 ) ) {
                     ter_set( cand, ants_food );
                 } else {
-                    ter_set( cand, ants_larvae );
+                    ter_set( cand, ordinary_ants ? ants_larvae : ants_larvae_acid );
                 }
             } else if( one_in( 5 ) ) {
                 // Branch off a side tunnel
-                build_tunnel( cand, s - rng( 1, 3 ), r );
+                build_tunnel( cand, s - rng( 1, 3 ), r, ordinary_ants );
             }
         }
     }
-    build_tunnel( next, s - 1, dir );
+    build_tunnel( next, s - 1, dir, ordinary_ants );
 }
 
 bool overmap::build_slimepit( const tripoint_om_omt &origin, int s )

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -421,8 +421,9 @@ class overmap
         bool build_lab( const tripoint_om_omt &p, lab &l, int size,
                         std::vector<point_om_omt> &lab_train_points,
                         const std::string &prefix, int train_odds );
-        void build_anthill( const tripoint_om_omt &p, int s );
-        void build_tunnel( const tripoint_om_omt &p, int s, om_direction::type dir );
+        void build_anthill( const tripoint_om_omt &p, int s, bool ordinary_ants = true );
+        void build_tunnel( const tripoint_om_omt &p, int s, om_direction::type dir,
+                           bool ordinary_ants = true );
         bool build_slimepit( const tripoint_om_omt &origin, int s );
         void build_mine( const tripoint_om_omt &origin, int s );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "DDA port: Fix for acidic ant queens and acidic ant larvae spawning in ordinary ant tunnels"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Belatedly port over some fixes for acid anthills.

Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/786
Fixes https://github.com/cataclysmbnteam/Cataclysm-BN/issues/2968

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Ported over changes to IDs of overmap terrain, adding acid variants.
2. Ported over changes to mapgen_functions.cpp and .h, defining acid ant variations on the larva and queen chamber rooms and reworking how the rooms are used.
3. Ported over changes to overmap.cpp and .h, where it properly uses the acid variants of the rooms.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Figuring out the least annoying way to JSONize anthills. DDA seems to rely on mutable overmap stuff which seems kinda eh.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected JSON file for syntax and lint errors.
2. Compiled and load-tested.
3. Revealed the map in debug and warped over to an acid anthill with a clairvoyance artifact, confirmed could only see acid ants.
4. Did the same with a normal anthill, only found normal ants.
5. Checked affected C++ files for astyle.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR, by @Night-Pyranik: https://github.com/CleverRaven/Cataclysm-DDA/pull/48348