### PR TITLE
fix(L10n): make extracting bodypart fields optional

### DIFF
--- a/lang/extract_json_strings.py
+++ b/lang/extract_json_strings.py
@@ -226,9 +226,11 @@ def extract_bodypart(state, item):
     writestr(state, item["accusative"])
     if "accusative_multiple" in item:
         writestr(state, item["accusative_multiple"])
-    writestr(state, item["encumbrance_text"])
+    if "encumbrance_text" in item:
+        writestr(state, item["encumbrance_text"])
     writestr(state, item["heading"])
-    writestr(state, item["heading_multiple"])
+    if "heading_multiple" in item:
+        writestr(state, item["heading_multiple"])
     if "hp_bar_ui_text" in item:
         writestr(state, item["hp_bar_ui_text"])
 
@@ -259,7 +261,7 @@ def extract_material(state, item):
         writestr(state, item["dmg_adj"][3])
         wrote = True
     if not wrote and not "copy-from" in item:
-        print("WARNING: {}: no mandatory field in item: {}".format(state.current_source_file, item))        
+        print("WARNING: {}: no mandatory field in item: {}".format(state.current_source_file, item))
 
 
 def extract_martial_art(state, item):
@@ -910,7 +912,7 @@ def writestr(state, string, context=None, format_strings=False, comment=None, pl
         return;
     else:
         raise WrongJSONItem("ERROR: value is not a string, dict, list, or None", string)
-    
+
     flags = []
     if format_strings and ("%" in str_singular or (str_pl is not None and "%" in str_pl)):
         flags.append('c-format')


### PR DESCRIPTION

#### Summary

SUMMARY: I18N "Account for optional body part fields when extracting json"

#### Purpose of change

- fix #2978 

#### Describe the solution

made finding `heading_multiple` and `encumbrance_text` optional.

#### Describe alternatives you've considered

scream

#### Testing

it works on my machine! /s

<details><summary>Before</summary>

```
 ~/r/c/Cataclysm   $-  lang/update_pot.sh                                2023년 06월 20일 (화) 오후 08시 51분 17초
> Extracting strings from json
==> Generating the list of all Git tracked files
==> Parsing JSON
----> Traversing directory data/help
----> Traversing directory data/json
Traceback (most recent call last):
  File "/home/scarf/repo/cata/Cataclysm/lang/extract_json_strings.py", line 1268, in <module>
    extract_all_from_dir(state, i)
  File "/home/scarf/repo/cata/Cataclysm/lang/extract_json_strings.py", line 1178, in extract_all_from_dir
    extract_all_from_file(state, full_name)
  File "/home/scarf/repo/cata/Cataclysm/lang/extract_json_strings.py", line 1200, in extract_all_from_file
    extract(state, jsonobject)
  File "/home/scarf/repo/cata/Cataclysm/lang/extract_json_strings.py", line 1001, in extract
    extract_specials[object_type](state, item)
  File "/home/scarf/repo/cata/Cataclysm/lang/extract_json_strings.py", line 231, in extract_bodypart
    writestr(state, item["heading_multiple"])
                    ~~~~^^^^^^^^^^^^^^^^^^^^
KeyError: 'heading_multiple'
Error in extract_json_strings.py. Aborting
```

</details> 

<details><summary>After</summary>

```
 !  ~/r/c/Cataclysm   smol-house-fix *$…  lang/update_pot.sh            2023년 06월 20일 (화) 오후 08시 45분 41초
> Extracting strings from json
==> Generating the list of all Git tracked files
==> Parsing JSON
----> Traversing directory data/help
----> Traversing directory data/json
WARNING: data/json/construction_group.json: nothing translatable found in item: {'type': 'construction_group', 'id': '', 'name': ''}
WARNING: data/json/species.json: nothing translatable found in item: {'type': 'SPECIES', 'id': 'HALLUCINATION'}
WARNING: data/json/species.json: nothing translatable found in item: {'type': 'SPECIES', 'id': 'UNKNOWN'}
WARNING: data/json/npcs/npc.json: nothing translatable found in item: {'type': 'npc', 'id': 'tracker_gunslinger', '//': 'the gunslinger that spawns for MISSION_RECRUIT_TRACKER', 'class': 'NC_COWBOY', 'attitude': 1, 'mission': 3, 'mission_offered': 'MISSION_JOIN_TRACKER', 'chat': 'TALK_STRANGER_FRIENDLY', 'faction': 'no_faction'}
WARNING: data/json/obsoletion/flags.json: nothing translatable found in item: {'id': 'FREEZERBURN', 'type': 'json_flag', 'context': ['COMESTIBLE']}
WARNING: data/json/overmap/overmap_land_use_codes.json: nothing translatable found in item: {'//': 'https://docs.digital.mass.gov/dataset/massgis-data-land-use-2005', 'type': 'overmap_land_use_code', 'id': '', 'sym': '#', 'color': 'white'}
----> Traversing directory data/mods
WARNING: data/mods/Magiclysm/species.json: nothing translatable found in item: {'type': 'SPECIES', 'id': 'MAGICAL_BEAST'}
WARNING: data/mods/Magiclysm/species.json: nothing translatable found in item: {'type': 'SPECIES', 'id': 'DRAGON', 'anger_triggers': ['HURT', 'PLAYER_CLOSE', 'PLAYER_WEAK', 'STALK']}
WARNING: data/mods/Magiclysm/species.json: nothing translatable found in item: {'type': 'SPECIES', 'id': 'LIZARDFOLK', 'anger_triggers': ['FRIEND_ATTACKED'], 'fear_triggers': ['FIRE']}
WARNING: data/mods/Magiclysm/monsters/demon_spider.json: nothing translatable found in item: {'type': 'SPECIES', 'id': 'DEMON_SPIDER', 'anger_triggers': ['FRIEND_DIED', 'HURT', 'PLAYER_CLOSE', 'PLAYER_WEAK']}
----> Traversing directory data/raw
WARNING: data/raw/keybindings/keybindings.json: nothing translatable found in item: {'type': 'keybinding', 'id': 'repair_metal', 'category': 'ITEM_ACTIONS', 'bindings': [{'input_method': 'keyboard', 'key': 'w'}]}
WARNING: data/raw/keybindings/keybindings.json: nothing translatable found in item: {'type': 'keybinding', 'id': 'firestarter', 'category': 'ITEM_ACTIONS', 'bindings': [{'input_method': 'keyboard', 'key': 'f'}]}
WARNING: data/raw/keybindings/keybindings.json: nothing translatable found in item: {'type': 'keybinding', 'id': 'holster', 'category': 'ITEM_ACTIONS', 'bindings': [{'input_method': 'keyboard', 'key': 'h'}]}
==> Checking types
==> Writing POT
> Extracting strings from source code
> Fixing .pot file headers
> Combining JSON and source code strings
==> Merging 'lang/po/temp-json.pot' and 'lang/po/temp-code.pot' into 'lang/po/cataclysm-bn.pot
> Resolving duplicates and conflicts
WARNING: plural form mismatch for msgid='heavy power armor' msgctxt='None' in data/json/items/armor/power_armor.json and data/mods/No_Hope/Items/armor.json: 'suits of heavy power armor' vs 'heavy power armors'
WARNING: plural form mismatch for msgid='light power armor' msgctxt='None' in data/json/items/armor/power_armor.json and data/mods/No_Hope/Items/armor.json: 'suits of light power armor' vs 'light power armors'
> Testing to compile the .pot file
lang/po/cataclysm-bn.pot:3: 경고: 헤더에 헤더 필드 'PO-Revision-Date'이(가) 빠졌음
lang/po/cataclysm-bn.pot:3: 경고: 헤더에 헤더 필드 'Last-Translator'이(가) 빠졌음
lang/po/cataclysm-bn.pot:3: 경고: 헤더에 헤더 필드 'Language-Team'이(가) 빠졌음
lang/po/cataclysm-bn.pot:3: 경고: 'Language' 헤더 필드가 아직도 초기의 기본값을 가지고 있습니다
> Checking for wrong Unicode symbols
> Cleaning up
ALL DONE!
```

</details> 
