### PR TITLE
Allows NPC morale sources to decay

### DIFF
--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -189,6 +189,17 @@ void Character::process_turn()
     } );
 
     suffer();
+
+    // Handle player and NPC morale ticks
+
+    if( calendar::once_every( 1_minutes ) ) {
+        update_morale();
+    }
+
+    if( calendar::once_every( 9_turns ) ) {
+        check_and_recover_morale();
+    }
+
     // NPCs currently don't make any use of their scent, pointless to calculate it
     // TODO: make use of NPC scent.
     if( !is_npc() ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1583,14 +1583,6 @@ bool game::do_turn()
     character_funcs::update_body_wetness( u, get_weather().get_precise() );
     u.apply_wetness_morale( weather.temperature );
 
-    if( calendar::once_every( 1_minutes ) ) {
-        u.update_morale();
-    }
-
-    if( calendar::once_every( 9_turns ) ) {
-        u.check_and_recover_morale();
-    }
-
     if( !u.is_deaf() ) {
         sfx::remove_hearing_loss();
     }


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "NPC temporary morale sources will now decay with time."

#### Purpose of change

I noticed that an NPC follower was perpetually unhappy with no apparent cause. The debug menu only showed the overall value and not the individual sources, so I poked into the save file and found piles of negative morale from all the books that I had made him read to skill up, all with age zero. Example: `{"type":"morale_book","subtype":{"subtype_type":"by_item","item_type":"atomic_survival"},"bonus":-45,"duration":3600,"decay_start":1800,"age":0}`. These were mostly balanced out by positive morale books, also all at age 0.

This can be reproduced by getting a fresh follower and making him read every 'for fun' book in a library, making him the happiest person in the apocalypse indefinitely. If you have NPC needs enabled, this also applies to morale from foods and drinks.

#### Describe the solution

This moves the checks that make morale sources decay over time out of `game::do_turn` and into `character::process_turn` so they apply to both the player and NPCs equally.

#### Describe alternatives you've considered

Maybe there's a better place to put it? The main part only goes off once every ingame minute, so I don't think there are any serious timing issues where it is.

I also thought about moving the weather/wetness morale effects (also in `game::do_turn`, only for the player) to apply to NPCs, but I don't think they're smart enough to pull out an umbrella or put on a jacket, and trying to micromanage that whenever it rains sounds more annoying than anything else.

#### Testing

Spawned and recruited an NPC, made him read a magazine, checked his morale with both the debug menu and the save file, waited in 15 minute increments to check that it correctly started decreasing and eventually vanished at the same time as the player. The save file also showed the age going up like it should be. Did the same by feeding him a burger with NPC needs enabled, that also correctly decayed.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
