### PR TITLE
Fixes some active item cache problems

### DIFF
--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -8,10 +8,12 @@
 
 void active_item_cache::remove( const item *it )
 {
-    active_items[it->processing_speed()].remove_if( [it]( const item_reference & active_item ) {
-        item *const target = active_item.item_ref.get();
-        return !target || target == it;
-    } );
+    for( auto &list : active_items ) {
+        list.second.remove_if( [it]( const item_reference & active_item ) {
+            item *const target = active_item.item_ref.get();
+            return !target || target == it;
+        } );
+    }
     if( it->can_revive() ) {
         special_items[ special_item_type::corpse ].remove_if( [it]( const item_reference & active_item ) {
             item *const target = active_item.item_ref.get();

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -743,11 +743,13 @@ std::list<item> visitable<map_cursor>::remove_items_with( const
             iter = stack.erase( iter );
 
             if( --count == 0 ) {
+                here.update_submap_active_item_status( *cur );
                 return res;
             }
         } else {
             iter->contents.remove_internal( filter, count, res );
             if( count == 0 ) {
+                here.update_submap_active_item_status( *cur );
                 return res;
             }
             ++iter;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Mitigate active item cache corruption"

#### Purpose of change

Prevent stuff getting stuck in the active item cache.

#### Describe the solution

The active item cache is keyed by processing time, but some items change their processing time. Such as a jar full of food becoming empty. This causes them to get stuck. It'll now search the whole cache for items it removes.

There's also a similar fix I found while looking for this. Some of the paths through visitable::remove_item weren't updating the cache properly.

#### Describe alternatives you've considered

Making sure that items move into the right cache as soon as their speed changes, but that's a lot more work and I'm pretty sure it's impossible to trigger this in meaningful way now.

#### Testing

Should be better.

#### Additional context

Stuff getting stuck in the cache is what has been breaking the tests.