### PR TITLE
Updated crafting menu example with existing item

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -838,7 +838,7 @@ const recipe *select_crafting_recipe( int &batch_size )
                 { 'q', _( "metal sawing" ), _( "<color_cyan>quality</color> of resulting item" ) },
                 //~ Example result description search term
                 { 'd', _( "reach attack" ), _( "<color_cyan>full description</color> of resulting item (slow)" ) },
-                { 'c', _( "two by four" ), _( "<color_cyan>component</color> required to craft" ) },
+                { 'c', _( "plank" ), _( "<color_cyan>component</color> required to craft" ) },
                 { 'p', _( "tailoring" ), _( "<color_cyan>primary skill</color> used to craft" ) },
                 { 's', _( "cooking" ), _( "<color_cyan>any skill</color> used to craft" ) },
                 { 'Q', _( "fine bolt turning" ), _( "<color_cyan>quality</color> required to craft" ) },


### PR DESCRIPTION
#### Summary
SUMMARY: Interface "Replaced an example in the crafting menu with an item that exists"

#### Purpose of change
When searching for items in the crafting menu one the examples uses "two by four" as an example, this exists as an id but to the player it's called "plank"

#### Describe the solution
Switched "two by four" with "plank".

#### Describe alternatives you've considered
Ignore it.

#### Testing
Open the crafting menu and try to search, plank is now given as an example.