### PR TITLE
Cone AoE attack improvements - msg, npcs, armor wrecking

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8181,7 +8181,7 @@ bool Character::armor_absorb( damage_unit &du, item &armor )
 
     // Don't damage armor as much when bypassed by armor piercing
     // Most armor piercing damage comes from bypassing armor, not forcing through
-    const int raw_dmg = du.amount;
+    const int raw_dmg = du.amount * std::min( 1.0f, du.damage_multiplier );
     if( raw_dmg > armors_own_resist ) {
         // If damage is above armor value, the chance to avoid armor damage is
         // 50% + 50% * 1/dmg

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2042,6 +2042,11 @@ int npc::confident_gun_mode_range( const gun_mode &gun, int at_recoil ) const
         return 0;
     }
 
+    const std::optional<shape_factory> shaped = ranged::get_shape_factory( *gun.target );
+    if( shaped ) {
+        return static_cast<int>( shaped->get_range() );
+    }
+
     // Doesn't use calculate_dispersion because that requires a map
     // TODO: Turn this into a common function.
     int gun_recoil = gun->gun_recoil();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2044,7 +2044,7 @@ int npc::confident_gun_mode_range( const gun_mode &gun, int at_recoil ) const
 
     const std::optional<shape_factory> shaped = ranged::get_shape_factory( *gun.target );
     if( shaped ) {
-        return static_cast<int>( shaped->get_range() );
+        return static_cast<int>( shaped->get_range() ) - 1;
     }
 
     // Doesn't use calculate_dispersion because that requires a map

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -856,10 +856,7 @@ int ranged::fire_gun( Character &who, const tripoint &target, int max_shots, ite
         debugmsg( "Attempted to fire zero or negative shots using %s", gun.tname() );
     }
 
-    std::optional<shape_factory> shape;
-    if( gun.ammo_current() && gun.ammo_current()->ammo ) {
-        shape = gun.ammo_current()->ammo->shape;
-    }
+    std::optional<shape_factory> shape = ranged::get_shape_factory( gun );
 
     map &here = get_map();
     // Shaped attacks don't allow aiming, so they don't suffer from lack of aim either
@@ -3958,4 +3955,13 @@ double ranged::aim_per_move( const Character &who, const item &gun, double recoi
 
     // Never improve by more than the currently used sights permit.
     return std::min( aim_speed, recoil - limit );
+}
+
+std::optional<shape_factory> ranged::get_shape_factory( const item &gun )
+{
+    if( gun.ammo_current() && gun.ammo_current()->ammo ) {
+        return gun.ammo_current()->ammo->shape;
+    }
+
+    return {};
 }

--- a/src/ranged.h
+++ b/src/ranged.h
@@ -101,6 +101,9 @@ float str_draw_damage_modifier( const item &it, const Character &p );
 float str_draw_dispersion_modifier( const item &it, const Character &p );
 float str_draw_range_modifier( const item &it, const Character &p );
 
+/** Returns shaped attack used by the gun+ammo, if set */
+std::optional<shape_factory> get_shape_factory( const item &gun );
+
 /** AoE attack, with area given by shape */
 void execute_shaped_attack( const shape &sh, const projectile &proj, Creature &attacker );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Bugfixes "Cone AoE attack improvements - msg, npcs, armor wrecking"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Close #2791

Make cone AoE, like from birdshot, work more properly when used against the player in clothing and by NPCs.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

* Being hit by gun AoE now prints proper body part - if exactly one was damaged - or "in total", if multiple body parts got damaged
* NPCs understand that anything in cone AoE is in confident range
* Armor damaged by attacks with low damage modifier - glancing shots, cone AoE - is less likely to be damaged

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

* Redesigning armor damage completely
* Dropping all armor damage
* Hacking armor damage from cone AoE with some tag

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

* Spawn a NPC
* Give it a shotgun with birdshot
* Anger it
* Get shot at while wearing thin clothing with some slots uncovered
* See clothing damaged, but not completely shredded all the time
* Check the "got hit in" message to see that it has "in total"
* Wear power armor with no helmet and get shot at
* Receive "got hit in the head" message

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
