### PR TITLE
Fix display saying food is still cold after reheating

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -879,6 +879,11 @@ bool Character::eat( item &food, bool force )
     } else if( spoiled && saprophage ) {
         add_msg_if_player( m_good, _( "Mmm, this %s tastes delicious…" ), food.tname() );
     }
+    // Store the fact that the food was cold to later reapply it to the rest of the stack, to prevent rot.
+    // Note: Implemented to fix display error when eating reheated food.
+    bool food_was_cold = food.has_flag( flag_COLD );
+    bool food_was_very_cold = food.has_flag( flag_VERY_COLD );
+
     if( !consume_effects( food ) ) {
         // Already consumed by using `food.type->invoke`?
         if( charges_used > 0 ) {
@@ -948,6 +953,14 @@ bool Character::eat( item &food, bool force )
         add_msg_player_or_npc( _( "You eat your %s." ), _( "<npcname> eats a %s." ),
                                food.tname() );
     }
+
+    if ( food_was_cold ) {
+        food.set_flag( flag_COLD );
+    }
+
+    if ( food_was_very_cold ) {
+        food.set_flag( flag_VERY_COLD );
+    }   
 
     if( food.get_comestible()->tool->tool ) {
         // Tools like lighters get used

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -151,6 +151,8 @@ static const std::string flag_RADIOACTIVE( "RADIOACTIVE" );
 static const std::string flag_RAW( "RAW" );
 static const std::string flag_URSINE_HONEY( "URSINE_HONEY" );
 static const std::string flag_USE_EAT_VERB( "USE_EAT_VERB" );
+static const std::string flag_COLD( "COLD" );
+static const std::string flag_VERY_COLD( "VERY_COLD" );
 
 const std::vector<std::string> carnivore_blacklist {{
         flag_ALLERGEN_VEGGY, flag_ALLERGEN_FRUIT, flag_ALLERGEN_WHEAT, flag_ALLERGEN_NUT,
@@ -1065,6 +1067,8 @@ void Character::modify_morale( item &food, int nutr )
                                    _( "You heat up your %1$s using the %2$s." ),
                                    _( "<npcname> heats up their %1$s using the %2$s." ),
                                    food.tname(), heater->it.tname() );
+            food.unset_flag( flag_COLD );
+            food.unset_flag( flag_VERY_COLD );
             morale_time = 3_hours;
             int clamped_nutr = std::max( 5, std::min( 20, nutr / 10 ) );
             add_morale( MORALE_FOOD_HOT, clamped_nutr, 20, morale_time, morale_time / 2 );

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -954,11 +954,11 @@ bool Character::eat( item &food, bool force )
                                food.tname() );
     }
 
-    if ( food_was_cold ) {
+    if( food_was_cold ) {
         food.set_flag( flag_COLD );
     }
 
-    if ( food_was_very_cold ) {
+    if( food_was_very_cold ) {
         food.set_flag( flag_VERY_COLD );
     }   
 

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -960,7 +960,7 @@ bool Character::eat( item &food, bool force )
 
     if( food_was_very_cold ) {
         food.set_flag( flag_VERY_COLD );
-    }   
+    }
 
     if( food.get_comestible()->tool->tool ) {
         // Tools like lighters get used


### PR DESCRIPTION
#### Summary
SUMMARY: Bugfixes "Fix display saying food is still cold after reheating"

#### Purpose of change
Chaosvolt reported the display error that occurs when you automatically heat food before eating it.

#### Describe the solution
1. Store if the food was "cold" or "very cold" in a bool
2. After the message that says the food was heated, unset the flags "cold" and "very_cold".
3. After the message that says you ate the food, reapply the flags to the item stack if the flags existed before. 

While the player only eats one food item the effects of the function apply to every item of the same type, so I have to ensure the flags remain afterwards.

#### Describe alternatives you've considered
Improve the system further by adding a "hot" flag so food items to be considered hot, as something that is recently cooked still needs to be reheated to be eaten as hot.

#### Testing
Before:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/60388907/2ab3a6c6-0226-4264-97cf-dc804ab0b013)

After:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/60388907/1b59278b-6f85-4b22-939b-61085f338867)
