### PR TITLE
Spawns manhole cover when manhole is pried

### DIFF
--- a/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
+++ b/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
@@ -149,7 +149,10 @@
       "fail_message": "You pry, but cannot lift the manhole cover.",
       "pry_quality": 1,
       "difficulty": 4,
-      "new_ter_type": "t_manhole"
+      "new_ter_type": "t_manhole",
+      "pry_items": [
+        { "item": "manhole_cover" }
+      ]
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary
SUMMARY: Bugfixes "Manholes now leave manhole covers when pried open.


#### Purpose of change
When opening a manhole with a crowbar the manhole cover is never created, making the construction option of replacing it fairly useless. It also prevents you from sealing a hole with monsters or whatever beneath you, if that ever comes up.


#### Describe the solution

Use the apparently unused pry_items field to spawn the cover when the hole is pried open.


#### Describe alternatives you've considered

Cry about it.

#### Testing

Teleport to manhole location, pry open with crowbar, see that the cover does spawn.
Go down and up the manhole, replace the cover with the construction open, open it again, go down and up, it still works.
Fail to pry with a low strength character and see that the cover correctly does not spawn.

#### Additional context

Sewer generation could probably use a look at, a lot of small towns didn't spawn with any manhole access at all, I needed to teleport to a pumping station to reliably find one.