### PR TITLE
Port over change making elephant gun a double rifle

### DIFF
--- a/data/json/items/gun/700nx.json
+++ b/data/json/items/gun/700nx.json
@@ -4,7 +4,7 @@
     "copy-from": "rifle_1shot",
     "type": "GUN",
     "name": { "str": "Elephant gun" },
-    "description": "A custom-made single shot rifle specially designed for the hunting of huge game.  You could obviously kill everything with this, EVERYTHING.  If you ever find enough ammo of course.",
+    "description": "A ornately engraved, custom-made double rifle specially designed for the hunting of huge game.  You could obviously kill everything with this, EVERYTHING.  If you ever find enough ammo of course.",
     "weight": "8082 g",
     "volume": "3 L",
     "price": 2000000,
@@ -14,8 +14,8 @@
     "color": "light_blue",
     "ammo": "700nx",
     "dispersion": 90,
-    "clip_size": 1,
-    "reload": 600,
+    "clip_size": 2,
+    "reload": 300,
     "barrel_length": "1000 ml",
     "valid_mod_locations": [
       [ "accessories", 4 ],
@@ -27,6 +27,7 @@
       [ "sling", 1 ],
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
-    ]
+    ],
+    "extend": { "flags": [ "RELOAD_ONE" ] }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Port over changes from DDA converting elephant gun to a double rifle"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Minor improvement that's been on my to-do list for a while, back over in DDA it was noted that elephant guns tend to be double rifles, that the .700 NX rifle is in the right general size range for one weight-wise, and that giving it the ability to fire a follow-up shot gives it a bit more spice to make it more distinct from other old-school high-damage weapons like the flintlock or blunderbuss, to compliment its rarity.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Ported over changes from DDA that gives the elephant gun a clip size of 2, halves its hefty reload time (since gotta do it twice), adds `RELOAD_ONE`, and updates the description.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Adding a separate double-barrel version as an excuse to make the single-barrel version spawn in different locations, as some sort of custom bolt-action range toy to contrast with the fancy mansion gun.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected file for syntax and lint errors.
2. Ported file changes over to test build to load-test.
3. Spawned one in and had some confirm, also confirming it loads 1 at a time.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/c7c188ad-ca69-42e5-a0cd-04a6b033e5d1)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

Source PR, by @Terrorforge: https://github.com/CleverRaven/Cataclysm-DDA/pull/64674