### PR TITLE
Updates to axe, hammer, and anvil qualities

### DIFF
--- a/data/json/furniture_and_terrain/terrain-railroads.json
+++ b/data/json/furniture_and_terrain/terrain-railroads.json
@@ -39,11 +39,7 @@
     },
     "deconstruct": {
       "ter_set": "t_rock_floor",
-      "items": [
-        { "item": "steel_lump", "count": [ 1, 2 ] },
-        { "item": "steel_chunk", "count": [ 1, 4 ] },
-        { "item": "scrap", "count": [ 3, 12 ] }
-      ]
+      "items": [ { "item": "railroad_track_small", "count": [ 1, 2 ] }, { "item": "sheet_metal", "count": [ 1, 2 ] } ]
     },
     "connects_to": "RAIL",
     "flags": [ "BASHABLE", "RAIL", "TRANSPARENT" ]
@@ -70,11 +66,7 @@
     },
     "deconstruct": {
       "ter_set": "t_rock_floor",
-      "items": [
-        { "item": "steel_lump", "count": [ 1, 2 ] },
-        { "item": "steel_chunk", "count": [ 1, 4 ] },
-        { "item": "scrap", "count": [ 3, 12 ] }
-      ]
+      "items": [ { "item": "railroad_track_small", "count": [ 1, 2 ] }, { "item": "sheet_metal", "count": [ 1, 2 ] } ]
     },
     "connects_to": "RAIL",
     "flags": [ "BASHABLE", "RAIL", "TRANSPARENT" ]
@@ -101,11 +93,7 @@
     },
     "deconstruct": {
       "ter_set": "t_rock_floor",
-      "items": [
-        { "item": "steel_lump", "count": [ 1, 2 ] },
-        { "item": "steel_chunk", "count": [ 1, 4 ] },
-        { "item": "scrap", "count": [ 3, 12 ] }
-      ]
+      "items": [ { "item": "railroad_track_small", "count": [ 1, 2 ] }, { "item": "sheet_metal", "count": [ 1, 2 ] } ]
     },
     "connects_to": "RAIL",
     "flags": [ "BASHABLE", "RAIL", "TRANSPARENT" ]
@@ -132,11 +120,7 @@
     },
     "deconstruct": {
       "ter_set": "t_rock_floor",
-      "items": [
-        { "item": "steel_lump", "count": [ 1, 2 ] },
-        { "item": "steel_chunk", "count": [ 1, 4 ] },
-        { "item": "scrap", "count": [ 3, 12 ] }
-      ]
+      "items": [ { "item": "railroad_track_small", "count": [ 1, 2 ] }, { "item": "sheet_metal", "count": [ 1, 2 ] } ]
     },
     "connects_to": "RAIL",
     "flags": [ "BASHABLE", "RAIL", "TRANSPARENT" ]
@@ -163,11 +147,7 @@
     },
     "deconstruct": {
       "ter_set": "t_rock_floor",
-      "items": [
-        { "item": "steel_lump", "count": [ 1, 2 ] },
-        { "item": "steel_chunk", "count": [ 1, 4 ] },
-        { "item": "scrap", "count": [ 3, 12 ] }
-      ]
+      "items": [ { "item": "railroad_track_small", "count": [ 1, 2 ] }, { "item": "sheet_metal", "count": [ 1, 2 ] } ]
     },
     "connects_to": "RAIL",
     "flags": [ "BASHABLE", "RAIL", "TRANSPARENT" ]
@@ -194,11 +174,7 @@
     },
     "deconstruct": {
       "ter_set": "t_rock_floor",
-      "items": [
-        { "item": "steel_lump", "count": [ 1, 2 ] },
-        { "item": "steel_chunk", "count": [ 1, 4 ] },
-        { "item": "scrap", "count": [ 3, 12 ] }
-      ]
+      "items": [ { "item": "railroad_track_small", "count": [ 1, 2 ] }, { "item": "sheet_metal", "count": [ 1, 2 ] } ]
     },
     "connects_to": "RAIL",
     "flags": [ "BASHABLE", "RAIL", "TRANSPARENT" ]
@@ -313,17 +289,18 @@
         { "item": "steel_lump", "count": [ 1, 2 ] },
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 3, 12 ] },
-        { "item": "splinter", "count": [ 10, 20 ] }
+        { "item": "splinter", "count": [ 10, 20 ] },
+        { "item": "nail", "charges": [ 0, 20 ] }
       ]
     },
     "deconstruct": {
       "ter_set": "t_rock_floor",
       "items": [
-        { "item": "steel_lump", "count": [ 1, 2 ] },
-        { "item": "steel_chunk", "count": [ 1, 4 ] },
-        { "item": "scrap", "count": [ 3, 12 ] },
+        { "item": "railroad_track_small", "count": [ 1, 2 ] },
         { "item": "log", "count": [ 0, 1 ] },
-        { "item": "splinter", "count": [ 10, 20 ] }
+        { "item": "splinter", "count": [ 10, 20 ] },
+        { "item": "nail", "charges": [ 10, 30 ] },
+        { "item": "sheet_metal", "count": [ 1, 2 ] }
       ]
     },
     "connects_to": "RAIL",
@@ -347,17 +324,18 @@
         { "item": "steel_lump", "count": [ 1, 2 ] },
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 3, 12 ] },
-        { "item": "splinter", "count": [ 10, 20 ] }
+        { "item": "splinter", "count": [ 10, 20 ] },
+        { "item": "nail", "charges": [ 0, 20 ] }
       ]
     },
     "deconstruct": {
       "ter_set": "t_rock_floor",
       "items": [
-        { "item": "steel_lump", "count": [ 1, 2 ] },
-        { "item": "steel_chunk", "count": [ 1, 4 ] },
-        { "item": "scrap", "count": [ 3, 12 ] },
+        { "item": "railroad_track_small", "count": [ 1, 2 ] },
         { "item": "log", "count": [ 0, 1 ] },
-        { "item": "splinter", "count": [ 10, 20 ] }
+        { "item": "splinter", "count": [ 10, 20 ] },
+        { "item": "nail", "charges": [ 10, 30 ] },
+        { "item": "sheet_metal", "count": [ 1, 2 ] }
       ]
     },
     "connects_to": "RAIL",
@@ -381,17 +359,18 @@
         { "item": "steel_lump", "count": [ 1, 2 ] },
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 3, 12 ] },
-        { "item": "splinter", "count": [ 10, 20 ] }
+        { "item": "splinter", "count": [ 10, 20 ] },
+        { "item": "nail", "charges": [ 0, 20 ] }
       ]
     },
     "deconstruct": {
       "ter_set": "t_rock_floor",
       "items": [
-        { "item": "steel_lump", "count": [ 1, 2 ] },
-        { "item": "steel_chunk", "count": [ 1, 4 ] },
-        { "item": "scrap", "count": [ 3, 12 ] },
+        { "item": "railroad_track_small", "count": [ 1, 2 ] },
         { "item": "log", "count": [ 0, 1 ] },
-        { "item": "splinter", "count": [ 10, 20 ] }
+        { "item": "splinter", "count": [ 10, 20 ] },
+        { "item": "nail", "charges": [ 10, 30 ] },
+        { "item": "sheet_metal", "count": [ 1, 2 ] }
       ]
     },
     "connects_to": "RAIL",
@@ -415,17 +394,18 @@
         { "item": "steel_lump", "count": [ 1, 2 ] },
         { "item": "steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 3, 12 ] },
-        { "item": "splinter", "count": [ 10, 20 ] }
+        { "item": "splinter", "count": [ 10, 20 ] },
+        { "item": "nail", "charges": [ 0, 20 ] }
       ]
     },
     "deconstruct": {
       "ter_set": "t_rock_floor",
       "items": [
-        { "item": "steel_lump", "count": [ 1, 2 ] },
-        { "item": "steel_chunk", "count": [ 1, 4 ] },
-        { "item": "scrap", "count": [ 3, 12 ] },
+        { "item": "railroad_track_small", "count": [ 1, 2 ] },
         { "item": "log", "count": [ 0, 1 ] },
-        { "item": "splinter", "count": [ 10, 20 ] }
+        { "item": "splinter", "count": [ 10, 20 ] },
+        { "item": "nail", "charges": [ 10, 30 ] },
+        { "item": "sheet_metal", "count": [ 1, 2 ] }
       ]
     },
     "connects_to": "RAIL",
@@ -578,16 +558,17 @@
         { "item": "steel_lump", "count": [ 0, 1 ] },
         { "item": "steel_chunk", "count": [ 0, 2 ] },
         { "item": "scrap", "count": [ 2, 6 ] },
-        { "item": "splinter", "count": [ 6, 12 ] }
+        { "item": "splinter", "count": [ 6, 12 ] },
+        { "item": "nail", "charges": [ 0, 10 ] }
       ]
     },
     "deconstruct": {
       "ter_set": "t_railroad_rubble",
       "items": [
-        { "item": "steel_lump", "count": [ 0, 1 ] },
-        { "item": "steel_chunk", "count": [ 0, 2 ] },
-        { "item": "scrap", "count": [ 2, 6 ] },
-        { "item": "splinter", "count": [ 6, 12 ] }
+        { "item": "railroad_track_small", "count": 1 },
+        { "item": "2x4", "count": 4 },
+        { "item": "nail", "charges": 20 },
+        { "item": "sheet_metal_small", "count": 2 }
       ]
     },
     "connects_to": "RAIL",
@@ -609,10 +590,10 @@
       "sound_fail": "clang!",
       "ter_set": "t_railroad_rubble",
       "items": [
-        { "item": "steel_lump", "count": [ 0, 1 ] },
-        { "item": "steel_chunk", "count": [ 0, 2 ] },
-        { "item": "scrap", "count": [ 2, 6 ] },
-        { "item": "splinter", "count": [ 6, 12 ] }
+        { "item": "railroad_track_small", "count": 1 },
+        { "item": "2x4", "count": 4 },
+        { "item": "nail", "charges": 20 },
+        { "item": "sheet_metal_small", "count": 2 }
       ]
     },
     "deconstruct": {
@@ -621,7 +602,8 @@
         { "item": "steel_lump", "count": [ 0, 1 ] },
         { "item": "steel_chunk", "count": [ 0, 2 ] },
         { "item": "scrap", "count": [ 2, 6 ] },
-        { "item": "splinter", "count": [ 6, 12 ] }
+        { "item": "splinter", "count": [ 6, 12 ] },
+        { "item": "nail", "charges": [ 0, 10 ] }
       ]
     },
     "connects_to": "RAIL",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -683,7 +683,8 @@
     "price_postapoc": 10,
     "material": [ "wood", "steel" ],
     "weight": "40 kg",
-    "volume": "30000 ml"
+    "volume": "30000 ml",
+    "qualities": [ [ "ANVIL", 2 ] ]
   },
   {
     "type": "GENERIC",
@@ -2964,7 +2965,7 @@
     "color": "brown",
     "name": { "str": "fire brick" },
     "category": "spare_parts",
-    "description": "A reinforced brick designed to withstand intense heat.",
+    "description": "A reinforced brick designed to withstand intense heat.  It could also be used as an impromptu anvil for light metalworking.",
     "price": 2500,
     "price_postapoc": 10,
     "material": [ "clay", "stone" ],
@@ -2972,7 +2973,7 @@
     "volume": "500 ml",
     "bashing": 8,
     "to_hit": -2,
-    "qualities": [ [ "HAMMER", 1 ] ]
+    "qualities": [ [ "HAMMER", 1 ], [ "ANVIL", 1 ] ]
   },
   {
     "id": "survival_kit",

--- a/data/json/items/melee/axes.json
+++ b/data/json/items/melee/axes.json
@@ -67,7 +67,7 @@
     "bashing": 19,
     "cutting": 51,
     "price_postapoc": 10000,
-    "qualities": [ [ "COOK", 1 ], [ "BUTCHER", -70 ] ]
+    "qualities": [ [ "AXE", 1 ], [ "COOK", 1 ], [ "BUTCHER", -70 ] ]
   },
   {
     "id": "halberd_fake",

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -322,7 +322,7 @@
     "to_hit": 1,
     "price": 12000,
     "price_postapoc": 500,
-    "qualities": [ [ "HAMMER", 1 ] ]
+    "qualities": [ [ "HAMMER", 2 ] ]
   },
   {
     "id": "hammer_sledge_short",
@@ -367,7 +367,7 @@
     "to_hit": -1,
     "price": 6000,
     "price_postapoc": 250,
-    "qualities": [ [ "HAMMER", 2 ] ]
+    "qualities": [ [ "HAMMER", 3 ] ]
   },
   {
     "id": "hockey_stick",
@@ -477,7 +477,7 @@
     "cutting": 34,
     "to_hit": 1,
     "price_postapoc": 10000,
-    "qualities": [ [ "COOK", 1 ] ]
+    "qualities": [ [ "HAMMER", 2 ], [ "COOK", 1 ] ]
   },
   {
     "id": "lucern_hammerfake",
@@ -493,7 +493,8 @@
     "weight": "2700 g",
     "volume": "3750 ml",
     "bashing": 48,
-    "cutting": 8
+    "cutting": 8,
+    "qualities": [ [ "HAMMER", 1 ], [ "COOK", 1 ] ]
   },
   {
     "id": "mace",
@@ -906,6 +907,6 @@
     "bashing": 22,
     "cutting": 23,
     "price": 16000,
-    "qualities": [ [ "HAMMER", 1 ] ]
+    "qualities": [ [ "HAMMER", 2 ] ]
   }
 ]

--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -32,7 +32,7 @@
     "material": "bronze",
     "symbol": ";",
     "color": "yellow",
-    "qualities": [ [ "ANVIL", 2 ] ],
+    "qualities": [ [ "ANVIL", 3 ] ],
     "flags": [ "DURABLE_MELEE" ]
   },
   {

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -122,7 +122,7 @@
     "material": [ "wood", "copper" ],
     "symbol": "/",
     "color": "brown",
-    "qualities": [ [ "AXE", 1 ], [ "BUTCHER", -44 ] ],
+    "qualities": [ [ "AXE", 2 ], [ "BUTCHER", -44 ] ],
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
     "flags": [ "NONCONDUCTIVE", "SHEATH_AXE" ]
   },

--- a/data/json/items/vehicle/plating.json
+++ b/data/json/items/vehicle/plating.json
@@ -64,7 +64,7 @@
     "category": "veh_parts",
     "price": 12000,
     "price_postapoc": 250,
-    "qualities": [ [ "COOK", 1 ] ]
+    "qualities": [ [ "COOK", 1 ], [ "ANVIL", 2 ] ]
   },
   {
     "type": "GENERIC",
@@ -81,7 +81,7 @@
     "category": "veh_parts",
     "price": 18500,
     "price_postapoc": 500,
-    "qualities": [ [ "COOK", 1 ] ]
+    "qualities": [ [ "COOK", 1 ], [ "ANVIL", 2 ] ]
   },
   {
     "type": "GENERIC",
@@ -133,7 +133,7 @@
     "category": "veh_parts",
     "price": 16000,
     "price_postapoc": 500,
-    "qualities": [ [ "COOK", 1 ], [ "ANVIL", 1 ] ]
+    "qualities": [ [ "COOK", 1 ], [ "ANVIL", 2 ] ]
   },
   {
     "type": "GENERIC",
@@ -150,7 +150,7 @@
     "category": "veh_parts",
     "price": 16000,
     "price_postapoc": 750,
-    "qualities": [ [ "COOK", 1 ] ]
+    "qualities": [ [ "COOK", 1 ], [ "ANVIL", 2 ] ]
   },
   {
     "type": "GENERIC",

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -459,7 +459,7 @@
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
     "skill_used": "fabrication",
-    "difficulty": 3,
+    "difficulty": 4,
     "time": "1 h",
     "reversible": true,
     "autolearn": true,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "More use of mid-tier axe, hammer, and anvil quality for relative items"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

This fixes some peculiarities here and there with tool qualities, making progression as skills escalate a bit more smooth, and lays some of the groundwork for once of these days when I eventually make variations in anvil quality actually matter some.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Increased axe quality of copper axe from 1 to 2, as it uses a harder to get material that takes more work than stone, plus this reasonably makes it in between the stone axe and a proper forged axe in quality.
2. In exchange, bumped the recipe for copper axe from 3 fabrication to 4, putting it in between stone axe and the proper wood axe.
3. Increased hammer quality of sledgehammers and warhammer from 1 to 2. Idea is, these are comparable to the makeshift hammer and stone hammer in still being a solid hammer-shaped object, and being more involved to make than a stone hammer one might reasonably expect them to be better at actually being a hammer than the almighty rock.
4. In return, upgraded engineer's hammer from 2 to 3 hammering quality, it being stated to be more like a tool than a weapon, and already previously having higher hammering quality, making it more reasonably a standin for the sort of short sledge one might use at a blacksmith's shop.
5. Gave halberds axe quality of 2 to match the battle axe, it being literally a polearm with an axe head, logically less suited for proper work than a wood axe but better than the stone axe.
6. Added hammering quality of 2 to lucerne hammer since comparable to war hammer, with the fake version getting a downgrade to hammering 1 since it's a lump of cheap aluminum.

At long last began my planned overhaul of what anvil quality means. In a nutshell, set it so that items that offer just a flat, hard non-metal surface has a quality of 1, metal flat surfaces in general offer 2, and anything metal that's properly anvil-like tends to be level 3:
7. Added anvil quality of 1 to fire brick, with description gaining a mention of this. Of the brick items it would logically stand up to having a piece of hot metal banged out on it the most.
8. Railroad track item given an anvil quality of 2, it being a common source of makeshift anvils IRL.
9. Railroad track terrain set to actually deconstruct into what they need to construct, making it possible to actually loot a subway track for rails to start your backyard smithing project. The constructable ones yield exactly what you put into them (yet another tiny step in my unending quest to phase out magically losing construction components), while the normal ones yield more variable amounts. Bashing also can actually yield some nails too given those are included in construction.
10. Steel, superalloy, and composite plating given an anvil quality of 2, and hard plating upgraded from 1 to 2, to make them consistent in all being a flat piece of good-quality metal for banging on.
11. The bronze anvil gets to actually be the bronze alternative to the normal anvil and not it's more annoying to make yet inferior brother, going from 2 quality to 3. Fits the general plan of bronze tools generally being comparable to equivalent basic metal tools.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. We could also standardize the skills used for stone tools. Most use fabrication first and survival second, but a few random ones here and there (like stone axe) use survival first then fabrication, and some like the stone knife use just survival.
2. Could add some way to build a brick or stone equivalent to gravestones or slabs as a construction source of level 1 anvil quality.
3. Adding level 1 or two anvil quality to workbenches on the basis of being big and heavy flat things.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

Checked affected JSON for syntax and lint errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
