### PR TITLE
Fix segfault when NPC is set to use silent weapons

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1376,9 +1376,9 @@ npc_action npc::method_of_attack()
 
     gun_mode g_mode = cbm_active.is_null() ? primary_weapon().gun_current_mode() :
                       cbm_fake_active.gun_current_mode();
-    if( !can_use_gun || dist <= 1 || g_mode &&
-        ( ( use_silent && !g_mode->is_silent() ) ||
-          ( item_funcs::shots_remaining( *this, *g_mode ) < g_mode.qty ) ) ) {
+    if( !can_use_gun || dist <= 1 ||
+        ( g_mode && ( ( use_silent && !g_mode->is_silent() ) ||
+                      ( item_funcs::shots_remaining( *this, *g_mode ) < g_mode.qty ) ) ) ) {
         g_mode = gun_mode();
     }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1376,8 +1376,9 @@ npc_action npc::method_of_attack()
 
     gun_mode g_mode = cbm_active.is_null() ? primary_weapon().gun_current_mode() :
                       cbm_fake_active.gun_current_mode();
-    if( !can_use_gun || ( use_silent && !g_mode->is_silent() ) ||
-        ( g_mode && ( item_funcs::shots_remaining( *this, *g_mode ) < g_mode.qty || dist <= 1 ) ) ) {
+    if( !can_use_gun || dist <= 1 || g_mode &&
+        ( ( use_silent && !g_mode->is_silent() ) ||
+          ( item_funcs::shots_remaining( *this, *g_mode ) < g_mode.qty ) ) ) {
         g_mode = gun_mode();
     }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3438,8 +3438,8 @@ bool npc::wield_better_weapon()
     const Creature *critter = current_target();
     const int dist = critter ? rl_dist( pos(), critter->pos() ) : - 1;
 
-    if( get_npc_ai_info_cache( npc_ai_info::range ) == dist ) {
-        add_msg( m_debug, "Distance hasn't changed from last wield check, cancelling." );
+    if( get_npc_ai_info_cache( npc_ai_info::range ) == dist && !has_new_items ) {
+        add_msg( m_debug, "Distance unchanged and npc has no new items, cancelling." );
         return false;
     }
     if( primary_weapon().has_flag( flag_NO_UNWIELD ) && cbm_toggled.is_null() ) {


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix segfault when NPC is set to use silent weapons."

#### Purpose of change

User on Discord reported that DDA NPCs caused segfaults when set to use silent weapons. Checked and the problem persists in BN, if slightly different, core issue is NPCs checking for `is_silent()` on non-gun items, causing null references.

#### Describe the solution

Only check `is_silent()` if the object in question is a gun. Also restructured the arguments a bit so the faster ones are in front.

#### Describe alternatives you've considered

#### Testing

Mind Control NPC and give them a rule to use silent weapons, then give them a gun, check that they will not use the gun but instead attack the target in melee. Remove rule and check that they will then use the gun.

#### Additional context
