### PR TITLE
Expand tool options for glass, paper, and neoprene crafting

### DIFF
--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -439,7 +439,7 @@
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
-      [ [ "sheet_metal", -1 ] ],
+      [ [ "tool_flat_press_large", 1, "LIST" ], [ "tool_flat_press_small", 1, "LIST" ] ],
       [ [ "forge", 25 ] ],
       [ [ "surface_heat", 15, "LIST" ] ]
     ],
@@ -460,7 +460,12 @@
     "difficulty": 3,
     "time": "1 h",
     "autolearn": true,
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "sheet_metal", -1 ] ], [ [ "forge", 75 ] ] ],
+    "tools": [
+      [ [ "tongs", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
+      [ [ "tool_flat_press_large", 1, "LIST" ] ],
+      [ [ "forge", 75 ] ]
+    ],
     "components": [ [ [ "glass_shard", 18 ], [ "jar_glass", 9 ], [ "flask_glass", 18 ], [ "test_tube", 36 ] ] ]
   },
   {
@@ -532,7 +537,13 @@
     "time": "2 h",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "CUT", "level": 1 } ],
-    "tools": [ [ [ "sheet_metal", -1 ] ] ],
+    "tools": [
+      [
+        [ "tool_flat_press_large", 1, "LIST" ],
+        [ "tool_flat_press_small", 1, "LIST" ],
+        [ "tool_flat_press_improvised", 1, "LIST" ]
+      ]
+    ],
     "components": [ [ [ "splinter", 10 ], [ "stick", 4 ], [ "2x4", 4 ], [ "withered", 20 ] ], [ [ "water", 4 ], [ "water_clean", 4 ] ] ]
   },
   {
@@ -913,7 +924,14 @@
     "book_learn": [ [ "adv_chemistry", 3 ], [ "textbook_chemistry", 3 ] ],
     "result_mult": 9,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 100, "LIST" ] ], [ [ "sheet_metal", -1 ] ] ],
+    "tools": [
+      [ [ "surface_heat", 100, "LIST" ] ],
+      [
+        [ "tool_flat_press_large", 1, "LIST" ],
+        [ "tool_flat_press_small", 1, "LIST" ],
+        [ "tool_flat_press_improvised", 1, "LIST" ]
+      ]
+    ],
     "components": [
       [ [ "chem_ethanol", 50 ], [ "denat_alcohol", 50 ] ],
       [ [ "copper_scrap_equivalent", 2, "LIST" ] ],
@@ -1059,7 +1077,12 @@
     "difficulty": 4,
     "time": "1 h",
     "autolearn": true,
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "sheet_metal", -1 ] ], [ [ "forge", 75 ] ] ],
+    "tools": [
+      [ [ "tongs", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
+      [ [ "tool_flat_press_large", 1, "LIST" ] ],
+      [ [ "forge", 75 ] ]
+    ],
     "components": [ [ [ "glass_shard", 40 ], [ "flask_glass", 12 ], [ "jar_glass", 4 ] ] ]
   },
   {
@@ -1071,7 +1094,12 @@
     "difficulty": 4,
     "time": "1 h",
     "autolearn": true,
-    "tools": [ [ [ "tongs", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "sheet_metal", -1 ] ], [ [ "forge", 75 ] ] ],
+    "tools": [
+      [ [ "tongs", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
+      [ [ "tool_flat_press_large", 1, "LIST" ] ],
+      [ [ "forge", 75 ] ]
+    ],
     "components": [ [ [ "plastic_chunk", 200 ] ] ]
   },
   {
@@ -1291,7 +1319,7 @@
     "tools": [
       [ [ "tongs", -1 ] ],
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
-      [ [ "sheet_metal_small", -1 ], [ "sheet_metal", -1 ] ],
+      [ [ "tool_flat_press_large", 1, "LIST" ], [ "tool_flat_press_small", 1, "LIST" ] ],
       [ [ "forge", 60 ] ]
     ],
     "components": [ [ [ "glass_shard", 2 ] ], [ [ "chem_sulphur", 1 ] ], [ [ "scrap", 1 ] ], [ [ "charcoal", 1 ] ] ]

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -176,5 +176,31 @@
       { "id": "PRY", "level": 3 },
       { "id": "SCREW", "level": 1 }
     ]
+  },
+  {
+    "id": "tool_flat_press_large",
+    "type": "requirement",
+    "//": "For making sheets of material, e.g. paper, neoprene, etc.  For larger items like glass panes.",
+    "tools": [ [ [ "sheet_metal", -1 ], [ "steel_plate", -1 ], [ "alloy_plate", -1 ], [ "hard_plate", -1 ] ] ]
+  },
+  {
+    "id": "tool_flat_press_small",
+    "type": "requirement",
+    "//": "For making sheets of material, e.g. paper, neoprene, etc.  For smaller items like neoprene.",
+    "tools": [ [ [ "sheet_metal_small", -1 ], [ "alloy_sheet", -1 ] ] ]
+  },
+  {
+    "id": "tool_flat_press_improvised",
+    "type": "requirement",
+    "//": "For making sheets of material, e.g. paper, neoprene, etc.  Allow for makeshift items where high temps aren't a concern.",
+    "tools": [
+      [
+        [ "glass_sheet", -1 ],
+        [ "tempered_glass_sheet", -1 ],
+        [ "rigid_plastic_sheet", -1 ],
+        [ "wood_panel", -1 ],
+        [ "wood_sheet", -1 ]
+      ]
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Balance "Expand options for tools that can press paper, neoprene, and glass sheets"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

An update to the paper recipe that came to mind, allowing a few options for the main roadblock to making paper the old-school way, making it so that having access to city resources or bootstrapping metalworking isn't needed to get paper.

Also applies similar consistency changes to other recipes in the same file that involve a flat sheet being laid out.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

1. Changed the recipe for paper to allow small metal sheets, steel/alloy/hard plating, sheets of glass and tempered glass, wooden panels/sheets, and rigid plastic sheets as alternatives to sheet metal. Mil-comp and especially spiked plating excluded on the assumption that they might not be as good and flat, likewise reinforced glass mentions wiring that might presumably be welded on the outside.
2. Additionally, the other recipes in the same file to use sheet metal for glass sheet production and neoprene have been standardized to allow sheet metal, small metal sheets (shards and tinted glass, but not full-size sheets), alloy sheets (again, the two smaller items only), and the relevant plating items, with neoprene also allowing the glass and wood options.
3. Since I realized these would entail a lot of redundant tool usage, predicting that it'd be good to have these streamlined by some other method, I implemented them as crafting requirements instead of asking for the same lists of big flat items each time. Divided up based on how the most fitting items for each recipe seemed to fit, into big items like sheet metal, ones for smaller recipes like small metal sheets, then glass and wood items for non-glassmaking recipes.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. Making some kinda paper-pressing quality for the relevant items to have instead.
2. Setting the plating and sheet items to use `sub` to reduce the amount of tools specified in the crafting requirements.
3. Allowing rags as an alternative to wood, in the vein of cotton paper. Wood is generally the easier resource to get both innawoods and in cities, though.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

1. Checked affected files for syntax and lint errors.
2. Load-tested in compiled build.

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/7764243d-9646-4aaf-aacf-50d207e27b88)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->

I checked DDA out of curiosity, they at some point did a more barebones attempt at this same idea:
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/11582235/3478264b-7a69-48be-a444-6a133ea7e2a5)

Didn't do anything with sheets of glass it looks like though. Also surprised there isn't a papermaking proficiency,