### PR TITLE
Show vehicle speed when not using cruise control, standardize speed display

### DIFF
--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -1659,16 +1659,16 @@ static void draw_health_classic( avatar &u, const catacurses::window &w )
         mvwprintz( w, point( 35, 4 ), c_light_gray, veh->face.to_string_azimuth_from_north() );
         // target speed > current speed
         const float strain = veh->strain();
+        nc_color col_vel = strain <= 0 ? c_light_blue :
+                           ( strain <= 0.2 ? c_yellow :
+                             ( strain <= 0.4 ? c_light_red : c_red ) );
+        int t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
+        int c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
+        int offset = get_int_digits( c_speed );
+        const std::string type = get_option<std::string>( "USE_METRIC_SPEEDS" );
+        mvwprintz( w, point( 21, 5 ), c_light_gray, type );
+        mvwprintz( w, point( 26, 5 ), col_vel, "%d", c_speed );
         if( veh->cruise_on ) {
-            nc_color col_vel = strain <= 0 ? c_light_blue :
-                               ( strain <= 0.2 ? c_yellow :
-                                 ( strain <= 0.4 ? c_light_red : c_red ) );
-            int t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
-            int c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
-            int offset = get_int_digits( t_speed );
-            const std::string type = get_option<std::string>( "USE_METRIC_SPEEDS" );
-            mvwprintz( w, point( 21, 5 ), c_light_gray, type );
-            mvwprintz( w, point( 26, 5 ), col_vel, "%d", c_speed );
             mvwprintz( w, point( 26 + offset, 5 ), c_light_gray, ">" );
             mvwprintz( w, point( 28 + offset, 5 ), c_light_green, "%d", t_speed );
         }
@@ -1773,18 +1773,18 @@ static void draw_veh_compact( const avatar &u, const catacurses::window &w )
         mvwprintz( w, point( 6, 0 ), c_light_gray, veh->face.to_string_azimuth_from_north() );
         // target speed > current speed
         const float strain = veh->strain();
+        nc_color col_vel = strain <= 0 ? c_light_blue :
+                           ( strain <= 0.2 ? c_yellow :
+                             ( strain <= 0.4 ? c_light_red : c_red ) );
+        int t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
+        int c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
+        int offset = get_int_digits( c_speed );
+        const std::string type = get_option<std::string>( "USE_METRIC_SPEEDS" );
+        mvwprintz( w, point( 12, 0 ), c_light_gray, "%s :", type );
+        mvwprintz( w, point( 19, 0 ), col_vel, "%d", c_speed );
         if( veh->cruise_on ) {
-            nc_color col_vel = strain <= 0 ? c_light_blue :
-                               ( strain <= 0.2 ? c_yellow :
-                                 ( strain <= 0.4 ? c_light_red : c_red ) );
-            int t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
-            int c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
-            int offset = get_int_digits( t_speed );
-            const std::string type = get_option<std::string>( "USE_METRIC_SPEEDS" );
-            mvwprintz( w, point( 12, 0 ), c_light_gray, "%s :", type );
-            mvwprintz( w, point( 19, 0 ), c_light_green, "%d", t_speed );
             mvwprintz( w, point( 20 + offset, 0 ), c_light_gray, "%s", ">" );
-            mvwprintz( w, point( 22 + offset, 0 ), col_vel, "%d", c_speed );
+            mvwprintz( w, point( 22 + offset, 0 ), c_light_green, "%d", t_speed );
         }
     }
 
@@ -1808,15 +1808,15 @@ static void draw_veh_padding( const avatar &u, const catacurses::window &w )
         nc_color col_vel = strain <= 0 ? c_light_blue :
                            ( strain <= 0.2 ? c_yellow :
                              ( strain <= 0.4 ? c_light_red : c_red ) );
+        int t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
+        int c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
+        int offset = get_int_digits( c_speed );
+        const std::string type = get_option<std::string>( "USE_METRIC_SPEEDS" );
+        mvwprintz( w, point( 13, 0 ), c_light_gray, "%s :", type );
+        mvwprintz( w, point( 20, 0 ), col_vel, "%d", c_speed );
         if( veh->cruise_on ) {
-            int t_speed = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
-            int c_speed = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
-            int offset = get_int_digits( t_speed );
-            const std::string type = get_option<std::string>( "USE_METRIC_SPEEDS" );
-            mvwprintz( w, point( 13, 0 ), c_light_gray, "%s :", type );
-            mvwprintz( w, point( 20, 0 ), c_light_green, "%d", t_speed );
             mvwprintz( w, point( 21 + offset, 0 ), c_light_gray, "%s", ">" );
-            mvwprintz( w, point( 23 + offset, 0 ), col_vel, "%d", c_speed );
+            mvwprintz( w, point( 23 + offset, 0 ), c_light_green, "%d", t_speed );
         }
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

SUMMARY: Interface "Vehicle speed is shown when cruise control is disabled."

#### Purpose of change

I tried to save some probably insignificant amount of fuel by disabling cruise control and coasting the final distance towards a destination, but noticed that the speed display vanished entirely. If the universal Vehicle Controls allow maintaining an exact speed via cruise control, presumably they have a regular speedometer (or whatever the equivalent would be for a boat or helicopter) so that seemed weird and unhelpful.

#### Describe the solution

When cruise control is disabled, only the target speed stops being shown, the current speed remains.

When doing this, I noticed that the order of target speed / current speed was inconsistent between sidebar display styles, and decided to standardize them as `[Units] [Current Speed] > [Target Speed]`, just to make it easier to clip off the latter half when not cruising. If there are objections to this I can change it back.

#### Describe alternatives you've considered

Maybe use the empty space to show current acceleration for manual driving? Not sure how that'd fit in the more cramped sidebar styles in a way that's easily readable for new players.

#### Testing

Start world, spawn character, spawn car.
Get in and drive, see that the cruise control indicator still works and is the same for each sidebar style, and that the current speed correctly changes color per engine strain.
Turn off cruise control and can still see current speed, accelerate and decelerate to check that it shows correctly.
Switched around speed display to mph and tiles per second in options, they all still show correctly.

#### Additional context

Sidebar styles in order classic, compact, labels, labels-narrow.

Cruise control on.
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/29438599/6a6bfb04-a0c0-40e2-821d-93bf3fc2250a)

Cruise control off.
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/29438599/8d3c9be1-5965-46e0-9ef6-aed2ab5218a0)
