### PR TITLE
Fix a crash when using chop tree zones

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4232,10 +4232,17 @@ void activity_handlers::chop_tree_finish( player_activity *act, player *p )
     act->set_to_null();
 
     // Quality of tool used and assistants can together both reduce intensity of work.
+    if( act->targets.empty() ) {
+        debugmsg( "woodcutting item location not set" );
+        resume_for_multi_activities( *p );
+        return;
+    }
+
     item_location &loc = act->targets[ 0 ];
     item *it = loc.get_item();
     if( it == nullptr ) {
         debugmsg( "woodcutting item location lost" );
+        resume_for_multi_activities( *p );
         return;
     }
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2453,10 +2453,12 @@ static bool chop_tree_activity( player &p, const tripoint &src_loc )
     const ter_id ter = here.ter( src_loc );
     if( here.has_flag( flag_TREE, src_loc ) ) {
         p.assign_activity( ACT_CHOP_TREE, moves, -1, p.get_item_position( best_qual ) );
+        p.activity.targets.push_back( item_location( p, best_qual ) );
         p.activity.placement = here.getabs( src_loc );
         return true;
     } else if( ter == t_trunk || ter == t_stump ) {
         p.assign_activity( ACT_CHOP_LOGS, moves, -1, p.get_item_position( best_qual ) );
+        p.activity.targets.push_back( item_location( p, best_qual ) );
         p.activity.placement = here.getabs( src_loc );
         return true;
     }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix a crash when chopping trees or logs from a zone"

#### Purpose of change

Fix #3015 

#### Describe the solution

Adds the item as the activity target when the activity is started from a zone as well. Also a check to turn the crash into red text.

#### Testing

Crashed every time previously. Doesn't crash now.
