### PR TITLE
Prevent a possible crash in spells

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4844,7 +4844,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, player *p )
             }
         }
     }
-    if( !act->targets.empty() ) {
+    if( !act->targets.empty() && act->targets.front() ) {
         item &it = *act->targets.front();
         if( !it.has_flag( "USE_PLAYER_ENERGY" ) ) {
             p->consume_charges( it, it.type->charges_to_use() );


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix a crash in spells"

#### Purpose of change

Prevents a segfault.

#### Describe the solution

When a spellcast has an item (from which it will take charges), it doesn't check if that item location is still valid. 

#### Testing

Previously crashing save no longer crashes.

#### Additional context

Killing the flesh guys in secronom is what triggers this.
