### PR TITLE
Fixes an overflow in monster splatter

### DIFF
--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -223,9 +223,9 @@ void mdeath::splatter( monster &z )
     // 1% of the weight of the monster is the base, with overflow damage as a multiplier
     int gibbed_weight = rng( 0, std::round( to_gram( z.get_weight() ) / 100.0 *
                                             ( overflow_damage / max_hp + 1 ) ) );
-    const int z_weight = to_gram( z.get_weight() );
+    const uint64_t z_weight = to_gram( z.get_weight() );
     // limit gibbing to 15%
-    gibbed_weight = std::min( gibbed_weight, z_weight * 15 / 100 );
+    gibbed_weight = std::min( static_cast<uint64_t>( gibbed_weight ), z_weight * 15 / 100 );
 
     if( pulverized && gibbable ) {
         float overflow_ratio = overflow_damage / max_hp + 1;


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fix an overflow when big monsters splat"

#### Purpose of change

When calculating splatter the game look at 15% of the weight. This is done by first multiplying by 15 and then dividing by 100. 32 bits isn't enough for some of the weights in secronom * 15. 

#### Describe the solution

Use 64 bit unsigned for that calculation.

#### Describe alternatives you've considered

Rearranging the maths a bit, but it's not like performance is a concern for monster splatter.

#### Testing

I only noticed this because I was hunting another issue, but it's just a width upgrade.
