### PR TITLE
Make "wall_floor_glass_removal_standard" more rational

### DIFF
--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -154,11 +154,10 @@
     "//": "Tools for removing a normal wall / floor / glass",
     "qualities": [
       { "id": "HAMMER", "level": 2 },
-      { "id": "CHISEL", "level": 2 },
-      { "id": "PRY", "level": 3 },
+      { "id": "CHISEL", "level": 1 },
+      { "id": "PRY", "level": 2 },
       { "id": "DIG", "level": 3 }
-    ],
-    "tools": [ [ [ "angle_grinder", 200 ] ] ]
+    ]
   },
   {
     "id": "linoleum_removal_standard",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

SUMMARY: Balance "Remove angle grinder from wall_floor_glass_removal_standard, lower CHISEL and PRY requirements"

#### Purpose of change

It seemed remarkably strange for the deconstruction of wooden walls, empty window frames, and similar items to require an angle grinder. While this requirement makes sense for concrete and rebar, it does not make sense for wood and glass. I also noticed that the chiseling quality requirement of 2 was not actually held by any item, with only a quality of 1 or 3 being granted to an item in Vanilla so far as I could see. The prying requirement seemed somewhat unnecessarily restrictive, as a claw bar, crash axe, or ice axe all seemed like they could reasonably be used in this situation for any prying necessary.

#### Describe the solution

-  Removed the Angle Grinder requirement from wall_floor_glass_removal_standard, which is the item used by the deconstructions that I was targeting
- Lowered the chiseling requirement to 1. No vanilla tool with Chiseling 2 exists, and putting it with Chiseling 1 felt more reasonable and natural than putting it with chiseling 3.
- Lowered the prying requirement to 2. The claw bar, ice axe, and crash axe seem perfectly reasonable for the prying needs of deconstructing these walls.

#### Describe alternatives you've considered

- Removing the Angle Grinder, but leaving the quality requirements alone
Considering there isn't a tool with Chiseling 2 yet, at the very least I feel like that requirement should be changed to be rational. The prying requirement changing was more of personal opinion in regards to what quality felt right for what was being accomplished.
- Not changing anything
As described earlier, the Angle Grinder requirement for something as simple as a wooden wall or an empty window frame seems incredibly odd. It makes plenty of sense for concrete and rebar, but not for this.

#### Testing

1. Edited toolsets.json to make the proposed changes
2. Loaded into the game
3. Approached a nearby empty window frame from a derelict shed
4. Opened the construct menu and checked the relevant deconstruction task
5. Requirements successfully changed
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/30732426/e077ee91-528c-4e6e-a7d5-e4d3985efe17)


#### Additional context
