### PR TITLE
perf: port AIM UI update optimization

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1430,7 +1430,11 @@ void advanced_inventory::display()
                advanced_inventory::side::left;
 
         if( ui ) {
-            ui_manager::redraw();
+            ui->invalidate_ui();
+            if( recalc ) {
+                g->invalidate_main_ui_adaptor();
+            }
+            ui_manager::redraw_invalidated();
         }
 
         recalc = false;


### PR DESCRIPTION
#### Summary

SUMMARY: Performance "Port Advanced Inventory Management UI update optimization from DDA"

#### Purpose of change

- port https://github.com/CleverRaven/Cataclysm-DDA/pull/67403 by @inogenous 

#### Testing

1. built cata with `RelWithDebugInfo` enabled.
2. invoked callgrind with:
```
valgrind --tool=callgrind --instr-atstart=no --collect-atstart=no '--toggle-collect=advanced_inventory::display()' ./cataclysm-tiles
```
3. created an empty world, dropped all items on the floor.
4. invoked `callgrind_control -i on` on other shell.
5. `alt-tabbed` to game, pressed up and down key ten times.
6. invoked `callgrind_control -i off` on other shell.
7. `ctrl-c`ed the process, with 3.7 billion IRs collected.

<details><summary>Details</summary>

```
 ~/D/CataclysmBN  valgrind --tool=callgrind --instr-atstart=no --collect-atstart=no '--toggle-collect=advanced_inventory::display()' ./cataclysm-tiles
==170190== /home/scarf/.valgrindrc was not read as it is either not a regular file,
==170190==     or is world writeable, or is not owned by the current user.
==170190== Callgrind, a call-graph generating cache profiler
==170190== Copyright (C) 2002-2017, and GNU GPL'd, by Josef Weidendorfer et al.
==170190== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==170190== Command: ./cataclysm-tiles
==170190== 
==170190== For interactive control, run 'callgrind_control -h'.
==170190== brk segment overflow in thread #1: can't grow to 0x483c000
==170190== (see section Limitations in user manual)
==170190== NOTE: further instances of this message will not be shown
libpng warning: iCCP: known incorrect sRGB profile
^C==170190== 
==170190== Events    : Ir
==170190== Collected : 3739843911
==170190== 
==170190== I   refs:      3,739,843,911
```

</details> 

![callgrind](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/23d9932e-bb96-438e-98cd-dc85f3d140c1)

after porting, kcachegrind call graph showed similar output from the one from DDA.

to reduce slowdown caused by callgrind: https://stackoverflow.com//questions/48573177/minimum-callgrind-command-for-callgraph-generation-and-profiling#answer-49063952
