### PR TITLE
fix: reset aftershock `river_scale`

### DIFF
--- a/data/mods/Aftershock/region_settings.json
+++ b/data/mods/Aftershock/region_settings.json
@@ -2,7 +2,7 @@
   {
     "type": "region_overlay",
     "regions": [ "all" ],
-    "river_scale": 2.0,
+    "river_scale": 1.0,
     "city": {
       "shop_radius": 1,
       "shop_sigma": 300,


### PR DESCRIPTION
#### Summary

SUMMARY: Mods "Stop aftershock mapgen turning the world into ocean"

#### Purpose of change

![1691477183](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/9e3d8c16-1c4c-4935-89be-fb45f7ad3040)

https://gall.dcinside.com/board/view/?id=rlike&no=445258
https://gall.dcinside.com/board/view/?id=rlike&no=445260

issue reported by @NobleJake 

#### Describe the solution

reset `river_scale` from 2 to 1

#### Describe alternatives you've considered

enjoy water contents
