### PR TITLE
feat: better error messages for sfx errors

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -570,18 +570,21 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
                                 effect_to_play ) == 0 ) {
             // We'll be unable to de-allocate the chunk, stop the playback right now.
             failed = true;
-            dbg( DL::Warn ) << "Mix_RegisterEffect failed: " << Mix_GetError();
+            dbg( DL::Warn ) << "Mix_RegisterEffect failed { id: " << id << ", variant: " << variant << " }: " <<
+                            Mix_GetError();
             Mix_HaltChannel( channel );
         }
     }
     if( !failed ) {
         if( Mix_SetPosition( channel, static_cast<Sint16>( to_degrees( angle ) ), 1 ) == 0 ) {
             // Not critical
-            dbg( DL::Info ) << "Mix_SetPosition failed: " << Mix_GetError();
+            dbg( DL::Info ) << "Mix_SetPosition failed { id: " << id << ", variant: " << variant << " }: " <<
+                            Mix_GetError();
         }
     }
     if( failed ) {
-        dbg( DL::Error ) << "Failed to play sound effect: " << Mix_GetError();
+        dbg( DL::Error ) << "Failed to play sound effect { id: " << id << ", variant: " << variant << " }: "
+                         << Mix_GetError();
         if( is_pitched ) {
             cleanup_when_channel_finished( channel, effect_to_play );
         }
@@ -624,12 +627,14 @@ void sfx::play_ambient_variant_sound( const std::string &id, const std::string &
         if( Mix_RegisterEffect( ch, empty_effect, cleanup_when_channel_finished, effect_to_play ) == 0 ) {
             // We'll be unable to de-allocate the chunk, stop the playback right now.
             failed = true;
-            dbg( DL::Warn ) << "Mix_RegisterEffect failed: " << Mix_GetError();
+            dbg( DL::Warn ) << "Mix_RegisterEffect failed { id: " << id << ", variant: " << variant << " }: " <<
+                            Mix_GetError();
             Mix_HaltChannel( ch );
         }
     }
     if( failed ) {
-        dbg( DL::Error ) << "Failed to play sound effect: " << Mix_GetError();
+        dbg( DL::Error ) << "Failed to play sound effect { id: " << id << ", variant: " << variant << " }: "
+                         << Mix_GetError();
         if( is_pitched ) {
             cleanup_when_channel_finished( ch, effect_to_play );
         }

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -340,8 +340,7 @@ static Mix_Chunk *load_chunk( const std::string &path )
 {
     Mix_Chunk *result = Mix_LoadWAV( path.c_str() );
     if( result == nullptr ) {
-        // Failing to load a sound file is not a fatal error worthy of a backtrace
-        dbg( DL::Warn ) << "Failed to load sfx audio file " << path << ": " << Mix_GetError();
+        debugmsg( "Failed to load sfx audio file %s: %s", path.c_str(), Mix_GetError() );
         result = make_null_chunk();
     }
     return result;


### PR DESCRIPTION
#### Summary

- fixes #114 
- fixes #2523

SUMMARY: Bugfixes "debugmsg on invalid sfx path on game startup. add more info to sfx error debug log"

#### Purpose of change

invalid sfx file path can throw 5-second debug error backtrace when actually using that sfx. as it's not a crash and only logged in `debug.log`, it could be mistook as #2523

#### Describe the solution

use `debugmsg` when loading game and sfx, as it's better to notice this kind of errors earlier

related: https://github.com/CleverRaven/Cataclysm-DDA/pull/53709

#### Testing

~~worked on my machine~~
