### PR TITLE
feat: double the projectile speed

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -43,7 +43,7 @@ namespace
 class basic_animation
 {
     public:
-        explicit basic_animation( const int scale ) :
+        explicit basic_animation( const float scale ) :
             delay( static_cast<size_t>( get_option<int>( "ANIMATION_DELAY" ) ) * scale * 1000000L ) {
         }
 
@@ -89,7 +89,7 @@ class explosion_animation : public basic_animation
 class bullet_animation : public basic_animation
 {
     public:
-        bullet_animation() : basic_animation( 1 ) {
+        bullet_animation() : basic_animation( 0.5 ) {
         }
 };
 


### PR DESCRIPTION
#### Summary

SUMMARY: Interface "doubled projectile animation speed"

#### Purpose of change

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/ba13a0ec-9aab-443e-9d82-2ee8dc703c7d

faster bullets! better machine guns!

#### Describe the solution

made bullets take half the time to travel

#### Describe alternatives you've considered

fine grained control for each categories of animations? might be better to choose this route but wonder if we should keep 'global animation delay'.

#### Testing

changes this small can't break anything, right?
...right?

#### Additional context

haha bullets go brrrrrr