### PR TITLE
perf(port): do not copy regional settings for overmaps

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1146,7 +1146,7 @@ overmap::overmap( const point_abs_om &p ) : loc( p )
         // gonna die now =[
         debugmsg( "overmap %s: can't find region '%s'", loc.to_string(), rsettings_id.c_str() );
     }
-    settings = pimpl<regional_settings>( rsit->second );
+    settings = &rsit->second;
 
     init_layers();
 }
@@ -1168,7 +1168,7 @@ void overmap::populate( overmap_special_batch &enabled_specials )
 void overmap::populate()
 {
     overmap_special_batch enabled_specials = overmap_specials::get_default_batch( loc );
-    overmap_feature_flag_settings &overmap_feature_flag = settings->overmap_feature_flag;
+    const overmap_feature_flag_settings &overmap_feature_flag = settings->overmap_feature_flag;
 
     const bool should_blacklist = !overmap_feature_flag.blacklist.empty();
     const bool should_whitelist = !overmap_feature_flag.whitelist.empty();

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -352,7 +352,7 @@ class overmap
         // TODO: Should have individual instances grouped by placement (ie. 2 adjacent houses aren't one house)
         std::unordered_map<tripoint_om_omt, overmap_special_id> overmap_special_placements;
 
-        pimpl<regional_settings> settings;
+        const regional_settings *settings;
 
         oter_id get_default_terrain( int z ) const;
 

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -479,7 +479,7 @@ void overmap::unserialize( std::istream &fin, const std::string &file_path )
                 t_regional_settings_map_citr rit = region_settings_map.find( new_region_id );
                 if( rit != region_settings_map.end() ) {
                     // TODO: optimize
-                    settings = pimpl<regional_settings>( rit->second );
+                    settings = &rit->second;
                 }
             }
         } else if( name == "mongroups" ) {


### PR DESCRIPTION
#### Summary

SUMMARY: Performance "DDA Port: Stop copying regional settings for every overmap"

#### Purpose of change

performance gainz

#### Describe the solution

port https://github.com/CleverRaven/Cataclysm-DDA/pull/59313 by @jbytheway 

#### Testing

i trust DDA and CI pipeline.