### PR TITLE
docs: fix field typo on `price_postapoc`

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -1713,7 +1713,7 @@ See also VEHICLE_JSON.md
 "rigid": false,                              // For non-rigid items volume (and for worn items encumbrance) increases proportional to contents
 "insulation": 1,                             // (Optional, default = 1) If container or vehicle part, how much insulation should it provide to the contents
 "price": 100,                                // Used when bartering with NPCs. For stackable items (ammo, comestibles) this is the price for stack_size charges. Can use string "cent" "USD" or "kUSD".
-"price_post": "1 USD",                       // Same as price but represent value post cataclysm. Can use string "cent" "USD" or "kUSD".
+"price_postapoc": "1 USD",                   // Same as price but represent value post cataclysm. Can use string "cent" "USD" or "kUSD".
 "material": ["COTTON"],                      // Material types, can be as many as you want.  See materials.json for possible options
 "weapon_category": [ "WEAPON_CAT1" ],        // (Optional) Weapon categories this item is in for martial arts.
 "cutting": 0,                                // (Optional, default = 0) Cutting damage caused by using it as a melee weapon.  This value cannot be negative.


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Fixed documentation typo on `price_postapoc`"


#### Purpose of change

it was wrongly written as `price_post` in docs.

https://github.com/cataclysmbnteam/Cataclysm-BN/blob/8548854c24573f240e5268257f3b6a061b26d90c/src/item_factory.cpp#L2409