### PR TITLE
Add an option to draw bullets as lines

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -232,7 +232,8 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
                         proj.has_effect( ammo_effect_JET );
     const char bullet = stream ? '#' : '*';
     const bool no_item_damage = proj.has_effect( ammo_effect_NO_ITEM_DAMAGE );
-    const bool do_draw_line = proj.has_effect( ammo_effect_DRAW_AS_LINE );
+    const bool do_draw_line = proj.has_effect( ammo_effect_DRAW_AS_LINE ) ||
+                              get_option<bool>( "BULLETS_AS_LASERS" );
     const bool null_source = proj.has_effect( ammo_effect_NULL_SOURCE );
     // Determines whether it can penetrate obstacles
     const bool is_bullet = proj_arg.speed >= 200 &&

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1827,6 +1827,11 @@ void options_manager::add_options_graphics()
 
     get_option( "ANIMATION_DELAY" ).setPrerequisite( "ANIMATIONS" );
 
+    add( "BULLETS_AS_LASERS", graphics, translate_marker( "Draw bullets as lines" ),
+         translate_marker( "If true, bullets are drawn as lines of images, and the animation lasts only one frame." ),
+         false
+       );
+
     add( "BLINK_SPEED", graphics, translate_marker( "Blinking effects speed" ),
          translate_marker( "The speed of every blinking effects in ms." ),
          100, 5000, 800


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->

SUMMARY: Features "Add an option to draw bullets as lines"

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

Making burst fire not take forever, especially if it's a long burst.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

Option to draw each bullet as one line rather than a dot that changes position once per frame.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

* Batch multiple bullet "points" and draw lines that fly forward - actually tried that, but dropped due to it being relatively complicated, while not achieving much more than this one

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

* Enable the option in graphics
* Burst fire a gun
* Each bullet should only take one frame and show the entire flight path (clipped to viewport, of course)
* Repeat in curses mode

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->