### PR TITLE
Add sulphuric acid synthesis; Update chemicals.json

### DIFF
--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -391,6 +391,22 @@
   },
   {
     "type": "recipe",
+    "result": "chem_sulphuric_acid",
+	  "id_suffix": "from SO3",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_CHEMICALS",
+    "skill_used": "cooking",
+    "difficulty": 8,
+    "time": "60 m",
+    "book_learn": [ [ "textbook_chemistry", 4 ], [ "adv_chemistry", 5 ] ],
+    "batch_time_factors": [ 80, 5 ],
+    "qualities": [ { "id": "BOIL", "level": 2 }, { "id": "CHEM", "level": 2 } ],
+	  "using": [ [ "forging_standard", 50 ] ],
+    "tools": [ [ [ "surface_heat", 25, "LIST" ] ], [ [ "platinum_grille", -1 ] ] ],
+    "components": [ [ [ "water_clean", 1 ] ], [ [ "chem_sulphur", 470 ] ] ]
+  },
+  {
+    "type": "recipe",
     "result": "chem_nitric_acid",
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_CHEMICALS",

--- a/data/json/recipes/chem/chemicals.json
+++ b/data/json/recipes/chem/chemicals.json
@@ -392,7 +392,7 @@
   {
     "type": "recipe",
     "result": "chem_sulphuric_acid",
-	  "id_suffix": "from SO3",
+    "id_suffix": "from SO3",
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_CHEMICALS",
     "skill_used": "cooking",
@@ -401,7 +401,7 @@
     "book_learn": [ [ "textbook_chemistry", 4 ], [ "adv_chemistry", 5 ] ],
     "batch_time_factors": [ 80, 5 ],
     "qualities": [ { "id": "BOIL", "level": 2 }, { "id": "CHEM", "level": 2 } ],
-	  "using": [ [ "forging_standard", 50 ] ],
+    "using": [ [ "forging_standard", 50 ] ],
     "tools": [ [ [ "surface_heat", 25, "LIST" ] ], [ [ "platinum_grille", -1 ] ] ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "chem_sulphur", 470 ] ] ]
   },


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Content] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->
Content

Making sulphuric acid from sulfur and water.



#### Purpose of change
Currently sulphuric acid can only be made from hydrogen peroxide (conc.) and sulfur. As it is not more difficult to make than nitric acid from ammonia, I added it according to the recipe described below.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Expanded chemicals.json to include sulphuric acid craft.

The reaction is done according to the contact process (https://en.wikipedia.org/wiki/Sulfuric_acid); there are also multiple other avenues for making sulfur into sulfuric acid, but that would be bloat. The industrial process is annoying, but can be replicated in a lab setting.

A liter of 98% sulph. acid is roughly 18.8 mol of the acid (https://www.quora.com/What-is-the-molarity-of-98-of-sulphuric-acid - can attest this post is correct in principle). Therefore a CBN unit is 4.7 mol (250 ml). This is exactly 470 units of sulfur in-game. Could be increased to 500 to account for reaction yield, but I think that's overcomplicated for a game. You would also technically need much less than 1 CBN unit of clean water, but that would, again, be bloat.

The contact process requires V2O5 as a catalyst. I don't want to add semi-useless items to the game for a single reaction, so a platinum grille is required as a catch-all catalyst. As the reaction proceeds at 400-600 C, a forge is required. This also balances the production a bit.

The gist of the reaction is:
Burn S to SO2, burn SO2 to SO3 (V2O5 catalyst, in this case platinum grille). React SO3 with water (should be with sulphuric acid into oleum, then dilute, but pointless to go into such detail). Molar balance as per IRL 98% sulph. acid - 4.7 mol/250ml.

So the recipe logic is 60 min for 250 ml, with the same batch savings as other acid recipes. Difficulty-wise, the recipe is learned from chem textbooks, not autolearned, and one level higher than the other sulphuric acid craft, similar to nitric's two recipes.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

Not adding this. I've considered how this changes early-game balance, and I think the requirements preclude this recipe from everything but the late game, where overpoweredness is not a major concern.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested in-game, recipe works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

I am happy to make the recipe more advanced, or require different tools/go along a different reaction, such as older lab-based recipes, but I think that's just tedium for little gain. Getting sulfur in decent quantities still requires a trip to a mine.

Off topic:
That said, I would love to add a recipe for a pressure cooker tool (for the purposes of crafting nitric acid), especially since we have barometers and thermometers all over the place, and that could be a use for them. It's currently a find-only item.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
