### PR TITLE
Add pressure cooker recipe; Update tools.json

### DIFF
--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -1014,8 +1014,8 @@
     "time": "2 h",
     "autolearn": true,
     "using": [ [ "blacksmithing_intermediate", 4 ], [ "steel_standard", 4 ] ],
-	"components": [
-      [ [ "pot_canning", 1], [ "stock_pot", 1], [ "pot", 1], [ "steel_lump", 1 ], [ "steel_chunk", 4 ], [ "scrap", 20 ] ],
+    "components": [
+      [ [ "pot_canning", 1 ], [ "stock_pot", 1 ], [ "pot", 1 ], [ "steel_lump", 1 ], [ "steel_chunk", 4 ], [ "scrap", 20 ] ],
       [ [ "thermometer", 1 ] ],
       [ [ "barometer", 1 ] ],
       [ [ "chunk_rubber", 5 ] ]

--- a/data/json/recipes/other/tools.json
+++ b/data/json/recipes/other/tools.json
@@ -1006,6 +1006,23 @@
   },
   {
     "type": "recipe",
+    "result": "pressure_cooker",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "time": "2 h",
+    "autolearn": true,
+    "using": [ [ "blacksmithing_intermediate", 4 ], [ "steel_standard", 4 ] ],
+	"components": [
+      [ [ "pot_canning", 1], [ "stock_pot", 1], [ "pot", 1], [ "steel_lump", 1 ], [ "steel_chunk", 4 ], [ "scrap", 20 ] ],
+      [ [ "thermometer", 1 ] ],
+      [ [ "barometer", 1 ] ],
+      [ [ "chunk_rubber", 5 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
     "result": "teapot",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary: Content "Add pressure cooker recipe"

<!-- This section should consist of exactly one line, formatted like this:

SUMMARY: [Category] "[Briefly describe the change in these quotation marks]"

Do not enter the square brackets [].  Category must be one of these:

- Features
- Content
- Interface
- Mods
- Balance
- Bugfixes
- Performance
- Infrastructure
- Build
- I18N

For more on the meaning of each category, see:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/doc/CHANGELOG_GUIDELINES.md

If approved and merged, your summary will be added to the project changelog:
https://github.com/cataclysmbnteam/Cataclysm-BN/blob/master/data/changelog.txt
-->


#### Purpose of change

Pressure cookers are missing a crafting recipe, and are currently loot only. 

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution

A pressure cooker is reasonably craftable, so this change makes pressure cookers craftable from either various steel pots or scrap. Needs a barometer and thermometer, since the primary use for these is chemical crafting, and to not make them trivial to craft (i.e. 100 scrap metal equivalent and 5 rubber, just smash a car to bits). The additional steel required is for bracing/reinforcement, the rubber is for the seal. 2h crafting time might be low, let me know.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered

Not adding the recipe.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Built one in-game successfully.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

Going through various chem recipes, nitric acid is the only place a pressure cooker is used afaik. Players can make more complicated and dangerous stuff than a pressure cooker, so adding the recipe seemed sensible.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
