### PR TITLE
compile: fix extra ';' [-Werror=pedantic] complaints

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -231,7 +231,7 @@ constexpr float FLING_MAX_RANGE = 50.0;
 //   different time scale and this constant is the scaling factor
 //   between the two
 constexpr float FLING_SLOWDOWN = 5.0;
-}; // namespace ExplosionConstants
+} // namespace ExplosionConstants
 
 namespace explosion_handler
 {
@@ -465,7 +465,7 @@ void ExplosionProcess::fill_maps()
 
     std::stable_sort( blast_map.begin(), blast_map.end(), dist_comparator );
     std::stable_sort( shrapnel_map.begin(), shrapnel_map.end(), dist_comparator );
-};
+}
 void ExplosionProcess::init_event_queue()
 {
     // Start with shrapnel first
@@ -489,7 +489,7 @@ void ExplosionProcess::init_event_queue()
         //   which, as stated before, converts trig_dist into int implicitly
         add_event( time_taken, ExplosionEvent::tile_blast( position, static_cast<int>( distance ) ) );
     }
-};
+}
 inline bool ExplosionProcess::is_occluded( const tripoint from, const tripoint to )
 {
     if( from == to ) {
@@ -517,7 +517,7 @@ inline bool ExplosionProcess::is_occluded( const tripoint from, const tripoint t
         last_position = position;
     }
     return false;
-};
+}
 
 inline float ExplosionProcess::generate_fling_angle( const tripoint from, const tripoint to )
 {
@@ -888,7 +888,7 @@ void ExplosionProcess::blast_tile( const tripoint position, const int rl_distanc
         }
     }
     request_redraw |= position.z == g->u.posz();
-};
+}
 
 void ExplosionProcess::add_field( const tripoint position,
                                   const field_type_id field,
@@ -898,14 +898,14 @@ void ExplosionProcess::add_field( const tripoint position,
     map &here = get_map();
     here.add_field( position, field, intensity, 0_turns, hit_player );
     request_redraw |= position.z == g->u.posz();
-};
+}
 
 void ExplosionProcess::remove_field( const tripoint position, field_type_id target )
 {
     map &here = get_map();
     here.remove_field( position, target );
     request_redraw |= position.z == g->u.posz();
-};
+}
 
 void ExplosionProcess::move_entity( const tripoint position,
                                     const ExplosionEvent::PropelledEntity &datum,
@@ -1013,7 +1013,7 @@ void ExplosionProcess::move_entity( const tripoint position,
                                            std::get<safe_reference<item>>( cur_target ), new_angle, new_velocity, cur_relative_time )
         );
     }
-};
+}
 
 void ExplosionProcess::run()
 {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.

CODE STYLE: please follow below guide.
JSON: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/JSON_STYLE.md
C++: https://github.com/cataclysmbnteam/Cataclysm-BN/blob/upload/doc/CODE_STYLE.md
-->

#### Summary
SUMMARY: Build "remove extra ';' to make compiler stop complaining"

#### Purpose of change
Build using Make was complaining about the extra ';'s.
```
$ ./build.sh
Using default system compiler: g++
Chosen compiler: CCACHE_SLOPPINESS=pch_defines,time_macros ccache g++
Chosen linker:   CCACHE_SLOPPINESS=pch_defines,time_macros ccache g++
explosion.o
src/explosion.cpp:234:2: error: extra ‘;’ [-Werror=pedantic]
  234 | }; // namespace ExplosionConstants
      |  ^
src/explosion.cpp:468:2: error: extra ‘;’ [-Werror=pedantic]
  468 | };
      |  ^
src/explosion.cpp:492:2: error: extra ‘;’ [-Werror=pedantic]
  492 | };
      |  ^
src/explosion.cpp:520:2: error: extra ‘;’ [-Werror=pedantic]
  520 | };
      |  ^
src/explosion.cpp:891:2: error: extra ‘;’ [-Werror=pedantic]
  891 | };
      |  ^
src/explosion.cpp:901:2: error: extra ‘;’ [-Werror=pedantic]
  901 | };
      |  ^
src/explosion.cpp:908:2: error: extra ‘;’ [-Werror=pedantic]
  908 | };
      |  ^
src/explosion.cpp:1016:2: error: extra ‘;’ [-Werror=pedantic]
 1016 | };
      |  ^
cc1plus: error: unrecognized command line option ‘-Wno-range-loop-analysis’ [-Werror]
cc1plus: error: unrecognized command line option ‘-Wno-dangling-reference’ [-Werror]
cc1plus: error: unrecognized command line option ‘-Wno-unknown-warning-option’ [-Werror]
cc1plus: all warnings being treated as errors
make: *** [Makefile:920: obj/tiles/explosion.o] Error 1
make: Target 'all' not remade because of errors.
```
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution
Removed extra ';'s, now builds properly
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Considered turning off pedantic error reporting but that did not seem like the best idea.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Build completes now.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
