### PR TITLE
feat: export vehicle as its JSON representation

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -52,6 +52,8 @@
 #include "item.h"
 #include "item_group.h"
 #include "item_location.h"
+#include "json.h"
+#include "json_export.h"
 #include "language.h"
 #include "magic.h"
 #include "map.h"
@@ -178,6 +180,7 @@ enum debug_menu_index {
     DEBUG_DISPLAY_SUBMAP_GRID,
     DEBUG_TEST_MAP_EXTRA_DISTRIBUTION,
     DEBUG_VEHICLE_BATTERY_CHARGE,
+    DEBUG_VEHICLE_COPY_JSON,
     DEBUG_HOUR_TIMER,
     DEBUG_NESTED_MAPGEN,
     DEBUG_RESET_IGNORED_MESSAGES,
@@ -254,6 +257,7 @@ static int vehicle_uilist()
 {
     std::vector<uilist_entry> uilist_initializer = {
         { uilist_entry( DEBUG_VEHICLE_BATTERY_CHARGE, true, 'b', _( "Change [b]attery charge" ) ) },
+        { uilist_entry( DEBUG_VEHICLE_COPY_JSON, true, 'j', _( "Copy [j]son representation" ) ) },
     };
 
     return uilist( _( "Vehicle…" ), uilist_initializer );
@@ -2068,6 +2072,24 @@ void debug()
                     veh.discharge_battery( -amount, false );
                 }
             }
+            break;
+        }
+        case DEBUG_VEHICLE_COPY_JSON: {
+            const optional_vpart_position v_part_pos = g->m.veh_at( u.pos() );
+            if( !v_part_pos ) {
+                add_msg( m_bad, _( "There's no vehicle there." ) );
+                break;
+            }
+            const vehicle &veh = v_part_pos->vehicle();
+            std::stringstream ss;
+            JsonOut json( ss, true );
+            json_export::vehicle( json, veh );
+
+            int clipboard_result = SDL_SetClipboardText( ss.str().c_str() );
+            printErrorIf( clipboard_result != 0, "Error while copying the game report to the clipboard." );
+
+            std::string popup_msg = _( "Copied Vehicle JSON to clipboard." );
+            popup( popup_msg );
             break;
         }
 

--- a/src/json_export.h
+++ b/src/json_export.h
@@ -1,0 +1,15 @@
+#pragma once
+#ifndef CATA_SRC_JSON_EXPORT_H
+#define CATA_SRC_JSON_EXPORT_H
+
+#include "json.h"
+
+class vehicle;
+
+namespace json_export
+{
+auto vehicle( JsonOut &json, const vehicle &v ) -> void;
+
+} // namespace json_export
+
+#endif // CATA_SRC_JSON_EXPORT_H

--- a/src/vehicle_export.cpp
+++ b/src/vehicle_export.cpp
@@ -1,0 +1,100 @@
+#include <algorithm>
+#include "json.h"
+#include "string_id.h"
+#include "type_id.h"
+#include "veh_type.h"
+#include "vehicle.h"
+#include "json_export.h"
+#include "vpart_position.h"
+#include "vpart_range.h"
+
+namespace
+{
+
+using refs = std::vector<vpart_reference>;
+
+auto grouped_refs( const class vehicle &v ) ->  std::vector<refs>
+{
+    std::vector<refs> part_group;
+    for( const auto &p : v.get_all_parts() ) {
+        const auto &last = part_group.rbegin();
+        if( last != part_group.rend() && p.mount() == last->begin()->mount() ) {
+            last->emplace_back( p );
+        } else {
+            part_group.emplace_back( refs{ p } );
+        }
+    }
+    return part_group;
+}
+
+auto is_plain_id( const vpart_reference &vpr ) -> bool
+{
+    const auto &p = vpr.part();
+    return !p.is_turret() && ( !p.is_tank() || p.ammo_current().is_null() );
+}
+
+auto json_part_write( JsonOut &json, const vpart_reference &vpr ) -> void
+{
+    const auto &p = vpr.part();
+    const auto &id  = p.info().get_id();
+    const auto &ammo_type = p.ammo_current();
+
+    json.member( "part", id );
+    if( p.is_tank() ) {
+        json.member( "fuel", ammo_type );
+    } else if( p.is_turret() ) {
+        // TODO: serializing items are not implemented, thus ammo must be 0
+        json.member( "ammo_types", std::array{ ammo_type } );
+        json.member( "ammo_qty", std::array{ 0, p.ammo_capacity() } );
+    }
+}
+
+auto json_parts_write( JsonOut &json, const refs &parts ) -> void
+{
+    const auto &first = parts.front();
+
+    if( parts.size() == 1 ) {
+        json_part_write( json, first );
+    } else {
+        json.member( "parts" );
+        json.start_array();
+        for( const auto &p : parts ) {
+            if( is_plain_id( p ) ) {
+                json.write( p.info().get_id() );
+            } else {
+                json.start_object();
+                json_part_write( json, p );
+                json.end_object();
+            }
+        }
+        json.end_array();
+    }
+}
+
+} // namespace
+
+auto json_export::vehicle( JsonOut &json, const class vehicle &v ) -> void
+{
+    const auto part_group = grouped_refs( v );
+
+    json.start_object();
+    json.member( "id", v.type );
+    json.member( "type", "vehicle" );
+    json.member( "name", v.name );
+    // TODO: calculate blueprints from parts
+    // json.member( "blueprint", "wip" );
+
+    json.member( "parts" );
+    json.start_array();
+    for( const auto &parts : part_group ) {
+        const auto [x, y] = parts.begin()->mount();
+
+        json.start_object();
+        json.member( "x",  x );
+        json.member( "y", y );
+        json_parts_write( json, parts );
+        json.end_object();
+    }
+    json.end_array();
+    json.end_object();
+}


### PR DESCRIPTION
#### Summary

SUMMARY: Features "Added debug command to export vehicle as its JSON representation"

#### Purpose of change

It's often easier to design a vehicle inside the game, but there were no easy way to export it. Major benefits are:

- modders: easier modding
- players: easier vehicle template sharing across saves

#### Describe the solution

- added `json_export.h` to store all future JSON exports (e.g terrain, houses, etc)
- added `Copy [j]son representation` in debug/vehicle tab.

#### Describe alternatives you've considered

- format the output, however i'm not sure it's worth the effort to mainline `tools/format.cpp` inside `src/`
- generating items section/blueprint, however that would take too much time.

#### Testing

![Cataclysm: Bright Nights - -128_01](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/8b11f69a-5ade-457e-a7a7-db8f46fa56f6)
![Cataclysm: Bright Nights - -128_02](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/9c9f6d75-05c4-4763-92ad-f4f0f0ee61f0)

https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/de167c1e-de03-4a1f-aba7-d9ab70d9cb7e


![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/92b1c1dc-a1a2-496c-8795-2d235d624532)

generated (left) and original (right)

#### Additional context

the error message from video is because existing apaches required `item` field but the copy-pasted JSON lacked one.