### PR TITLE
fix: vehicle JSON export breaking curses build

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -257,7 +257,7 @@ static int vehicle_uilist()
 {
     std::vector<uilist_entry> uilist_initializer = {
         { uilist_entry( DEBUG_VEHICLE_BATTERY_CHARGE, true, 'b', _( "Change [b]attery charge" ) ) },
-        { uilist_entry( DEBUG_VEHICLE_EXPORT_JSON, true, 'j', _( "Copy [j]son representation" ) ) },
+        { uilist_entry( DEBUG_VEHICLE_EXPORT_JSON, true, 'j', _( "Export [j]son template" ) ) },
     };
 
     return uilist( _( "Vehicle…" ), uilist_initializer );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -180,7 +180,7 @@ enum debug_menu_index {
     DEBUG_DISPLAY_SUBMAP_GRID,
     DEBUG_TEST_MAP_EXTRA_DISTRIBUTION,
     DEBUG_VEHICLE_BATTERY_CHARGE,
-    DEBUG_VEHICLE_COPY_JSON,
+    DEBUG_VEHICLE_EXPORT_JSON,
     DEBUG_HOUR_TIMER,
     DEBUG_NESTED_MAPGEN,
     DEBUG_RESET_IGNORED_MESSAGES,
@@ -257,7 +257,7 @@ static int vehicle_uilist()
 {
     std::vector<uilist_entry> uilist_initializer = {
         { uilist_entry( DEBUG_VEHICLE_BATTERY_CHARGE, true, 'b', _( "Change [b]attery charge" ) ) },
-        { uilist_entry( DEBUG_VEHICLE_COPY_JSON, true, 'j', _( "Copy [j]son representation" ) ) },
+        { uilist_entry( DEBUG_VEHICLE_EXPORT_JSON, true, 'j', _( "Copy [j]son representation" ) ) },
     };
 
     return uilist( _( "Vehicle…" ), uilist_initializer );
@@ -2074,7 +2074,7 @@ void debug()
             }
             break;
         }
-        case DEBUG_VEHICLE_COPY_JSON: {
+        case DEBUG_VEHICLE_EXPORT_JSON: {
             const optional_vpart_position v_part_pos = g->m.veh_at( u.pos() );
             if( !v_part_pos ) {
                 add_msg( m_bad, _( "There's no vehicle there." ) );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2085,10 +2085,17 @@ void debug()
             JsonOut json( ss, true );
             json_export::vehicle( json, veh );
 
-            int clipboard_result = SDL_SetClipboardText( ss.str().c_str() );
-            printErrorIf( clipboard_result != 0, "Error while copying the game report to the clipboard." );
-
-            std::string popup_msg = _( "Copied Vehicle JSON to clipboard." );
+            // write to log
+            DebugLog( DL::Info, DC::Main ) << " JSON TEMPLATE EXPORT:\n" << ss.str();
+            std::string popup_msg = _( "JSON template written to debug.log" );
+#if defined(TILES)
+            // copy to clipboard
+            const int clipboard_result = SDL_SetClipboardText( ss.str().c_str() );
+            printErrorIf( clipboard_result != 0, "Error while exporting JSON to the clipboard." );
+            if( clipboard_result == 0 ) {
+                popup_msg += _( " and to the clipboard." );
+            }
+#endif
             popup( popup_msg );
             break;
         }

--- a/src/vehicle_export.cpp
+++ b/src/vehicle_export.cpp
@@ -43,7 +43,7 @@ auto json_part_write( JsonOut &json, const vpart_reference &vpr ) -> void
     if( p.is_tank() ) {
         json.member( "fuel", ammo_type );
     } else if( p.is_turret() ) {
-        // TODO: serializing items are not implemented, thus ammo must be 0
+        json.member( "ammo", 50 );
         json.member( "ammo_types", std::array{ ammo_type } );
         json.member( "ammo_qty", std::array{ 0, p.ammo_capacity() } );
     }


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Fixed broken curses build caused by #3086"

#### Purpose of change

fix curses build failure caused by #3086

- https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3086#discussion_r1305883096
- https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3086#discussion_r1305885400

#### Describe the solution

- enabled clipboard only for tiles
- reworded debug command
- added `ammo` field back as i mistook it as number of rounds but [it was percentage](https://github.com/CleverRaven/Cataclysm-DDA/blob/afd4746d0e859d65652e5350b66cfa17d65180a1/doc/VEHICLES_JSON.md?plain=1#L59)

#### Testing

![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/afe8bf1b-1b42-4804-ba81-df05661cf7c0)

i'll check curses result on CI as it's been late

#### Additional context

thanks @olanti-p for finding out the regression quickly.