### PR TITLE
Rivtech ammo crafting changes and additions

### DIFF
--- a/data/json/items/ammo/8x40mm.json
+++ b/data/json/items/ammo/8x40mm.json
@@ -10,6 +10,36 @@
     "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
   },
   {
+    "id": "8mm_bootleg_caseless",
+    "copy-from": "8mm_caseless",
+    "type": "AMMO",
+    "name": { "str": "bootleg 8x40mm caseless" },
+    "description": "Bootleg duplicates of Rivtech 8x40mm caseless rounds.  Being caseless rounds, these cannot be disassembled or reloaded.",
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
+    "extend": { "effects": [ "RECYCLED" ] },
+    "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
+  },
+  {
+    "id": "8mm_bootleg_hvp",
+    "copy-from": "8mm_hvp",
+    "type": "AMMO",
+    "name": { "str": "bootleg 8x40mm HVP" },
+    "description": "Bootleg duplicates of Rivtech 8x40mm caseless rounds.  Being caseless rounds, these cannot be disassembled or reloaded.",
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
+    "extend": { "effects": [ "RECYCLED" ] },
+    "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
+  },
+  {
+    "id": "8mm_bootleg_inc",
+    "copy-from": "8mm_inc",
+    "type": "AMMO",
+    "name": { "str": "bootleg 8x40mm tracer" },
+    "description": "Bootleg duplicates of Rivtech 8x40mm caseless rounds.  Being caseless rounds, these cannot be disassembled or reloaded.",
+    "proportional": { "price": 0.7, "damage": { "damage_type": "bullet", "amount": 0.9 }, "dispersion": 1.1 },
+    "extend": { "effects": [ "RECYCLED" ] },
+    "delete": { "effects": [ "NEVER_MISFIRES" ], "flags": [ "IRREPLACEABLE_CONSUMABLE" ] }
+  },
+  {
     "id": "8mm_caseless",
     "type": "AMMO",
     "name": { "str_sp": "8x40mm caseless" },

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -406,15 +406,15 @@
     "time": "2 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_caseless", 4 ] ],
-    "charges": 1,
-    "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ] ],
+    "charges": 8,
+    "using": [ [ "bullet_forming", 16 ], [ "ammo_bullet", 8 ] ],
     "tools": [ [ [ "mold_plastic", -1 ] ] ],
     "components": [
-      [ [ "5x50_hull", 1 ] ],
+      [ [ "5x50_hull", 8 ] ],
       [ [ "plastic_chunk", 1 ] ],
-      [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder", 3 ] ],
-      [ [ "combatnail", 1 ] ]
+      [ [ "smrifle_primer", 8 ] ],
+      [ [ "gunpowder", 24 ] ],
+      [ [ "combatnail", 8 ] ]
     ]
   },
   {
@@ -428,15 +428,15 @@
     "time": "2 m",
     "batch_time_factors": [ 60, 5 ],
     "book_learn": [ [ "recipe_caseless", 4 ] ],
-    "charges": 1,
-    "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 3 ] ],
+    "charges": 8,
+    "using": [ [ "bullet_forming", 16 ], [ "ammo_bullet", 24 ] ],
     "tools": [ [ [ "mold_plastic", -1 ] ] ],
     "components": [
-      [ [ "5x50_hull", 1 ] ],
+      [ [ "5x50_hull", 8 ] ],
       [ [ "plastic_chunk", 1 ] ],
-      [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder", 4 ] ],
-      [ [ "scrap", 1 ] ]
+      [ [ "smrifle_primer", 8 ] ],
+      [ [ "gunpowder", 32 ] ],
+      [ [ "scrap", 8 ] ]
     ]
   },
   {

--- a/data/mods/Craft_Gunpowder/cgp_recipes.json
+++ b/data/mods/Craft_Gunpowder/cgp_recipes.json
@@ -104,7 +104,7 @@
         [ "solder_wire", 100 ]
       ],
       [ [ "copper", 35 ] ],
-	  [ [ "steel_lump", 1 ], ["scrap", 4] ]
+      [ [ "steel_lump", 1 ], [ "scrap", 4 ] ]
     ]
   },
   {

--- a/data/mods/Craft_Gunpowder/cgp_recipes.json
+++ b/data/mods/Craft_Gunpowder/cgp_recipes.json
@@ -125,12 +125,7 @@
       [ [ "plastic_chunk", 5 ] ],
       [ [ "oxy_powder", 120 ] ],
       [ [ "incendiary", 120 ] ],
-      [
-        [ "lead", 100 ],
-        [ "tin", 100 ],
-        [ "bismuth", 100 ],
-        [ "solder_wire", 100 ]
-      ],
+      [ [ "lead", 100 ], [ "tin", 100 ], [ "bismuth", 100 ], [ "solder_wire", 100 ] ],
       [ [ "copper", 35 ] ],
 	  [ [ "platinum_small", 1], [ "gold_small", 1 ], [ "silver_small", 1 ] ],
 	  [ [ "steel_lump", 1 ], ["scrap", 4] ]

--- a/data/mods/Craft_Gunpowder/cgp_recipes.json
+++ b/data/mods/Craft_Gunpowder/cgp_recipes.json
@@ -158,7 +158,7 @@
         [ "solder_wire", 100 ]
       ],
       [ [ "copper", 35 ] ],
-	  [ [ "steel_lump", 1 ], ["scrap", 4] ]
+      [ [ "steel_lump", 1 ], [ "scrap", 4 ] ]
     ]
   },
   {

--- a/data/mods/Craft_Gunpowder/cgp_recipes.json
+++ b/data/mods/Craft_Gunpowder/cgp_recipes.json
@@ -141,7 +141,7 @@
     "difficulty": 9,
     "time": 50000,
     "book_learn": [ [ "recipe_caseless", 5 ] ],
-	"charges": 40,
+    "charges": 40,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
     "components": [

--- a/data/mods/Craft_Gunpowder/cgp_recipes.json
+++ b/data/mods/Craft_Gunpowder/cgp_recipes.json
@@ -117,7 +117,7 @@
     "difficulty": 9,
     "time": 50000,
     "book_learn": [ [ "recipe_caseless", 5 ] ],
-	"charges": 40,
+    "charges": 40,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
     "components": [

--- a/data/mods/Craft_Gunpowder/cgp_recipes.json
+++ b/data/mods/Craft_Gunpowder/cgp_recipes.json
@@ -127,8 +127,8 @@
       [ [ "incendiary", 120 ] ],
       [ [ "lead", 100 ], [ "tin", 100 ], [ "bismuth", 100 ], [ "solder_wire", 100 ] ],
       [ [ "copper", 35 ] ],
-	  [ [ "platinum_small", 1], [ "gold_small", 1 ], [ "silver_small", 1 ] ],
-	  [ [ "steel_lump", 1 ], ["scrap", 4] ]
+      [ [ "platinum_small", 1 ], [ "gold_small", 1 ], [ "silver_small", 1 ] ],
+      [ [ "steel_lump", 1 ], [ "scrap", 4 ] ]
     ]
   },
   {

--- a/data/mods/Craft_Gunpowder/cgp_recipes.json
+++ b/data/mods/Craft_Gunpowder/cgp_recipes.json
@@ -87,7 +87,7 @@
     "difficulty": 9,
     "time": 45000,
     "book_learn": [ [ "recipe_caseless", 5 ] ],
-	"charges": 40,
+    "charges": 40,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
     "components": [

--- a/data/mods/Craft_Gunpowder/cgp_recipes.json
+++ b/data/mods/Craft_Gunpowder/cgp_recipes.json
@@ -58,7 +58,7 @@
     "difficulty": 8,
     "time": 45000,
     "book_learn": [ [ "recipe_caseless", 5 ], [ "recipe_bullets", 9 ], [ "manual_pistol", 10 ], [ "manual_rifle", 10 ] ],
-	"charges": 40,
+    "charges": 40,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
     "components": [

--- a/data/mods/Craft_Gunpowder/cgp_recipes.json
+++ b/data/mods/Craft_Gunpowder/cgp_recipes.json
@@ -52,12 +52,13 @@
     "type": "recipe",
     "result": "8mm_bootleg",
     "category": "CC_AMMO",
-    "subcategory": "CSC_AMMO_PISTOL",
+    "subcategory": "CSC_AMMO_RIFLE",
     "skill_used": "fabrication",
     "skills_required": [ "cooking", 2 ],
     "difficulty": 8,
     "time": 45000,
     "book_learn": [ [ "recipe_caseless", 5 ], [ "recipe_bullets", 9 ], [ "manual_pistol", 10 ], [ "manual_rifle", 10 ] ],
+	"charges": 40,
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
     "components": [
@@ -74,6 +75,95 @@
         [ "solder_wire", 75 ]
       ],
       [ [ "copper", 35 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "8mm_bootleg_caseless",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_RIFLE",
+    "skill_used": "fabrication",
+    "skills_required": [ "cooking", 2 ],
+    "difficulty": 9,
+    "time": 45000,
+    "book_learn": [ [ "recipe_caseless", 5 ] ],
+	"charges": 40,
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
+    "components": [
+      [ [ "acid", 1 ] ],
+      [ [ "plastic_chunk", 5 ] ],
+      [ [ "oxy_powder", 100 ] ],
+      [ [ "incendiary", 100 ] ],
+      [
+        [ "lead", 100 ],
+        [ "gold_small", 100 ],
+        [ "silver_small", 100 ],
+        [ "tin", 100 ],
+        [ "bismuth", 100 ],
+        [ "solder_wire", 100 ]
+      ],
+      [ [ "copper", 35 ] ],
+	  [ [ "steel_lump", 1 ], ["scrap", 4] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "8mm_bootleg_hvp",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_RIFLE",
+    "skill_used": "fabrication",
+    "skills_required": [ "cooking", 2 ],
+    "difficulty": 9,
+    "time": 50000,
+    "book_learn": [ [ "recipe_caseless", 5 ] ],
+	"charges": 40,
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
+    "components": [
+      [ [ "acid", 1 ] ],
+      [ [ "plastic_chunk", 5 ] ],
+      [ [ "oxy_powder", 120 ] ],
+      [ [ "incendiary", 120 ] ],
+      [
+        [ "lead", 100 ],
+        [ "tin", 100 ],
+        [ "bismuth", 100 ],
+        [ "solder_wire", 100 ]
+      ],
+      [ [ "copper", 35 ] ],
+	  [ [ "platinum_small", 1], [ "gold_small", 1 ], [ "silver_small", 1 ] ],
+	  [ [ "steel_lump", 1 ], ["scrap", 4] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "8mm_bootleg_inc",
+    "category": "CC_AMMO",
+    "subcategory": "CSC_AMMO_RIFLE",
+    "skill_used": "fabrication",
+    "skills_required": [ "cooking", 2 ],
+    "difficulty": 9,
+    "time": 50000,
+    "book_learn": [ [ "recipe_caseless", 5 ] ],
+	"charges": 40,
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 50, "LIST" ] ], [ [ "press", -1 ] ] ],
+    "components": [
+      [ [ "acid", 1 ] ],
+      [ [ "plastic_chunk", 5 ] ],
+      [ [ "oxy_powder", 100 ] ],
+      [ [ "incendiary", 200 ] ],
+      [
+        [ "lead", 100 ],
+        [ "gold_small", 100 ],
+        [ "silver_small", 100 ],
+        [ "tin", 100 ],
+        [ "bismuth", 100 ],
+        [ "solder_wire", 100 ]
+      ],
+      [ [ "copper", 35 ] ],
+	  [ [ "steel_lump", 1 ], ["scrap", 4] ]
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Content "Rebalanced Rivtech ammo crafting as per #3082"

#### Purpose of change

As per #3082, and since Rivtech guns are not that much more powerful than .556, crafting recipes have been added for the 8x40 ammo.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the Github issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #1234.

If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified.
-->

#### Describe the solution

Vanilla:
5x50 ammo was changed to be made in batches of 8 while keeping 1 plastic chunk as crafting requirement (0.125 plastic chunks per bullet instead of 1 per bullet, other requirements scaled accordingly).

Craftable Gun Pack:
All variants of 8x40 can now be made (as nerfed bootleg ammo), provided you found the rivtech design binder (not the other books that are easier to find and contain the trash bootleg JHP recipe).

The existing distribution between mainline and mod was kept, although I would put all of the rivtech ammo crafting into mainline, myself (but not the gun crafting part of the mod).

Depending on comments from senior devs, I will gladly make any changes, or, if you prefer not to merge this, that's fine too - I'll keep them for my personal mod. Balance comments are especially welcome, as is the input of "Noctifer-de-Mortem", the maintainer of the Craftable Gun Pack mod.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged.  -->

#### Describe alternatives you've considered
Spending time actually playing the game instead of doing this ;)
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned book, learned recipes, crafting interface requirements and products seem correct.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers.  -->

#### Additional context

I found that .556 is entirely enough to take out pretty much anything in the game, and 8x40 is barely better. That said, at least in my playthroughs, the Rivtech line of guns either doesn't get used due to 'saving for later' syndrome, or because the useful ammo is gone, and there is no way to make more. I don't think the weapons are that much better to warrant such restrictions, so imho this could be mainlined. It is, however, in this PR, kept as it was, with updates to the mod, and a minor update to vanilla 5x50 ammo crafting (that I think makes more sense resource wise).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.  -->
