### PR TITLE
Port: Craftable Body Pillows from DDA

### DIFF
--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -51,6 +51,18 @@
   },
   {
     "type": "recipe",
+    "result": "bodypillow",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "tailor",
+    "time": "20 m",
+    "difficulty": 2,
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 12 ], [ "drawing_tool", 20 ] ],
+    "components": [ [ [ "sheet", 1 ] ], [ [ "cotton_ball", 20 ] ] ]
+  },
+  {
+    "type": "recipe",
     "result": "shelter_kit",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_OTHER",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -91,6 +91,12 @@
     "components": [ [ [ "solder_wire", 1 ] ] ]
   },
   {
+    "id": "drawing_tool",
+    "type": "requirement",
+    "//": "Things suitable for drawing or writing something on paper, cardboard, cloth or similar materials.",
+    "tools": [ [ [ "permanent_marker", 1 ], [ "survival_marker", 1 ] ] ]
+  },
+  {
     "id": "coding_standard",
     "type": "requirement",
     "//": "For writing software",


### PR DESCRIPTION
#### Summary

SUMMARY: Balance "Port the recipe to craft a body pillow from DDA"

#### Purpose of change

We have body pillows, but due to their rarity, you may go many playthroughs without actually finding one. Now, with a simple recipe, you too can draw your ultimate waifu and cuddle them to sleep! (More seriously, I don't see any reason why the body pillow item shouldn't be craftable. It's not like it offers much of an advantage over a standard pillow, from what I understand.)

#### Describe the solution

1. Add the drawing standard to the toolsets JSON (Which could be used by anything else that needs a convenient drawing tools standard)
2. Port over the recipe from DDA, changing it to fit our system

#### Describe alternatives you've considered

- Not porting this recipe
I see no reason to not port this over so long as body pillows remain in the game.

- Not porting / defining the drawing tool standard, and instead just defining the drawing tools in the recipe
Actually putting it in the toolsets allows for other PRs down the line to make use of it when relevant, alongside of course any mods that want a convenient drawing tools reference. 

#### Testing

1. Added the relevant parts in the two JSON files
2. Loaded into the game, checked the crafting menu
3. Voila!
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/30732426/379f980e-2763-4efa-a232-8051855e6e09)

#### Additional context

I chose not to include the "pen" item in the drawing tools because I'm pretty sure we don't actually model ink in those pens. If someone does add ink / charges to those pens, then it likely should be added.

Original DDA PR: https://github.com/CleverRaven/Cataclysm-DDA/pull/47715