### PR TITLE
fix(i18n): `SPECIES` not in `needs_plural` breaking translation

### DIFF
--- a/lang/extract_json_strings.py
+++ b/lang/extract_json_strings.py
@@ -197,6 +197,7 @@ needs_plural = {
     "MAGAZINE",
     "MONSTER",
     "PET_ARMOR",
+    "SPECIES",
     "TOOL",
     "TOOLMOD",
     "TOOL_ARMOR",

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2460,6 +2460,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         "GUNMOD",
         "MAGAZINE",
         "PET_ARMOR",
+        "SPECIES",
         "TOOL",
         "TOOLMOD",
         "TOOL_ARMOR",


### PR DESCRIPTION
#### Summary

SUMMARY: I18N "fix SPECIES not in needs_plural breaking translation"

#### Purpose of change

- fixes #3095

regression was caused by `str_sp` for `SPECIES` in #2720.

#### Describe the solution

added `SPECIES` in `needs_plural`

#### Describe alternatives you've considered

add PR check to ensure `update.pot` does not fail so we don't miss issues like these go unnoticed for weeks, this isn't the first time. (#2978)

#### Testing
![image](https://github.com/cataclysmbnteam/Cataclysm-BN/assets/54838975/95445877-4105-4d1c-9216-b3a402de1a37)

`./update_pot.sh` works again.
