### PR TITLE
fix: lua compilation warnings

### DIFF
--- a/src/lua/lundump.c
+++ b/src/lua/lundump.c
@@ -241,7 +241,7 @@ static void fchecksize (LoadState *S, size_t size, const char *tname) {
 #define checksize(S,t)	fchecksize(S,sizeof(t),#t)
 
 static void checkHeader (LoadState *S) {
-  checkliteral(S, LUA_SIGNATURE + 1, "not a");  /* 1st char already checked */
+  checkliteral(S, &LUA_SIGNATURE[1], "not a"); /* 1st char already checked */
   if (LoadByte(S) != LUAC_VERSION)
     error(S, "version mismatch in");
   if (LoadByte(S) != LUAC_FORMAT)


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "lua compilation warnings"

#### Purpose of change

fix compilation warnings emitted caused by pointer arithmetic

#### Describe the solution

https://github.com/lua/lua/blob/9b4f39ab14fb2e55345c3d23537d129dac23b091/lundump.c#L294
