### PR TITLE
Complete the "Nested" and Everyday carry Gun lists 

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
@@ -1674,5 +1674,157 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [ { "item": "streetsweeper", "charges-min": 0, "charges-max": 12 }, { "group": "on_hand_shot" } ]
+  },
+    {
+    "id": "everyday_rm228",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "rm228", "charges-min": 0, "charges-max": 10 },
+      { "item": "20x66_10_mag" },
+      { "item": "20x66_10_mag", "prob": 50 }
+    ]
+  },
+  {
+    "id": "everyday_an94",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "an94", "charges-min": 0, "charges-max": 30 },
+      { "item": "ak74mag" },
+      { "item": "ak74mag", "prob": 50 }
+    ]
+  },
+  {
+    "id": "everyday_USAS_12",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "USAS_12", "charges-min": 0, "charges-max": 10 },
+      { "item": "USAS10mag" },
+      { "item": "USAS10mag", "prob": 50 }
+    ]
+  },
+  {
+    "id": "everyday_as50",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "as50", "charges-min": 0, "charges-max": 10 },
+      { "item": "as50mag" },
+      { "item": "as50mag", "prob": 50 }
+    ]
+  },
+    {
+    "id": "everyday_needlepistol",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "needlepistol", "charges-min": 0, "charges-max": 50 },
+      { "item": "5x50_50_mag" },
+      { "item": "5x50_50_mag", "prob": 50 }
+    ]
+  },
+  {
+    "id": "everyday_rm99_pistol",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "rm99_pistol", "charges-min": 0, "charges-max": 50 },
+      { "item": "8x40_50_mag" },
+      { "item": "8x40_50_mag", "prob": 50 }
+    ]
+  },
+  {
+    "id": "everyday_ppsh",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "ppsh", "charges-min": 0, "charges-max": 35 },
+      { "item": "ppshmag" },
+      { "item": "ppshmag", "prob": 50 }
+    ]
+  },
+  {
+    "id": "everyday_skorpion_61",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "skorpion_61", "charges-min": 0, "charges-max": 20 },
+      { "item": "skorpion61mag" },
+      { "item": "skorpion61mag", "prob": 50 }
+    ]
+  },
+  {
+    "id": "everyday_skorpion_82",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "skorpion_82", "charges-min": 0, "charges-max": 20 },
+      { "item": "skorpion82mag" },
+      { "item": "skorpion82mag", "prob": 50 }
+    ]
+  },
+  {
+    "id": "everyday_acr",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "acr", "charges-min": 0, "charges-max": 30 },
+      { "item": "stanag30" },
+      { "item": "stanag30", "prob": 50 }
+    ]
+  },
+  {
+    "id": "everyday_ar15_retool_300blk",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "ar15_retool_300blk", "charges-min": 0, "charges-max": 30 },
+      { "item": "stanag30" },
+      { "item": "stanag30", "prob": 50 }
+    ]
+  },
+  {
+    "id": "everyday_needlegun",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "needlegun", "charges-min": 0, "charges-max": 100 },
+      { "item": "5x50_100_mag" },
+      { "item": "5x50_100_mag", "prob": 50 }
+    ]
+  },
+    {
+    "id": "everyday_rm120c",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [ { "item": "rm120c", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_20x66mm" } ]
   }
 ]

--- a/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/everydaycarry_guns.json
@@ -1675,7 +1675,7 @@
     "ammo": 100,
     "entries": [ { "item": "streetsweeper", "charges-min": 0, "charges-max": 12 }, { "group": "on_hand_shot" } ]
   },
-    {
+  {
     "id": "everyday_rm228",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
@@ -1693,11 +1693,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [
-      { "item": "an94", "charges-min": 0, "charges-max": 30 },
-      { "item": "ak74mag" },
-      { "item": "ak74mag", "prob": 50 }
-    ]
+    "entries": [ { "item": "an94", "charges-min": 0, "charges-max": 30 }, { "item": "ak74mag" }, { "item": "ak74mag", "prob": 50 } ]
   },
   {
     "id": "everyday_USAS_12",
@@ -1717,13 +1713,9 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [
-      { "item": "as50", "charges-min": 0, "charges-max": 10 },
-      { "item": "as50mag" },
-      { "item": "as50mag", "prob": 50 }
-    ]
+    "entries": [ { "item": "as50", "charges-min": 0, "charges-max": 10 }, { "item": "as50mag" }, { "item": "as50mag", "prob": 50 } ]
   },
-    {
+  {
     "id": "everyday_needlepistol",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
@@ -1753,11 +1745,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [
-      { "item": "ppsh", "charges-min": 0, "charges-max": 35 },
-      { "item": "ppshmag" },
-      { "item": "ppshmag", "prob": 50 }
-    ]
+    "entries": [ { "item": "ppsh", "charges-min": 0, "charges-max": 35 }, { "item": "ppshmag" }, { "item": "ppshmag", "prob": 50 } ]
   },
   {
     "id": "everyday_skorpion_61",
@@ -1789,11 +1777,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [
-      { "item": "acr", "charges-min": 0, "charges-max": 30 },
-      { "item": "stanag30" },
-      { "item": "stanag30", "prob": 50 }
-    ]
+    "entries": [ { "item": "acr", "charges-min": 0, "charges-max": 30 }, { "item": "stanag30" }, { "item": "stanag30", "prob": 50 } ]
   },
   {
     "id": "everyday_ar15_retool_300blk",
@@ -1819,7 +1803,7 @@
       { "item": "5x50_100_mag", "prob": 50 }
     ]
   },
-    {
+  {
     "id": "everyday_rm120c",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -198,7 +198,7 @@
       { "group": "nested_usp_45", "prob": 15 },
       { "group": "nested_m1911_MEU", "prob": 5 },
       { "group": "nested_glock_19", "prob": 20 },
-      { "item": "needlepistol", "prob": 45, "charges-min": 0, "charges-max": 50 },
+      { "group": "nested_needlepistol", "prob": 45 },
       { "group": "nested_rm103a_pistol", "prob": 35 }
     ]
   },
@@ -213,7 +213,7 @@
       { "group": "everyday_usp_45", "prob": 15 },
       { "group": "everyday_m1911_MEU", "prob": 5 },
       { "group": "everyday_glock_19", "prob": 20 },
-      { "item": "needlepistol", "prob": 45, "charges-min": 0, "charges-max": 50 },
+      { "group": "everyday_needlepistol", "prob": 45 },
       { "group": "everyday_rm103a_pistol", "prob": 35 }
     ]
   },
@@ -232,7 +232,7 @@
       { "group": "nested_pistol_flintlock", "prob": 150 },
       { "group": "nested_raging_bull", "prob": 100 },
       { "group": "nested_raging_judge", "prob": 20 },
-      { "item": "rm99_pistol", "prob": 150, "charges-min": 0, "charges-max": 5 },
+      { "group": "nested_rm99_pistol", "prob": 150 },
       { "group": "nested_tokarev", "prob": 100 },
       { "group": "nested_walther_ppk", "prob": 100 },
       { "group": "nested_colt_saa", "prob": 150 }
@@ -253,7 +253,7 @@
       { "group": "everyday_pistol_flintlock", "prob": 150 },
       { "group": "everyday_raging_bull", "prob": 100 },
       { "group": "everyday_raging_judge", "prob": 20 },
-      { "item": "rm99_pistol", "prob": 150, "charges-min": 0, "charges-max": 5 },
+      { "group": "everyday_rm99_pistol", "prob": 150 },
       { "group": "everyday_tokarev", "prob": 100 },
       { "group": "everyday_walther_ppk", "prob": 100 },
       { "group": "everyday_colt_saa", "prob": 150 }
@@ -362,7 +362,7 @@
     "//": "Military specification SMGs only ever found at military sites.",
     "items": [
       { "group": "nested_hk_mp7", "prob": 100 },
-      { "item": "needlegun", "prob": 30, "charges-min": 0, "charges-max": 50 },
+      { "group": "nested_needlegun", "prob": 30 },
       { "group": "nested_rm2000_smg", "prob": 50 },
       { "group": "nested_hk_mp5", "prob": 100 },
       { "group": "nested_hk_mp5k", "prob": 10 },
@@ -375,7 +375,7 @@
     "//": "Military specification SMGs only ever carried by the military. Comes with mags or loose ammo.",
     "items": [
       { "group": "everyday_hk_mp7", "prob": 100 },
-      { "item": "needlegun", "prob": 30, "charges-min": 0, "charges-max": 50 },
+      { "group": "everyday_needlegun", "prob": 30 },
       { "group": "everyday_rm2000_smg", "prob": 50 },
       { "group": "everyday_hk_mp5", "prob": 100 },
       { "group": "everyday_hk_mp5k", "prob": 10 },
@@ -387,9 +387,19 @@
     "id": "guns_smg_obscure",
     "//": "Imported or otherwise very obscure SMGs.",
     "items": [
-      { "item": "ppsh", "prob": 150, "charges-min": 0, "charges-max": 35 },
-      { "item": "skorpion_61", "prob": 100, "charges-min": 0, "charges-max": 20 },
-      { "item": "skorpion_82", "prob": 100, "charges-min": 0, "charges-max": 20 }
+      { "group": "nested_ppsh", "prob": 150 },
+      { "group": "nested_skorpion_61", "prob": 100 },
+      { "group": "nested_skorpion_82", "prob": 100 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "carried_guns_smg_obscure",
+    "//": "Imported or otherwise very obscure SMGs. Just mags, no loose ammo.",
+    "items": [
+      { "group": "everyday_ppsh", "prob": 150 },
+      { "group": "everyday_skorpion_61", "prob": 100 },
+      { "group": "everyday_skorpion_82", "prob": 100 }
     ]
   },
   {
@@ -477,7 +487,7 @@
     "id": "guns_rifle_rare",
     "//": "Less common rifles including those only used by police/paramilitary forces.",
     "items": [
-      { "item": "acr", "prob": 25, "charges-min": 0, "charges-max": 30 },
+      { "group": "nested_acr", "prob": 25 },
       { "group": "nested_colt_lightning", "prob": 15 },
       { "group": "nested_fn_fal", "prob": 40 },
       { "group": "nested_hk_g3", "prob": 40 },
@@ -495,7 +505,7 @@
       { "group": "nested_sharps", "prob": 15 },
       { "group": "nested_weatherby_5", "prob": 15 },
       { "group": "nested_hk417_13", "prob": 40 },
-      { "item": "ar15_retool_300blk", "prob": 15, "charges-min": 0, "charges-max": 30 },
+      { "group": "nested_ar15_retool_300blk", "prob": 15 },
       { "group": "nested_iwi_tavor_x95_300blk", "prob": 10 }
     ]
   },
@@ -504,7 +514,7 @@
     "id": "carried_guns_rifle_rare",
     "//": "Less common rifles including those only carried by police/paramilitary forces. Served with mags or a side of loose ammo.",
     "items": [
-      { "item": "acr", "prob": 25, "charges-min": 0, "charges-max": 30 },
+      { "group": "everyday_acr", "prob": 25 },
       { "group": "everyday_colt_lightning", "prob": 15 },
       { "group": "everyday_fn_fal", "prob": 40 },
       { "group": "everyday_hk_g3", "prob": 40 },
@@ -522,7 +532,7 @@
       { "group": "everyday_sharps", "prob": 15 },
       { "group": "everyday_weatherby_5", "prob": 15 },
       { "group": "everyday_hk417_13", "prob": 40 },
-      { "item": "ar15_retool_300blk", "prob": 15, "charges-min": 0, "charges-max": 30 },
+      { "group": "everyday_ar15_retool_300blk", "prob": 15 },
       { "group": "everyday_iwi_tavor_x95_300blk", "prob": 10 }
     ]
   },
@@ -626,13 +636,13 @@
       { "group": "nested_rm88_battle_rifle", "prob": 10 },
       { "group": "nested_rm103a_pistol", "prob": 10 },
       { "group": "nested_m110a1", "prob": 10 },
-      { "item": "needlegun", "prob": 10, "charges-min": 0, "charges-max": 50 },
-      { "item": "needlepistol", "prob": 10, "charges-min": 0, "charges-max": 50 },
+      { "group": "nested_needlegun", "prob": 10 },
+      { "group": "nested_needlepistol", "prob": 10 },
       { "group": "nested_ksg-25", "prob": 10 },
       { "group": "nested_tavor_12", "prob": 10 },
       { "group": "nested_SPAS_12", "prob": 10 },
-      { "item": "rm120c", "prob": 10, "charges-min": 0, "charges-max": 5 },
-      { "item": "rm228", "prob": 10, "charges-min": 0, "charges-max": 10 },
+      { "group": "nested_rm120c", "prob": 10 },
+      { "group": "nested_rm228", "prob": 10 },
       { "group": "nested_deagle_44", "prob": 10 }
     ]
   },
@@ -654,7 +664,7 @@
     "items": [
       { "group": "nested_ak47", "prob": 100 },
       { "group": "nested_ak74", "prob": 60 },
-      { "item": "an94", "prob": 40, "charges-min": 0, "charges-max": 30 },
+      { "group": "nested_an94", "prob": 40 },
       { "group": "nested_bh_m89", "prob": 20 },
       { "group": "nested_bfg50", "prob": 5 },
       { "group": "nested_carbine_flintlock", "prob": 140 },
@@ -675,7 +685,7 @@
     "items": [
       { "group": "everyday_ak47", "prob": 100 },
       { "group": "everyday_ak74", "prob": 60 },
-      { "item": "an94", "prob": 40, "charges-min": 0, "charges-max": 30 },
+      { "group": "everyday_an94", "prob": 40 },
       { "group": "everyday_bh_m89", "prob": 20 },
       { "group": "everyday_bfg50", "prob": 5 },
       { "group": "everyday_carbine_flintlock", "prob": 140 },
@@ -762,8 +772,8 @@
       { "group": "nested_tavor_12", "prob": 5 },
       { "group": "nested_m1014", "prob": 10 },
       { "group": "nested_SPAS_12", "prob": 2 },
-      { "item": "rm120c", "prob": 5, "charges-min": 0, "charges-max": 5 },
-      { "item": "rm228", "prob": 5, "charges-min": 0, "charges-max": 10 }
+      { "group": "nested_rm120c", "prob": 5 },
+      { "group": "nested_rm228", "prob": 5 }
     ]
   },
   {
@@ -777,8 +787,8 @@
       { "group": "everyday_tavor_12", "prob": 5 },
       { "group": "everyday_m1014", "prob": 10 },
       { "group": "everyday_SPAS_12", "prob": 2 },
-      { "item": "rm120c", "prob": 5, "charges-min": 0, "charges-max": 5 },
-      { "item": "rm228", "prob": 5, "charges-min": 0, "charges-max": 10 }
+      { "group": "everyday_rm120c", "prob": 5 },
+      { "group": "everyday_rm228", "prob": 5 }
     ]
   },
   {
@@ -856,7 +866,7 @@
     "items": [
       { "group": "nested_saiga_12", "prob": 50 },
       { "group": "nested_streetsweeper", "prob": 4 },
-      { "item": "USAS_12", "prob": 1, "charges-min": 0, "charges-max": 10 },
+      { "group": "nested_USAS_12", "prob": 1 },
       { "group": "nested_saiga_410", "prob": 40 }
     ]
   },
@@ -867,7 +877,7 @@
     "items": [
       { "group": "everyday_saiga_12", "prob": 50 },
       { "group": "everyday_streetsweeper", "prob": 4 },
-      { "item": "USAS_12", "prob": 1, "charges-min": 0, "charges-max": 10 },
+      { "group": "everyday_USAS_12", "prob": 1 },
       { "group": "everyday_saiga_410", "prob": 40 }
     ]
   },
@@ -1090,8 +1100,8 @@
       { "group": "nested_hk_mp5sd", "prob": 5 },
       { "group": "nested_m1014", "prob": 10 },
       { "group": "nested_m4a1", "prob": 35 },
-      { "item": "as50", "prob": 5, "charges-min": 0, "charges-max": 10 },
-      { "item": "USAS_12", "prob": 1, "charges-min": 0, "charges-max": 10 },
+      { "group": "nested_as50", "prob": 5 },
+      { "group": "nested_USAS_12", "prob": 1 },
       { "group": "nested_hk417_13", "prob": 30 }
     ]
   },
@@ -1107,8 +1117,8 @@
       { "group": "everyday_hk_mp5sd", "prob": 5 },
       { "group": "everyday_m1014", "prob": 10 },
       { "group": "everyday_m4a1", "prob": 35 },
-      { "item": "as50", "prob": 5, "charges-min": 0, "charges-max": 10 },
-      { "item": "USAS_12", "prob": 1, "charges-min": 0, "charges-max": 10 },
+      { "group": "everyday_as50", "prob": 5 },
+      { "group": "everyday_USAS_12", "prob": 1 },
       { "group": "everyday_hk417_13", "prob": 30 }
     ]
   },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_ammo.json
@@ -354,5 +354,15 @@
       { "item": "20x66_inc", "prob": 100, "charges": [ 10, 20 ] },
       { "item": "20x66_slug", "prob": 100, "charges": [ 10, 20 ] }
     ]
+  },
+  {
+    "id": "on_hand_5x50mm",
+    "type": "item_group",
+    "//": "a collection of ammo that would be found with a loaded gun.",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "5x50dart", "prob": 100, "charges": [ 25, 50 ] },
+      { "item": "5x50heavy", "prob": 30, "charges": [ 25, 50 ] }
+    ]
   }
 ]

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -1932,5 +1932,169 @@
       { "item": "saiga410mag_10rd", "prob": 50 },
       { "group": "on_hand_410shot" }
     ]
+  },
+  {
+    "id": "nested_needlepistol",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "needlepistol", "charges-min": 0, "charges-max": 50 },
+      { "item": "5x50_50_mag" },
+      { "item": "5x50_50_mag", "prob": 50 },
+      { "group": "on_hand_5x50mm" }
+    ]
+  },
+  {
+    "id": "nested_rm99_pistol",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "rm99_pistol", "charges-min": 0, "charges-max": 50 },
+      { "item": "8x40_50_mag" },
+      { "item": "8x40_50_mag", "prob": 50 },
+      { "group": "on_hand_8x40" }
+    ]
+  },
+  {
+    "id": "nested_ppsh",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "ppsh", "charges-min": 0, "charges-max": 35 },
+      { "item": "ppshmag" },
+      { "item": "ppshmag", "prob": 50 },
+      { "group": "on_hand_762x25" }
+    ]
+  },
+  {
+    "id": "nested_skorpion_61",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "skorpion_61", "charges-min": 0, "charges-max": 20 },
+      { "item": "skorpion61mag" },
+      { "item": "skorpion61mag", "prob": 50 },
+      { "group": "on_hand_32" }
+    ]
+  },
+  {
+    "id": "nested_skorpion_82",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "skorpion_82", "charges-min": 0, "charges-max": 20 },
+      { "item": "skorpion82mag" },
+      { "item": "skorpion82mag", "prob": 50 },
+      { "group": "on_hand_9x18" }
+    ]
+  },
+  {
+    "id": "nested_acr",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "acr", "charges-min": 0, "charges-max": 30 },
+      { "item": "stanag30" },
+      { "item": "stanag30", "prob": 50 },
+      { "group": "on_hand_223" }
+    ]
+  },
+  {
+    "id": "nested_ar15_retool_300blk",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "ar15_retool_300blk", "charges-min": 0, "charges-max": 30 },
+      { "item": "stanag30" },
+      { "item": "stanag30", "prob": 50 },
+      { "group": "on_hand_300BLK" }
+    ]
+  },
+  {
+    "id": "nested_needlegun",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "needlegun", "charges-min": 0, "charges-max": 100 },
+      { "item": "5x50_100_mag" },
+      { "item": "5x50_100_mag", "prob": 50 },
+      { "group": "on_hand_5x50mm" }
+    ]
+  },
+  {
+    "id": "nested_rm120c",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [ { "item": "rm120c", "charges-min": 0, "charges-max": 5 }, { "group": "on_hand_20x66mm" } ]
+  },
+  {
+    "id": "nested_rm228",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "rm228", "charges-min": 0, "charges-max": 10 },
+      { "item": "20x66_10_mag" },
+      { "item": "20x66_10_mag", "prob": 50 },
+      { "group": "on_hand_20x66mm" }
+    ]
+  },
+  {
+    "id": "nested_an94",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "an94", "charges-min": 0, "charges-max": 30 },
+      { "item": "ak74mag" },
+      { "item": "ak74mag", "prob": 50 },
+      { "group": "on_hand_545x39" }
+    ]
+  },
+  {
+    "id": "nested_USAS_12",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "USAS_12", "charges-min": 0, "charges-max": 10 },
+      { "item": "USAS10mag" },
+      { "item": "USAS10mag", "prob": 50 },
+      { "group": "on_hand_shot" }
+    ]
+  },
+  {
+    "id": "nested_as50",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "as50", "charges-min": 0, "charges-max": 10 },
+      { "item": "as50mag" },
+      { "item": "as50mag", "prob": 50 },
+      { "group": "on_hand_50" }
+    ]
   }
 ]


### PR DESCRIPTION

#### Summary

SUMMARY: Balance "Fixes the few normal guns I left out of the previous Nested Guns and Everyday Carry PRs"

#### Purpose of change

A few normal (i.e. Not Improvised) guns were left out of the previous Nested Guns and Everyday Carry PRs. This aims to fix that.

#### Describe the solution

1. Add the missing 5x50mm ammo type to nested_ammo.json
2. Add the missing guns to nested_guns.json
3. Add the missing guns to everydaycarry_guns.json
4. Edit the existing itemgroups in guns.json (and in the case of the obscure SMGs, add the everyday carry category) 

#### Describe alternatives you've considered

- Also adding the improvised guns along with the normal ones
Less pressing of a concern, and I feel like they're relatively unimportant.

- Leaving it how it was previously
I mean, entirely possible, but I don't know *why* anyone would be against making it (more) complete and comprehensive.

#### Testing

1. Run files through JSON linter (so that the github bot shouldn't yell at me)
2. Load into one of my worlds, confirm that no errors were spit out on loading

#### Additional context

If anyone actually wants to go and make the definitions for the improvised guns, be my guest. However, I don't particularly think I shall. At least not anytime soon.
