### PR TITLE
Prevent crash when `lastworld.json` is corrupted or empty.

### DIFF
--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -600,7 +600,7 @@ void worldfactory::load_last_world_info()
         return;
     }
 
-    JsonIn jsin( *file );
+    JsonIn jsin( *file, PATH_INFO::lastworld() );
     try {
         JsonObject data = jsin.get_object();
         last_world_name = data.get_string( "world_name" );

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -601,9 +601,13 @@ void worldfactory::load_last_world_info()
     }
 
     JsonIn jsin( *file );
-    JsonObject data = jsin.get_object();
-    last_world_name = data.get_string( "world_name" );
-    last_character_name = data.get_string( "character_name" );
+    try {
+        JsonObject data = jsin.get_object();
+        last_world_name = data.get_string( "world_name" );
+        last_character_name = data.get_string( "character_name" );
+    } catch( const std::exception &e ) {
+        debugmsg( e.what() );
+    }
 }
 
 void worldfactory::save_last_world_info()


### PR DESCRIPTION
#### Summary

SUMMARY: Bugfixes "Prevent crash when `lastworld.json` is corrupted or empty."

#### Purpose of change

Had an issue today where someone's computer didn't end the game appropriately, corrupting `lastworld.json`, this caused a crash that would consistently prevent the game from starting with no warning except crash log messages.

#### Describe the solution

Use try and catch to catch exceptions and report them when they occur loading `lastworld.json`

#### Describe alternatives you've considered

#### Testing

Need others to test for me, my computer is down. This should be tested via creating `lastworld.json` in the config folder. Either leave it empty or in various states of incomplete/wrong format.

#### Additional context
