### PR TITLE
refactor: extract to `vehicle_part.h`

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -37,6 +37,7 @@
 #include "ui.h"
 #include "ui_manager.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 static const quality_id qual_BUTCHER( "BUTCHER" );

--- a/src/active_tile_data.cpp
+++ b/src/active_tile_data.cpp
@@ -11,6 +11,7 @@
 #include "mapbuffer.h"
 #include "rng.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_range.h"
 #include "weather.h"
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -48,6 +48,7 @@
 #include "uistate.h"
 #include "units.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 static const itype_id itype_bone_human( "bone_human" );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -103,6 +103,7 @@
 #include "value_ptr.h"
 #include "veh_interact.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 static const activity_id ACT_ADV_INVENTORY( "ACT_ADV_INVENTORY" );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -70,6 +70,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "vpart_position.h"
 #include "weather.h"

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -55,6 +55,7 @@
 #include "units.h"
 #include "units_utility.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 
 #if defined(__ANDROID__)

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -29,6 +29,7 @@
 #include "uistate.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 int advanced_inv_area::get_item_count() const

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -18,6 +18,7 @@
 #include "uistate.h"
 #include "units.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 
 #if defined(__ANDROID__)
 #   include <SDL_keyboard.h>

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -74,6 +74,7 @@
 #include "ui.h"
 #include "value_ptr.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 static const activity_id ACT_READ( "ACT_READ" );

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -59,6 +59,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 class player;

--- a/src/avatar_functions.cpp
+++ b/src/avatar_functions.cpp
@@ -20,6 +20,7 @@
 #include "trap.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 static const trait_id trait_CHLOROMORPH( "CHLOROMORPH" );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -80,6 +80,7 @@
 #include "units_utility.h"
 #include "value_ptr.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "weather.h"
 #include "weather_gen.h"

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -74,6 +74,7 @@
 #include "type_id.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "weather.h"
 #include "weighted_list.h"

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -98,6 +98,7 @@
 #include "veh_interact.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "vitamin.h"
 #include "vpart_position.h"

--- a/src/character_effects.cpp
+++ b/src/character_effects.cpp
@@ -16,6 +16,7 @@
 #include "trap.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "weather_gen.h"
 #include "weather.h"

--- a/src/character_functions.cpp
+++ b/src/character_functions.cpp
@@ -24,6 +24,7 @@
 #include "uistate.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "vpart_position.h"
 #include "weather_gen.h"

--- a/src/character_turn.cpp
+++ b/src/character_turn.cpp
@@ -23,6 +23,7 @@
 #include "trap.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "weather_gen.h"
 #include "weather.h"

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -36,6 +36,7 @@
 #include "ui.h"
 #include "value_ptr.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 static const std::string flag_FIREWOOD( "FIREWOOD" );

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -39,6 +39,7 @@
 #include "string_id.h"
 #include "type_id.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 class basecamp;

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -62,6 +62,7 @@
 #include "units_serde.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 static const activity_id ACT_BUILD( "ACT_BUILD" );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -74,6 +74,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "vpart_position.h"
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -45,6 +45,7 @@
 #include "translations.h"
 #include "value_ptr.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 static const ammo_effect_str_id ammo_effect_APPLY_SAP( "APPLY_SAP" );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -101,6 +101,7 @@
 #include "units_utility.h"
 #include "url_utility.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "veh_type.h"
 #include "vitamin.h"
 #include "vpart_position.h"

--- a/src/distribution_grid.cpp
+++ b/src/distribution_grid.cpp
@@ -68,6 +68,7 @@ void distribution_grid::update( time_point to )
 
 // TODO: Shouldn't be here
 #include "vehicle.h"
+#include "vehicle_part.h"
 static itype_id itype_battery( "battery" );
 int distribution_grid::mod_resource( int amt, bool recurse )
 {

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -32,6 +32,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vitamin.h"
 
 static const std::string flag_VARSIZE( "VARSIZE" );

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -54,6 +54,7 @@
 #include "ui_manager.h"
 #include "uistate.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 static constexpr tripoint editmap_boundary_min( 0, 0, -OVERMAP_DEPTH );

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -64,6 +64,7 @@
 #include "units.h"
 #include "ui_manager.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 static const ammo_effect_str_id ammo_effect_NULL_SOURCE( "NULL_SOURCE" );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -73,6 +73,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 #include "weather.h"

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -172,6 +172,7 @@
 #include "veh_interact.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 #include "wcwidth.h"

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -33,6 +33,7 @@
 #include "type_id.h"
 #include "units.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 // Gates namespace

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -14,6 +14,7 @@
 #include "point.h"
 #include "sounds.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "debug.h"
 #include "rng.h"

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -86,6 +86,7 @@
 #include "units.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 #include "weather.h"

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -36,6 +36,7 @@
 #include "type_id.h"
 #include "ui.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -106,6 +106,7 @@
 #include "units_utility.h"
 #include "value_ptr.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "weather.h"
 

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -24,6 +24,7 @@
 #include "options.h"
 #include "translations.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "calendar.h"
 #include "character.h"

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -28,6 +28,7 @@
 #include "ui_manager.h"
 #include "units_utility.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "visitable.h"
 #include "vpart_position.h"

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -98,6 +98,7 @@
 #include "units_utility.h"
 #include "value_ptr.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vitamin.h"
 #include "vpart_position.h"
 #include "weather.h"

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -29,6 +29,7 @@
 #include "string_formatter.h"
 #include "translations.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "visitable.h"
 #include "vpart_position.h"

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -114,6 +114,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "visitable.h"
 #include "vpart_position.h"

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -80,6 +80,7 @@
 #include "units_utility.h"
 #include "value_ptr.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "visitable.h"
 #include "vitamin.h"

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -38,6 +38,7 @@
 #include "type_id.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 #include "weather.h"

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -51,6 +51,7 @@
 #include "type_id.h"
 #include "units.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 static const ammo_effect_str_id ammo_effect_magic( "magic" );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -94,6 +94,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "visitable.h"
 #include "vpart_position.h"
 #include "vpart_range.h"

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -55,6 +55,7 @@
 #include "units.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_group.h"
 #include "vpart_position.h"
 #include "vpart_range.h"

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -58,6 +58,7 @@
 #include "type_id.h"
 #include "units.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "weather.h"
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -70,6 +70,7 @@
 #include "trap.h"
 #include "value_ptr.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_group.h"
 #include "vpart_position.h"
 #include "vpart_range.h"

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -30,6 +30,7 @@
 #include "sounds.h"
 #include "translations.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_range.h"
 
 static const efftype_id effect_badpoison( "badpoison" );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -61,6 +61,7 @@
 #include "type_id.h"
 #include "units.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "weighted_list.h"
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -46,6 +46,7 @@
 #include "translations.h"
 #include "trap.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 static const efftype_id effect_ai_waiting( "ai_waiting" );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -71,6 +71,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "visitable.h"
 #include "vpart_position.h"
 #include "vpart_range.h"

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -67,6 +67,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "visitable.h"
 #include "vpart_position.h"
 #include "vpart_range.h"

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -79,6 +79,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -71,6 +71,7 @@
 #include "uistate.h"
 #include "units.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "weather.h"
 #include "weather_gen.h"

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -42,6 +42,7 @@
 #include "string_utils.h"
 #include "translations.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 
 class map_extra;
 

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -57,6 +57,7 @@
 #include "units.h"
 #include "units_utility.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "weather.h"
 

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -19,6 +19,7 @@
 #include "trap.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "line.h"
 #include "type_id.h"

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -58,6 +58,7 @@
 #include "units.h"
 #include "units_utility.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "vpart_position.h"
 

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -33,6 +33,7 @@
 #include "pixel_minimap_projectors.h"
 #include "sdl_utils.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 extern void set_displaybuffer_rendertarget();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -81,6 +81,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "visitable.h"
 #include "vitamin.h"
 #include "vpart_position.h"

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -70,6 +70,7 @@
 #include "units_utility.h"
 #include "value_ptr.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 struct ammo_effect;

--- a/src/ranged_aoe.cpp
+++ b/src/ranged_aoe.cpp
@@ -7,6 +7,7 @@
 #include "ranged.h"
 #include "shape.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 #include "explosion.h"

--- a/src/rot.cpp
+++ b/src/rot.cpp
@@ -3,6 +3,7 @@
 #include "item_location.h"
 #include "map.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "units.h"
 #include "veh_type.h"
 #include "vpart_position.h"

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -110,6 +110,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vitamin.h"
 #include "vpart_position.h"
 #include "vpart_range.h"

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -91,6 +91,7 @@
 #include "inventory.h"
 #include "map.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "worldfactory.h"
 #endif

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -46,6 +46,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "weather.h"
 

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -12,6 +12,7 @@
 #include "tileray.h"
 #include "trap.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 
 template<int sx, int sy>
 void maptile_soa<sx, sy>::swap_soa_tile( point p1, point p2 )

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -1,4 +1,5 @@
-#include "vehicle.h" // IWYU pragma: associated
+#include "vehicle.h"
+#include "vehicle_part.h" // IWYU pragma: associated
 
 #include <algorithm>
 #include <memory>

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -66,6 +66,7 @@
 #include "veh_type.h"
 #include "veh_utils.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "vpart_position.h"
 #include "vpart_range.h"

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -32,6 +32,7 @@
 #include "units_utility.h"
 #include "value_ptr.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_group.h"
 
 class npc;

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -463,60 +463,60 @@ void vpart_info::finalize()
 {
     DynamicDataLoader::get_instance().load_deferred( deferred );
 
-    for( auto &e : vpart_info_all ) {
-        if( e.second.folded_volume > 0_ml ) {
-            e.second.set_flag( "FOLDABLE" );
+    for( auto &[_id, info] : vpart_info_all ) {
+        if( info.folded_volume > 0_ml ) {
+            info.set_flag( "FOLDABLE" );
         }
 
-        for( const auto &f : e.second.flags ) {
+        for( const auto &f : info.flags ) {
             auto b = vpart_bitflag_map.find( f );
             if( b != vpart_bitflag_map.end() ) {
-                e.second.bitflags.set( b->second );
+                info.bitflags.set( b->second );
             }
         }
 
         // Calculate and cache z-ordering based off of location
         // list_order is used when inspecting the vehicle
-        if( e.second.location == "on_roof" ) {
-            e.second.z_order = 9;
-            e.second.list_order = 3;
-        } else if( e.second.location == "on_cargo" ) {
-            e.second.z_order = 8;
-            e.second.list_order = 6;
-        } else if( e.second.location == "center" ) {
-            e.second.z_order = 7;
-            e.second.list_order = 7;
-        } else if( e.second.location == "under" ) {
+        if( info.location == "on_roof" ) {
+            info.z_order = 9;
+            info.list_order = 3;
+        } else if( info.location == "on_cargo" ) {
+            info.z_order = 8;
+            info.list_order = 6;
+        } else if( info.location == "center" ) {
+            info.z_order = 7;
+            info.list_order = 7;
+        } else if( info.location == "under" ) {
             // Have wheels show up over frames
-            e.second.z_order = 6;
-            e.second.list_order = 10;
-        } else if( e.second.location == "structure" ) {
-            e.second.z_order = 5;
-            e.second.list_order = 1;
-        } else if( e.second.location == "engine_block" ) {
+            info.z_order = 6;
+            info.list_order = 10;
+        } else if( info.location == "structure" ) {
+            info.z_order = 5;
+            info.list_order = 1;
+        } else if( info.location == "engine_block" ) {
             // Should be hidden by frames
-            e.second.z_order = 4;
-            e.second.list_order = 8;
-        } else if( e.second.location == "on_battery_mount" ) {
+            info.z_order = 4;
+            info.list_order = 8;
+        } else if( info.location == "on_battery_mount" ) {
             // Should be hidden by frames
-            e.second.z_order = 3;
-            e.second.list_order = 10;
-        } else if( e.second.location == "fuel_source" ) {
+            info.z_order = 3;
+            info.list_order = 10;
+        } else if( info.location == "fuel_source" ) {
             // Should be hidden by frames
-            e.second.z_order = 3;
-            e.second.list_order = 9;
-        } else if( e.second.location == "roof" ) {
+            info.z_order = 3;
+            info.list_order = 9;
+        } else if( info.location == "roof" ) {
             // Shouldn't be displayed
-            e.second.z_order = -1;
-            e.second.list_order = 4;
-        } else if( e.second.location == "armor" ) {
+            info.z_order = -1;
+            info.list_order = 4;
+        } else if( info.location == "armor" ) {
             // Shouldn't be displayed (the color is used, but not the symbol)
-            e.second.z_order = -2;
-            e.second.list_order = 2;
+            info.z_order = -2;
+            info.list_order = 2;
         } else {
             // Everything else
-            e.second.z_order = 0;
-            e.second.list_order = 5;
+            info.z_order = 0;
+            info.list_order = 5;
         }
     }
 }
@@ -539,42 +539,42 @@ void vpart_info::check()
             part.removal_moves = part.install_moves / 2;
         }
 
-        for( auto &e : part.install_skills ) {
-            if( !e.first.is_valid() ) {
-                debugmsg( "vehicle part %s has unknown install skill %s", part.id.c_str(), e.first.c_str() );
+        for( const auto &[skill, level] : part.install_skills ) {
+            if( !skill.is_valid() ) {
+                debugmsg( "vehicle part %s has unknown install skill %s", part.id.c_str(), skill.c_str() );
             }
         }
 
-        for( auto &e : part.removal_skills ) {
-            if( !e.first.is_valid() ) {
-                debugmsg( "vehicle part %s has unknown removal skill %s", part.id.c_str(), e.first.c_str() );
+        for( const auto &[skill, level] : part.removal_skills ) {
+            if( !skill.is_valid() ) {
+                debugmsg( "vehicle part %s has unknown removal skill %s", part.id.c_str(), skill.c_str() );
             }
         }
 
-        for( auto &e : part.repair_skills ) {
-            if( !e.first.is_valid() ) {
-                debugmsg( "vehicle part %s has unknown repair skill %s", part.id.c_str(), e.first.c_str() );
+        for( const auto &[skill, level] : part.repair_skills ) {
+            if( !skill.is_valid() ) {
+                debugmsg( "vehicle part %s has unknown repair skill %s", part.id.c_str(), skill.c_str() );
             }
         }
 
-        for( const auto &e : part.install_reqs ) {
-            if( !e.first.is_valid() || e.second <= 0 ) {
+        for( const auto &[skill, multiplier] : part.install_reqs ) {
+            if( !skill.is_valid() || multiplier <= 0 ) {
                 debugmsg( "vehicle part %s has unknown or incorrectly specified install requirements %s",
-                          part.id.c_str(), e.first.c_str() );
+                          part.id.c_str(), skill.c_str() );
             }
         }
 
-        for( const auto &e : part.install_reqs ) {
-            if( !( e.first.is_null() || e.first.is_valid() ) || e.second < 0 ) {
+        for( const auto &[req, multiplier] : part.install_reqs ) {
+            if( !( req.is_null() || req.is_valid() ) || multiplier < 0 ) {
                 debugmsg( "vehicle part %s has unknown or incorrectly specified removal requirements %s",
-                          part.id.c_str(), e.first.c_str() );
+                          part.id.c_str(), req.c_str() );
             }
         }
 
-        for( const auto &e : part.repair_reqs ) {
-            if( !( e.first.is_null() || e.first.is_valid() ) || e.second < 0 ) {
+        for( const auto &[req, multiplier] : part.repair_reqs ) {
+            if( !( req.is_null() || req.is_valid() ) || multiplier < 0 ) {
                 debugmsg( "vehicle part %s has unknown or incorrectly specified repair requirements %s",
-                          part.id.c_str(), e.first.c_str() );
+                          part.id.c_str(), req.c_str() );
             }
         }
 

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -16,6 +16,7 @@
 #include "player.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_range.h"
 #include "character.h"
 #include "enums.h"

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1,4 +1,5 @@
-#include "vehicle.h" // IWYU pragma: associated
+#include "vehicle.h"
+#include "vehicle_part.h" // IWYU pragma: associated
 #include "vpart_position.h" // IWYU pragma: associated
 #include "vpart_range.h" // IWYU pragma: associated
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -17,20 +17,17 @@
 
 #include "active_item_cache.h"
 #include "calendar.h"
-#include "character_id.h"
 #include "clzones.h"
 #include "colony.h"
 #include "coordinates.h"
 #include "damage.h"
 #include "game_constants.h"
 #include "item.h"
-#include "item_group.h"
 #include "item_location.h"
 #include "item_stack.h"
 #include "point.h"
 #include "tileray.h"
 #include "type_id.h"
-#include "units.h"
 
 class avatar;
 class Character;
@@ -43,6 +40,7 @@ class nc_color;
 class npc;
 class player;
 class vehicle;
+struct vehicle_part;
 class vehicle_cursor;
 class vehicle_part_range;
 class vpart_info;
@@ -179,297 +177,6 @@ int mps_to_vmiph( double mps );
 double vmiph_to_mps( int vmiph );
 int cmps_to_vmiph( int cmps );
 int vmiph_to_cmps( int vmiph );
-
-/**
- * Structure, describing vehicle part (i.e., wheel, seat)
- */
-struct vehicle_part {
-        friend vehicle;
-        friend class veh_interact;
-        friend visitable<vehicle_cursor>;
-        friend item_location;
-        friend class turret_data;
-
-        enum : int { passenger_flag = 1,
-                     animal_flag = 2,
-                     carried_flag = 4,
-                     carrying_flag = 8,
-                     tracked_flag = 16, //carried vehicle part with tracking enabled
-                     targets_grid = 32, // Jumper cable is to grid, not vehicle
-                   };
-
-        vehicle_part(); /** DefaultConstructible */
-
-        vehicle_part( const vpart_id &vp, point dp, item &&obj );
-
-        /** Check this instance is non-null (not default constructed) */
-        explicit operator bool() const;
-
-        // TODO: Make all of those use the above enum
-        bool has_flag( const int flag ) const noexcept {
-            return flag & flags;
-        }
-        int  set_flag( const int flag )       noexcept {
-            return flags |= flag;
-        }
-        int  remove_flag( const int flag )    noexcept {
-            return flags &= ~flag;
-        }
-
-        /**
-         * Translated name of a part inclusive of any current status effects
-         * with_prefix as true indicates the durability symbol should be prepended
-         */
-        std::string name( bool with_prefix = true ) const;
-
-        static constexpr int name_offset = 7;
-        /** Stack of the containing vehicle's name, when it it stored as part of another vehicle */
-        std::stack<std::string, std::vector<std::string> > carry_names;
-
-        /** Specific type of fuel, charges or ammunition currently contained by a part */
-        itype_id ammo_current() const;
-
-        /** Maximum amount of fuel, charges or ammunition that can be contained by a part */
-        int ammo_capacity() const;
-
-        /** Amount of fuel, charges or ammunition currently contained by a part */
-        int ammo_remaining() const;
-
-        /** Type of fuel used by an engine */
-        itype_id fuel_current() const;
-        /** Set an engine to use a different type of fuel */
-        bool fuel_set( const itype_id &fuel );
-        /**
-         * Set fuel, charges or ammunition for this part removing any existing ammo
-         * @param ammo specific type of ammo (must be compatible with vehicle part)
-         * @param qty maximum ammo (capped by part capacity) or negative to fill to capacity
-         * @return amount of ammo actually set or negative on failure
-         */
-        int ammo_set( const itype_id &ammo, int qty = -1 );
-
-        /** Remove all fuel, charges or ammunition (if any) from this part */
-        void ammo_unset();
-
-        /**
-         * Consume fuel, charges or ammunition (if available)
-         * @param qty maximum amount of ammo that should be consumed
-         * @param pos current global location of part from which ammo is being consumed
-         * @return amount consumed which will be between 0 and specified qty
-         */
-        int ammo_consume( int qty, const tripoint &pos );
-
-        /**
-         * Consume fuel by energy content.
-         * @param ftype Type of fuel to consume
-         * @param energy_j Energy to consume, in J
-         * @return Energy actually consumed, in J
-         */
-        double consume_energy( const itype_id &ftype, double energy_j );
-
-        /* @retun true if part in current state be reloaded optionally with specific itype_id */
-        bool can_reload( const item &obj = item() ) const;
-
-        /**
-         * If this part is capable of wholly containing something, process the
-         * items in there.
-         * @param pos Position of this part for item::process
-         * @param e_heater Engine has a heater and is on
-         */
-        void process_contents( const tripoint &pos, bool e_heater );
-
-        /**
-         *  Try adding @param liquid to tank optionally limited by @param qty
-         *  @return whether any of the liquid was consumed (which may be less than qty)
-         */
-        bool fill_with( item &liquid, int qty = INT_MAX );
-
-        /** Current faults affecting this part (if any) */
-        const std::set<fault_id> &faults() const;
-
-        /** Faults which could potentially occur with this part (if any) */
-        std::set<fault_id> faults_potential() const;
-
-        /** Try to set fault returning false if specified fault cannot occur with this item */
-        bool fault_set( const fault_id &f );
-
-        /** Get wheel diameter times wheel width (inches^2) or return 0 if part is not wheel */
-        int wheel_area() const;
-
-        /** Get wheel diameter (inches) or return 0 if part is not wheel */
-        int wheel_diameter() const;
-
-        /** Get wheel width (inches) or return 0 if part is not wheel */
-        int wheel_width() const;
-
-        /**
-         *  Get NPC currently assigned to this part (seat, turret etc)?
-         *  @note checks crew member is alive and currently allied to the player
-         *  @return nullptr if no valid crew member is currently assigned
-         */
-        npc *crew() const;
-
-        /** Set crew member for this part (seat, turret etc) who must be a player ally)
-         *  @return true if part can have crew members and passed npc was suitable
-         */
-        bool set_crew( const npc &who );
-
-        /** Remove any currently assigned crew member for this part */
-        void unset_crew();
-
-        /** Reset the target for this part. */
-        void reset_target( const tripoint &pos );
-
-        /**
-         * @name Part capabilities
-         *
-         * A part can provide zero or more capabilities. Some capabilities are mutually
-         * exclusive, for example a part cannot be both a fuel tank and battery
-         */
-        /*@{*/
-
-        /** Can this part provide power or propulsion? */
-        bool is_engine() const;
-
-        /** Is this any type of vehicle light? */
-        bool is_light() const;
-
-        /** Can this part store fuel of any type
-         * @skip_broke exclude broken parts
-         */
-        bool is_fuel_store( bool skip_broke = true ) const;
-
-        /** Can this part contain liquid fuels? */
-        bool is_tank() const;
-
-        /** Can this part store electrical charge? */
-        bool is_battery() const;
-
-        /** Is this part a reactor? */
-        bool is_reactor() const;
-
-        /** is this part currently unable to retain to fluid/charge?
-         *  this doesn't take into account whether or not the part has any contents
-         *  remaining to leak
-         */
-        bool is_leaking() const;
-
-        /** Can this part function as a turret? */
-        bool is_turret() const;
-
-        /** Can a player or NPC use this part as a seat? */
-        bool is_seat() const;
-
-        /* if this is a carried part, what is the name of the carried vehicle */
-        std::string carried_name() const;
-        /*@}*/
-
-    public:
-        /** mount point: x is on the forward/backward axis, y is on the left/right axis */
-        point mount;
-
-        /** mount translated to face.dir [0] and turn_dir [1] */
-        // NOLINTNEXTLINE(cata-use-named-point-constants)
-        std::array<tripoint, 2> precalc = { { tripoint( -1, -1, 0 ), tripoint( -1, -1, 0 ) } };
-
-        /** current part health with range [0,durability] */
-        int hp() const;
-
-        /** Current part damage in same units as item::damage. */
-        int damage() const;
-        /** max damage of part base */
-        int max_damage() const;
-
-        /** Current part damage level in same units as item::damage_level */
-        int damage_level( int max ) const;
-
-        /** Current part damage as a percentage of maximum, with 0.0 being perfect condition */
-        double damage_percent() const;
-        /** Current part health as a percentage of maximum, with 1.0 being perfect condition */
-        double health_percent() const;
-
-        /** parts are considered broken at zero health */
-        bool is_broken() const;
-
-        /** parts are unavailable if broken or if carried is true, if they have the CARRIED flag */
-        bool is_unavailable( bool carried = true ) const;
-        /** parts are available if they aren't unavailable */
-        bool is_available( bool carried = true ) const;
-
-        /** how much blood covers part (in turns). */
-        int blood = 0;
-
-        /**
-         * if tile provides cover.
-         * WARNING: do not read it directly, use vpart_position::is_inside() instead
-         */
-        bool inside = false;
-
-        /**
-         * true if this part is removed. The part won't disappear until the end of the turn
-         * so our indices can remain consistent.
-         */
-        bool removed = false;
-        bool enabled = true;
-        int flags = 0;
-
-        /** ID of player passenger */
-        character_id passenger_id;
-
-        /** door is open */
-        bool open = false;
-
-        /** direction the part is facing */
-        units::angle direction = 0_degrees;
-
-
-        vpart_id proxy_part_id = vpart_id::NULL_ID();
-        char proxy_sym = '\0';
-        /**
-         * Coordinates for some kind of target; jumper cables and turrets use this
-         * Two coordinate pairs are stored: actual target point, and target vehicle center.
-         * Both cases use absolute coordinates (relative to world origin)
-         */
-        std::pair<tripoint, tripoint> target = { tripoint_min, tripoint_min };
-
-    private:
-        /** What type of part is this? */
-        vpart_id id;
-
-        /** As a performance optimization we cache the part information here on first lookup */
-        mutable const vpart_info *info_cache = nullptr;
-
-        item base;
-        cata::colony<item> items; // inventory
-
-        /** Preferred ammo type when multiple are available */
-        itype_id ammo_pref = itype_id::NULL_ID();
-
-        /**
-         *  What NPC (if any) is assigned to this part (seat, turret etc)?
-         *  @see vehicle_part::crew() accessor which excludes dead and non-allied NPC's
-         */
-        character_id crew_id;
-
-    public:
-        /** Get part definition common to all parts of this type */
-        const vpart_info &info() const;
-
-        void serialize( JsonOut &json ) const;
-        void deserialize( JsonIn &jsin );
-
-        const item &get_base() const;
-        void set_base( const item &new_base );
-        /**
-         * Generate the corresponding item from this vehicle part. It includes
-         * the hp (item damage), fuel charges (battery or liquids), aspect, ...
-         */
-        item properties_to_item() const;
-        /**
-         * Returns an ItemList of the pieces that should arise from breaking
-         * this part.
-         */
-        item_group::ItemList pieces_for_broken_part() const;
-};
 
 class turret_data
 {
@@ -2042,6 +1749,6 @@ class vehicle
 namespace rot
 {
 temperature_flag temperature_flag_for_part( const vehicle &veh, size_t part );
-}
+} // namespace rot
 
 #endif // CATA_SRC_VEHICLE_H

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -1,4 +1,5 @@
-#include "vehicle.h" // IWYU pragma: associated
+#include "vehicle.h"
+#include "vehicle_part.h" // IWYU pragma: associated
 
 #include <algorithm>
 #include <array>

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -1,4 +1,5 @@
-#include "vehicle.h" // IWYU pragma: associated
+#include "vehicle.h"
+#include "vehicle_part.h" // IWYU pragma: associated
 
 #include <cstdlib>
 #include <algorithm>

--- a/src/vehicle_export.cpp
+++ b/src/vehicle_export.cpp
@@ -4,6 +4,7 @@
 #include "type_id.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "json_export.h"
 #include "vpart_position.h"
 #include "vpart_range.h"

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -14,6 +14,7 @@
 #include "translations.h"
 #include "units_angle.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 using vplacement_id = string_id<VehiclePlacement>;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1,4 +1,5 @@
-#include "vehicle.h" // IWYU pragma: associated
+#include "vehicle.h"
+#include "vehicle_part.h" // IWYU pragma: associated
 #include "vehicle_move.h" // IWYU pragma: associated
 
 #include <cassert>

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -1,4 +1,5 @@
-#include "vehicle.h" // IWYU pragma: associated
+#include "vehicle.h"
+#include "vehicle_part.h" // IWYU pragma: associated
 
 #include <algorithm>
 #include <cassert>

--- a/src/vehicle_part.h
+++ b/src/vehicle_part.h
@@ -1,0 +1,312 @@
+#pragma once
+
+#ifndef CATA_SRC_VEHICLE_PART_H
+#define CATA_SRC_VEHICLE_PART_H
+
+#include <stack>
+#include <set>
+
+#include "character_id.h"
+#include "colony.h"
+#include "item.h"
+#include "item_group.h"
+#include "point.h"
+#include "visitable.h"
+
+class vehicle;
+class item_location;
+class vehicle_cursor;
+class npc;
+
+/**
+ * Structure, describing vehicle part (i.e., wheel, seat)
+ */
+struct vehicle_part {
+        friend vehicle;
+        friend class veh_interact;
+        friend visitable<vehicle_cursor>;
+        friend item_location;
+        friend class turret_data;
+
+        enum : int { passenger_flag = 1,
+                     animal_flag = 2,
+                     carried_flag = 4,
+                     carrying_flag = 8,
+                     tracked_flag = 16, //carried vehicle part with tracking enabled
+                     targets_grid = 32, // Jumper cable is to grid, not vehicle
+                   };
+
+        vehicle_part(); /** DefaultConstructible */
+
+        vehicle_part( const vpart_id &vp, point dp, item &&obj );
+
+        /** Check this instance is non-null (not default constructed) */
+        explicit operator bool() const;
+
+        // TODO: Make all of those use the above enum
+        bool has_flag( const int flag ) const noexcept {
+            return flag & flags;
+        }
+        int  set_flag( const int flag )       noexcept {
+            return flags |= flag;
+        }
+        int  remove_flag( const int flag )    noexcept {
+            return flags &= ~flag;
+        }
+
+        /**
+         * Translated name of a part inclusive of any current status effects
+         * with_prefix as true indicates the durability symbol should be prepended
+         */
+        std::string name( bool with_prefix = true ) const;
+
+        static constexpr int name_offset = 7;
+        /** Stack of the containing vehicle's name, when it it stored as part of another vehicle */
+        std::stack<std::string, std::vector<std::string> > carry_names;
+
+        /** Specific type of fuel, charges or ammunition currently contained by a part */
+        itype_id ammo_current() const;
+
+        /** Maximum amount of fuel, charges or ammunition that can be contained by a part */
+        int ammo_capacity() const;
+
+        /** Amount of fuel, charges or ammunition currently contained by a part */
+        int ammo_remaining() const;
+
+        /** Type of fuel used by an engine */
+        itype_id fuel_current() const;
+        /** Set an engine to use a different type of fuel */
+        bool fuel_set( const itype_id &fuel );
+        /**
+         * Set fuel, charges or ammunition for this part removing any existing ammo
+         * @param ammo specific type of ammo (must be compatible with vehicle part)
+         * @param qty maximum ammo (capped by part capacity) or negative to fill to capacity
+         * @return amount of ammo actually set or negative on failure
+         */
+        int ammo_set( const itype_id &ammo, int qty = -1 );
+
+        /** Remove all fuel, charges or ammunition (if any) from this part */
+        void ammo_unset();
+
+        /**
+         * Consume fuel, charges or ammunition (if available)
+         * @param qty maximum amount of ammo that should be consumed
+         * @param pos current global location of part from which ammo is being consumed
+         * @return amount consumed which will be between 0 and specified qty
+         */
+        int ammo_consume( int qty, const tripoint &pos );
+
+        /**
+         * Consume fuel by energy content.
+         * @param ftype Type of fuel to consume
+         * @param energy_j Energy to consume, in J
+         * @return Energy actually consumed, in J
+         */
+        double consume_energy( const itype_id &ftype, double energy_j );
+
+        /* @retun true if part in current state be reloaded optionally with specific itype_id */
+        bool can_reload( const item &obj = item() ) const;
+
+        /**
+         * If this part is capable of wholly containing something, process the
+         * items in there.
+         * @param pos Position of this part for item::process
+         * @param e_heater Engine has a heater and is on
+         */
+        void process_contents( const tripoint &pos, bool e_heater );
+
+        /**
+         *  Try adding @param liquid to tank optionally limited by @param qty
+         *  @return whether any of the liquid was consumed (which may be less than qty)
+         */
+        bool fill_with( item &liquid, int qty = INT_MAX );
+
+        /** Current faults affecting this part (if any) */
+        const std::set<fault_id> &faults() const;
+
+        /** Faults which could potentially occur with this part (if any) */
+        std::set<fault_id> faults_potential() const;
+
+        /** Try to set fault returning false if specified fault cannot occur with this item */
+        bool fault_set( const fault_id &f );
+
+        /** Get wheel diameter times wheel width (inches^2) or return 0 if part is not wheel */
+        int wheel_area() const;
+
+        /** Get wheel diameter (inches) or return 0 if part is not wheel */
+        int wheel_diameter() const;
+
+        /** Get wheel width (inches) or return 0 if part is not wheel */
+        int wheel_width() const;
+
+        /**
+         *  Get NPC currently assigned to this part (seat, turret etc)?
+         *  @note checks crew member is alive and currently allied to the player
+         *  @return nullptr if no valid crew member is currently assigned
+         */
+        npc *crew() const;
+
+        /** Set crew member for this part (seat, turret etc) who must be a player ally)
+         *  @return true if part can have crew members and passed npc was suitable
+         */
+        bool set_crew( const npc &who );
+
+        /** Remove any currently assigned crew member for this part */
+        void unset_crew();
+
+        /** Reset the target for this part. */
+        void reset_target( const tripoint &pos );
+
+        /**
+         * @name Part capabilities
+         *
+         * A part can provide zero or more capabilities. Some capabilities are mutually
+         * exclusive, for example a part cannot be both a fuel tank and battery
+         */
+        /*@{*/
+
+        /** Can this part provide power or propulsion? */
+        bool is_engine() const;
+
+        /** Is this any type of vehicle light? */
+        bool is_light() const;
+
+        /** Can this part store fuel of any type
+         * @skip_broke exclude broken parts
+         */
+        bool is_fuel_store( bool skip_broke = true ) const;
+
+        /** Can this part contain liquid fuels? */
+        bool is_tank() const;
+
+        /** Can this part store electrical charge? */
+        bool is_battery() const;
+
+        /** Is this part a reactor? */
+        bool is_reactor() const;
+
+        /** is this part currently unable to retain to fluid/charge?
+         *  this doesn't take into account whether or not the part has any contents
+         *  remaining to leak
+         */
+        bool is_leaking() const;
+
+        /** Can this part function as a turret? */
+        bool is_turret() const;
+
+        /** Can a player or NPC use this part as a seat? */
+        bool is_seat() const;
+
+        /* if this is a carried part, what is the name of the carried vehicle */
+        std::string carried_name() const;
+        /*@}*/
+
+    public:
+        /** mount point: x is on the forward/backward axis, y is on the left/right axis */
+        point mount;
+
+        /** mount translated to face.dir [0] and turn_dir [1] */
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        std::array<tripoint, 2> precalc = { { tripoint( -1, -1, 0 ), tripoint( -1, -1, 0 ) } };
+
+        /** current part health with range [0,durability] */
+        int hp() const;
+
+        /** Current part damage in same units as item::damage. */
+        int damage() const;
+        /** max damage of part base */
+        int max_damage() const;
+
+        /** Current part damage level in same units as item::damage_level */
+        int damage_level( int max ) const;
+
+        /** Current part damage as a percentage of maximum, with 0.0 being perfect condition */
+        double damage_percent() const;
+        /** Current part health as a percentage of maximum, with 1.0 being perfect condition */
+        double health_percent() const;
+
+        /** parts are considered broken at zero health */
+        bool is_broken() const;
+
+        /** parts are unavailable if broken or if carried is true, if they have the CARRIED flag */
+        bool is_unavailable( bool carried = true ) const;
+        /** parts are available if they aren't unavailable */
+        bool is_available( bool carried = true ) const;
+
+        /** how much blood covers part (in turns). */
+        int blood = 0;
+
+        /**
+         * if tile provides cover.
+         * WARNING: do not read it directly, use vpart_position::is_inside() instead
+         */
+        bool inside = false;
+
+        /**
+         * true if this part is removed. The part won't disappear until the end of the turn
+         * so our indices can remain consistent.
+         */
+        bool removed = false;
+        bool enabled = true;
+        int flags = 0;
+
+        /** ID of player passenger */
+        character_id passenger_id;
+
+        /** door is open */
+        bool open = false;
+
+        /** direction the part is facing */
+        units::angle direction = 0_degrees;
+
+
+        vpart_id proxy_part_id = vpart_id::NULL_ID();
+        char proxy_sym = '\0';
+        /**
+         * Coordinates for some kind of target; jumper cables and turrets use this
+         * Two coordinate pairs are stored: actual target point, and target vehicle center.
+         * Both cases use absolute coordinates (relative to world origin)
+         */
+        std::pair<tripoint, tripoint> target = { tripoint_min, tripoint_min };
+
+    private:
+        /** What type of part is this? */
+        vpart_id id;
+
+        /** As a performance optimization we cache the part information here on first lookup */
+        mutable const vpart_info *info_cache = nullptr;
+
+        item base;
+        cata::colony<item> items; // inventory
+
+        /** Preferred ammo type when multiple are available */
+        itype_id ammo_pref = itype_id::NULL_ID();
+
+        /**
+         *  What NPC (if any) is assigned to this part (seat, turret etc)?
+         *  @see vehicle_part::crew() accessor which excludes dead and non-allied NPC's
+         */
+        character_id crew_id;
+
+    public:
+        /** Get part definition common to all parts of this type */
+        const vpart_info &info() const;
+
+        void serialize( JsonOut &json ) const;
+        void deserialize( JsonIn &jsin );
+
+        const item &get_base() const;
+        void set_base( const item &new_base );
+        /**
+         * Generate the corresponding item from this vehicle part. It includes
+         * the hp (item damage), fuel charges (battery or liquids), aspect, ...
+         */
+        item properties_to_item() const;
+        /**
+         * Returns an ItemList of the pieces that should arise from breaking
+         * this part.
+         */
+        item_group::ItemList pieces_for_broken_part() const;
+};
+
+#endif

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1,5 +1,6 @@
 #include "character.h"
-#include "vehicle.h" // IWYU pragma: associated
+#include "vehicle.h"
+#include "vehicle_part.h" // IWYU pragma: associated
 
 #include <algorithm>
 #include <array>

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -29,6 +29,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 
 static const itype_id itype_apparatus( "apparatus" );

--- a/tests/electric_grid_test.cpp
+++ b/tests/electric_grid_test.cpp
@@ -16,6 +16,7 @@
 #include "state_helpers.h"
 #include "stringmaker.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 
 static furn_str_id f_battery( "f_battery" );
 static furn_str_id f_cable_connector( "f_cable_connector" );

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -25,6 +25,7 @@
 #include "type_id.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 

--- a/tests/find_auto_consume_test.cpp
+++ b/tests/find_auto_consume_test.cpp
@@ -13,6 +13,7 @@
 #include "player_helpers.h"
 #include "state_helpers.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "type_id.h"
 
 #include "catch/catch.hpp"

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -30,6 +30,7 @@
 #include "type_id.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 
 class Creature;

--- a/tests/ranged_aiming_test.cpp
+++ b/tests/ranged_aiming_test.cpp
@@ -23,6 +23,7 @@
 #include "ranged.h"
 #include "state_helpers.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 
 extern bool can_fire_turret( avatar &you, const map &m, const turret_data &turret );
 

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -26,6 +26,7 @@
 #include "type_id.h"
 #include "value_ptr.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 
 class player;

--- a/tests/reload_on_location_test.cpp
+++ b/tests/reload_on_location_test.cpp
@@ -16,6 +16,7 @@
 #include "state_helpers.h"
 #include "type_id.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "veh_type.h"
 

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -18,6 +18,7 @@
 #include "test_statistics.h"
 #include "type_id.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -30,6 +30,7 @@
 #include "units.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -18,6 +18,7 @@
 #include "type_id.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 
 static void test_repair( const std::vector<item> &tools, bool expect_craftable )
 {

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -18,6 +18,7 @@
 #include "state_helpers.h"
 #include "type_id.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "weather.h"
 

--- a/tests/vehicle_rails_test.cpp
+++ b/tests/vehicle_rails_test.cpp
@@ -16,6 +16,7 @@
 #include "veh_type.h"
 #include "vehicle_move.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -19,6 +19,7 @@
 #include "map_iterator.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_range.h"
 #include "bodypart.h"
 #include "calendar.h"

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -7,6 +7,7 @@
 #include "character.h"
 #include "map.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "type_id.h"
 #include "point.h"
 #include "state_helpers.h"

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -15,6 +15,7 @@
 #include "state_helpers.h"
 #include "type_id.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "veh_type.h"
 

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -21,6 +21,7 @@
 #include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 
 static std::vector<const vpart_info *> turret_types()
 {

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -26,6 +26,7 @@
 #include "type_id.h"
 #include "weather.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
 

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -23,6 +23,7 @@
 #include "state_helpers.h"
 #include "type_id.h"
 #include "vehicle.h"
+#include "vehicle_part.h"
 #include "vehicle_selector.h"
 #include "visitable.h"
 #include "vpart_position.h"


### PR DESCRIPTION
#### Summary

SUMMARY: Infrastructure "Separate vehicle.h with vehicle_part.h"

- blocked by #3101 (will rebase once it gets approved and merged)

#### Purpose of change

`vehicle.cpp` and `vehicle_part.cpp` are already separated, doing the same for headers make sense as it means less chance to recompile everything (in the future)

#### Describe the solution

cut and pasted `vehicle_part` class into `vehicle_part.h`.

#### Testing

built without errors on my machine.