### PR TITLE
fix(i18n): translation generator script ignoring JSONs

### DIFF
--- a/lang/extract_json_strings.py
+++ b/lang/extract_json_strings.py
@@ -1372,7 +1372,6 @@ def extract_all_from_dir(state, dir):
 
 
 def extract_all_from_json_file(state, json_file):
-    return
     "Extract translatable strings from every object in the specified JSON file."
     state.current_source_file = json_file
     log_verbose("Loading {}".format(json_file))


### PR DESCRIPTION
#### Summary

SUMMARY: I18N "fix translation generator script ignoring JSONs"

#### Purpose of change

- fix #3105

#### Describe the solution

removed `return` in first line on `extract_all_from_json_file` which prevented all JSONs from getting extracted.

https://github.com/cataclysmbnteam/Cataclysm-BN/blob/603db6e1d75e8f7fa1f68e04528e96a9e0caf537/lang/extract_json_strings.py#L1374-L1378

before:
```sh
$ wc po/cataclysm-bn.pot 
 257629  935222 7093763 po/cataclysm-bn.pot
```
after:
```sh
$ wc po/cataclysm-bn.pot
 48860 130276 895919 po/cataclysm-bn.pot
```

#### Additional context

must've missed it in #2216. I should _really_ make a github actions check for these kind of things but i'm too lazy...